### PR TITLE
refactor(audio): naming consistency + deprecation plan

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Audio low-level API names are now explicit with `_opus` suffix:
+  `start_audio_rx_opus()`, `stop_audio_rx_opus()`, `start_audio_tx_opus()`,
+  `push_audio_tx_opus()`, `stop_audio_tx_opus()`, plus full-duplex
+  `start_audio_opus()` / `stop_audio_opus()`.
+
+### Deprecated
+
+- Ambiguous audio aliases are deprecated (still functional during a two-minor-release window):
+  `start_audio_rx()`, `stop_audio_rx()`, `start_audio_tx()`, `push_audio_tx()`,
+  `stop_audio_tx()`, `start_audio()`, `stop_audio()`.
+- Synchronous wrapper aliases are likewise deprecated in favor of
+  `icom_lan.sync.IcomRadio.*_opus()` names.
+
 ## [0.6.0] — 2026-02-25
 
 ### Added

--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -2,6 +2,19 @@
 
 Audio RX/TX via the Icom audio UDP port (default 50003).
 
+## Naming Map
+
+Low-level Opus methods are now explicitly suffixed with `_opus`.
+High-level PCM names are reserved for upcoming APIs.
+
+| Scope | Preferred method names |
+|------|-------------------------|
+| Low-level Opus (current) | `start_audio_rx_opus`, `stop_audio_rx_opus`, `start_audio_tx_opus`, `push_audio_tx_opus`, `stop_audio_tx_opus`, `start_audio_opus`, `stop_audio_opus` |
+| High-level PCM (planned) | `start_audio_rx_pcm`, `stop_audio_rx_pcm`, `start_audio_tx_pcm`, `push_audio_tx_pcm`, `stop_audio_tx_pcm` |
+
+Deprecated aliases still work during the deprecation window (two minor releases):
+`start_audio_rx`, `stop_audio_rx`, `start_audio_tx`, `push_audio_tx`, `stop_audio_tx`, `start_audio`, `stop_audio`.
+
 ## AudioStream
 
 ::: icom_lan.audio.AudioStream
@@ -36,27 +49,27 @@ async with IcomRadio("192.168.1.100", username="u", password="p") as radio:
         if pkt is not None:  # None = gap (missing packet)
             received.append(pkt.data)
 
-    await radio.start_audio_rx(on_audio)
+    await radio.start_audio_rx_opus(on_audio)
     await asyncio.sleep(10)
-    await radio.stop_audio_rx()
+    await radio.stop_audio_rx_opus()
 ```
 
 ### TX Audio (push-based)
 
 ```python
 async with IcomRadio("192.168.1.100", username="u", password="p") as radio:
-    await radio.start_audio_tx()
-    await radio.push_audio_tx(opus_frame)
-    await radio.stop_audio_tx()
+    await radio.start_audio_tx_opus()
+    await radio.push_audio_tx_opus(opus_frame)
+    await radio.stop_audio_tx_opus()
 ```
 
 ### Full-Duplex
 
 ```python
 async with IcomRadio("192.168.1.100", username="u", password="p") as radio:
-    await radio.start_audio(rx_callback=on_audio, tx_enabled=True)
+    await radio.start_audio_opus(rx_callback=on_audio, tx_enabled=True)
     # ... push TX frames, receive RX via callback ...
-    await radio.stop_audio()
+    await radio.stop_audio_opus()
 ```
 
 ### Codec Selection
@@ -75,3 +88,17 @@ radio = IcomRadio(
     `OPUS_1CH` (0x40) and `OPUS_2CH` (0x41) are only supported when
     the radio reports `connection_type == "WFVIEW"`. Standard connections
     use LPCM16 (0x04).
+
+## Migration
+
+Use the explicit `_opus` methods now:
+
+| Deprecated alias | Replacement |
+|------------------|-------------|
+| `start_audio_rx` | `start_audio_rx_opus` |
+| `stop_audio_rx` | `stop_audio_rx_opus` |
+| `start_audio_tx` | `start_audio_tx_opus` |
+| `push_audio_tx` | `push_audio_tx_opus` |
+| `stop_audio_tx` | `stop_audio_tx_opus` |
+| `start_audio` | `start_audio_opus` |
+| `stop_audio` | `stop_audio_opus` |

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -16,6 +16,7 @@ import logging
 import os
 import struct
 import time
+import warnings
 from typing import TYPE_CHECKING, AsyncGenerator
 
 if TYPE_CHECKING:
@@ -346,14 +347,31 @@ class IcomRadio:
     # Audio streaming
     # ------------------------------------------------------------------
 
-    async def start_audio_rx(self, callback: "Callable[[AudioPacket], None]") -> None:
-        """Start receiving audio from the radio.
+    @staticmethod
+    def _warn_audio_alias(old_name: str, replacement: str) -> None:
+        warnings.warn(
+            (
+                f"IcomRadio.{old_name}() is deprecated and will be removed after two "
+                f"minor releases; use IcomRadio.{replacement}() instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    async def start_audio_rx_opus(
+        self,
+        callback: "Callable[[AudioPacket], None]",
+        *,
+        jitter_depth: int = 5,
+    ) -> None:
+        """Start receiving Opus audio from the radio.
 
         Connects the audio transport if not already connected,
         then begins streaming RX audio to the callback.
 
         Args:
             callback: Called with each :class:`AudioPacket`.
+            jitter_depth: Jitter buffer depth (0 to disable, default 5).
 
         Raises:
             ConnectionError: If not connected or audio port unavailable.
@@ -361,15 +379,15 @@ class IcomRadio:
         self._check_connected()
         await self._ensure_audio_transport()
         assert self._audio_stream is not None
-        await self._audio_stream.start_rx(callback)
+        await self._audio_stream.start_rx(callback, jitter_depth=jitter_depth)
 
-    async def stop_audio_rx(self) -> None:
-        """Stop receiving audio from the radio."""
+    async def stop_audio_rx_opus(self) -> None:
+        """Stop receiving Opus audio from the radio."""
         if self._audio_stream is not None:
             await self._audio_stream.stop_rx()
 
-    async def start_audio_tx(self) -> None:
-        """Start transmitting audio to the radio.
+    async def start_audio_tx_opus(self) -> None:
+        """Start transmitting Opus audio to the radio.
 
         Connects the audio transport if not already connected.
 
@@ -381,7 +399,7 @@ class IcomRadio:
         assert self._audio_stream is not None
         await self._audio_stream.start_tx()
 
-    async def push_audio_tx(self, opus_data: bytes) -> None:
+    async def push_audio_tx_opus(self, opus_data: bytes) -> None:
         """Send an Opus-encoded audio frame to the radio.
 
         Args:
@@ -396,18 +414,19 @@ class IcomRadio:
             raise RuntimeError("Audio TX not started")
         await self._audio_stream.push_tx(opus_data)
 
-    async def stop_audio_tx(self) -> None:
-        """Stop transmitting audio to the radio."""
+    async def stop_audio_tx_opus(self) -> None:
+        """Stop transmitting Opus audio to the radio."""
         if self._audio_stream is not None:
             await self._audio_stream.stop_tx()
 
-    async def start_audio(
+    async def start_audio_opus(
         self,
         rx_callback: "Callable[[AudioPacket], None]",
         *,
         tx_enabled: bool = True,
+        jitter_depth: int = 5,
     ) -> None:
-        """Start full-duplex audio (RX + optional TX).
+        """Start full-duplex Opus audio (RX + optional TX).
 
         Convenience method that starts both RX and TX audio streams
         on the same transport.
@@ -415,19 +434,60 @@ class IcomRadio:
         Args:
             rx_callback: Called with each :class:`AudioPacket` (or None for gaps).
             tx_enabled: Whether to also enable TX (default True).
+            jitter_depth: Jitter buffer depth (0 to disable, default 5).
 
         Raises:
             ConnectionError: If not connected or audio port unavailable.
         """
-        await self.start_audio_rx(rx_callback)
+        await self.start_audio_rx_opus(rx_callback, jitter_depth=jitter_depth)
         if tx_enabled:
             assert self._audio_stream is not None
             await self._audio_stream.start_tx()
 
+    async def stop_audio_opus(self) -> None:
+        """Stop all Opus audio streams (RX and TX)."""
+        await self.stop_audio_tx_opus()
+        await self.stop_audio_rx_opus()
+
+    async def start_audio_rx(self, callback: "Callable[[AudioPacket], None]") -> None:
+        """Deprecated alias for :meth:`start_audio_rx_opus`."""
+        self._warn_audio_alias("start_audio_rx", "start_audio_rx_opus")
+        await self.start_audio_rx_opus(callback)
+
+    async def stop_audio_rx(self) -> None:
+        """Deprecated alias for :meth:`stop_audio_rx_opus`."""
+        self._warn_audio_alias("stop_audio_rx", "stop_audio_rx_opus")
+        await self.stop_audio_rx_opus()
+
+    async def start_audio_tx(self) -> None:
+        """Deprecated alias for :meth:`start_audio_tx_opus`."""
+        self._warn_audio_alias("start_audio_tx", "start_audio_tx_opus")
+        await self.start_audio_tx_opus()
+
+    async def push_audio_tx(self, opus_data: bytes) -> None:
+        """Deprecated alias for :meth:`push_audio_tx_opus`."""
+        self._warn_audio_alias("push_audio_tx", "push_audio_tx_opus")
+        await self.push_audio_tx_opus(opus_data)
+
+    async def stop_audio_tx(self) -> None:
+        """Deprecated alias for :meth:`stop_audio_tx_opus`."""
+        self._warn_audio_alias("stop_audio_tx", "stop_audio_tx_opus")
+        await self.stop_audio_tx_opus()
+
+    async def start_audio(
+        self,
+        rx_callback: "Callable[[AudioPacket], None]",
+        *,
+        tx_enabled: bool = True,
+    ) -> None:
+        """Deprecated alias for :meth:`start_audio_opus`."""
+        self._warn_audio_alias("start_audio", "start_audio_opus")
+        await self.start_audio_opus(rx_callback, tx_enabled=tx_enabled)
+
     async def stop_audio(self) -> None:
-        """Stop all audio streams (RX and TX)."""
-        await self.stop_audio_tx()
-        await self.stop_audio_rx()
+        """Deprecated alias for :meth:`stop_audio_opus`."""
+        self._warn_audio_alias("stop_audio", "stop_audio_opus")
+        await self.stop_audio_opus()
 
     @property
     def audio_codec(self) -> "AudioCodec":

--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -13,6 +13,7 @@ Example::
 """
 
 import asyncio
+import warnings
 from typing import Callable
 
 from .audio import AudioPacket
@@ -65,6 +66,17 @@ class IcomRadio:
     def _run(self, coro):  # type: ignore[no-untyped-def]
         """Run a coroutine on the internal event loop."""
         return self._loop.run_until_complete(coro)
+
+    @staticmethod
+    def _warn_audio_alias(old_name: str, replacement: str) -> None:
+        warnings.warn(
+            (
+                f"icom_lan.sync.IcomRadio.{old_name}() is deprecated and will be "
+                f"removed after two minor releases; use {replacement}() instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     # ------------------------------------------------------------------
     # Connection
@@ -255,25 +267,55 @@ class IcomRadio:
     # Audio
     # ------------------------------------------------------------------
 
+    def start_audio_rx_opus(
+        self,
+        callback: Callable[[AudioPacket], None],
+        *,
+        jitter_depth: int = 5,
+    ) -> None:
+        """Start receiving Opus audio from the radio (blocking setup)."""
+        self._run(self._radio.start_audio_rx_opus(callback, jitter_depth=jitter_depth))
+
+    def stop_audio_rx_opus(self) -> None:
+        """Stop Opus RX audio."""
+        self._run(self._radio.stop_audio_rx_opus())
+
+    def start_audio_tx_opus(self) -> None:
+        """Start Opus TX audio."""
+        self._run(self._radio.start_audio_tx_opus())
+
+    def push_audio_tx_opus(self, opus_data: bytes) -> None:
+        """Send an Opus audio frame to the radio."""
+        self._run(self._radio.push_audio_tx_opus(opus_data))
+
+    def stop_audio_tx_opus(self) -> None:
+        """Stop Opus TX audio."""
+        self._run(self._radio.stop_audio_tx_opus())
+
     def start_audio_rx(self, callback: Callable[[AudioPacket], None]) -> None:
-        """Start receiving audio from the radio (blocking setup)."""
-        self._run(self._radio.start_audio_rx(callback))
+        """Deprecated alias for :meth:`start_audio_rx_opus`."""
+        self._warn_audio_alias("start_audio_rx", "start_audio_rx_opus")
+        self.start_audio_rx_opus(callback)
 
     def stop_audio_rx(self) -> None:
-        """Stop receiving audio."""
-        self._run(self._radio.stop_audio_rx())
+        """Deprecated alias for :meth:`stop_audio_rx_opus`."""
+        self._warn_audio_alias("stop_audio_rx", "stop_audio_rx_opus")
+        self.stop_audio_rx_opus()
 
     def start_audio_tx(self) -> None:
-        """Start transmitting audio."""
-        self._run(self._radio.start_audio_tx())
+        """Deprecated alias for :meth:`start_audio_tx_opus`."""
+        self._warn_audio_alias("start_audio_tx", "start_audio_tx_opus")
+        self.start_audio_tx_opus()
 
     def push_audio_tx(self, opus_data: bytes) -> None:
-        """Send an audio frame to the radio."""
-        self._run(self._radio.push_audio_tx(opus_data))
+        """Deprecated alias for :meth:`push_audio_tx_opus`."""
+        self._warn_audio_alias("push_audio_tx", "push_audio_tx_opus")
+        self.push_audio_tx_opus(opus_data)
 
     def stop_audio_tx(self) -> None:
-        """Stop transmitting audio."""
-        self._run(self._radio.stop_audio_tx())
+        """Deprecated alias for :meth:`stop_audio_tx_opus`."""
+        self._warn_audio_alias("stop_audio_tx", "stop_audio_tx_opus")
+        self.stop_audio_tx_opus()
 
     @property
     def audio_codec(self) -> AudioCodec:

--- a/tests/test_audio_fullduplex.py
+++ b/tests/test_audio_fullduplex.py
@@ -35,9 +35,9 @@ class TestFullDuplex:
         radio._audio_transport = mock_transport
         radio._audio_stream = AudioStream(mock_transport)
         received = []
-        await radio.start_audio(lambda pkt: received.append(pkt), tx_enabled=True)
+        await radio.start_audio_opus(lambda pkt: received.append(pkt), tx_enabled=True)
         assert radio._audio_stream.state == AudioState.TRANSMITTING
-        await radio.stop_audio()
+        await radio.stop_audio_opus()
 
     @pytest.mark.asyncio
     async def test_start_audio_rx_only(
@@ -47,19 +47,19 @@ class TestFullDuplex:
         radio._audio_transport = mock_transport
         radio._audio_stream = AudioStream(mock_transport)
         received = []
-        await radio.start_audio(lambda pkt: received.append(pkt), tx_enabled=False)
+        await radio.start_audio_opus(lambda pkt: received.append(pkt), tx_enabled=False)
         assert radio._audio_stream.state == AudioState.RECEIVING
-        await radio.stop_audio()
+        await radio.stop_audio_opus()
 
     @pytest.mark.asyncio
     async def test_start_audio_disconnected(self) -> None:
         r = IcomRadio("192.168.1.100")
         with pytest.raises(ConnectionError):
-            await r.start_audio(lambda pkt: None)
+            await r.start_audio_opus(lambda pkt: None)
 
     @pytest.mark.asyncio
     async def test_stop_audio_noop(self, radio: IcomRadio) -> None:
-        await radio.stop_audio()  # should not raise
+        await radio.stop_audio_opus()  # should not raise
 
 
 class TestAudioStreamJitter:

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -1,5 +1,7 @@
 """Extended tests for IcomRadio — VFO, split, attenuator, preamp, CW, power control, audio, disconnected states."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from icom_lan.commands import (
@@ -340,41 +342,79 @@ class TestPowerControl:
 
 class TestAudio:
     @pytest.mark.asyncio
+    async def test_start_audio_rx_alias_warns_and_calls_opus(
+        self, radio: IcomRadio
+    ) -> None:
+        radio._audio_stream = MagicMock()
+        radio._audio_stream.start_rx = AsyncMock()
+
+        with pytest.warns(DeprecationWarning, match="start_audio_rx_opus"):
+            await radio.start_audio_rx(lambda pkt: None)
+
+        radio._audio_stream.start_rx.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_push_audio_tx_alias_warns_and_calls_opus(
+        self, radio: IcomRadio
+    ) -> None:
+        radio._audio_stream = MagicMock()
+        radio._audio_stream.push_tx = AsyncMock()
+
+        with pytest.warns(DeprecationWarning, match="push_audio_tx_opus"):
+            await radio.push_audio_tx(b"\x00" * 10)
+
+        radio._audio_stream.push_tx.assert_awaited_once_with(b"\x00" * 10)
+
+    @pytest.mark.asyncio
+    async def test_start_audio_alias_warns_and_calls_opus(
+        self, radio: IcomRadio
+    ) -> None:
+        radio._audio_stream = MagicMock()
+        radio._audio_stream.start_rx = AsyncMock()
+        radio._audio_stream.start_tx = AsyncMock()
+
+        with pytest.warns(DeprecationWarning, match="start_audio_opus"):
+            await radio.start_audio(lambda pkt: None, tx_enabled=True)
+
+        radio._audio_stream.start_rx.assert_awaited_once()
+        radio._audio_stream.start_tx.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_start_rx_disconnected(self) -> None:
         r = IcomRadio("192.168.1.100")
         with pytest.raises(ConnectionError):
-            await r.start_audio_rx(lambda pkt: None)
+            await r.start_audio_rx_opus(lambda pkt: None)
 
     @pytest.mark.asyncio
     async def test_start_tx_disconnected(self) -> None:
         r = IcomRadio("192.168.1.100")
         with pytest.raises(ConnectionError):
-            await r.start_audio_tx()
+            await r.start_audio_tx_opus()
 
     @pytest.mark.asyncio
     async def test_push_tx_disconnected(self) -> None:
         r = IcomRadio("192.168.1.100")
         with pytest.raises(ConnectionError):
-            await r.push_audio_tx(b"\x00" * 100)
+            await r.push_audio_tx_opus(b"\x00" * 100)
 
     @pytest.mark.asyncio
     async def test_push_tx_not_started(self, radio: IcomRadio) -> None:
         with pytest.raises(RuntimeError, match="Audio TX not started"):
-            await radio.push_audio_tx(b"\x00" * 100)
+            await radio.push_audio_tx_opus(b"\x00" * 100)
 
     @pytest.mark.asyncio
     async def test_no_audio_port(self, radio: IcomRadio) -> None:
         radio._audio_port = 0
         with pytest.raises(ConnectionError, match="Audio port not available"):
-            await radio.start_audio_rx(lambda pkt: None)
+            await radio.start_audio_rx_opus(lambda pkt: None)
 
     @pytest.mark.asyncio
     async def test_stop_rx_noop_when_no_stream(self, radio: IcomRadio) -> None:
-        await radio.stop_audio_rx()  # should not raise
+        await radio.stop_audio_rx_opus()  # should not raise
 
     @pytest.mark.asyncio
     async def test_stop_tx_noop_when_no_stream(self, radio: IcomRadio) -> None:
-        await radio.stop_audio_tx()  # should not raise
+        await radio.stop_audio_tx_opus()  # should not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,5 +1,9 @@
 """Tests for synchronous API wrapper."""
 
+from unittest.mock import AsyncMock
+
+import pytest
+
 from icom_lan.sync import IcomRadio
 from icom_lan.types import AudioCodec
 
@@ -40,3 +44,24 @@ class TestSyncContextManager:
         r = IcomRadio("192.168.1.100")
         # Can't actually connect without a radio, but test the mechanism
         r._loop.close()  # just verify it's closeable
+
+
+class TestSyncAudioNaming:
+    def test_start_audio_rx_alias_warns_and_calls_opus(self) -> None:
+        r = IcomRadio("192.168.1.100")
+        r._radio.start_audio_rx_opus = AsyncMock()
+
+        with pytest.warns(DeprecationWarning, match="start_audio_rx_opus"):
+            r.start_audio_rx(lambda pkt: None)
+
+        r._radio.start_audio_rx_opus.assert_awaited_once()
+        r._loop.close()
+
+    def test_new_opus_method_calls_async_impl(self) -> None:
+        r = IcomRadio("192.168.1.100")
+        r._radio.push_audio_tx_opus = AsyncMock()
+
+        r.push_audio_tx_opus(b"\x01\x02")
+
+        r._radio.push_audio_tx_opus.assert_awaited_once_with(b"\x01\x02")
+        r._loop.close()


### PR DESCRIPTION
## Summary
- Introduce explicit low-level Opus method names (`*_opus`) in async and sync APIs.
- Keep old ambiguous names as backward-compatible aliases with `DeprecationWarning`.
- Document naming map + migration table and deprecation window.
- Update tests to cover new names and alias warnings.

## Validation
- `uv run --extra dev pytest tests/test_audio.py tests/test_audio_fullduplex.py tests/test_radio_extended.py tests/test_sync.py -q`
- Result: 94 passed

Fixes morozsm/icom-lan#10
