### PR TITLE
feat(audio): add high-level PCM TX API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upcoming high-level PCM audio APIs.
 - Typed audio exceptions for actionable codec/format failures:
   `AudioCodecBackendError`, `AudioFormatError`, `AudioTranscodeError`.
-- High-level async PCM RX API on `IcomRadio`:
-  `start_audio_rx_pcm()` and `stop_audio_rx_pcm()`.
-  The callback receives decoded PCM frame bytes (or `None` gap placeholders).
+- High-level async PCM audio APIs on `IcomRadio`:
+  - RX: `start_audio_rx_pcm()` / `stop_audio_rx_pcm()`
+  - TX: `start_audio_tx_pcm()` / `push_audio_tx_pcm()` / `stop_audio_tx_pcm()`
+  RX callbacks receive decoded PCM frame bytes (or `None` gap placeholders).
 - Audio capability introspection API:
   - `IcomRadio.audio_capabilities()` (async and sync wrappers)
   - `get_audio_capabilities()` and `AudioCapabilities` export
@@ -27,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `start_audio_rx_opus()`, `stop_audio_rx_opus()`, `start_audio_tx_opus()`,
   `push_audio_tx_opus()`, `stop_audio_tx_opus()`, plus full-duplex
   `start_audio_opus()` / `stop_audio_opus()`.
-- Added internal `IcomRadio` PCM hook methods that use the transcoder without
-  changing current low-level Opus streaming APIs.
+- Added parameter validation for high-level PCM TX startup and clearer runtime
+  errors when PCM TX is pushed before startup.
 - Added parameter validation for high-level PCM RX startup
   (`sample_rate`, `channels`, `frame_ms`, `jitter_depth`, callback).
 - Audio defaults now come from deterministic capability rules:

--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -5,12 +5,12 @@ Audio RX/TX via the Icom audio UDP port (default 50003).
 ## Naming Map
 
 Low-level Opus methods are now explicitly suffixed with `_opus`.
-High-level PCM RX is available via `start_audio_rx_pcm()` / `stop_audio_rx_pcm()`.
+High-level PCM APIs are available for both RX and TX.
 
 | Scope | Preferred method names |
 |------|-------------------------|
 | Low-level Opus (current) | `start_audio_rx_opus`, `stop_audio_rx_opus`, `start_audio_tx_opus`, `push_audio_tx_opus`, `stop_audio_tx_opus`, `start_audio_opus`, `stop_audio_opus` |
-| High-level PCM | `start_audio_rx_pcm`, `stop_audio_rx_pcm` |
+| High-level PCM | `start_audio_rx_pcm`, `stop_audio_rx_pcm`, `start_audio_tx_pcm`, `push_audio_tx_pcm`, `stop_audio_tx_pcm` |
 
 Deprecated aliases still work during the deprecation window (two minor releases):
 `start_audio_rx`, `stop_audio_rx`, `start_audio_tx`, `push_audio_tx`, `stop_audio_tx`, `start_audio`, `stop_audio`.
@@ -96,6 +96,15 @@ async with IcomRadio("192.168.1.100", username="u", password="p") as radio:
     await radio.stop_audio_tx_opus()
 ```
 
+### TX Audio (high-level PCM)
+
+```python
+async with IcomRadio("192.168.1.100", username="u", password="p") as radio:
+    await radio.start_audio_tx_pcm(sample_rate=48000, channels=1, frame_ms=20)
+    await radio.push_audio_tx_pcm(pcm_frame)  # one 20ms PCM frame (1920 bytes)
+    await radio.stop_audio_tx_pcm()
+```
+
 ### Full-Duplex
 
 ```python
@@ -160,3 +169,8 @@ For RX PCM, migrate callback-side decoding to the built-in API:
 
 - Before: `start_audio_rx_opus()` + manual Opus decode in callback.
 - Now: `start_audio_rx_pcm()` and receive `bytes | None` directly.
+
+For TX PCM, migrate manual Opus encoding to the built-in API:
+
+- Before: encode PCM to Opus yourself, then `push_audio_tx_opus()`.
+- Now: `start_audio_tx_pcm()` and `push_audio_tx_pcm()` with fixed-size PCM frames.

--- a/docs/guide/audio-recipes.md
+++ b/docs/guide/audio-recipes.md
@@ -12,7 +12,7 @@ export ICOM_PASS=YOUR_PASS
 ```
 
 ```bash
-pip install icom-lan
+pip install "icom-lan[audio]"
 ```
 
 ---
@@ -48,9 +48,9 @@ async def main() -> None:
         frames.append(pkt.data)
 
     async with radio:
-        await radio.start_audio_rx(on_audio)
+        await radio.start_audio_rx_opus(on_audio)
         await asyncio.sleep(SECONDS)
-        await radio.stop_audio_rx()
+        await radio.stop_audio_rx_opus()
 
     with wave.open("rx.wav", "wb") as wf:
         wf.setnchannels(CHANNELS)
@@ -64,7 +64,7 @@ asyncio.run(main())
 
 ---
 
-## 2) WAV file -> TX
+## 2) WAV file -> TX (high-level PCM API)
 
 Читает `tx.wav` (16-bit mono 48kHz PCM) и отправляет на TX.
 
@@ -97,16 +97,20 @@ async def main() -> None:
         pcm = wf.readframes(wf.getnframes())
 
     async with radio:
-        await radio.start_audio_tx()
+        await radio.start_audio_tx_pcm(
+            sample_rate=SAMPLE_RATE,
+            channels=CHANNELS,
+            frame_ms=FRAME_MS,
+        )
         try:
             for i in range(0, len(pcm), BYTES_PER_FRAME):
                 chunk = pcm[i : i + BYTES_PER_FRAME]
                 if not chunk:
                     break
-                await radio.push_audio_tx(chunk)
+                await radio.push_audio_tx_pcm(chunk)
                 await asyncio.sleep(FRAME_MS / 1000)
         finally:
-            await radio.stop_audio_tx()
+            await radio.stop_audio_tx_pcm()
 
 
 asyncio.run(main())
@@ -163,18 +167,22 @@ async def main() -> None:
         rx_packets += 1
 
     async with radio:
-        await radio.start_audio_rx(on_audio)
-        await radio.start_audio_tx()
+        await radio.start_audio_rx_opus(on_audio)
+        await radio.start_audio_tx_pcm(
+            sample_rate=SAMPLE_RATE,
+            channels=CHANNELS,
+            frame_ms=FRAME_MS,
+        )
 
         phase = 0.0
         frames = int(SECONDS * 1000 / FRAME_MS)
         for _ in range(frames):
             chunk, phase = make_tone_frame(phase)
-            await radio.push_audio_tx(chunk)
+            await radio.push_audio_tx_pcm(chunk)
             await asyncio.sleep(FRAME_MS / 1000)
 
-        await radio.stop_audio_tx()
-        await radio.stop_audio_rx()
+        await radio.stop_audio_tx_pcm()
+        await radio.stop_audio_rx_opus()
 
     print({"rx_packets": rx_packets})
 

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -159,6 +159,7 @@ class IcomRadio:
         self._audio_stream: AudioStream | None = None
         self._pcm_transcoder: PcmOpusTranscoder | None = None
         self._pcm_transcoder_fmt: tuple[int, int, int] | None = None
+        self._pcm_tx_fmt: tuple[int, int, int] | None = None
         self._connected = False
         self._token: int = 0
         self._tok_request: int = 0
@@ -330,6 +331,7 @@ class IcomRadio:
                 await self._audio_stream.stop_rx()
                 await self._audio_stream.stop_tx()
                 self._audio_stream = None
+            self._pcm_tx_fmt = None
             if self._audio_transport is not None:
                 try:
                     await self._send_audio_open_close(open_stream=False)
@@ -477,6 +479,48 @@ class IcomRadio:
         assert self._audio_stream is not None
         await self._audio_stream.start_tx()
 
+    async def start_audio_tx_pcm(
+        self,
+        *,
+        sample_rate: int = 48000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> None:
+        """Start transmitting PCM audio to the radio.
+
+        This high-level API validates PCM format settings, initializes
+        the Opus transcoder backend, and starts the underlying Opus TX stream.
+
+        Args:
+            sample_rate: PCM sample rate in Hz (Opus-supported values only).
+            channels: PCM channels (1 or 2).
+            frame_ms: Frame duration in ms (10/20/40/60).
+
+        Raises:
+            ConnectionError: If not connected or audio port unavailable.
+            TypeError: If numeric args are not ints.
+            AudioCodecBackendError: If Opus backend is unavailable.
+            AudioFormatError: If PCM format is unsupported.
+        """
+        for name, value in (
+            ("sample_rate", sample_rate),
+            ("channels", channels),
+            ("frame_ms", frame_ms),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an int, got {type(value).__name__}.")
+
+        self._check_connected()
+
+        # Validate codec/backend and PCM format before stream startup.
+        self._get_pcm_transcoder(
+            sample_rate=sample_rate,
+            channels=channels,
+            frame_ms=frame_ms,
+        )
+        await self.start_audio_tx_opus()
+        self._pcm_tx_fmt = (sample_rate, channels, frame_ms)
+
     async def push_audio_tx_opus(self, opus_data: bytes) -> None:
         """Send an Opus-encoded audio frame to the radio.
 
@@ -492,10 +536,43 @@ class IcomRadio:
             raise RuntimeError("Audio TX not started")
         await self._audio_stream.push_tx(opus_data)
 
+    async def push_audio_tx_pcm(
+        self,
+        pcm_bytes: bytes | bytearray | memoryview,
+    ) -> None:
+        """Encode and send one PCM audio frame to the radio.
+
+        Args:
+            pcm_bytes: One fixed-size PCM frame (s16le, interleaved).
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If PCM TX not started with :meth:`start_audio_tx_pcm`.
+            AudioFormatError: If frame type/size is invalid.
+            AudioTranscodeError: If encode operation fails.
+        """
+        self._check_connected()
+        if self._pcm_tx_fmt is None:
+            raise RuntimeError(
+                "PCM TX not started; call start_audio_tx_pcm() before push_audio_tx_pcm()."
+            )
+        sample_rate, channels, frame_ms = self._pcm_tx_fmt
+        await self._push_audio_tx_pcm_internal(
+            pcm_bytes,
+            sample_rate=sample_rate,
+            channels=channels,
+            frame_ms=frame_ms,
+        )
+
+    async def stop_audio_tx_pcm(self) -> None:
+        """Stop transmitting PCM audio to the radio."""
+        await self.stop_audio_tx_opus()
+
     async def stop_audio_tx_opus(self) -> None:
         """Stop transmitting Opus audio to the radio."""
         if self._audio_stream is not None:
             await self._audio_stream.stop_tx()
+        self._pcm_tx_fmt = None
 
     async def start_audio_opus(
         self,
@@ -628,7 +705,7 @@ class IcomRadio:
 
     async def _push_audio_tx_pcm_internal(
         self,
-        pcm_data: bytes,
+        pcm_data: bytes | bytearray | memoryview,
         *,
         sample_rate: int = 48000,
         channels: int = 1,
@@ -641,7 +718,7 @@ class IcomRadio:
             frame_ms=frame_ms,
         )
         opus_data = transcoder.pcm_to_opus(pcm_data)
-        await self.push_audio_tx(opus_data)
+        await self.push_audio_tx_opus(opus_data)
 
     @property
     def audio_codec(self) -> "AudioCodec":

--- a/tests/test_audio_transcoder.py
+++ b/tests/test_audio_transcoder.py
@@ -121,7 +121,7 @@ class TestRadioPcmHooks:
     @pytest.mark.asyncio
     async def test_push_audio_tx_pcm_internal_uses_transcoder(self) -> None:
         radio = IcomRadio("192.168.1.100")
-        radio.push_audio_tx = AsyncMock()  # type: ignore[method-assign]
+        radio.push_audio_tx_opus = AsyncMock()  # type: ignore[method-assign]
 
         class _DummyTranscoder:
             def pcm_to_opus(self, pcm: bytes) -> bytes:
@@ -131,7 +131,7 @@ class TestRadioPcmHooks:
         radio._pcm_transcoder_fmt = (48000, 1, 20)
 
         await radio._push_audio_tx_pcm_internal(b"\x01\x02" * 960)
-        radio.push_audio_tx.assert_awaited_once_with(b"opus:\x01\x02")
+        radio.push_audio_tx_opus.assert_awaited_once_with(b"opus:\x01\x02")
 
     def test_decode_audio_packet_to_pcm_and_callback_adapter(self) -> None:
         radio = IcomRadio("192.168.1.100")
@@ -226,3 +226,120 @@ class TestRadioPcmRxApi:
         radio = IcomRadio("192.168.1.100")
         with pytest.raises(ConnectionError, match="Not connected to radio"):
             await radio.start_audio_rx_pcm(lambda _: None)
+
+
+class TestRadioPcmTxApi:
+    @pytest.mark.asyncio
+    async def test_start_audio_tx_pcm_starts_opus_and_tracks_format(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        radio._connected = True
+        radio._civ_transport = MagicMock()
+        radio._audio_stream = MagicMock()
+        radio._audio_stream.start_tx = AsyncMock()
+        radio._pcm_transcoder = object()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        await radio.start_audio_tx_pcm(sample_rate=48000, channels=1, frame_ms=20)
+
+        radio._audio_stream.start_tx.assert_awaited_once()
+        assert radio._pcm_tx_fmt == (48000, 1, 20)
+
+    @pytest.mark.asyncio
+    async def test_push_audio_tx_pcm_encodes_and_sends(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        radio._connected = True
+        radio._civ_transport = MagicMock()
+        radio._pcm_tx_fmt = (48000, 1, 20)
+        radio.push_audio_tx_opus = AsyncMock()  # type: ignore[method-assign]
+
+        class _DummyTranscoder:
+            def pcm_to_opus(self, pcm: bytes | bytearray | memoryview) -> bytes:
+                return b"opus:" + bytes(pcm)[:2]
+
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        await radio.push_audio_tx_pcm(b"\x01\x02" * 960)
+        radio.push_audio_tx_opus.assert_awaited_once_with(b"opus:\x01\x02")
+
+    @pytest.mark.asyncio
+    async def test_push_audio_tx_pcm_not_started(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        radio._connected = True
+        radio._civ_transport = MagicMock()
+
+        with pytest.raises(RuntimeError, match="start_audio_tx_pcm"):
+            await radio.push_audio_tx_pcm(b"\x00" * 1920)
+
+    @pytest.mark.asyncio
+    async def test_start_audio_tx_pcm_invalid_types(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        with pytest.raises(TypeError, match="sample_rate must be an int"):
+            await radio.start_audio_tx_pcm(sample_rate=True)  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="channels must be an int"):
+            await radio.start_audio_tx_pcm(channels=1.5)  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="frame_ms must be an int"):
+            await radio.start_audio_tx_pcm(frame_ms="20")  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_start_audio_tx_pcm_invalid_format(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        radio._connected = True
+        radio._civ_transport = MagicMock()
+
+        with pytest.raises(AudioFormatError, match="Unsupported sample_rate"):
+            await radio.start_audio_tx_pcm(sample_rate=44100)
+
+    @pytest.mark.asyncio
+    async def test_start_audio_tx_pcm_backend_error_is_actionable(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        radio._connected = True
+        radio._civ_transport = MagicMock()
+        radio._audio_stream = MagicMock()
+        radio._audio_stream.start_tx = AsyncMock()
+        radio._get_pcm_transcoder = MagicMock(  # type: ignore[method-assign]
+            side_effect=AudioCodecBackendError(
+                "Audio codec backend unavailable; install icom-lan[audio]."
+            )
+        )
+
+        with pytest.raises(AudioCodecBackendError, match="install icom-lan\\[audio\\]"):
+            await radio.start_audio_tx_pcm()
+        radio._audio_stream.start_tx.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_push_audio_tx_pcm_frame_size_error(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        radio._connected = True
+        radio._civ_transport = MagicMock()
+        radio._pcm_tx_fmt = (48000, 1, 20)
+
+        class _DummyTranscoder:
+            def pcm_to_opus(self, pcm: bytes | bytearray | memoryview) -> bytes:
+                _ = pcm
+                raise AudioFormatError(
+                    "PCM frame size mismatch: expected 1920 bytes, got 1919."
+                )
+
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        with pytest.raises(AudioFormatError, match="expected 1920 bytes"):
+            await radio.push_audio_tx_pcm(b"\x00" * 1919)
+
+    @pytest.mark.asyncio
+    async def test_stop_audio_tx_pcm_delegates_and_clears_state(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        radio._audio_stream = MagicMock()
+        radio._audio_stream.stop_tx = AsyncMock()
+        radio._pcm_tx_fmt = (48000, 1, 20)
+
+        await radio.stop_audio_tx_pcm()
+        radio._audio_stream.stop_tx.assert_awaited_once()
+        assert radio._pcm_tx_fmt is None
+
+    @pytest.mark.asyncio
+    async def test_start_audio_tx_pcm_disconnected(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        with pytest.raises(ConnectionError, match="Not connected to radio"):
+            await radio.start_audio_tx_pcm()

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -403,6 +403,17 @@ class TestAudio:
             await radio.push_audio_tx_opus(b"\x00" * 100)
 
     @pytest.mark.asyncio
+    async def test_start_tx_pcm_disconnected(self) -> None:
+        r = IcomRadio("192.168.1.100")
+        with pytest.raises(ConnectionError):
+            await r.start_audio_tx_pcm()
+
+    @pytest.mark.asyncio
+    async def test_push_tx_pcm_not_started(self, radio: IcomRadio) -> None:
+        with pytest.raises(RuntimeError, match="start_audio_tx_pcm"):
+            await radio.push_audio_tx_pcm(b"\x00" * 1920)
+
+    @pytest.mark.asyncio
     async def test_no_audio_port(self, radio: IcomRadio) -> None:
         radio._audio_port = 0
         with pytest.raises(ConnectionError, match="Audio port not available"):
@@ -415,6 +426,10 @@ class TestAudio:
     @pytest.mark.asyncio
     async def test_stop_tx_noop_when_no_stream(self, radio: IcomRadio) -> None:
         await radio.stop_audio_tx_opus()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_stop_tx_pcm_noop_when_no_stream(self, radio: IcomRadio) -> None:
+        await radio.stop_audio_tx_pcm()  # should not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add high-level async PCM TX API on `IcomRadio`:
  - `start_audio_tx_pcm()`
  - `push_audio_tx_pcm()`
  - `stop_audio_tx_pcm()`
- Preserve low-level Opus TX APIs and route PCM TX through existing transcoder internals.
- Add validation and actionable errors for invalid params, backend absence, and push-before-start misuse.
- Update docs/changelog and audio recipes for TX PCM usage.
- Extend tests for happy path and failure paths.

## Validation
- `uv run --extra dev pytest -q tests/test_audio.py tests/test_audio_transcoder.py tests/test_radio_extended.py tests/test_sync.py`
- Result: 115 passed

Fixes morozsm/icom-lan#3
