### PR TITLE
feat(cli): add audio rx/tx/loopback subcommands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `IcomRadio.audio_capabilities()` (async and sync wrappers)
   - `get_audio_capabilities()` and `AudioCapabilities` export
 - CLI command: `icom-lan audio caps` with optional `--json` output.
+- CLI audio subcommands:
+  - `icom-lan audio rx --out rx.wav --seconds 10`
+  - `icom-lan audio tx --in tx.wav`
+  - `icom-lan audio loopback --seconds 10`
+  with shared `--sample-rate`, `--channels`, `--json`, and `--stats` flags.
 
 ### Changed
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -151,6 +151,43 @@ JSON output example:
 }
 ```
 
+### `audio rx`
+
+Capture RX audio to a 16-bit PCM WAV file.
+
+```bash
+icom-lan audio rx --out rx.wav --seconds 10
+icom-lan audio rx --out rx.wav --seconds 10 --sample-rate 48000 --channels 1
+icom-lan audio rx --out rx.wav --json
+```
+
+### `audio tx`
+
+Transmit a WAV file (`16-bit PCM`, matching sample rate/channels).
+
+```bash
+icom-lan audio tx --in tx.wav
+icom-lan audio tx --in tx.wav --sample-rate 48000 --channels 1
+icom-lan audio tx --in tx.wav --json
+```
+
+### `audio loopback`
+
+Run a quick RX-to-TX PCM loopback window.
+
+```bash
+icom-lan audio loopback --seconds 10
+icom-lan audio loopback --seconds 10 --sample-rate 48000 --channels 1
+icom-lan audio loopback --json
+```
+
+### Shared audio flags (`rx`/`tx`/`loopback`)
+
+- `--sample-rate` — PCM sample rate in Hz (must be supported by `icom-lan`)
+- `--channels` — PCM channel count (must be supported by `icom-lan`)
+- `--json` — machine-readable JSON output
+- `--stats` — print transfer counters/metrics (human-readable mode)
+
 ### `att`
 
 Get or set the attenuator level.

--- a/src/icom_lan/cli.py
+++ b/src/icom_lan/cli.py
@@ -7,6 +7,9 @@ Usage:
     icom-lan power [VALUE] [--host HOST] [--user USER] [--pass PASS]
     icom-lan meter [--host HOST] [--user USER] [--pass PASS]
     icom-lan audio caps [--json]
+    icom-lan audio rx --out rx.wav [--seconds 10]
+    icom-lan audio tx --in tx.wav
+    icom-lan audio loopback [--seconds 10]
     icom-lan att [VALUE] [--host HOST] [--user USER] [--pass PASS]
     icom-lan preamp [VALUE] [--host HOST] [--user USER] [--pass PASS]
     icom-lan ptt {on,off} [--host HOST] [--user USER] [--pass PASS]
@@ -15,12 +18,19 @@ Usage:
 
 import argparse
 import asyncio
+import json
 import os
 import sys
+import time
+import wave
+from typing import Any
 
 from . import __version__
 from .radio import IcomRadio
 from .types import Mode
+
+_AUDIO_FRAME_MS = 20
+_PCM_SAMPLE_WIDTH_BYTES = 2
 
 
 def _get_env(name: str, default: str = "") -> str:
@@ -119,6 +129,85 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Show icom-lan audio capabilities and defaults",
     )
     _add_json(audio_caps_p)
+
+    audio_caps = IcomRadio.audio_capabilities()
+
+    def _add_audio_common_flags(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument(
+            "--sample-rate",
+            type=int,
+            default=audio_caps.default_sample_rate_hz,
+            help=(
+                "PCM sample rate in Hz "
+                f"(default: {audio_caps.default_sample_rate_hz})"
+            ),
+        )
+        sp.add_argument(
+            "--channels",
+            type=int,
+            default=audio_caps.default_channels,
+            help=f"PCM channels (default: {audio_caps.default_channels})",
+        )
+        sp.add_argument("--json", action="store_true", help="Output as JSON")
+        sp.add_argument(
+            "--stats",
+            action="store_true",
+            help="Print transfer statistics (ignored when --json is set)",
+        )
+
+    audio_rx_p = audio_sub.add_parser(
+        "rx",
+        help="Capture RX audio to a WAV file",
+        description=(
+            "Capture PCM audio from the radio and write a 16-bit PCM WAV file.\n"
+            "Example: icom-lan audio rx --out rx.wav --seconds 10"
+        ),
+    )
+    _add_audio_common_flags(audio_rx_p)
+    audio_rx_p.add_argument(
+        "--out",
+        dest="output_file",
+        required=True,
+        help="Output WAV file path",
+    )
+    audio_rx_p.add_argument(
+        "--seconds",
+        type=float,
+        default=10.0,
+        help="Capture duration in seconds (default: 10)",
+    )
+
+    audio_tx_p = audio_sub.add_parser(
+        "tx",
+        help="Transmit audio from a WAV file",
+        description=(
+            "Read a 16-bit PCM WAV file and transmit it over LAN audio.\n"
+            "Example: icom-lan audio tx --in tx.wav"
+        ),
+    )
+    _add_audio_common_flags(audio_tx_p)
+    audio_tx_p.add_argument(
+        "--in",
+        dest="input_file",
+        required=True,
+        help="Input WAV file path",
+    )
+
+    audio_loopback_p = audio_sub.add_parser(
+        "loopback",
+        help="RX->TX PCM loopback for quick audio path checks",
+        description=(
+            "Receive PCM audio and immediately feed it back to TX.\n"
+            "Example: icom-lan audio loopback --seconds 10"
+        ),
+    )
+    _add_audio_common_flags(audio_loopback_p)
+    audio_loopback_p.add_argument(
+        "--seconds",
+        type=float,
+        default=10.0,
+        help="Loopback duration in seconds (default: 10)",
+    )
 
     # ptt
     ptt_p = sub.add_parser("ptt", help="PTT control")
@@ -223,8 +312,6 @@ async def _run(args: argparse.Namespace) -> int:
     if args.command == "audio":
         if args.audio_command == "caps":
             return await _cmd_audio_caps(args)
-        print("Error: unknown audio command", file=sys.stderr)
-        return 1
 
     radio = IcomRadio(
         args.host,
@@ -256,6 +343,15 @@ async def _run(args: argparse.Namespace) -> int:
                 return await _cmd_preamp(radio, args)
             elif args.command == "scope":
                 return await _cmd_scope(radio, args)
+            elif args.command == "audio":
+                if args.audio_command == "rx":
+                    return await _cmd_audio_rx(radio, args)
+                elif args.audio_command == "tx":
+                    return await _cmd_audio_tx(radio, args)
+                elif args.audio_command == "loopback":
+                    return await _cmd_audio_loopback(radio, args)
+                print("Error: unknown audio command", file=sys.stderr)
+                return 1
             elif args.command == "power-on":
                 await radio.power_control(True)
                 print("Power ON")
@@ -269,6 +365,48 @@ async def _run(args: argparse.Namespace) -> int:
     except Exception as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+
+
+def _audio_frame_bytes(sample_rate: int, channels: int, frame_ms: int = _AUDIO_FRAME_MS) -> int:
+    return sample_rate * channels * _PCM_SAMPLE_WIDTH_BYTES * frame_ms // 1000
+
+
+def _validate_audio_format_args(sample_rate: int, channels: int) -> str | None:
+    if sample_rate <= 0:
+        return "--sample-rate must be > 0."
+    if channels <= 0:
+        return "--channels must be > 0."
+
+    caps = IcomRadio.audio_capabilities()
+    if sample_rate not in caps.supported_sample_rates_hz:
+        supported = ", ".join(str(rate) for rate in caps.supported_sample_rates_hz)
+        return f"Unsupported --sample-rate {sample_rate}. Supported values: {supported}."
+    if channels not in caps.supported_channels:
+        supported = ", ".join(str(ch) for ch in caps.supported_channels)
+        return f"Unsupported --channels {channels}. Supported values: {supported}."
+    return None
+
+
+def _validate_positive_seconds(seconds: float) -> str | None:
+    if seconds <= 0:
+        return "--seconds must be > 0."
+    return None
+
+
+def _emit_audio_result(
+    args: argparse.Namespace,
+    *,
+    message: str,
+    payload: dict[str, Any],
+) -> None:
+    if args.json:
+        print(json.dumps(payload))
+        return
+
+    print(message)
+    if args.stats:
+        for key, value in payload.items():
+            print(f"{key}: {value}")
 
 
 async def _cmd_status(radio: IcomRadio, args: argparse.Namespace) -> int:
@@ -329,6 +467,297 @@ async def _cmd_audio_caps(args: argparse.Namespace) -> int:
         print("  codec: first supported codec in preference order")
         print("  sample_rate_hz: highest supported rate")
         print("  channels: from default codec (fallback to minimum)")
+    return 0
+
+
+async def _cmd_audio_rx(radio: IcomRadio, args: argparse.Namespace) -> int:
+    fmt_error = _validate_audio_format_args(args.sample_rate, args.channels)
+    if fmt_error is not None:
+        print(f"Error: {fmt_error}", file=sys.stderr)
+        return 1
+
+    seconds_error = _validate_positive_seconds(args.seconds)
+    if seconds_error is not None:
+        print(f"Error: {seconds_error}", file=sys.stderr)
+        return 1
+
+    frame_bytes = _audio_frame_bytes(args.sample_rate, args.channels)
+    silence_frame = b"\x00" * frame_bytes
+    frames: list[bytes] = []
+    rx_frames = 0
+    gap_frames = 0
+    started = False
+    start_time = time.monotonic()
+
+    def on_pcm(frame: bytes | None) -> None:
+        nonlocal rx_frames, gap_frames
+        if frame is None:
+            gap_frames += 1
+            frames.append(silence_frame)
+            return
+        rx_frames += 1
+        frames.append(frame)
+
+    try:
+        await radio.start_audio_rx_pcm(
+            on_pcm,
+            sample_rate=args.sample_rate,
+            channels=args.channels,
+            frame_ms=_AUDIO_FRAME_MS,
+        )
+        started = True
+        await asyncio.sleep(args.seconds)
+    finally:
+        if started:
+            try:
+                await radio.stop_audio_rx_pcm()
+            except Exception:
+                pass
+
+    pcm_bytes = b"".join(frames)
+    try:
+        with wave.open(args.output_file, "wb") as wf:
+            wf.setnchannels(args.channels)
+            wf.setsampwidth(_PCM_SAMPLE_WIDTH_BYTES)
+            wf.setframerate(args.sample_rate)
+            wf.writeframes(pcm_bytes)
+    except Exception as exc:
+        print(f"Error: failed to write WAV file '{args.output_file}': {exc}", file=sys.stderr)
+        return 1
+
+    elapsed = round(time.monotonic() - start_time, 3)
+    payload = {
+        "command": "audio-rx",
+        "output_file": args.output_file,
+        "seconds_requested": args.seconds,
+        "seconds_elapsed": elapsed,
+        "sample_rate": args.sample_rate,
+        "channels": args.channels,
+        "rx_frames": rx_frames,
+        "gap_frames": gap_frames,
+        "bytes_written": len(pcm_bytes),
+    }
+    _emit_audio_result(
+        args,
+        message=f"Saved RX audio to {args.output_file}",
+        payload=payload,
+    )
+    return 0
+
+
+def _load_wav_pcm(input_file: str) -> tuple[int, int, int, bytes]:
+    with wave.open(input_file, "rb") as wf:
+        channels = wf.getnchannels()
+        sample_width = wf.getsampwidth()
+        sample_rate = wf.getframerate()
+        pcm = wf.readframes(wf.getnframes())
+    return sample_rate, channels, sample_width, pcm
+
+
+async def _cmd_audio_tx(radio: IcomRadio, args: argparse.Namespace) -> int:
+    fmt_error = _validate_audio_format_args(args.sample_rate, args.channels)
+    if fmt_error is not None:
+        print(f"Error: {fmt_error}", file=sys.stderr)
+        return 1
+
+    try:
+        file_sample_rate, file_channels, sample_width, pcm = _load_wav_pcm(args.input_file)
+    except FileNotFoundError:
+        print(f"Error: input file not found: {args.input_file}", file=sys.stderr)
+        return 1
+    except wave.Error as exc:
+        print(f"Error: invalid WAV file '{args.input_file}': {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"Error: failed to read '{args.input_file}': {exc}", file=sys.stderr)
+        return 1
+
+    if sample_width != _PCM_SAMPLE_WIDTH_BYTES:
+        print(
+            (
+                "Error: input WAV must be 16-bit PCM "
+                f"(got {sample_width * 8}-bit)."
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    if file_sample_rate != args.sample_rate:
+        print(
+            (
+                f"Error: input WAV sample rate is {file_sample_rate} Hz, "
+                f"but --sample-rate is {args.sample_rate}. "
+                "Use a matching WAV or pass the file's sample rate."
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    if file_channels != args.channels:
+        print(
+            (
+                f"Error: input WAV has {file_channels} channel(s), "
+                f"but --channels is {args.channels}. "
+                "Use a matching WAV or pass the file's channel count."
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    if not pcm:
+        print("Error: input WAV contains no PCM frames.", file=sys.stderr)
+        return 1
+
+    frame_bytes = _audio_frame_bytes(args.sample_rate, args.channels)
+    frame_interval = _AUDIO_FRAME_MS / 1000.0
+    start_time = time.monotonic()
+    tx_frames = 0
+    started = False
+
+    try:
+        await radio.start_audio_tx_pcm(
+            sample_rate=args.sample_rate,
+            channels=args.channels,
+            frame_ms=_AUDIO_FRAME_MS,
+        )
+        started = True
+        for i in range(0, len(pcm), frame_bytes):
+            chunk = pcm[i : i + frame_bytes]
+            if not chunk:
+                break
+            if len(chunk) < frame_bytes:
+                chunk = chunk + (b"\x00" * (frame_bytes - len(chunk)))
+            await radio.push_audio_tx_pcm(chunk)
+            tx_frames += 1
+            await asyncio.sleep(frame_interval)
+    finally:
+        if started:
+            try:
+                await radio.stop_audio_tx_pcm()
+            except Exception:
+                pass
+
+    elapsed = round(time.monotonic() - start_time, 3)
+    payload = {
+        "command": "audio-tx",
+        "input_file": args.input_file,
+        "seconds_elapsed": elapsed,
+        "sample_rate": args.sample_rate,
+        "channels": args.channels,
+        "tx_frames": tx_frames,
+        "bytes_read": len(pcm),
+    }
+    _emit_audio_result(
+        args,
+        message=f"Transmitted WAV audio from {args.input_file}",
+        payload=payload,
+    )
+    return 0
+
+
+async def _cmd_audio_loopback(radio: IcomRadio, args: argparse.Namespace) -> int:
+    fmt_error = _validate_audio_format_args(args.sample_rate, args.channels)
+    if fmt_error is not None:
+        print(f"Error: {fmt_error}", file=sys.stderr)
+        return 1
+
+    seconds_error = _validate_positive_seconds(args.seconds)
+    if seconds_error is not None:
+        print(f"Error: {seconds_error}", file=sys.stderr)
+        return 1
+
+    frame_bytes = _audio_frame_bytes(args.sample_rate, args.channels)
+    silence_frame = b"\x00" * frame_bytes
+    frame_interval = _AUDIO_FRAME_MS / 1000.0
+    queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=256)
+    stop_event = asyncio.Event()
+
+    rx_frames = 0
+    gap_frames = 0
+    tx_frames = 0
+    dropped_frames = 0
+
+    def on_pcm(frame: bytes | None) -> None:
+        nonlocal rx_frames, gap_frames, dropped_frames
+        if frame is None:
+            gap_frames += 1
+            out = silence_frame
+        else:
+            rx_frames += 1
+            out = frame
+        try:
+            queue.put_nowait(out)
+        except asyncio.QueueFull:
+            dropped_frames += 1
+
+    async def tx_worker() -> None:
+        nonlocal tx_frames
+        while not (stop_event.is_set() and queue.empty()):
+            try:
+                frame = await asyncio.wait_for(queue.get(), timeout=0.1)
+            except asyncio.TimeoutError:
+                continue
+            await radio.push_audio_tx_pcm(frame)
+            tx_frames += 1
+            await asyncio.sleep(frame_interval)
+
+    rx_started = False
+    tx_started = False
+    worker_task: asyncio.Task[None] | None = None
+    worker_error: Exception | None = None
+    start_time = time.monotonic()
+
+    try:
+        await radio.start_audio_tx_pcm(
+            sample_rate=args.sample_rate,
+            channels=args.channels,
+            frame_ms=_AUDIO_FRAME_MS,
+        )
+        tx_started = True
+        worker_task = asyncio.create_task(tx_worker())
+        await radio.start_audio_rx_pcm(
+            on_pcm,
+            sample_rate=args.sample_rate,
+            channels=args.channels,
+            frame_ms=_AUDIO_FRAME_MS,
+        )
+        rx_started = True
+        await asyncio.sleep(args.seconds)
+    finally:
+        if rx_started:
+            try:
+                await radio.stop_audio_rx_pcm()
+            except Exception:
+                pass
+        stop_event.set()
+        if worker_task is not None:
+            try:
+                await worker_task
+            except Exception as exc:
+                worker_error = exc
+        if tx_started:
+            try:
+                await radio.stop_audio_tx_pcm()
+            except Exception:
+                pass
+
+    if worker_error is not None:
+        raise worker_error
+
+    elapsed = round(time.monotonic() - start_time, 3)
+    payload = {
+        "command": "audio-loopback",
+        "seconds_requested": args.seconds,
+        "seconds_elapsed": elapsed,
+        "sample_rate": args.sample_rate,
+        "channels": args.channels,
+        "rx_frames": rx_frames,
+        "gap_frames": gap_frames,
+        "tx_frames": tx_frames,
+        "dropped_frames": dropped_frames,
+    }
+    _emit_audio_result(
+        args,
+        message="Audio loopback completed",
+        payload=payload,
+    )
     return 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,49 @@ class TestBuildParser:
         assert args.audio_command == "caps"
         assert args.json is True
 
+    def test_audio_rx(self):
+        p = _build_parser()
+        args = p.parse_args(["audio", "rx", "--out", "rx.wav", "--seconds", "10"])
+        assert args.command == "audio"
+        assert args.audio_command == "rx"
+        assert args.output_file == "rx.wav"
+        assert args.seconds == 10.0
+
+    def test_audio_rx_common_flags(self):
+        p = _build_parser()
+        args = p.parse_args(
+            [
+                "audio",
+                "rx",
+                "--out",
+                "rx.wav",
+                "--sample-rate",
+                "24000",
+                "--channels",
+                "2",
+                "--json",
+                "--stats",
+            ]
+        )
+        assert args.sample_rate == 24000
+        assert args.channels == 2
+        assert args.json is True
+        assert args.stats is True
+
+    def test_audio_tx(self):
+        p = _build_parser()
+        args = p.parse_args(["audio", "tx", "--in", "tx.wav"])
+        assert args.command == "audio"
+        assert args.audio_command == "tx"
+        assert args.input_file == "tx.wav"
+
+    def test_audio_loopback(self):
+        p = _build_parser()
+        args = p.parse_args(["audio", "loopback", "--seconds", "3"])
+        assert args.command == "audio"
+        assert args.audio_command == "loopback"
+        assert args.seconds == 3.0
+
     def test_ptt_on(self):
         p = _build_parser()
         args = p.parse_args(["ptt", "on"])

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -1,6 +1,7 @@
 """Tests for CLI async command handlers using mocked IcomRadio."""
 
 import json
+import wave
 from argparse import Namespace
 from unittest.mock import AsyncMock, patch
 
@@ -8,6 +9,9 @@ import pytest
 
 from icom_lan.cli import (
     _cmd_audio_caps,
+    _cmd_audio_loopback,
+    _cmd_audio_rx,
+    _cmd_audio_tx,
     _cmd_cw,
     _cmd_freq,
     _cmd_meter,
@@ -46,6 +50,11 @@ def mock_radio():
     radio.capture_scope_frame = AsyncMock()
     radio.capture_scope_frames = AsyncMock()
     radio.disable_scope = AsyncMock()
+    radio.start_audio_rx_pcm = AsyncMock()
+    radio.stop_audio_rx_pcm = AsyncMock()
+    radio.start_audio_tx_pcm = AsyncMock()
+    radio.stop_audio_tx_pcm = AsyncMock()
+    radio.push_audio_tx_pcm = AsyncMock()
     return radio
 
 
@@ -103,6 +112,101 @@ class TestCmdAudioCaps:
         assert data["default_sample_rate_hz"] == 48000
         assert data["default_channels"] == 1
         assert any(c["name"] == "OPUS_1CH" for c in data["supported_codecs"])
+
+
+# ---------------------------------------------------------------------------
+# _cmd_audio_rx / _cmd_audio_tx / _cmd_audio_loopback
+# ---------------------------------------------------------------------------
+
+
+class TestCmdAudioCli:
+    @pytest.mark.asyncio
+    async def test_audio_rx_smoke(self, mock_radio, tmp_path, capsys) -> None:
+        frame = b"\x01\x02" * 960
+
+        async def _start_rx(cb, **_kwargs) -> None:
+            cb(frame)
+            cb(None)
+
+        mock_radio.start_audio_rx_pcm = AsyncMock(side_effect=_start_rx)
+
+        out_file = tmp_path / "rx.wav"
+        args = Namespace(
+            output_file=str(out_file),
+            seconds=0.01,
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_rx(mock_radio, args)
+
+        assert rc == 0
+        mock_radio.start_audio_rx_pcm.assert_awaited_once()
+        mock_radio.stop_audio_rx_pcm.assert_awaited_once()
+        with wave.open(str(out_file), "rb") as wf:
+            assert wf.getframerate() == 48000
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2
+            assert wf.getnframes() > 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["command"] == "audio-rx"
+        assert data["bytes_written"] > 0
+
+    @pytest.mark.asyncio
+    async def test_audio_tx_smoke(self, mock_radio, tmp_path, capsys) -> None:
+        in_file = tmp_path / "tx.wav"
+        with wave.open(str(in_file), "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(48000)
+            wf.writeframes(b"\x01\x02" * 960)
+
+        args = Namespace(
+            input_file=str(in_file),
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_tx(mock_radio, args)
+
+        assert rc == 0
+        mock_radio.start_audio_tx_pcm.assert_awaited_once()
+        mock_radio.stop_audio_tx_pcm.assert_awaited_once()
+        assert mock_radio.push_audio_tx_pcm.await_count >= 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["command"] == "audio-tx"
+        assert data["tx_frames"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_audio_loopback_smoke(self, mock_radio, capsys) -> None:
+        frame = b"\x03\x04" * 960
+
+        async def _start_rx(cb, **_kwargs) -> None:
+            cb(frame)
+            cb(None)
+
+        mock_radio.start_audio_rx_pcm = AsyncMock(side_effect=_start_rx)
+
+        args = Namespace(
+            seconds=0.05,
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_loopback(mock_radio, args)
+
+        assert rc == 0
+        mock_radio.start_audio_rx_pcm.assert_awaited_once()
+        mock_radio.stop_audio_rx_pcm.assert_awaited_once()
+        mock_radio.start_audio_tx_pcm.assert_awaited_once()
+        mock_radio.stop_audio_tx_pcm.assert_awaited_once()
+        assert mock_radio.push_audio_tx_pcm.await_count >= 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["command"] == "audio-loopback"
+        assert data["tx_frames"] >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -317,6 +421,91 @@ class TestRunErrorHandling:
         assert rc == 1
         err = capsys.readouterr().err
         assert "Error" in err
+
+    @pytest.mark.asyncio
+    async def test_run_audio_rx_routes_to_handler(self) -> None:
+        args = Namespace(
+            host="192.168.1.100",
+            port=50001,
+            user="",
+            password="",
+            timeout=5.0,
+            command="audio",
+            audio_command="rx",
+            output_file="rx.wav",
+            seconds=1.0,
+            sample_rate=48000,
+            channels=1,
+            json=False,
+            stats=False,
+        )
+        with patch("icom_lan.cli.IcomRadio") as radio_cls:
+            radio = AsyncMock()
+            radio.__aenter__.return_value = radio
+            radio.__aexit__.return_value = None
+            radio_cls.return_value = radio
+            with patch("icom_lan.cli._cmd_audio_rx", new_callable=AsyncMock) as cmd:
+                cmd.return_value = 0
+                rc = await _run(args)
+        assert rc == 0
+        cmd.assert_awaited_once_with(radio, args)
+
+    @pytest.mark.asyncio
+    async def test_run_audio_tx_routes_to_handler(self) -> None:
+        args = Namespace(
+            host="192.168.1.100",
+            port=50001,
+            user="",
+            password="",
+            timeout=5.0,
+            command="audio",
+            audio_command="tx",
+            input_file="tx.wav",
+            sample_rate=48000,
+            channels=1,
+            json=False,
+            stats=False,
+        )
+        with patch("icom_lan.cli.IcomRadio") as radio_cls:
+            radio = AsyncMock()
+            radio.__aenter__.return_value = radio
+            radio.__aexit__.return_value = None
+            radio_cls.return_value = radio
+            with patch("icom_lan.cli._cmd_audio_tx", new_callable=AsyncMock) as cmd:
+                cmd.return_value = 0
+                rc = await _run(args)
+        assert rc == 0
+        cmd.assert_awaited_once_with(radio, args)
+
+    @pytest.mark.asyncio
+    async def test_run_audio_loopback_routes_to_handler(self) -> None:
+        args = Namespace(
+            host="192.168.1.100",
+            port=50001,
+            user="",
+            password="",
+            timeout=5.0,
+            command="audio",
+            audio_command="loopback",
+            seconds=1.0,
+            sample_rate=48000,
+            channels=1,
+            json=False,
+            stats=False,
+        )
+        with patch("icom_lan.cli.IcomRadio") as radio_cls:
+            radio = AsyncMock()
+            radio.__aenter__.return_value = radio
+            radio.__aexit__.return_value = None
+            radio_cls.return_value = radio
+            with patch(
+                "icom_lan.cli._cmd_audio_loopback",
+                new_callable=AsyncMock,
+            ) as cmd:
+                cmd.return_value = 0
+                rc = await _run(args)
+        assert rc == 0
+        cmd.assert_awaited_once_with(radio, args)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add new CLI audio subcommands:
  - `icom-lan audio rx --out <path> --seconds <n>`
  - `icom-lan audio tx --in <path>`
  - `icom-lan audio loopback --seconds <n>`
- Add common flags for the audio subcommands:
  - `--sample-rate`
  - `--channels`
  - `--json`
  - `--stats`
- Add help text and user-facing validation errors for bad inputs.
- Add CLI smoke tests for rx/tx/loopback flows.
- Update CLI docs/changelog.

## Validation
- `uv run --extra dev pytest -q tests/test_cli.py tests/test_cli_async.py tests/test_audio_transcoder.py`
- Result: 92 passed

Fixes morozsm/icom-lan#4
