### PR TITLE
feat: audio capability introspection API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,12 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Audio capability introspection API:
+  - `IcomRadio.audio_capabilities()` (async and sync wrappers)
+  - `get_audio_capabilities()` and `AudioCapabilities` export
+- CLI command: `icom-lan audio caps` with optional `--json` output.
+
 ### Changed
 
 - Audio low-level API names are now explicit with `_opus` suffix:
   `start_audio_rx_opus()`, `stop_audio_rx_opus()`, `start_audio_tx_opus()`,
   `push_audio_tx_opus()`, `stop_audio_tx_opus()`, plus full-duplex
   `start_audio_opus()` / `stop_audio_opus()`.
+- Audio defaults now come from deterministic capability rules:
+  codec preference order, highest sample rate, and channels implied by codec.
 
 ### Deprecated
 

--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -84,6 +84,26 @@ radio = IcomRadio(
 )
 ```
 
+### Capability Introspection
+
+Use the capability API to inspect negotiated client-side audio options and defaults:
+
+```python
+from icom_lan import IcomRadio
+
+caps = IcomRadio.audio_capabilities()
+print(caps.supported_codecs)
+print(caps.supported_sample_rates_hz)
+print(caps.supported_channels)
+print(caps.default_codec, caps.default_sample_rate_hz, caps.default_channels)
+```
+
+Deterministic default selection rules:
+
+1. Codec: first supported codec in icom-lan preference order.
+2. Sample rate: highest supported sample rate.
+3. Channels: the channel count implied by default codec (fallback: minimum supported channels).
+
 !!! note "Opus codecs"
     `OPUS_1CH` (0x40) and `OPUS_2CH` (0x41) are only supported when
     the radio reports `connection_type == "WFVIEW"`. Standard connections

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -77,6 +77,32 @@ Whether the radio is currently connected and ready for commands.
 
 ---
 
+## Audio Capabilities
+
+### `audio_capabilities()`
+
+```python
+@staticmethod
+def audio_capabilities() -> AudioCapabilities
+```
+
+Return the stable icom-lan audio capability structure:
+
+- `supported_codecs`
+- `supported_sample_rates_hz`
+- `supported_channels`
+- `default_codec`
+- `default_sample_rate_hz`
+- `default_channels`
+
+Default values are deterministic:
+
+1. Codec: first supported codec in icom-lan preference order.
+2. Sample rate: highest supported sample rate.
+3. Channels: implied by default codec (fallback to minimum supported channels).
+
+---
+
 ## Connection Methods
 
 ### `connect()`

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -81,6 +81,26 @@ Parsed CI-V frame.
 
 ---
 
+### `AudioCapabilities`
+
+```python
+from icom_lan import AudioCapabilities
+```
+
+Stable audio capability structure returned by `get_audio_capabilities()` and
+`IcomRadio.audio_capabilities()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `supported_codecs` | `tuple[AudioCodec, ...]` | Supported codecs in stable order |
+| `supported_sample_rates_hz` | `tuple[int, ...]` | Supported sample rates |
+| `supported_channels` | `tuple[int, ...]` | Supported channel counts |
+| `default_codec` | `AudioCodec` | Deterministic default codec |
+| `default_sample_rate_hz` | `int` | Deterministic default sample rate |
+| `default_channels` | `int` | Deterministic default channel count |
+
+---
+
 ## Helper Functions
 
 ### `bcd_encode()`
@@ -110,6 +130,14 @@ Decode 5-byte BCD to frequency in Hz.
 >>> bcd_decode(bytes.fromhex('0040071400'))
 14074000
 ```
+
+### `get_audio_capabilities()`
+
+```python
+from icom_lan import get_audio_capabilities
+```
+
+Return the static icom-lan audio capability matrix and deterministic defaults.
 
 ---
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -118,6 +118,39 @@ ALC      n/a
 !!! info
     SWR and ALC are only available during TX. They show `n/a` when receiving.
 
+### `audio caps`
+
+Show icom-lan audio capability metadata and deterministic defaults.
+
+```bash
+icom-lan audio caps
+icom-lan audio caps --json
+```
+
+Text output includes:
+
+- supported codecs
+- supported sample rates
+- supported channels
+- default codec/rate/channels
+- deterministic selection rules used for defaults
+
+JSON output example:
+
+```json
+{
+  "supported_codecs": [
+    {"name": "ULAW_1CH", "value": 1},
+    {"name": "PCM_1CH_8BIT", "value": 2}
+  ],
+  "supported_sample_rates_hz": [8000, 16000, 24000, 48000],
+  "supported_channels": [1, 2],
+  "default_codec": {"name": "PCM_1CH_16BIT", "value": 4},
+  "default_sample_rate_hz": 48000,
+  "default_channels": 1
+}
+```
+
 ### `att`
 
 Get or set the attenuator level.

--- a/src/icom_lan/__init__.py
+++ b/src/icom_lan/__init__.py
@@ -75,6 +75,7 @@ except ImportError:
     _SCOPE_RENDER_AVAILABLE = False
 from .types import (
     HEADER_SIZE,
+    AudioCapabilities,
     AudioCodec,
     CivFrame,
     Mode,
@@ -83,6 +84,7 @@ from .types import (
     ScopeCompletionPolicy,
     bcd_decode,
     bcd_encode,
+    get_audio_capabilities,
 )
 
 __all__ = [
@@ -105,12 +107,14 @@ __all__ = [
     "PacketType",
     "Mode",
     "AudioCodec",
+    "AudioCapabilities",
     "ScopeCompletionPolicy",
     "PacketHeader",
     "CivFrame",
     "HEADER_SIZE",
     "bcd_encode",
     "bcd_decode",
+    "get_audio_capabilities",
     # Commands
     "IC_7610_ADDR",
     "CONTROLLER_ADDR",

--- a/src/icom_lan/cli.py
+++ b/src/icom_lan/cli.py
@@ -6,6 +6,7 @@ Usage:
     icom-lan mode [VALUE] [--host HOST] [--user USER] [--pass PASS]
     icom-lan power [VALUE] [--host HOST] [--user USER] [--pass PASS]
     icom-lan meter [--host HOST] [--user USER] [--pass PASS]
+    icom-lan audio caps [--json]
     icom-lan att [VALUE] [--host HOST] [--user USER] [--pass PASS]
     icom-lan preamp [VALUE] [--host HOST] [--user USER] [--pass PASS]
     icom-lan ptt {on,off} [--host HOST] [--user USER] [--pass PASS]
@@ -109,6 +110,16 @@ def _build_parser() -> argparse.ArgumentParser:
     meter_p = sub.add_parser("meter", help="Read all meters")
     _add_json(meter_p)
 
+    # audio
+    audio_p = sub.add_parser("audio", help="Audio helper commands")
+    audio_sub = audio_p.add_subparsers(dest="audio_command", help="Audio command")
+    audio_sub.required = True
+    audio_caps_p = audio_sub.add_parser(
+        "caps",
+        help="Show icom-lan audio capabilities and defaults",
+    )
+    _add_json(audio_caps_p)
+
     # ptt
     ptt_p = sub.add_parser("ptt", help="PTT control")
     ptt_p.add_argument(
@@ -209,6 +220,12 @@ def _parse_frequency(value: str) -> int:
 
 
 async def _run(args: argparse.Namespace) -> int:
+    if args.command == "audio":
+        if args.audio_command == "caps":
+            return await _cmd_audio_caps(args)
+        print("Error: unknown audio command", file=sys.stderr)
+        return 1
+
     radio = IcomRadio(
         args.host,
         port=args.port,
@@ -279,6 +296,39 @@ async def _cmd_status(radio: IcomRadio, args: argparse.Namespace) -> int:
         print(f"Mode:      {mode.name}")
         print(f"S-meter:   {s_meter}")
         print(f"Power:     {power}")
+    return 0
+
+
+async def _cmd_audio_caps(args: argparse.Namespace) -> int:
+    caps = IcomRadio.audio_capabilities()
+
+    if args.json:
+        import json
+
+        print(json.dumps(caps.to_dict()))
+    else:
+        print("Supported codecs:")
+        for codec in caps.supported_codecs:
+            print(f"  - {codec.name} (0x{int(codec):02X})")
+        print(
+            "Supported sample rates (Hz): "
+            + ", ".join(str(rate) for rate in caps.supported_sample_rates_hz)
+        )
+        print(
+            "Supported channels: "
+            + ", ".join(str(channels) for channels in caps.supported_channels)
+        )
+        print("Defaults:")
+        print(
+            f"  codec: {caps.default_codec.name} "
+            f"(0x{int(caps.default_codec):02X})"
+        )
+        print(f"  sample_rate_hz: {caps.default_sample_rate_hz}")
+        print(f"  channels: {caps.default_channels}")
+        print("Selection rules:")
+        print("  codec: first supported codec in preference order")
+        print("  sample_rate_hz: highest supported rate")
+        print("  channels: from default codec (fallback to minimum)")
     return 0
 
 

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -84,7 +84,14 @@ from .civ import (
 )
 from .scope import ScopeAssembler, ScopeFrame
 from .transport import ConnectionState, IcomTransport
-from .types import AudioCodec, CivFrame, Mode, ScopeCompletionPolicy
+from .types import (
+    AudioCapabilities,
+    AudioCodec,
+    CivFrame,
+    Mode,
+    ScopeCompletionPolicy,
+    get_audio_capabilities,
+)
 
 __all__ = ["IcomRadio", "AudioCodec", "ScopeFrame", "ScopeCompletionPolicy"]
 
@@ -95,6 +102,9 @@ OPENCLOSE_SIZE = 0x16  # per wfview packettypes.h
 TOKEN_ACK_SIZE = 0x40
 CONNINFO_SIZE = 0x90
 STATUS_SIZE = 0x50
+_AUDIO_CAPABILITIES = get_audio_capabilities()
+_DEFAULT_AUDIO_CODEC = _AUDIO_CAPABILITIES.default_codec
+_DEFAULT_AUDIO_SAMPLE_RATE = _AUDIO_CAPABILITIES.default_sample_rate_hz
 
 
 class IcomRadio:
@@ -127,8 +137,8 @@ class IcomRadio:
         password: str = "",
         radio_addr: int = IC_7610_ADDR,
         timeout: float = 5.0,
-        audio_codec: AudioCodec | int = AudioCodec.PCM_1CH_16BIT,
-        audio_sample_rate: int = 48000,
+        audio_codec: AudioCodec | int = _DEFAULT_AUDIO_CODEC,
+        audio_sample_rate: int = _DEFAULT_AUDIO_SAMPLE_RATE,
         auto_reconnect: bool = False,
         reconnect_delay: float = 2.0,
         reconnect_max_delay: float = 60.0,
@@ -498,6 +508,11 @@ class IcomRadio:
     def audio_sample_rate(self) -> int:
         """Configured audio sample rate in Hz."""
         return self._audio_sample_rate
+
+    @staticmethod
+    def audio_capabilities() -> AudioCapabilities:
+        """Return icom-lan audio capabilities and deterministic defaults."""
+        return get_audio_capabilities()
 
     async def _ensure_audio_transport(self) -> None:
         """Connect the audio transport if not already connected."""

--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -18,7 +18,7 @@ from typing import Callable
 
 from .audio import AudioPacket
 from .radio import IcomRadio as _AsyncIcomRadio
-from .types import AudioCodec, Mode
+from .types import AudioCapabilities, AudioCodec, Mode
 
 __all__ = ["IcomRadio"]
 
@@ -326,3 +326,8 @@ class IcomRadio:
     def audio_sample_rate(self) -> int:
         """Configured audio sample rate."""
         return self._radio.audio_sample_rate
+
+    @staticmethod
+    def audio_capabilities() -> AudioCapabilities:
+        """Return icom-lan audio capabilities and deterministic defaults."""
+        return _AsyncIcomRadio.audio_capabilities()

--- a/src/icom_lan/types.py
+++ b/src/icom_lan/types.py
@@ -7,6 +7,8 @@ __all__ = [
     "PacketType",
     "Mode",
     "AudioCodec",
+    "AudioCapabilities",
+    "get_audio_capabilities",
     "ScopeCompletionPolicy",
     "PacketHeader",
     "CivFrame",
@@ -83,6 +85,99 @@ class ScopeCompletionPolicy(StrEnum):
     STRICT = "strict"  # Wait for a CI-V ACK response
     FAST = "fast"      # Fire-and-forget, do not wait for ACK
     VERIFY = "verify"  # Fire-and-forget, but await actual scope data activity
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCapabilities:
+    """Static icom-lan audio capability matrix and defaults."""
+
+    supported_codecs: tuple[AudioCodec, ...]
+    supported_sample_rates_hz: tuple[int, ...]
+    supported_channels: tuple[int, ...]
+    default_codec: AudioCodec
+    default_sample_rate_hz: int
+    default_channels: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly representation with stable key ordering."""
+        return {
+            "supported_codecs": [
+                {"name": codec.name, "value": int(codec)}
+                for codec in self.supported_codecs
+            ],
+            "supported_sample_rates_hz": list(self.supported_sample_rates_hz),
+            "supported_channels": list(self.supported_channels),
+            "default_codec": {
+                "name": self.default_codec.name,
+                "value": int(self.default_codec),
+            },
+            "default_sample_rate_hz": self.default_sample_rate_hz,
+            "default_channels": self.default_channels,
+        }
+
+
+_SUPPORTED_AUDIO_CODECS: tuple[AudioCodec, ...] = tuple(AudioCodec)
+_SUPPORTED_AUDIO_SAMPLE_RATES_HZ: tuple[int, ...] = (8000, 16000, 24000, 48000)
+_AUDIO_CODEC_CHANNELS: dict[AudioCodec, int] = {
+    AudioCodec.ULAW_1CH: 1,
+    AudioCodec.PCM_1CH_8BIT: 1,
+    AudioCodec.PCM_1CH_16BIT: 1,
+    AudioCodec.PCM_2CH_8BIT: 2,
+    AudioCodec.PCM_2CH_16BIT: 2,
+    AudioCodec.ULAW_2CH: 2,
+    AudioCodec.OPUS_1CH: 1,
+    AudioCodec.OPUS_2CH: 2,
+}
+_DEFAULT_CODEC_PREFERENCE: tuple[AudioCodec, ...] = (
+    AudioCodec.PCM_1CH_16BIT,
+    AudioCodec.PCM_2CH_16BIT,
+    AudioCodec.ULAW_1CH,
+    AudioCodec.ULAW_2CH,
+    AudioCodec.PCM_1CH_8BIT,
+    AudioCodec.PCM_2CH_8BIT,
+    AudioCodec.OPUS_1CH,
+    AudioCodec.OPUS_2CH,
+)
+
+
+def _build_audio_capabilities() -> AudioCapabilities:
+    supported_channels = tuple(
+        sorted({_AUDIO_CODEC_CHANNELS[codec] for codec in _SUPPORTED_AUDIO_CODECS})
+    )
+    default_codec = next(
+        codec
+        for codec in _DEFAULT_CODEC_PREFERENCE
+        if codec in _SUPPORTED_AUDIO_CODECS
+    )
+    implied_default_channels = _AUDIO_CODEC_CHANNELS[default_codec]
+    default_channels = (
+        implied_default_channels
+        if implied_default_channels in supported_channels
+        else supported_channels[0]
+    )
+    default_sample_rate_hz = max(_SUPPORTED_AUDIO_SAMPLE_RATES_HZ)
+    return AudioCapabilities(
+        supported_codecs=_SUPPORTED_AUDIO_CODECS,
+        supported_sample_rates_hz=_SUPPORTED_AUDIO_SAMPLE_RATES_HZ,
+        supported_channels=supported_channels,
+        default_codec=default_codec,
+        default_sample_rate_hz=default_sample_rate_hz,
+        default_channels=default_channels,
+    )
+
+
+_AUDIO_CAPABILITIES = _build_audio_capabilities()
+
+
+def get_audio_capabilities() -> AudioCapabilities:
+    """Return icom-lan audio capabilities with deterministic defaults.
+
+    Default selection rules:
+    1. Codec: first supported codec from ``_DEFAULT_CODEC_PREFERENCE``.
+    2. Sample rate: highest supported sample rate.
+    3. Channels: channel-count implied by default codec (fallback to minimum).
+    """
+    return _AUDIO_CAPABILITIES
 
 
 

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from icom_lan.types import AudioCodec
+from icom_lan.types import AudioCapabilities, AudioCodec, get_audio_capabilities
 from icom_lan.radio import IcomRadio
 
 
@@ -51,3 +51,37 @@ class TestRadioAudioConfig:
     def test_codec_ulaw(self) -> None:
         r = IcomRadio("192.168.1.100", audio_codec=AudioCodec.ULAW_1CH)
         assert r.audio_codec == AudioCodec.ULAW_1CH
+
+
+class TestAudioCapabilities:
+    def test_capabilities_shape(self) -> None:
+        caps = get_audio_capabilities()
+        assert isinstance(caps, AudioCapabilities)
+        assert caps.supported_codecs
+        assert caps.supported_sample_rates_hz
+        assert caps.supported_channels
+
+    def test_default_selection_is_deterministic(self) -> None:
+        caps = get_audio_capabilities()
+        assert caps.default_codec == AudioCodec.PCM_1CH_16BIT
+        assert caps.default_sample_rate_hz == 48000
+        assert caps.default_channels == 1
+
+    def test_default_values_are_supported(self) -> None:
+        caps = get_audio_capabilities()
+        assert caps.default_codec in caps.supported_codecs
+        assert caps.default_sample_rate_hz in caps.supported_sample_rates_hz
+        assert caps.default_channels in caps.supported_channels
+
+    def test_radio_exposes_audio_capabilities(self) -> None:
+        caps = IcomRadio.audio_capabilities()
+        assert caps == get_audio_capabilities()
+
+    def test_to_dict_json_shape(self) -> None:
+        data = get_audio_capabilities().to_dict()
+        assert "supported_codecs" in data
+        assert "supported_sample_rates_hz" in data
+        assert "supported_channels" in data
+        assert data["default_codec"] == {"name": "PCM_1CH_16BIT", "value": 0x04}
+        assert data["default_sample_rate_hz"] == 48000
+        assert data["default_channels"] == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,6 +82,19 @@ class TestBuildParser:
         args = p.parse_args(["meter"])
         assert args.command == "meter"
 
+    def test_audio_caps(self):
+        p = _build_parser()
+        args = p.parse_args(["audio", "caps"])
+        assert args.command == "audio"
+        assert args.audio_command == "caps"
+
+    def test_audio_caps_json(self):
+        p = _build_parser()
+        args = p.parse_args(["audio", "caps", "--json"])
+        assert args.command == "audio"
+        assert args.audio_command == "caps"
+        assert args.json is True
+
     def test_ptt_on(self):
         p = _build_parser()
         args = p.parse_args(["ptt", "on"])

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from icom_lan.cli import (
+    _cmd_audio_caps,
     _cmd_cw,
     _cmd_freq,
     _cmd_meter,
@@ -19,7 +20,7 @@ from icom_lan.cli import (
     main,
 )
 from icom_lan.exceptions import TimeoutError as IcomTimeout
-from icom_lan.types import Mode
+from icom_lan.types import Mode, get_audio_capabilities
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +74,35 @@ class TestCmdStatus:
         assert data["mode"] == "USB"
         assert data["s_meter"] == 120
         assert data["power"] == 128
+
+
+# ---------------------------------------------------------------------------
+# _cmd_audio_caps
+# ---------------------------------------------------------------------------
+
+
+class TestCmdAudioCaps:
+    @pytest.mark.asyncio
+    async def test_audio_caps_text(self, capsys) -> None:
+        args = Namespace(json=False)
+        rc = await _cmd_audio_caps(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Supported codecs:" in out
+        assert "Defaults:" in out
+        assert "PCM_1CH_16BIT" in out
+        assert "48000" in out
+
+    @pytest.mark.asyncio
+    async def test_audio_caps_json(self, capsys) -> None:
+        args = Namespace(json=True)
+        rc = await _cmd_audio_caps(args)
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["default_codec"]["name"] == "PCM_1CH_16BIT"
+        assert data["default_sample_rate_hz"] == 48000
+        assert data["default_channels"] == 1
+        assert any(c["name"] == "OPUS_1CH" for c in data["supported_codecs"])
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +281,26 @@ class TestCmdCw:
 
 
 class TestRunErrorHandling:
+    @pytest.mark.asyncio
+    async def test_run_audio_caps_does_not_connect(self, capsys) -> None:
+        args = Namespace(
+            host="192.168.1.100",
+            port=50001,
+            user="",
+            password="",
+            timeout=5.0,
+            command="audio",
+            audio_command="caps",
+            json=True,
+        )
+        with patch("icom_lan.cli.IcomRadio") as radio_cls:
+            radio_cls.audio_capabilities.return_value = get_audio_capabilities()
+            rc = await _run(args)
+        assert rc == 0
+        radio_cls.assert_not_called()
+        data = json.loads(capsys.readouterr().out)
+        assert data["default_channels"] == 1
+
     @pytest.mark.asyncio
     async def test_run_exception(self, capsys) -> None:
         args = Namespace(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -65,3 +65,9 @@ class TestSyncAudioNaming:
 
         r._radio.push_audio_tx_opus.assert_awaited_once_with(b"\x01\x02")
         r._loop.close()
+
+    def test_audio_capabilities(self) -> None:
+        caps = IcomRadio.audio_capabilities()
+        assert caps.default_codec.name == "PCM_1CH_16BIT"
+        assert caps.default_sample_rate_hz == 48000
+        assert caps.default_channels == 1


### PR DESCRIPTION
Adds AudioCapabilities, get_audio_capabilities(), IcomRadio.audio_capabilities() (async+sync), CLI 'audio caps' command, deterministic defaults. 12 new tests.

Closes #8