### PR TITLE
fix: shield CI-V pipeline from caller cancellation

### DIFF
--- a/src/icom_lan/commander.py
+++ b/src/icom_lan/commander.py
@@ -137,15 +137,30 @@ class IcomCommander:
             while True:
                 _, _, item = await self._queue.get()
                 try:
+                    # Skip execution if the caller already cancelled their future
+                    # (e.g. TCP client disconnected before we got to this item).
+                    if item.future.cancelled():
+                        continue
+
                     now = asyncio.get_running_loop().time()
                     delta = now - self._last_send
                     if delta < self._min_interval:
                         await asyncio.sleep(self._min_interval - delta)
 
-                    resp = await self._execute(item.payload, item.wait_response)
+                    # Shield _execute from caller cancellation so that the CI-V
+                    # pipeline stays intact even when asyncio.wait_for() in the
+                    # server layer cancels a pending send() future.
+                    resp = await asyncio.shield(
+                        self._execute(item.payload, item.wait_response)
+                    )
                     self._last_send = asyncio.get_running_loop().time()
                     if not item.future.done():
                         item.future.set_result(resp)
+                except asyncio.CancelledError:
+                    # The caller's future was cancelled (e.g. client disconnect)
+                    # but _execute completed or was shielded.  Don't kill the loop.
+                    if not item.future.done():
+                        item.future.cancel()
                 except Exception as exc:
                     if not item.future.done():
                         item.future.set_exception(exc)

--- a/tests/test_commander.py
+++ b/tests/test_commander.py
@@ -122,3 +122,108 @@ async def test_stop_fails_pending() -> None:
     await c.stop()
     with pytest.raises(ConnectionError):
         await asyncio.wait_for(task, timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_send_does_not_break_pipeline() -> None:
+    """Cancelling a caller's send() must not kill the commander loop.
+
+    This is the core bug from issue #27: asyncio.wait_for() in the server
+    cancels a pending send(), which without shield() would propagate into
+    _loop() and kill the CI-V pipeline.
+    """
+    call_count = 0
+
+    async def execute(cmd: bytes, wait_response: bool = True) -> CivFrame | None:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.05)
+        return CivFrame(to_addr=0xE0, from_addr=0x98, command=0xFB, sub=None, data=b"")
+
+    c = IcomCommander(execute, min_interval=0.0)
+    c.start()
+    try:
+        # Start a send and cancel it mid-flight (simulates client disconnect)
+        task = asyncio.create_task(c.send(b"will-cancel"))
+        await asyncio.sleep(0.01)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # The next command must still work — pipeline not broken
+        resp = await asyncio.wait_for(c.send(b"after-cancel"), timeout=2.0)
+        assert resp is not None
+        assert call_count == 2
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_rapid_cancel_cycles() -> None:
+    """Simulate rapid connect/disconnect: cancel multiple sends, then verify recovery."""
+
+    async def execute(cmd: bytes, wait_response: bool = True) -> CivFrame | None:
+        await asyncio.sleep(0.02)
+        return CivFrame(to_addr=0xE0, from_addr=0x98, command=0xFB, sub=None, data=b"")
+
+    c = IcomCommander(execute, min_interval=0.0)
+    c.start()
+    try:
+        # 5 rapid cancel cycles
+        for _ in range(5):
+            task = asyncio.create_task(c.send(b"cancel-me"))
+            await asyncio.sleep(0.005)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # Pipeline must still work
+        resp = await asyncio.wait_for(c.send(b"final"), timeout=2.0)
+        assert resp is not None
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_already_cancelled_future_skipped() -> None:
+    """If a future is cancelled before _loop gets to it, skip execution."""
+    executed: list[bytes] = []
+
+    async def execute(cmd: bytes, wait_response: bool = True) -> CivFrame | None:
+        executed.append(cmd)
+        return CivFrame(to_addr=0xE0, from_addr=0x98, command=0xFB, sub=None, data=b"")
+
+    c = IcomCommander(execute, min_interval=0.0)
+    c.start()
+    try:
+        # Block the loop with a slow command
+        async def slow_exec(cmd: bytes, wait_response: bool = True) -> CivFrame | None:
+            executed.append(cmd)
+            await asyncio.sleep(0.1)
+            return CivFrame(to_addr=0xE0, from_addr=0x98, command=0xFB, sub=None, data=b"")
+
+        c._execute = slow_exec  # type: ignore[assignment]
+
+        blocker = asyncio.create_task(c.send(b"blocker"))
+        await asyncio.sleep(0.01)
+
+        # Queue a command and cancel before it's processed
+        queued = asyncio.create_task(c.send(b"pre-cancelled"))
+        await asyncio.sleep(0.001)
+        queued.cancel()
+
+        await blocker  # let blocker finish
+
+        # Restore fast executor
+        c._execute = execute  # type: ignore[assignment]
+
+        resp = await asyncio.wait_for(c.send(b"after"), timeout=2.0)
+        assert resp is not None
+        # "pre-cancelled" should have been skipped
+        assert b"pre-cancelled" not in executed
+    finally:
+        await c.stop()


### PR DESCRIPTION
## Problem
When rigctld TCP clients disconnect rapidly, `asyncio.wait_for()` cancels pending `send()` calls. Without protection, `CancelledError` propagates into `Commander._loop()`, killing the CI-V pipeline. All subsequent commands fail.

## Fix
- `asyncio.shield()` around `_execute()` in `_loop()` — caller cancellation no longer kills the pipeline
- Skip execution for futures already cancelled before dequeue
- Catch `CancelledError` per-item instead of letting it escape the loop

## Tests
- `test_cancel_pending_send_does_not_break_pipeline` — core regression test
- `test_rapid_cancel_cycles` — 5 rapid cancel/reconnect cycles
- `test_already_cancelled_future_skipped` — pre-cancelled items skipped

All 726 tests pass, 0 regressions.

Fixes #27