### PR TITLE
tests: e2e tests for PCM API and CLI audio workflows (issue #5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = [
     "integration: tests requiring real radio hardware (skip if not configured)",
+    "e2e: end-to-end tests for PCM API and CLI audio workflows",
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -1,0 +1,550 @@
+"""End-to-end tests for the CLI audio sub-commands.
+
+These tests invoke the real async CLI handler functions (_cmd_audio_rx,
+_cmd_audio_tx, _cmd_audio_loopback, _cmd_audio_caps) with a fully
+mocked IcomRadio, verifying file I/O, JSON output, and error handling.
+"""
+
+from __future__ import annotations
+
+import json
+import wave
+from argparse import Namespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from icom_lan.cli import (
+    _cmd_audio_caps,
+    _cmd_audio_loopback,
+    _cmd_audio_rx,
+    _cmd_audio_tx,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_radio():
+    """Fully-mocked IcomRadio for CLI handler tests."""
+    radio = AsyncMock()
+    radio.start_audio_rx_pcm = AsyncMock()
+    radio.stop_audio_rx_pcm = AsyncMock()
+    radio.start_audio_tx_pcm = AsyncMock()
+    radio.stop_audio_tx_pcm = AsyncMock()
+    radio.push_audio_tx_pcm = AsyncMock()
+    radio.get_audio_stats = MagicMock(return_value={
+        "active": True,
+        "state": "receiving",
+        "rx_packets_received": 10,
+        "rx_packets_delivered": 9,
+        "tx_packets_sent": 0,
+        "packets_lost": 1,
+        "packet_loss_percent": 10.0,
+        "jitter_ms": 2.5,
+        "jitter_max_ms": 20.0,
+        "underrun_count": 0,
+        "overrun_count": 0,
+        "estimated_latency_ms": 100.0,
+        "jitter_buffer_depth_packets": 5,
+        "jitter_buffer_pending_packets": 1,
+        "duplicates_dropped": 0,
+        "stale_packets_dropped": 0,
+        "out_of_order_packets": 0,
+    })
+    return radio
+
+
+def _make_wav(path, *, sample_rate=48000, channels=1, n_samples=960):
+    """Create a small valid WAV file for testing."""
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\x10\x00" * n_samples * channels)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# audio rx
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestCliAudioRxE2E:
+
+    @pytest.mark.asyncio
+    async def test_rx_creates_wav_with_correct_header(
+        self, mock_radio, tmp_path, capsys,
+    ) -> None:
+        """RX should create a valid WAV file with correct sample rate/channels."""
+        frame = b"\x01\x02" * 960  # 1920 bytes, one mono 48kHz 20ms frame
+
+        async def _start_rx(cb, **_kw) -> None:
+            cb(frame)
+            cb(frame)
+
+        mock_radio.start_audio_rx_pcm = AsyncMock(side_effect=_start_rx)
+        out_file = tmp_path / "rx_test.wav"
+
+        args = Namespace(
+            output_file=str(out_file),
+            seconds=0.01,
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_rx(mock_radio, args)
+
+        assert rc == 0
+        mock_radio.start_audio_rx_pcm.assert_awaited_once()
+        mock_radio.stop_audio_rx_pcm.assert_awaited_once()
+
+        with wave.open(str(out_file), "rb") as wf:
+            assert wf.getframerate() == 48000
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2
+            assert wf.getnframes() > 0
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["command"] == "audio-rx"
+        assert data["bytes_written"] > 0
+        assert data["rx_frames"] == 2
+
+    @pytest.mark.asyncio
+    async def test_rx_handles_gaps_as_silence(
+        self, mock_radio, tmp_path, capsys,
+    ) -> None:
+        """Gap (None) frames should be written as silence."""
+        frame = b"\xFF\x7F" * 960
+
+        async def _start_rx(cb, **_kw) -> None:
+            cb(frame)
+            cb(None)  # gap → silence
+            cb(frame)
+
+        mock_radio.start_audio_rx_pcm = AsyncMock(side_effect=_start_rx)
+        out_file = tmp_path / "rx_gaps.wav"
+
+        args = Namespace(
+            output_file=str(out_file),
+            seconds=0.01,
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_rx(mock_radio, args)
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["rx_frames"] == 2
+        assert data["gap_frames"] == 1
+        # Total bytes: 3 frames × 1920 bytes
+        assert data["bytes_written"] == 3 * 1920
+
+    @pytest.mark.asyncio
+    async def test_rx_stereo(self, mock_radio, tmp_path, capsys) -> None:
+        """RX with 2 channels should produce a stereo WAV."""
+        stereo_frame = b"\x01\x02" * 1920  # 3840 bytes for stereo 20ms
+
+        async def _start_rx(cb, **_kw) -> None:
+            cb(stereo_frame)
+
+        mock_radio.start_audio_rx_pcm = AsyncMock(side_effect=_start_rx)
+        out_file = tmp_path / "rx_stereo.wav"
+
+        args = Namespace(
+            output_file=str(out_file),
+            seconds=0.01,
+            sample_rate=48000,
+            channels=2,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_rx(mock_radio, args)
+
+        assert rc == 0
+        with wave.open(str(out_file), "rb") as wf:
+            assert wf.getnchannels() == 2
+
+    @pytest.mark.asyncio
+    async def test_rx_text_output(self, mock_radio, tmp_path, capsys) -> None:
+        """Text mode should print a human-readable message."""
+        async def _start_rx(cb, **_kw) -> None:
+            cb(b"\x00" * 1920)
+
+        mock_radio.start_audio_rx_pcm = AsyncMock(side_effect=_start_rx)
+        out_file = tmp_path / "rx_text.wav"
+
+        args = Namespace(
+            output_file=str(out_file),
+            seconds=0.01,
+            sample_rate=48000,
+            channels=1,
+            json=False,
+            stats=False,
+        )
+        rc = await _cmd_audio_rx(mock_radio, args)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Saved RX audio" in out
+
+
+# ---------------------------------------------------------------------------
+# audio tx
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestCliAudioTxE2E:
+
+    @pytest.mark.asyncio
+    async def test_tx_sends_frames(self, mock_radio, tmp_path, capsys) -> None:
+        """TX should read WAV and push PCM frames to the radio."""
+        in_file = _make_wav(tmp_path / "tx.wav", n_samples=960)
+
+        args = Namespace(
+            input_file=str(in_file),
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_tx(mock_radio, args)
+
+        assert rc == 0
+        mock_radio.start_audio_tx_pcm.assert_awaited_once()
+        mock_radio.stop_audio_tx_pcm.assert_awaited_once()
+        assert mock_radio.push_audio_tx_pcm.await_count >= 1
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["command"] == "audio-tx"
+        assert data["tx_frames"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_tx_multiple_frames(self, mock_radio, tmp_path, capsys) -> None:
+        """A WAV with 3 frames worth of data should push 3 frames."""
+        in_file = _make_wav(tmp_path / "tx_multi.wav", n_samples=960 * 3)
+
+        args = Namespace(
+            input_file=str(in_file),
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_tx(mock_radio, args)
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["tx_frames"] == 3
+
+    @pytest.mark.asyncio
+    async def test_tx_file_not_found(self, mock_radio, tmp_path, capsys) -> None:
+        """TX with nonexistent file should return error."""
+        args = Namespace(
+            input_file=str(tmp_path / "nonexistent.wav"),
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_tx(mock_radio, args)
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "not found" in err
+
+    @pytest.mark.asyncio
+    async def test_tx_text_output(self, mock_radio, tmp_path, capsys) -> None:
+        """Text mode should print a human-readable message."""
+        in_file = _make_wav(tmp_path / "tx_text.wav")
+
+        args = Namespace(
+            input_file=str(in_file),
+            sample_rate=48000,
+            channels=1,
+            json=False,
+            stats=False,
+        )
+        rc = await _cmd_audio_tx(mock_radio, args)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Transmitted WAV audio" in out
+
+    @pytest.mark.asyncio
+    async def test_tx_sample_rate_mismatch(
+        self, mock_radio, tmp_path, capsys,
+    ) -> None:
+        """TX should fail if WAV sample rate differs from --sample-rate."""
+        in_file = _make_wav(tmp_path / "tx_mismatch.wav", sample_rate=8000)
+
+        args = Namespace(
+            input_file=str(in_file),
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_tx(mock_radio, args)
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "sample rate" in err.lower()
+
+    @pytest.mark.asyncio
+    async def test_tx_channel_mismatch(
+        self, mock_radio, tmp_path, capsys,
+    ) -> None:
+        """TX should fail if WAV channels differ from --channels."""
+        in_file = _make_wav(tmp_path / "tx_ch.wav", channels=2)
+
+        args = Namespace(
+            input_file=str(in_file),
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_tx(mock_radio, args)
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "channel" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# audio loopback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestCliAudioLoopbackE2E:
+
+    @pytest.mark.asyncio
+    async def test_loopback_runs_and_exits(self, mock_radio, capsys) -> None:
+        """Loopback should start RX+TX, feed frames, and exit cleanly."""
+        frame = b"\x03\x04" * 960
+
+        async def _start_rx(cb, **_kw) -> None:
+            cb(frame)
+            cb(frame)
+            cb(None)
+
+        mock_radio.start_audio_rx_pcm = AsyncMock(side_effect=_start_rx)
+
+        args = Namespace(
+            seconds=0.05,
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_loopback(mock_radio, args)
+
+        assert rc == 0
+        mock_radio.start_audio_rx_pcm.assert_awaited_once()
+        mock_radio.stop_audio_rx_pcm.assert_awaited_once()
+        mock_radio.start_audio_tx_pcm.assert_awaited_once()
+        mock_radio.stop_audio_tx_pcm.assert_awaited_once()
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["command"] == "audio-loopback"
+        assert data["tx_frames"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_loopback_text_output(self, mock_radio, capsys) -> None:
+        """Text mode should print a human-readable summary."""
+        async def _start_rx(cb, **_kw) -> None:
+            cb(b"\x00" * 1920)
+
+        mock_radio.start_audio_rx_pcm = AsyncMock(side_effect=_start_rx)
+
+        args = Namespace(
+            seconds=0.05,
+            sample_rate=48000,
+            channels=1,
+            json=False,
+            stats=False,
+        )
+        rc = await _cmd_audio_loopback(mock_radio, args)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "loopback" in out.lower() or "Loopback" in out
+
+
+# ---------------------------------------------------------------------------
+# audio caps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestCliAudioCapsE2E:
+
+    @pytest.mark.asyncio
+    async def test_caps_json_format(self, capsys) -> None:
+        """JSON output should include codec list and defaults."""
+        args = Namespace(json=True)
+        rc = await _cmd_audio_caps(args)
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "supported_codecs" in data
+        assert data["default_sample_rate_hz"] == 48000
+        assert data["default_channels"] == 1
+
+    @pytest.mark.asyncio
+    async def test_caps_text_format(self, capsys) -> None:
+        """Text output should include recognizable labels."""
+        args = Namespace(json=False)
+        rc = await _cmd_audio_caps(args)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Supported codecs:" in out
+        assert "48000" in out
+
+    @pytest.mark.asyncio
+    async def test_caps_with_stats_json(self, capsys) -> None:
+        """Caps with --stats should include runtime_stats in JSON."""
+        runtime_stats = {
+            "active": True,
+            "state": "receiving",
+            "rx_packets_received": 50,
+            "rx_packets_delivered": 48,
+            "tx_packets_sent": 0,
+            "packets_lost": 2,
+            "packet_loss_percent": 4.0,
+            "jitter_ms": 5.0,
+            "jitter_max_ms": 25.0,
+            "underrun_count": 0,
+            "overrun_count": 0,
+            "estimated_latency_ms": 100.0,
+            "jitter_buffer_depth_packets": 5,
+            "jitter_buffer_pending_packets": 3,
+            "duplicates_dropped": 0,
+            "stale_packets_dropped": 0,
+            "out_of_order_packets": 1,
+        }
+        args = Namespace(json=True, stats=True)
+        rc = await _cmd_audio_caps(args, runtime_stats=runtime_stats)
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "runtime_stats" in data
+        assert data["runtime_stats"]["rx_packets_received"] == 50
+        assert data["runtime_stats"]["packet_loss_percent"] == 4.0
+
+    @pytest.mark.asyncio
+    async def test_caps_with_stats_text(self, capsys) -> None:
+        """Caps with --stats in text mode should show stats section."""
+        runtime_stats = {
+            "active": True,
+            "state": "receiving",
+            "rx_packets_received": 10,
+            "rx_packets_delivered": 9,
+            "tx_packets_sent": 0,
+            "packets_lost": 1,
+            "packet_loss_percent": 10.0,
+            "jitter_ms": 2.5,
+            "jitter_max_ms": 20.0,
+            "underrun_count": 1,
+            "overrun_count": 0,
+            "estimated_latency_ms": 100.0,
+            "jitter_buffer_depth_packets": 5,
+            "jitter_buffer_pending_packets": 1,
+            "duplicates_dropped": 0,
+            "stale_packets_dropped": 0,
+            "out_of_order_packets": 1,
+        }
+        args = Namespace(json=False, stats=True)
+        rc = await _cmd_audio_caps(args, runtime_stats=runtime_stats)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Runtime stats:" in out
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestCliAudioErrorCasesE2E:
+
+    @pytest.mark.asyncio
+    async def test_rx_invalid_sample_rate(
+        self, mock_radio, tmp_path, capsys,
+    ) -> None:
+        """RX with unsupported sample rate should fail."""
+        args = Namespace(
+            output_file=str(tmp_path / "bad.wav"),
+            seconds=1.0,
+            sample_rate=44100,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_rx(mock_radio, args)
+        assert rc == 1
+        assert "sample" in capsys.readouterr().err.lower()
+
+    @pytest.mark.asyncio
+    async def test_rx_invalid_channels(
+        self, mock_radio, tmp_path, capsys,
+    ) -> None:
+        """RX with invalid channel count should fail."""
+        args = Namespace(
+            output_file=str(tmp_path / "bad.wav"),
+            seconds=1.0,
+            sample_rate=48000,
+            channels=5,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_rx(mock_radio, args)
+        assert rc == 1
+        assert "channel" in capsys.readouterr().err.lower()
+
+    @pytest.mark.asyncio
+    async def test_rx_invalid_seconds(
+        self, mock_radio, tmp_path, capsys,
+    ) -> None:
+        """RX with zero/negative seconds should fail."""
+        args = Namespace(
+            output_file=str(tmp_path / "bad.wav"),
+            seconds=0,
+            sample_rate=48000,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_rx(mock_radio, args)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "seconds" in err.lower() or "positive" in err.lower()
+
+    @pytest.mark.asyncio
+    async def test_loopback_invalid_sample_rate(
+        self, mock_radio, capsys,
+    ) -> None:
+        """Loopback with unsupported sample rate should fail."""
+        args = Namespace(
+            seconds=1.0,
+            sample_rate=44100,
+            channels=1,
+            json=True,
+            stats=False,
+        )
+        rc = await _cmd_audio_loopback(mock_radio, args)
+        assert rc == 1
+        assert "sample" in capsys.readouterr().err.lower()

--- a/tests/test_pcm_e2e.py
+++ b/tests/test_pcm_e2e.py
@@ -1,0 +1,332 @@
+"""End-to-end tests for the PCM audio API.
+
+These tests exercise the full pipeline:
+  start_audio_rx_pcm  → feed fake Opus → callback gets PCM → stop
+  start_audio_tx_pcm  → push PCM → verify Opus sent           → stop
+
+All radio I/O is mocked — no real hardware needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from icom_lan.audio import AudioPacket, AudioState, AudioStats
+from icom_lan.radio import IcomRadio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _DummyTranscoder:
+    """Fake Opus transcoder that tags data instead of encoding/decoding."""
+
+    def opus_to_pcm(self, opus: bytes) -> bytes:
+        return b"pcm:" + opus
+
+    def pcm_to_opus(self, pcm: bytes | bytearray | memoryview) -> bytes:
+        return b"opus:" + bytes(pcm)[:4]
+
+
+def _make_radio() -> IcomRadio:
+    """Build an IcomRadio pre-wired with mocks for PCM pipeline tests."""
+    radio = IcomRadio("192.168.1.100")
+    radio._connected = True
+    radio._civ_transport = MagicMock()
+    radio._audio_stream = MagicMock()
+    radio._audio_stream.start_rx = AsyncMock()
+    radio._audio_stream.stop_rx = AsyncMock()
+    radio._audio_stream.start_tx = AsyncMock()
+    radio._audio_stream.stop_tx = AsyncMock()
+    radio._audio_stream.push_tx = AsyncMock()
+    radio._audio_stream.state = AudioState.IDLE
+    radio._audio_stream.get_audio_stats = MagicMock(
+        return_value=AudioStats.inactive().to_dict(),
+    )
+    # Pre-install dummy transcoder so _get_pcm_transcoder succeeds.
+    radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+    radio._pcm_transcoder_fmt = (48000, 1, 20)
+    return radio
+
+
+# ---------------------------------------------------------------------------
+# RX flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPcmRxE2E:
+    """RX pipeline: start → feed Opus packets → callback gets PCM → stop."""
+
+    @pytest.mark.asyncio
+    async def test_rx_happy_path(self) -> None:
+        radio = _make_radio()
+        received: list[bytes | None] = []
+
+        await radio.start_audio_rx_pcm(lambda frame: received.append(frame))
+
+        # Grab the internal Opus-level callback that was registered.
+        rx_cb = radio._audio_stream.start_rx.await_args.args[0]
+
+        # Simulate three Opus packets from the radio.
+        rx_cb(AudioPacket(ident=0x0080, send_seq=1, data=b"\x01\x02"))
+        rx_cb(AudioPacket(ident=0x0080, send_seq=2, data=b"\x03\x04"))
+        rx_cb(AudioPacket(ident=0x0080, send_seq=3, data=b"\x05\x06"))
+
+        assert len(received) == 3
+        assert received[0] == b"pcm:\x01\x02"
+        assert received[1] == b"pcm:\x03\x04"
+        assert received[2] == b"pcm:\x05\x06"
+
+        await radio.stop_audio_rx_pcm()
+        radio._audio_stream.stop_rx.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rx_gap_forwarded_as_none(self) -> None:
+        """Jitter-buffer gaps should be passed to callback as None."""
+        radio = _make_radio()
+        received: list[bytes | None] = []
+
+        await radio.start_audio_rx_pcm(lambda frame: received.append(frame))
+        rx_cb = radio._audio_stream.start_rx.await_args.args[0]
+
+        rx_cb(AudioPacket(ident=0x0080, send_seq=1, data=b"\xAA"))
+        rx_cb(None)  # gap
+        rx_cb(AudioPacket(ident=0x0080, send_seq=3, data=b"\xBB"))
+
+        assert received == [b"pcm:\xAA", None, b"pcm:\xBB"]
+
+        await radio.stop_audio_rx_pcm()
+
+    @pytest.mark.asyncio
+    async def test_rx_many_frames(self) -> None:
+        """Receive a burst of 100 frames without error."""
+        radio = _make_radio()
+        received: list[bytes | None] = []
+
+        await radio.start_audio_rx_pcm(lambda frame: received.append(frame))
+        rx_cb = radio._audio_stream.start_rx.await_args.args[0]
+
+        for seq in range(100):
+            rx_cb(AudioPacket(ident=0x0080, send_seq=seq, data=bytes([seq & 0xFF])))
+
+        assert len(received) == 100
+        await radio.stop_audio_rx_pcm()
+
+
+# ---------------------------------------------------------------------------
+# TX flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPcmTxE2E:
+    """TX pipeline: start → push PCM frames → Opus packets sent → stop."""
+
+    @pytest.mark.asyncio
+    async def test_tx_happy_path(self) -> None:
+        radio = _make_radio()
+
+        await radio.start_audio_tx_pcm()
+        radio._audio_stream.start_tx.assert_awaited_once()
+        assert radio._pcm_tx_fmt == (48000, 1, 20)
+
+        # Push a PCM frame.
+        pcm_frame = b"\x10\x00" * 960  # 1920 bytes = 960 samples × 2 bytes
+        await radio.push_audio_tx_pcm(pcm_frame)
+
+        # Transcoder produces "opus:" + first 4 bytes of PCM.
+        radio._audio_stream.push_tx.assert_awaited_once_with(b"opus:\x10\x00\x10\x00")
+
+        await radio.stop_audio_tx_pcm()
+        radio._audio_stream.stop_tx.assert_awaited_once()
+        assert radio._pcm_tx_fmt is None
+
+    @pytest.mark.asyncio
+    async def test_tx_multiple_frames(self) -> None:
+        radio = _make_radio()
+        await radio.start_audio_tx_pcm()
+
+        for _ in range(10):
+            await radio.push_audio_tx_pcm(b"\x00\x01" * 960)
+
+        assert radio._audio_stream.push_tx.await_count == 10
+        await radio.stop_audio_tx_pcm()
+
+    @pytest.mark.asyncio
+    async def test_push_without_start_raises(self) -> None:
+        radio = _make_radio()
+        with pytest.raises(RuntimeError, match="start_audio_tx_pcm"):
+            await radio.push_audio_tx_pcm(b"\x00" * 1920)
+
+
+# ---------------------------------------------------------------------------
+# Loopback (RX + TX simultaneously)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPcmLoopbackE2E:
+    """Full-duplex loopback: RX callback feeds back into TX."""
+
+    @pytest.mark.asyncio
+    async def test_loopback_flow(self) -> None:
+        radio = _make_radio()
+        rx_frames: list[bytes | None] = []
+
+        # RX callback is synchronous — just collect frames.
+        def _on_pcm(frame: bytes | None) -> None:
+            rx_frames.append(frame)
+
+        # Start TX first, then RX.
+        await radio.start_audio_tx_pcm()
+        await radio.start_audio_rx_pcm(_on_pcm)
+
+        rx_cb = radio._audio_stream.start_rx.await_args.args[0]
+
+        # Feed 5 Opus packets through the RX pipeline.
+        for seq in range(5):
+            rx_cb(AudioPacket(ident=0x0080, send_seq=seq, data=bytes([seq])))
+
+        assert len(rx_frames) == 5
+
+        # Now push them back through the TX pipeline.
+        for frame in rx_frames:
+            if frame is not None:
+                await radio.push_audio_tx_pcm(frame)
+
+        assert radio._audio_stream.push_tx.await_count == 5
+
+        await radio.stop_audio_rx_pcm()
+        await radio.stop_audio_tx_pcm()
+
+
+# ---------------------------------------------------------------------------
+# Repeated start/stop cycles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPcmStartStopCycles:
+    """Repeated start→stop should not leak state or raise errors."""
+
+    @pytest.mark.asyncio
+    async def test_rx_start_stop_5_cycles(self) -> None:
+        for _ in range(5):
+            radio = _make_radio()
+            received: list[bytes | None] = []
+
+            await radio.start_audio_rx_pcm(lambda frame: received.append(frame))
+            rx_cb = radio._audio_stream.start_rx.await_args.args[0]
+            rx_cb(AudioPacket(ident=0x0080, send_seq=0, data=b"\xCC"))
+            assert received == [b"pcm:\xCC"]
+
+            await radio.stop_audio_rx_pcm()
+            radio._audio_stream.stop_rx.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_tx_start_stop_5_cycles(self) -> None:
+        for _ in range(5):
+            radio = _make_radio()
+
+            await radio.start_audio_tx_pcm()
+            await radio.push_audio_tx_pcm(b"\xAA\xBB" * 960)
+            assert radio._audio_stream.push_tx.await_count == 1
+
+            await radio.stop_audio_tx_pcm()
+            assert radio._pcm_tx_fmt is None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPcmEdgeCases:
+
+    @pytest.mark.asyncio
+    async def test_stop_rx_without_start_is_noop(self) -> None:
+        """Stopping RX before starting should not raise."""
+        radio = _make_radio()
+        await radio.stop_audio_rx_pcm()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_stop_tx_without_start_is_noop(self) -> None:
+        """Stopping TX before starting should not raise."""
+        radio = _make_radio()
+        await radio.stop_audio_tx_pcm()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_double_start_rx_raises(self) -> None:
+        """Starting RX twice should raise RuntimeError."""
+        radio = _make_radio()
+        radio._audio_stream.start_rx = AsyncMock(
+            side_effect=[None, RuntimeError("Already receiving")],
+        )
+        await radio.start_audio_rx_pcm(lambda _: None)
+        with pytest.raises(RuntimeError, match="Already receiving"):
+            await radio.start_audio_rx_pcm(lambda _: None)
+        await radio.stop_audio_rx_pcm()
+
+    @pytest.mark.asyncio
+    async def test_double_start_tx_raises(self) -> None:
+        """Starting TX twice should raise RuntimeError."""
+        radio = _make_radio()
+        radio._audio_stream.start_tx = AsyncMock(
+            side_effect=[None, RuntimeError("Already transmitting")],
+        )
+        await radio.start_audio_tx_pcm()
+        with pytest.raises(RuntimeError, match="Already transmitting"):
+            await radio.start_audio_tx_pcm()
+        await radio.stop_audio_tx_pcm()
+
+
+# ---------------------------------------------------------------------------
+# Stats after activity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPcmStatsE2E:
+
+    def test_stats_idle(self) -> None:
+        radio = _make_radio()
+        # No audio stream => inactive stats.
+        radio._audio_stream = None
+        stats = radio.get_audio_stats()
+        assert stats["active"] is False
+        assert stats["state"] == "idle"
+
+    def test_stats_after_rx(self) -> None:
+        radio = _make_radio()
+        radio._audio_stream.get_audio_stats = MagicMock(
+            return_value={
+                "active": True,
+                "state": "receiving",
+                "rx_packets_received": 42,
+                "rx_packets_delivered": 40,
+                "tx_packets_sent": 0,
+                "packets_lost": 2,
+                "packet_loss_percent": 4.76,
+                "jitter_ms": 3.5,
+                "jitter_max_ms": 15.0,
+                "underrun_count": 1,
+                "overrun_count": 0,
+                "estimated_latency_ms": 100.0,
+                "jitter_buffer_depth_packets": 5,
+                "jitter_buffer_pending_packets": 2,
+                "duplicates_dropped": 0,
+                "stale_packets_dropped": 0,
+                "out_of_order_packets": 1,
+            },
+        )
+        stats = radio.get_audio_stats()
+        assert stats["active"] is True
+        assert stats["rx_packets_received"] == 42
+        assert stats["packets_lost"] == 2
+        assert stats["jitter_ms"] == 3.5


### PR DESCRIPTION
## Summary

35 end-to-end tests for the PCM audio API and CLI audio subcommands.

### tests/test_pcm_e2e.py (15 tests)
- **RX pipeline**: start → feed Opus → callback gets PCM → stop (happy path, gaps as None, 100-frame burst)
- **TX pipeline**: start → push PCM → Opus sent → stop (happy path, multi-frame, push without start)
- **Loopback**: RX feeding back into TX
- **Start/stop cycles**: 5x repeated start→stop for RX and TX (leak detection)
- **Edge cases**: stop without start (no-op), double start (raises), stats after activity

### tests/test_cli_e2e.py (20 tests)
- **audio rx**: WAV creation with correct headers, gaps→silence, stereo, text/JSON output
- **audio tx**: frame sending, multi-frame, file not found, sample rate mismatch, channel mismatch, text output
- **audio loopback**: dry-run with mock radio, text/JSON output
- **audio caps**: JSON format, text format, with stats JSON/text
- **Error cases**: invalid sample rate, channels, seconds

### CI
- `e2e` pytest marker added to pyproject.toml
- Run with: `pytest -m e2e`

### Results
- 35 new tests, all passing in 0.45s
- All deterministic, no flaky timing

Closes #5