### PR TITLE
feat: auto-recover audio streams on reconnect (#7)

### DIFF
--- a/src/icom_lan/__init__.py
+++ b/src/icom_lan/__init__.py
@@ -33,7 +33,7 @@ from .audio import (
 )
 from .transport import ConnectionState, IcomTransport
 from .commander import IcomCommander, Priority
-from .radio import IcomRadio
+from .radio import AudioRecoveryState, IcomRadio
 from .radios import RADIOS, RadioModel, get_civ_addr
 from .commands import (
     CONTROLLER_ADDR,
@@ -101,6 +101,7 @@ from .types import (
 __all__ = [
     "__version__",
     # Radio
+    "AudioRecoveryState",
     "IcomRadio",
     "IcomCommander",
     "Priority",

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -12,6 +12,8 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import dataclasses
+import enum
 import logging
 import os
 import struct
@@ -77,7 +79,7 @@ from .exceptions import (
     TimeoutError,
 )
 from ._audio_transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
-from .audio import AudioPacket, AudioStats, AudioStream
+from .audio import AudioPacket, AudioState, AudioStats, AudioStream
 from .commander import IcomCommander, Priority
 from .civ import (
     CivEvent,
@@ -97,7 +99,34 @@ from .types import (
     get_audio_capabilities,
 )
 
-__all__ = ["IcomRadio", "AudioCodec", "ScopeFrame", "ScopeCompletionPolicy"]
+__all__ = [
+    "AudioRecoveryState",
+    "IcomRadio",
+    "AudioCodec",
+    "ScopeFrame",
+    "ScopeCompletionPolicy",
+]
+
+
+class AudioRecoveryState(enum.Enum):
+    """State emitted by the ``on_audio_recovery`` callback."""
+
+    RECOVERING = "recovering"
+    RECOVERED = "recovered"
+    FAILED = "failed"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _AudioSnapshot:
+    """Captured audio state before disconnect for auto-recovery."""
+
+    rx_active: bool
+    tx_active: bool
+    pcm_mode: bool
+    pcm_rx_callback: "Callable[[bytes | None], None] | None"
+    opus_rx_callback: "Callable[[AudioPacket | None], None] | None"
+    pcm_params: tuple[int, int, int] | None
+    jitter_depth: int
 
 logger = logging.getLogger(__name__)
 
@@ -147,6 +176,8 @@ class IcomRadio:
         reconnect_delay: float = 2.0,
         reconnect_max_delay: float = 60.0,
         watchdog_timeout: float = 30.0,
+        auto_recover_audio: bool = True,
+        on_audio_recovery: "Callable[[AudioRecoveryState], None] | None" = None,
     ) -> None:
         self._host = host
         self._port = port
@@ -193,6 +224,12 @@ class IcomRadio:
         self._watchdog_task: asyncio.Task | None = None
         self._reconnect_task: asyncio.Task | None = None
         self._intentional_disconnect = False
+        self._auto_recover_audio = auto_recover_audio
+        self._on_audio_recovery = on_audio_recovery
+        self._pcm_rx_user_callback: Callable[[bytes | None], None] | None = None
+        self._pcm_rx_jitter_depth: int = 5
+        self._opus_rx_user_callback: Callable[[AudioPacket | None], None] | None = None
+        self._opus_rx_jitter_depth: int = 5
         self._scope_assembler: ScopeAssembler = ScopeAssembler()
         self._scope_callback: Callable[[ScopeFrame], Any] | None = None
         self._civ_rx_task: asyncio.Task[None] | None = None
@@ -353,6 +390,8 @@ class IcomRadio:
                 await self._audio_stream.stop_tx()
                 self._audio_stream = None
             self._pcm_tx_fmt = None
+            self._pcm_rx_user_callback = None
+            self._opus_rx_user_callback = None
             if self._audio_transport is not None:
                 try:
                     await self._send_audio_open_close(open_stream=False)
@@ -415,6 +454,8 @@ class IcomRadio:
         self._check_connected()
         await self._ensure_audio_transport()
         assert self._audio_stream is not None
+        self._opus_rx_user_callback = callback
+        self._opus_rx_jitter_depth = jitter_depth
         await self._audio_stream.start_rx(callback, jitter_depth=jitter_depth)
 
     async def start_audio_rx_pcm(
@@ -468,6 +509,8 @@ class IcomRadio:
             channels=channels,
             frame_ms=frame_ms,
         )
+        self._pcm_rx_user_callback = callback
+        self._pcm_rx_jitter_depth = jitter_depth
         await self.start_audio_rx_opus(
             self._build_pcm_rx_callback(
                 callback,
@@ -480,10 +523,12 @@ class IcomRadio:
 
     async def stop_audio_rx_pcm(self) -> None:
         """Stop receiving decoded PCM audio from the radio."""
+        self._pcm_rx_user_callback = None
         await self.stop_audio_rx_opus()
 
     async def stop_audio_rx_opus(self) -> None:
         """Stop receiving Opus audio from the radio."""
+        self._opus_rx_user_callback = None
         if self._audio_stream is not None:
             await self._audio_stream.stop_rx()
 
@@ -767,6 +812,93 @@ class IcomRadio:
     def audio_capabilities() -> AudioCapabilities:
         """Return icom-lan audio capabilities and deterministic defaults."""
         return get_audio_capabilities()
+
+    # ------------------------------------------------------------------
+    # Audio auto-recovery helpers
+    # ------------------------------------------------------------------
+
+    def _capture_audio_snapshot(self) -> _AudioSnapshot | None:
+        """Capture current audio state for recovery after reconnect.
+
+        Returns ``None`` if no audio stream is active.
+        """
+        if self._audio_stream is None:
+            return None
+
+        state = self._audio_stream.state
+        if state == AudioState.IDLE:
+            return None
+
+        rx_active = state in (AudioState.RECEIVING, AudioState.TRANSMITTING) and (
+            self._pcm_rx_user_callback is not None
+            or self._opus_rx_user_callback is not None
+        )
+        tx_active = state == AudioState.TRANSMITTING or self._pcm_tx_fmt is not None
+        pcm_mode = self._pcm_rx_user_callback is not None or self._pcm_tx_fmt is not None
+
+        # Determine PCM params from TX format or transcoder format.
+        pcm_params = self._pcm_tx_fmt or self._pcm_transcoder_fmt
+
+        jitter_depth = (
+            self._pcm_rx_jitter_depth
+            if self._pcm_rx_user_callback is not None
+            else self._opus_rx_jitter_depth
+        )
+
+        return _AudioSnapshot(
+            rx_active=rx_active,
+            tx_active=tx_active,
+            pcm_mode=pcm_mode,
+            pcm_rx_callback=self._pcm_rx_user_callback,
+            opus_rx_callback=self._opus_rx_user_callback,
+            pcm_params=pcm_params,
+            jitter_depth=jitter_depth,
+        )
+
+    async def _recover_audio(self, snapshot: _AudioSnapshot) -> None:
+        """Attempt to restart audio streams from a pre-disconnect snapshot.
+
+        Recovery failure is logged but does not raise.
+        """
+        if self._on_audio_recovery is not None:
+            self._on_audio_recovery(AudioRecoveryState.RECOVERING)
+
+        try:
+            if snapshot.rx_active:
+                if snapshot.pcm_mode and snapshot.pcm_rx_callback is not None:
+                    sr, ch, fms = snapshot.pcm_params or (48000, 1, 20)
+                    await self.start_audio_rx_pcm(
+                        snapshot.pcm_rx_callback,
+                        sample_rate=sr,
+                        channels=ch,
+                        frame_ms=fms,
+                        jitter_depth=snapshot.jitter_depth,
+                    )
+                elif snapshot.opus_rx_callback is not None:
+                    await self.start_audio_rx_opus(
+                        snapshot.opus_rx_callback,
+                        jitter_depth=snapshot.jitter_depth,
+                    )
+
+            if snapshot.tx_active:
+                if snapshot.pcm_mode and snapshot.pcm_params is not None:
+                    sr, ch, fms = snapshot.pcm_params
+                    await self.start_audio_tx_pcm(
+                        sample_rate=sr,
+                        channels=ch,
+                        frame_ms=fms,
+                    )
+                else:
+                    await self.start_audio_tx_opus()
+
+        except Exception as exc:
+            logger.warning("Audio auto-recovery failed: %s", exc)
+            if self._on_audio_recovery is not None:
+                self._on_audio_recovery(AudioRecoveryState.FAILED)
+            return
+
+        if self._on_audio_recovery is not None:
+            self._on_audio_recovery(AudioRecoveryState.RECOVERED)
 
     async def _ensure_audio_transport(self) -> None:
         """Connect the audio transport if not already connected."""
@@ -1074,6 +1206,8 @@ class IcomRadio:
                 logger.info("Reconnect attempt %d (delay=%.1fs)", attempt, delay)
                 try:
                     self._advance_civ_generation("reconnect-attempt")
+                    # Capture audio state for auto-recovery.
+                    audio_snapshot = self._capture_audio_snapshot()
                     # Clean up old transports
                     self._stop_token_renewal()
                     if self._audio_stream is not None:
@@ -1104,6 +1238,8 @@ class IcomRadio:
                     self._ctrl_transport = IcomTransport()
                     await self.connect()
                     logger.info("Reconnected successfully after %d attempts", attempt)
+                    if self._auto_recover_audio and audio_snapshot is not None:
+                        await self._recover_audio(audio_snapshot)
                     return
                 except Exception as exc:
                     logger.warning("Reconnect attempt %d failed: %s", attempt, exc)

--- a/tests/test_audio_recovery.py
+++ b/tests/test_audio_recovery.py
@@ -1,0 +1,451 @@
+"""Tests for auto-recovery of audio streams after reconnect (issue #7).
+
+Verifies that when the radio disconnects and reconnects, audio streams
+(RX/TX, PCM/Opus) are automatically restarted with the same callbacks
+and parameters. All radio I/O is mocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from icom_lan.audio import AudioPacket, AudioState, AudioStream
+from icom_lan.radio import AudioRecoveryState, IcomRadio, _AudioSnapshot
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_radio(**kwargs) -> IcomRadio:
+    """Build a connected IcomRadio with mocked internals."""
+    defaults = dict(
+        auto_reconnect=True,
+        reconnect_delay=0.05,
+        reconnect_max_delay=0.2,
+        watchdog_timeout=0.3,
+        auto_recover_audio=True,
+    )
+    defaults.update(kwargs)
+    radio = IcomRadio("192.168.1.100", **defaults)
+    mt = MagicMock()
+    mt.connect = AsyncMock()
+    mt.disconnect = AsyncMock()
+    mt.start_ping_loop = MagicMock()
+    mt.start_retransmit_loop = MagicMock()
+    mt._packet_queue = asyncio.Queue()
+    mt.ping_seq = 0
+    radio._ctrl_transport = mt
+    radio._civ_transport = MagicMock()
+    radio._civ_transport.disconnect = AsyncMock()
+    radio._connected = True
+    radio._token = 0x1234
+    return radio
+
+
+def _install_audio_stream(radio: IcomRadio) -> MagicMock:
+    """Install a mock AudioStream on the radio."""
+    stream = MagicMock(spec=AudioStream)
+    stream.start_rx = AsyncMock()
+    stream.stop_rx = AsyncMock()
+    stream.start_tx = AsyncMock()
+    stream.stop_tx = AsyncMock()
+    stream.push_tx = AsyncMock()
+    stream.state = AudioState.IDLE
+    radio._audio_stream = stream
+    radio._audio_transport = MagicMock()
+    radio._audio_transport.disconnect = AsyncMock()
+    return stream
+
+
+class _DummyTranscoder:
+    """Stub transcoder for PCM mode detection."""
+
+    def opus_to_pcm(self, opus: bytes) -> bytes:
+        return b"pcm:" + opus
+
+    def pcm_to_opus(self, pcm: bytes | bytearray | memoryview) -> bytes:
+        return b"opus:" + bytes(pcm)[:4]
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestAudioRecoveryConfig:
+
+    def test_default_auto_recover_true(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        assert radio._auto_recover_audio is True
+
+    def test_disable_auto_recover(self) -> None:
+        radio = IcomRadio("192.168.1.100", auto_recover_audio=False)
+        assert radio._auto_recover_audio is False
+
+    def test_on_audio_recovery_callback_stored(self) -> None:
+        cb = MagicMock()
+        radio = IcomRadio("192.168.1.100", on_audio_recovery=cb)
+        assert radio._on_audio_recovery is cb
+
+    def test_on_audio_recovery_default_none(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        assert radio._on_audio_recovery is None
+
+
+# ---------------------------------------------------------------------------
+# AudioRecoveryState enum
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestAudioRecoveryStateEnum:
+
+    def test_values(self) -> None:
+        assert AudioRecoveryState.RECOVERING.value == "recovering"
+        assert AudioRecoveryState.RECOVERED.value == "recovered"
+        assert AudioRecoveryState.FAILED.value == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot capture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestAudioSnapshotCapture:
+
+    def test_snapshot_idle_returns_none(self) -> None:
+        radio = _make_radio()
+        assert radio._capture_audio_snapshot() is None
+
+    def test_snapshot_no_stream_returns_none(self) -> None:
+        radio = _make_radio()
+        radio._audio_stream = None
+        assert radio._capture_audio_snapshot() is None
+
+    def test_snapshot_rx_pcm(self) -> None:
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.RECEIVING
+
+        cb = MagicMock()
+        radio._pcm_rx_user_callback = cb
+        radio._pcm_rx_jitter_depth = 7
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        snap = radio._capture_audio_snapshot()
+        assert snap is not None
+        assert snap.rx_active is True
+        assert snap.tx_active is False
+        assert snap.pcm_mode is True
+        assert snap.pcm_rx_callback is cb
+        assert snap.pcm_params == (48000, 1, 20)
+        assert snap.jitter_depth == 7
+
+    def test_snapshot_rx_opus(self) -> None:
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.RECEIVING
+
+        cb = MagicMock()
+        radio._opus_rx_user_callback = cb
+        radio._opus_rx_jitter_depth = 3
+
+        snap = radio._capture_audio_snapshot()
+        assert snap is not None
+        assert snap.rx_active is True
+        assert snap.pcm_mode is False
+        assert snap.opus_rx_callback is cb
+        assert snap.jitter_depth == 3
+
+    def test_snapshot_tx_pcm(self) -> None:
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.TRANSMITTING
+
+        radio._pcm_tx_fmt = (48000, 2, 20)
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 2, 20)
+
+        snap = radio._capture_audio_snapshot()
+        assert snap is not None
+        assert snap.tx_active is True
+        assert snap.pcm_mode is True
+        assert snap.pcm_params == (48000, 2, 20)
+
+    def test_snapshot_full_duplex_pcm(self) -> None:
+        """TRANSMITTING state with a stored PCM RX callback = full duplex."""
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.TRANSMITTING
+
+        rx_cb = MagicMock()
+        radio._pcm_rx_user_callback = rx_cb
+        radio._pcm_rx_jitter_depth = 5
+        radio._pcm_tx_fmt = (48000, 1, 20)
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        snap = radio._capture_audio_snapshot()
+        assert snap is not None
+        assert snap.rx_active is True
+        assert snap.tx_active is True
+        assert snap.pcm_mode is True
+        assert snap.pcm_rx_callback is rx_cb
+
+
+# ---------------------------------------------------------------------------
+# Recovery after reconnect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestAudioRecoveryAfterReconnect:
+
+    @pytest.mark.asyncio
+    async def test_rx_pcm_recovered(self) -> None:
+        """PCM RX should be restarted with same callback/params after reconnect."""
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.RECEIVING
+
+        rx_cb = MagicMock()
+        radio._pcm_rx_user_callback = rx_cb
+        radio._pcm_rx_jitter_depth = 7
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        with patch.object(radio, "connect", new_callable=AsyncMock) as mock_connect, \
+             patch.object(radio, "start_audio_rx_pcm", new_callable=AsyncMock) as mock_start:
+            mock_connect.return_value = None
+            radio._intentional_disconnect = False
+            await radio._reconnect_loop()
+
+        mock_start.assert_awaited_once_with(
+            rx_cb,
+            sample_rate=48000,
+            channels=1,
+            frame_ms=20,
+            jitter_depth=7,
+        )
+
+    @pytest.mark.asyncio
+    async def test_tx_pcm_recovered(self) -> None:
+        """PCM TX should be restarted after reconnect."""
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.TRANSMITTING
+
+        radio._pcm_tx_fmt = (48000, 1, 20)
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        with patch.object(radio, "connect", new_callable=AsyncMock) as mock_connect, \
+             patch.object(radio, "start_audio_tx_pcm", new_callable=AsyncMock) as mock_start:
+            mock_connect.return_value = None
+            radio._intentional_disconnect = False
+            await radio._reconnect_loop()
+
+        mock_start.assert_awaited_once_with(
+            sample_rate=48000,
+            channels=1,
+            frame_ms=20,
+        )
+
+    @pytest.mark.asyncio
+    async def test_full_duplex_recovered(self) -> None:
+        """Both RX and TX should be restarted after reconnect."""
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.TRANSMITTING
+
+        rx_cb = MagicMock()
+        radio._pcm_rx_user_callback = rx_cb
+        radio._pcm_rx_jitter_depth = 5
+        radio._pcm_tx_fmt = (48000, 1, 20)
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        with patch.object(radio, "connect", new_callable=AsyncMock), \
+             patch.object(radio, "start_audio_rx_pcm", new_callable=AsyncMock) as mock_rx, \
+             patch.object(radio, "start_audio_tx_pcm", new_callable=AsyncMock) as mock_tx:
+            await radio._reconnect_loop()
+
+        mock_rx.assert_awaited_once()
+        mock_tx.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_opus_rx_recovered(self) -> None:
+        """Opus RX should be restarted with same callback after reconnect."""
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.RECEIVING
+
+        opus_cb = MagicMock()
+        radio._opus_rx_user_callback = opus_cb
+        radio._opus_rx_jitter_depth = 3
+
+        with patch.object(radio, "connect", new_callable=AsyncMock), \
+             patch.object(radio, "start_audio_rx_opus", new_callable=AsyncMock) as mock_start:
+            await radio._reconnect_loop()
+
+        mock_start.assert_awaited_once_with(
+            opus_cb,
+            jitter_depth=3,
+        )
+
+    @pytest.mark.asyncio
+    async def test_recovery_disabled(self) -> None:
+        """With auto_recover_audio=False, audio should NOT restart."""
+        radio = _make_radio(auto_recover_audio=False)
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.RECEIVING
+
+        radio._pcm_rx_user_callback = MagicMock()
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        with patch.object(radio, "connect", new_callable=AsyncMock), \
+             patch.object(radio, "start_audio_rx_pcm", new_callable=AsyncMock) as mock_start:
+            await radio._reconnect_loop()
+
+        mock_start.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_recovery_callback_states(self) -> None:
+        """on_audio_recovery should be called with RECOVERING then RECOVERED."""
+        recovery_cb = MagicMock()
+        radio = _make_radio(on_audio_recovery=recovery_cb)
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.RECEIVING
+
+        radio._pcm_rx_user_callback = MagicMock()
+        radio._pcm_rx_jitter_depth = 5
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        with patch.object(radio, "connect", new_callable=AsyncMock), \
+             patch.object(radio, "start_audio_rx_pcm", new_callable=AsyncMock):
+            await radio._reconnect_loop()
+
+        assert recovery_cb.call_count == 2
+        recovery_cb.assert_any_call(AudioRecoveryState.RECOVERING)
+        recovery_cb.assert_any_call(AudioRecoveryState.RECOVERED)
+        # Verify order: RECOVERING first, then RECOVERED
+        calls = [c.args[0] for c in recovery_cb.call_args_list]
+        assert calls == [AudioRecoveryState.RECOVERING, AudioRecoveryState.RECOVERED]
+
+    @pytest.mark.asyncio
+    async def test_recovery_failure_logged_not_crashed(self, caplog) -> None:
+        """Recovery failure should log warning and emit FAILED, not crash."""
+        recovery_cb = MagicMock()
+        radio = _make_radio(on_audio_recovery=recovery_cb)
+        stream = _install_audio_stream(radio)
+        stream.state = AudioState.RECEIVING
+
+        radio._pcm_rx_user_callback = MagicMock()
+        radio._pcm_rx_jitter_depth = 5
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        with patch.object(radio, "connect", new_callable=AsyncMock), \
+             patch.object(
+                 radio, "start_audio_rx_pcm",
+                 new_callable=AsyncMock,
+                 side_effect=RuntimeError("audio port gone"),
+             ):
+            with caplog.at_level(logging.WARNING, logger="icom_lan.radio"):
+                await radio._reconnect_loop()
+
+        # Should not have crashed
+        assert any("audio" in r.message.lower() for r in caplog.records)
+        recovery_cb.assert_any_call(AudioRecoveryState.FAILED)
+
+    @pytest.mark.asyncio
+    async def test_no_audio_active_skips_recovery(self) -> None:
+        """If no audio was active, recovery should be skipped entirely."""
+        recovery_cb = MagicMock()
+        radio = _make_radio(on_audio_recovery=recovery_cb)
+        # No audio stream installed
+
+        with patch.object(radio, "connect", new_callable=AsyncMock):
+            await radio._reconnect_loop()
+
+        recovery_cb.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_intentional_disconnect_clears_callbacks(self) -> None:
+        """disconnect() should clear stored callbacks."""
+        radio = _make_radio()
+        radio._pcm_rx_user_callback = MagicMock()
+        radio._opus_rx_user_callback = MagicMock()
+
+        await radio.disconnect()
+
+        assert radio._pcm_rx_user_callback is None
+        assert radio._opus_rx_user_callback is None
+
+
+# ---------------------------------------------------------------------------
+# Callback storage at start time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestCallbackStorageAtStart:
+
+    @pytest.mark.asyncio
+    async def test_start_audio_rx_pcm_stores_callback(self) -> None:
+        """start_audio_rx_pcm should store the user callback on the radio."""
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
+        radio._pcm_transcoder_fmt = (48000, 1, 20)
+
+        cb = MagicMock()
+        await radio.start_audio_rx_pcm(cb, jitter_depth=7)
+
+        assert radio._pcm_rx_user_callback is cb
+        assert radio._pcm_rx_jitter_depth == 7
+
+    @pytest.mark.asyncio
+    async def test_stop_audio_rx_pcm_clears_callback(self) -> None:
+        """stop_audio_rx_pcm should clear the stored callback."""
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        radio._pcm_rx_user_callback = MagicMock()
+
+        await radio.stop_audio_rx_pcm()
+
+        assert radio._pcm_rx_user_callback is None
+
+    @pytest.mark.asyncio
+    async def test_start_audio_rx_opus_stores_callback(self) -> None:
+        """start_audio_rx_opus should store the callback on the radio."""
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+
+        cb = MagicMock()
+        await radio.start_audio_rx_opus(cb, jitter_depth=3)
+
+        assert radio._opus_rx_user_callback is cb
+        assert radio._opus_rx_jitter_depth == 3
+
+    @pytest.mark.asyncio
+    async def test_stop_audio_rx_opus_clears_callback(self) -> None:
+        """stop_audio_rx_opus should clear the stored callback."""
+        radio = _make_radio()
+        stream = _install_audio_stream(radio)
+        radio._opus_rx_user_callback = MagicMock()
+
+        await radio.stop_audio_rx_opus()
+
+        assert radio._opus_rx_user_callback is None


### PR DESCRIPTION
## Summary

Implements automatic audio stream recovery after reconnection (issue #7).

### Changes
- **radio.py**: Snapshot audio state before reconnect, restore after `connect()`, callback states (`recovering`/`recovered`/`failed`)
- **__init__.py**: Export `AudioRecoveryState`
- **tests/test_audio_recovery.py**: 24 new tests, all passing

### Details
- Recovery is best-effort — no crashes on failure
- Backward compatible: `auto_recover_audio=True` by default
- Pre-existing flaky test in `test_radio.py::TestScopeCallbackSafety` is unrelated

Closes #7