### PR TITLE
fix: fix flaky test_soft_reconnect_handles_connect_failure

### DIFF
--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -1383,10 +1383,8 @@ async def test_soft_reconnect_calls_on_reconnect_callback(
     assert reconnect_called[0]
 
 
-@pytest.mark.skip(reason="Flaky in CI: mock doesn't prevent real IcomTransport.connect() retry loop. Passes locally.")
 async def test_soft_reconnect_handles_connect_failure(radio: IcomRadio) -> None:
     """soft_reconnect() raises ConnectionError when transport.connect() fails (lines 444-447)."""
-    from icom_lan.exceptions import TimeoutError as IcomTimeout
     from icom_lan.transport import IcomTransport
 
     radio._civ_transport = None
@@ -1394,12 +1392,12 @@ async def test_soft_reconnect_handles_connect_failure(radio: IcomRadio) -> None:
 
     # Patch IcomTransport constructor to return a mock that fails on connect
     async def failing_connect(*args, **kwargs):
-        raise IcomTimeout("discovery failed")
-    
+        raise OSError("connection refused")
+
     fake_transport = AsyncMock(spec=IcomTransport)
     fake_transport.connect = failing_connect
 
-    with patch("icom_lan.radio.IcomTransport", return_value=fake_transport):
+    with patch("icom_lan._control_phase.IcomTransport", return_value=fake_transport):
         with pytest.raises(ConnectionError, match="Failed to reconnect CI-V"):
             await radio.soft_reconnect()
 


### PR DESCRIPTION
## Summary
Fixes flaky test `test_soft_reconnect_handles_connect_failure` by correcting mock patch target and exception type.

## Changes
- **Patch correct module**: `icom_lan._control_phase.IcomTransport` (not `icom_lan.radio`)
  - `soft_reconnect()` lives in `_control_phase.py` and imports `IcomTransport` there
- **Raise OSError** (not `IcomTimeout`) so `soft_reconnect()` catches it
  - `soft_reconnect()` catches `OSError` on line 445-447
- **Remove `@pytest.mark.skip` decorator**

## Root Cause
1. **Wrong patch target**: Test patched `icom_lan.radio.IcomTransport`, but `soft_reconnect()` imports from `_control_phase`
2. **Wrong exception type**: Mock raised `IcomTimeout` (extends `Exception`), which passed through uncaught, bypassing `ConnectionError` wrapping

## Verification
✅ 10/10 local runs passed (previously flaky in CI)

```bash
pytest tests/test_radio_coverage.py::test_soft_reconnect_handles_connect_failure -v --tb=short -x
```

Closes #229