### PR TITLE
fix: Correct FTX-1 CAT command formats (SH, ML, BS) (#378)

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -235,8 +235,11 @@ get_vfo_select = { cat = { read = "VS;", parse = "VS{vfo};" } }
 set_vfo_select = { cat = { write = "VS{vfo};" } }
 vfo_a_to_b     = { cat = { write = "AB;" } }
 vfo_b_to_a     = { cat = { write = "BA;" } }
-get_band       = { cat = { read = "BS0;", parse = "BS0{band:02d};" } }
+# BS: FTX-1 does NOT support BS read (returns ?;)
+# Band select is write-only. BD/BU are fire-and-forget (no response).
+# BS format: BS + P1(rx 0/1) + P2P2(band 00-14)
 set_band       = { cat = { write = "BS0{band:02d};" } }
+set_band_sub   = { cat = { write = "BS1{band:02d};" } }
 band_up        = { cat = { write = "BU0;" } }
 band_down      = { cat = { write = "BD0;" } }
 
@@ -264,8 +267,13 @@ get_rf_gain    = { cat = { read = "RG0;", parse = "RG0{level:03d};" } }
 set_rf_gain    = { cat = { write = "RG0{level:03d};" } }
 get_squelch    = { cat = { read = "SQ0;", parse = "SQ0{level:03d};" } }
 set_squelch    = { cat = { write = "SQ0{level:03d};" } }
-get_monitor_level = { cat = { read = "ML;", parse = "ML{level:03d};" } }
-set_monitor_level = { cat = { write = "ML{level:03d};" } }
+# ML: P1=0 (MONI ON/OFF), P1=1 (MONI Level)
+# ML0; → ML0000 (OFF) or ML0001 (ON)
+# ML1; → ML1050 (level=50)
+get_monitor_on     = { cat = { read = "ML0;", parse = "ML0{level:03d};" } }
+set_monitor_on     = { cat = { write = "ML0{level:03d};" } }
+get_monitor_level  = { cat = { read = "ML1;", parse = "ML1{level:03d};" } }
+set_monitor_level  = { cat = { write = "ML1{level:03d};" } }
 
 # ── RF Front End ──
 get_attenuator = { cat = { read = "RA0;", parse = "RA0{state};" } }
@@ -290,10 +298,13 @@ get_agc        = { cat = { read = "GT0;", parse = "GT0{mode};" } }
 set_agc        = { cat = { write = "GT0{mode};" } }
 
 # ── Filter / IF ──
-get_filter_width = { cat = { read = "SH00;", parse = "SH00{value:02d};" } }
-set_filter_width = { cat = { write = "SH00{value:02d};" } }
-get_filter_shift = { cat = { read = "SH01;", parse = "SH01{value:02d};" } }
-set_filter_shift = { cat = { write = "SH01{value:02d};" } }
+# SH: P1=rx (0=MAIN,1=SUB), P2P2P2=value (3 digits)
+# SH0; reads MAIN width, SH1; reads SUB width
+# Response: SH0020 = MAIN, value 020
+get_filter_width = { cat = { read = "SH0;", parse = "SH0{level:03d};" } }
+set_filter_width = { cat = { write = "SH0{level:03d};" } }
+get_filter_width_sub = { cat = { read = "SH1;", parse = "SH1{level:03d};" } }
+set_filter_width_sub = { cat = { write = "SH1{level:03d};" } }
 get_if_shift   = { cat = { read = "IS0;", parse = "IS00{sign}{offset:04d};" } }
 set_if_shift   = { cat = { write = "IS00{sign}{offset:04d};" } }
 get_narrow     = { cat = { read = "NA0;", parse = "NA0{state};" } }

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -568,22 +568,22 @@ class YaesuCatRadio:
     # -- D4: Filters --------------------------------------------------------
 
     async def get_filter_width(self, receiver: int = 0) -> int:
-        """Get filter width index (SH00)."""
-        result = await self._query("get_filter_width")
-        return result["value"]
+        """Get filter width index (SH0/SH1).
+
+        Args:
+            receiver: 0=MAIN, 1=SUB.
+
+        Returns:
+            Width index (0-255, mode-dependent mapping).
+        """
+        cmd = "get_filter_width" if receiver == 0 else "get_filter_width_sub"
+        result = await self._query(cmd)
+        return result["level"]
 
     async def set_filter_width(self, value: int, receiver: int = 0) -> None:
-        """Set filter width index (SH00)."""
-        await self._write("set_filter_width", value=value)
-
-    async def get_filter_shift(self, receiver: int = 0) -> int:
-        """Get filter shift index (SH01)."""
-        result = await self._query("get_filter_shift")
-        return result["value"]
-
-    async def set_filter_shift(self, value: int, receiver: int = 0) -> None:
-        """Set filter shift index (SH01)."""
-        await self._write("set_filter_shift", value=value)
+        """Set filter width index (SH0/SH1)."""
+        cmd = "set_filter_width" if receiver == 0 else "set_filter_width_sub"
+        await self._write(cmd, level=value)
 
     async def get_if_shift(self, receiver: int = 0) -> int:
         """Get IF shift offset in Hz (signed, IS0).
@@ -702,13 +702,22 @@ class YaesuCatRadio:
         """Set processor level (0–3)."""
         await self._write("set_processor_level", level=level)
 
+    async def get_monitor_on(self) -> bool:
+        """Get monitor ON/OFF state (ML0)."""
+        result = await self._query("get_monitor_on")
+        return result["level"] != 0
+
+    async def set_monitor_on(self, state: bool) -> None:
+        """Set monitor ON/OFF (ML0)."""
+        await self._write("set_monitor_on", level=1 if state else 0)
+
     async def get_monitor_level(self) -> int:
-        """Get monitor level (0–255)."""
+        """Get monitor level (0–100, ML1)."""
         result = await self._query("get_monitor_level")
         return result["level"]
 
     async def set_monitor_level(self, level: int) -> None:
-        """Set monitor level (0–255)."""
+        """Set monitor level (0–100, ML1)."""
         await self._write("set_monitor_level", level=level)
 
     # -- D7: CW -------------------------------------------------------------
@@ -845,14 +854,16 @@ class YaesuCatRadio:
         """Set dial lock state."""
         await self._write("set_lock", state="1" if state else "0")
 
-    async def get_band(self, receiver: int = 0) -> int:
-        """Get current band index (BS0)."""
-        result = await self._query("get_band")
-        return result["band"]
-
     async def set_band(self, band: int, receiver: int = 0) -> None:
-        """Set current band by index (BS0)."""
-        await self._write("set_band", band=band)
+        """Set current band by index (BS, write-only on FTX-1).
+
+        Note: FTX-1 does not support BS read (returns ?;).
+        Band values: 00=1.8M, 01=3.5M, 02=5M, 03=7M, 04=10M,
+        05=14M, 06=18M, 07=21M, 08=24.5M, 09=28M, 10=50M,
+        11=70M/GEN, 12=AIR, 13=144M, 14=430M.
+        """
+        cmd = "set_band" if receiver == 0 else "set_band_sub"
+        await self._write(cmd, band=band)
 
     async def band_up(self, receiver: int = 0) -> None:
         """Step up one band (BU0)."""


### PR DESCRIPTION
## Hardware Smoke Test Results

**Before fix:** 25/27 (93%) — SH, ML, BS returned `?;`
**After fix:** 28/28 (100%) 🎉

### Fixed Commands

| Command | Before (wrong) | After (correct) | Issue |
|---------|----------------|-----------------|-------|
| SH (Filter) | `SH00;` read | `SH0;` read → `SH0020` | P1=rx only, 3-digit value |
| ML (Monitor) | `ML;` read | `ML0;` / `ML1;` | P1 mandatory (0=ON/OFF, 1=Level) |
| BS (Band) | `BS0;` read | write-only | FTX-1 doesn't support BS read |

### All 28 Tests Passed on Live FTX-1:
- ✅ ID, Freq get/set, Mode, PTT, S-meter
- ✅ AF/RF gain, Squelch, ATT, Preamp
- ✅ NB, NR, Auto Notch
- ✅ **Filter Width** (fixed!)
- ✅ VFO, Split, Power, Mic gain
- ✅ **Monitor ON/OFF + Level** (fixed!)
- ✅ Keyer speed, Clarifier, AGC, Lock, Auto-info
- ✅ **Band Select write** (fixed!)

Closes #378