### PR TITLE
feat: Audio FFT Scope — IF waterfall from USB audio stream (#383)

### DIFF
--- a/.rag-update.sh
+++ b/.rag-update.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+cd /Users/moroz/Projects/icom-lan || exit 1
+
+# Find and re-ingest all modified files in last 24h
+find docs/ src/ frontend/src -type f \( -name '*.md' -o -name '*.py' -o -name '*.ts' -o -name '*.svelte' \) \
+  ! -path '*/node_modules/*' \
+  ! -path '*/__pycache__/*' \
+  ! -path '*/.venv/*' \
+  ! -path '*/__tests__/*' \
+  ! -name '*.test.*' \
+  ! -name '*.spec.*' \
+  -mtime -1 2>/dev/null | while read f; do
+    mcporter call local-rag.ingest_file filePath="$(pwd)/$f" 2>&1 | grep -q '"success":true' && echo "✓ $f" || echo "✗ $f"
+done
+
+# Print final status
+echo "---"
+mcporter call local-rag.status 2>&1 | grep -o '"documentCount":[0-9]*,"chunkCount":[0-9]*'

--- a/config/mcporter.json
+++ b/config/mcporter.json
@@ -1,0 +1,1 @@
+/Users/moroz/clawd/config/mcporter.json

--- a/src/icom_lan/audio_fft_scope.py
+++ b/src/icom_lan/audio_fft_scope.py
@@ -1,0 +1,278 @@
+"""Audio FFT Scope — derive IF panadapter from RX audio PCM stream.
+
+Performs real-time FFT on audio PCM data to generate :class:`ScopeFrame`
+objects compatible with the existing spectrum/waterfall display pipeline.
+
+Typical bandwidth is ±24 kHz (48 kHz sample rate) centered on the current
+VFO frequency, showing signals within the receiver passband.
+
+Usage::
+
+    scope = AudioFftScope(fft_size=2048, fps=20)
+    scope.set_center_freq(14_074_000)
+    scope.on_frame(my_callback)
+
+    # In audio RX callback:
+    scope.feed_audio(pcm_bytes)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Callable
+
+from .scope import ScopeFrame
+
+__all__ = ["AudioFftScope"]
+
+_log = logging.getLogger(__name__)
+
+# Scope mode: center (matches SpectrumPanel expected mode)
+_SCOPE_MODE_CENTER = 0
+
+# Amplitude mapping: FFT dB range → 0-160 pixel range (ScopeFrame convention)
+_PIXEL_MAX = 160
+_DB_FLOOR = -120.0  # noise floor dB
+_DB_CEIL = 0.0  # clipping level dB
+
+
+def _import_numpy():
+    """Lazy-import numpy to avoid hard dependency at module level."""
+    try:
+        import numpy as np
+
+        return np
+    except ImportError:
+        raise ImportError(
+            "Audio FFT scope requires numpy. Install with: pip install numpy"
+        ) from None
+
+
+class AudioFftScope:
+    """Real-time FFT scope derived from audio PCM stream.
+
+    Consumes 16-bit signed mono PCM audio frames and produces
+    :class:`ScopeFrame` objects at a configurable frame rate.
+
+    Args:
+        fft_size: FFT window size in samples. Power of 2 recommended.
+            Larger = better frequency resolution, more latency.
+            1024 → ~47 Hz/bin, 2048 → ~23 Hz/bin, 4096 → ~12 Hz/bin.
+        fps: Target scope frames per second (default 20).
+        window: Window function name ('hann', 'blackman', 'hamming').
+        avg_count: Number of FFT frames to average for smoothing (1 = no averaging).
+        sample_rate: Audio sample rate in Hz (default 48000).
+    """
+
+    def __init__(
+        self,
+        fft_size: int = 2048,
+        fps: int = 20,
+        window: str = "hann",
+        avg_count: int = 4,
+        sample_rate: int = 48000,
+    ) -> None:
+        np = _import_numpy()
+        self._np = np
+
+        self._fft_size = fft_size
+        self._fps = max(1, fps)
+        self._avg_count = max(1, avg_count)
+        self._sample_rate = sample_rate
+        self._center_freq: int = 0
+        self._callback: Callable[[ScopeFrame], None] | None = None
+
+        # Pre-compute window function
+        self._window = self._make_window(window, fft_size)
+
+        # Audio sample accumulation buffer (float32)
+        self._buf = np.zeros(0, dtype=np.float32)
+
+        # Rolling average buffer
+        self._avg_buf: list[object] = []  # list of numpy arrays
+
+        # Frame rate limiting
+        self._min_interval = 1.0 / self._fps
+        self._last_frame_time: float = 0.0
+
+        # Sequence counter
+        self._seq: int = 0
+
+        _log.info(
+            "AudioFftScope: fft_size=%d fps=%d window=%s avg=%d sr=%d",
+            fft_size,
+            fps,
+            window,
+            avg_count,
+            sample_rate,
+        )
+
+    def _make_window(self, name: str, size: int):
+        """Create a numpy window function array."""
+        np = self._np
+        windows = {
+            "hann": np.hanning,
+            "blackman": np.blackman,
+            "hamming": np.hamming,
+        }
+        fn = windows.get(name)
+        if fn is None:
+            _log.warning("Unknown window '%s', using hann", name)
+            fn = np.hanning
+        return fn(size).astype(np.float32)
+
+    def set_center_freq(self, freq_hz: int) -> None:
+        """Update the VFO center frequency for RF mapping.
+
+        Args:
+            freq_hz: Center frequency in Hz.
+        """
+        self._center_freq = freq_hz
+
+    def set_sample_rate(self, rate: int) -> None:
+        """Update the audio sample rate.
+
+        Args:
+            rate: Sample rate in Hz (e.g. 48000).
+        """
+        if rate != self._sample_rate:
+            self._sample_rate = rate
+            self._window = self._make_window("hann", self._fft_size)
+            self._buf = self._np.zeros(0, dtype=self._np.float32)
+            self._avg_buf.clear()
+            _log.info("AudioFftScope: sample rate changed to %d", rate)
+
+    def on_frame(self, callback: Callable[[ScopeFrame], None] | None) -> None:
+        """Register or unregister scope frame callback.
+
+        Args:
+            callback: Function receiving :class:`ScopeFrame`, or None to unregister.
+        """
+        self._callback = callback
+
+    def feed_audio(self, pcm_data: bytes) -> None:
+        """Feed raw PCM16 mono audio data.
+
+        Called from audio RX callback. Non-blocking — FFT is computed
+        inline since numpy FFT on 2048 samples takes <0.1ms.
+
+        Args:
+            pcm_data: Raw 16-bit signed little-endian mono PCM bytes.
+        """
+        if self._callback is None:
+            return
+
+        np = self._np
+
+        # Convert PCM16 bytes to float32 [-1.0, 1.0]
+        samples = np.frombuffer(pcm_data, dtype=np.int16).astype(np.float32) / 32768.0
+
+        # Append to accumulation buffer
+        self._buf = np.concatenate([self._buf, samples])
+
+        # Process as many complete FFT windows as available
+        while len(self._buf) >= self._fft_size:
+            now = time.monotonic()
+            if now - self._last_frame_time < self._min_interval:
+                # Frame rate limit: skip this window
+                self._buf = self._buf[self._fft_size :]
+                continue
+
+            chunk = self._buf[: self._fft_size]
+            self._buf = self._buf[self._fft_size :]
+            self._process_chunk(chunk, now)
+
+    def _process_chunk(self, chunk, now: float) -> None:
+        """Perform FFT on one window and emit a ScopeFrame."""
+        np = self._np
+        callback = self._callback
+        if callback is None:
+            return
+
+        # Apply window function
+        windowed = chunk * self._window
+
+        # Real FFT → positive frequencies only
+        spectrum = np.fft.rfft(windowed)
+        magnitudes = np.abs(spectrum)
+
+        # Avoid log(0)
+        magnitudes = np.maximum(magnitudes, 1e-10)
+
+        # Convert to dB (normalized to FFT size)
+        db = 20.0 * np.log10(magnitudes / self._fft_size)
+
+        # Rolling average
+        self._avg_buf.append(db)
+        if len(self._avg_buf) > self._avg_count:
+            self._avg_buf = self._avg_buf[-self._avg_count :]
+
+        if len(self._avg_buf) > 1:
+            avg_db = np.mean(np.stack(self._avg_buf), axis=0)
+        else:
+            avg_db = db
+
+        # Map dB to pixel values (0-160)
+        # Linear mapping: _DB_FLOOR → 0, _DB_CEIL → _PIXEL_MAX
+        db_range = _DB_CEIL - _DB_FLOOR
+        pixels_float = (avg_db - _DB_FLOOR) / db_range * _PIXEL_MAX
+        pixels_uint8 = np.clip(pixels_float, 0, _PIXEL_MAX).astype(np.uint8)
+
+        # rfft produces fft_size//2 + 1 bins from DC to Nyquist.
+        # Bin 0 = DC (center freq), bin N = Nyquist (+sample_rate/2).
+        # We want a symmetric display: -Nyquist ... DC ... +Nyquist
+        # Mirror: [N..1] + [0..N] = full symmetric spectrum
+        positive = pixels_uint8[1:]  # skip DC
+        negative = positive[::-1]  # mirror
+        dc = pixels_uint8[0:1]
+        symmetric = np.concatenate([negative, dc, positive])
+
+        # RF frequency mapping
+        half_bw = self._sample_rate // 2
+        start_freq = self._center_freq - half_bw
+        end_freq = self._center_freq + half_bw
+
+        frame = ScopeFrame(
+            receiver=0,
+            mode=_SCOPE_MODE_CENTER,
+            start_freq_hz=start_freq,
+            end_freq_hz=end_freq,
+            pixels=bytes(symmetric),
+            out_of_range=False,
+        )
+
+        self._last_frame_time = now
+        self._seq += 1
+
+        try:
+            callback(frame)
+        except Exception:
+            _log.exception("AudioFftScope: frame callback error")
+
+    def stop(self) -> None:
+        """Stop the scope and clear buffers."""
+        self._callback = None
+        self._buf = self._np.zeros(0, dtype=self._np.float32)
+        self._avg_buf.clear()
+        _log.info("AudioFftScope stopped")
+
+    @property
+    def fft_size(self) -> int:
+        """Current FFT window size."""
+        return self._fft_size
+
+    @property
+    def fps(self) -> int:
+        """Target frames per second."""
+        return self._fps
+
+    @property
+    def bin_count(self) -> int:
+        """Number of pixels in output (symmetric spectrum)."""
+        return self._fft_size  # rfft gives fft_size//2+1, symmetric = 2*(N/2) + 1 ≈ N
+
+    @property
+    def frequency_resolution(self) -> float:
+        """Frequency resolution per bin in Hz."""
+        return self._sample_rate / self._fft_size

--- a/src/icom_lan/web/handlers.py
+++ b/src/icom_lan/web/handlers.py
@@ -12,7 +12,7 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 
 from .._audio_buffer_pool import AudioBufferPool
 from .._audio_codecs import decode_ulaw_to_pcm16
@@ -1246,6 +1246,8 @@ class AudioBroadcaster:
         self._sample_rate: int = 48000
         self._channels: int = 1
         self._lock = asyncio.Lock()
+        # PCM tap for audio FFT scope (called with decoded PCM16 bytes)
+        self._pcm_tap: Callable[[bytes], None] | None = None
         # Buffer pool for audio encoding/decoding operations
         # Pre-allocates buffers for common audio frame sizes (20ms @ 16kHz stereo = 1280 bytes)
         self._buffer_pool = AudioBufferPool(buffer_size=1280, max_buffers=5, name="audio-broadcaster")
@@ -1274,6 +1276,18 @@ class AudioBroadcaster:
             if not self._clients and self._subscription is not None:
                 await self._stop_relay()
         logger.info("audio-broadcaster: client removed (total=%d)", len(self._clients))
+
+    def set_pcm_tap(self, callback: "Callable[[bytes], None] | None") -> None:
+        """Register a tap that receives decoded PCM16 audio data.
+
+        Used by AudioFftScope to derive spectrum from audio stream.
+        The callback is called synchronously in the relay loop with
+        PCM16 mono/stereo bytes after any codec decoding.
+
+        Args:
+            callback: Function receiving PCM16 bytes, or None to unregister.
+        """
+        self._pcm_tap = callback
 
     def reap_dead_clients(self) -> int:
         """Remove clients whose WebSocket is no longer alive. Returns count removed."""
@@ -1380,6 +1394,14 @@ class AudioBroadcaster:
                         )
                         # Fall back to original data
                         audio_data = pkt.data
+
+                # Tee PCM data to audio FFT scope if registered
+                pcm_tap = self._pcm_tap
+                if pcm_tap is not None and self._web_codec == AUDIO_CODEC_PCM16:
+                    try:
+                        pcm_tap(audio_data)
+                    except Exception:
+                        logger.debug("audio: pcm_tap error", exc_info=True)
 
                 frame = encode_audio_frame(
                     MSG_TYPE_AUDIO_RX,

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -31,7 +31,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from .. import __version__
 from ..radio_state import RadioState
-from ..radio_protocol import AudioCapable, PowerControlCapable
+from ..radio_protocol import AudioCapable, PowerControlCapable, ScopeCapable
+from ..audio_fft_scope import AudioFftScope
 from ._delta_encoder import DeltaEncoder
 from .dx_cluster import DXClusterClient, SpotBuffer
 from .handlers import AudioBroadcaster, AudioHandler, ControlHandler, ScopeHandler
@@ -237,6 +238,13 @@ class WebServer:
             raw_radio_state if isinstance(raw_radio_state, RadioState) else RadioState()
         )
         self._audio_broadcaster = AudioBroadcaster(radio)
+        # Audio FFT scope: auto-enable when radio has audio but no hardware scope
+        self._audio_fft_scope: AudioFftScope | None = None
+        if radio is not None and isinstance(radio, AudioCapable) and not isinstance(radio, ScopeCapable):
+            self._audio_fft_scope = AudioFftScope(fft_size=2048, fps=20, avg_count=4)
+            self._audio_fft_scope.on_frame(self._broadcast_scope)
+            self._audio_broadcaster.set_pcm_tap(self._audio_fft_scope.feed_audio)
+            logger.info("Audio FFT scope enabled (no hardware scope, audio available)")
         self._command_queue: CommandQueue = CommandQueue()
         self._radio_poller: RadioPoller | None = None
         # Control handler event queues
@@ -326,11 +334,20 @@ class WebServer:
         """Register a scope handler and enable scope on radio if needed.
 
         Scope enable goes through the RadioPoller command queue to avoid
-        concurrent CI-V access.
+        concurrent CI-V access.  For audio FFT scope, no hardware enable
+        is needed — frames are generated from the audio stream.
         """
         async with self._scope_enable_lock:
             self._scope_handlers.add(handler)
             if self._radio is not None:
+                # Audio FFT scope: no hardware enable needed, just register handler
+                if self._audio_fft_scope is not None:
+                    logger.info(
+                        "scope: audio FFT scope active (%d handlers)",
+                        len(self._scope_handlers),
+                    )
+                    self._update_fft_scope_freq()
+                    return
                 if not _supports_scope(self._radio):
                     logger.info(
                         "scope: active radio does not expose runtime scope support"
@@ -397,6 +414,16 @@ class WebServer:
         # Scope health: track whether frames carry real data
         self._scope_health_check(frame)
 
+    def _update_fft_scope_freq(self) -> None:
+        """Sync AudioFftScope center frequency from current radio state."""
+        if self._audio_fft_scope is None:
+            return
+        main = getattr(self._radio_state, "main", None)
+        if main is not None:
+            freq = getattr(main, "freq", 0)
+            if isinstance(freq, int) and freq > 0:
+                self._audio_fft_scope.set_center_freq(freq)
+
     # ------------------------------------------------------------------
     # RadioPoller integration
     # ------------------------------------------------------------------
@@ -435,6 +462,9 @@ class WebServer:
         if now - self._last_state_broadcast < 0.05:
             return
         self._last_state_broadcast = now
+
+        # Keep audio FFT scope center freq in sync with VFO
+        self._update_fft_scope_freq()
 
         body = self.build_public_state()
 
@@ -1316,10 +1346,16 @@ class WebServer:
                     profile.data_mode_labels if profile.data_mode_labels else {}
                 ),
                 "keyboard": _serialize_keyboard_config(profile),
+                "scopeSource": (
+                    "audio_fft" if self._audio_fft_scope is not None
+                    else ("hardware" if "scope" in caps else None)
+                ),
                 "scopeConfig": {
                     "centerMode": True,
                     "amplitudeMax": 160,
-                    "defaultSpan": 500000,
+                    "defaultSpan": (
+                        48000 if self._audio_fft_scope is not None else 500000
+                    ),
                 },
                 "audioConfig": {
                     "sampleRate": 48000,

--- a/tests/test_audio_fft_scope.py
+++ b/tests/test_audio_fft_scope.py
@@ -1,0 +1,391 @@
+"""Tests for AudioFftScope — audio-based IF panadapter."""
+
+from __future__ import annotations
+
+import struct
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from icom_lan.audio_fft_scope import AudioFftScope
+from icom_lan.scope import ScopeFrame
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_pcm_tone(freq_hz: float, duration_s: float, sample_rate: int = 48000) -> bytes:
+    """Generate PCM16 mono sine wave at given frequency."""
+    t = np.arange(int(sample_rate * duration_s)) / sample_rate
+    samples = (np.sin(2 * np.pi * freq_hz * t) * 16000).astype(np.int16)
+    return samples.tobytes()
+
+
+def _make_pcm_silence(num_samples: int) -> bytes:
+    """Generate PCM16 mono silence."""
+    return b"\x00\x00" * num_samples
+
+
+def _make_pcm_noise(num_samples: int, amplitude: int = 1000) -> bytes:
+    """Generate PCM16 mono white noise."""
+    rng = np.random.default_rng(42)
+    samples = (rng.uniform(-1, 1, num_samples) * amplitude).astype(np.int16)
+    return samples.tobytes()
+
+
+# ── Basic construction ───────────────────────────────────────────────────────
+
+
+class TestAudioFftScopeConstruction:
+    """Test AudioFftScope initialization and configuration."""
+
+    def test_default_construction(self):
+        scope = AudioFftScope()
+        assert scope.fft_size == 2048
+        assert scope.fps == 20
+
+    def test_custom_params(self):
+        scope = AudioFftScope(fft_size=4096, fps=30, window="blackman", avg_count=8)
+        assert scope.fft_size == 4096
+        assert scope.fps == 30
+
+    def test_frequency_resolution(self):
+        scope = AudioFftScope(fft_size=2048, sample_rate=48000)
+        assert scope.frequency_resolution == pytest.approx(48000 / 2048, rel=1e-6)
+
+    def test_set_center_freq(self):
+        scope = AudioFftScope()
+        scope.set_center_freq(14_074_000)
+        # No error, center freq stored internally
+
+    def test_set_sample_rate(self):
+        scope = AudioFftScope()
+        scope.set_sample_rate(44100)
+        assert scope.frequency_resolution == pytest.approx(44100 / 2048, rel=1e-6)
+
+
+# ── Frame generation ────────────────────────────────────────────────────────
+
+
+class TestAudioFftScopeFrames:
+    """Test that AudioFftScope produces valid ScopeFrame objects."""
+
+    def test_produces_scope_frame(self):
+        """Feed enough audio to produce at least one frame."""
+        scope = AudioFftScope(fft_size=1024, fps=100, avg_count=1)
+        scope.set_center_freq(14_074_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        # Feed 2x fft_size samples to ensure at least one frame
+        pcm = _make_pcm_tone(1000.0, duration_s=1024 * 2 / 48000)
+        scope.feed_audio(pcm)
+
+        assert len(frames) >= 1
+        frame = frames[0]
+        assert isinstance(frame, ScopeFrame)
+        assert frame.receiver == 0
+        assert frame.mode == 0  # center
+        assert frame.out_of_range is False
+
+    def test_scope_frame_frequency_mapping(self):
+        """Verify start/end freq mapped correctly from center freq."""
+        scope = AudioFftScope(fft_size=1024, fps=100, avg_count=1, sample_rate=48000)
+        scope.set_center_freq(14_074_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        pcm = _make_pcm_tone(1000.0, duration_s=1024 * 2 / 48000)
+        scope.feed_audio(pcm)
+
+        assert len(frames) >= 1
+        frame = frames[0]
+        assert frame.start_freq_hz == 14_074_000 - 24_000
+        assert frame.end_freq_hz == 14_074_000 + 24_000
+
+    def test_pixel_range(self):
+        """All pixels should be in 0-160 range."""
+        scope = AudioFftScope(fft_size=1024, fps=100, avg_count=1)
+        scope.set_center_freq(7_000_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        pcm = _make_pcm_noise(1024 * 3, amplitude=5000)
+        scope.feed_audio(pcm)
+
+        assert len(frames) >= 1
+        for frame in frames:
+            for px in frame.pixels:
+                assert 0 <= px <= 160, f"pixel {px} out of range"
+
+    def test_symmetric_pixel_count(self):
+        """Output should be symmetric: 2 * (fft_size/2) + 1 pixels."""
+        fft_size = 1024
+        scope = AudioFftScope(fft_size=fft_size, fps=100, avg_count=1)
+        scope.set_center_freq(7_000_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        pcm = _make_pcm_noise(fft_size * 2)
+        scope.feed_audio(pcm)
+
+        assert len(frames) >= 1
+        # rfft gives fft_size//2 + 1 bins
+        # symmetric = 2 * fft_size//2 + 1 = fft_size + 1
+        n_positive = fft_size // 2  # bins 1..N (excluding DC)
+        expected_pixels = 2 * n_positive + 1  # negative + DC + positive
+        assert len(frames[0].pixels) == expected_pixels
+
+
+# ── Signal detection ────────────────────────────────────────────────────────
+
+
+class TestAudioFftScopeSignalDetection:
+    """Test that FFT correctly identifies signal frequencies."""
+
+    def test_tone_peak_location(self):
+        """A 1kHz tone should produce a peak near bin corresponding to 1kHz."""
+        fft_size = 2048
+        sample_rate = 48000
+        tone_freq = 1000.0
+
+        scope = AudioFftScope(
+            fft_size=fft_size, fps=100, avg_count=1, sample_rate=sample_rate
+        )
+        scope.set_center_freq(14_074_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        # Generate a clean tone
+        pcm = _make_pcm_tone(tone_freq, duration_s=fft_size * 2 / sample_rate)
+        scope.feed_audio(pcm)
+
+        assert len(frames) >= 1
+        pixels = np.frombuffer(frames[0].pixels, dtype=np.uint8)
+
+        # The peak should be in the right half (positive freq) of the symmetric spectrum
+        # Center pixel = DC, pixels to the right = positive frequencies
+        center = len(pixels) // 2
+        # Bin for 1kHz: bin_index = tone_freq / (sample_rate / fft_size)
+        expected_bin = int(tone_freq / (sample_rate / fft_size))
+
+        # Peak should be at center + expected_bin (± 2 bins for windowing)
+        peak_region = pixels[center + expected_bin - 3 : center + expected_bin + 4]
+        peak_val = int(np.max(peak_region))
+
+        # Also check the mirror (negative freq side)
+        mirror_region = pixels[center - expected_bin - 3 : center - expected_bin + 4]
+        mirror_val = int(np.max(mirror_region))
+
+        # Peak should be significantly above noise
+        noise_floor = int(np.median(pixels))
+        assert peak_val > noise_floor + 20, (
+            f"Peak {peak_val} not significantly above noise {noise_floor}"
+        )
+        assert mirror_val > noise_floor + 20, (
+            f"Mirror peak {mirror_val} not significantly above noise {noise_floor}"
+        )
+
+    def test_silence_low_amplitude(self):
+        """Silence should produce low pixel values."""
+        scope = AudioFftScope(fft_size=1024, fps=100, avg_count=1)
+        scope.set_center_freq(7_000_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        pcm = _make_pcm_silence(1024 * 2)
+        scope.feed_audio(pcm)
+
+        assert len(frames) >= 1
+        pixels = np.frombuffer(frames[0].pixels, dtype=np.uint8)
+        # Silence → all pixels near 0
+        assert np.max(pixels) < 30, f"Silence produced max pixel {np.max(pixels)}"
+
+    def test_two_tones_two_peaks(self):
+        """Two tones should produce two pairs of peaks (symmetric)."""
+        fft_size = 2048
+        sample_rate = 48000
+        scope = AudioFftScope(
+            fft_size=fft_size, fps=100, avg_count=1, sample_rate=sample_rate
+        )
+        scope.set_center_freq(14_074_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        # Generate two-tone signal
+        t = np.arange(int(fft_size * 2)) / sample_rate
+        signal = (
+            np.sin(2 * np.pi * 800 * t) * 10000
+            + np.sin(2 * np.pi * 2000 * t) * 10000
+        ).astype(np.int16)
+        scope.feed_audio(signal.tobytes())
+
+        assert len(frames) >= 1
+        pixels = np.frombuffer(frames[0].pixels, dtype=np.uint8)
+        center = len(pixels) // 2
+
+        # Check peaks at 800 Hz and 2000 Hz
+        bin_800 = int(800 / (sample_rate / fft_size))
+        bin_2000 = int(2000 / (sample_rate / fft_size))
+
+        peak_800 = int(np.max(pixels[center + bin_800 - 3 : center + bin_800 + 4]))
+        peak_2000 = int(np.max(pixels[center + bin_2000 - 3 : center + bin_2000 + 4]))
+        noise = int(np.median(pixels))
+
+        assert peak_800 > noise + 15, f"800Hz peak {peak_800} not above noise {noise}"
+        assert peak_2000 > noise + 15, f"2000Hz peak {peak_2000} not above noise {noise}"
+
+
+# ── Frame rate limiting ─────────────────────────────────────────────────────
+
+
+class TestAudioFftScopeFrameRate:
+    """Test frame rate limiting."""
+
+    def test_fps_limiting(self):
+        """With very high data rate, should not exceed target FPS."""
+        scope = AudioFftScope(fft_size=256, fps=10, avg_count=1)
+        scope.set_center_freq(7_000_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        # Feed much more data than needed (256 * 100 samples = 100 windows)
+        pcm = _make_pcm_noise(256 * 100)
+        scope.feed_audio(pcm)
+
+        # At 10 fps, processing ~0.5s of audio should yield few frames
+        # (actual count depends on monotonic clock, but should be limited)
+        # Main check: it doesn't produce 100 frames
+        assert len(frames) < 50, f"Too many frames: {len(frames)} (expected <50 at 10fps)"
+
+
+# ── Averaging ───────────────────────────────────────────────────────────────
+
+
+class TestAudioFftScopeAveraging:
+    """Test frame averaging."""
+
+    def test_averaging_smooths_output(self):
+        """Averaged frames should be smoother than single frames."""
+        fft_size = 1024
+
+        # No averaging
+        scope1 = AudioFftScope(fft_size=fft_size, fps=100, avg_count=1)
+        scope1.set_center_freq(7_000_000)
+        frames1: list[ScopeFrame] = []
+        scope1.on_frame(frames1.append)
+
+        # With averaging
+        scope4 = AudioFftScope(fft_size=fft_size, fps=100, avg_count=4)
+        scope4.set_center_freq(7_000_000)
+        frames4: list[ScopeFrame] = []
+        scope4.on_frame(frames4.append)
+
+        # Feed identical noise to both
+        pcm = _make_pcm_noise(fft_size * 8, amplitude=3000)
+        scope1.feed_audio(pcm)
+        scope4.feed_audio(pcm)
+
+        # Both should produce frames
+        assert len(frames1) >= 1
+        assert len(frames4) >= 1
+
+    def test_avg_count_1_means_no_averaging(self):
+        """avg_count=1 should produce frames identical to raw FFT."""
+        scope = AudioFftScope(fft_size=1024, fps=100, avg_count=1)
+        scope.set_center_freq(7_000_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        pcm = _make_pcm_tone(1500.0, duration_s=1024 * 3 / 48000)
+        scope.feed_audio(pcm)
+
+        assert len(frames) >= 1
+
+
+# ── No callback = no work ───────────────────────────────────────────────────
+
+
+class TestAudioFftScopeNoCallback:
+    """Test that no work is done without a callback."""
+
+    def test_no_callback_no_frames(self):
+        """Without a callback, feed_audio should be a no-op."""
+        scope = AudioFftScope(fft_size=1024, fps=100, avg_count=1)
+        scope.set_center_freq(7_000_000)
+        # No on_frame callback registered
+
+        pcm = _make_pcm_noise(1024 * 5)
+        scope.feed_audio(pcm)  # Should not raise
+
+    def test_unregister_callback(self):
+        """Unregistering callback should stop frame delivery."""
+        scope = AudioFftScope(fft_size=1024, fps=100, avg_count=1)
+        scope.set_center_freq(7_000_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        pcm1 = _make_pcm_noise(1024 * 2)
+        scope.feed_audio(pcm1)
+        count_before = len(frames)
+
+        scope.on_frame(None)  # Unregister
+
+        pcm2 = _make_pcm_noise(1024 * 2)
+        scope.feed_audio(pcm2)
+
+        assert len(frames) == count_before  # No new frames
+
+
+# ── Protocol compatibility ──────────────────────────────────────────────────
+
+
+class TestAudioFftScopeProtocolCompat:
+    """Test compatibility with existing scope binary protocol."""
+
+    def test_scope_frame_encodable(self):
+        """ScopeFrame from AudioFftScope should be encodable by protocol.py."""
+        from icom_lan.web.protocol import encode_scope_frame
+
+        scope = AudioFftScope(fft_size=1024, fps=100, avg_count=1)
+        scope.set_center_freq(14_074_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        pcm = _make_pcm_noise(1024 * 2)
+        scope.feed_audio(pcm)
+
+        assert len(frames) >= 1
+        # Should encode without error
+        binary = encode_scope_frame(frames[0], sequence=1)
+        assert len(binary) >= 16  # Header size
+        assert binary[0] == 0x01  # MSG_TYPE_SCOPE
+
+    def test_stop_clears_state(self):
+        """stop() should clear buffers and unregister callback."""
+        scope = AudioFftScope(fft_size=1024, fps=100, avg_count=1)
+        scope.set_center_freq(7_000_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        pcm = _make_pcm_noise(1024 * 2)
+        scope.feed_audio(pcm)
+        count = len(frames)
+
+        scope.stop()
+
+        scope.feed_audio(pcm)
+        assert len(frames) == count  # No new frames after stop

--- a/tests/test_ftx1_audio.py
+++ b/tests/test_ftx1_audio.py
@@ -1,0 +1,275 @@
+"""Tests for YaesuCatRadio AudioCapable integration."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from icom_lan.audio import AudioPacket
+from icom_lan.audio_bus import AudioBus
+from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
+from icom_lan.exceptions import AudioFormatError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_audio_driver():
+    driver = MagicMock()
+    driver.start_rx = AsyncMock()
+    driver.stop_rx = AsyncMock()
+    driver.start_tx = AsyncMock()
+    driver.stop_tx = AsyncMock()
+    driver.push_tx_pcm = AsyncMock()
+    driver.tx_running = False
+    return driver
+
+
+@pytest.fixture
+def radio(mock_audio_driver):
+    with patch(
+        "icom_lan.backends.yaesu_cat.radio.YaesuCatTransport"
+    ) as MockTransport:
+        transport = MagicMock()
+        transport.connected = True
+        transport.close = AsyncMock()
+        MockTransport.return_value = transport
+        r = YaesuCatRadio(
+            device="/dev/ttyUSB0",
+            audio_driver=mock_audio_driver,
+        )
+        return r
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+def test_audio_driver_initialized(radio, mock_audio_driver):
+    assert radio._audio_driver is mock_audio_driver
+
+
+def test_audio_bus_none_initially(radio):
+    assert radio._audio_bus is None
+
+
+def test_audio_seq_starts_at_zero(radio):
+    assert radio._audio_seq == 0
+
+
+def test_audio_driver_default_construction():
+    """UsbAudioDriver is created with correct args when not injected."""
+    with patch(
+        "icom_lan.backends.yaesu_cat.radio.YaesuCatTransport"
+    ), patch(
+        "icom_lan.backends.yaesu_cat.radio.UsbAudioDriver"
+    ) as MockDriver:
+        MockDriver.return_value = MagicMock()
+        YaesuCatRadio(
+            device="/dev/ttyUSB0",
+            rx_device="hw:1,0",
+            tx_device="hw:1,1",
+            audio_sample_rate=48000,
+        )
+        MockDriver.assert_called_once_with(
+            serial_port="/dev/ttyUSB0",
+            rx_device="hw:1,0",
+            tx_device="hw:1,1",
+            sample_rate=48000,
+            channels=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# AudioBus lazy init
+# ---------------------------------------------------------------------------
+
+
+def test_audio_bus_created_lazily(radio):
+    bus = radio.audio_bus
+    assert isinstance(bus, AudioBus)
+    assert radio._audio_bus is bus
+
+
+def test_audio_bus_same_instance(radio):
+    bus1 = radio.audio_bus
+    bus2 = radio.audio_bus
+    assert bus1 is bus2
+
+
+# ---------------------------------------------------------------------------
+# start_audio_rx_opus
+# ---------------------------------------------------------------------------
+
+
+async def test_start_audio_rx_opus_calls_driver(radio, mock_audio_driver):
+    callback = MagicMock()
+    await radio.start_audio_rx_opus(callback)
+    mock_audio_driver.start_rx.assert_called_once()
+    assert radio._opus_rx_user_callback is callback
+
+
+async def test_start_audio_rx_opus_bad_callback(radio):
+    with pytest.raises(TypeError, match="callback must be callable"):
+        await radio.start_audio_rx_opus("not-callable")
+
+
+async def test_start_audio_rx_opus_bad_jitter_type(radio):
+    with pytest.raises(TypeError, match="jitter_depth must be an int"):
+        await radio.start_audio_rx_opus(MagicMock(), jitter_depth="5")
+
+
+async def test_start_audio_rx_opus_negative_jitter(radio):
+    with pytest.raises(ValueError, match="jitter_depth must be >= 0"):
+        await radio.start_audio_rx_opus(MagicMock(), jitter_depth=-1)
+
+
+async def test_start_audio_rx_opus_emits_packets(radio, mock_audio_driver):
+    received: list[AudioPacket] = []
+
+    async def _start_rx(cb, **_kwargs):
+        # Simulate driver calling back with a PCM frame
+        cb(b"\x00" * 960)
+
+    mock_audio_driver.start_rx.side_effect = _start_rx
+
+    await radio.start_audio_rx_opus(received.append)
+
+    assert len(received) == 1
+    pkt = received[0]
+    assert isinstance(pkt, AudioPacket)
+    assert pkt.data == b"\x00" * 960
+    assert pkt.ident == 0x9781
+    assert pkt.send_seq == 0
+    assert radio._audio_seq == 1
+
+
+async def test_audio_seq_wraps(radio, mock_audio_driver):
+    radio._audio_seq = 0xFFFF
+    received: list[AudioPacket] = []
+
+    async def _start_rx(cb, **_kwargs):
+        cb(b"\x01" * 4)
+        cb(b"\x02" * 4)
+
+    mock_audio_driver.start_rx.side_effect = _start_rx
+    await radio.start_audio_rx_opus(received.append)
+
+    assert received[0].send_seq == 0xFFFF
+    assert received[1].send_seq == 0
+    assert radio._audio_seq == 1
+
+
+# ---------------------------------------------------------------------------
+# stop_audio_rx_opus
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_audio_rx_opus(radio, mock_audio_driver):
+    radio._opus_rx_user_callback = MagicMock()
+    await radio.stop_audio_rx_opus()
+    mock_audio_driver.stop_rx.assert_called_once()
+    assert radio._opus_rx_user_callback is None
+
+
+# ---------------------------------------------------------------------------
+# start_audio_rx_pcm
+# ---------------------------------------------------------------------------
+
+
+async def test_start_audio_rx_pcm_calls_driver(radio, mock_audio_driver):
+    callback = MagicMock()
+    await radio.start_audio_rx_pcm(callback, sample_rate=48000, channels=1, frame_ms=20)
+    mock_audio_driver.start_rx.assert_called_once_with(
+        callback, sample_rate=48000, channels=1, frame_ms=20
+    )
+    assert radio._pcm_rx_user_callback is callback
+
+
+async def test_start_audio_rx_pcm_bad_callback(radio):
+    with pytest.raises(TypeError, match="callback must be callable"):
+        await radio.start_audio_rx_pcm(42)
+
+
+async def test_start_audio_rx_pcm_bad_sample_rate(radio):
+    with pytest.raises(TypeError, match="sample_rate must be an int"):
+        await radio.start_audio_rx_pcm(MagicMock(), sample_rate=48000.0)
+
+
+async def test_start_audio_rx_pcm_bad_frame_size(radio):
+    # 44100 * 3 = 132300 — not divisible by 1000
+    with pytest.raises(AudioFormatError):
+        await radio.start_audio_rx_pcm(MagicMock(), sample_rate=44100, frame_ms=3)
+
+
+async def test_start_audio_rx_pcm_negative_jitter(radio):
+    with pytest.raises(ValueError, match="jitter_depth must be >= 0"):
+        await radio.start_audio_rx_pcm(MagicMock(), jitter_depth=-1)
+
+
+# ---------------------------------------------------------------------------
+# stop_audio_rx_pcm
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_audio_rx_pcm(radio, mock_audio_driver):
+    radio._pcm_rx_user_callback = MagicMock()
+    await radio.stop_audio_rx_pcm()
+    mock_audio_driver.stop_rx.assert_called_once()
+    assert radio._pcm_rx_user_callback is None
+
+
+# ---------------------------------------------------------------------------
+# start_audio_tx_pcm / stop_audio_tx_pcm / push_pcm_tx
+# ---------------------------------------------------------------------------
+
+
+async def test_start_audio_tx_pcm(radio, mock_audio_driver):
+    await radio.start_audio_tx_pcm(sample_rate=48000, channels=1, frame_ms=20)
+    mock_audio_driver.start_tx.assert_called_once_with(
+        sample_rate=48000, channels=1, frame_ms=20
+    )
+
+
+async def test_start_audio_tx_pcm_bad_frame_size(radio):
+    # 44100 * 3 = 132300 — not divisible by 1000
+    with pytest.raises(AudioFormatError):
+        await radio.start_audio_tx_pcm(sample_rate=44100, frame_ms=3)
+
+
+async def test_stop_audio_tx_pcm(radio, mock_audio_driver):
+    await radio.stop_audio_tx_pcm()
+    mock_audio_driver.stop_tx.assert_called_once()
+
+
+async def test_push_pcm_tx(radio, mock_audio_driver):
+    frame = b"\xAB" * 960
+    await radio.push_pcm_tx(frame)
+    mock_audio_driver.push_tx_pcm.assert_called_once_with(frame)
+
+
+async def test_push_pcm_tx_not_bytes(radio):
+    with pytest.raises(TypeError, match="frame must be bytes"):
+        await radio.push_pcm_tx("string")
+
+
+async def test_push_pcm_tx_empty(radio):
+    with pytest.raises(ValueError, match="frame must not be empty"):
+        await radio.push_pcm_tx(b"")
+
+
+# ---------------------------------------------------------------------------
+# disconnect stops audio driver
+# ---------------------------------------------------------------------------
+
+
+async def test_disconnect_stops_audio(radio, mock_audio_driver):
+    await radio.disconnect()
+    mock_audio_driver.stop_rx.assert_called_once()
+    mock_audio_driver.stop_tx.assert_called_once()

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -484,7 +484,7 @@ async def test_set_manual_notch_freq(connected_radio):
 async def test_get_filter_width(connected_radio):
     connected_radio._transport.query = AsyncMock(return_value="SH0010")
     assert await connected_radio.get_filter_width() == 10
-    connected_radio._transport.query.assert_called_once_with("SH00;")
+    connected_radio._transport.query.assert_called_once_with("SH0;")
 
 
 @pytest.mark.asyncio
@@ -624,17 +624,42 @@ async def test_get_processor(connected_radio):
 
 
 @pytest.mark.asyncio
+async def test_get_monitor_on(connected_radio):
+    """ML0 sub-command: monitor on/off state."""
+    connected_radio._transport.query = AsyncMock(return_value="ML0001")
+    assert await connected_radio.get_monitor_on() is True
+    connected_radio._transport.query.assert_called_once_with("ML0;")
+
+
+@pytest.mark.asyncio
+async def test_get_monitor_on_off(connected_radio):
+    """ML0 sub-command: monitor off."""
+    connected_radio._transport.query = AsyncMock(return_value="ML0000")
+    assert await connected_radio.get_monitor_on() is False
+
+
+@pytest.mark.asyncio
+async def test_set_monitor_on(connected_radio):
+    """ML0 sub-command: set monitor on."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_monitor_on(True)
+    connected_radio._transport.write.assert_called_once_with("ML0001;")
+
+
+@pytest.mark.asyncio
 async def test_get_monitor_level(connected_radio):
-    connected_radio._transport.query = AsyncMock(return_value="ML100")
+    """ML1 sub-command: monitor gain level."""
+    connected_radio._transport.query = AsyncMock(return_value="ML1100")
     assert await connected_radio.get_monitor_level() == 100
-    connected_radio._transport.query.assert_called_once_with("ML;")
+    connected_radio._transport.query.assert_called_once_with("ML1;")
 
 
 @pytest.mark.asyncio
 async def test_set_monitor_level(connected_radio):
+    """ML1 sub-command: set monitor gain level."""
     connected_radio._transport.write = AsyncMock()
     await connected_radio.set_monitor_level(128)
-    connected_radio._transport.write.assert_called_once_with("ML128;")
+    connected_radio._transport.write.assert_called_once_with("ML1128;")
 
 
 # ---------------------------------------------------------------------------
@@ -817,10 +842,9 @@ async def test_set_lock(connected_radio):
 
 
 @pytest.mark.asyncio
-async def test_get_band(connected_radio):
-    connected_radio._transport.query = AsyncMock(return_value="BS005")
-    assert await connected_radio.get_band() == 5
-    connected_radio._transport.query.assert_called_once_with("BS0;")
+async def test_get_band_not_supported(connected_radio):
+    """FTX-1 does not support BS read (write-only)."""
+    assert not hasattr(connected_radio, "get_band")
 
 
 @pytest.mark.asyncio

--- a/tests/test_usb_audio_stub.py
+++ b/tests/test_usb_audio_stub.py
@@ -197,7 +197,10 @@ def test_select_usb_audio_devices_explicit_overrides_take_precedence() -> None:
     assert selected_tx.name == "A"
 
 
-def test_select_usb_audio_devices_auto_detect_prefers_icom_like_name() -> None:
+def test_select_usb_audio_devices_auto_detect_prefers_usb_audio_codec() -> None:
+    # Generic "USB Audio CODEC" now ranks above vendor-specific names so the
+    # driver works equally well for Icom, Yaesu and Kenwood radios (all use
+    # the same Burr-Brown/TI USB Audio Class chip with this name).
     devices = [
         UsbAudioDevice(
             index=0,
@@ -220,8 +223,8 @@ def test_select_usb_audio_devices_auto_detect_prefers_icom_like_name() -> None:
         ),
     ]
     selected_rx, selected_tx = select_usb_audio_devices(devices)
-    assert selected_rx.name == "IC-7610 USB Audio"
-    assert selected_tx.name == "IC-7610 USB Audio"
+    assert selected_rx.name == "USB Audio CODEC"
+    assert selected_tx.name == "USB Audio CODEC"
 
 
 def test_select_usb_audio_devices_invalid_override_raises_clear_error() -> None:


### PR DESCRIPTION
## What
Audio FFT Scope — derives an IF panadapter from RX audio PCM stream for radios without hardware scope data (like FTX-1).

## Architecture
```
USB Audio (PCM 48kHz mono)
    ↓ AudioBroadcaster PCM tap
AudioFftScope (numpy FFT, windowing, averaging)
    ↓ generates ScopeFrame objects
WebSocket binary broadcast (existing protocol)
    ↓
SpectrumPanel + WaterfallCanvas (existing frontend)
```

## Changes
- **`src/icom_lan/audio_fft_scope.py`** — New FFT processor class (278 lines)
  - Configurable FFT size (1024/2048/4096), window (hann/blackman/hamming)
  - Rolling average for smooth display
  - Frame rate limiting (default 20 FPS)
  - Symmetric spectrum (negative + DC + positive frequencies)
  - dB-to-pixel mapping compatible with ScopeFrame (0-160 range)
  
- **`src/icom_lan/web/server.py`** — Auto-enables for AudioCapable + non-ScopeCapable radios
  - PCM tap on AudioBroadcaster feeds audio → FFT scope
  - Center freq synced from radio state
  - `scopeSource` field in capabilities API
  
- **`src/icom_lan/web/handlers.py`** — PCM tap callback in AudioBroadcaster relay loop

- **FTX-1 test fixes** — Updated for corrected command formats (SH0, ML0/ML1, BS write-only)

## Tests
- 19 new unit tests for AudioFftScope
- 3922 passed, 0 regressions

Closes #384, closes #385
Part of #383