### PR TITLE
fix(ic-705): harden Wi-Fi transport binding and validate LAN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Direct connection to your radio — no wfview, hamlib, or RS-BA1 required.
 | **Yaesu FTX-1** | Yaesu CAT | — | ✅ Tested | 17 modes, VHF/UHF, C4FM, Audio FFT Scope |
 | **Xiegu X6100** | CI-V `0x70` | — | Profile only | IC-705 compatible, QRP 8W, WiFi |
 | **Lab599 TX-500** | Kenwood CAT | — | Profile only | QRP 10W, minimal CAT |
-| IC-705 | CI-V `0xA4` | — | — | WiFi, should work |
+| IC-705 | CI-V `0xA4` | ✅ Validated | — | WiFi; community-validated LAN control path |
 | IC-9700 | CI-V `0xA2` | — | — | VHF/UHF/SHF |
 | IC-7851 | CI-V `0x8E` | — | — | |
 | IC-R8600 | CI-V `0x96` | — | — | RX only |
@@ -418,4 +418,3 @@ Icom™ and the Icom logo are registered trademarks of [Icom Incorporated](https
 Some future product planning, commercial exploration, or private implementation work may happen outside this repository in separate private repositories. That separation is intentional and does not change the open-source status of `icom-lan` itself.
 
 Public improvements that strengthen the core project may still be contributed here when appropriate.
-

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -99,10 +99,10 @@ backend adapters are not yet implemented or tested:
 - **VFO scheme:** `ab`
 - **Status:** Profile only. Kenwood CAT backend not yet implemented.
 
-## Has Rig Profile (Not Yet Backend-Tested)
+## Community-Validated / Maintainer Hardware Pending
 
-These radios have complete rig profiles and the CI-V backend should support them, but they
-have not been tested by the maintainers. Community testing and reports welcome!
+These radios have working field reports and validated user integrations, but the
+maintainer has not yet completed first-party hardware validation in this repo.
 
 ### IC-705
 
@@ -110,13 +110,19 @@ have not been tested by the maintainers. Community testing and reports welcome!
 - **Connectivity:** LAN (WiFi/Ethernet) + USB serial (CI-V)
 - **VFO scheme:** Single receiver (portable transceiver)
 - **Rig profile:** `rigs/ic705.toml`
-- **Expected features:** frequency, mode, power, S-meter, SWR, ALC, PTT, CW keying,
-  attenuator, preamp, NB, NR, APF, Twin Peak, scope/waterfall, audio RX/TX
-- **Status:** Profile complete. Backend untested — reports welcome.
+- **Validated features:** LAN connect/disconnect, reconnect, frequency, mode,
+  PTT, and audio path integrations on the WiFi backend
+- **Status:** Community-validated on LAN/WiFi. First-party maintainer hardware
+  validation is still pending.
 
 !!! tip "Setup Guides"
     - **[IC-705 USB Serial Backend Setup](ic705-usb-setup.md)** — Step-by-step USB configuration
     - Use **Menu → Set → Connectors → CI-V → CI-V USB Port** = `Link to [CI-V]`
+
+## Has Rig Profile (Not Yet Backend-Tested)
+
+These radios have complete rig profiles and the CI-V backend should support them, but they
+have not been tested by the maintainers. Community testing and reports welcome!
 
 ### IC-9700
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ Direct connection to your radio — no wfview, hamlib, or RS-BA1 required.
 | IC-7610 | CI-V `0x98` | :white_check_mark: Tested (LAN + USB) |
 | IC-7300 | CI-V `0x94` | :white_check_mark: Tested (USB) |
 | Yaesu FTX-1 | Yaesu CAT | :white_check_mark: Tested (USB) |
-| IC-705 | CI-V `0xA4` | :material-help-circle: Profile — not yet tested |
+| IC-705 | CI-V `0xA4` | :white_check_mark: Validated (LAN/WiFi community-tested) |
 | IC-9700 | CI-V `0xA2` | :material-help-circle: Profile — not yet tested |
 | Xiegu X6100 | CI-V `0x70` | :material-help-circle: Profile only |
 | Lab599 TX-500 | Kenwood CAT | :material-help-circle: Profile only |

--- a/src/icom_lan/_control_phase.py
+++ b/src/icom_lan/_control_phase.py
@@ -55,6 +55,25 @@ class ControlPhaseRuntime:
     def __init__(self, host: ControlPhaseHost) -> None:
         self._host = host
 
+    def _resolve_local_bind_host(self) -> str:
+        """Resolve the routed local interface IP used to reach the radio."""
+        h = self._host
+        probe = _socket.socket(_socket.AF_INET, _socket.SOCK_DGRAM)
+        try:
+            probe.connect((h._host, h._port))
+            local_host = probe.getsockname()[0]
+        except OSError:
+            logger.debug(
+                "Falling back to wildcard UDP bind while resolving local interface for %s:%d",
+                h._host,
+                h._port,
+                exc_info=True,
+            )
+            return "0.0.0.0"
+        finally:
+            probe.close()
+        return local_host or "0.0.0.0"
+
     async def connect(self) -> None:
         """Open connection to the radio and authenticate."""
         h = self._host
@@ -63,13 +82,23 @@ class ControlPhaseRuntime:
         h._civ_recovering = False
         h._last_status_error = 0
         h._last_status_disconnected = False
+        local_bind_host = self._resolve_local_bind_host()
+        h._local_bind_host = local_bind_host
 
         _reconnect = getattr(h, "_has_connected_once", False)
         try:
             if _reconnect:
-                await h._ctrl_transport.reconnect(h._host, h._port)
+                await h._ctrl_transport.reconnect(
+                    h._host,
+                    h._port,
+                    local_host=local_bind_host,
+                )
             else:
-                await h._ctrl_transport.connect(h._host, h._port)
+                await h._ctrl_transport.connect(
+                    h._host,
+                    h._port,
+                    local_host=local_bind_host,
+                )
         except OSError as exc:
             raise ConnectionError(
                 f"Failed to connect to {h._host}:{h._port}: {exc}"
@@ -109,15 +138,16 @@ class ControlPhaseRuntime:
         guid = await self._receive_guid()
 
         _civ_sock = _socket.socket(_socket.AF_INET, _socket.SOCK_DGRAM)
-        _civ_sock.bind(("", 0))
+        _civ_sock.bind((local_bind_host, 0))
         _civ_local_port = _civ_sock.getsockname()[1]
         _civ_sock.close()
         _audio_sock = _socket.socket(_socket.AF_INET, _socket.SOCK_DGRAM)
-        _audio_sock.bind(("", 0))
+        _audio_sock.bind((local_bind_host, 0))
         _audio_local_port = _audio_sock.getsockname()[1]
         _audio_sock.close()
         logger.debug(
-            "Reserved local ports: civ=%d, audio=%d",
+            "Reserved local ports on %s: civ=%d, audio=%d",
+            local_bind_host,
             _civ_local_port,
             _audio_local_port,
         )
@@ -178,6 +208,7 @@ class ControlPhaseRuntime:
             await h._civ_transport.connect(
                 h._host,
                 h._civ_port,
+                local_host=getattr(h, "_local_bind_host", None),
                 local_port=h._civ_local_port,
             )
         except OSError as exc:
@@ -299,6 +330,7 @@ class ControlPhaseRuntime:
             await h._civ_transport.connect(
                 h._host,
                 h._civ_port,
+                local_host=getattr(h, "_local_bind_host", None),
                 local_port=getattr(h, "_civ_local_port", 0),
             )
         except OSError as exc:
@@ -588,4 +620,3 @@ class ControlPhaseRuntime:
         if h._reconnect_task is not None and not h._reconnect_task.done():
             h._reconnect_task.cancel()
             h._reconnect_task = None
-

--- a/src/icom_lan/_runtime_protocols.py
+++ b/src/icom_lan/_runtime_protocols.py
@@ -125,6 +125,7 @@ class ControlPhaseHost(Protocol):
     _audio_port: int
     _civ_local_port: int
     _audio_local_port: int
+    _local_bind_host: str | None
 
     # Auth / token state
     _token: int

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -411,6 +411,7 @@ class Icom7610CoreRadio:
         self._auth_seq: int = 0
         self._civ_port: int = 0
         self._audio_port: int = 0
+        self._local_bind_host: str | None = None
         self._civ_send_seq: int = 0
         self._audio_send_seq: int = 0
         self._civ_lock = asyncio.Lock()
@@ -1559,6 +1560,7 @@ class Icom7610CoreRadio:
             await self._audio_transport.connect(
                 self._host,
                 self._audio_port,
+                local_host=getattr(self, "_local_bind_host", None),
                 local_port=getattr(self, "_audio_local_port", 0),
             )
         except OSError as exc:

--- a/src/icom_lan/transport.py
+++ b/src/icom_lan/transport.py
@@ -119,7 +119,14 @@ class IcomTransport:
         if self._udp_transport is not None:
             self._udp_transport.sendto(data)
 
-    async def connect(self, host: str, port: int, *, local_port: int = 0) -> None:
+    async def connect(
+        self,
+        host: str,
+        port: int,
+        *,
+        local_host: str | None = None,
+        local_port: int = 0,
+    ) -> None:
         """Open UDP connection and perform discovery handshake.
 
         Sends "Are You There" until the radio replies with "I Am Here",
@@ -128,6 +135,9 @@ class IcomTransport:
         Args:
             host: Radio IP address or hostname.
             port: Radio control port.
+            local_host: Local interface IP to bind to when reserving a port.
+                When omitted, the transport keeps the previous wildcard/default
+                bind behavior.
             local_port: Local UDP port to bind to (0 = random).
                 wfview binds CI-V/audio sockets to the same port sent in
                 conninfo so the radio knows where to send data.
@@ -137,7 +147,9 @@ class IcomTransport:
         """
         self.state = ConnectionState.CONNECTING
         loop = asyncio.get_event_loop()
-        local_addr = ("0.0.0.0", local_port) if local_port else None
+        local_addr = None
+        if local_port or local_host:
+            local_addr = (local_host or "0.0.0.0", local_port)
         await loop.create_datagram_endpoint(
             lambda: _UdpProtocol(self),
             remote_addr=(host, port),
@@ -159,7 +171,13 @@ class IcomTransport:
 
         logger.info("Discovery complete, remote_id=0x%08X", self.remote_id)
 
-    async def reconnect(self, host: str, port: int) -> None:
+    async def reconnect(
+        self,
+        host: str,
+        port: int,
+        *,
+        local_host: str | None = None,
+    ) -> None:
         """Reconnect to a known radio, skipping discovery.
 
         Reuses the previously learned ``remote_id`` and skips the
@@ -168,15 +186,17 @@ class IcomTransport:
         """
         if self.remote_id == 0:
             # No cached remote_id — do full connect
-            await self.connect(host, port)
+            await self.connect(host, port, local_host=local_host)
             return
 
         saved_remote_id = self.remote_id
         self.state = ConnectionState.CONNECTING
         loop = asyncio.get_event_loop()
+        local_addr = (local_host, 0) if local_host else None
         await loop.create_datagram_endpoint(
             lambda: _UdpProtocol(self),
             remote_addr=(host, port),
+            local_addr=local_addr,
         )
         saved_my_id = self.my_id
         if self._udp_transport is not None:

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -33,14 +33,45 @@ class ConnectMockTransport(MockTransport):
         super().__init__()
         self.state = ConnectionState.DISCONNECTED
 
-    async def connect(self, host: str, port: int) -> None:
+    async def connect(
+        self,
+        host: str,
+        port: int,
+        *,
+        local_host: str | None = None,
+        local_port: int = 0,
+    ) -> None:
         self.connected = True
         self.state = ConnectionState.CONNECTING
+        self.connect_args = {
+            "host": host,
+            "port": port,
+            "local_host": local_host,
+            "local_port": local_port,
+        }
+
+    async def reconnect(
+        self,
+        host: str,
+        port: int,
+        *,
+        local_host: str | None = None,
+    ) -> None:
+        self.connected = True
+        self.state = ConnectionState.CONNECTING
+        self.reconnect_args = {
+            "host": host,
+            "port": port,
+            "local_host": local_host,
+        }
 
     def start_ping_loop(self) -> None:
         pass
 
     def start_retransmit_loop(self) -> None:
+        pass
+
+    def start_idle_loop(self) -> None:
         pass
 
 
@@ -369,3 +400,80 @@ class TestConnectSessionRejection:
                 await radio.connect()
 
         assert mt.disconnected is True
+
+
+class _FakeSocket:
+    def __init__(self, sockname: tuple[str, int]) -> None:
+        self.sockname = sockname
+        self.bound: tuple[str, int] | None = None
+        self.connected: tuple[str, int] | None = None
+
+    def connect(self, addr: tuple[str, int]) -> None:
+        self.connected = addr
+
+    def bind(self, addr: tuple[str, int]) -> None:
+        self.bound = addr
+
+    def getsockname(self) -> tuple[str, int]:
+        return self.sockname
+
+    def close(self) -> None:
+        return None
+
+
+class TestWifiBindBehavior:
+    @pytest.mark.asyncio
+    async def test_connect_uses_routed_local_bind_host_for_control_and_civ(self) -> None:
+        radio = IcomRadio("192.168.2.1", username="u", password="p")
+        mt = ConnectMockTransport()
+        radio._ctrl_transport = mt
+
+        probe_sock = _FakeSocket(("192.168.2.194", 40000))
+        civ_sock = _FakeSocket(("192.168.2.194", 50002))
+        audio_sock = _FakeSocket(("192.168.2.194", 50003))
+
+        fake_civ_transport = ConnectMockTransport()
+
+        with (
+            patch(
+                "icom_lan._control_phase._socket.socket",
+                side_effect=[probe_sock, civ_sock, audio_sock],
+            ),
+            patch.object(
+                radio._control_phase,
+                "_wait_for_packet",
+                new=AsyncMock(return_value=_build_login_response()),
+            ),
+            patch.object(radio._control_phase, "_send_token_ack", new=AsyncMock()),
+            patch.object(
+                radio._control_phase,
+                "_receive_guid",
+                new=AsyncMock(return_value=b"\x00" * 16),
+            ),
+            patch.object(radio._control_phase, "_send_conninfo", new=AsyncMock()),
+            patch.object(
+                radio._control_phase,
+                "_receive_civ_port",
+                new=AsyncMock(return_value=50002),
+            ),
+            patch.object(radio._control_phase, "_start_token_renewal"),
+            patch.object(radio._control_phase, "_start_watchdog"),
+            patch.object(radio._control_phase, "_send_open_close", new=AsyncMock()),
+            patch.object(radio._control_phase, "_flush_queue", new=AsyncMock(return_value=0)),
+            patch.object(radio._civ_runtime, "start_pump"),
+            patch.object(radio._civ_runtime, "start_data_watchdog"),
+            patch.object(radio._civ_runtime, "start_worker"),
+            patch("icom_lan.transport.IcomTransport", return_value=fake_civ_transport),
+        ):
+            await radio.connect()
+
+        assert probe_sock.connected == ("192.168.2.1", 50001)
+        assert civ_sock.bound == ("192.168.2.194", 0)
+        assert audio_sock.bound == ("192.168.2.194", 0)
+        assert mt.connect_args["local_host"] == "192.168.2.194"
+        assert fake_civ_transport.connect_args == {
+            "host": "192.168.2.1",
+            "port": 50002,
+            "local_host": "192.168.2.194",
+            "local_port": 50002,
+        }

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -1707,6 +1707,7 @@ async def test_ensure_audio_transport_creates_transport(radio: IcomRadio) -> Non
     """_ensure_audio_transport connects audio transport (lines 993-1013)."""
 
     radio._audio_port = 50001  # non-zero port
+    radio._local_bind_host = "192.168.2.194"
 
     fake_transport = MagicMock()
     fake_transport.connect = AsyncMock()
@@ -1719,7 +1720,12 @@ async def test_ensure_audio_transport_creates_transport(radio: IcomRadio) -> Non
         await radio._ensure_audio_transport()
 
     assert radio._audio_transport is fake_transport
-    fake_transport.connect.assert_awaited_once()
+    fake_transport.connect.assert_awaited_once_with(
+        radio._host,
+        50001,
+        local_host="192.168.2.194",
+        local_port=0,
+    )
 
 
 async def test_ensure_audio_transport_noop_when_stream_exists(radio: IcomRadio) -> None:

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import struct
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -72,6 +73,43 @@ def transport() -> IcomTransport:
     return t
 
 
+class _FakeDatagramTransport:
+    def __init__(self, sockname: tuple[str, int]) -> None:
+        self._sockname = sockname
+
+    def get_extra_info(self, name: str):
+        if name == "sockname":
+            return self._sockname
+        return None
+
+    def sendto(self, data: bytes) -> None:
+        return None
+
+
+class _FakeLoop:
+    def __init__(self, sockname: tuple[str, int]) -> None:
+        self.sockname = sockname
+        self.calls: list[dict[str, object]] = []
+
+    async def create_datagram_endpoint(
+        self,
+        protocol_factory,
+        *,
+        remote_addr=None,
+        local_addr=None,
+    ):
+        transport = _FakeDatagramTransport(self.sockname)
+        protocol = protocol_factory()
+        protocol.connection_made(transport)
+        self.calls.append(
+            {
+                "remote_addr": remote_addr,
+                "local_addr": local_addr,
+            }
+        )
+        return transport, protocol
+
+
 # ---------------------------------------------------------------------------
 # Connection state
 # ---------------------------------------------------------------------------
@@ -88,6 +126,54 @@ class TestConnectionState:
         assert ConnectionState.DISCONNECTED == "disconnected"
         assert ConnectionState.CONNECTING == "connecting"
         assert ConnectionState.CONNECTED == "connected"
+
+    @pytest.mark.asyncio
+    async def test_connect_binds_to_specific_local_host_and_port(self) -> None:
+        t = IcomTransport()
+        loop = _FakeLoop(("192.168.2.194", 50002))
+
+        with (
+            patch("icom_lan.transport.asyncio.get_event_loop", return_value=loop),
+            patch.object(t, "_discover", new=AsyncMock()),
+            patch.object(t, "_ready_handshake", new=AsyncMock()),
+        ):
+            await t.connect(
+                "192.168.2.1",
+                50001,
+                local_host="192.168.2.194",
+                local_port=50002,
+            )
+
+        assert loop.calls == [
+            {
+                "remote_addr": ("192.168.2.1", 50001),
+                "local_addr": ("192.168.2.194", 50002),
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_reconnect_binds_to_specific_local_host(self) -> None:
+        t = IcomTransport()
+        t.remote_id = 0xAABBCCDD
+        t.my_id = 0x0001C352
+        loop = _FakeLoop(("192.168.2.194", 50001))
+
+        with (
+            patch("icom_lan.transport.asyncio.get_event_loop", return_value=loop),
+            patch.object(t, "_ready_handshake", new=AsyncMock()),
+        ):
+            await t.reconnect(
+                "192.168.2.1",
+                50001,
+                local_host="192.168.2.194",
+            )
+
+        assert loop.calls == [
+            {
+                "remote_addr": ("192.168.2.1", 50001),
+                "local_addr": ("192.168.2.194", 0),
+            }
+        ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR upstreams `icom-lan` fixes and validation that came out of integrating `icom-lan` runtime code into [OrbitDeck](https://github.com/Marzogh/OrbitDeck) for its IC-705 Wi-Fi control path.

What this changes:
1. Bind control, CI-V, audio, and reconnect UDP sockets to the routed local interface instead of relying on wildcard/default binds.
2. Preserve that routed bind behavior across reconnect.
3. Add regression tests for local bind propagation in the transport and radio connect paths.
4. Update IC-705 support/docs from “should work” / “profile not yet tested” to community-validated LAN/Wi-Fi support.

Why:
- While integrating `icom-lan` runtime code into OrbitDeck’s IC-705 Wi-Fi path, I found that wildcard/default UDP binds could leave radio-facing sockets on the wrong interface on multi-homed or VPN-connected systems.
- The same issue affected reconnect behavior.
- The fix keeps the session bound to the same interface the OS would actually use to reach the radio.

Validation:
- `PYTHONPATH=src pytest -q tests/test_transport.py tests/test_radio_connect.py tests/test_radio_coverage.py`
- `python -m compileall src/icom_lan`

Notes:
- This does not add new protocol features.
- It upstreams transport correctness fixes, tests, and docs based on real downstream use in OrbitDeck.
