### PR TITLE
feat(#109): descriptive audio bridge labels with radio model

### DIFF
--- a/src/icom_lan/audio_bridge.py
+++ b/src/icom_lan/audio_bridge.py
@@ -110,6 +110,9 @@ class AudioBridge:
             thread pool is used. For heavy usage or multiple bridge instances,
             pass a dedicated :class:`concurrent.futures.ThreadPoolExecutor` (e.g.
             ``max_workers=1`` or ``2``) to isolate TX I/O and avoid contention.
+        label: Descriptive label used in log messages (default ``"icom-lan"``).
+            When the radio model is known, callers typically pass
+            ``"icom-lan (IC-7610)"`` so logs clearly identify the radio.
     """
 
     def __init__(
@@ -123,8 +126,10 @@ class AudioBridge:
         frame_ms: int = FRAME_MS,
         tx_enabled: bool = True,
         tx_executor: Executor | None = None,
+        label: str = "icom-lan",
     ) -> None:
         self._radio = radio
+        self._label = label
         self._device_name = device_name
         self._tx_device_name = (
             tx_device_name  # separate TX device (if None, same as RX)
@@ -155,6 +160,11 @@ class AudioBridge:
         self._last_rx_time: float = 0.0
         self._last_tx_time: float = 0.0
         self._start_time: float = 0.0
+
+    @property
+    def label(self) -> str:
+        """Descriptive label used in log messages."""
+        return self._label
 
     @property
     def running(self) -> bool:
@@ -198,7 +208,7 @@ class AudioBridge:
         import sounddevice as sd  # noqa: F401
 
         if self._running:
-            logger.warning("audio-bridge: already running")
+            logger.warning("%s: already running", self._label)
             return
 
         self._start_time = time.monotonic()
@@ -215,7 +225,7 @@ class AudioBridge:
 
         dev_index = dev["index"]
         dev_name = dev["name"]
-        logger.info("audio-bridge: using device %r (index %d)", dev_name, dev_index)
+        logger.info("%s: using device %r (index %d)", self._label, dev_name, dev_index)
 
         samples_per_frame = self._sample_rate * self._frame_ms // 1000
 
@@ -253,10 +263,10 @@ class AudioBridge:
                     "Install with: pip install icom-lan[bridge]"
                 ) from None
             self._decoder = opuslib.Decoder(self._sample_rate, self._channels)
-            logger.info("audio-bridge: using Opus decoder")
+            logger.info("%s: using Opus decoder", self._label)
         else:
             self._decoder = None
-            logger.info("audio-bridge: PCM mode (no decode needed)")
+            logger.info("%s: PCM mode (no decode needed)", self._label)
 
         bus = self._radio.audio_bus
         self._subscription = bus.subscribe(name="audio-bridge")
@@ -277,13 +287,15 @@ class AudioBridge:
                 tx_dev = find_loopback_device(self._tx_device_name)
                 if tx_dev is None:
                     logger.warning(
-                        "audio-bridge: TX device %r not found, using RX device",
+                        "%s: TX device %r not found, using RX device",
+                        self._label,
                         self._tx_device_name,
                     )
                 else:
                     tx_dev_index = tx_dev["index"]
                     logger.info(
-                        "audio-bridge: TX device %r (index %d)",
+                        "%s: TX device %r (index %d)",
+                        self._label,
                         tx_dev["name"],
                         tx_dev_index,
                     )
@@ -304,7 +316,8 @@ class AudioBridge:
         self._running = True
         direction = "RX+TX" if self._tx_enabled else "RX only"
         logger.info(
-            "audio-bridge: started (%s, %dHz, %dch, %dms frames)",
+            "%s: started (%s, %dHz, %dch, %dms frames)",
+            self._label,
             direction,
             self._sample_rate,
             self._channels,
@@ -321,7 +334,7 @@ class AudioBridge:
                     self._rx_drops += 1
                     if self._rx_drops <= 3:
                         logger.debug(
-                            "audio-bridge: None packet (gap) #%d", self._rx_drops
+                            "%s: None packet (gap) #%d", self._label, self._rx_drops
                         )
                     if self._rx_stream and self._rx_stream.active:
                         self._rx_stream.write(self._silence)
@@ -356,7 +369,8 @@ class AudioBridge:
                     self._rx_drops += 1
                     if self._rx_drops <= 5 or self._rx_drops % 1000 == 0:
                         logger.warning(
-                            "audio-bridge: decode error #%d: %s (data=%d bytes)",
+                            "%s: decode error #%d: %s (data=%d bytes)",
+                            self._label,
                             self._rx_drops,
                             exc,
                             len(opus_data),
@@ -364,11 +378,11 @@ class AudioBridge:
         except asyncio.CancelledError:
             pass
         except Exception:
-            logger.error("audio-bridge: RX loop error", exc_info=True)
+            logger.error("%s: RX loop error", self._label, exc_info=True)
             # Try to restart after a brief pause
             await asyncio.sleep(1.0)
             if self._running and self._subscription:
-                logger.info("audio-bridge: restarting RX loop")
+                logger.info("%s: restarting RX loop", self._label)
                 self._rx_task = asyncio.create_task(self._rx_loop(np))
 
     async def _tx_loop(self) -> None:
@@ -389,7 +403,7 @@ class AudioBridge:
                     lambda: self._tx_stream.read(samples_per_frame),
                 )
                 if overflowed:
-                    logger.debug("audio-bridge: TX input overflow")
+                    logger.debug("%s: TX input overflow", self._label)
 
                 # Simple noise gate — don't TX silence
                 if np.max(np.abs(data)) < silence_threshold:
@@ -408,7 +422,8 @@ class AudioBridge:
                 if self._tx_frames <= 3 or self._tx_frames % 1000 == 0:
                     peak = int(np.max(np.abs(data)))
                     logger.info(
-                        "audio-bridge: TX frame #%d, %d bytes, peak=%d",
+                        "%s: TX frame #%d, %d bytes, peak=%d",
+                        self._label,
                         self._tx_frames,
                         len(pcm_bytes),
                         peak,
@@ -423,14 +438,14 @@ class AudioBridge:
                         await self._radio.push_audio_tx_opus(pcm_bytes)
                 except Exception:
                     if self._tx_frames <= 5:
-                        logger.warning("audio-bridge: TX push error", exc_info=True)
+                        logger.warning("%s: TX push error", self._label, exc_info=True)
                     else:
-                        logger.debug("audio-bridge: TX push error", exc_info=True)
+                        logger.debug("%s: TX push error", self._label, exc_info=True)
 
         except asyncio.CancelledError:
             pass
         except Exception:
-            logger.error("audio-bridge: TX loop error", exc_info=True)
+            logger.error("%s: TX loop error", self._label, exc_info=True)
 
     async def stop(self) -> None:
         """Stop the audio bridge and release resources."""
@@ -479,10 +494,11 @@ class AudioBridge:
             try:
                 await self._radio.stop_audio_tx_pcm()
             except Exception:
-                logger.debug("audio-bridge: stop TX error", exc_info=True)
+                logger.debug("%s: stop TX error", self._label, exc_info=True)
 
         logger.info(
-            "audio-bridge: stopped (rx=%d frames, tx=%d frames, drops=%d)",
+            "%s: stopped (rx=%d frames, tx=%d frames, drops=%d)",
+            self._label,
             self._rx_frames,
             self._tx_frames,
             self._rx_drops,

--- a/src/icom_lan/cli.py
+++ b/src/icom_lan/cli.py
@@ -367,6 +367,13 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="List available audio devices and exit",
     )
+    audio_bridge_p.add_argument(
+        "--label",
+        dest="bridge_label",
+        default=None,
+        metavar="LABEL",
+        help="Descriptive label for log messages (default: auto from radio model)",
+    )
 
     # ptt
     ptt_p = sub.add_parser("ptt", help="PTT control")
@@ -589,6 +596,13 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="web_bridge_rx_only",
         action="store_true",
         help="Bridge RX only (no TX from virtual device to radio)",
+    )
+    web_p.add_argument(
+        "--bridge-label",
+        dest="web_bridge_label",
+        default=None,
+        metavar="LABEL",
+        help="Descriptive label for audio bridge log messages (default: auto from radio model)",
     )
     web_p.add_argument(
         "--dx-cluster",
@@ -1953,11 +1967,21 @@ async def _cmd_audio_bridge(radio: Radio, args: argparse.Namespace) -> int:
     if CAP_AUDIO not in radio.capabilities:
         print("Error: audio bridge requires a radio that supports audio.", file=sys.stderr)
         return 1
+    # Derive label from CLI arg or radio model
+    bridge_label = getattr(args, "bridge_label", None)
+    if bridge_label is None:
+        model = getattr(radio, "model", None)
+        if isinstance(model, str) and model:
+            bridge_label = f"icom-lan ({model})"
+        else:
+            bridge_label = "icom-lan"
+
     try:
         bridge = AudioBridge(
             radio,
             device_name=args.device,
             tx_enabled=not args.rx_only,
+            label=bridge_label,
         )
         await bridge.start()
     except ImportError as exc:
@@ -2093,11 +2117,13 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
         device_name = None if bridge_device == "auto" else bridge_device
         tx_device_name = getattr(args, "web_bridge_tx_device", None)
         rx_only = getattr(args, "web_bridge_rx_only", False)
+        bridge_label = getattr(args, "web_bridge_label", None)
         try:
             await server.start_audio_bridge(
                 device_name=device_name,
                 tx_device_name=tx_device_name,
                 tx_enabled=not rx_only,
+                label=bridge_label,
             )
             direction = "RX only" if rx_only else "RX+TX"
             print(f"Audio bridge active ({direction})")

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -925,6 +925,7 @@ class WebServer:
         device_name: str | None = None,
         tx_device_name: str | None = None,
         tx_enabled: bool = True,
+        label: str | None = None,
     ) -> None:
         """Start the audio bridge to a virtual audio device.
 
@@ -933,6 +934,7 @@ class WebServer:
             tx_device_name: Separate device for TX (e.g. "BlackHole 16ch").
                             Required for bidirectional audio to avoid feedback.
             tx_enabled: Whether to bridge TX (device → radio).
+            label: Descriptive label for log messages. If ``None``, derived from radio model.
         """
         from ..audio_bridge import AudioBridge
 
@@ -946,11 +948,19 @@ class WebServer:
                 "Audio bridge is unavailable: active radio does not support audio streaming."
             )
 
+        if label is None:
+            model = getattr(self._radio, "model", None)
+            if isinstance(model, str) and model:
+                label = f"icom-lan ({model})"
+            else:
+                label = "icom-lan"
+
         self._audio_bridge = AudioBridge(
             self._radio,
             device_name=device_name,
             tx_device_name=tx_device_name,
             tx_enabled=tx_enabled,
+            label=label,
         )
         await self._audio_bridge.start()
         self.broadcast_notification("success", "Audio bridge started", "bridge")

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -412,3 +412,43 @@ def test_latency_buffer_capped_at_100():
 
     assert len(bridge._rx_latency_samples) == 100
     assert bridge.stats["buffer_size"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Label parameter
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_label_default():
+    """Default label is 'icom-lan'."""
+    radio = MagicMock()
+    bridge = AudioBridge(radio)
+    assert bridge.label == "icom-lan"
+
+
+def test_bridge_label_custom():
+    """Custom label is stored and accessible."""
+    radio = MagicMock()
+    bridge = AudioBridge(radio, label="icom-lan (IC-7610)")
+    assert bridge.label == "icom-lan (IC-7610)"
+
+
+def test_bridge_label_in_log_messages(caplog):
+    """Label appears in log messages instead of hardcoded 'audio-bridge'."""
+    import logging
+
+    radio = MagicMock()
+    bridge = AudioBridge(radio, label="icom-lan (IC-905)")
+
+    with caplog.at_level(logging.WARNING):
+        # Trigger the "already running" warning by setting _running=True
+        bridge._running = True
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(bridge.start())
+        finally:
+            loop.close()
+
+    assert "icom-lan (IC-905): already running" in caplog.text


### PR DESCRIPTION
## Summary

Audio bridge now uses descriptive labels in log messages. Default label derived from radio model: `"icom-lan (IC-7610)"` instead of generic `"audio-bridge"`.

## Why

Hard to tell which audio device belongs to which radio in logs and DAW/WSJT-X when running multiple instances.

## Changes

- **audio_bridge.py** — `AudioBridge` accepts `label` param (default `"icom-lan"`); all 18 log messages use `self._label` prefix
- **web/server.py** — `start_audio_bridge()` auto-derives label from `radio.model` → `"icom-lan (IC-7610)"`
- **cli.py** — `--bridge-label` option added to `web` and `audio` subcommands; default derived from radio model
- **tests/test_audio_bridge.py** — 3 new tests: default label, custom label, label in log output

## Validation

- Backend: **4391 passed, 0 failed**

## Issue

- Closes #109

## Notes

- CoreAudio system-level device rename (BlackHole) is intentionally out of scope — requires HAL plugins, too complex
- Goal achieved via descriptive log labels + CLI option