### PR TITLE
feat(web): WebRTC signaling scaffold (#104 slice)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ bridge = ["opuslib", "sounddevice", "numpy"]
 scope = [
     "pillow>=10.0",
 ]
+webrtc = ["aiortc>=1.9"]
 tls = ["cryptography>=41.0"]
 dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout", "ruff", "mypy"]
 

--- a/src/icom_lan/capabilities.py
+++ b/src/icom_lan/capabilities.py
@@ -24,6 +24,7 @@ __all__ = [
     "CAP_POWER_CONTROL", "CAP_DIAL_LOCK", "CAP_SCAN", "CAP_BSR", "CAP_MAIN_SUB_TRACKING",
     "CAP_TUNING_STEP", "CAP_BAND_EDGE", "CAP_XFC",
     "CAP_SYSTEM_SETTINGS",
+    "CAP_WEBRTC",
 ]
 
 # ---------------------------------------------------------------------------
@@ -112,6 +113,9 @@ CAP_BAND_EDGE = "band_edge"
 CAP_XFC = "xfc"
 CAP_SYSTEM_SETTINGS = "system_settings"
 
+# WebRTC — low-latency audio delivery via browser peer connection (issue #104)
+CAP_WEBRTC = "webrtc"
+
 # ---------------------------------------------------------------------------
 # Master set — rig_loader rejects any TOML tag not listed here.
 # ---------------------------------------------------------------------------
@@ -185,5 +189,7 @@ KNOWN_CAPABILITIES: frozenset[str] = frozenset(
         CAP_BAND_EDGE,
         CAP_XFC,
         CAP_SYSTEM_SETTINGS,
+        # WebRTC
+        CAP_WEBRTC,
     }
 )

--- a/src/icom_lan/web/rtc.py
+++ b/src/icom_lan/web/rtc.py
@@ -99,7 +99,7 @@ async def handle_rtc_offer(
 
     # --- aiortc is available; create a peer connection ---
     try:
-        from aiortc import (  # type: ignore[import-untyped]
+        from aiortc import (  # type: ignore[import-not-found,import-untyped]
             RTCPeerConnection,
             RTCSessionDescription,
         )

--- a/src/icom_lan/web/rtc.py
+++ b/src/icom_lan/web/rtc.py
@@ -44,7 +44,7 @@ def webrtc_available() -> bool:
     global _aiortc_checked, _aiortc_ok  # noqa: PLW0603
     if not _aiortc_checked:
         try:
-            import aiortc  # noqa: F401
+            import aiortc  # type: ignore[import-untyped]  # noqa: F401
 
             _aiortc_ok = True
         except ImportError:
@@ -98,7 +98,7 @@ async def handle_rtc_offer(
 
     # --- aiortc is available; create a peer connection ---
     try:
-        from aiortc import (  # type: ignore[import-untyped]
+        from aiortc import (  # type: ignore[import-untyped,unused-ignore]
             RTCPeerConnection,
             RTCSessionDescription,
         )

--- a/src/icom_lan/web/rtc.py
+++ b/src/icom_lan/web/rtc.py
@@ -1,0 +1,157 @@
+"""WebRTC signaling support for icom-lan.
+
+Provides SDP offer/answer handling for low-latency audio delivery via
+WebRTC.  The ``aiortc`` library is an optional dependency — when absent,
+the module gracefully reports unavailability so clients can fall back to
+the existing WebSocket audio path.
+
+Usage from the web server::
+
+    from .rtc import webrtc_available, handle_rtc_offer
+
+    if webrtc_available():
+        answer = await handle_rtc_offer(sdp_offer, radio)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..radio_protocol import Radio
+
+__all__ = [
+    "webrtc_available",
+    "handle_rtc_offer",
+    "rtc_capability_info",
+]
+
+logger = logging.getLogger(__name__)
+
+_INSTALL_HINT = "WebRTC backend unavailable; install icom-lan[webrtc]."
+
+# ---------------------------------------------------------------------------
+# Lazy aiortc availability check
+# ---------------------------------------------------------------------------
+
+_aiortc_checked: bool = False
+_aiortc_ok: bool = False
+
+
+def webrtc_available() -> bool:
+    """Return True if the aiortc library is importable."""
+    global _aiortc_checked, _aiortc_ok  # noqa: PLW0603
+    if not _aiortc_checked:
+        try:
+            import aiortc  # noqa: F401
+
+            _aiortc_ok = True
+        except ImportError:
+            _aiortc_ok = False
+        _aiortc_checked = True
+    return _aiortc_ok
+
+
+def rtc_capability_info() -> dict[str, Any]:
+    """Return WebRTC capability metadata for /api/v1/info and /capabilities."""
+    available = webrtc_available()
+    return {
+        "available": available,
+        "reason": None if available else "aiortc not installed",
+        "supportedDirections": ["rx"] if available else [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# SDP offer/answer
+# ---------------------------------------------------------------------------
+
+
+async def handle_rtc_offer(
+    offer_sdp: str,
+    offer_type: str,
+    radio: "Radio | None",
+) -> dict[str, Any]:
+    """Process an SDP offer and return an answer or error dict.
+
+    Returns a dict with either:
+      {"status": "ok", "sdp": <answer_sdp>, "type": "answer"}
+    or:
+      {"status": "error", "code": <str>, "message": <str>}
+    """
+    if not webrtc_available():
+        return {
+            "status": "error",
+            "code": "webrtc_unavailable",
+            "message": _INSTALL_HINT,
+        }
+
+    from ..radio_protocol import AudioCapable
+
+    if radio is None or not isinstance(radio, AudioCapable):
+        return {
+            "status": "error",
+            "code": "audio_unavailable",
+            "message": "Radio audio is not available.",
+        }
+
+    # --- aiortc is available; create a peer connection ---
+    try:
+        from aiortc import (  # type: ignore[import-untyped]
+            RTCPeerConnection,
+            RTCSessionDescription,
+        )
+    except ImportError:
+        # Race / broken install — should not happen after webrtc_available()
+        return {
+            "status": "error",
+            "code": "webrtc_unavailable",
+            "message": _INSTALL_HINT,
+        }
+
+    pc = RTCPeerConnection()
+
+    # Add a single audio transceiver in sendonly mode (RX audio to browser).
+    # Actual media track wiring is a follow-up; for now we create a valid
+    # SDP answer so clients can verify the signaling contract.
+    pc.addTransceiver("audio", direction="sendonly")
+
+    try:
+        offer = RTCSessionDescription(sdp=offer_sdp, type=offer_type)
+        await pc.setRemoteDescription(offer)
+        answer = await pc.createAnswer()
+        await pc.setLocalDescription(answer)
+    except Exception as exc:
+        logger.warning("WebRTC offer processing failed: %s", exc)
+        await pc.close()
+        return {
+            "status": "error",
+            "code": "sdp_error",
+            "message": f"Failed to process SDP offer: {exc}",
+        }
+
+    local_desc = pc.localDescription
+    if local_desc is None:
+        await pc.close()
+        return {
+            "status": "error",
+            "code": "sdp_error",
+            "message": "Failed to generate SDP answer.",
+        }
+
+    logger.info("WebRTC signaling: answer generated for peer")
+
+    # NOTE: The peer connection is created but no audio track is wired yet.
+    # Full media relay from radio.audio_bus → WebRTC track is a follow-up.
+    # For now we close immediately after answering — the client will see
+    # ICE connection fail, which is expected for this scaffolding slice.
+    # TODO(#104): wire audio track and manage PC lifecycle
+    await pc.close()
+
+    return {
+        "status": "ok",
+        "sdp": local_desc.sdp,
+        "type": local_desc.type,
+        "note": "Signaling scaffold only; media track not yet wired.",
+    }

--- a/src/icom_lan/web/rtc.py
+++ b/src/icom_lan/web/rtc.py
@@ -44,8 +44,9 @@ def webrtc_available() -> bool:
     global _aiortc_checked, _aiortc_ok  # noqa: PLW0603
     if not _aiortc_checked:
         try:
-            import aiortc  # type: ignore[import-untyped]  # noqa: F401
+            import importlib
 
+            importlib.import_module("aiortc")
             _aiortc_ok = True
         except ImportError:
             _aiortc_ok = False
@@ -98,7 +99,7 @@ async def handle_rtc_offer(
 
     # --- aiortc is available; create a peer connection ---
     try:
-        from aiortc import (  # type: ignore[import-untyped,unused-ignore]
+        from aiortc import (  # type: ignore[import-untyped]
             RTCPeerConnection,
             RTCSessionDescription,
         )

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -37,6 +37,7 @@ from ..startup_checks import assert_radio_startup_ready
 from ._delta_encoder import DeltaEncoder
 from .dx_cluster import DXClusterClient, SpotBuffer
 from .handlers import AudioBroadcaster, AudioHandler, ControlHandler, ScopeHandler
+from .rtc import handle_rtc_offer, rtc_capability_info, webrtc_available
 from .radio_poller import CommandQueue, DisableScope, EnableScope, RadioPoller
 from .runtime_helpers import (
     build_public_state_payload,
@@ -1281,6 +1282,13 @@ class WebServer:
             )
             return
 
+        if path == "/api/v1/rtc/offer":
+            if method != "POST":
+                await _send_response(writer, 405, "Method Not Allowed", b"", {})
+                return
+            await self._handle_rtc_offer(writer, headers, reader)
+            return
+
         if method not in ("GET", "HEAD"):
             await _send_response(writer, 405, "Method Not Allowed", b"", {})
             return
@@ -1356,6 +1364,7 @@ class WebServer:
                     "hasDualReceiver": has_dual_rx,
                     "hasTuner": "tuner" in caps,
                     "hasCw": "cw" in caps,
+                    "hasWebrtc": webrtc_available() and "audio" in caps,
                     "maxReceivers": (
                         profile.receiver_count
                         if self._radio is not None
@@ -1511,6 +1520,7 @@ class WebServer:
                     "codecs": ["opus"],
                 },
                 "antennas": profile.antenna_tx_count,
+                "webrtc": rtc_capability_info(),
                 **({"controls": profile.controls} if profile.controls else {}),
                 "txBands": [
                     {"name": b.name, "start": b.start, "end": b.end}
@@ -1890,6 +1900,90 @@ class WebServer:
         body = json.dumps(resp, separators=(",", ":")).encode()
         await _send_response(
             writer, 200, "OK", body, {"Content-Type": "application/json"},
+        )
+
+    async def _handle_rtc_offer(
+        self,
+        writer: asyncio.StreamWriter,
+        headers: dict[str, str] | None,
+        reader: asyncio.StreamReader | None,
+    ) -> None:
+        """Handle POST /api/v1/rtc/offer — WebRTC SDP signaling."""
+        if not webrtc_available():
+            body = json.dumps(
+                {"status": "error", "code": "webrtc_unavailable",
+                 "message": "WebRTC backend unavailable; install icom-lan[webrtc]."},
+                separators=(",", ":"),
+            ).encode()
+            await _send_response(
+                writer, 501, "Not Implemented", body,
+                {"Content-Type": "application/json"},
+            )
+            return
+
+        # Read request body
+        body_bytes = b""
+        if reader is not None:
+            cl = int((headers or {}).get("content-length", "0"))
+            if cl > 0:
+                body_bytes = await asyncio.wait_for(
+                    reader.readexactly(cl), timeout=5.0,
+                )
+        if not body_bytes:
+            err = json.dumps(
+                {"status": "error", "code": "missing_body",
+                 "message": "JSON body with 'sdp' and 'type' required."},
+                separators=(",", ":"),
+            ).encode()
+            await _send_response(
+                writer, 400, "Bad Request", err,
+                {"Content-Type": "application/json"},
+            )
+            return
+
+        try:
+            payload = json.loads(body_bytes)
+        except (json.JSONDecodeError, ValueError):
+            err = json.dumps(
+                {"status": "error", "code": "invalid_json",
+                 "message": "Request body is not valid JSON."},
+                separators=(",", ":"),
+            ).encode()
+            await _send_response(
+                writer, 400, "Bad Request", err,
+                {"Content-Type": "application/json"},
+            )
+            return
+
+        sdp = payload.get("sdp")
+        offer_type = payload.get("type", "offer")
+        if not isinstance(sdp, str) or not sdp.strip():
+            err = json.dumps(
+                {"status": "error", "code": "missing_sdp",
+                 "message": "Field 'sdp' is required and must be a non-empty string."},
+                separators=(",", ":"),
+            ).encode()
+            await _send_response(
+                writer, 400, "Bad Request", err,
+                {"Content-Type": "application/json"},
+            )
+            return
+
+        result = await handle_rtc_offer(sdp, offer_type, self._radio)
+
+        if result.get("status") == "ok":
+            status_code, reason = 200, "OK"
+        elif result.get("code") == "audio_unavailable":
+            status_code, reason = 503, "Service Unavailable"
+        elif result.get("code") == "sdp_error":
+            status_code, reason = 400, "Bad Request"
+        else:
+            status_code, reason = 500, "Internal Server Error"
+
+        resp_body = json.dumps(result, separators=(",", ":")).encode()
+        await _send_response(
+            writer, status_code, reason, resp_body,
+            {"Content-Type": "application/json"},
         )
 
     async def _handle_bridge(

--- a/tests/test_webrtc_signaling.py
+++ b/tests/test_webrtc_signaling.py
@@ -1,0 +1,381 @@
+"""Tests for WebRTC signaling scaffold (issue #104).
+
+Covers:
+- aiortc availability detection
+- /api/v1/rtc/offer endpoint behavior with and without aiortc
+- Capability exposure in /api/v1/info and /api/v1/capabilities
+- Error handling (missing body, bad JSON, no radio audio)
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from icom_lan.web.server import WebServer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeWriter:
+    """Minimal asyncio.StreamWriter stand-in that captures bytes."""
+
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+def _parse_response(writer: _FakeWriter) -> tuple[int, dict]:
+    """Extract HTTP status code and JSON body from captured response."""
+    text = writer.buffer.decode("ascii", errors="replace")
+    status_line = text.split("\r\n", 1)[0]
+    status_code = int(status_line.split(" ", 2)[1])
+    body_start = text.index("\r\n\r\n") + 4
+    body = json.loads(text[body_start:]) if text[body_start:] else {}
+    return status_code, body
+
+
+def _make_radio(*, audio: bool = True, caps: set[str] | None = None):
+    """Build a fake radio, optionally implementing AudioCapable."""
+    from icom_lan.radio_protocol import AudioCapable, ScopeCapable
+
+    bases: list[type] = [ScopeCapable]
+    if audio:
+        bases.append(AudioCapable)
+
+    class _FakeRadio(*bases):  # type: ignore[misc]
+        pass
+
+    radio = _FakeRadio()
+    radio.model = "IC-7610"
+    radio.connected = True
+    radio.control_connected = False
+    radio.radio_ready = True
+    radio.capabilities = caps if caps is not None else {"audio", "scope"}
+    return radio
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: rtc module
+# ---------------------------------------------------------------------------
+
+
+class TestWebrtcAvailability:
+    """webrtc_available() detection."""
+
+    def test_reports_false_when_aiortc_missing(self):
+        import icom_lan.web.rtc as rtc_mod
+
+        # Reset cached state
+        rtc_mod._aiortc_checked = False
+        rtc_mod._aiortc_ok = False
+
+        with patch.dict("sys.modules", {"aiortc": None}):
+            rtc_mod._aiortc_checked = False
+            result = rtc_mod.webrtc_available()
+
+        assert result is False
+
+    def test_caches_result(self):
+        import icom_lan.web.rtc as rtc_mod
+
+        rtc_mod._aiortc_checked = True
+        rtc_mod._aiortc_ok = True
+        # Even if import would fail, cached True is returned
+        assert rtc_mod.webrtc_available() is True
+        # Reset
+        rtc_mod._aiortc_checked = False
+
+
+class TestRtcCapabilityInfo:
+    """rtc_capability_info() output."""
+
+    def test_unavailable_info(self):
+        from icom_lan.web.rtc import rtc_capability_info
+
+        with patch("icom_lan.web.rtc.webrtc_available", return_value=False):
+            info = rtc_capability_info()
+
+        assert info["available"] is False
+        assert info["reason"] is not None
+        assert info["supportedDirections"] == []
+
+    def test_available_info(self):
+        from icom_lan.web.rtc import rtc_capability_info
+
+        with patch("icom_lan.web.rtc.webrtc_available", return_value=True):
+            info = rtc_capability_info()
+
+        assert info["available"] is True
+        assert info["reason"] is None
+        assert "rx" in info["supportedDirections"]
+
+
+class TestHandleRtcOffer:
+    """handle_rtc_offer() logic."""
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_aiortc_missing(self):
+        from icom_lan.web.rtc import handle_rtc_offer
+
+        radio = _make_radio()
+        with patch("icom_lan.web.rtc.webrtc_available", return_value=False):
+            result = await handle_rtc_offer("v=0\r\n", "offer", radio)
+
+        assert result["status"] == "error"
+        assert result["code"] == "webrtc_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_no_radio(self):
+        from icom_lan.web.rtc import handle_rtc_offer
+
+        with patch("icom_lan.web.rtc.webrtc_available", return_value=True):
+            result = await handle_rtc_offer("v=0\r\n", "offer", None)
+
+        assert result["status"] == "error"
+        assert result["code"] == "audio_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_success_includes_scaffold_note(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from icom_lan.web.rtc import handle_rtc_offer
+
+        radio = _make_radio()
+
+        mock_desc = MagicMock()
+        mock_desc.sdp = "v=0\r\nanswer"
+        mock_desc.type = "answer"
+
+        mock_pc = MagicMock()
+        mock_pc.addTransceiver = MagicMock()
+        mock_pc.setRemoteDescription = AsyncMock()
+        mock_pc.createAnswer = AsyncMock()
+        mock_pc.setLocalDescription = AsyncMock()
+        mock_pc.localDescription = mock_desc
+        mock_pc.close = AsyncMock()
+
+        fake_aiortc = MagicMock()
+        fake_aiortc.RTCPeerConnection.return_value = mock_pc
+        fake_aiortc.RTCSessionDescription.return_value = MagicMock()
+
+        with patch("icom_lan.web.rtc.webrtc_available", return_value=True), \
+             patch.dict("sys.modules", {"aiortc": fake_aiortc}):
+            result = await handle_rtc_offer("v=0\r\n", "offer", radio)
+
+        assert result["status"] == "ok"
+        assert "note" in result
+        assert "not yet" in result["note"].lower()
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_radio_has_no_audio(self):
+        from icom_lan.web.rtc import handle_rtc_offer
+
+        radio = _make_radio(audio=False)
+        with patch("icom_lan.web.rtc.webrtc_available", return_value=True):
+            result = await handle_rtc_offer("v=0\r\n", "offer", radio)
+
+        assert result["status"] == "error"
+        assert result["code"] == "audio_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests: _handle_rtc_offer on WebServer
+# ---------------------------------------------------------------------------
+
+
+class TestRtcOfferEndpoint:
+    """POST /api/v1/rtc/offer via WebServer._handle_rtc_offer."""
+
+    @pytest.mark.asyncio
+    async def test_501_when_aiortc_unavailable(self):
+        srv = WebServer(radio=None)
+        writer = _FakeWriter()
+
+        with patch("icom_lan.web.server.webrtc_available", return_value=False):
+            await srv._handle_rtc_offer(writer, {}, None)  # noqa: SLF001
+
+        status, body = _parse_response(writer)
+        assert status == 501
+        assert body["code"] == "webrtc_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_400_when_no_body(self):
+        srv = WebServer(radio=None)
+        writer = _FakeWriter()
+
+        with patch("icom_lan.web.server.webrtc_available", return_value=True):
+            await srv._handle_rtc_offer(writer, {}, None)  # noqa: SLF001
+
+        status, body = _parse_response(writer)
+        assert status == 400
+        assert body["code"] == "missing_body"
+
+    @pytest.mark.asyncio
+    async def test_400_when_invalid_json(self):
+        import asyncio
+
+        srv = WebServer(radio=None)
+        writer = _FakeWriter()
+
+        raw = b"not json"
+        reader = asyncio.StreamReader()
+        reader.feed_data(raw)
+        reader.feed_eof()
+        headers = {"content-length": str(len(raw))}
+
+        with patch("icom_lan.web.server.webrtc_available", return_value=True):
+            await srv._handle_rtc_offer(writer, headers, reader)  # noqa: SLF001
+
+        status, body = _parse_response(writer)
+        assert status == 400
+        assert body["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_400_when_sdp_missing(self):
+        import asyncio
+
+        srv = WebServer(radio=None)
+        writer = _FakeWriter()
+
+        raw = json.dumps({"type": "offer"}).encode()
+        reader = asyncio.StreamReader()
+        reader.feed_data(raw)
+        reader.feed_eof()
+        headers = {"content-length": str(len(raw))}
+
+        with patch("icom_lan.web.server.webrtc_available", return_value=True):
+            await srv._handle_rtc_offer(writer, headers, reader)  # noqa: SLF001
+
+        status, body = _parse_response(writer)
+        assert status == 400
+        assert body["code"] == "missing_sdp"
+
+    @pytest.mark.asyncio
+    async def test_503_when_radio_audio_unavailable(self):
+        import asyncio
+
+        radio = _make_radio(audio=False, caps={"scope"})
+        srv = WebServer(radio=radio)
+        writer = _FakeWriter()
+
+        raw = json.dumps({"sdp": "v=0\r\n", "type": "offer"}).encode()
+        reader = asyncio.StreamReader()
+        reader.feed_data(raw)
+        reader.feed_eof()
+        headers = {"content-length": str(len(raw))}
+
+        with patch("icom_lan.web.server.webrtc_available", return_value=True), \
+             patch("icom_lan.web.rtc.webrtc_available", return_value=True):
+            await srv._handle_rtc_offer(writer, headers, reader)  # noqa: SLF001
+
+        status, body = _parse_response(writer)
+        assert status == 503
+        assert body["code"] == "audio_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_400_when_sdp_error(self):
+        import asyncio
+        from unittest.mock import MagicMock
+
+        radio = _make_radio()
+        with patch("icom_lan.web.server.AudioFftScope", MagicMock()):
+            srv = WebServer(radio=radio)
+        writer = _FakeWriter()
+
+        raw = json.dumps({"sdp": "v=0\r\n", "type": "offer"}).encode()
+        reader = asyncio.StreamReader()
+        reader.feed_data(raw)
+        reader.feed_eof()
+        headers = {"content-length": str(len(raw))}
+
+        sdp_err = {"status": "error", "code": "sdp_error", "message": "bad"}
+        with patch("icom_lan.web.server.webrtc_available", return_value=True), \
+             patch("icom_lan.web.server.handle_rtc_offer", return_value=sdp_err):
+            await srv._handle_rtc_offer(writer, headers, reader)  # noqa: SLF001
+
+        status, body = _parse_response(writer)
+        assert status == 400
+        assert body["code"] == "sdp_error"
+
+
+# ---------------------------------------------------------------------------
+# Capability exposure tests
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityExposure:
+    """WebRTC info appears in /api/v1/info and /api/v1/capabilities."""
+
+    @pytest.mark.asyncio
+    async def test_info_includes_has_webrtc_false(self):
+        srv = WebServer(radio=None)
+        writer = _FakeWriter()
+
+        with patch("icom_lan.web.server.webrtc_available", return_value=False):
+            await srv._serve_info(writer)  # noqa: SLF001
+
+        _, body = _parse_response(writer)
+        assert body["capabilities"]["hasWebrtc"] is False
+
+    @pytest.mark.asyncio
+    async def test_info_includes_has_webrtc_true_with_audio(self):
+        from unittest.mock import MagicMock
+
+        radio = _make_radio()
+
+        with patch("icom_lan.web.server.AudioFftScope", MagicMock()):
+            srv = WebServer(radio=radio)
+
+        writer = _FakeWriter()
+
+        with patch("icom_lan.web.server.webrtc_available", return_value=True):
+            await srv._serve_info(writer)  # noqa: SLF001
+
+        _, body = _parse_response(writer)
+        assert body["capabilities"]["hasWebrtc"] is True
+
+    @pytest.mark.asyncio
+    async def test_info_webrtc_false_when_no_audio_cap(self):
+        radio = _make_radio(audio=False, caps={"scope"})
+        srv = WebServer(radio=radio)
+        writer = _FakeWriter()
+
+        with patch("icom_lan.web.server.webrtc_available", return_value=True):
+            await srv._serve_info(writer)  # noqa: SLF001
+
+        _, body = _parse_response(writer)
+        # webrtc_available() is True but audio cap is missing
+        assert body["capabilities"]["hasWebrtc"] is False
+
+    @pytest.mark.asyncio
+    async def test_capabilities_includes_webrtc_block(self):
+        srv = WebServer(radio=None)
+        writer = _FakeWriter()
+
+        with patch("icom_lan.web.server.rtc_capability_info", return_value={
+            "available": False,
+            "reason": "aiortc not installed",
+            "supportedDirections": [],
+        }):
+            await srv._serve_capabilities(writer)  # noqa: SLF001
+
+        _, body = _parse_response(writer)
+        assert "webrtc" in body
+        assert body["webrtc"]["available"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,37 @@ wheels = [
 ]
 
 [[package]]
+name = "aioice"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "ifaddr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/04/df7286233f468e19e9bedff023b6b246182f0b2ccb04ceeb69b2994021c6/aioice-0.10.2.tar.gz", hash = "sha256:bf236c6829ee33c8e540535d31cd5a066b531cb56de2be94c46be76d68b1a806", size = 44307, upload-time = "2025-11-28T15:56:48.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e3/0d23b1f930c17d371ce1ec36ee529f22fd19ebc2a07fe3418e3d1d884ce2/aioice-0.10.2-py3-none-any.whl", hash = "sha256:14911c15ab12d096dd14d372ebb4aecbb7420b52c9b76fdfcf54375dec17fcbf", size = 24875, upload-time = "2025-11-28T15:56:47.847Z" },
+]
+
+[[package]]
+name = "aiortc"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aioice" },
+    { name = "av" },
+    { name = "cryptography" },
+    { name = "google-crc32c" },
+    { name = "pyee" },
+    { name = "pylibsrtp" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/9c/4e027bfe0195de0442da301e2389329496745d40ae44d2d7c4571c4290ce/aiortc-1.14.0.tar.gz", hash = "sha256:adc8a67ace10a085721e588e06a00358ed8eaf5f6b62f0a95358ff45628dd762", size = 1180864, upload-time = "2025-10-13T21:40:37.905Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/ab/31646a49209568cde3b97eeade0d28bb78b400e6645c56422c101df68932/aiortc-1.14.0-py3-none-any.whl", hash = "sha256:4b244d7e482f4e1f67e685b3468269628eca1ec91fa5b329ab517738cfca086e", size = 93183, upload-time = "2025-10-13T21:40:36.59Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -133,6 +164,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "av"
+version = "16.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/cd/3a83ffbc3cc25b39721d174487fb0d51a76582f4a1703f98e46170ce83d4/av-16.1.0.tar.gz", hash = "sha256:a094b4fd87a3721dacf02794d3d2c82b8d712c85b9534437e82a8a978c175ffd", size = 4285203, upload-time = "2026-01-11T07:31:33.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/d0/b71b65d1b36520dcb8291a2307d98b7fc12329a45614a303ff92ada4d723/av-16.1.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:e88ad64ee9d2b9c4c5d891f16c22ae78e725188b8926eb88187538d9dd0b232f", size = 26927747, upload-time = "2026-01-09T20:18:16.976Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/79/720a5a6ccdee06eafa211b945b0a450e3a0b8fc3d12922f0f3c454d870d2/av-16.1.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:cb296073fa6935724de72593800ba86ae49ed48af03960a4aee34f8a611f442b", size = 21492232, upload-time = "2026-01-09T20:18:19.266Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4f/a1ba8d922f2f6d1a3d52419463ef26dd6c4d43ee364164a71b424b5ae204/av-16.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:720edd4d25aa73723c1532bb0597806d7b9af5ee34fc02358782c358cfe2f879", size = 39291737, upload-time = "2026-01-09T20:18:21.513Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/31/fc62b9fe8738d2693e18d99f040b219e26e8df894c10d065f27c6b4f07e3/av-16.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c7f2bc703d0df260a1fdf4de4253c7f5500ca9fc57772ea241b0cb241bcf972e", size = 40846822, upload-time = "2026-01-09T20:18:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/53/10/ab446583dbce730000e8e6beec6ec3c2753e628c7f78f334a35cad0317f4/av-16.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d69c393809babada7d54964d56099e4b30a3e1f8b5736ca5e27bd7be0e0f3c83", size = 40675604, upload-time = "2026-01-09T20:18:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d7/1003be685277005f6d63fd9e64904ee222fe1f7a0ea70af313468bb597db/av-16.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:441892be28582356d53f282873c5a951592daaf71642c7f20165e3ddcb0b4c63", size = 42015955, upload-time = "2026-01-09T20:18:29.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/4a/fa2a38ee9306bf4579f556f94ecbc757520652eb91294d2a99c7cf7623b9/av-16.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:273a3e32de64819e4a1cd96341824299fe06f70c46f2288b5dc4173944f0fd62", size = 31750339, upload-time = "2026-01-09T20:18:32.249Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/84/2535f55edcd426cebec02eb37b811b1b0c163f26b8d3f53b059e2ec32665/av-16.1.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:640f57b93f927fba8689f6966c956737ee95388a91bd0b8c8b5e0481f73513d6", size = 26945785, upload-time = "2026-01-09T20:18:34.486Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/17/ffb940c9e490bf42e86db4db1ff426ee1559cd355a69609ec1efe4d3a9eb/av-16.1.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ae3fb658eec00852ebd7412fdc141f17f3ddce8afee2d2e1cf366263ad2a3b35", size = 21481147, upload-time = "2026-01-09T20:18:36.716Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c1/e0d58003d2d83c3921887d5c8c9b8f5f7de9b58dc2194356a2656a45cfdc/av-16.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ee558d9c02a142eebcbe55578a6d817fedfde42ff5676275504e16d07a7f86", size = 39517197, upload-time = "2026-01-11T09:57:31.937Z" },
+    { url = "https://files.pythonhosted.org/packages/32/77/787797b43475d1b90626af76f80bfb0c12cfec5e11eafcfc4151b8c80218/av-16.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7ae547f6d5fa31763f73900d43901e8c5fa6367bb9a9840978d57b5a7ae14ed2", size = 41174337, upload-time = "2026-01-11T09:57:35.792Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/d90df7f1e3b97fc5554cf45076df5045f1e0a6adf13899e10121229b826c/av-16.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8cf065f9d438e1921dc31fc7aa045790b58aee71736897866420d80b5450f62a", size = 40817720, upload-time = "2026-01-11T09:57:39.039Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6f/13c3a35f9dbcebafd03fe0c4cbd075d71ac8968ec849a3cfce406c35a9d2/av-16.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a345877a9d3cc0f08e2bc4ec163ee83176864b92587afb9d08dff50f37a9a829", size = 42267396, upload-time = "2026-01-11T09:57:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b9/275df9607f7fb44317ccb1d4be74827185c0d410f52b6e2cd770fe209118/av-16.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:f49243b1d27c91cd8c66fdba90a674e344eb8eb917264f36117bf2b6879118fd", size = 31752045, upload-time = "2026-01-11T09:57:45.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2a/63797a4dde34283dd8054219fcb29294ba1c25d68ba8c8c8a6ae53c62c45/av-16.1.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:ce2a1b3d8bf619f6c47a9f28cfa7518ff75ddd516c234a4ee351037b05e6a587", size = 26916715, upload-time = "2026-01-11T09:57:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c4/0b49cf730d0ae8cda925402f18ae814aef351f5772d14da72dd87ff66448/av-16.1.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:408dbe6a2573ca58a855eb8cd854112b33ea598651902c36709f5f84c991ed8e", size = 21452167, upload-time = "2026-01-11T09:57:50.606Z" },
+    { url = "https://files.pythonhosted.org/packages/51/23/408806503e8d5d840975aad5699b153aaa21eb6de41ade75248a79b7a37f/av-16.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:57f657f86652a160a8a01887aaab82282f9e629abf94c780bbdbb01595d6f0f7", size = 39215659, upload-time = "2026-01-11T09:57:53.757Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/19/a8528d5bba592b3903f44c28dab9cc653c95fcf7393f382d2751a1d1523e/av-16.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:adbad2b355c2ee4552cac59762809d791bda90586d134a33c6f13727fb86cb3a", size = 40874970, upload-time = "2026-01-11T09:57:56.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/24/2dbcdf0e929ad56b7df078e514e7bd4ca0d45cba798aff3c8caac097d2f7/av-16.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f42e1a68ec2aebd21f7eb6895be69efa6aa27eec1670536876399725bbda4b99", size = 40530345, upload-time = "2026-01-11T09:58:00.421Z" },
+    { url = "https://files.pythonhosted.org/packages/54/27/ae91b41207f34e99602d1c72ab6ffd9c51d7c67e3fbcd4e3a6c0e54f882c/av-16.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58fe47aeaef0f100c40ec8a5de9abbd37f118d3ca03829a1009cf288e9aef67c", size = 41972163, upload-time = "2026-01-11T09:58:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7a/22158fb923b2a9a00dfab0e96ef2e8a1763a94dd89e666a5858412383d46/av-16.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:565093ebc93b2f4b76782589564869dadfa83af5b852edebedd8fee746457d06", size = 31729230, upload-time = "2026-01-11T09:58:07.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f1/878f8687d801d6c4565d57ebec08449c46f75126ebca8e0fed6986599627/av-16.1.0-cp313-cp313t-macosx_11_0_x86_64.whl", hash = "sha256:574081a24edb98343fd9f473e21ae155bf61443d4ec9d7708987fa597d6b04b2", size = 27008769, upload-time = "2026-01-11T09:58:10.266Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f1/bd4ce8c8b5cbf1d43e27048e436cbc9de628d48ede088a1d0a993768eb86/av-16.1.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:9ab00ea29c25ebf2ea1d1e928d7babb3532d562481c5d96c0829212b70756ad0", size = 21590588, upload-time = "2026-01-11T09:58:12.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/c81f6f9209201ff0b5d5bed6da6c6e641eef52d8fbc930d738c3f4f6f75d/av-16.1.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:a84a91188c1071f238a9523fd42dbe567fb2e2607b22b779851b2ce0eac1b560", size = 40638029, upload-time = "2026-01-11T09:58:15.399Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4d/07edff82b78d0459a6e807e01cd280d3180ce832efc1543de80d77676722/av-16.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c2cd0de4dd022a7225ff224fde8e7971496d700be41c50adaaa26c07bb50bf97", size = 41970776, upload-time = "2026-01-11T09:58:19.075Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9d/1f48b354b82fa135d388477cd1b11b81bdd4384bd6a42a60808e2ec2d66b/av-16.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0816143530624a5a93bc5494f8c6eeaf77549b9366709c2ac8566c1e9bff6df5", size = 41764751, upload-time = "2026-01-11T09:58:22.788Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c7/a509801e98db35ec552dd79da7bdbcff7104044bfeb4c7d196c1ce121593/av-16.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e3a28053af29644696d0c007e897d19b1197585834660a54773e12a40b16974c", size = 43034355, upload-time = "2026-01-11T09:58:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/36/8b/e5f530d9e8f640da5f5c5f681a424c65f9dd171c871cd255d8a861785a6e/av-16.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e3e67144a202b95ed299d165232533989390a9ea3119d37eccec697dc6dbb0c", size = 31947047, upload-time = "2026-01-11T09:58:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/df/18/8812221108c27d19f7e5f486a82c827923061edf55f906824ee0fcaadf50/av-16.1.0-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:39a634d8e5a87e78ea80772774bfd20c0721f0d633837ff185f36c9d14ffede4", size = 26916179, upload-time = "2026-01-11T09:58:36.506Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ef/49d128a9ddce42a2766fe2b6595bd9c49e067ad8937a560f7838a541464e/av-16.1.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0ba32fb9e9300948a7fa9f8a3fc686e6f7f77599a665c71eb2118fdfd2c743f9", size = 21460168, upload-time = "2026-01-11T09:58:39.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a9/b310d390844656fa74eeb8c2750e98030877c75b97551a23a77d3f982741/av-16.1.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ca04d17815182d34ce3edc53cbda78a4f36e956c0fd73e3bab249872a831c4d7", size = 39210194, upload-time = "2026-01-11T09:58:42.138Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7b/e65aae179929d0f173af6e474ad1489b5b5ad4c968a62c42758d619e54cf/av-16.1.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ee0e8de2e124a9ef53c955fe2add6ee7c56cc8fd83318265549e44057db77142", size = 40811675, upload-time = "2026-01-11T09:58:45.871Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3f/5d7edefd26b6a5187d6fac0f5065ee286109934f3dea607ef05e53f05b31/av-16.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:22bf77a2f658827043a1e184b479c3bf25c4c43ab32353677df2d119f080e28f", size = 40543942, upload-time = "2026-01-11T09:58:49.759Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/24/f8b17897b67be0900a211142f5646a99d896168f54d57c81f3e018853796/av-16.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2dd419d262e6a71cab206d80bbf28e0a10d0f227b671cdf5e854c028faa2d043", size = 41924336, upload-time = "2026-01-11T09:58:53.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/d32bc6bbbcf60b65f6510c54690ed3ae1c4ca5d9fafbce835b6056858686/av-16.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:53585986fd431cd436f290fba662cfb44d9494fbc2949a183de00acc5b33fa88", size = 31735077, upload-time = "2026-01-11T09:58:56.684Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f4/9b63dc70af8636399bd933e9df4f3025a0294609510239782c1b746fc796/av-16.1.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:76f5ed8495cf41e1209a5775d3699dc63fdc1740b94a095e2485f13586593205", size = 27014423, upload-time = "2026-01-11T09:58:59.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/da/787a07a0d6ed35a0888d7e5cfb8c2ffa202f38b7ad2c657299fac08eb046/av-16.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:8d55397190f12a1a3ae7538be58c356cceb2bf50df1b33523817587748ce89e5", size = 21595536, upload-time = "2026-01-11T09:59:02.508Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f4/9a7d8651a611be6e7e3ab7b30bb43779899c8cac5f7293b9fb634c44a3f3/av-16.1.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:9d51d9037437218261b4bbf9df78a95e216f83d7774fbfe8d289230b5b2e28e2", size = 40642490, upload-time = "2026-01-11T09:59:05.842Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e4/eb79bc538a94b4ff93cd4237d00939cba797579f3272490dd0144c165a21/av-16.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0ce07a89c15644407f49d942111ca046e323bbab0a9078ff43ee57c9b4a50dad", size = 41976905, upload-time = "2026-01-11T09:59:09.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/f6db0dd86b70167a4d55ee0d9d9640983c570d25504f2bde42599f38241e/av-16.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cac0c074892ea97113b53556ff41c99562db7b9f09f098adac1f08318c2acad5", size = 41770481, upload-time = "2026-01-11T09:59:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/33651d658e45e16ab7671ea5fcf3d20980ea7983234f4d8d0c63c65581a5/av-16.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7dec3dcbc35a187ce450f65a2e0dda820d5a9e6553eea8344a1459af11c98649", size = 43036824, upload-time = "2026-01-11T09:59:16.507Z" },
+    { url = "https://files.pythonhosted.org/packages/83/41/7f13361db54d7e02f11552575c0384dadaf0918138f4eaa82ea03a9f9580/av-16.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6f90dc082ff2068ddbe77618400b44d698d25d9c4edac57459e250c16b33d700", size = 31948164, upload-time = "2026-01-11T09:59:19.501Z" },
 ]
 
 [[package]]
@@ -495,6 +576,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -612,6 +702,36 @@ wheels = [
 ]
 
 [[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -652,6 +772,9 @@ scope = [
 tls = [
     { name = "cryptography" },
 ]
+webrtc = [
+    { name = "aiortc" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -668,6 +791,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiortc", marker = "extra == 'webrtc'", specifier = ">=1.9" },
     { name = "cryptography", marker = "extra == 'tls'", specifier = ">=41.0" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy", marker = "extra == 'bridge'" },
@@ -683,7 +807,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sounddevice", marker = "extra == 'bridge'" },
 ]
-provides-extras = ["audio", "bridge", "scope", "tls", "dev"]
+provides-extras = ["audio", "bridge", "scope", "webrtc", "tls", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -705,6 +829,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "ifaddr"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485, upload-time = "2022-06-15T21:40:27.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314, upload-time = "2022-06-15T21:40:25.756Z" },
 ]
 
 [[package]]
@@ -1503,12 +1636,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pylibsrtp"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/a6/6e532bec974aaecbf9fe4e12538489fb1c28456e65088a50f305aeab9f89/pylibsrtp-1.0.0.tar.gz", hash = "sha256:b39dff075b263a8ded5377f2490c60d2af452c9f06c4d061c7a2b640612b34d4", size = 10858, upload-time = "2025-10-13T16:12:31.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/af/89e61a62fa3567f1b7883feb4d19e19564066c2fcd41c37e08d317b51881/pylibsrtp-1.0.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:822c30ea9e759b333dc1f56ceac778707c51546e97eb874de98d7d378c000122", size = 1865017, upload-time = "2025-10-13T16:12:15.62Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0e/8d215484a9877adcf2459a8b28165fc89668b034565277fd55d666edd247/pylibsrtp-1.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:aaad74e5c8cbc1c32056c3767fea494c1e62b3aea2c908eda2a1051389fdad76", size = 2182739, upload-time = "2025-10-13T16:12:17.121Z" },
+    { url = "https://files.pythonhosted.org/packages/57/3f/76a841978877ae13eac0d4af412c13bbd5d83b3df2c1f5f2175f2e0f68e5/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9209b86e662ebbd17c8a9e8549ba57eca92a3e87fb5ba8c0e27b8c43cd08a767", size = 2732922, upload-time = "2025-10-13T16:12:18.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/14/cf5d2a98a66fdfe258f6b036cda570f704a644fa861d7883a34bc359501e/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:293c9f2ac21a2bd689c477603a1aa235d85cf252160e6715f0101e42a43cbedc", size = 2434534, upload-time = "2025-10-13T16:12:20.074Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/08/a3f6e86c04562f7dce6717cd2206a0f84ca85c5e38121d998e0e330194c3/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:81fb8879c2e522021a7cbd3f4bda1b37c192e1af939dfda3ff95b4723b329663", size = 2345818, upload-time = "2025-10-13T16:12:21.439Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d5/130c2b5b4b51df5631684069c6f0a6761c59d096a33d21503ac207cf0e47/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4ddb562e443cf2e557ea2dfaeef0d7e6b90e96dd38eb079b4ab2c8e34a79f50b", size = 2774490, upload-time = "2025-10-13T16:12:22.659Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e3/715a453bfee3bea92a243888ad359094a7727cc6d393f21281320fe7798c/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:f02e616c9dfab2b03b32d8cc7b748f9d91814c0211086f987629a60f05f6e2cc", size = 2372603, upload-time = "2025-10-13T16:12:24.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/56/52fa74294254e1f53a4ff170ee2006e57886cf4bb3db46a02b4f09e1d99f/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c134fa09e7b80a5b7fed626230c5bc257fd771bd6978e754343e7a61d96bc7e6", size = 2451269, upload-time = "2025-10-13T16:12:25.475Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/51/2e9b34f484cbdd3bac999bf1f48b696d7389433e900639089e8fc4e0da0d/pylibsrtp-1.0.0-cp310-abi3-win32.whl", hash = "sha256:bae377c3b402b17b9bbfbfe2534c2edba17aa13bea4c64ce440caacbe0858b55", size = 1247503, upload-time = "2025-10-13T16:12:27.39Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/70/43db21af194580aba2d9a6d4c7bd8c1a6e887fa52cd810b88f89096ecad2/pylibsrtp-1.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:8d6527c4a78a39a8d397f8862a8b7cdad4701ee866faf9de4ab8c70be61fd34d", size = 1601659, upload-time = "2025-10-13T16:12:29.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ec/6e02b2561d056ea5b33046e3cad21238e6a9097b97d6ccc0fbe52b50c858/pylibsrtp-1.0.0-cp310-abi3-win_arm64.whl", hash = "sha256:2696bdb2180d53ac55d0eb7b58048a2aa30cd4836dd2ca683669889137a94d2a", size = 1159246, upload-time = "2025-10-13T16:12:30.285Z" },
 ]
 
 [[package]]
@@ -1522,6 +1689,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/11/a62e1d33b373da2b2c2cd9eb508147871c80f12b1cacde3c5d314922afdd/pyopenssl-26.0.0.tar.gz", hash = "sha256:f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc", size = 185534, upload-time = "2026-03-15T14:28:26.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/7d/d4f7d908fa8415571771b30669251d57c3cf313b36a856e6d7548ae01619/pyopenssl-26.0.0-py3-none-any.whl", hash = "sha256:df94d28498848b98cc1c0ffb8ef1e71e40210d3b0a8064c9d29571ed2904bf81", size = 57969, upload-time = "2026-03-15T14:28:24.864Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Backend-only WebRTC signaling scaffold — an incremental first slice for #104.

## Changes

- **Optional dependency**: `[webrtc]` extra with `aiortc>=1.9` in pyproject.toml
- **Signaling endpoint**: `POST /api/v1/rtc/offer` — accepts SDP offer, returns answer or structured error
  - **501** when aiortc not installed
  - **400** for missing body, bad JSON, missing SDP, or invalid SDP
  - **503** when radio audio unavailable
  - **200** with SDP answer when everything is available
- **Capability exposure**:
  - `/api/v1/info` → `capabilities.hasWebrtc` (bool)
  - `/api/v1/capabilities` → `webrtc: {available, reason, supportedDirections}`
- **Lazy import**: zero impact when aiortc is not installed

## Validation

- `uv run pytest tests/test_webrtc_signaling.py -q` → 18 passed
- `uv run ruff check ...` → All checks passed
- Independent code review completed — no blocking issues found

## Scope

This is a **scaffolding slice only** — media relay, frontend migration, TX, and STUN/TURN are follow-ups.

## Related

- Issue: #104
- This does not close #104 — it lands an incremental backend foundation