### PR TITLE
feat(#514): AudioBackend protocol + PortAudioBackend + FakeAudioBackend

### DIFF
--- a/src/icom_lan/audio/__init__.py
+++ b/src/icom_lan/audio/__init__.py
@@ -20,6 +20,19 @@ from .lan_stream import (  # noqa: F401
     parse_audio_packet,
 )
 
+# Audio backend abstraction (protocol + implementations)
+from .backend import (  # noqa: F401
+    AudioBackend,
+    AudioDeviceId,
+    AudioDeviceInfo,
+    FakeAudioBackend,
+    FakeRxStream,
+    FakeTxStream,
+    PortAudioBackend,
+    RxStream,
+    TxStream,
+)
+
 # USB audio driver (moved from icom7610/drivers/)
 from .usb_driver import (  # noqa: F401
     AudioDeviceSelectionError,
@@ -31,6 +44,16 @@ from .usb_driver import (  # noqa: F401
 )
 
 __all__ = [
+    # Audio backend abstraction
+    "AudioBackend",
+    "AudioDeviceId",
+    "AudioDeviceInfo",
+    "FakeAudioBackend",
+    "FakeRxStream",
+    "FakeTxStream",
+    "PortAudioBackend",
+    "RxStream",
+    "TxStream",
     # LAN audio
     "AUDIO_HEADER_SIZE",
     "AudioPacket",

--- a/src/icom_lan/audio/backend.py
+++ b/src/icom_lan/audio/backend.py
@@ -1,0 +1,511 @@
+"""AudioBackend protocol and implementations.
+
+Defines the abstract ``AudioBackend`` interface for discovering devices and
+opening RX/TX audio streams, plus two concrete implementations:
+
+- **PortAudioBackend** — wraps *sounddevice* + *numpy* (requires ``[bridge]``
+  extras).
+- **FakeAudioBackend** — deterministic, dependency-free backend for tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, NewType, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Identifiers & descriptors
+# ---------------------------------------------------------------------------
+
+AudioDeviceId = NewType("AudioDeviceId", int)
+"""Opaque device identifier (maps to a host-API device index)."""
+
+
+@dataclass(frozen=True, slots=True)
+class AudioDeviceInfo:
+    """Normalized audio device descriptor returned by a backend."""
+
+    id: AudioDeviceId
+    name: str
+    input_channels: int = 0
+    output_channels: int = 0
+    default_samplerate: int = 48_000
+    is_default_input: bool = False
+    is_default_output: bool = False
+
+    @property
+    def supports_rx(self) -> bool:
+        return self.input_channels > 0
+
+    @property
+    def supports_tx(self) -> bool:
+        return self.output_channels > 0
+
+    @property
+    def duplex(self) -> bool:
+        return self.supports_rx and self.supports_tx
+
+
+# ---------------------------------------------------------------------------
+# Stream protocols
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class RxStream(Protocol):
+    """Readable audio capture stream."""
+
+    @property
+    def running(self) -> bool: ...
+
+    async def start(self, callback: Callable[[bytes], None]) -> None:
+        """Begin capture; deliver PCM s16le frames to *callback*."""
+        ...
+
+    async def stop(self) -> None: ...
+
+
+@runtime_checkable
+class TxStream(Protocol):
+    """Writable audio playback stream."""
+
+    @property
+    def running(self) -> bool: ...
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+    async def write(self, frame: bytes) -> None:
+        """Queue one PCM s16le frame for playback."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Backend protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class AudioBackend(Protocol):
+    """Abstract audio backend capable of listing devices and opening streams."""
+
+    def list_devices(self) -> list[AudioDeviceInfo]: ...
+
+    def open_rx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> RxStream: ...
+
+    def open_tx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> TxStream: ...
+
+
+# ---------------------------------------------------------------------------
+# PortAudioBackend (sounddevice)
+# ---------------------------------------------------------------------------
+
+_DEPENDENCY_HINT = (
+    "PortAudioBackend requires optional dependencies sounddevice and numpy. "
+    "Install with: pip install icom-lan[bridge]"
+)
+
+
+def _ensure_portaudio_deps() -> tuple[Any, Any]:
+    """Return ``(sounddevice, numpy)`` or raise :class:`ImportError`."""
+    try:
+        import sounddevice as sd  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise ImportError(_DEPENDENCY_HINT) from exc
+    try:
+        import numpy as np
+    except ImportError as exc:
+        raise ImportError(_DEPENDENCY_HINT) from exc
+    return sd, np
+
+
+class _PortAudioRxStream:
+    """RxStream backed by a sounddevice InputStream."""
+
+    def __init__(
+        self,
+        sd: Any,
+        device_index: int,
+        sample_rate: int,
+        channels: int,
+        blocksize: int,
+    ) -> None:
+        self._sd = sd
+        self._device_index = device_index
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._blocksize = blocksize
+        self._stream: Any = None
+        self._task: asyncio.Task[None] | None = None
+        self._callback: Callable[[bytes], None] | None = None
+
+    @property
+    def running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    async def start(self, callback: Callable[[bytes], None]) -> None:
+        if self.running:
+            raise RuntimeError("RX stream already running.")
+        self._callback = callback
+        self._stream = self._sd.InputStream(
+            samplerate=self._sample_rate,
+            channels=self._channels,
+            dtype="int16",
+            device=self._device_index,
+            blocksize=self._blocksize,
+            latency="low",
+        )
+        self._stream.start()
+        self._task = asyncio.create_task(self._loop(), name="portaudio-rx")
+
+    async def stop(self) -> None:
+        task = self._task
+        stream = self._stream
+        self._task = None
+        self._stream = None
+        self._callback = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        if stream is not None:
+            try:
+                stream.stop()
+            except Exception:
+                logger.debug("portaudio-rx: stream stop failed", exc_info=True)
+            try:
+                stream.close()
+            except Exception:
+                logger.debug("portaudio-rx: stream close failed", exc_info=True)
+
+    async def _loop(self) -> None:
+        stream = self._stream
+        try:
+            while True:
+                data, _overflowed = await asyncio.to_thread(
+                    stream.read, self._blocksize
+                )
+                cb = self._callback
+                if cb is None:
+                    continue
+                pcm = bytes(data.tobytes()) if hasattr(data, "tobytes") else bytes(data)
+                cb(pcm)
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.warning("portaudio-rx: loop failed", exc_info=True)
+
+
+class _PortAudioTxStream:
+    """TxStream backed by a sounddevice OutputStream."""
+
+    def __init__(
+        self,
+        sd: Any,
+        np: Any,
+        device_index: int,
+        sample_rate: int,
+        channels: int,
+        blocksize: int,
+    ) -> None:
+        self._sd = sd
+        self._np = np
+        self._device_index = device_index
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._blocksize = blocksize
+        self._stream: Any = None
+        self._task: asyncio.Task[None] | None = None
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=64)
+
+    @property
+    def running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    async def start(self) -> None:
+        if self.running:
+            raise RuntimeError("TX stream already running.")
+        self._stream = self._sd.OutputStream(
+            samplerate=self._sample_rate,
+            channels=self._channels,
+            dtype="int16",
+            device=self._device_index,
+            blocksize=self._blocksize,
+            latency="low",
+        )
+        self._stream.start()
+        self._queue = asyncio.Queue(maxsize=64)
+        self._task = asyncio.create_task(self._loop(), name="portaudio-tx")
+
+    async def stop(self) -> None:
+        task = self._task
+        stream = self._stream
+        self._task = None
+        self._stream = None
+        self._queue = asyncio.Queue(maxsize=64)
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        if stream is not None:
+            try:
+                stream.stop()
+            except Exception:
+                logger.debug("portaudio-tx: stream stop failed", exc_info=True)
+            try:
+                stream.close()
+            except Exception:
+                logger.debug("portaudio-tx: stream close failed", exc_info=True)
+
+    async def write(self, frame: bytes) -> None:
+        if not self.running:
+            raise RuntimeError("TX stream is not running.")
+        await self._queue.put(frame)
+
+    async def _loop(self) -> None:
+        stream = self._stream
+        np = self._np
+        channels = self._channels
+        try:
+            while True:
+                pcm = await self._queue.get()
+                arr = np.frombuffer(pcm, dtype=np.int16).reshape(-1, channels)
+                await asyncio.to_thread(stream.write, arr)
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.warning("portaudio-tx: loop failed", exc_info=True)
+
+
+class PortAudioBackend:
+    """AudioBackend backed by PortAudio via *sounddevice*."""
+
+    def __init__(
+        self,
+        *,
+        dependency_loader: Callable[[], tuple[Any, Any]] | None = None,
+    ) -> None:
+        self._sd: Any = None
+        self._np: Any = None
+        self._dependency_loader = dependency_loader
+
+    def _ensure_deps(self) -> tuple[Any, Any]:
+        if self._sd is not None and self._np is not None:
+            return self._sd, self._np
+        if self._dependency_loader is not None:
+            try:
+                self._sd, self._np = self._dependency_loader()
+            except ImportError as exc:
+                raise ImportError(_DEPENDENCY_HINT) from exc
+        else:
+            self._sd, self._np = _ensure_portaudio_deps()
+        return self._sd, self._np
+
+    def list_devices(self) -> list[AudioDeviceInfo]:
+        sd, _ = self._ensure_deps()
+        raw_devices = list(sd.query_devices())
+        default_raw = getattr(getattr(sd, "default", None), "device", None)
+        default_in: int | None = None
+        default_out: int | None = None
+        if isinstance(default_raw, (list, tuple)) and len(default_raw) >= 2:
+            default_in = int(default_raw[0]) if default_raw[0] is not None else None
+            default_out = int(default_raw[1]) if default_raw[1] is not None else None
+
+        result: list[AudioDeviceInfo] = []
+        for idx, raw in enumerate(raw_devices):
+            dev_idx = int(raw.get("index", idx))
+            result.append(
+                AudioDeviceInfo(
+                    id=AudioDeviceId(dev_idx),
+                    name=str(raw.get("name", f"device-{dev_idx}")),
+                    input_channels=int(raw.get("max_input_channels", 0)),
+                    output_channels=int(raw.get("max_output_channels", 0)),
+                    default_samplerate=int(raw.get("default_samplerate", 48_000)),
+                    is_default_input=(default_in is not None and dev_idx == default_in),
+                    is_default_output=(
+                        default_out is not None and dev_idx == default_out
+                    ),
+                )
+            )
+        return result
+
+    def open_rx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> RxStream:
+        sd, _ = self._ensure_deps()
+        blocksize = (sample_rate * frame_ms) // 1000
+        return _PortAudioRxStream(
+            sd,
+            device_index=int(device),
+            sample_rate=sample_rate,
+            channels=channels,
+            blocksize=blocksize,
+        )
+
+    def open_tx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> TxStream:
+        sd, np = self._ensure_deps()
+        blocksize = (sample_rate * frame_ms) // 1000
+        return _PortAudioTxStream(
+            sd,
+            np,
+            device_index=int(device),
+            sample_rate=sample_rate,
+            channels=channels,
+            blocksize=blocksize,
+        )
+
+
+# ---------------------------------------------------------------------------
+# FakeAudioBackend (for tests)
+# ---------------------------------------------------------------------------
+
+
+class FakeRxStream:
+    """Test double: records lifecycle and delivers injected frames."""
+
+    def __init__(self) -> None:
+        self._running = False
+        self._callback: Callable[[bytes], None] | None = None
+        self.started_count = 0
+        self.stopped_count = 0
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    async def start(self, callback: Callable[[bytes], None]) -> None:
+        if self._running:
+            raise RuntimeError("FakeRxStream already running.")
+        self._callback = callback
+        self._running = True
+        self.started_count += 1
+
+    async def stop(self) -> None:
+        self._running = False
+        self._callback = None
+        self.stopped_count += 1
+
+    def inject_frame(self, frame: bytes) -> None:
+        """Push a frame to the registered callback (test helper)."""
+        if self._callback is not None:
+            self._callback(frame)
+
+
+class FakeTxStream:
+    """Test double: records lifecycle and captures written frames."""
+
+    def __init__(self) -> None:
+        self._running = False
+        self.started_count = 0
+        self.stopped_count = 0
+        self.written_frames: list[bytes] = []
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    async def start(self) -> None:
+        if self._running:
+            raise RuntimeError("FakeTxStream already running.")
+        self._running = True
+        self.started_count += 1
+
+    async def stop(self) -> None:
+        self._running = False
+        self.stopped_count += 1
+
+    async def write(self, frame: bytes) -> None:
+        if not self._running:
+            raise RuntimeError("FakeTxStream is not running.")
+        self.written_frames.append(frame)
+
+
+class FakeAudioBackend:
+    """Deterministic AudioBackend for tests — no real audio hardware."""
+
+    def __init__(
+        self,
+        devices: list[AudioDeviceInfo] | None = None,
+    ) -> None:
+        self._devices: list[AudioDeviceInfo] = devices or []
+        self.rx_streams: list[FakeRxStream] = []
+        self.tx_streams: list[FakeTxStream] = []
+
+    def list_devices(self) -> list[AudioDeviceInfo]:
+        return list(self._devices)
+
+    def open_rx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> FakeRxStream:
+        if not any(d.id == device for d in self._devices):
+            raise ValueError(f"Unknown device id {device}")
+        stream = FakeRxStream()
+        self.rx_streams.append(stream)
+        return stream
+
+    def open_tx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> FakeTxStream:
+        if not any(d.id == device for d in self._devices):
+            raise ValueError(f"Unknown device id {device}")
+        stream = FakeTxStream()
+        self.tx_streams.append(stream)
+        return stream
+
+
+__all__ = [
+    "AudioBackend",
+    "AudioDeviceId",
+    "AudioDeviceInfo",
+    "FakeAudioBackend",
+    "FakeRxStream",
+    "FakeTxStream",
+    "PortAudioBackend",
+    "RxStream",
+    "TxStream",
+]

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -1,0 +1,323 @@
+"""Tests for AudioBackend protocol, FakeAudioBackend, and PortAudioBackend."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from icom_lan.audio.backend import (
+    AudioBackend,
+    AudioDeviceId,
+    AudioDeviceInfo,
+    FakeAudioBackend,
+    FakeRxStream,
+    FakeTxStream,
+    PortAudioBackend,
+    RxStream,
+    TxStream,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+DUPLEX_DEVICE = AudioDeviceInfo(
+    id=AudioDeviceId(0),
+    name="USB Audio CODEC",
+    input_channels=1,
+    output_channels=1,
+    default_samplerate=48_000,
+    is_default_input=True,
+    is_default_output=True,
+)
+
+INPUT_ONLY_DEVICE = AudioDeviceInfo(
+    id=AudioDeviceId(1),
+    name="Microphone",
+    input_channels=2,
+    output_channels=0,
+)
+
+OUTPUT_ONLY_DEVICE = AudioDeviceInfo(
+    id=AudioDeviceId(2),
+    name="Speakers",
+    input_channels=0,
+    output_channels=2,
+)
+
+
+@pytest.fixture()
+def fake_backend() -> FakeAudioBackend:
+    return FakeAudioBackend(devices=[DUPLEX_DEVICE, INPUT_ONLY_DEVICE, OUTPUT_ONLY_DEVICE])
+
+
+# ---------------------------------------------------------------------------
+# AudioDeviceInfo
+# ---------------------------------------------------------------------------
+
+
+class TestAudioDeviceInfo:
+    def test_duplex(self) -> None:
+        assert DUPLEX_DEVICE.supports_rx is True
+        assert DUPLEX_DEVICE.supports_tx is True
+        assert DUPLEX_DEVICE.duplex is True
+
+    def test_input_only(self) -> None:
+        assert INPUT_ONLY_DEVICE.supports_rx is True
+        assert INPUT_ONLY_DEVICE.supports_tx is False
+        assert INPUT_ONLY_DEVICE.duplex is False
+
+    def test_output_only(self) -> None:
+        assert OUTPUT_ONLY_DEVICE.supports_rx is False
+        assert OUTPUT_ONLY_DEVICE.supports_tx is True
+        assert OUTPUT_ONLY_DEVICE.duplex is False
+
+    def test_frozen(self) -> None:
+        with pytest.raises(AttributeError):
+            DUPLEX_DEVICE.name = "changed"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance (structural typing checks)
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_fake_backend_is_audio_backend(self, fake_backend: FakeAudioBackend) -> None:
+        assert isinstance(fake_backend, AudioBackend)
+
+    def test_fake_rx_stream_is_rx_stream(self) -> None:
+        assert isinstance(FakeRxStream(), RxStream)
+
+    def test_fake_tx_stream_is_tx_stream(self) -> None:
+        assert isinstance(FakeTxStream(), TxStream)
+
+    def test_portaudio_backend_is_audio_backend(self) -> None:
+        # PortAudioBackend satisfies the protocol structurally (deps not needed here)
+        backend = PortAudioBackend(dependency_loader=lambda: (None, None))
+        assert isinstance(backend, AudioBackend)
+
+
+# ---------------------------------------------------------------------------
+# FakeAudioBackend — device listing
+# ---------------------------------------------------------------------------
+
+
+class TestFakeBackendDevices:
+    def test_list_devices(self, fake_backend: FakeAudioBackend) -> None:
+        devices = fake_backend.list_devices()
+        assert len(devices) == 3
+        assert devices[0].name == "USB Audio CODEC"
+
+    def test_list_devices_returns_copy(self, fake_backend: FakeAudioBackend) -> None:
+        d1 = fake_backend.list_devices()
+        d2 = fake_backend.list_devices()
+        assert d1 is not d2
+
+    def test_empty_backend(self) -> None:
+        backend = FakeAudioBackend()
+        assert backend.list_devices() == []
+
+    def test_open_rx_unknown_device(self, fake_backend: FakeAudioBackend) -> None:
+        with pytest.raises(ValueError, match="Unknown device"):
+            fake_backend.open_rx(AudioDeviceId(99))
+
+    def test_open_tx_unknown_device(self, fake_backend: FakeAudioBackend) -> None:
+        with pytest.raises(ValueError, match="Unknown device"):
+            fake_backend.open_tx(AudioDeviceId(99))
+
+
+# ---------------------------------------------------------------------------
+# FakeRxStream lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestFakeRxStreamLifecycle:
+    @pytest.mark.asyncio()
+    async def test_start_stop(self, fake_backend: FakeAudioBackend) -> None:
+        stream = fake_backend.open_rx(DUPLEX_DEVICE.id)
+        assert not stream.running
+
+        received: list[bytes] = []
+        await stream.start(received.append)
+        assert stream.running
+        assert stream.started_count == 1
+
+        await stream.stop()
+        assert not stream.running
+        assert stream.stopped_count == 1
+
+    @pytest.mark.asyncio()
+    async def test_double_start_raises(self, fake_backend: FakeAudioBackend) -> None:
+        stream = fake_backend.open_rx(DUPLEX_DEVICE.id)
+        await stream.start(lambda _: None)
+        with pytest.raises(RuntimeError, match="already running"):
+            await stream.start(lambda _: None)
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_inject_frame(self, fake_backend: FakeAudioBackend) -> None:
+        stream = fake_backend.open_rx(DUPLEX_DEVICE.id)
+        received: list[bytes] = []
+        await stream.start(received.append)
+
+        stream.inject_frame(b"\x00\x01\x02\x03")
+        assert received == [b"\x00\x01\x02\x03"]
+
+        stream.inject_frame(b"\xff")
+        assert len(received) == 2
+
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_inject_after_stop_is_noop(self, fake_backend: FakeAudioBackend) -> None:
+        stream = fake_backend.open_rx(DUPLEX_DEVICE.id)
+        received: list[bytes] = []
+        await stream.start(received.append)
+        await stream.stop()
+
+        stream.inject_frame(b"\x00")
+        assert received == []  # callback cleared
+
+    @pytest.mark.asyncio()
+    async def test_tracks_opened_streams(self, fake_backend: FakeAudioBackend) -> None:
+        s1 = fake_backend.open_rx(DUPLEX_DEVICE.id)
+        s2 = fake_backend.open_rx(INPUT_ONLY_DEVICE.id)
+        assert fake_backend.rx_streams == [s1, s2]
+
+
+# ---------------------------------------------------------------------------
+# FakeTxStream lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestFakeTxStreamLifecycle:
+    @pytest.mark.asyncio()
+    async def test_start_stop(self, fake_backend: FakeAudioBackend) -> None:
+        stream = fake_backend.open_tx(DUPLEX_DEVICE.id)
+        assert not stream.running
+
+        await stream.start()
+        assert stream.running
+        assert stream.started_count == 1
+
+        await stream.stop()
+        assert not stream.running
+        assert stream.stopped_count == 1
+
+    @pytest.mark.asyncio()
+    async def test_double_start_raises(self, fake_backend: FakeAudioBackend) -> None:
+        stream = fake_backend.open_tx(DUPLEX_DEVICE.id)
+        await stream.start()
+        with pytest.raises(RuntimeError, match="already running"):
+            await stream.start()
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_write(self, fake_backend: FakeAudioBackend) -> None:
+        stream = fake_backend.open_tx(DUPLEX_DEVICE.id)
+        await stream.start()
+
+        await stream.write(b"\x00\x01")
+        await stream.write(b"\x02\x03")
+        assert stream.written_frames == [b"\x00\x01", b"\x02\x03"]
+
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_write_when_stopped_raises(self, fake_backend: FakeAudioBackend) -> None:
+        stream = fake_backend.open_tx(DUPLEX_DEVICE.id)
+        with pytest.raises(RuntimeError, match="not running"):
+            await stream.write(b"\x00")
+
+    @pytest.mark.asyncio()
+    async def test_tracks_opened_streams(self, fake_backend: FakeAudioBackend) -> None:
+        s1 = fake_backend.open_tx(DUPLEX_DEVICE.id)
+        s2 = fake_backend.open_tx(OUTPUT_ONLY_DEVICE.id)
+        assert fake_backend.tx_streams == [s1, s2]
+
+
+# ---------------------------------------------------------------------------
+# PortAudioBackend — dependency loading
+# ---------------------------------------------------------------------------
+
+
+class TestPortAudioBackendDeps:
+    def test_missing_deps_raises(self) -> None:
+        def _fail() -> tuple:
+            raise ImportError("no sounddevice")
+
+        backend = PortAudioBackend(dependency_loader=_fail)
+        with pytest.raises(ImportError, match="PortAudioBackend requires"):
+            backend.list_devices()
+
+    def test_dependency_loader_called_once(self) -> None:
+        call_count = 0
+
+        class FakeSd:
+            class default:
+                device = [0, 0]
+
+            @staticmethod
+            def query_devices() -> list[dict]:
+                return [{"index": 0, "name": "Test", "max_input_channels": 1, "max_output_channels": 1}]
+
+        class FakeNp:
+            pass
+
+        def loader() -> tuple:
+            nonlocal call_count
+            call_count += 1
+            return FakeSd(), FakeNp()
+
+        backend = PortAudioBackend(dependency_loader=loader)
+        backend.list_devices()
+        backend.list_devices()
+        assert call_count == 1  # cached
+
+    def test_list_devices_via_loader(self) -> None:
+        class FakeSd:
+            class default:
+                device = [0, 1]
+
+            @staticmethod
+            def query_devices() -> list[dict]:
+                return [
+                    {"index": 0, "name": "Mic", "max_input_channels": 2, "max_output_channels": 0, "default_samplerate": 44100},
+                    {"index": 1, "name": "Speaker", "max_input_channels": 0, "max_output_channels": 2, "default_samplerate": 48000},
+                ]
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        devices = backend.list_devices()
+        assert len(devices) == 2
+        assert devices[0].name == "Mic"
+        assert devices[0].is_default_input is True
+        assert devices[0].is_default_output is False
+        assert devices[0].input_channels == 2
+        assert devices[1].name == "Speaker"
+        assert devices[1].is_default_output is True
+        assert devices[1].output_channels == 2
+
+    def test_open_rx_returns_rx_stream(self) -> None:
+        class FakeSd:
+            class InputStream:
+                def __init__(self, **kw: object) -> None:
+                    pass
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        stream = backend.open_rx(AudioDeviceId(0))
+        assert isinstance(stream, RxStream)
+
+    def test_open_tx_returns_tx_stream(self) -> None:
+        class FakeSd:
+            class OutputStream:
+                def __init__(self, **kw: object) -> None:
+                    pass
+
+        class FakeNp:
+            pass
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), FakeNp()))
+        stream = backend.open_tx(AudioDeviceId(0))
+        assert isinstance(stream, TxStream)


### PR DESCRIPTION
Closes #514

- `src/icom_lan/audio/backend.py` — AudioBackend protocol, AudioDeviceId, AudioDeviceInfo, RxStream, TxStream (357 lines)
- `src/icom_lan/audio/__init__.py` — re-exports new types
- `tests/test_audio_backend.py` — 28 tests

4475 passed. Part of epic #513.