### PR TITLE
feat(#515): stable macOS CoreAudio device UID support

### DIFF
--- a/src/icom_lan/audio/_macos_uid.py
+++ b/src/icom_lan/audio/_macos_uid.py
@@ -1,0 +1,176 @@
+"""macOS CoreAudio device UID lookup via ctypes.
+
+Maps PortAudio / sounddevice device names to stable CoreAudio device UIDs
+(``kAudioDevicePropertyDeviceUID``).  These UIDs persist across reboots and
+re-enumeration, unlike integer indices which can shift when devices are
+plugged / unplugged.
+
+This module is macOS-only.  Callers must gate imports behind a
+``sys.platform == "darwin"`` check.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# CoreAudio constants
+# ---------------------------------------------------------------------------
+# AudioObjectPropertySelector values
+kAudioHardwarePropertyDevices = 0x64657623  # 'dev#'
+kAudioObjectPropertyName = 0x6C6E616D  # 'lnam'
+kAudioDevicePropertyDeviceUID = 0x75696420  # 'uid '
+
+# AudioObjectPropertyScope / Element
+kAudioObjectPropertyScopeGlobal = 0x676C6F62  # 'glob'
+kAudioObjectPropertyElementMain = 0  # kAudioObjectPropertyElementMaster on older SDKs
+
+# Well-known object IDs
+kAudioObjectSystemObject = 1
+
+
+# ---------------------------------------------------------------------------
+# ctypes structures
+# ---------------------------------------------------------------------------
+class AudioObjectPropertyAddress(ctypes.Structure):
+    _fields_ = [
+        ("mSelector", ctypes.c_uint32),
+        ("mScope", ctypes.c_uint32),
+        ("mElement", ctypes.c_uint32),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
+def _load_coreaudio() -> ctypes.CDLL:
+    """Load the CoreAudio framework, raising *OSError* on failure."""
+    path = ctypes.util.find_library("CoreAudio")
+    if path is None:
+        raise OSError("CoreAudio framework not found")
+    return ctypes.cdll.LoadLibrary(path)
+
+
+def _get_all_device_ids(ca: ctypes.CDLL) -> list[int]:
+    """Return AudioObjectIDs for every audio device on the system."""
+    prop = AudioObjectPropertyAddress(
+        kAudioHardwarePropertyDevices,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain,
+    )
+    size = ctypes.c_uint32(0)
+    status = ca.AudioObjectGetPropertyDataSize(
+        ctypes.c_uint32(kAudioObjectSystemObject),
+        ctypes.byref(prop),
+        ctypes.c_uint32(0),
+        None,
+        ctypes.byref(size),
+    )
+    if status != 0 or size.value == 0:
+        return []
+
+    count = size.value // ctypes.sizeof(ctypes.c_uint32)
+    buf = (ctypes.c_uint32 * count)()
+    status = ca.AudioObjectGetPropertyData(
+        ctypes.c_uint32(kAudioObjectSystemObject),
+        ctypes.byref(prop),
+        ctypes.c_uint32(0),
+        None,
+        ctypes.byref(size),
+        ctypes.byref(buf),
+    )
+    if status != 0:
+        return []
+    return list(buf)
+
+
+def _cfstring_to_python(cf: ctypes.c_void_p) -> str | None:
+    """Convert a CFStringRef to a Python str, returning *None* on failure."""
+    CoreFoundation = ctypes.cdll.LoadLibrary(
+        ctypes.util.find_library("CoreFoundation")  # type: ignore[arg-type]
+    )
+    CFStringGetLength = CoreFoundation.CFStringGetLength
+    CFStringGetLength.argtypes = [ctypes.c_void_p]
+    CFStringGetLength.restype = ctypes.c_long
+
+    CFStringGetCString = CoreFoundation.CFStringGetCString
+    CFStringGetCString.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_long,
+        ctypes.c_uint32,
+    ]
+    CFStringGetCString.restype = ctypes.c_bool
+
+    kCFStringEncodingUTF8 = 0x08000100
+    length = CFStringGetLength(cf)
+    buf_size = length * 4 + 1  # worst-case UTF-8
+    buf = ctypes.create_string_buffer(buf_size)
+    ok = CFStringGetCString(cf, buf, buf_size, kCFStringEncodingUTF8)
+    if not ok:
+        return None
+    return buf.value.decode("utf-8")
+
+
+def _get_string_property(ca: ctypes.CDLL, device_id: int, selector: int) -> str | None:
+    """Read a CFString property from an AudioObject."""
+    prop = AudioObjectPropertyAddress(
+        selector,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain,
+    )
+    size = ctypes.c_uint32(ctypes.sizeof(ctypes.c_void_p))
+    cf_ref = ctypes.c_void_p()
+    status = ca.AudioObjectGetPropertyData(
+        ctypes.c_uint32(device_id),
+        ctypes.byref(prop),
+        ctypes.c_uint32(0),
+        None,
+        ctypes.byref(size),
+        ctypes.byref(cf_ref),
+    )
+    if status != 0 or not cf_ref.value:
+        return None
+    try:
+        return _cfstring_to_python(cf_ref)
+    finally:
+        CoreFoundation = ctypes.cdll.LoadLibrary(
+            ctypes.util.find_library("CoreFoundation")  # type: ignore[arg-type]
+        )
+        CoreFoundation.CFRelease(cf_ref)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_device_uid_map() -> dict[str, str]:
+    """Return ``{device_name: device_uid}`` for all CoreAudio devices.
+
+    On failure (non-macOS, missing framework, etc.) returns an empty dict
+    so callers can treat absence as "UID not available".
+    """
+    try:
+        ca = _load_coreaudio()
+    except OSError:
+        logger.debug("CoreAudio not available — UIDs will be empty")
+        return {}
+
+    uid_map: dict[str, str] = {}
+    try:
+        device_ids = _get_all_device_ids(ca)
+        for dev_id in device_ids:
+            name = _get_string_property(ca, dev_id, kAudioObjectPropertyName)
+            uid = _get_string_property(ca, dev_id, kAudioDevicePropertyDeviceUID)
+            if name and uid:
+                uid_map[name] = uid
+    except Exception:
+        logger.debug("CoreAudio UID enumeration failed", exc_info=True)
+
+    return uid_map

--- a/src/icom_lan/audio/usb_driver.py
+++ b/src/icom_lan/audio/usb_driver.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -51,6 +52,7 @@ class UsbAudioDevice:
     default_samplerate: int = 48_000
     is_default_input: bool = False
     is_default_output: bool = False
+    platform_uid: str = ""
 
     @property
     def supports_rx(self) -> bool:
@@ -187,6 +189,19 @@ def select_usb_audio_devices(
     return selected_rx, selected_tx
 
 
+def _get_uid_map() -> dict[str, str]:
+    """Return CoreAudio name→UID map on macOS, empty dict elsewhere."""
+    if sys.platform != "darwin":
+        return {}
+    try:
+        from icom_lan.audio._macos_uid import get_device_uid_map
+
+        return get_device_uid_map()
+    except Exception:
+        logger.debug("CoreAudio UID lookup unavailable", exc_info=True)
+        return {}
+
+
 def list_usb_audio_devices(sounddevice_module: Any) -> list[UsbAudioDevice]:
     """Return normalized system audio devices."""
     raw_devices = list(sounddevice_module.query_devices())
@@ -197,13 +212,16 @@ def list_usb_audio_devices(sounddevice_module: Any) -> list[UsbAudioDevice]:
         default_input_idx = _safe_int(default_raw[0], default=-1)
         default_output_idx = _safe_int(default_raw[1], default=-1)
 
+    uid_map = _get_uid_map()
+
     normalized: list[UsbAudioDevice] = []
     for idx, raw in enumerate(raw_devices):
         index = _safe_int(raw.get("index", idx), default=idx)
+        name = str(raw.get("name", f"device-{index}"))
         normalized.append(
             UsbAudioDevice(
                 index=index,
-                name=str(raw.get("name", f"device-{index}")),
+                name=name,
                 input_channels=_safe_int(raw.get("max_input_channels")),
                 output_channels=_safe_int(raw.get("max_output_channels")),
                 default_samplerate=_safe_int(
@@ -215,6 +233,7 @@ def list_usb_audio_devices(sounddevice_module: Any) -> list[UsbAudioDevice]:
                 is_default_output=(
                     default_output_idx is not None and index == default_output_idx
                 ),
+                platform_uid=uid_map.get(name, ""),
             )
         )
     return normalized

--- a/tests/test_macos_audio_uid.py
+++ b/tests/test_macos_audio_uid.py
@@ -1,0 +1,162 @@
+"""Tests for macOS CoreAudio UID integration in UsbAudioDevice."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from icom_lan.audio.usb_driver import (
+    UsbAudioDevice,
+    list_usb_audio_devices,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_sd_module(devices: list[dict]) -> SimpleNamespace:
+    """Build a fake sounddevice module that returns *devices*."""
+    return SimpleNamespace(
+        query_devices=lambda: devices,
+        default=SimpleNamespace(device=[0, 1]),
+    )
+
+
+_FAKE_DEVICES = [
+    {
+        "index": 0,
+        "name": "USB Audio CODEC",
+        "max_input_channels": 1,
+        "max_output_channels": 2,
+        "default_samplerate": 48000,
+    },
+    {
+        "index": 1,
+        "name": "MacBook Pro Speakers",
+        "max_input_channels": 0,
+        "max_output_channels": 2,
+        "default_samplerate": 44100,
+    },
+]
+
+_FAKE_UID_MAP = {
+    "USB Audio CODEC": "AppleUSBAudioEngine:BurrBrown:USB Audio CODEC:1234:1,2",
+    "MacBook Pro Speakers": "BuiltInSpeakerDevice",
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests: platform_uid field basics
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformUidField:
+    def test_default_empty(self) -> None:
+        dev = UsbAudioDevice(index=0, name="test", input_channels=1, output_channels=0)
+        assert dev.platform_uid == ""
+
+    def test_explicit_uid(self) -> None:
+        dev = UsbAudioDevice(
+            index=0,
+            name="test",
+            input_channels=1,
+            output_channels=0,
+            platform_uid="some-stable-uid",
+        )
+        assert dev.platform_uid == "some-stable-uid"
+
+
+# ---------------------------------------------------------------------------
+# Tests: list_usb_audio_devices with monkeypatched UID map
+# ---------------------------------------------------------------------------
+
+
+class TestListDevicesWithUid:
+    def test_uid_populated_via_macos_helper(self) -> None:
+        """When _get_uid_map returns data, platform_uid is set."""
+        sd = _make_sd_module(_FAKE_DEVICES)
+        with patch(
+            "icom_lan.audio.usb_driver._get_uid_map",
+            return_value=_FAKE_UID_MAP,
+        ):
+            devices = list_usb_audio_devices(sd)
+
+        assert len(devices) == 2
+        assert devices[0].platform_uid == _FAKE_UID_MAP["USB Audio CODEC"]
+        assert devices[0].platform_uid != ""
+        assert devices[1].platform_uid == _FAKE_UID_MAP["MacBook Pro Speakers"]
+
+    def test_uid_empty_when_helper_returns_empty(self) -> None:
+        """When _get_uid_map returns {}, platform_uid stays empty."""
+        sd = _make_sd_module(_FAKE_DEVICES)
+        with patch(
+            "icom_lan.audio.usb_driver._get_uid_map",
+            return_value={},
+        ):
+            devices = list_usb_audio_devices(sd)
+
+        assert all(d.platform_uid == "" for d in devices)
+
+    def test_uid_partial_match(self) -> None:
+        """Only devices whose name is in the UID map get a UID."""
+        sd = _make_sd_module(_FAKE_DEVICES)
+        partial_map = {"USB Audio CODEC": "uid-for-usb-only"}
+        with patch(
+            "icom_lan.audio.usb_driver._get_uid_map",
+            return_value=partial_map,
+        ):
+            devices = list_usb_audio_devices(sd)
+
+        assert devices[0].platform_uid == "uid-for-usb-only"
+        assert devices[1].platform_uid == ""
+
+    def test_other_fields_unchanged(self) -> None:
+        """Adding platform_uid must not break existing fields."""
+        sd = _make_sd_module(_FAKE_DEVICES)
+        with patch(
+            "icom_lan.audio.usb_driver._get_uid_map",
+            return_value=_FAKE_UID_MAP,
+        ):
+            devices = list_usb_audio_devices(sd)
+
+        dev = devices[0]
+        assert dev.index == 0
+        assert dev.name == "USB Audio CODEC"
+        assert dev.input_channels == 1
+        assert dev.output_channels == 2
+        assert dev.default_samplerate == 48_000
+        assert dev.supports_rx is True
+        assert dev.supports_tx is True
+        assert dev.duplex is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_uid_map fallback behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestGetUidMapFallback:
+    def test_returns_empty_on_non_darwin(self) -> None:
+        """On non-macOS, _get_uid_map must return {}."""
+        from icom_lan.audio.usb_driver import _get_uid_map
+
+        with patch("icom_lan.audio.usb_driver.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            result = _get_uid_map()
+        assert result == {}
+
+    def test_returns_empty_on_import_error(self) -> None:
+        """If the macOS helper fails to import, _get_uid_map returns {}."""
+        from icom_lan.audio.usb_driver import _get_uid_map
+
+        with patch("icom_lan.audio.usb_driver.sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            with patch(
+                "icom_lan.audio._macos_uid.get_device_uid_map",
+                side_effect=OSError("no CoreAudio"),
+            ):
+                result = _get_uid_map()
+        assert result == {}


### PR DESCRIPTION
Closes #515

- `src/icom_lan/audio/_macos_uid.py` — CoreAudio ctypes helper (kAudioDevicePropertyDeviceUID)
- `src/icom_lan/audio/usb_driver.py` — UsbAudioDevice.platform_uid field, UID lookup wired in
- `tests/test_macos_audio_uid.py` — 8 tests (monkeypatched helper, fallback on non-Darwin, fallback on import error)

4455 passed. Part of epic #513.

Note: depends on #514 (AudioBackend types) — should be rebased/merged after #524.