### PR TITLE
feat(#556): add meter_redlines field to RadioProfile

### DIFF
--- a/src/icom_lan/profiles.py
+++ b/src/icom_lan/profiles.py
@@ -165,6 +165,7 @@ class RadioProfile:
     protocol_type: str = "civ"
     controls: dict[str, ControlSpec] | None = None
     meter_calibrations: dict[str, list[MeterCalibrationPoint]] | None = None
+    meter_redlines: dict[str, int] | None = None
     rules: tuple[RuleSpec, ...] = ()
     keyboard: KeyboardConfig | None = None
     antenna_tx_count: int = 1

--- a/src/icom_lan/rig_loader.py
+++ b/src/icom_lan/rig_loader.py
@@ -146,6 +146,7 @@ class RigConfig:
             protocol_type=self.protocol_type,
             controls=self.controls,
             meter_calibrations=self.meter_calibrations,
+            meter_redlines=self.meter_redlines,
             rules=self.rules,
             keyboard=self.keyboard,
             antenna_tx_count=self.antenna_tx_count,


### PR DESCRIPTION
## Summary
- Add missing `meter_redlines: dict[str, int] | None` field to `RadioProfile` dataclass
- Wire `meter_redlines` through `RigConfig.to_profile()` so TOML-parsed redline data reaches the web handler's profile fallback path

Part of #556 (task T1 — foundation for moving meter calibration from hardcoded to TOML).

## Context
The TOML parser (`rig_loader.py`) and `RigConfig` already supported `meter_redlines`, and the web handler (`_get_meter_cal_payload`) already tried to read it from RadioProfile via `getattr`. But the field was never defined on RadioProfile nor passed in `to_profile()`, so the profile-based path always returned `None`.

## Test plan
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4449 passed
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] Existing `test_rig_multi_vendor.py` tests cover TOML parsing of redline_raw

Closes #556 (partial — T1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)