### PR TITLE
test(#555): add DspPanel and CwPanel component-level render tests

### DIFF
--- a/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import CwPanel from '../CwPanel.svelte';
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasCapability: vi.fn(() => true),
+}));
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountPanel(props: ComponentProps<typeof CwPanel>) {
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  const component = mount(CwPanel, { target: t, props });
+  flushSync();
+  components.push(component);
+  return t;
+}
+
+beforeEach(() => {
+  components = [];
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+});
+
+const baseProps: ComponentProps<typeof CwPanel> = {
+  cwPitch: 600,
+  keySpeed: 12,
+  breakIn: 0,
+  breakInDelay: 0,
+  apfMode: 0,
+  twinPeak: false,
+  currentMode: 'CW',
+};
+
+describe('CwPanel component rendering', () => {
+  it('mounts without errors', () => {
+    const t = mountPanel(baseProps);
+    expect(t.querySelector('.panel-body')).not.toBeNull();
+  });
+
+  it('renders RX mode line with current mode', () => {
+    const t = mountPanel(baseProps);
+    expect(t.querySelector('.cw-mode-value')?.textContent).toBe('CW');
+  });
+
+  it('renders CW Pitch control', () => {
+    const t = mountPanel(baseProps);
+    const labels = Array.from(t.querySelectorAll('.vc-label'));
+    expect(labels.some((el) => el.textContent === 'CW Pitch')).toBe(true);
+  });
+
+  it('renders Key Speed control', () => {
+    const t = mountPanel(baseProps);
+    const labels = Array.from(t.querySelectorAll('.vc-label'));
+    expect(labels.some((el) => el.textContent === 'Key Speed')).toBe(true);
+  });
+
+  it('renders SEMI break-in button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim() === 'SEMI')).toBe(true);
+  });
+
+  it('renders FULL break-in button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim() === 'FULL')).toBe(true);
+  });
+
+  it('renders APF button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim() === 'APF')).toBe(true);
+  });
+
+  it('renders TPF (twin peak) button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim() === 'TPF')).toBe(true);
+  });
+
+  it('renders AUTO TUNE button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim() === 'AUTO TUNE')).toBe(true);
+  });
+
+  it('unmounts cleanly', () => {
+    const t = mountPanel(baseProps);
+    const comp = components.pop()!;
+    unmount(comp);
+    expect(t.innerHTML).toBe('');
+  });
+});

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import DspPanel from '../DspPanel.svelte';
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasCapability: vi.fn(() => true),
+}));
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountPanel(props: ComponentProps<typeof DspPanel>) {
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  const component = mount(DspPanel, { target: t, props });
+  flushSync();
+  components.push(component);
+  return t;
+}
+
+beforeEach(() => {
+  components = [];
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+});
+
+const baseProps: ComponentProps<typeof DspPanel> = {
+  nrMode: 0,
+  nrLevel: 5,
+  nbActive: false,
+  nbLevel: 128,
+  notchMode: 'off',
+  notchFreq: 1000,
+  onNrModeChange: vi.fn(),
+  onNrLevelChange: vi.fn(),
+  onNbToggle: vi.fn(),
+  onNbLevelChange: vi.fn(),
+  onNotchModeChange: vi.fn(),
+  onNotchFreqChange: vi.fn(),
+  nbDepth: 0,
+  nbWidth: 0,
+  manualNotchWidth: 0,
+  agcTimeConstant: 0,
+  onNbDepthChange: vi.fn(),
+  onNbWidthChange: vi.fn(),
+  onManualNotchWidthChange: vi.fn(),
+  onAgcTimeChange: vi.fn(),
+};
+
+describe('DspPanel component rendering', () => {
+  it('mounts without errors', () => {
+    const t = mountPanel(baseProps);
+    expect(t.querySelector('.dsp-panel')).not.toBeNull();
+  });
+
+  it('renders NB button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim().startsWith('NB'))).toBe(true);
+  });
+
+  it('renders NR button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim().startsWith('NR'))).toBe(true);
+  });
+
+  it('renders NOTCH button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim() === 'NOTCH')).toBe(true);
+  });
+
+  it('renders A-NOTCH button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim() === 'A-NOTCH')).toBe(true);
+  });
+
+  it('renders AGC-T button', () => {
+    const t = mountPanel(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button'));
+    expect(buttons.some((b) => b.textContent?.trim().startsWith('AGC-T'))).toBe(true);
+  });
+
+  it('unmounts cleanly', () => {
+    const t = mountPanel(baseProps);
+    const comp = components.pop()!;
+    unmount(comp);
+    expect(t.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- **DspPanel** (7 tests): mounts, renders NB/NR/NOTCH/A-NOTCH/AGC-T buttons, clean unmount
- **CwPanel** (10 tests): mounts, renders CW Pitch/Key Speed controls, SEMI/FULL break-in, APF/TPF, AUTO TUNE, RX mode, clean unmount

## Review findings addressed
- Added 8 missing required props to DspPanel baseProps (nbDepth, nbWidth, manualNotchWidth, agcTimeConstant + callbacks)

## Test plan
- [x] `npx vitest run` — 1322 passed (66 files)
- [x] No source files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)