### PR TITLE
test(#555): add audio subsystem tests (constants, rx-player, tx-mic)

### DIFF
--- a/frontend/src/lib/audio/__tests__/constants.test.ts
+++ b/frontend/src/lib/audio/__tests__/constants.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { buildTxHeader, parseRxHeader, AUDIO_HEADER_SIZE, MSG_TYPE_RX, MSG_TYPE_TX,
+  CODEC_OPUS, CODEC_PCM16, SAMPLE_RATE, CHANNELS, FRAME_DURATION_MS } from '../constants';
+
+describe('buildTxHeader', () => {
+  it('produces correct 8-byte header', () => {
+    const v = new DataView(buildTxHeader(42).buffer);
+    expect(v.getUint8(0)).toBe(MSG_TYPE_TX);
+    expect(v.getUint8(1)).toBe(CODEC_OPUS);
+    expect(v.getUint16(2, true)).toBe(42);
+    expect(v.getUint16(4, true)).toBe(SAMPLE_RATE / 100);
+    expect(v.getUint8(6)).toBe(CHANNELS);
+    expect(v.getUint8(7)).toBe(FRAME_DURATION_MS);
+  });
+  it('wraps seq at 16-bit boundary', () => {
+    // 0x10000 should roll over to 0x0000
+    expect(new DataView(buildTxHeader(0x10000).buffer).getUint16(2, true)).toBe(0);
+    // 0x1FFFF & 0xFFFF = 0xFFFF
+    expect(new DataView(buildTxHeader(0x1FFFF).buffer).getUint16(2, true)).toBe(0xFFFF);
+  });
+});
+
+describe('parseRxHeader', () => {
+  it('parses valid PCM16 frame', () => {
+    const buf = new ArrayBuffer(AUDIO_HEADER_SIZE + 960);
+    const v = new DataView(buf);
+    v.setUint8(0, MSG_TYPE_RX); v.setUint8(1, CODEC_PCM16);
+    v.setUint16(4, SAMPLE_RATE / 100, true); v.setUint8(6, 1);
+    const hdr = parseRxHeader(buf)!;
+    expect(hdr.codec).toBe(CODEC_PCM16);
+    expect(hdr.sampleRate).toBe(SAMPLE_RATE);
+    expect(hdr.payload.byteLength).toBe(960);
+  });
+  it('rejects too-short or wrong type', () => {
+    expect(parseRxHeader(new ArrayBuffer(4))).toBeNull();
+    const buf = new ArrayBuffer(AUDIO_HEADER_SIZE);
+    new DataView(buf).setUint8(0, 0xFF);
+    expect(parseRxHeader(buf)).toBeNull();
+  });
+});

--- a/frontend/src/lib/audio/__tests__/rx-player.test.ts
+++ b/frontend/src/lib/audio/__tests__/rx-player.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RxPlayer } from '../rx-player';
+import { AUDIO_HEADER_SIZE, MSG_TYPE_RX, CODEC_PCM16, SAMPLE_RATE, FRAME_DURATION_MS } from '../constants';
+
+let ctx: any;
+beforeEach(() => {
+  const gain = { gain: { value: 1 }, connect: vi.fn() };
+  ctx = {
+    state: 'running', currentTime: 0, destination: {},
+    resume: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined),
+    createGain: vi.fn(() => gain),
+    createBuffer: vi.fn((ch: number, n: number, sr: number) => ({
+      duration: n / sr, getChannelData: () => new Float32Array(n),
+    })),
+    _lastSrc: null as any,
+    createBufferSource: vi.fn(function (this: any) {
+      const src = { buffer: null, connect: vi.fn(), start: vi.fn() };
+      ctx._lastSrc = src;
+      return src;
+    }),
+    _gain: gain,
+  };
+  (globalThis as any).AudioContext = function () { return ctx; } as any;
+});
+afterEach(() => { delete (globalThis as any).AudioContext; });
+
+function pcm16(n: number): ArrayBuffer {
+  const buf = new ArrayBuffer(AUDIO_HEADER_SIZE + n * 2);
+  const v = new DataView(buf);
+  v.setUint8(0, MSG_TYPE_RX); v.setUint8(1, CODEC_PCM16);
+  v.setUint16(4, SAMPLE_RATE / 100, true); v.setUint8(6, 1); v.setUint8(7, FRAME_DURATION_MS);
+  return buf;
+}
+
+describe('RxPlayer', () => {
+  it('creates AudioContext and GainNode on start', () => {
+    const p = new RxPlayer(); p.start();
+    expect(ctx.createGain).toHaveBeenCalled();
+    expect(ctx._gain.connect).toHaveBeenCalledWith(ctx.destination);
+    expect(p.active).toBe(true); p.stop();
+  });
+  it('is inactive before start and after stop', () => {
+    const p = new RxPlayer();
+    expect(p.active).toBe(false); p.start(); p.stop(); expect(p.active).toBe(false);
+  });
+  it('resumes suspended context', () => {
+    ctx.state = 'suspended'; const p = new RxPlayer(); p.start(); p.start();
+    expect(ctx.resume).toHaveBeenCalled(); p.stop();
+  });
+  it('handles missing AudioContext', () => {
+    delete (globalThis as any).AudioContext;
+    const p = new RxPlayer(); p.start(); expect(p.active).toBe(false);
+  });
+  it('clamps volume and applies to gain', () => {
+    const p = new RxPlayer(); p.start();
+    p.volume = -1; expect(p.volume).toBe(0);
+    p.volume = 5; expect(p.volume).toBe(1);
+    p.volume = 0.3; expect(ctx._gain.gain.value).toBeCloseTo(0.3); p.stop();
+  });
+  it('processes PCM16 frame and schedules playback', () => {
+    const p = new RxPlayer(); p.start(); p.feed(pcm16(480));
+    expect(ctx.createBuffer).toHaveBeenCalledWith(1, 480, SAMPLE_RATE);
+    expect(ctx.createBufferSource).toHaveBeenCalled();
+    expect(ctx._lastSrc.start).toHaveBeenCalled();
+    p.stop();
+  });
+  it('ignores feed when stopped', () => {
+    new RxPlayer().feed(pcm16(480));
+    expect(ctx.createBuffer).not.toHaveBeenCalled();
+  });
+  it('cleans up on stop', () => {
+    const p = new RxPlayer(); p.start(); p.stop();
+    expect(ctx.close).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/audio/__tests__/tx-mic.test.ts
+++ b/frontend/src/lib/audio/__tests__/tx-mic.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TxMic } from '../tx-mic';
+import { SAMPLE_RATE, CHANNELS, TX_BITRATE } from '../constants';
+
+let mockTrack: any, mockEncoder: any, mockReader: any;
+beforeEach(() => {
+  mockTrack = { stop: vi.fn(), kind: 'audio' };
+  mockReader = { read: vi.fn(() => Promise.resolve({ done: true })), cancel: vi.fn().mockResolvedValue(undefined) };
+  mockEncoder = { configure: vi.fn(), encode: vi.fn(), close: vi.fn(), state: 'configured' };
+  (globalThis as any).AudioEncoder = function (this: any) { Object.assign(this, mockEncoder); return mockEncoder; };
+  (globalThis as any).MediaStreamTrackProcessor = function () {
+    return { readable: { getReader: () => mockReader } };
+  };
+  const stream = { getTracks: () => [mockTrack], getAudioTracks: () => [mockTrack] };
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) } },
+    writable: true, configurable: true,
+  });
+});
+afterEach(() => { delete (globalThis as any).AudioEncoder; delete (globalThis as any).MediaStreamTrackProcessor; });
+
+describe('TxMic', () => {
+  it('detects support based on WebCodecs', () => {
+    expect(TxMic.supported()).toBe(true);
+    delete (globalThis as any).AudioEncoder;
+    expect(TxMic.supported()).toBe(false);
+  });
+  it('errors when WebCodecs missing', async () => {
+    delete (globalThis as any).AudioEncoder;
+    const m = new TxMic(vi.fn());
+    expect(await m.start()).toContain('WebCodecs not supported');
+  });
+  it('requests mic with correct constraints', async () => {
+    const m = new TxMic(vi.fn()); await m.start();
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+      audio: { channelCount: CHANNELS, sampleRate: SAMPLE_RATE, echoCancellation: true, noiseSuppression: true },
+    });
+    expect(m.active).toBe(true); m.stop();
+  });
+  it('handles permission denied', async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockRejectedValueOnce(new Error('denied'));
+    expect(await new TxMic(vi.fn()).start()).toContain('permission denied');
+  });
+  it('configures encoder correctly', async () => {
+    const m = new TxMic(vi.fn()); await m.start();
+    expect(mockEncoder.configure).toHaveBeenCalledWith({
+      codec: 'opus', sampleRate: SAMPLE_RATE, numberOfChannels: CHANNELS, bitrate: TX_BITRATE,
+    });
+    m.stop();
+  });
+  it('cleans up all resources on stop', async () => {
+    const m = new TxMic(vi.fn()); await m.start(); m.stop();
+    expect(mockTrack.stop).toHaveBeenCalled();
+    expect(mockReader.cancel).toHaveBeenCalled();
+    expect(mockEncoder.close).toHaveBeenCalled();
+    expect(m.active).toBe(false);
+  });
+  it('is idempotent on double start', async () => {
+    const m = new TxMic(vi.fn()); await m.start();
+    expect(await m.start()).toBeNull();
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1); m.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- **constants.test.ts**: buildTxHeader layout, 16-bit seq rollover, parseRxHeader valid/invalid
- **rx-player.test.ts**: AudioContext creation, lifecycle, volume clamping, PCM16 frame scheduling with start() assertion, feed-when-stopped guard
- **tx-mic.test.ts**: WebCodecs detection, mic permission flow, Opus encoder config, resource cleanup, idempotent double-start

## Review findings addressed
- Added explicit `0x10000 → 0` rollover case for seq wrapping
- Captured BufferSource mock via `ctx._lastSrc` to assert `start()` called during PCM frame scheduling

## Test plan
- [x] `npx vitest run` — 1324 passed (67 files)
- [x] No source files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)