### PR TITLE
refactor(#590): extract SpectrumPanel inline logic to spectrum-logic.ts

### DIFF
--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -29,34 +29,14 @@
     getFilterWidthFromRightEdgePx,
     getPassbandGeometry,
   } from './passband-geometry';
-
-  // --- Scope frame binary protocol ---
-  interface ScopeFrame {
-    receiver: number;
-    mode: number;       // 0=CTR, 1=FIX, 2=SCROLL-C, 3=SCROLL-F
-    startFreq: number;
-    endFreq: number;
-    pixels: Uint8Array;
-  }
-
-  function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
-    const view = new DataView(buf);
-    // Magic byte 0x01, minimum 16-byte header
-    if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
-    const receiver = view.getUint8(1);
-    const mode = view.getUint8(2);
-    const startFreq = view.getUint32(3, true);
-    const endFreq = view.getUint32(7, true);
-    const pixelCount = view.getUint16(14, true);
-    if (16 + pixelCount > view.byteLength) return null;
-    return {
-      receiver,
-      mode,
-      startFreq,
-      endFreq,
-      pixels: new Uint8Array(buf, 16, pixelCount),
-    };
-  }
+  import {
+    parseScopeFrame,
+    formatFreqOffset,
+    deriveFreqTicks,
+    getDragInterval,
+    isFixedScope as isFixedScopeFn,
+    type ScopeFrame,
+  } from './spectrum-logic';
 
   // --- Component state ---
   let scopePixels = $state<Uint8Array | null>(null);
@@ -105,7 +85,7 @@
   // Falls back to control state if no frame received yet.
   let scopeMode = $derived(frameScopeMode ?? (radio.current?.scopeControls?.mode ?? 0));
   // Tuning indicator: center for CTR/SCROLL-C, proportional for FIX/SCROLL-F
-  let isFixedScope = $derived(scopeMode === 1 || scopeMode === 3);
+  let isFixedScope = $derived(isFixedScopeFn(scopeMode));
   let tuneLinePct = $derived(
     isFixedScope && spanHz > 0 && tuneHz > 0 && tuneHz >= startFreq && tuneHz <= endFreq
       ? ((tuneHz - startFreq) / spanHz) * 100
@@ -140,16 +120,6 @@
     colorScheme,
   });
 
-  // --- Scale helpers ---
-  function formatFreqOffset(hz: number): string {
-    if (hz === 0) return '0';
-    const absHz = Math.abs(hz);
-    const sign = hz < 0 ? '-' : '+';
-    if (absHz >= 1e6) return `${sign}${(absHz / 1e6).toFixed(1)}M`;
-    if (absHz >= 1e3) return `${sign}${(absHz / 1e3).toFixed(0)}k`;
-    return `${sign}${absHz}`;
-  }
-
   const DB_TICKS = [
     { position: 0, label: '0' },
     { position: 33, label: '-20' },
@@ -157,14 +127,7 @@
     { position: 100, label: '-60' },
   ];
 
-  let freqTicks = $derived(
-    spanHz > 0
-      ? [-1, -0.5, 0, 0.5, 1].map((ratio) => ({
-          position: (ratio + 1) * 50,
-          label: formatFreqOffset((spanHz * ratio) / 2),
-        }))
-      : [],
-  );
+  let freqTicks = $derived(deriveFreqTicks(spanHz));
 
   // Passband overlay position derived from the same geometry as the spectrum renderer.
   // In FIX mode pass tuneLinePct so passband follows the carrier indicator.
@@ -314,14 +277,7 @@
     dragFreq = newFreq;
 
     // Adaptive interval: slow = responsive, fast = coarse
-    let intervalMs: number;
-    if (dragSpeed > 600) {
-      intervalMs = 700;
-    } else if (dragSpeed > 200) {
-      intervalMs = 400;
-    } else {
-      intervalMs = 200;
-    }
+    const intervalMs = getDragInterval(dragSpeed);
 
     if (now - lastDragSendTime < intervalMs) return;
     if (newFreq === lastDragSendFreq) return;

--- a/frontend/src/components/spectrum/__tests__/spectrum-panel-logic.test.ts
+++ b/frontend/src/components/spectrum/__tests__/spectrum-panel-logic.test.ts
@@ -3,28 +3,16 @@
  * scale ticks, drag rate limiting, scope mode classification, click-to-tune.
  */
 import { describe, it, expect } from 'vitest';
+import {
+  parseScopeFrame,
+  formatFreqOffset,
+  deriveFreqTicks,
+  getDragInterval,
+  isFixedScope,
+  freqFromPixel,
+} from '../spectrum-logic';
 
-// ── Re-implemented pure functions from SpectrumPanel.svelte ─────────────────
-
-interface ScopeFrame {
-  receiver: number;
-  mode: number;
-  startFreq: number;
-  endFreq: number;
-  pixels: Uint8Array;
-}
-
-function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
-  const view = new DataView(buf);
-  if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
-  const receiver = view.getUint8(1);
-  const mode = view.getUint8(2);
-  const startFreq = view.getUint32(3, true);
-  const endFreq = view.getUint32(7, true);
-  const pixelCount = view.getUint16(14, true);
-  if (16 + pixelCount > view.byteLength) return null;
-  return { receiver, mode, startFreq, endFreq, pixels: new Uint8Array(buf, 16, pixelCount) };
-}
+// ── Test helpers ────────────────────────────────────────────────────────────
 
 function encodeFrame(rx: number, mode: number, sf: number, ef: number, px: Uint8Array): ArrayBuffer {
   const buf = new ArrayBuffer(16 + px.length);
@@ -37,36 +25,6 @@ function encodeFrame(rx: number, mode: number, sf: number, ef: number, px: Uint8
   v.setUint16(14, px.length, true);
   new Uint8Array(buf, 16).set(px);
   return buf;
-}
-
-function formatFreqOffset(hz: number): string {
-  if (hz === 0) return '0';
-  const absHz = Math.abs(hz);
-  const sign = hz < 0 ? '-' : '+';
-  if (absHz >= 1e6) return `${sign}${(absHz / 1e6).toFixed(1)}M`;
-  if (absHz >= 1e3) return `${sign}${(absHz / 1e3).toFixed(0)}k`;
-  return `${sign}${absHz}`;
-}
-
-function deriveFreqTicks(spanHz: number): { position: number; label: string }[] {
-  if (spanHz <= 0) return [];
-  return [-1, -0.5, 0, 0.5, 1].map((ratio) => ({
-    position: (ratio + 1) * 50,
-    label: formatFreqOffset((spanHz * ratio) / 2),
-  }));
-}
-
-function getDragInterval(speed: number): number {
-  if (speed > 600) return 700;
-  if (speed > 200) return 400;
-  return 200;
-}
-
-function isFixedScope(mode: number): boolean { return mode === 1 || mode === 3; }
-
-function freqFromPixel(clientX: number, rectLeft: number, rectWidth: number,
-  startFreq: number, spanHz: number): number {
-  return startFreq + ((clientX - rectLeft) / rectWidth) * spanHz;
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────

--- a/frontend/src/components/spectrum/__tests__/tuning-indicator.test.ts
+++ b/frontend/src/components/spectrum/__tests__/tuning-indicator.test.ts
@@ -55,27 +55,9 @@ function computeTunePx(
   return width / 2;
 }
 
-// ── Scope frame parsing (with mode byte) ────────────────────────────────────────
+// ── Scope frame parsing — imported from canonical module ──────────────────────
 
-interface ScopeFrame {
-  receiver: number;
-  mode: number;
-  startFreq: number;
-  endFreq: number;
-  pixels: Uint8Array;
-}
-
-function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
-  const view = new DataView(buf);
-  if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
-  const receiver = view.getUint8(1);
-  const mode = view.getUint8(2);
-  const startFreq = view.getUint32(3, true);
-  const endFreq = view.getUint32(7, true);
-  const pixelCount = view.getUint16(14, true);
-  if (16 + pixelCount > view.byteLength) return null;
-  return { receiver, mode, startFreq, endFreq, pixels: new Uint8Array(buf, 16, pixelCount) };
-}
+import { parseScopeFrame, type ScopeFrame } from '../spectrum-logic';
 
 function encodeFrame(
   receiver: number,

--- a/frontend/src/components/spectrum/spectrum-logic.ts
+++ b/frontend/src/components/spectrum/spectrum-logic.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure logic extracted from SpectrumPanel.svelte for testability.
+ */
+
+// --- Scope frame binary protocol ---
+export interface ScopeFrame {
+  receiver: number;
+  mode: number;       // 0=CTR, 1=FIX, 2=SCROLL-C, 3=SCROLL-F
+  startFreq: number;
+  endFreq: number;
+  pixels: Uint8Array;
+}
+
+export function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
+  const view = new DataView(buf);
+  // Magic byte 0x01, minimum 16-byte header
+  if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
+  const receiver = view.getUint8(1);
+  const mode = view.getUint8(2);
+  const startFreq = view.getUint32(3, true);
+  const endFreq = view.getUint32(7, true);
+  const pixelCount = view.getUint16(14, true);
+  if (16 + pixelCount > view.byteLength) return null;
+  return {
+    receiver,
+    mode,
+    startFreq,
+    endFreq,
+    pixels: new Uint8Array(buf, 16, pixelCount),
+  };
+}
+
+// --- Scale helpers ---
+export function formatFreqOffset(hz: number): string {
+  if (hz === 0) return '0';
+  const absHz = Math.abs(hz);
+  const sign = hz < 0 ? '-' : '+';
+  if (absHz >= 1e6) return `${sign}${(absHz / 1e6).toFixed(1)}M`;
+  if (absHz >= 1e3) return `${sign}${(absHz / 1e3).toFixed(0)}k`;
+  return `${sign}${absHz}`;
+}
+
+export function deriveFreqTicks(spanHz: number): { position: number; label: string }[] {
+  if (spanHz <= 0) return [];
+  return [-1, -0.5, 0, 0.5, 1].map((ratio) => ({
+    position: (ratio + 1) * 50,
+    label: formatFreqOffset((spanHz * ratio) / 2),
+  }));
+}
+
+// --- Drag helpers ---
+export function getDragInterval(speed: number): number {
+  if (speed > 600) return 700;
+  if (speed > 200) return 400;
+  return 200;
+}
+
+// --- Scope mode helpers ---
+export function isFixedScope(mode: number): boolean {
+  return mode === 1 || mode === 3;
+}
+
+// --- Click-to-tune helpers ---
+export function freqFromPixel(
+  clientX: number,
+  rectLeft: number,
+  rectWidth: number,
+  startFreq: number,
+  spanHz: number,
+): number {
+  return startFreq + ((clientX - rectLeft) / rectWidth) * spanHz;
+}


### PR DESCRIPTION
## Summary
- Extract 6 pure functions from `SpectrumPanel.svelte` into new `spectrum-logic.ts` module
- Functions: `parseScopeFrame`, `formatFreqOffset`, `deriveFreqTicks`, `getDragInterval`, `isFixedScope`, `freqFromPixel`
- Update `spectrum-panel-logic.test.ts` to import from real module (not re-implemented copies)
- Update `tuning-indicator.test.ts` to import `parseScopeFrame` + `ScopeFrame` from canonical module

## Review findings addressed
- Removed unused `freqFromPixel` import from SpectrumPanel.svelte
- Replaced re-implemented `ScopeFrame`/`parseScopeFrame` in tuning-indicator.test.ts with imports

## Impact
- Pure refactoring — zero behavior change
- Tests now exercise the actual module code → v8 coverage increases for spectrum-logic.ts
- 4 files changed, +94/-126 (net -32 LOC)

## Test plan
- [x] `npx vitest run` — 1407 passed (74 files)
- [x] No behavior change verified by unchanged test assertions

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)