### PR TITLE
refactor(#591): extract MobileRadioLayout logic to mobile-layout-logic.ts

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -33,6 +33,7 @@
     vfoLayoutStyleVars,
   } from './vfo-layout-tokens';
   import { getTxPermit } from '$lib/utils/tx-permit';
+  import { getStepsForMode, formatStep, formatSValue, formatDbm, formatPower } from './mobile-layout-logic';
   import {
     toVfoProps, toVfoOpsProps, toMeterProps,
     toRfFrontEndProps, toModeProps, toFilterProps, toAgcProps, toRitXitProps,
@@ -110,22 +111,6 @@
   let powerModalOpen = $state(false);
 
   // ── Tuning strip ──
-  // Mode-aware step presets
-  const SSB_STEPS = [10, 50, 100, 500, 1000];
-  const CW_STEPS  = [10, 50, 100, 500];
-  const AM_STEPS  = [1000, 5000, 9000, 10000];
-  const FM_STEPS  = [5000, 10000, 12500, 25000];
-  const DEFAULT_STEPS = [10, 50, 100, 500, 1000, 5000, 10000, 100000];
-
-  function getStepsForMode(m: string): number[] {
-    const upper = (m || '').toUpperCase();
-    if (upper === 'USB' || upper === 'LSB') return SSB_STEPS;
-    if (upper === 'CW' || upper === 'CW-R') return CW_STEPS;
-    if (upper === 'AM') return AM_STEPS;
-    if (upper === 'FM') return FM_STEPS;
-    return DEFAULT_STEPS;
-  }
-
   let availableSteps = $derived(getStepsForMode(mode.currentMode));
   let tuningStep = $state(1000); // Hz
   let stepPickerOpen = $state(false);
@@ -146,11 +131,6 @@
   function selectStep(hz: number) {
     tuningStep = hz;
     stepPickerOpen = false;
-  }
-
-  function formatStep(hz: number): string {
-    if (hz >= 1000) return `${hz / 1000} kHz`;
-    return `${hz} Hz`;
   }
 
   // ── Quick modes (SSB operation essentials) ──
@@ -375,30 +355,6 @@
     if (!atuDidLongPress) {
       txHandlers.onAtuToggle(); // Short press = toggle on/off
     }
-  }
-
-  // ── S-meter formatting ──
-  function formatSValue(raw: number): string {
-    if (raw <= 0) return 'S0';
-    if (raw <= 120) {
-      const s = Math.round(raw / 120 * 9);
-      return `S${Math.min(9, Math.max(0, s))}`;
-    }
-    const over = Math.round((raw - 120) / 120 * 60);
-    return `S9+${over}`;
-  }
-
-  function formatDbm(raw: number): string {
-    // S9 = -73 dBm, each S-unit = 6 dB
-    const dbm = -73 + (raw - 120) / 120 * 60;
-    return `${Math.round(dbm)} dBm`;
-  }
-
-  // ── RF Power display ──
-  function formatPower(raw: number): string {
-    // 0-255 → 0-100W (approx for IC-7610)
-    const watts = Math.round(raw / 255 * 100);
-    return `${watts}W`;
   }
 
   // ── ATU status ──

--- a/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SSB_STEPS, CW_STEPS, AM_STEPS, FM_STEPS, DEFAULT_STEPS,
+  getStepsForMode, formatStep, formatSValue, formatDbm, formatPower,
+} from '../mobile-layout-logic';
+
+describe('getStepsForMode', () => {
+  it('returns SSB_STEPS for USB', () => {
+    expect(getStepsForMode('USB')).toBe(SSB_STEPS);
+  });
+
+  it('returns SSB_STEPS for LSB', () => {
+    expect(getStepsForMode('LSB')).toBe(SSB_STEPS);
+  });
+
+  it('returns SSB_STEPS for lowercase usb', () => {
+    expect(getStepsForMode('usb')).toBe(SSB_STEPS);
+  });
+
+  it('returns CW_STEPS for CW', () => {
+    expect(getStepsForMode('CW')).toBe(CW_STEPS);
+  });
+
+  it('returns CW_STEPS for CW-R', () => {
+    expect(getStepsForMode('CW-R')).toBe(CW_STEPS);
+  });
+
+  it('returns AM_STEPS for AM', () => {
+    expect(getStepsForMode('AM')).toBe(AM_STEPS);
+  });
+
+  it('returns FM_STEPS for FM', () => {
+    expect(getStepsForMode('FM')).toBe(FM_STEPS);
+  });
+
+  it('returns DEFAULT_STEPS for unknown mode', () => {
+    expect(getStepsForMode('RTTY')).toBe(DEFAULT_STEPS);
+  });
+
+  it('returns DEFAULT_STEPS for empty string', () => {
+    expect(getStepsForMode('')).toBe(DEFAULT_STEPS);
+  });
+});
+
+describe('formatStep', () => {
+  it('formats Hz for values below 1000', () => {
+    expect(formatStep(100)).toBe('100 Hz');
+    expect(formatStep(50)).toBe('50 Hz');
+    expect(formatStep(10)).toBe('10 Hz');
+  });
+
+  it('formats kHz for values >= 1000', () => {
+    expect(formatStep(1000)).toBe('1 kHz');
+    expect(formatStep(5000)).toBe('5 kHz');
+    expect(formatStep(10000)).toBe('10 kHz');
+    expect(formatStep(12500)).toBe('12.5 kHz');
+  });
+});
+
+describe('formatSValue', () => {
+  it('returns S0 for zero', () => {
+    expect(formatSValue(0)).toBe('S0');
+  });
+
+  it('returns S0 for negative values', () => {
+    expect(formatSValue(-10)).toBe('S0');
+  });
+
+  it('returns S-unit for mid-range', () => {
+    // raw 60 → 60/120*9 = 4.5 → round = 5
+    expect(formatSValue(60)).toBe('S5');
+  });
+
+  it('returns S9 at raw 120', () => {
+    expect(formatSValue(120)).toBe('S9');
+  });
+
+  it('returns S9+ for values above 120', () => {
+    const result = formatSValue(200);
+    expect(result).toMatch(/^S9\+/);
+  });
+});
+
+describe('formatDbm', () => {
+  it('returns -73 dBm at S9 (raw=120)', () => {
+    expect(formatDbm(120)).toBe('-73 dBm');
+  });
+
+  it('returns lower dBm for weaker signals', () => {
+    const result = formatDbm(0);
+    // raw=0 → -73 + (0-120)/120*60 = -73 + (-60) = -133
+    expect(result).toBe('-133 dBm');
+  });
+
+  it('returns higher dBm for strong signals', () => {
+    const result = formatDbm(240);
+    // raw=240 → -73 + (240-120)/120*60 = -73 + 60 = -13
+    expect(result).toBe('-13 dBm');
+  });
+});
+
+describe('formatPower', () => {
+  it('returns 0W for zero', () => {
+    expect(formatPower(0)).toBe('0W');
+  });
+
+  it('returns 100W for max (255)', () => {
+    expect(formatPower(255)).toBe('100W');
+  });
+
+  it('returns approximate wattage for mid-range', () => {
+    // 128/255*100 ≈ 50.2 → round = 50
+    expect(formatPower(128)).toBe('50W');
+  });
+});

--- a/frontend/src/components-v2/layout/mobile-layout-logic.ts
+++ b/frontend/src/components-v2/layout/mobile-layout-logic.ts
@@ -1,0 +1,49 @@
+// Pure helper functions and constants extracted from MobileRadioLayout.svelte
+
+// ── Tuning step presets (mode-aware) ──
+
+export const SSB_STEPS = [10, 50, 100, 500, 1000];
+export const CW_STEPS = [10, 50, 100, 500];
+export const AM_STEPS = [1000, 5000, 9000, 10000];
+export const FM_STEPS = [5000, 10000, 12500, 25000];
+export const DEFAULT_STEPS = [10, 50, 100, 500, 1000, 5000, 10000, 100000];
+
+export function getStepsForMode(m: string): number[] {
+  const upper = (m || '').toUpperCase();
+  if (upper === 'USB' || upper === 'LSB') return SSB_STEPS;
+  if (upper === 'CW' || upper === 'CW-R') return CW_STEPS;
+  if (upper === 'AM') return AM_STEPS;
+  if (upper === 'FM') return FM_STEPS;
+  return DEFAULT_STEPS;
+}
+
+export function formatStep(hz: number): string {
+  if (hz >= 1000) return `${hz / 1000} kHz`;
+  return `${hz} Hz`;
+}
+
+// ── S-meter formatting ──
+
+export function formatSValue(raw: number): string {
+  if (raw <= 0) return 'S0';
+  if (raw <= 120) {
+    const s = Math.round(raw / 120 * 9);
+    return `S${Math.min(9, Math.max(0, s))}`;
+  }
+  const over = Math.round((raw - 120) / 120 * 60);
+  return `S9+${over}`;
+}
+
+export function formatDbm(raw: number): string {
+  // S9 = -73 dBm, each S-unit = 6 dB
+  const dbm = -73 + (raw - 120) / 120 * 60;
+  return `${Math.round(dbm)} dBm`;
+}
+
+// ── RF Power display ──
+
+export function formatPower(raw: number): string {
+  // 0-255 → 0-100W (approx for IC-7610)
+  const watts = Math.round(raw / 255 * 100);
+  return `${watts}W`;
+}


### PR DESCRIPTION
## Summary
- Extract 5 pure functions + 5 step constants from `MobileRadioLayout.svelte` (1747 LOC) into `mobile-layout-logic.ts`
- Functions: `getStepsForMode`, `formatStep`, `formatSValue`, `formatDbm`, `formatPower`
- 22 new tests importing from canonical module
- Net -45 LOC from component, +120 in module+tests

## Review
Clean extraction — no issues found by code-reviewer agent.

## Test plan
- [x] `npx vitest run` — 1429 passed (75 files)
- [x] Zero behavior change

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)