### PR TITLE
refactor(#592): extract BandPlanOverlay logic to band-plan-logic.ts

### DIFF
--- a/frontend/src/components/spectrum/BandPlanOverlay.svelte
+++ b/frontend/src/components/spectrum/BandPlanOverlay.svelte
@@ -6,6 +6,14 @@
     SEGMENT_LABEL_COLORS,
     type BandSegmentMode,
   } from '../../lib/data/arrl-band-plan';
+  import {
+    formatFreq,
+    hexToRgb,
+    computePosition,
+    filterOverlapping,
+    shouldSkipFetch,
+    type RemoteSegment,
+  } from './band-plan-logic';
 
   interface Props {
     startFreq: number;
@@ -17,25 +25,6 @@
   let { startFreq, endFreq, visible = true, hiddenLayers = [] }: Props = $props();
 
   let containerWidth = $state(0);
-
-  // Remote segments from REST API
-  interface RemoteSegment {
-    start: number;
-    end: number;
-    mode: string;
-    label: string;
-    color: string;
-    opacity: number;
-    band: string;
-    layer: string;
-    priority: number;
-    url?: string | null;
-    notes?: string | null;
-    station?: string | null;
-    language?: string | null;
-    schedule?: string | null;
-    license?: string | null;
-  }
 
   let remoteSegments = $state<RemoteSegment[]>([]);
   let lastFetchRange = $state({ start: 0, end: 0 });
@@ -61,18 +50,14 @@
 
   // Debounced fetch from REST API
   function fetchSegments(start: number, end: number) {
-    const span = end - start;
-    if (
-      lastFetchRange.start > 0 &&
-      Math.abs(start - lastFetchRange.start) < span * 0.01 &&
-      Math.abs(end - lastFetchRange.end) < span * 0.01
-    ) {
+    if (shouldSkipFetch(start, end, lastFetchRange.start, lastFetchRange.end)) {
       return;
     }
 
     if (fetchTimeout) clearTimeout(fetchTimeout);
     fetchTimeout = setTimeout(async () => {
       try {
+        const span = end - start;
         const margin = Math.round(span * 0.5);
         const fetchStart = Math.max(0, start - margin);
         const fetchEnd = end + margin;
@@ -104,39 +89,16 @@
     popupSegment = null;
   });
 
-  function formatFreq(hz: number): string {
-    if (hz >= 1_000_000) return `${(hz / 1_000_000).toFixed(3)} MHz`;
-    if (hz >= 1_000) return `${(hz / 1_000).toFixed(1)} kHz`;
-    return `${hz} Hz`;
-  }
-
   // Use remote segments if available, fall back to local
   let segments = $derived(() => {
     if (!visible || endFreq <= startFreq) return [];
     const span = endFreq - startFreq;
 
     if (remoteSegments.length > 0) {
-      // Filter: don't show broadcast/utility/eibi segments that overlap with ham segments
-      const visibleRemote = remoteSegments.filter((s) => s.end > startFreq && s.start < endFreq && !hiddenLayers.includes(s.layer));
-      const hamSegs = visibleRemote.filter((s) => s.layer === 'ham');
-      const filtered = visibleRemote.filter((s) => {
-        if (s.layer === 'ham') return true;
-        // Hide non-ham segment if it significantly overlaps any ham segment
-        return !hamSegs.some((h) => {
-          const overlapStart = Math.max(s.start, h.start);
-          const overlapEnd = Math.min(s.end, h.end);
-          if (overlapEnd <= overlapStart) return false;
-          const overlapRatio = (overlapEnd - overlapStart) / (s.end - s.start);
-          return overlapRatio > 0.3; // >30% overlap → suppress
-        });
-      });
+      const filtered = filterOverlapping(remoteSegments, startFreq, endFreq, hiddenLayers);
       return filtered
         .map((s) => {
-          const rawLeft = ((s.start - startFreq) / span) * 100;
-          const rawRight = ((s.end - startFreq) / span) * 100;
-          const leftPct = Math.max(0, Math.min(100, rawLeft));
-          const rightPct = Math.max(0, Math.min(100, rawRight));
-          const widthPct = rightPct - leftPct;
+          const { leftPct, widthPct } = computePosition(s.start, s.end, startFreq, endFreq);
           const widthPx = (widthPct / 100) * containerWidth;
           return {
             start: s.start,
@@ -163,11 +125,7 @@
 
     // Fallback to local hardcoded data
     return getVisibleSegments(startFreq, endFreq).map(({ segment }) => {
-      const rawLeft = ((segment.startHz - startFreq) / span) * 100;
-      const rawRight = ((segment.endHz - startFreq) / span) * 100;
-      const leftPct = Math.max(0, Math.min(100, rawLeft));
-      const rightPct = Math.max(0, Math.min(100, rawRight));
-      const widthPct = rightPct - leftPct;
+      const { leftPct, widthPct } = computePosition(segment.startHz, segment.endHz, startFreq, endFreq);
       const widthPx = (widthPct / 100) * containerWidth;
       return {
         start: segment.startHz,
@@ -231,14 +189,6 @@
     }
     return boundaries;
   });
-
-  function hexToRgb(hex: string): string {
-    const h = hex.replace('#', '');
-    const r = parseInt(h.substring(0, 2), 16);
-    const g = parseInt(h.substring(2, 4), 16);
-    const b = parseInt(h.substring(4, 6), 16);
-    return `${r},${g},${b}`;
-  }
 
   function handleSegmentClick(seg: typeof segments extends () => (infer T)[] ? T : never, e: MouseEvent) {
     e.stopPropagation();

--- a/frontend/src/components/spectrum/__tests__/band-plan-overlay.test.ts
+++ b/frontend/src/components/spectrum/__tests__/band-plan-overlay.test.ts
@@ -1,90 +1,15 @@
 /**
- * Tests for BandPlanOverlay logic: position calculations, overlap suppression,
- * frequency formatting, hex-to-RGB conversion, and fetch debounce skip logic.
- *
- * Pure functions are re-implemented here to mirror the component's inline logic
- * since they cannot be imported from a .svelte file.
+ * Tests for BandPlanOverlay pure logic extracted to band-plan-logic.ts.
  */
 import { describe, it, expect } from 'vitest';
-
-// ── Re-implementations of BandPlanOverlay inline logic ──
-
-interface RemoteSegment {
-  start: number;
-  end: number;
-  mode: string;
-  label: string;
-  color: string;
-  opacity: number;
-  band: string;
-  layer: string;
-  priority: number;
-  url?: string | null;
-  notes?: string | null;
-  license?: string | null;
-}
-
-function formatFreq(hz: number): string {
-  if (hz >= 1_000_000) return `${(hz / 1_000_000).toFixed(3)} MHz`;
-  if (hz >= 1_000) return `${(hz / 1_000).toFixed(1)} kHz`;
-  return `${hz} Hz`;
-}
-
-function hexToRgb(hex: string): string {
-  const h = hex.replace('#', '');
-  const r = parseInt(h.substring(0, 2), 16);
-  const g = parseInt(h.substring(2, 4), 16);
-  const b = parseInt(h.substring(4, 6), 16);
-  return `${r},${g},${b}`;
-}
-
-/** Compute segment position as left% and width% given a display range. */
-function computePosition(
-  segStart: number,
-  segEnd: number,
-  startFreq: number,
-  endFreq: number,
-): { leftPct: number; widthPct: number } {
-  const span = endFreq - startFreq;
-  const rawLeft = ((segStart - startFreq) / span) * 100;
-  const rawRight = ((segEnd - startFreq) / span) * 100;
-  const leftPct = Math.max(0, Math.min(100, rawLeft));
-  const rightPct = Math.max(0, Math.min(100, rawRight));
-  return { leftPct, widthPct: rightPct - leftPct };
-}
-
-/** Filter non-ham segments that overlap >30% with any ham segment. */
-function filterOverlapping(segments: RemoteSegment[], startFreq: number, endFreq: number, hiddenLayers: string[] = []): RemoteSegment[] {
-  const visible = segments.filter(
-    (s) => s.end > startFreq && s.start < endFreq && !hiddenLayers.includes(s.layer),
-  );
-  const hamSegs = visible.filter((s) => s.layer === 'ham');
-  return visible.filter((s) => {
-    if (s.layer === 'ham') return true;
-    return !hamSegs.some((h) => {
-      const overlapStart = Math.max(s.start, h.start);
-      const overlapEnd = Math.min(s.end, h.end);
-      if (overlapEnd <= overlapStart) return false;
-      const overlapRatio = (overlapEnd - overlapStart) / (s.end - s.start);
-      return overlapRatio > 0.3;
-    });
-  });
-}
-
-/** Should the debounced fetch be skipped? (range moved less than 1% of span) */
-function shouldSkipFetch(
-  start: number,
-  end: number,
-  lastStart: number,
-  lastEnd: number,
-): boolean {
-  if (lastStart === 0) return false; // first fetch always runs
-  const span = end - start;
-  return (
-    Math.abs(start - lastStart) < span * 0.01 &&
-    Math.abs(end - lastEnd) < span * 0.01
-  );
-}
+import {
+  formatFreq,
+  hexToRgb,
+  computePosition,
+  filterOverlapping,
+  shouldSkipFetch,
+  type RemoteSegment,
+} from '../band-plan-logic';
 
 // ── Tests ──
 

--- a/frontend/src/components/spectrum/band-plan-logic.ts
+++ b/frontend/src/components/spectrum/band-plan-logic.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure functions extracted from BandPlanOverlay.svelte.
+ * No reactive ($state/$derived) dependencies — safe to import and test directly.
+ */
+
+export interface RemoteSegment {
+  start: number;
+  end: number;
+  mode: string;
+  label: string;
+  color: string;
+  opacity: number;
+  band: string;
+  layer: string;
+  priority: number;
+  url?: string | null;
+  notes?: string | null;
+  license?: string | null;
+  station?: string | null;
+  language?: string | null;
+  schedule?: string | null;
+}
+
+/** Format frequency for human display: Hz → "X.XXX MHz" / "X.X kHz" / "X Hz". */
+export function formatFreq(hz: number): string {
+  if (hz >= 1_000_000) return `${(hz / 1_000_000).toFixed(3)} MHz`;
+  if (hz >= 1_000) return `${(hz / 1_000).toFixed(1)} kHz`;
+  return `${hz} Hz`;
+}
+
+/** Convert "#RRGGBB" (or "RRGGBB") to "R,G,B" decimal string for rgba(). */
+export function hexToRgb(hex: string): string {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.substring(0, 2), 16);
+  const g = parseInt(h.substring(2, 4), 16);
+  const b = parseInt(h.substring(4, 6), 16);
+  return `${r},${g},${b}`;
+}
+
+/** Compute segment position as left% and width%, clamped to [0, 100]. */
+export function computePosition(
+  segStart: number,
+  segEnd: number,
+  startFreq: number,
+  endFreq: number,
+): { leftPct: number; widthPct: number } {
+  const span = endFreq - startFreq;
+  const rawLeft = ((segStart - startFreq) / span) * 100;
+  const rawRight = ((segEnd - startFreq) / span) * 100;
+  const leftPct = Math.max(0, Math.min(100, rawLeft));
+  const rightPct = Math.max(0, Math.min(100, rawRight));
+  return { leftPct, widthPct: rightPct - leftPct };
+}
+
+/**
+ * Filter remote segments: exclude hidden layers, exclude segments outside the
+ * display range, and suppress non-ham segments that overlap >30% with any ham segment.
+ */
+export function filterOverlapping(
+  segments: RemoteSegment[],
+  startFreq: number,
+  endFreq: number,
+  hiddenLayers: string[] = [],
+): RemoteSegment[] {
+  const visible = segments.filter(
+    (s) => s.end > startFreq && s.start < endFreq && !hiddenLayers.includes(s.layer),
+  );
+  const hamSegs = visible.filter((s) => s.layer === 'ham');
+  return visible.filter((s) => {
+    if (s.layer === 'ham') return true;
+    return !hamSegs.some((h) => {
+      const overlapStart = Math.max(s.start, h.start);
+      const overlapEnd = Math.min(s.end, h.end);
+      if (overlapEnd <= overlapStart) return false;
+      const overlapRatio = (overlapEnd - overlapStart) / (s.end - s.start);
+      return overlapRatio > 0.3;
+    });
+  });
+}
+
+/**
+ * Should the debounced fetch be skipped?
+ * Returns true when range moved less than 1% of span (and it's not the first fetch).
+ */
+export function shouldSkipFetch(
+  start: number,
+  end: number,
+  lastStart: number,
+  lastEnd: number,
+): boolean {
+  if (lastStart === 0) return false;
+  const span = end - start;
+  return (
+    Math.abs(start - lastStart) < span * 0.01 &&
+    Math.abs(end - lastEnd) < span * 0.01
+  );
+}


### PR DESCRIPTION
## Summary
- Extract 5 pure functions + RemoteSegment interface from BandPlanOverlay.svelte into band-plan-logic.ts
- Functions: `formatFreq`, `hexToRgb`, `computePosition`, `filterOverlapping`, `shouldSkipFetch`
- Tests now import from canonical module (80+ lines of re-implemented copies removed)
- Net -28 LOC

## Review: clean, no issues

## Test plan
- [x] `npx vitest run` — 1407 passed
- [x] Zero behavior change

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)