### PR TITLE
refactor(#593): extract SpectrumToolbar logic to spectrum-toolbar-logic.ts

### DIFF
--- a/frontend/src/components/spectrum/SpectrumToolbar.svelte
+++ b/frontend/src/components/spectrum/SpectrumToolbar.svelte
@@ -5,6 +5,12 @@
   import { sendCommand } from '../../lib/transport/ws-client';
   import { hasCapability, hasDualReceiver } from '../../lib/stores/capabilities.svelte';
   import ScopeSettingsPopover from './ScopeSettingsPopover.svelte';
+  import {
+    SPAN_LABELS, SPEED_LABELS, MODE_BUTTONS,
+    toggleLayer as toggleLayerFn, isLayerVisible,
+    isSpanApplicable, isEdgeApplicable,
+    clampSpan, clampSpeed, clampBrt, clampRef,
+  } from './spectrum-toolbar-logic';
 
   interface LayerInfo {
     name: string;
@@ -77,15 +83,7 @@
   }
 
   function toggleLayer(layer: string) {
-    if (hiddenLayers.includes(layer)) {
-      hiddenLayers = hiddenLayers.filter(l => l !== layer);
-    } else {
-      hiddenLayers = [...hiddenLayers, layer];
-    }
-  }
-
-  function isLayerVisible(layer: string): boolean {
-    return !hiddenLayers.includes(layer);
+    hiddenLayers = toggleLayerFn(hiddenLayers, layer);
   }
 
   let stepHz = $derived(getTuningStep());
@@ -102,33 +100,17 @@
     adjustTuningStep('down');
   }
 
-  const SPAN_LABELS: Record<number, string> = {
-    0: '±2.5k', 1: '±5k', 2: '±10k', 3: '±25k',
-    4: '±50k', 5: '±100k', 6: '±250k', 7: '±500k',
-  };
-  const SPEED_LABELS: Record<number, string> = { 0: 'FST', 1: 'MID', 2: 'SLO' };
-
   let scopeControls = $derived(radio.current?.scopeControls);
 
-  // Scope mode labels: 0=Center, 1=Fixed, 2=Scroll-Center, 3=Scroll-Fixed
-  const MODE_BUTTONS: [number, string][] = [[0, 'CTR'], [1, 'FIX'], [2, 'S-C'], [3, 'S-F']];
-
-  // SPAN is only meaningful in center modes (0=CTR, 2=S-C)
-  let spanApplicable = $derived(scopeControls?.mode === 0 || scopeControls?.mode === 2);
-
-  // EDGE selector is shown in FIX (1) and SCROLL-F (3) modes
-  let edgeApplicable = $derived(scopeControls?.mode === 1 || scopeControls?.mode === 3);
+  let spanApplicable = $derived(isSpanApplicable(scopeControls?.mode));
+  let edgeApplicable = $derived(isEdgeApplicable(scopeControls?.mode));
 
   function cycleSpan(delta: -1 | 1) {
-    const cur = scopeControls?.span ?? 3;
-    sendCommand('set_scope_span', { span: Math.max(0, Math.min(7, cur + delta)) });
+    sendCommand('set_scope_span', { span: clampSpan(scopeControls?.span ?? 3, delta) });
   }
 
   function cycleSpeed(delta: -1 | 1) {
-    // speed: 0=FST, 1=MID, 2=SLO — ◀ should speed up (decrease), ▶ slow down (increase)
-    // But visually ▶ means "more/faster", so invert: ▶ = decrease speed value
-    const cur = scopeControls?.speed ?? 1;
-    sendCommand('set_scope_speed', { speed: Math.max(0, Math.min(2, cur - delta)) });
+    sendCommand('set_scope_speed', { speed: clampSpeed(scopeControls?.speed ?? 1, delta) });
   }
 
   function toggleHold() {
@@ -176,17 +158,17 @@
   <div class="toolbar-separator"></div>
   <div class="toolbar-group">
     <span class="toolbar-label">BRT</span>
-    <button class="toolbar-btn small" onclick={() => (brtLevel = Math.max(-30, brtLevel - 5))}>−</button>
+    <button class="toolbar-btn small" onclick={() => (brtLevel = clampBrt(brtLevel, -5))}>−</button>
     <span class="toolbar-value ref-value">{brtLevel > 0 ? '+' : ''}{brtLevel}</span>
-    <button class="toolbar-btn small" onclick={() => (brtLevel = Math.min(30, brtLevel + 5))}>+</button>
+    <button class="toolbar-btn small" onclick={() => (brtLevel = clampBrt(brtLevel, 5))}>+</button>
   </div>
   {#if hasCapability('scope')}
     <div class="toolbar-separator"></div>
     <div class="toolbar-group">
       <span class="toolbar-label">REF</span>
-      <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: Math.max(-30, (scopeControls?.refDb ?? 0) - 5) })}>−</button>
+      <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: clampRef(scopeControls?.refDb ?? 0, -5) })}>−</button>
       <span class="toolbar-value ref-value">{(scopeControls?.refDb ?? 0) > 0 ? '+' : ''}{scopeControls?.refDb ?? 0}</span>
-      <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: Math.min(10, (scopeControls?.refDb ?? 0) + 5) })}>+</button>
+      <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: clampRef(scopeControls?.refDb ?? 0, 5) })}>+</button>
     </div>
     <div class="toolbar-separator"></div>
     <div class="toolbar-group">
@@ -293,7 +275,7 @@
             <label class="layer-option">
               <input
                 type="checkbox"
-                checked={isLayerVisible(layer.layer)}
+                checked={isLayerVisible(hiddenLayers, layer.layer)}
                 onchange={() => toggleLayer(layer.layer)}
               />
               <span class="layer-name">{layer.name}</span>

--- a/frontend/src/components/spectrum/__tests__/spectrum-toolbar.test.ts
+++ b/frontend/src/components/spectrum/__tests__/spectrum-toolbar.test.ts
@@ -6,47 +6,12 @@
  * and verify it independently of DOM rendering.
  */
 import { describe, it, expect } from 'vitest';
-
-// ── Constants replicated from SpectrumToolbar.svelte ──
-
-const SPAN_LABELS: Record<number, string> = {
-  0: '±2.5k', 1: '±5k', 2: '±10k', 3: '±25k',
-  4: '±50k', 5: '±100k', 6: '±250k', 7: '±500k',
-};
-
-const SPEED_LABELS: Record<number, string> = { 0: 'FST', 1: 'MID', 2: 'SLO' };
-
-const MODE_BUTTONS: [number, string][] = [[0, 'CTR'], [1, 'FIX'], [2, 'S-C'], [3, 'S-F']];
-
-// ── Pure logic extracted from component ──
-
-function toggleLayer(hiddenLayers: string[], layer: string): string[] {
-  if (hiddenLayers.includes(layer)) {
-    return hiddenLayers.filter(l => l !== layer);
-  }
-  return [...hiddenLayers, layer];
-}
-
-function isLayerVisible(hiddenLayers: string[], layer: string): boolean {
-  return !hiddenLayers.includes(layer);
-}
-
-function isSpanApplicable(mode: number | undefined): boolean {
-  return mode === 0 || mode === 2;
-}
-
-function isEdgeApplicable(mode: number | undefined): boolean {
-  return mode === 1 || mode === 3;
-}
-
-function clampSpan(cur: number, delta: -1 | 1): number {
-  return Math.max(0, Math.min(7, cur + delta));
-}
-
-/** Speed cycling inverts delta: visual ▶ means decrease speed value */
-function clampSpeed(cur: number, delta: -1 | 1): number {
-  return Math.max(0, Math.min(2, cur - delta));
-}
+import {
+  SPAN_LABELS, SPEED_LABELS, MODE_BUTTONS,
+  toggleLayer, isLayerVisible,
+  isSpanApplicable, isEdgeApplicable,
+  clampSpan, clampSpeed, clampBrt, clampRef,
+} from '../spectrum-toolbar-logic';
 
 function nextReceiver(current: number): number {
   return current === 1 ? 0 : 1;
@@ -209,10 +174,6 @@ describe('Receiver switching', () => {
 });
 
 describe('BRT level clamping', () => {
-  function clampBrt(current: number, delta: number): number {
-    if (delta > 0) return Math.min(30, current + delta);
-    return Math.max(-30, current + delta);
-  }
 
   it('increases within range', () => {
     expect(clampBrt(0, 5)).toBe(5);
@@ -232,10 +193,6 @@ describe('BRT level clamping', () => {
 });
 
 describe('REF level clamping', () => {
-  function clampRef(current: number, delta: number): number {
-    if (delta > 0) return Math.min(10, current + delta);
-    return Math.max(-30, current + delta);
-  }
 
   it('REF range is -30 to +10 (asymmetric)', () => {
     expect(clampRef(10, 5)).toBe(10);

--- a/frontend/src/components/spectrum/spectrum-toolbar-logic.ts
+++ b/frontend/src/components/spectrum/spectrum-toolbar-logic.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure functions and constants extracted from SpectrumToolbar.svelte.
+ * All functions are side-effect-free and independently testable.
+ */
+
+/* ── Constants ── */
+
+export const SPAN_LABELS: Record<number, string> = {
+  0: '\u00b12.5k', 1: '\u00b15k', 2: '\u00b110k', 3: '\u00b125k',
+  4: '\u00b150k', 5: '\u00b1100k', 6: '\u00b1250k', 7: '\u00b1500k',
+};
+
+export const SPEED_LABELS: Record<number, string> = { 0: 'FST', 1: 'MID', 2: 'SLO' };
+
+/** Scope mode buttons: [modeIndex, label] */
+export const MODE_BUTTONS: [number, string][] = [[0, 'CTR'], [1, 'FIX'], [2, 'S-C'], [3, 'S-F']];
+
+/* ── Layer visibility ── */
+
+export function toggleLayer(hiddenLayers: string[], layer: string): string[] {
+  return hiddenLayers.includes(layer)
+    ? hiddenLayers.filter(l => l !== layer)
+    : [...hiddenLayers, layer];
+}
+
+export function isLayerVisible(hiddenLayers: string[], layer: string): boolean {
+  return !hiddenLayers.includes(layer);
+}
+
+/* ── Scope mode predicates ── */
+
+/** SPAN is only meaningful in center modes (0=CTR, 2=S-C) */
+export function isSpanApplicable(mode: number | undefined): boolean {
+  return mode === 0 || mode === 2;
+}
+
+/** EDGE selector is shown in FIX (1) and SCROLL-F (3) modes */
+export function isEdgeApplicable(mode: number | undefined): boolean {
+  return mode === 1 || mode === 3;
+}
+
+/* ── Range clamps ── */
+
+export function clampSpan(current: number, delta: number): number {
+  return Math.max(0, Math.min(7, current + delta));
+}
+
+/**
+ * Clamp speed value after applying delta.
+ * Note: delta is inverted — higher speed value = slower sweep.
+ */
+export function clampSpeed(current: number, delta: number): number {
+  return Math.max(0, Math.min(2, current - delta));
+}
+
+export function clampBrt(current: number, delta: number): number {
+  return Math.max(-30, Math.min(30, current + delta));
+}
+
+export function clampRef(current: number, delta: number): number {
+  return Math.max(-30, Math.min(10, current + delta));
+}


### PR DESCRIPTION
## Summary
- Extract 8 functions + 3 constants from SpectrumToolbar.svelte into spectrum-toolbar-logic.ts
- Tests updated to import from canonical module (inline copies eliminated)
- Net +1 LOC (3 files, +84/-83)

## Review findings addressed
- Test file now imports all functions from spectrum-toolbar-logic.ts instead of re-implementing them
- Removed inline clampBrt/clampRef duplicates from test describe blocks

## Test plan
- [x] `npx vitest run` — 1407 passed
- [x] Zero behavior change

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)