### PR TITLE
fix(#600): clear stale state on disconnect — reset delta and radio store

### DIFF
--- a/frontend/src/lib/stores/radio.svelte.test.ts
+++ b/frontend/src/lib/stores/radio.svelte.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { radio, setRadioState, resetRadioState, getRadioState, getLastRevision } from './radio.svelte';
+import type { ServerState } from '../types/state';
+
+function makeState(revision: number): ServerState {
+  return {
+    revision,
+    active: 'MAIN',
+    powerOn: true,
+    ptt: false,
+    split: false,
+    dualWatch: false,
+    main: {
+      freqHz: 14074000,
+      mode: 'USB',
+      filter: 1,
+      dataMode: 0,
+      sMeter: 0,
+      att: 0,
+      preamp: 0,
+      nb: false,
+      nr: false,
+      afLevel: 50,
+      rfGain: 100,
+      squelch: 0,
+    },
+    sub: {
+      freqHz: 7074000,
+      mode: 'LSB',
+      filter: 1,
+      dataMode: 0,
+      sMeter: 0,
+      att: 0,
+      preamp: 0,
+      nb: false,
+      nr: false,
+      afLevel: 50,
+      rfGain: 100,
+      squelch: 0,
+    },
+  } as ServerState;
+}
+
+describe('resetRadioState', () => {
+  beforeEach(() => {
+    // Ensure clean state
+    resetRadioState();
+  });
+
+  it('clears radio.current to null', () => {
+    setRadioState(makeState(1));
+    expect(radio.current).not.toBeNull();
+
+    resetRadioState();
+    expect(radio.current).toBeNull();
+  });
+
+  it('resets lastRevision to -1', () => {
+    setRadioState(makeState(42));
+    expect(getLastRevision()).toBe(42);
+
+    resetRadioState();
+    expect(getLastRevision()).toBe(-1);
+  });
+
+  it('allows new state to be set after reset', () => {
+    setRadioState(makeState(10));
+    resetRadioState();
+
+    // After reset, a state with revision=1 should be accepted
+    setRadioState(makeState(1));
+    expect(radio.current).not.toBeNull();
+    expect(getLastRevision()).toBe(1);
+  });
+
+  it('getRadioState returns null after reset', () => {
+    setRadioState(makeState(5));
+    resetRadioState();
+    expect(getRadioState()).toBeNull();
+  });
+});

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -75,6 +75,15 @@ function applyOptimistic(state: ServerState): ServerState {
   return result;
 }
 
+/** Clear all radio state on disconnect. */
+export function resetRadioState(): void {
+  radio.current = null;
+  lastRevision = -1;
+  optimisticMain.clear();
+  optimisticSub.clear();
+  lockedFields.clear();
+}
+
 export function setRadioState(state: ServerState): void {
   const isReset = lastRevision > 10 && state.revision < lastRevision / 2;
   const isInitial = radio.current === null;

--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -10,8 +10,10 @@ vi.mock('../../stores/connection.svelte', () => ({
 }));
 
 vi.mock('../../stores/radio.svelte', () => ({
+  getRadioState: vi.fn().mockReturnValue(null),
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
+  resetRadioState: vi.fn(),
   setRadioState: vi.fn(),
 }));
 

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -1,7 +1,7 @@
 import type { WsCommand, WsIncoming } from '../types/protocol';
 import { makeCommandId } from '../types/protocol';
 import { setWsConnected, setHttpConnected, markStateUpdated, setReconnecting } from '../stores/connection.svelte';
-import { getRadioState, patchActiveReceiver, patchRadioState, setRadioState } from '../stores/radio.svelte';
+import { getRadioState, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 type MessageHandler = (msg: WsIncoming) => void;
@@ -223,9 +223,15 @@ const _ctrl = new WsChannel();
 _ctrl.onStateChange((s) => {
   setWsConnected(s === 'connected');
   setReconnecting(s === 'connecting' || s === 'reconnecting');
+  if (s === 'disconnected') {
+    _fullState = {};
+    _hasReceivedFullState = false;
+    resetRadioState();
+  }
 });
 // Delta state tracking for incremental updates
 let _fullState: Record<string, unknown> = {};
+let _hasReceivedFullState = false;
 
 function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, unknown> | null {
   const deltaType = envelope.type as string;
@@ -235,10 +241,13 @@ function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, u
     _fullState = { ...(envelope.data as Record<string, unknown>) };
     // Carry revision at top level for setRadioState
     _fullState.revision = envelope.revision as number;
+    _hasReceivedFullState = true;
     return _fullState;
   }
 
   if (deltaType === 'delta') {
+    // Reject delta if we haven't received a full state yet
+    if (!_hasReceivedFullState) return null;
     // Incremental update — apply changed fields, remove deleted keys
     const changed = (envelope.changed ?? {}) as Record<string, unknown>;
     const removed = (envelope.removed ?? []) as string[];


### PR DESCRIPTION
## Summary
- Add `resetRadioState()` that clears radio.current, lastRevision, optimistic patches, and input locks
- On WS disconnect: clear `_fullState`, reset `_hasReceivedFullState` flag, call `resetRadioState()`
- Guard delta messages — reject if no full state received yet
- 4 tests for reset behavior

## Review findings addressed
- Added `lockedFields.clear()` to prevent stale input locks surviving disconnect
- Added `getRadioState` and `resetRadioState` to ws-client test mock

## Test plan
- [x] `npx vitest run` — 1411 passed (75 files)

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)