### PR TITLE
fix(#604): use encoder revision for initial state snapshot

### DIFF
--- a/src/icom_lan/web/_delta_encoder.py
+++ b/src/icom_lan/web/_delta_encoder.py
@@ -126,6 +126,11 @@ class DeltaEncoder:
 
         return result
 
+    @property
+    def revision(self) -> int:
+        """Current revision counter."""
+        return self._revision
+
     def reset(self) -> None:
         """Reset encoder state (e.g., on client reconnect)."""
         self._previous_state = None

--- a/src/icom_lan/web/handlers/control.py
+++ b/src/icom_lan/web/handlers/control.py
@@ -371,7 +371,8 @@ class ControlHandler:
         if self._server is not None:
             try:
                 initial_state = self._server.build_public_state()
-                msg = {"type": "state_update", "data": {"type": "full", "data": initial_state, "revision": 0}}
+                rev = self._server._delta_encoder.revision
+                msg = {"type": "state_update", "data": {"type": "full", "data": initial_state, "revision": rev}}
                 await self._ws.send_text(encode_json(msg))
             except Exception:
                 logger.debug("control: failed to send initial state", exc_info=True)


### PR DESCRIPTION
## Summary
- Add `revision` property to DeltaEncoder (read-only, no side effects)
- Initial state snapshot now uses the encoder's current revision instead of hardcoded `0`
- Clients see continuous revision sequence regardless of when they connect

## Test plan
- [x] `uv run pytest tests/test_web_server.py tests/test_handlers_coverage.py` — 264 passed
- [x] `uv run ruff check` — clean

Closes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)