### PR TITLE
fix(#605): coerce null numeric fields to defaults in state adapter

### DIFF
--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -101,14 +101,15 @@ export function toVfoProps(
   if (state.split) badges['SPLIT'] = true;
 
   const filters = ['FIL1', 'FIL2', 'FIL3'];
-  const filterLabel = filters[rx.filter - 1] ?? `FIL${rx.filter}`;
+  const fil = rx.filter ?? 1;
+  const filterLabel = filters[fil - 1] ?? `FIL${fil}`;
 
   return {
     receiver,
-    freq: rx.freqHz,
-    mode: rx.mode,
+    freq: rx.freqHz ?? 14074000,
+    mode: rx.mode ?? 'USB',
     filter: filterLabel,
-    sValue: rx.sMeter,
+    sValue: rx.sMeter ?? 0,
     isActive,
     badges,
     rit: state.ritOn


### PR DESCRIPTION
## Summary
- Add null coalescing guards to 4 fields in \`toVfoProps()\`: freqHz, mode, filter, sMeter
- Other adapter functions already had guards — only toVfoProps was missing them

## Test plan
- [x] \`npx vitest run\` — 1407 passed

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)