### PR TITLE
fix(#603): add null guards for missing receiver state

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
@@ -43,6 +43,16 @@ describe('toModeProps', () => {
 });
 
 describe('toVfoProps', () => {
+  it('returns defaults when receiver state is missing from ServerState', () => {
+    // State exists but sub receiver is undefined — must not crash
+    const state = { active: 'SUB', main: { freqHz: 14074000, mode: 'USB', filter: 1, sMeter: 0, att: 0, preamp: 0, nb: false, nr: false, afLevel: 0, rfGain: 255, squelch: 0, dataMode: 0 } } as any;
+    const props = toVfoProps(state, 'sub');
+    expect(props.receiver).toBe('sub');
+    expect(props.freq).toBe(14074000);
+    expect(props.mode).toBe('USB');
+    expect(props.badges).toEqual({});
+  });
+
   it('adds a DATA badge when numeric data mode is active', () => {
     const props = toVfoProps(
       {

--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -80,6 +80,17 @@ export function toVfoProps(
   }
 
   const rx = state[receiver];
+  if (!rx) {
+    return {
+      receiver,
+      freq: 14074000,
+      mode: 'USB',
+      filter: 'FIL1',
+      sValue: 0,
+      isActive: receiver === 'main',
+      badges: {},
+    };
+  }
   const isActive = (state.active === 'SUB') === (receiver === 'sub');
 
   // Always show all possible badges, active state determines if they light up

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -26,6 +26,7 @@ function applyOptimistic(state: ServerState): ServerState {
   for (const [map, key] of [[optimisticMain, 'main'], [optimisticSub, 'sub']] as const) {
     if (map.size === 0) continue;
     const serverRx = result[key];
+    if (!serverRx) continue;
     const rx = { ...serverRx };
     let changed = false;
     for (const [field, entry] of map) {


### PR DESCRIPTION
## Summary
- Guard `applyOptimistic()` against missing `main`/`sub` in partial state
- Guard `toVfoProps()` against undefined receiver — returns safe defaults
- Test: verify missing SUB receiver doesn't crash

## Test plan
- [x] `npx vitest run` — 1408 passed

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)