### PR TITLE
fix(#602): expose connection readiness fields from backend state

### DIFF
--- a/frontend/src/lib/stores/connection.svelte.ts
+++ b/frontend/src/lib/stores/connection.svelte.ts
@@ -6,6 +6,9 @@ let scopeConnected = $state(false);
 let scopeLastFrame = $state(0);
 let radioStatus = $state<'connected' | 'connecting' | 'reconnecting' | 'disconnected'>('disconnected');
 let radioPowerOn = $state<boolean | null>(null);
+let rigConnected = $state(false);
+let radioReady = $state(false);
+let controlConnected = $state(false);
 let lastResponseTime = $state<number | null>(null);
 
 let lastStateUpdate = $state(0);
@@ -121,4 +124,28 @@ export function setRadioPowerOn(v: boolean | null): void {
 
 export function getRadioPowerOn(): boolean | null {
   return radioPowerOn;
+}
+
+export function setRigConnected(v: boolean): void {
+  rigConnected = v;
+}
+
+export function getRigConnected(): boolean {
+  return rigConnected;
+}
+
+export function setRadioReady(v: boolean): void {
+  radioReady = v;
+}
+
+export function getRadioReady(): boolean {
+  return radioReady;
+}
+
+export function setControlConnected(v: boolean): void {
+  controlConnected = v;
+}
+
+export function getControlConnected(): boolean {
+  return controlConnected;
 }

--- a/frontend/src/lib/stores/connection.test.ts
+++ b/frontend/src/lib/stores/connection.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setRigConnected,
+  getRigConnected,
+  setRadioReady,
+  getRadioReady,
+  setControlConnected,
+  getControlConnected,
+} from './connection.svelte';
+
+describe('connection readiness fields', () => {
+  it('rigConnected defaults to false and can be set', () => {
+    expect(getRigConnected()).toBe(false);
+    setRigConnected(true);
+    expect(getRigConnected()).toBe(true);
+    setRigConnected(false);
+    expect(getRigConnected()).toBe(false);
+  });
+
+  it('radioReady defaults to false and can be set', () => {
+    expect(getRadioReady()).toBe(false);
+    setRadioReady(true);
+    expect(getRadioReady()).toBe(true);
+    setRadioReady(false);
+    expect(getRadioReady()).toBe(false);
+  });
+
+  it('controlConnected defaults to false and can be set', () => {
+    expect(getControlConnected()).toBe(false);
+    setControlConnected(true);
+    expect(getControlConnected()).toBe(true);
+    setControlConnected(false);
+    expect(getControlConnected()).toBe(false);
+  });
+});

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -1,5 +1,5 @@
 import type { ServerState, ReceiverState } from '../types/state';
-import { setRadioPowerOn } from './connection.svelte';
+import { setRadioPowerOn, setRigConnected, setRadioReady, setControlConnected } from './connection.svelte';
 
 /**
  * Shared radio state — class-based $state pattern for cross-module reactivity.
@@ -89,6 +89,12 @@ export function setRadioState(state: ServerState): void {
     // Sync power status to connection store
     if (state.powerOn !== undefined) {
       setRadioPowerOn(state.powerOn);
+    }
+    // Sync connection readiness fields
+    if (state.connection) {
+      setRigConnected(state.connection.rigConnected);
+      setRadioReady(state.connection.radioReady);
+      setControlConnected(state.connection.controlConnected);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `rigConnected`, `radioReady`, `controlConnected` state + setters/getters to connection store
- Extract `state.connection.*` in `setRadioState()` and forward to connection store
- 3 tests for default values and round-trips

## Test plan
- [x] `npx vitest run` — 1410 passed (75 files)

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)