### PR TITLE
feat(#611): add missing LCD indicators + capability gating

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
@@ -76,12 +76,19 @@
   let nbActive = $derived((rx?.nb ?? false) || nbLevel > 0);
   let nrActive = $derived((rx?.nr ?? false) || nrLevel > 0);
   let agcMode = $derived(rx?.agc ?? 0);
-  let notchActive = $derived(rx?.autoNotch ?? false);
+  let notchActive = $derived(rx?.manualNotch ?? false);
   let compActive = $derived(radioState?.compressorOn ?? false);
   let compLevel = $derived(radioState?.compressorLevel ?? 0);
   let lockActive = $derived(radioState?.dialLock ?? false);
   let contourActive = $derived((rx?.contour ?? 0) > 0);
   let contourLevel = $derived(rx?.contour ?? 0);
+  let digiSelActive = $derived(rx?.digisel ?? false);
+  let ipPlusActive = $derived(rx?.ipplus ?? false);
+  let anfActive = $derived(rx?.autoNotch ?? false);
+  let manualNotchActive = $derived(rx?.manualNotch ?? false);
+  let rfgReduced = $derived((rx?.rfGain ?? 255) < 255);
+  let sqlActive = $derived((rx?.squelch ?? 0) > 0);
+  let dataActive = $derived(!!rx?.dataMode);
   let filterWidthHz = $derived(rx?.filterWidth ?? 2400);
   let filterWidthMax = $derived.by(() => {
     const caps = getCapabilities();
@@ -163,6 +170,8 @@
       <!-- RF front-end -->
       <span class="lcd-ind" class:active={attActive}>ATT</span>
       <span class="lcd-ind active">{preamp === 0 ? 'IPO' : preamp === 1 ? 'AMP1' : 'AMP2'}</span>
+      <span class="lcd-ind" class:active={digiSelActive}>DIGI-SEL</span>
+      <span class="lcd-ind" class:active={ipPlusActive}>IP+</span>
       <span class="lcd-ind" class:active={atuActive}>ATU</span>
 
       <span class="ind-sep"></span>
@@ -172,13 +181,17 @@
       <span class="lcd-ind" class:active={nrActive}>NR{nrActive ? ` ${nrLevel}` : ''}</span>
       <span class="lcd-ind" class:active={contourActive}>CONT</span>
       <span class="lcd-ind" class:active={notchActive}>NOTCH</span>
+      <span class="lcd-ind" class:active={anfActive}>ANF</span>
       <span class="lcd-ind active">AGC {agcLabel(agcMode)}</span>
 
       <span class="ind-sep"></span>
 
       <!-- VFO / system -->
+      <span class="lcd-ind" class:active={rfgReduced}>RFG</span>
+      <span class="lcd-ind" class:active={sqlActive}>SQL</span>
       <span class="lcd-ind" class:active={ritActive}>RIT</span>
       <span class="lcd-ind" class:active={splitActive}>SPLIT</span>
+      {#if dataActive}<span class="lcd-ind active">DATA</span>{/if}
       <span class="lcd-ind" class:active={lockActive}>LOCK</span>
     </div>
 

--- a/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { radio } from '$lib/stores/radio.svelte';
-  import { isAudioFftScope, hasAudioFft, hasDualReceiver, getCapabilities } from '$lib/stores/capabilities.svelte';
+  import { isAudioFftScope, hasAudioFft, hasDualReceiver, getCapabilities, hasCapability } from '$lib/stores/capabilities.svelte';
   import { resolveFilterModeConfig } from '../../wiring/state-adapter';
   import AmberFrequency from './AmberFrequency.svelte';
   import AmberSmeter from './AmberSmeter.svelte';
@@ -158,41 +158,41 @@
       <AmberSmeter value={sValue} {txActive} />
     </div>
 
-    <!-- ═══ Indicators (below S-meter) — grouped by function ═══ -->
+    <!-- ═══ Indicators (below S-meter) — gated by capabilities ═══ -->
     <div class="lcd-ind-row">
-      <!-- TX group -->
+      <!-- TX group (always shown) -->
       <span class="lcd-ind" class:active={txActive} class:ind-tx={txActive}>TX</span>
-      <span class="lcd-ind" class:active={voxActive}>VOX</span>
-      <span class="lcd-ind" class:active={compActive}>PROC{compActive ? ` ${compLevel}` : ''}</span>
+      {#if hasCapability('vox')}<span class="lcd-ind" class:active={voxActive}>VOX</span>{/if}
+      {#if hasCapability('compressor')}<span class="lcd-ind" class:active={compActive}>PROC{compActive ? ` ${compLevel}` : ''}</span>{/if}
 
       <span class="ind-sep"></span>
 
       <!-- RF front-end -->
-      <span class="lcd-ind" class:active={attActive}>ATT</span>
-      <span class="lcd-ind active">{preamp === 0 ? 'IPO' : preamp === 1 ? 'AMP1' : 'AMP2'}</span>
-      <span class="lcd-ind" class:active={digiSelActive}>DIGI-SEL</span>
-      <span class="lcd-ind" class:active={ipPlusActive}>IP+</span>
-      <span class="lcd-ind" class:active={atuActive}>ATU</span>
+      {#if hasCapability('attenuator')}<span class="lcd-ind" class:active={attActive}>ATT</span>{/if}
+      {#if hasCapability('preamp')}<span class="lcd-ind active">{preamp === 0 ? 'IPO' : preamp === 1 ? 'AMP1' : 'AMP2'}</span>{/if}
+      {#if hasCapability('digisel')}<span class="lcd-ind" class:active={digiSelActive}>DIGI-SEL</span>{/if}
+      {#if hasCapability('ip_plus')}<span class="lcd-ind" class:active={ipPlusActive}>IP+</span>{/if}
+      {#if hasCapability('tuner')}<span class="lcd-ind" class:active={atuActive}>ATU</span>{/if}
 
       <span class="ind-sep"></span>
 
       <!-- DSP / filters -->
-      <span class="lcd-ind" class:active={nbActive}>NB{nbActive ? ` ${nbLevel}` : ''}</span>
-      <span class="lcd-ind" class:active={nrActive}>NR{nrActive ? ` ${nrLevel}` : ''}</span>
-      <span class="lcd-ind" class:active={contourActive}>CONT</span>
-      <span class="lcd-ind" class:active={notchActive}>NOTCH</span>
-      <span class="lcd-ind" class:active={anfActive}>ANF</span>
+      {#if hasCapability('nb')}<span class="lcd-ind" class:active={nbActive}>NB{nbActive ? ` ${nbLevel}` : ''}</span>{/if}
+      {#if hasCapability('nr')}<span class="lcd-ind" class:active={nrActive}>NR{nrActive ? ` ${nrLevel}` : ''}</span>{/if}
+      {#if hasCapability('contour')}<span class="lcd-ind" class:active={contourActive}>CONT</span>{/if}
+      {#if hasCapability('notch')}<span class="lcd-ind" class:active={notchActive}>NOTCH</span>{/if}
+      {#if hasCapability('notch')}<span class="lcd-ind" class:active={anfActive}>ANF</span>{/if}
       <span class="lcd-ind active">AGC {agcLabel(agcMode)}</span>
 
       <span class="ind-sep"></span>
 
       <!-- VFO / system -->
-      <span class="lcd-ind" class:active={rfgReduced}>RFG</span>
-      <span class="lcd-ind" class:active={sqlActive}>SQL</span>
-      <span class="lcd-ind" class:active={ritActive}>RIT</span>
-      <span class="lcd-ind" class:active={splitActive}>SPLIT</span>
+      {#if hasCapability('rf_gain')}<span class="lcd-ind" class:active={rfgReduced}>RFG</span>{/if}
+      {#if hasCapability('squelch')}<span class="lcd-ind" class:active={sqlActive}>SQL</span>{/if}
+      {#if hasCapability('rit')}<span class="lcd-ind" class:active={ritActive}>RIT</span>{/if}
+      {#if hasCapability('split')}<span class="lcd-ind" class:active={splitActive}>SPLIT</span>{/if}
       {#if dataActive}<span class="lcd-ind active">DATA</span>{/if}
-      <span class="lcd-ind" class:active={lockActive}>LOCK</span>
+      {#if hasCapability('dial_lock')}<span class="lcd-ind" class:active={lockActive}>LOCK</span>{/if}
     </div>
 
     <!-- ═══ VFO A + AF Scope row ═══ -->


### PR DESCRIPTION
## Summary
- **#612**: Add 6 missing indicators: DIGI-SEL, IP+, ANF, RFG, SQL, DATA
- **#613**: Gate ALL indicators by capabilities — unsupported features don't render
- Fix NOTCH indicator (was autoNotch, now manualNotch; ANF added separately)
- DATA shown only when active (dynamic)
- TX and AGC always shown

## Capability mapping
ATT→attenuator, PRE→preamp, DIGI-SEL→digisel, IP+→ip_plus, ATU→tuner,
NB→nb, NR→nr, CONT→contour, NOTCH/ANF→notch, RFG→rf_gain, SQL→squelch,
VOX→vox, PROC→compressor, RIT→rit, SPLIT→split, LOCK→dial_lock

## Test plan
- [x] \`npx vitest run\` — 1437 passed

Closes #612, closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)