### PR TITLE
feat(#618): add ATU status indicator to V2 and LCD

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
@@ -68,6 +68,7 @@
   let splitActive = $derived(radioState?.split ?? false);
   let voxActive = $derived(radioState?.voxOn ?? false);
   let atuActive = $derived((radioState?.tunerStatus ?? 0) > 0);
+  let atuTuning = $derived((radioState?.tunerStatus ?? 0) === 2);
   let preamp = $derived(rx?.preamp ?? 0);
   let attActive = $derived((rx?.att ?? 0) > 0);
   // FTX-1: no separate NB/NR on/off — level > 0 means active
@@ -163,7 +164,7 @@
       <!-- RF front-end -->
       <span class="lcd-ind" class:active={attActive}>ATT</span>
       <span class="lcd-ind active">{preamp === 0 ? 'IPO' : preamp === 1 ? 'AMP1' : 'AMP2'}</span>
-      <span class="lcd-ind" class:active={atuActive}>ATU</span>
+      <span class="lcd-ind" class:active={atuActive} class:ind-tuning={atuTuning}>{atuTuning ? 'TUNE' : 'ATU'}</span>
 
       <span class="ind-sep"></span>
 
@@ -319,6 +320,13 @@
     color: #5A0800;
     border-color: rgba(90, 8, 0, 0.5);
     font-size: 15px;
+  }
+  .lcd-ind.ind-tuning {
+    animation: lcd-blink 0.6s steps(1) infinite;
+  }
+  @keyframes lcd-blink {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0.15; }
   }
 
   /* ── VFO + Scope row ── */

--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -105,11 +105,13 @@ export function toVfoProps(
     'PRE': rx.preamp > 0,
     'RFG': (rx.rfGain ?? 255) < 255,  // RF Gain reduced from max
     'SQL': (rx.squelch ?? 0) > 0,     // Squelch active
+    'ATU': (state.tunerStatus ?? 0) > 0,  // Antenna tuner active
   };
   
   // Dynamic badges (only show when active)
   if (rx.dataMode) badges['DATA'] = true;
   if (state.split) badges['SPLIT'] = true;
+  if ((state.tunerStatus ?? 0) === 2) badges['TUNE'] = true;
 
   const filters = ['FIL1', 'FIL2', 'FIL3'];
   const fil = rx.filter ?? 1;


### PR DESCRIPTION
## Summary

**V2 desktop (VFO badges):**
- New `ATU` badge: lit when tuner active (tunerStatus > 0)
- New `TUNE` dynamic badge: appears only during active tuning (tunerStatus === 2)

**LCD display:**
- ATU indicator shows "TUNE" with blinking animation during active tuning
- Shows "ATU" when tuner is on but idle
- Data: `radioState.tunerStatus` (0=off, 1=on, 2=tuning)

## Test plan
- [x] `npx vitest run` — 1437 passed

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)