### PR TITLE
feat(#616): add TX meters, meter source selector, and sub-RX meter to LCD

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
@@ -62,7 +62,36 @@
   let mode = $derived(rx?.mode ?? '---');
   let filter = $derived(rx?.filter ?? '');
   let sValue = $derived(rx?.sMeter ?? 0);
+  let subSValue = $derived(radioState?.sub?.sMeter ?? 0);
   let txActive = $derived(radioState?.ptt ?? false);
+  let poValue = $derived(radioState?.powerMeter ?? 0);
+  let swrValue = $derived(radioState?.swrMeter ?? 0);
+  let alcValue = $derived(radioState?.alcMeter ?? 0);
+  let compMeterValue = $derived(radioState?.compMeter ?? 0);
+
+  type MeterSource = 'S' | 'PO' | 'SWR' | 'ALC' | 'COMP';
+  const METER_SOURCES: MeterSource[] = ['S', 'PO', 'SWR', 'ALC', 'COMP'];
+  let userMeterSource = $state<MeterSource>('S');
+
+  // Auto-switch to PO during TX if user hasn't selected a TX meter
+  let activeMeterSource = $derived<MeterSource>(
+    txActive && userMeterSource === 'S' ? 'PO' : userMeterSource
+  );
+
+  let meterValue = $derived.by(() => {
+    switch (activeMeterSource) {
+      case 'PO': return poValue;
+      case 'SWR': return swrValue;
+      case 'ALC': return alcValue;
+      case 'COMP': return compMeterValue;
+      default: return sValue;
+    }
+  });
+
+  function cycleMeterSource() {
+    const idx = METER_SOURCES.indexOf(userMeterSource);
+    userMeterSource = METER_SOURCES[(idx + 1) % METER_SOURCES.length];
+  }
   let ritActive = $derived(radioState?.ritOn ?? false);
   let ritOffset = $derived(radioState?.ritFreq ?? 0);
   let splitActive = $derived(radioState?.split ?? false);
@@ -158,8 +187,14 @@
 
     <!-- ═══ S-Meter ═══ -->
     <div class="lcd-meter-row">
-      <AmberSmeter value={sValue} {txActive} />
+      <AmberSmeter value={meterValue} {txActive} source={activeMeterSource} />
+      <button class="lcd-meter-src-btn" onclick={cycleMeterSource}>{activeMeterSource}</button>
     </div>
+    {#if hasDualReceiver() && !txActive}
+      <div class="lcd-meter-row lcd-meter-sub">
+        <AmberSmeter value={subSValue} source="S" />
+      </div>
+    {/if}
 
     <!-- ═══ Indicators (below S-meter) — gated by capabilities ═══ -->
     <div class="lcd-ind-row">
@@ -481,6 +516,34 @@
   .lcd-meter-row {
     position: relative;
     z-index: 2;
+    display: flex;
+    align-items: center;
+  }
+  .lcd-meter-row :global(.lcd-smeter) {
+    flex: 1;
+  }
+  .lcd-meter-src-btn {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    font-weight: 700;
+    color: #1A1000;
+    background: transparent;
+    border: 1.5px solid rgba(26, 16, 0, 0.3);
+    border-radius: 3px;
+    padding: 2px 6px;
+    margin-right: 4px;
+    cursor: pointer;
+    min-width: 36px;
+    text-align: center;
+  }
+  .lcd-meter-src-btn:hover {
+    border-color: rgba(26, 16, 0, 0.5);
+  }
+  .lcd-meter-sub {
+    opacity: 0.6;
+    transform: scaleY(0.7);
+    transform-origin: top;
+    margin-top: -4px;
   }
 
   /* ── Sub VFO ── */

--- a/frontend/src/components-v2/panels/lcd/AmberSmeter.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberSmeter.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import { getCalibrationPoints, getS9Raw, rawToSUnit, rawToDbm } from '../../meters/smeter-scale';
 
+  type MeterSource = 'S' | 'PO' | 'SWR' | 'ALC' | 'COMP';
+
   interface Props {
-    value: number;      // Raw S-meter 0-255
+    value: number;      // Raw meter 0-255
     txActive?: boolean;
+    source?: MeterSource;
   }
 
-  let { value, txActive = false }: Props = $props();
+  let { value, txActive = false, source = 'S' }: Props = $props();
 
   const MAX_RAW = 255;
   const SEGMENTS = 192;
@@ -43,9 +46,13 @@
 
   let filledSegs = $derived(Math.round(Math.min(SEGMENTS, Math.max(0, (value / MAX_RAW) * SEGMENTS))));
 
-  let sReadout = $derived({
-    sUnit: rawToSUnit(value),
-    dbm: rawToDbm(value).toString(),
+  let sReadout = $derived.by(() => {
+    if (source === 'S') return { label: rawToSUnit(value), sub: rawToDbm(value) + ' dBm' };
+    if (source === 'PO') return { label: 'PO', sub: Math.round(value / 255 * 100) + 'W' };
+    if (source === 'SWR') return { label: 'SWR', sub: (1.0 + value / 255 * 8.9).toFixed(1) };
+    if (source === 'ALC') return { label: 'ALC', sub: Math.round(value / 255 * 100) + '%' };
+    if (source === 'COMP') return { label: 'COMP', sub: Math.round(value / 255 * 20) + 'dB' };
+    return { label: rawToSUnit(value), sub: rawToDbm(value) + ' dBm' };
   });
 </script>
 
@@ -87,8 +94,8 @@
 
   <!-- Readout -->
   <div class="meter-readout">
-    <span class="readout-s">{sReadout.sUnit}</span>
-    <span class="readout-dbm">{sReadout.dbm}<span class="readout-unit">dBm</span></span>
+    <span class="readout-s">{sReadout.label}</span>
+    <span class="readout-dbm">{sReadout.sub}</span>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

**#622 — Auto-switch meter during TX:**
- AmberSmeter accepts \`source\` prop: S | PO | SWR | ALC | COMP
- Each source has proper readout formatting (watts, SWR ratio, %, dB)
- LCD auto-switches from S-meter to PO during TX (matches IC-7610 hardware)

**#623 — Meter source selector:**
- Cycle button next to S-meter: S → PO → SWR → ALC → COMP → S
- Shows current source label
- LCD amber palette styling

**#624 — Sub-receiver S-meter:**
- Compact meter (70% height, dimmed) below main meter
- Gated by \`dual_rx\` capability
- Hidden during TX

## Test plan
- [x] \`npx vitest run\` — 1437 passed
- [x] \`npm run build\` — clean

Closes #616, closes #622, closes #623, closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)