### PR TITLE
feat(#617): add ATU tune, CW auto tune, break-in mode to LCD

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
@@ -83,6 +83,8 @@
   let compActive = $derived(radioState?.compressorOn ?? false);
   let compLevel = $derived(radioState?.compressorLevel ?? 0);
   let lockActive = $derived(radioState?.dialLock ?? false);
+  let isCwMode = $derived(mode === 'CW' || mode === 'CW-R');
+  let breakInMode = $derived(radioState?.breakIn ?? 0);  // 0=off, 1=semi, 2=full
   let contourActive = $derived((rx?.contour ?? 0) > 0);
   let contourLevel = $derived(rx?.contour ?? 0);
   let digiSelActive = $derived(rx?.digisel ?? false);
@@ -256,6 +258,15 @@
       {#if hasCapability('rit')}
         <button class="lcd-btn" class:active={xitActive} onclick={() => sendCommand('set_rit_tx_status', { on: !xitActive })}>XIT</button>
         <button class="lcd-btn" onclick={() => sendCommand('set_rit_frequency', { freq: 0 })}>CLR</button>
+      {/if}
+      {#if hasCapability('tuner')}
+        <button class="lcd-btn" onclick={() => sendCommand('atu_tune', {})}>TUNE</button>
+      {/if}
+      {#if isCwMode && hasCapability('cw')}
+        <button class="lcd-btn" onclick={() => sendCommand('cw_auto_tune', {})}>AUTO</button>
+        {#if hasCapability('break_in')}
+          <button class="lcd-btn" class:active={breakInMode > 0} onclick={() => sendCommand('set_break_in_mode', { mode: breakInMode === 0 ? 1 : breakInMode === 1 ? 2 : 0 })}>{breakInMode === 0 ? 'BK-OFF' : breakInMode === 1 ? 'SEMI' : 'FULL'}</button>
+        {/if}
       {/if}
     </div>
 


### PR DESCRIPTION
## Summary
- **TUNE** button: fires \`atu_tune\` command, gated by \`tuner\`
- **AUTO** button: fires \`cw_auto_tune\`, shown only in CW/CW-R mode, gated by \`cw\`
- **BK-OFF/SEMI/FULL** cycle button: cycles break-in mode, gated by \`break_in\`, CW mode only
- All in LCD amber palette, VFO control row

## Test plan
- [x] \`npx vitest run\` — 1437 passed
- [x] 1 file, +11 LOC

Closes #617, closes #625, closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)