### PR TITLE
fix(#634): Yaesu server clean shutdown — close PortAudio before task cancel

### DIFF
--- a/src/icom_lan/audio/backend.py
+++ b/src/icom_lan/audio/backend.py
@@ -197,17 +197,12 @@ class _PortAudioRxStream:
         self._task = asyncio.create_task(self._loop(), name="portaudio-rx")
 
     async def stop(self) -> None:
-        task = self._task
         stream = self._stream
-        self._task = None
+        task = self._task
         self._stream = None
+        self._task = None
         self._callback = None
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        # Close stream FIRST — unblocks executor thread stuck in stream.read()
         if stream is not None:
             try:
                 stream.stop()
@@ -217,6 +212,13 @@ class _PortAudioRxStream:
                 stream.close()
             except Exception:
                 logger.debug("portaudio-rx: stream close failed", exc_info=True)
+        # Now cancel the task (thread is already unblocked)
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     async def _loop(self) -> None:
         stream = self._stream
@@ -278,17 +280,12 @@ class _PortAudioTxStream:
         self._task = asyncio.create_task(self._loop(), name="portaudio-tx")
 
     async def stop(self) -> None:
-        task = self._task
         stream = self._stream
-        self._task = None
+        task = self._task
         self._stream = None
+        self._task = None
         self._queue = asyncio.Queue(maxsize=64)
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        # Close stream FIRST — unblocks executor thread stuck in stream.write()
         if stream is not None:
             try:
                 stream.stop()
@@ -298,6 +295,13 @@ class _PortAudioTxStream:
                 stream.close()
             except Exception:
                 logger.debug("portaudio-tx: stream close failed", exc_info=True)
+        # Now cancel the task (thread is already unblocked)
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     async def write(self, frame: bytes) -> None:
         if not self.running:


### PR DESCRIPTION
## Problem

Yaesu FTX-1 server hangs on Ctrl-C. Executor threads are blocked on `stream.read()`/`stream.write()` via `asyncio.to_thread()`. `task.cancel()` doesn't interrupt the thread — only the async wrapper.

## Fix

Reorder operations in both `_PortAudioRxStream.stop()` and `_PortAudioTxStream.stop()`:
1. Close PortAudio stream FIRST (unblocks the blocked thread)
2. THEN cancel the async task (thread is already free)

## Test plan
- [x] `uv run pytest -k audio` — 609 passed
- [x] `uv run ruff check` — clean
- 1 file, net +4 LOC (reordered, added comments)

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)