### PR TITLE
fix(#642): Yaesu USB audio + frontend architecture ADR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ ROADMAP_TESTING.md
 docs/STRATEGY.md
 docs/ROADMAP.md
 docs/RELEASE_READINESS.md
-docs/plans/
+# docs/plans/
 docs/sprints/
 docs/sessions/
 docs/reviews/

--- a/docs/plans/2026-03-04-dx-cluster.md
+++ b/docs/plans/2026-03-04-dx-cluster.md
@@ -1,0 +1,222 @@
+# DX Cluster Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Display real-time DX cluster spots as markers on the waterfall, with click-to-tune.
+
+**Architecture:** Asyncio telnet client connects to DX cluster server, parses spot lines into DXSpot dataclasses, broadcasts to web clients via existing WebSocket control channel. Frontend renders spot markers on waterfall canvas overlay and provides click-to-tune. Feature is opt-in via `--dx-cluster` CLI flag.
+
+**Tech Stack:** Python asyncio (stdlib telnet), existing WebSocket server, Canvas2D overlay
+
+---
+
+## Task 1: DXSpot dataclass + spot parser
+
+**File:** `src/icom_lan/web/dx_cluster.py` (NEW)
+
+1. Write test file `tests/test_dx_cluster.py`:
+   ```python
+   def test_parse_dxspider_spot():
+       line = "DX de K1ABC:     14074.0  JA1XYZ       FT8 +05dB from PM95   1234Z"
+       spot = parse_spot(line)
+       assert spot.spotter == "K1ABC"
+       assert spot.freq == 14074000  # Hz
+       assert spot.call == "JA1XYZ"
+       assert spot.comment == "FT8 +05dB from PM95"
+   ```
+   Add 10+ test cases: DXSpider, AR-Cluster, CC Cluster formats, edge cases (no comment, weird spacing, non-spot lines return None).
+
+2. Run tests — verify they fail (RED).
+
+3. Implement in `dx_cluster.py`:
+   ```python
+   @dataclass(frozen=True, slots=True)
+   class DXSpot:
+       spotter: str
+       freq: int          # Hz
+       call: str
+       comment: str = ""
+       time_utc: str = ""
+       timestamp: float = field(default_factory=time.monotonic)
+   
+   _SPOT_RE = re.compile(r"^DX de\s+(\S+):\s+(\d+\.?\d*)\s+(\S+)\s+(.*?)\s+(\d{4}Z)?\s*$")
+   
+   def parse_spot(line: str) -> DXSpot | None:
+       ...
+   ```
+
+4. Run tests — verify they pass (GREEN).
+
+5. Commit: `feat(dx): DXSpot dataclass + spot parser with 10+ test cases`
+
+---
+
+## Task 2: DXClusterClient — asyncio telnet
+
+**File:** `src/icom_lan/web/dx_cluster.py`
+
+1. Write tests in `tests/test_dx_cluster.py`:
+   - Test client connects and sends callsign login
+   - Test client calls `on_spot` callback for each parsed line
+   - Test client ignores non-spot lines
+   - Test client reconnects after disconnect (exponential backoff)
+   - Test client stop/cleanup
+   - Use asyncio mock streams (`asyncio.StreamReader/Writer`)
+
+2. Run tests — RED.
+
+3. Implement:
+   ```python
+   class DXClusterClient:
+       def __init__(self, host: str, port: int, callsign: str,
+                    on_spot: Callable[[DXSpot], None]):
+           ...
+       
+       async def start(self) -> None:
+           """Connect and read spots in a loop. Auto-reconnects."""
+           ...
+       
+       async def stop(self) -> None:
+           """Disconnect and cancel tasks."""
+           ...
+   ```
+   - `asyncio.open_connection(host, port)`
+   - Read lines, parse each with `parse_spot()`
+   - On disconnect: log, wait `min(2**attempt, 60)` seconds, retry
+   - Login: send `callsign\n` after connect
+
+4. Run tests — GREEN.
+
+5. Commit: `feat(dx): DXClusterClient with auto-reconnect`
+
+---
+
+## Task 3: Spot buffer + REST API
+
+**File:** `src/icom_lan/web/dx_cluster.py` + `src/icom_lan/web/server.py`
+
+1. Write tests:
+   - SpotBuffer: max 200 spots, oldest dropped on overflow
+   - SpotBuffer: `get_spots(band=None)` returns filtered list
+   - SpotBuffer: `to_json()` serialization
+   - REST endpoint: `GET /api/v1/dx/spots` returns current spots
+
+2. Run tests — RED.
+
+3. Implement:
+   ```python
+   class SpotBuffer:
+       def __init__(self, maxlen: int = 200):
+           self._spots: deque[DXSpot] = deque(maxlen=maxlen)
+       
+       def add(self, spot: DXSpot) -> None: ...
+       def get_spots(self, band: str | None = None) -> list[dict]: ...
+       def expire(self, max_age_s: float = 1800) -> None: ...
+   ```
+   
+   In `server.py`:
+   - Add `SpotBuffer` instance
+   - Add `GET /api/v1/dx/spots` route
+   - On spot callback: add to buffer + broadcast via control WS
+
+4. Run tests — GREEN.
+
+5. Commit: `feat(dx): SpotBuffer + REST endpoint`
+
+---
+
+## Task 4: WebSocket broadcast
+
+**File:** `src/icom_lan/web/server.py` + `src/icom_lan/web/handlers.py`
+
+1. Write tests:
+   - New spot → JSON message `{"type": "dx_spot", "spot": {...}}` sent to all control WS clients
+   - Client connect → receives current spot buffer as `{"type": "dx_spots", "spots": [...]}`
+
+2. Run tests — RED.
+
+3. Implement:
+   - `server._broadcast_dx_spot(spot)` — sends to all ControlHandler clients
+   - `ControlHandler._send_state_snapshot()` — include current spots if DX cluster active
+   - Message format: `{"type": "dx_spot", "spot": {"call": "JA1XYZ", "freq": 14074000, "spotter": "K1ABC", ...}}`
+
+4. Run tests — GREEN.
+
+5. Commit: `feat(dx): WebSocket spot broadcast`
+
+---
+
+## Task 5: CLI flags
+
+**File:** `src/icom_lan/cli.py`
+
+1. Write tests:
+   - `--dx-cluster` flag parsed correctly (host:port)
+   - `--callsign` flag parsed
+   - Without `--dx-cluster` → no DX client started
+   - Invalid format → clear error
+
+2. Run tests — RED.
+
+3. Implement:
+   - `web` command: add `--dx-cluster HOST:PORT` and `--callsign CALL`
+   - Pass to WebServer → start DXClusterClient if configured
+   - Graceful shutdown: stop DX client on server stop
+
+4. Run tests — GREEN.
+
+5. Commit: `feat(dx): CLI --dx-cluster and --callsign flags`
+
+---
+
+## Task 6: Frontend — spot overlay on waterfall
+
+**File:** `src/icom_lan/web/static/index.html`
+
+1. No automated tests (canvas rendering). Manual testing.
+
+2. Implement:
+   - Listen for `dx_spot` / `dx_spots` WS messages
+   - Store spots in `state.dxSpots[]`
+   - In `renderLoop()`: draw spot markers on spectrum canvas
+     - Only spots within current scope freq range
+     - Marker: small triangle `▼` + callsign text
+     - Color by age: bright cyan (fresh) → dim gray (>15 min) → remove (>30 min)
+   - Click handler on spectrum canvas: if click near spot marker → `sendCommand('set_freq', {freq: spot.freq})`
+   - DX toggle button in toolbar (shows/hides overlay + connects/disconnects)
+
+3. Commit: `feat(dx): frontend spot overlay + click-to-tune`
+
+---
+
+## Task 7: Integration test + docs
+
+1. Manual integration test:
+   - Start server with `--dx-cluster dxc.nc7j.com:7373 --callsign KN4KYD`
+   - Verify spots appear on waterfall
+   - Click spot → radio tunes to frequency
+   - Toggle DX off → spots disappear, telnet disconnects
+   - Toggle DX on → reconnects, spots reappear
+
+2. Update docs:
+   - `docs/guide/cli.md` — add `--dx-cluster` and `--callsign` flags
+   - `docs/guide/web-ui.md` — DX cluster section
+   - `README.md` — mention DX cluster feature
+
+3. Update issue #108 with implementation status
+
+4. Commit: `docs: DX cluster setup guide`
+
+5. Run full test suite: `uv run python -m pytest tests/ -q --tb=short`
+
+---
+
+## Agent Assignment (tmux)
+
+| Agent | Tasks | Window |
+|-------|-------|--------|
+| **claude:dx-backend** | Tasks 1-3 (parser, client, buffer) | `agents:backend` |
+| **claude:dx-frontend** | Task 6 (overlay, click-to-tune) | `agents:frontend` |
+| **sequential** | Tasks 4-5, 7 (integration, CLI, docs) | after backend done |
+
+Backend and frontend can run in parallel (no file conflicts).

--- a/docs/plans/2026-03-07-ui-architecture.md
+++ b/docs/plans/2026-03-07-ui-architecture.md
@@ -1,0 +1,674 @@
+# Web UI Architecture — Desktop + Mobile
+
+**Date:** 2026-03-07
+**Authors:** Сергей + Жора
+**Status:** Approved
+**Framework:** Svelte 5 + TypeScript
+**Replaces:** `2026-03-07-ui-architecture-research.md`, `2026-03-04-mobile-ui-design.md`
+
+---
+
+## 1. Core Principle
+
+**Server state is the single source of truth.**
+
+The backend exposes authoritative system state via:
+```
+GET /api/v1/state         → full radio state (124 fields)
+GET /api/v1/capabilities  → model, supported features, modes, filters
+```
+
+The frontend NEVER treats DOM state or local UI interactions as truth.
+
+```
+rendered UI = server_state + pending_actions + local_ui_state
+```
+
+---
+
+## 2. Existing Backend API (already implemented)
+
+### 2.1 `/api/v1/capabilities` — ✅ Already exists
+
+```json
+{
+  "model": "IC-7610",
+  "scope": true,
+  "audio": true,
+  "tx": true,
+  "capabilities": [
+    "af_level", "attenuator", "audio", "cw", "digisel",
+    "dual_rx", "ip_plus", "meters", "nb", "nr",
+    "preamp", "rf_gain", "scope", "squelch", "tx"
+  ],
+  "freq_ranges": [
+    {"start": 30000, "end": 60000000, "label": "HF"},
+    {"start": 50000000, "end": 54000000, "label": "6m"}
+  ],
+  "modes": ["USB", "LSB", "CW", "AM", "FM", "RTTY", "CWR"],
+  "filters": ["FIL1", "FIL2", "FIL3"]
+}
+```
+
+**Backend protocol layer** (`radio_protocol.py`) already defines:
+- `Radio.capabilities -> set[str]` — runtime capability tags
+- `AudioCapable`, `ScopeCapable`, `DualReceiverCapable` — Protocol classes
+- `_runtime_capabilities()` — conservative capability resolution
+- `RadioModel` dataclass with `receivers`, `has_lan`, `has_wifi`
+
+**What to add for multi-radio support:**
+```json
+{
+  "capabilities": {
+    "hasSpectrum": true,
+    "hasDualReceiver": true,
+    "hasTx": true,
+    "hasTuner": true,
+    "hasCw": true,
+    "maxReceivers": 2
+  }
+}
+```
+This is a frontend-friendly restructuring of existing backend data. No backend changes needed — the frontend can derive structured capabilities from the flat `capabilities[]` array.
+
+### 2.2 `/api/v1/state` — ✅ Already exists
+
+124 fields, including:
+- `main.*` / `sub.*` — per-receiver state (freq, mode, filter, meters, DSP)
+- `ptt`, `split`, `dual_watch`, `tuner_status`
+- `scope_controls` — spectrum configuration
+- `connected`, `radio_ready`, `control_connected`
+
+**What to add:**
+- `revision: number` — monotonic counter for stale packet detection
+- `updatedAt: string` — ISO timestamp
+
+### 2.3 WebSocket — ✅ Already exists
+
+Current model: WS for commands + binary scope data. State via HTTP poll (200ms).
+
+**Future optimization (Phase 3+):**
+- WS delta push: `{ revision: 42, patch: { "main.freq": 14074000 } }`
+- Gap detection: if `revision` gap > 1 → full re-fetch via GET
+- Reduces mobile bandwidth
+
+---
+
+## 3. State Architecture
+
+### 3.1 Server State (authoritative)
+
+```typescript
+interface ServerState {
+  revision: number;
+  updatedAt: string;
+
+  active: "MAIN" | "SUB";
+  ptt: boolean;
+  split: boolean;
+  dualWatch: boolean;
+  tunerStatus: number;
+
+  main: ReceiverState;
+  sub: ReceiverState;
+
+  connection: {
+    rigConnected: boolean;
+    radioReady: boolean;
+    controlConnected: boolean;
+  };
+}
+
+interface ReceiverState {
+  freqHz: number;
+  mode: string;
+  filter: number;
+  dataMode: boolean;
+  sMeter: number;
+  att: number;
+  preamp: number;
+  nb: boolean;
+  nr: boolean;
+  afLevel: number;
+  rfGain: number;
+  squelch: number;
+  // ... etc
+}
+```
+
+### 3.2 UI State (client-only)
+
+```typescript
+interface UiState {
+  layout: "desktop" | "mobile";
+  activePanel: "main" | "audio" | "memories" | "settings";
+  spectrumFullscreen: boolean;
+  freqEntryOpen: boolean;
+  theme: "dark" | "light";
+  gestures: {
+    tuning: boolean;
+    draggingSpectrum: boolean;
+  };
+}
+```
+
+UI state NEVER modifies server state directly.
+
+### 3.3 Pending Commands
+
+```typescript
+interface PendingCommand {
+  id: string;
+  type: "set_freq" | "set_mode" | "set_filter" | "ptt_on" | "ptt_off";
+  payload: unknown;
+  createdAt: number;
+  status: "pending" | "acked" | "failed";
+  timeoutMs: number;
+}
+```
+
+Commands are sent via WS, then reconciled with server state on next poll/push.
+
+---
+
+## 4. System Layers
+
+### 4.1 Transport Layer
+
+Networking, protocol, reconnection.
+
+```
+src/lib/transport/
+├── ws-client.ts        # WebSocket connection + reconnect
+├── http-client.ts      # REST API calls (state, capabilities)
+└── protocol.ts         # Message types, serialization
+```
+
+### 4.2 Domain / State Layer
+
+Pure data management. No DOM access.
+
+```
+src/lib/stores/
+├── radio.ts            # Server state store ($radioState)
+├── audio.ts            # Audio state + controls
+├── ui.ts               # UI-only state ($uiState)
+├── connection.ts       # Connection health
+├── capabilities.ts     # Radio capabilities (from /api/v1/capabilities)
+└── commands.ts         # Pending command queue
+```
+
+Svelte 5 runes (`$state`, `$derived`) for reactivity.
+
+### 4.3 Rendering Engines (framework-agnostic)
+
+Imperative Canvas rendering. Pure JS/TS, no Svelte dependencies.
+
+```
+src/lib/renderers/
+├── spectrum-renderer.ts    # Spectrum line chart
+├── waterfall-renderer.ts   # Waterfall bitmap
+└── meter-renderer.ts       # S-meter, SWR, power bars
+```
+
+These are portable — can migrate to any framework or vanilla JS.
+
+### 4.4 UI Components (Svelte)
+
+```
+src/components/
+├── layout/
+│   ├── AppShell.svelte         # Root layout switcher (desktop/mobile)
+│   ├── DesktopLayout.svelte    # Desktop grid
+│   └── MobileLayout.svelte     # Mobile stacked
+├── vfo/
+│   ├── VfoDisplay.svelte       # Frequency display + editing
+│   ├── VfoDigit.svelte         # Individual digit (click-to-edit)
+│   └── FreqEntry.svelte        # Direct frequency input modal
+├── spectrum/
+│   ├── SpectrumPanel.svelte    # Spectrum + waterfall container
+│   ├── SpectrumCanvas.svelte   # Canvas wrapper for spectrum
+│   ├── WaterfallCanvas.svelte  # Canvas wrapper for waterfall
+│   └── DxOverlay.svelte        # DX cluster spots overlay
+├── controls/
+│   ├── BandSelector.svelte     # Band dropdown
+│   ├── ModeSelector.svelte     # Mode dropdown
+│   ├── FilterSelector.svelte   # Filter dropdown
+│   ├── FeatureToggles.svelte   # NB, NR, ATT, PRE toggles
+│   └── ReceiverSwitch.svelte   # MAIN/SUB toggle
+├── meters/
+│   ├── SMeter.svelte           # S-meter bar
+│   ├── SwrMeter.svelte         # SWR bar
+│   └── PowerMeter.svelte       # TX power bar
+├── audio/
+│   ├── AudioControls.svelte    # Volume, mute, audio status
+│   └── PttButton.svelte        # Push-to-talk
+├── dx/
+│   └── DxClusterPanel.svelte   # DX spot list
+├── shared/
+│   ├── Toast.svelte            # Notification toasts
+│   ├── StatusBar.svelte        # Connection status
+│   └── BottomBar.svelte        # Mobile fixed bottom bar
+└── settings/
+    └── SettingsPanel.svelte    # Audio, display, connection settings
+```
+
+---
+
+## 5. CSS Architecture
+
+Design system with CSS custom properties:
+
+```css
+:root {
+  /* Colors */
+  --bg: #0b0f14;
+  --panel: #121922;
+  --panel-border: #1e293b;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --accent: #4db6ff;
+  --accent-hover: #6dc6ff;
+  --danger: #f85149;
+  --warning: #d29922;
+  --success: #3fb950;
+
+  /* Spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+
+  /* Typography */
+  --font-mono: 'JetBrains Mono', 'SF Mono', monospace;
+  --font-sans: system-ui, -apple-system, sans-serif;
+  --font-vfo: 'Segment7', var(--font-mono);
+
+  /* Layout */
+  --radius: 8px;
+  --radius-lg: 12px;
+  --tap-target: 44px;        /* minimum touch target */
+  --bottom-bar-height: 56px;
+
+  /* Breakpoints (reference, actual in @media) */
+  --mobile-max: 768px;
+  --tablet-max: 1024px;
+}
+```
+
+Component styles are scoped (Svelte `<style>`). Global tokens in `src/styles/`.
+
+---
+
+## 6. Desktop Layout
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  IC-7610 · 🟢 Connected · UTC 14:23                     │
+├───────────────────────────────────┬─────────────────────┤
+│                                   │  S ████████░░  S7   │
+│  VFO A    14.074.000  USB FIL1    │  SWR  1.0           │
+│  VFO B     3.573.000  USB FIL1    │  PWR  50W           │
+│                                   │                     │
+├───────────────────────────────────┤  [20m] [USB] [FIL1] │
+│  ┌─────────────────────────────┐  │  [NB] [NR] [ATT]   │
+│  │        SPECTRUM             │  │  [PRE] [COMP] [AGC] │
+│  │  ═══════════════════════    │  │                     │
+│  │                             │  ├─────────────────────┤
+│  │        WATERFALL            │  │  🔊 Vol ═══════     │
+│  │                             │  │  🎤 Mic ═══════     │
+│  │    · DX spots overlay ·     │  │  [PTT]              │
+│  └─────────────────────────────┘  │                     │
+├───────────────────────────────────┤  DX Cluster         │
+│  Band: 160 80 40 30 20 17 15 12  │  ├ W1AW   14.074    │
+│                            10  6 │  ├ JA1XX  14.076    │
+└───────────────────────────────────┴─────────────────────┘
+```
+
+Features:
+- Resizable panels (CSS grid with drag handles)
+- Keyboard shortcuts (F1-F12 bands, M mode, arrows tune)
+- Dual VFO display (MAIN + SUB)
+- Side panel: meters + controls + DX cluster
+
+---
+
+## 7. Mobile Layout (<768px, portrait)
+
+```
+┌─────────────────────────┐
+│ IC-7610 · 🟢 · 14:23 UTC│
+├─────────────────────────┤
+│ VFO A        14.074.000 │  swipe L/R = tune
+│ USB · FIL1    [MAIN|sub]│  tap digit = edit
+├─────────────────────────┤
+│ ┌─────────────────────┐ │
+│ │   SPECTRUM          │ │  ~30% screen
+│ │   ═══════════════   │ │  tap → fullscreen
+│ │   WATERFALL         │ │  tap-to-tune
+│ └─────────────────────┘ │
+├─────────────────────────┤
+│ S ████████░░░░  S7      │
+│ [BAND▾] [MODE▾] [FIL▾] │
+├─────────────────────────┤
+│ 🔊 Vol  │ [===PTT===]  │  fixed bottom bar
+│  on/off │  hold-to-TX  │  height: 56px
+└─────────────────────────┘
+```
+
+Touch interactions:
+- Swipe on VFO → tune (step configurable)
+- Tap on waterfall → tune to frequency
+- Pinch-zoom on waterfall → change span
+- Hold PTT → transmit (release = RX)
+- Pull-down → additional controls drawer
+
+---
+
+## 8. Critical UX Interactions
+
+### 8.1 VFO Control
+
+Primary interaction element.
+- Large segmented frequency display
+- Digit-based editing (tap digit → increment/decrement)
+- Swipe tuning (horizontal gesture)
+- Direct frequency entry (tap freq → numpad modal)
+- Step size selector (1Hz, 10Hz, 100Hz, 1kHz, etc.)
+
+### 8.2 Waterfall Interaction
+
+- **Tap-to-tune**: touch → set frequency
+- **Pinch-zoom**: change spectrum span
+- **Drag to pan**: shift center frequency
+- **DX spot overlay**: clickable callsign badges
+
+### 8.3 PTT Handling
+
+**Mobile:** Hold-to-talk with strong visual TX feedback (red border, pulsing indicator).
+
+**Desktop:** Toggle button + keyboard hotkey (Space or configurable).
+
+**PTT must NOT rely on optimistic UI.** Server confirmation determines TX state. Pending state shows "TX pending..." indicator.
+
+### 8.4 Band Switching
+
+Quick-access band buttons (desktop: horizontal bar, mobile: dropdown).
+- Show current band highlighted
+- Band stacking registers (remember freq/mode per band)
+- One-tap switching
+
+---
+
+## 9. Data Flow
+
+### Startup Sequence
+
+```
+1. Load shell (Svelte app)
+2. GET /api/v1/capabilities → populate feature flags
+3. GET /api/v1/state → initial render
+4. Connect WebSocket
+5. Subscribe: scope, dx_spots, notifications
+6. Start HTTP poll (200ms) for state updates
+```
+
+### Command Flow
+
+```
+User action → create PendingCommand → send via WS
+→ server processes → state changes
+→ next poll/push → reconcile with pending
+→ clear PendingCommand → re-render
+```
+
+### Stale Data Protection
+
+State responses include `revision` (monotonic counter).
+- If incoming `revision` ≤ current → discard
+- If `revision` gap > 1 → full re-fetch
+- `updatedAt` timestamp for debugging
+
+---
+
+## 10. Project Structure
+
+```
+frontend/
+├── src/
+│   ├── App.svelte
+│   ├── main.ts
+│   ├── app.css                 # Global styles + CSS tokens
+│   ├── lib/
+│   │   ├── transport/          # WS + HTTP clients
+│   │   ├── stores/             # Svelte state stores
+│   │   ├── renderers/          # Canvas engines (framework-agnostic)
+│   │   ├── types/              # TypeScript interfaces
+│   │   └── utils/              # Helpers (BCD, frequency formatting)
+│   └── components/             # Svelte UI components (see §4.4)
+├── static/
+│   ├── fonts/                  # Segment display font
+│   └── icons/                  # PWA icons
+├── package.json
+├── vite.config.ts
+├── svelte.config.js
+├── tsconfig.json
+└── README.md
+```
+
+Build output → `frontend/dist/` → served by Python backend or embedded in package.
+
+---
+
+## 11. Build & Integration
+
+### Development
+
+```bash
+cd frontend
+pnpm install
+pnpm dev          # Vite dev server with HMR, proxy to backend :8080
+```
+
+### Production
+
+```bash
+pnpm build        # → dist/ (single bundle.js + index.html)
+```
+
+Integration options:
+1. **Embedded**: Copy `dist/` into `src/icom_lan/web/static/` at build time
+2. **Separate**: Serve frontend separately, backend = pure API
+3. **Both**: Dev uses Vite proxy, production embeds
+
+Recommended: **Option 1** (embedded) — single `pip install icom-lan` includes everything.
+
+---
+
+## 12. Server-Side Improvements Needed
+
+| Change | Priority | Effort |
+|--------|----------|--------|
+| Add `revision` counter to state | P1 | S (1h) |
+| Add `updatedAt` to state | P1 | S (1h) |
+| Restructure capabilities for frontend | P2 | S (2h) |
+| WS delta push (instead of full poll) | P3 | M (1-2d) |
+| Connection health metrics | P3 | S (2h) |
+
+---
+
+## 13. Implementation Roadmap
+
+### Sprint 0: Foundation (2-3 days) 🏗️
+*Parallelizable: 2 agents*
+
+**Agent A: Frontend scaffold**
+- [ ] Init Svelte 5 + TypeScript + Vite project
+- [ ] CSS design system (tokens, base styles)
+- [ ] AppShell with desktop/mobile layout switcher
+- [ ] Empty component shells for all major components
+
+**Agent B: Backend prep**
+- [ ] Add `revision` counter to `/api/v1/state`
+- [ ] Add `updatedAt` timestamp
+- [ ] Create `GET /api/v1/info` (merged capabilities + connection health)
+- [ ] Tests for new endpoints
+
+### Sprint 1: Transport + State (2-3 days) 🔌
+*Parallelizable: 2 agents*
+
+**Agent A: Transport layer**
+- [ ] WebSocket client with auto-reconnect
+- [ ] HTTP client for state polling + capabilities fetch
+- [ ] Protocol types (message schemas)
+- [ ] Connection state management
+
+**Agent B: State stores**
+- [ ] `radioStore` — server state with revision tracking
+- [ ] `uiStore` — layout, panels, gestures
+- [ ] `commandStore` — pending commands queue
+- [ ] `capabilitiesStore` — feature flags from backend
+- [ ] Unit tests for stores
+
+### Sprint 2: Core Rendering (3-4 days) 📊
+*Parallelizable: 3 agents*
+
+**Agent A: Spectrum + Waterfall**
+- [ ] Port spectrum renderer to TypeScript
+- [ ] Port waterfall renderer to TypeScript
+- [ ] SpectrumCanvas.svelte + WaterfallCanvas.svelte wrappers
+- [ ] DX overlay layer
+- [ ] Responsive sizing
+
+**Agent B: VFO + Meters**
+- [ ] VfoDisplay component (segmented font, digit editing)
+- [ ] FreqEntry modal (direct input)
+- [ ] SMeter, SwrMeter, PowerMeter components
+- [ ] ReceiverSwitch (MAIN/SUB)
+
+**Agent C: Controls**
+- [ ] BandSelector, ModeSelector, FilterSelector
+- [ ] FeatureToggles (NB, NR, ATT, PRE, etc.)
+- [ ] Audio controls (volume, mute)
+- [ ] PttButton (desktop toggle)
+
+### Sprint 3: Desktop Layout (2-3 days) 🖥️
+*Sequential (integration)*
+
+- [ ] Assemble DesktopLayout with all components
+- [ ] Resizable panels (CSS grid + drag)
+- [ ] Keyboard shortcuts
+- [ ] DxClusterPanel integration
+- [ ] StatusBar + Toast notifications
+- [ ] Desktop testing + polish
+
+### Sprint 4: Mobile Layout (2-3 days) 📱
+*Parallelizable: 2 agents*
+
+**Agent A: Mobile layout + components**
+- [ ] MobileLayout with stacked design
+- [ ] BottomBar (audio + PTT)
+- [ ] Compact VFO display
+- [ ] Grouped dropdown controls
+- [ ] Fullscreen spectrum toggle
+
+**Agent B: Touch interactions**
+- [ ] Swipe-to-tune on VFO
+- [ ] Tap-to-tune on waterfall
+- [ ] Pinch-zoom span control
+- [ ] Hold-to-talk PTT
+- [ ] Pull-down controls drawer
+
+### Sprint 5: PWA + Polish (2-3 days) ✨
+*Parallelizable: 2 agents*
+
+**Agent A: PWA**
+- [ ] manifest.json + icons
+- [ ] Service Worker (offline shell)
+- [ ] Add-to-homescreen prompt
+- [ ] Offline state indicator
+
+**Agent B: UX Polish**
+- [ ] Dark/light theme toggle
+- [ ] Haptic feedback (navigator.vibrate)
+- [ ] Settings panel (preferences)
+- [ ] Loading states + error boundaries
+- [ ] Performance optimization (lazy loading, memoization)
+
+### Total: ~14-19 days
+
+---
+
+## 14. Conventions & Contracts
+
+### Naming
+
+| Layer | Convention | Example |
+|-------|-----------|---------|
+| Components | PascalCase | `VfoDisplay.svelte` |
+| Stores | camelCase + `Store` suffix | `radioStore.ts` |
+| Types/Interfaces | PascalCase, `I` prefix optional | `ServerState`, `ReceiverState` |
+| CSS variables | kebab-case, `--` prefix | `--panel-border` |
+| Events | kebab-case | `freq-change`, `ptt-toggle` |
+| API endpoints | kebab-case, `/api/v1/` prefix | `/api/v1/state` |
+
+### Component Contract
+
+Every component:
+1. Receives data via **props** (never fetches directly)
+2. Dispatches user actions via **events** (`createEventDispatcher`)
+3. Has **scoped CSS** (no global side effects)
+4. Is **self-contained** (renders correctly in isolation)
+5. Uses **TypeScript** for props interface
+
+```svelte
+<script lang="ts">
+  interface Props {
+    freq: number;
+    mode: string;
+    active: boolean;
+  }
+
+  let { freq, mode, active }: Props = $props();
+
+  function handleTune(newFreq: number) {
+    // dispatch to parent → command store → WS
+  }
+</script>
+```
+
+### State Contract
+
+1. **Server state** — read-only in components (via store subscription)
+2. **UI state** — read/write in components (via store)
+3. **Commands** — write-only in components (dispatch action → store handles WS)
+4. **Never** derive radio truth from UI interactions
+
+### WS Message Contract
+
+```typescript
+// Outgoing (client → server)
+interface WsCommand {
+  type: string;           // "set_freq", "set_mode", etc.
+  id: string;             // unique command ID
+  [key: string]: unknown; // command-specific payload
+}
+
+// Incoming (server → client)
+interface WsMessage {
+  type: "scope_data" | "dx_spot" | "notification" | "ack" | "error";
+  [key: string]: unknown;
+}
+```
+
+### Testing Contract
+
+- Stores: unit tests (vitest)
+- Renderers: unit tests (canvas mocking)
+- Components: component tests (svelte testing library)
+- E2E: Playwright (Phase 3+)
+
+---
+
+*This document is the single source of truth for frontend architecture decisions.*

--- a/docs/plans/2026-03-m5-m6-roadmap.md
+++ b/docs/plans/2026-03-m5-m6-roadmap.md
@@ -1,0 +1,417 @@
+# M5/M6 Roadmap — Multi-Radio Expansion & Productization
+
+**Status:** Draft for CEO review
+**Created:** 2026-03-22
+**Context:** Post-M4 (IC-7610 parity complete), planning next phases
+
+---
+
+## Executive Summary
+
+With M3 (IC-7610 USB backend) complete and M4 (IC-7610 command parity) at 100%, `icom-lan` has achieved **complete IC-7610 coverage** across LAN and serial backends. The library is production-ready for IC-7610 users.
+
+**Next strategic phases:**
+
+- **M5 (Multi-Radio Expansion)** — Extend proven architecture to popular Icom models (IC-705, IC-7300, IC-9700)
+- **M6 (Productization)** — Polish, performance, deployment patterns, documentation, community growth
+
+**Timeline estimate:** M5 (6-8 weeks) + M6 (4-6 weeks) = ~3 months total, assuming continuation of current development velocity.
+
+**Key dependencies:**
+- M5 requires M4 completion (cross-surface exposure of advanced features)
+- M6 benefits from M5 multi-radio test matrix but can run in parallel for non-radio-specific work
+
+---
+
+## Phase M5 — Multi-Radio Expansion
+
+### Goals
+
+1. **Extend backend architecture to 3 additional popular models:**
+   - IC-705 (portable HF/VHF/UHF transceiver) — most requested community model
+   - IC-7300 (HF base station) — entry-level HF, large user base
+   - IC-9700 (VHF/UHF/SHF all-mode) — satellite/VHF enthusiast favorite
+
+2. **Unify model-specific capabilities** via `RadioProfile` system (already scaffolded in M2)
+
+3. **Enable runtime auto-detection** for model selection (LAN: from conninfo; serial: from `get_id`)
+
+4. **Maintain backward compatibility** — existing IC-7610 API/CLI/Web code works unchanged
+
+### Success Criteria
+
+- ✅ All 4 models (IC-7610/IC-705/IC-7300/IC-9700) pass core integration suite (connect, CI-V, audio, scope)
+- ✅ CLI `--model` flag + auto-detection work for all models
+- ✅ Web UI detects model and adapts control visibility (no IC-7300 scope controls, etc.)
+- ✅ Profile system documents capabilities per model (docs/radios/)
+- ✅ PyPI package works across all 4 models with single `pip install icom-lan`
+
+### Task Breakdown
+
+#### M5.1 — IC-705 Backend (Portable HF/VHF/UHF)
+
+**Why IC-705 first?** Most-requested model in GitHub issues/discussions. Portable use case (field ops, POTA/SOTA) is distinct from IC-7610 base station.
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Research IC-705 CI-V command set vs IC-7610 | 2d | Use wfview parity, Icom CI-V docs |
+| Create `IC705Profile` with capabilities | 1d | Likely subset of IC-7610 (single receiver, no dual scope) |
+| Implement IC-705 LAN backend | 3d | Port differences, smaller conninfo, different model ID |
+| Implement IC-705 serial backend | 3d | USB CI-V + audio device handling (same pattern as 7610) |
+| Audio capability matrix (LAN Opus support?) | 1d | Verify IC-705 audio codec support |
+| Scope/waterfall support (single receiver) | 2d | IC-705 has spectrum scope, verify cmd 0x27 format |
+| Integration tests with real IC-705 | 3d | Requires hardware loan or community tester |
+| CLI/Web smoke tests | 1d | Verify auto-detect, control visibility |
+| **Total** | **16d (~3 weeks)** | |
+
+**Hardware dependency:** Need access to IC-705 (borrow, buy used ~$1000, or remote test with community member).
+
+#### M5.2 — IC-7300 Backend (Entry-Level HF)
+
+**Why IC-7300?** Largest user base for Icom HF (most affordable HF SDR transceiver). No second receiver, no dual scope.
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Research IC-7300 CI-V differences | 2d | Older firmware, some commands may differ |
+| Create `IC7300Profile` | 1d | Single receiver, standard HF modes |
+| Implement IC-7300 LAN backend | 3d | Verify LAN protocol compatibility (should be similar to IC-7610) |
+| Implement IC-7300 serial backend | 3d | USB CI-V + audio |
+| Scope support (single receiver, center-mode only?) | 2d | IC-7300 has spectrum scope but fewer modes than IC-7610 |
+| Audio capability matrix | 1d | Verify codec support |
+| Integration tests with real IC-7300 | 3d | Requires hardware access |
+| CLI/Web smoke tests | 1d | |
+| **Total** | **16d (~3 weeks)** | |
+
+**Hardware dependency:** Need access to IC-7300 (more common, ~$1100 new, ~$800 used).
+
+#### M5.3 — IC-9700 Backend (VHF/UHF/SHF All-Mode)
+
+**Why IC-9700?** Covers VHF/UHF/SHF (satellite ops, VHF contesting). Different band plan, different modes (includes D-STAR).
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Research IC-9700 CI-V differences | 2d | Satellite mode, D-STAR, different bands |
+| Create `IC9700Profile` | 1d | Dual receiver (like IC-7610), different band edges |
+| Implement IC-9700 LAN backend | 3d | Should be similar to IC-7610 protocol-wise |
+| Implement IC-9700 serial backend | 3d | USB CI-V + audio |
+| Scope support (dual receiver, satellite mode) | 3d | Verify scope behavior on VHF/UHF bands |
+| D-STAR mode handling (if applicable) | 2d | May need special mode enum, test with D-STAR enabled |
+| Integration tests with real IC-9700 | 3d | Requires hardware access or remote tester |
+| CLI/Web smoke tests | 1d | |
+| **Total** | **18d (~3.5 weeks)** | |
+
+**Hardware dependency:** Need access to IC-9700 (~$1500 new, ~$1200 used). Community member with satellite station?
+
+#### M5.4 — Unified Model Selection & Auto-Detection
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Enhance `RadioProfile` system | 2d | Document model-specific capabilities in profiles |
+| CLI `--model` flag + auto-detect logic | 2d | Fallback: auto-detect from radio ID, else use `--model` |
+| Web UI model detection + control hiding | 2d | Don't show dual scope controls for IC-7300/IC-705 |
+| Backend factory enhancements | 1d | Route to correct backend based on model |
+| Profile documentation in docs/radios/ | 2d | Per-model capability matrix |
+| **Total** | **9d (~2 weeks)** | |
+
+#### M5.5 — Multi-Model Testing & Regression
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Expand integration matrix for 4 models | 3d | Parametrize tests by model |
+| Multi-model CI strategy (mock vs real) | 2d | Real tests require hardware, mocks for CI |
+| Golden fixture expansion (per model) | 2d | Capture model-specific CI-V responses |
+| Regression gate for all models | 2d | Ensure IC-7610 coverage doesn't regress |
+| **Total** | **9d (~2 weeks)** | |
+
+### Total M5 Effort
+
+| Milestone | Effort |
+|-----------|--------|
+| M5.1 IC-705 | 16d (~3 weeks) |
+| M5.2 IC-7300 | 16d (~3 weeks) |
+| M5.3 IC-9700 | 18d (~3.5 weeks) |
+| M5.4 Unified Selection | 9d (~2 weeks) |
+| M5.5 Multi-Model Testing | 9d (~2 weeks) |
+| **Total** | **68d (~13.5 weeks or 3+ months)** |
+
+**Note:** Sequential hardware access would extend this. Parallel work (e.g., IC-705 integration while IC-7300 profile dev) could reduce calendar time.
+
+### Dependencies & Sequencing
+
+1. **M4 completion** — Finish cross-surface exposure (#138) before M5 starts
+2. **Hardware access** — Critical path bottleneck. Options:
+   - Buy used radios (~$3000 total for 3 radios)
+   - Borrow from community (ham radio clubs, online forums)
+   - Remote test access (TeamViewer / remote desktop with volunteer)
+3. **Profile system** — Already scaffolded in M2, needs expansion
+4. **Backward compat** — IC-7610 tests must remain green throughout M5
+
+### Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| **Hardware access delays** | High | High | Prioritize IC-705 (most requested), use community testers |
+| **Protocol differences** | Medium | Medium | IC-705/7300/9700 use same base protocol, differences should be minor |
+| **Audio codec variance** | Low | Medium | Some models may not support Opus; fallback to PCM |
+| **Scope format changes** | Medium | Low | cmd 0x27 format may vary; study wfview per-model parsing |
+| **D-STAR complexity (IC-9700)** | Low | Low | D-STAR is radio-internal, likely no library impact |
+| **Regression in IC-7610** | Low | High | Maintain strict regression gate; run full IC-7610 suite on every change |
+
+---
+
+## Phase M6 — Productization
+
+### Goals
+
+1. **Performance optimization** — Profile and optimize critical paths (latency, CPU, memory)
+2. **Production deployment patterns** — Document systemd, Docker, monitoring best practices
+3. **Web UI polish** — Mobile responsiveness, accessibility (a11y), PWA installability
+4. **Documentation expansion** — Tutorials, troubleshooting, API examples, video guides
+5. **Community engagement** — Discord/forum, contributor guide, roadmap transparency
+6. **PyPI optimization** — Reduce install time, optional dependencies, wheel size
+
+### Success Criteria
+
+- ✅ Latency benchmarks published (audio RTT, CI-V command latency, scope frame rate)
+- ✅ Docker image + docker-compose.yml for one-command deployment
+- ✅ systemd unit file for Linux server deployment
+- ✅ Web UI passes WCAG 2.1 AA accessibility audit
+- ✅ Web UI installable as PWA (offline-capable for cached assets)
+- ✅ Contributor guide (CONTRIBUTING.md) with dev setup, testing, PR workflow
+- ✅ Video tutorials (YouTube) for setup and common use cases
+- ✅ Discord server or GitHub Discussions active with community Q&A
+- ✅ PyPI install time <30s on common platforms
+
+### Task Breakdown
+
+#### M6.1 — Performance Profiling & Optimization
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Audio latency benchmark (LAN vs serial) | 2d | Measure RX/TX round-trip time, compare to wfview/RS-BA1 |
+| CI-V command latency profile | 1d | Measure get_frequency(), set_mode(), etc. |
+| Scope frame rate optimization | 2d | Reduce CPU usage for waterfall rendering |
+| Memory profiling (long-running sessions) | 2d | Check for leaks in audio/scope buffers |
+| CPU profiling (hot paths) | 2d | Identify bottlenecks in protocol/transport layers |
+| Optimize imports (lazy loading) | 1d | Reduce startup time |
+| Async task profiling (task count, backpressure) | 2d | Ensure no task leaks or runaway loops |
+| Document performance characteristics | 1d | Publish benchmarks in docs/performance.md |
+| **Total** | **13d (~2.5 weeks)** | |
+
+#### M6.2 — Production Deployment Patterns
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Docker image (slim Python + icom-lan) | 2d | Multi-stage build, <200MB image size |
+| docker-compose.yml (web + rigctld services) | 1d | One-command deployment |
+| systemd unit file + install script | 2d | Auto-restart, logging, user guide |
+| Monitoring / metrics (Prometheus exporter?) | 3d | Expose uptime, command counts, audio stats |
+| Logging best practices guide | 1d | Structured logging, log levels, rotation |
+| Production checklist (security, firewall, TLS) | 2d | Document network security for web UI |
+| Kubernetes manifest (optional) | 2d | For k8s users (lower priority) |
+| **Total** | **13d (~2.5 weeks)** | |
+
+#### M6.3 — Web UI Polish
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Mobile responsiveness audit (phone/tablet) | 2d | Test on iOS Safari, Android Chrome |
+| Accessibility audit (WCAG 2.1 AA) | 3d | Keyboard navigation, ARIA labels, screen reader testing |
+| PWA manifest + service worker | 2d | Installable, offline-capable for cached assets |
+| Touch gestures for waterfall (pinch-zoom, pan) | 3d | Improve mobile UX |
+| Dark/light theme polish | 1d | Already implemented, refine color palette |
+| Loading states & error boundaries | 2d | Better UX for network failures |
+| WebSocket reconnect UX | 1d | Auto-reconnect with toast notifications (already works, polish) |
+| **Total** | **14d (~3 weeks)** | |
+
+#### M6.4 — Documentation Expansion
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Quickstart video (5-min YouTube) | 2d | Setup, connect, basic operation |
+| Troubleshooting guide expansion | 2d | Common issues, debug logs, FAQ |
+| API examples (10+ code snippets) | 3d | Frequency scanning, memory recall, CW keyer, etc. |
+| CLI cookbook (common workflows) | 2d | rigctld setup, audio loopback, etc. |
+| Architecture deep-dive (internals docs) | 3d | For contributors, protocol details |
+| CONTRIBUTING.md | 1d | Dev setup, testing, PR workflow, code style |
+| Release process documentation | 1d | For maintainers (PyPI publish, changelogs) |
+| **Total** | **14d (~3 weeks)** | |
+
+#### M6.5 — Community Engagement
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Discord server setup | 1d | Channels: #general, #support, #dev, #announcements |
+| GitHub Discussions activation | 1d | Q&A, feature requests, show-and-tell |
+| Roadmap transparency (public M5/M6 issues) | 1d | GitHub project board with progress |
+| Community call for testers (IC-705/7300/9700) | 1d | Reddit, QRZ, eHam forums |
+| Contributor recognition (CONTRIBUTORS.md) | 1d | Credit community contributions |
+| Social media presence (Twitter/Mastodon) | Ongoing | Project announcements, milestone releases |
+| **Total** | **6d (~1 week)** | |
+
+#### M6.6 — PyPI Optimization
+
+| Task | Effort | Notes |
+|------|--------|-------|
+| Dependency audit (remove unused deps) | 1d | Minimize install size |
+| Optional dependencies (serial, audio, web) | 2d | `pip install icom-lan[serial,web]` for extras |
+| Wheel size optimization | 1d | Ensure no unnecessary files in wheel |
+| Install time benchmark (Linux/macOS/Windows) | 1d | Target <30s on common platforms |
+| Pre-built binary wheels for common platforms | 2d | manylinux, macOS arm64/x86_64, Windows |
+| **Total** | **7d (~1.5 weeks)** | |
+
+### Total M6 Effort
+
+| Milestone | Effort |
+|-----------|--------|
+| M6.1 Performance | 13d (~2.5 weeks) |
+| M6.2 Deployment | 13d (~2.5 weeks) |
+| M6.3 Web UI Polish | 14d (~3 weeks) |
+| M6.4 Documentation | 14d (~3 weeks) |
+| M6.5 Community | 6d (~1 week) |
+| M6.6 PyPI Optimization | 7d (~1.5 weeks) |
+| **Total** | **67d (~13.5 weeks or 3+ months)** |
+
+**Note:** M6 work can largely run in parallel with M5 (except M6.1 multi-model performance comparison needs M5 completion).
+
+### Dependencies & Sequencing
+
+1. **M4 completion** — Cross-surface exposure should be done before heavy docs/polish work
+2. **M5 optional** — Most M6 work (except multi-model performance) can start before M5
+3. **Community testers** — M6.5 benefits from M5 multi-model support (more testers with different radios)
+4. **Web UI stability** — M6.3 assumes current web UI is feature-complete (Phase 7.3 done)
+
+### Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| **Performance regressions** | Low | Medium | Maintain benchmark suite, run on every PR |
+| **Accessibility gaps** | Medium | Low | Hire a11y consultant or use community testers |
+| **Documentation drift** | High | Medium | Automate API doc generation (Sphinx), link examples to tests |
+| **Community silence** | Medium | Low | Seed Discord with initial content, be responsive |
+| **Docker image size bloat** | Low | Low | Multi-stage builds, alpine base, prune dependencies |
+| **PyPI install failures** | Medium | High | Test on fresh VMs for each platform before release |
+
+---
+
+## Sequencing Strategy
+
+### Option A: Sequential (M5 → M6)
+
+**Timeline:** 6-7 months total
+**Pros:** Clear focus, easier testing, less context switching
+**Cons:** Longer time to community features, delayed user feedback on multi-radio
+
+```
+┌──────────────┬──────────────┐
+│      M5      │      M6      │
+│  (3 months)  │  (3 months)  │
+└──────────────┴──────────────┘
+```
+
+### Option B: Parallel (M5 + M6 overlapped)
+
+**Timeline:** 4-5 months total
+**Pros:** Faster to market, community engagement starts sooner
+**Cons:** Higher context switching, potential resource conflicts
+
+```
+┌──────────────────────────────┐
+│             M5               │
+│         (3 months)           │
+└──────────────────────────────┘
+         ┌──────────────────────┐
+         │         M6           │
+         │     (3 months)       │
+         └──────────────────────┘
+```
+
+**Recommended:** Start M6.4 (docs), M6.5 (community), M6.6 (PyPI) early while M5.1-M5.3 run. Hold M6.1 (multi-model performance) until M5 completes.
+
+### Option C: Staggered (IC-705 first, then parallel)
+
+**Timeline:** 5-6 months total
+**Pros:** Early IC-705 release builds momentum, validates multi-model approach
+**Cons:** Slightly longer calendar time
+
+```
+┌─────────┬────────────────────┐
+│ M5.1    │ M5.2/M5.3 parallel │
+│ IC-705  │ (IC-7300 + IC-9700)│
+│(3 weeks)│   (6-8 weeks)      │
+└─────────┴────────────────────┘
+              ┌────────────────┐
+              │       M6       │
+              │  (3 months)    │
+              └────────────────┘
+```
+
+**Recommendation for CEO:** **Option C (Staggered)** — ship IC-705 support early to validate architecture and build community momentum, then parallelize IC-7300/IC-9700 with M6 work.
+
+---
+
+## Success Metrics
+
+### M5 Success Metrics
+- 4 models fully supported (IC-7610, IC-705, IC-7300, IC-9700)
+- 100% of IC-7610 integration tests pass for all 4 models (where hardware capabilities allow)
+- GitHub issues/requests for IC-705/7300/9700 support resolved
+- PyPI downloads increase (more radio models = larger user base)
+
+### M6 Success Metrics
+- Docker deployment guide followed by 10+ community members
+- Web UI accessibility score >90 (Lighthouse)
+- Discord server reaches 50+ members within 1 month of launch
+- 5+ external contributors (non-maintainer PRs merged)
+- PyPI install time <30s on all platforms
+- Performance benchmarks documented and published
+
+---
+
+## Resource Requirements
+
+### Hardware
+- IC-705 (~$1000 used) — **Priority 1**
+- IC-7300 (~$800 used) — **Priority 2**
+- IC-9700 (~$1200 used) — **Priority 3**
+- **Alternative:** Remote test access via community volunteers (TeamViewer, AnyDesk)
+
+### Development Time
+- M5: ~13.5 weeks full-time (or 6 months part-time)
+- M6: ~13.5 weeks full-time (or 6 months part-time)
+- **Staggered (Option C):** ~5-6 months calendar time with parallel work
+
+### Community Support
+- Beta testers for IC-705/7300/9700 (10+ volunteers)
+- Accessibility tester for WCAG audit (1-2 volunteers)
+- Documentation reviewers (3-5 technical writers / ham ops)
+
+---
+
+## Open Questions for CEO Review
+
+1. **Hardware procurement strategy?** Buy used radios vs rely on community remote access?
+2. **Sequencing preference?** Sequential (A), Parallel (B), or Staggered (C)?
+3. **Budget for M6 tools?** E.g., Docker registry ($5/mo), YouTube channel (free), accessibility tools ($0-500)
+4. **Community platform preference?** Discord (most ham radio activity) vs GitHub Discussions (lower friction)?
+5. **M5 model priority?** IC-705 first (most requested), IC-7300 (largest base), or IC-9700 (satellite niche)?
+6. **Release cadence during M5?** Incremental releases (v0.12 IC-705, v0.13 IC-7300) or bundled (v1.0 all 4 models)?
+
+---
+
+## Conclusion
+
+M5 and M6 represent the transition from **single-radio library** (IC-7610 focus) to **multi-radio platform** (community-driven, production-ready). The work is substantial but well-scoped:
+
+- **M5 expands market reach** (4x radio models → 4x potential users)
+- **M6 lowers adoption friction** (better docs, easier deployment, community support)
+
+With disciplined execution and community engagement, `icom-lan` can become the **de facto open-source library** for Icom transceiver control, competing with (and surpassing) wfview and RS-BA1 in usability, features, and ecosystem reach.
+
+**Recommended next step:** CEO approval → Create detailed GitHub issues for M5.1 (IC-705) → Begin community outreach for IC-705 hardware access → Kick off M6.4 (docs) and M6.5 (community) in parallel.
+
+---
+
+**Author:** CEO Agent
+**Review Status:** Awaiting CEO approval
+**Next Review:** After M4.138 completion

--- a/docs/plans/2026-04-05-desktop-companion-architecture.md
+++ b/docs/plans/2026-04-05-desktop-companion-architecture.md
@@ -1,0 +1,329 @@
+# Desktop Companion Architecture (dual-mode remote access)
+
+**Date:** 2026-04-05  
+**Status:** Accepted architectural direction  
+**Scope:** Remote access, desktop integration, RC-28, local audio bridge, WSJTX interoperability
+
+## Summary
+
+`icom-lan` will keep its current **remote-first web/server architecture** as the primary open-core experience.
+
+A separate **optional desktop companion** will be introduced for desktop-only integrations that do not fit a browser-first model:
+- RC-28 / local hardware controllers
+- local virtual audio devices
+- WSJTX / desktop digital-mode interoperability
+- desktop-specific UX and OS integration
+
+The desktop companion will be developed in a **separate closed-source repository** (currently referred to as `icom-lan-pro`, exact repo name to verify).
+
+This is a **dual-mode architecture**:
+
+1. **Direct remote web mode** — browser connects directly to the remote `icom-lan` server
+2. **Desktop companion mode** — local companion proxies the remote server to `localhost` and adds desktop integrations
+
+## Decision
+
+### Keep the remote web server
+
+The remote `icom-lan` web server remains a first-class product surface.
+
+It is required for:
+- mobile/phone access
+- tablet/browser-only access
+- zero-install remote operation
+- simple remote control from any browser
+
+The companion must **not** replace or deprecate direct remote web access.
+
+### Add an optional desktop companion
+
+The companion is a **desktop-only edge adapter / local gateway**, not a second radio server.
+
+It will:
+- connect to a remote `icom-lan` server over an encrypted channel
+- expose a local `localhost` entrypoint for browser-based desktop use
+- proxy web assets / API / websocket streams from the remote server
+- provide local integrations that are not practical from the browser
+
+### Keep the companion closed-source and in a separate repository
+
+The companion should live in a separate private/closed repository (`icom-lan-pro`, exact name to verify), not in the main `icom-lan` repository.
+
+## Why this decision makes sense
+
+### 1. Browser-only is insufficient for desktop radio workflows
+
+A browser-first approach is still correct for mobile and casual remote access, but it is the wrong foundation for:
+- RC-28 integration
+- local HID/USB controller support
+- local virtual audio devices
+- direct WSJTX/JTDX/Fldigi interoperability
+- desktop-grade system integration
+
+Even where WebHID/WebUSB/Web MIDI exist, they are inconsistent across browsers and operating systems and create fragile permission-dependent UX.
+
+### 2. Companion solves desktop problems without weakening mobile
+
+With a dual-mode design:
+- **phones** use the remote server directly
+- **desktops/laptops** can optionally use the companion
+
+That means mobile does not depend on a local service, and desktop gets the features a browser cannot provide well.
+
+### 3. Closed companion is a good boundary
+
+The companion is likely to contain high-friction platform-specific glue:
+- HID/RC-28 integration
+- audio-device management
+- installers / updater logic
+- platform-specific background service behavior
+- proxy/tunnel/session glue
+
+That code is support-heavy and product-specific. Keeping it separate and closed allows faster iteration without polluting the open-core repository.
+
+### 4. Open server + public API remains the source of truth
+
+The remote `icom-lan` server remains the authoritative system for:
+- radio state
+- protocol/backends
+- web UI contract
+- authentication/authorization behavior
+- capabilities and events
+
+The companion must be an adapter layer, not a second source of truth.
+
+## Non-goals
+
+The companion is **not** intended to:
+- duplicate radio state machine logic locally
+- become a forked second implementation of `icom-lan`
+- replace direct remote web access
+- support phones/mobile OSes as a local service
+- require hidden/private server behavior unavailable to normal clients
+
+## Architecture
+
+## Mode A — Direct Remote Web
+
+Used by:
+- phones
+- tablets
+- zero-install remote access
+- browser-only environments
+
+Flow:
+
+`Browser -> HTTPS/WSS -> remote icom-lan server -> radio`
+
+Benefits:
+- no local install
+- first-class mobile support
+- simplest access path
+
+Limitations:
+- no RC-28
+- no local audio devices
+- limited desktop interoperability
+
+## Mode B — Desktop Companion / Local Proxy
+
+Used by:
+- desktop/laptop users
+- RC-28 users
+- WSJTX/JTDX/Fldigi users
+- users who need local audio bridge devices or desktop-native integrations
+
+Flow:
+
+`Desktop browser / desktop apps -> localhost companion -> encrypted tunnel -> remote icom-lan server -> radio`
+
+The companion provides:
+- local HTTP proxy for the web UI
+- API/WebSocket proxying
+- local hardware-controller integration
+- local virtual audio-device integration
+- desktop-specific helper services
+
+## Boundary: what stays open vs closed
+
+### Open (`icom-lan` repo)
+
+- remote server
+- radio backends
+- web UI
+- public API contracts
+- event model
+- capability model
+- documented transport expectations
+- browser/mobile direct access
+
+### Closed companion repo (`icom-lan-pro`)
+
+- desktop proxy service
+- RC-28 / HID / local controller adapters
+- local audio-device integration and packaging
+- desktop-only UX
+- installer/update/distribution logic
+- power-user integrations for local desktop workflows
+
+## Hard architectural constraints
+
+### 1. Public APIs only
+
+The companion must consume **documented public APIs/contracts**.
+
+It must not depend on:
+- hidden endpoints
+- private companion-only wire behavior
+- undocumented server state assumptions
+- server hacks unavailable to first-class web clients
+
+### 2. One source of truth
+
+The remote server remains the authoritative source of state.
+
+The companion may cache or proxy, but it must not become a second state authority.
+
+### 3. Companion-only features must be clearly namespaced
+
+If the companion needs local-only APIs, they should be clearly separated from remote-server APIs.
+
+Recommended split:
+- `/api/v1/...` — server-compatible public API
+- `/api/local/v1/...` — companion-local desktop integrations
+
+This avoids ambiguity between direct mode and companion mode.
+
+### 4. Mobile remains first-class without companion
+
+Everything needed for mobile/browser remote operation must continue to work without any companion present.
+
+## Transport direction
+
+Initial assumption:
+- use encrypted HTTPS/WSS-based communication between companion and remote server
+- use reconnect-friendly token-based auth/session model
+
+Why:
+- works cleanly through NAT/reverse proxy setups
+- fits current browser/web transport model
+- avoids inventing a second premature transport stack
+
+Future alternatives (not MVP):
+- QUIC
+- gRPC streams
+- mTLS device identity
+
+## Audio direction
+
+For MVP, the companion should initially reuse the existing remote audio/control model where practical, then adapt it into local desktop-facing devices.
+
+That means:
+- receive remote audio stream
+- expose it locally to desktop workflows
+- send local TX audio back over the encrypted tunnel
+
+The platform-specific local audio-device strategy will likely differ per OS and should be abstracted inside the companion.
+
+## Multi-platform assumptions
+
+The companion is explicitly **desktop-only** and should target:
+- macOS
+- Windows
+- Linux
+
+Mobile platforms are not a target for the companion.
+
+### Implication
+
+- mobile = direct remote web
+- desktop = either direct remote web or optional companion mode
+
+## Risks and tradeoffs
+
+### Risk: two access modes diverge
+
+If direct remote web and companion mode see different behavior, the product becomes confusing.
+
+Mitigation:
+- maintain one public API contract
+- use companion as a proxy/adapter, not a forked API surface
+- isolate local-only desktop APIs under a clearly separate namespace
+
+### Risk: platform-specific audio complexity
+
+Audio-device plumbing varies heavily across macOS/Windows/Linux.
+
+Mitigation:
+- keep platform audio abstraction entirely inside the companion
+- do not let OS-specific audio assumptions leak into open-core server APIs
+
+### Risk: support burden
+
+Desktop glue code tends to generate operational complexity.
+
+Mitigation:
+- keep it in the separate companion repo
+- version and ship it independently
+- keep the open server repo focused on portable core logic
+
+## MVP roadmap
+
+### MVP 1 — Local proxy companion
+
+- authenticate to remote `icom-lan`
+- expose a localhost browser entrypoint
+- proxy remote web/API/websocket traffic
+- establish encrypted tunnel foundation
+
+### MVP 2 — RC-28 / local controller integration
+
+- detect RC-28 / supported local controllers
+- translate local device input into semantic tuning/PTT actions
+- send those actions to the remote server
+
+### MVP 3 — Local audio bridge / desktop interoperability
+
+- expose local RX/TX audio path for desktop software
+- support WSJTX-style local integration
+- keep remote server as audio source of truth
+
+### MVP 4 — Optional desktop polish
+
+- installer/autostart
+- tray/menu-bar integration
+- reconnect/status UX
+- optional local notifications
+
+## Practical implication for issue #315
+
+Issue #315 should not be treated as a browser-only `WebUSB/WebHID/MIDI` feature.
+
+The correct long-term framing is broader:
+- desktop companion / local controller integration for remote radios
+- local desktop interoperability layer
+
+That may justify either:
+- rewriting/reframing #315, or
+- creating a new companion epic and downgrading #315 to an optional experimental browser path
+
+## Accepted decisions
+
+1. Keep direct remote web access as a first-class product path
+2. Add an optional desktop companion for desktop-specific integrations
+3. Develop the companion in a separate closed-source repository (`icom-lan-pro`, exact repo name to verify)
+4. Keep the remote server and protocol surface open and documented
+5. Require companion/server interaction to use public APIs/contracts only
+6. Treat mobile as direct-remote only; companion is desktop-only
+
+## Next steps
+
+1. Verify the exact private repository name for the companion
+2. Open an architecture/epic issue for the companion layer
+3. Define companion/server public API boundary explicitly
+4. Decompose MVP into:
+   - local proxy/tunnel
+   - controller integration
+   - local audio bridge
+   - desktop packaging
+5. Save this decision in project memory / RAG for future planning and cross-session continuity

--- a/docs/plans/2026-04-11-frontend-migration-plan.md
+++ b/docs/plans/2026-04-11-frontend-migration-plan.md
@@ -1,0 +1,369 @@
+# Frontend Runtime Unification Migration Plan
+
+**Date:** 2026-04-11
+**Status:** Draft
+**Issue:** `#645`
+**Depends on:** `#641`, `#642`, `#643`, `#644`, `#646`
+**Base commit:** `f0e78cc0ea0fcfbafdadbb4a20167ba0bc110d6a`
+
+## Executive summary
+
+The frontend does not need a big-bang rewrite. It needs controlled completion of an architecture that already partially exists.
+
+Current state:
+
+- one app bootstrap
+- one shared store layer
+- one `state-adapter`
+- one `command-bus`
+- LCD already expressed as a layout branch inside `v2`
+
+Current problem:
+
+- runtime ownership still leaks into layout and leaf components
+- audio/scope/command behavior can still depend on mounted component path
+- parity is not enforced by tests or architecture guardrails
+
+Therefore the migration strategy should be:
+
+1. instrument and prove the current failure mode
+2. add anti-drift guardrails
+3. centralize runtime ownership
+4. formalize presentation boundaries
+5. migrate one layout at a time
+6. cut over only after parity checks exist
+
+## Confirmed findings
+
+From `#641`:
+
+- LCD is not a separate frontend in current `origin/main`; it is a layout branch within `v2`
+- runtime side effects still leak into UI components
+- duplicated protocol parsing and direct transport access still exist
+
+From `#642`:
+
+- audio transport success is not enough to prove playback success
+- plausible failure points include:
+  - suspended `AudioContext`
+  - missing usable `AudioDecoder`
+  - codec normalization mismatch, especially 8-bit PCM -> web PCM16
+- next step should be instrumentation, not speculative fixes
+
+From `#643`:
+
+- frontend needs one runtime shell and controller-owned side-effect layer
+- layouts and panels must become presentation-only
+
+From `#646`:
+
+- theme, skin, and layout variant must be separate concepts
+- presentation flexibility should come from tokens, semantic renderers, and composition
+- none of them may own runtime behavior
+
+From `#644`:
+
+- parity must be defined by behavior slices, not visual similarity
+- the critical regression scenario is `scope=false + audio=true`
+
+## Final target state
+
+The final frontend shape should be:
+
+- one shared runtime shell
+- controller-owned transport/audio/scope/system behavior
+- pure adapters
+- semantic components
+- skins/themes/layout variants above the semantic layer
+- parity coverage around capability scenarios and critical flows
+
+## What must happen first
+
+### First priority
+
+Make the system observable and anti-drift safe before moving behavior.
+
+That means:
+
+- diagnostic instrumentation for the current RX audio failure
+- architectural guardrails against new direct transport imports in presentation components
+
+### Second priority
+
+Move ownership of side effects, not visuals.
+
+The first migration work should extract:
+
+- audio ownership
+- scope ownership
+- system HTTP ownership
+
+### Third priority
+
+After runtime ownership is centralized, migrate layouts onto the new contract one by one.
+
+## What should not change early
+
+During early phases, do **not**:
+
+- redesign the UI
+- rewrite both layouts at once
+- mix skin/theme work into transport ownership changes
+- change backend protocol unless instrumentation proves it is necessary
+- move every component into a new directory structure up front
+
+Early phases should preserve user-visible behavior as much as possible.
+
+## Recommended phase sequence
+
+The placeholder implementation phases are directionally correct and should be kept, with one important clarification:
+
+- diagnostic instrumentation belongs at the very start of Phase 0
+
+## Phase 0 — Guardrails + diagnostics
+
+Issue anchor: `#647`
+
+Objectives:
+
+- add minimal diagnostic instrumentation for RX playback failures
+- add forbidden-import guardrails for presentation components
+- define temporary ownership exceptions explicitly
+
+Outputs:
+
+- logs that classify current LCD audio failure
+- lint/test guardrails preventing new `sendCommand`, `getChannel`, `audioManager`, and backend `fetch` imports in presentational UI
+
+Rollback risk:
+
+- very low
+
+### Why Phase 0 exists
+
+Without diagnostics, we may refactor around the wrong root cause.
+Without guardrails, model-generated changes can keep reintroducing the same leak.
+
+## Phase 1 — Shared runtime shell and adapter boundary
+
+Issue anchor: `#648`
+
+Objectives:
+
+- introduce a formal `FrontendRuntime` boundary
+- define controller/action interfaces
+- ensure layouts receive runtime-backed semantic props/callbacks rather than reaching into transports
+
+Outputs:
+
+- runtime shell scaffold
+- injected runtime/actions interface
+- presentation components no longer need direct runtime imports for newly migrated slices
+
+Rollback risk:
+
+- low if behavior slices are migrated incrementally
+
+## Phase 2 — Centralize audio and scope ownership
+
+Issue anchor: `#649`
+
+Objectives:
+
+- move `/api/v1/audio`, `/api/v1/scope`, `/api/v1/audio-scope` ownership into controllers
+- move binary frame parsing out of presentation components
+- unify RX/TX audio lifecycle ownership
+
+Outputs:
+
+- one audio controller
+- one scope controller per scope type
+- no direct `getChannel(...)` usage in scope-rendering surfaces
+- no direct `audioManager` usage in presentation components
+
+Rollback risk:
+
+- medium
+- mitigated by instrumentation and scenario-B parity checks
+
+## Phase 3 — Semantic presentation layer
+
+Issue anchor: `#650`
+
+Objectives:
+
+- formalize semantic component contracts
+- separate semantic components from primitives
+- create skin/theme-ready presentation boundaries
+
+Outputs:
+
+- semantic component APIs
+- initial skin registry pattern
+- layout slots/composition contract
+
+Rollback risk:
+
+- low to medium
+- mostly structural if runtime ownership is already centralized
+
+## Phase 4 — Migrate standard V2 onto unified architecture
+
+Issue anchor: `#651`
+
+Objectives:
+
+- move the standard desktop layout onto the new runtime/presentation contract
+
+Outputs:
+
+- standard layout consuming only semantic props/actions
+- no direct transport ownership in standard layout/panels
+
+Rollback risk:
+
+- medium
+- mitigated by keeping LCD untouched during this phase
+
+## Phase 5 — Migrate LCD onto unified architecture
+
+Issue anchor: `#652`
+
+Objectives:
+
+- move LCD layout and LCD renderers onto the same contract
+- remove remaining LCD-only runtime ownership
+
+Outputs:
+
+- LCD expressed as skin/layout over shared runtime
+- `scope=false + audio=true` explicitly validated
+
+Rollback risk:
+
+- medium to high
+- this is where the current bug class is most likely to surface
+
+## Phase 6 — Cutover and remove obsolete paths
+
+Issue anchor: `#653`
+
+Objectives:
+
+- make unified architecture the only production path
+- delete superseded transport ownership code and temporary compatibility layers
+
+Outputs:
+
+- one default runtime path
+- cleaned legacy code
+- cutover checklist completed
+
+Rollback risk:
+
+- medium
+- should only happen after parity matrix acceptance checks pass
+
+## Implementation backlog mapping
+
+The existing issue set is mostly correct:
+
+- `#647` keep, but explicitly include diagnostic instrumentation
+- `#648` keep
+- `#649` keep
+- `#650` keep
+- `#651` keep
+- `#652` keep
+- `#653` keep
+
+No renumbering or major backlog reshuffle is necessary at this stage.
+
+## Evidence gates between phases
+
+These should block progression.
+
+### Gate after Phase 0
+
+- current RX playback failure classified with evidence
+- forbidden-import guardrails active
+
+### Gate after Phase 2
+
+- one controller-owned audio path exists
+- one controller-owned scope path exists
+- no remaining presentation-owned WS connections for migrated slices
+
+### Gate after Phase 3
+
+- semantic component contracts are stable enough for both standard and LCD
+
+### Gate before Phase 6 cutover
+
+- parity checks for all four capability scenarios exist
+- Scenario B (`scope=false + audio=true`) explicitly passes
+- manual hardware validation completed on affected radio class
+
+## Relationship between runtime and presentation architecture
+
+The migration has two independent but coordinated goals:
+
+### Runtime goal
+
+Make behavior single-owned and layout-independent.
+
+### Presentation goal
+
+Make visuals extensible without behavior forks.
+
+The runtime work must happen first.
+Presentation flexibility only becomes safe after runtime ownership is fixed.
+
+## Main risks
+
+### Risk 1
+
+Fixing the current audio symptom by ad hoc patching the visible LCD path.
+
+Effect:
+
+- symptom may disappear temporarily
+- architecture drift gets worse
+
+### Risk 2
+
+Trying to introduce the full skin/theme system before centralizing runtime ownership.
+
+Effect:
+
+- visual flexibility increases while correctness decreases
+
+### Risk 3
+
+Judging parity by screenshots or layout similarity.
+
+Effect:
+
+- behavior regressions slip through
+
+## Immediate next step
+
+The next concrete execution step should be:
+
+- Phase 0 diagnostic instrumentation patch for RX playback
+
+Reason:
+
+- it directly resolves the highest-uncertainty finding from `#642`
+- it is low-risk
+- it informs whether later migration must include a codec fix, browser playback fix, or both
+
+## Provisional conclusion
+
+The existing implementation backlog is valid. It only needs to be interpreted as a disciplined migration story:
+
+- diagnose
+- guard
+- centralize ownership
+- formalize semantic presentation
+- migrate one layout at a time
+- cut over only after behavior parity is proven

--- a/docs/plans/2026-04-11-parity-matrix.md
+++ b/docs/plans/2026-04-11-parity-matrix.md
@@ -1,0 +1,340 @@
+# V2/LCD Parity Matrix And Regression Harness
+
+**Date:** 2026-04-11
+**Status:** Draft
+**Issue:** `#644`
+**Based on:** `#641`, `#642`, `#643`, `#646`
+**Base commit:** `f0e78cc0ea0fcfbafdadbb4a20167ba0bc110d6a`
+
+## Objective
+
+Define what "parity" means for standard `v2` and LCD, and which checks must exist before and during migration to the unified architecture.
+
+Parity here means:
+
+- same runtime behavior
+- same capability semantics
+- same command side effects
+- same audio/scope lifecycle behavior
+
+It does **not** mean identical DOM or identical visuals.
+
+## First-class capability scenarios
+
+These capability combinations must be treated as explicit scenarios.
+
+### Scenario A
+
+- hardware scope: yes
+- live audio: yes
+
+Expected presentations:
+
+- standard layout available
+- LCD layout available
+- audio and scope both functional
+
+### Scenario B
+
+- hardware scope: no
+- live audio: yes
+
+Expected presentations:
+
+- LCD is a valid first-class layout
+- live audio still works exactly as in Scenario A
+- lack of scope must not change audio behavior
+
+This is the most important regression scenario for the current problem.
+
+### Scenario C
+
+- hardware scope: yes
+- live audio: no
+
+Expected presentations:
+
+- scope still works
+- no `LIVE` monitor path is offered
+- local AF control still works if radio supports AF
+
+### Scenario D
+
+- hardware scope: no
+- live audio: no
+
+Expected presentations:
+
+- LCD remains valid
+- no live-audio path
+- no scope path
+- core tuning / mode / meter / tx behavior still works
+
+## High-risk flows
+
+These are the flows most likely to regress during runtime unification.
+
+### 1. App bootstrap
+
+Check:
+
+- state polling starts
+- capabilities load
+- control WS connects
+- runtime derives the correct semantic availability for scope/audio
+
+### 2. Layout selection
+
+Check:
+
+- `auto` chooses the expected layout from capabilities
+- forcing LCD/standard changes presentation only
+- switching layout does not change transport ownership
+
+### 3. RX monitor mode transitions
+
+Check:
+
+- `RADIO -> LIVE`
+- `LIVE -> MUTE`
+- `MUTE -> RADIO`
+- `MUTE -> LIVE`
+
+Expected:
+
+- same state transitions in standard and LCD
+- same audio controller behavior
+- same AF-level semantics
+
+### 4. AF level changes
+
+Check separately:
+
+- AF level change in `RADIO`
+- AF level change in `LIVE`
+
+Expected:
+
+- `RADIO` controls radio AF command path
+- `LIVE` controls browser playback volume path
+- LCD and standard must not disagree about which path is active
+
+### 5. Receiver switching
+
+Check:
+
+- MAIN/SUB active receiver change
+- monitor mode preserved correctly
+- commands address the intended receiver
+- displayed meter/frequency/mode are derived from the same active receiver semantics
+
+### 6. Reconnect / remount
+
+Check:
+
+- control WS reconnect
+- audio WS reconnect
+- layout remount while runtime remains alive
+- runtime rehydrates view models correctly
+
+Expected:
+
+- mounted component path does not decide which transport reconnects
+
+### 7. Scope unavailable while audio remains available
+
+Check:
+
+- capability or runtime state where scope is absent but audio is present
+
+Expected:
+
+- `LIVE` still functions
+- no hidden dependency on scope mount state
+
+### 8. PTT / TX interaction with audio
+
+Check:
+
+- entering TX
+- leaving TX
+- monitor/audio state around TX transitions
+
+Expected:
+
+- same TX audio lifecycle regardless of layout
+
+## Parity matrix
+
+## Scenario A: `scope=true`, `audio=true`
+
+| Flow | Standard V2 | LCD | Automation target |
+|---|---|---|---|
+| Bootstrap | Pass | Pass | unit + component |
+| `LIVE` playback path | Must work | Must work | unit + browser/manual |
+| Scope stream | Must work | Optional render variant, same runtime ownership | unit + browser/manual |
+| Layout switch | No transport restart due only to layout | Same | browser/manual |
+| Receiver switch | Same active receiver semantics | Same | unit + component |
+
+## Scenario B: `scope=false`, `audio=true`
+
+| Flow | Standard V2 | LCD | Automation target |
+|---|---|---|---|
+| Auto layout choice | LCD fallback or equivalent | Pass | unit |
+| `LIVE` playback path | Must work | Must work | unit + browser/manual |
+| Scope ownership | Absent | Absent | unit |
+| AF level semantics | Same | Same | unit |
+| Layout remount | Audio unaffected | Audio unaffected | browser/manual |
+
+## Scenario C: `scope=true`, `audio=false`
+
+| Flow | Standard V2 | LCD | Automation target |
+|---|---|---|---|
+| `LIVE` option visibility | Hidden | Hidden | component |
+| Scope path | Works | Same runtime semantics if rendered | unit + browser/manual |
+| AF local control | Works if radio AF exists | Works | unit |
+
+## Scenario D: `scope=false`, `audio=false`
+
+| Flow | Standard V2 | LCD | Automation target |
+|---|---|---|---|
+| Auto layout choice | LCD fallback or equivalent | Pass | unit |
+| `LIVE` option visibility | Hidden | Hidden | component |
+| Core radio control flows | Same | Same | unit + component |
+
+## Regression harness strategy
+
+### Layer 1: pure unit tests
+
+Target:
+
+- adapters
+- capability resolution
+- layout selection logic
+- monitor mode derivation
+- receiver selection semantics
+
+Good candidates:
+
+- `state-adapter`
+- layout mode resolution
+- semantic view-model builders
+
+### Layer 2: component tests
+
+Target:
+
+- semantic components
+- layout composition decisions
+- option visibility
+- callback wiring
+
+Good candidates:
+
+- `RxAudioControl`
+- `ScopeSurface`
+- `VfoDisplay`
+- layout wrappers
+
+### Layer 3: controller/runtime tests
+
+Target:
+
+- audio controller
+- scope controller
+- reconnect behavior
+- ownership invariants
+
+Needed especially for:
+
+- `LIVE` start/stop
+- ws reconnect
+- layout remount while runtime state persists
+
+This layer is currently weak and should be added during migration.
+
+### Layer 4: browser integration tests
+
+Target:
+
+- autoplay/user-gesture interactions
+- actual `AudioContext` state
+- layout switching in a browser environment
+- route through real runtime shell
+
+These should use Playwright with controlled mocks for backend endpoints where possible.
+
+### Layer 5: manual / hardware validation
+
+Still required for:
+
+- real radio codec negotiation
+- actual audio output audibility
+- hardware scope + audio coexistence
+- radio/backend-specific codec combinations
+
+## Current blind spots
+
+These are the important gaps in current automation.
+
+### Blind spot 1
+
+No meaningful tests for `audioManager` RX lifecycle.
+
+Current tests do not prove:
+
+- `/api/v1/audio` connect/start behavior
+- reconnect behavior
+- first-frame handling
+
+### Blind spot 2
+
+No meaningful tests for Opus decode availability.
+
+Current tests do not prove:
+
+- `AudioDecoder` presence/absence handling
+- decoder recreation after error
+
+### Blind spot 3
+
+No tests for mounted-layout independence.
+
+Current tests do not prove:
+
+- transport ownership is unchanged when switching between standard and LCD
+
+### Blind spot 4
+
+No backend tests around codec normalization edge cases.
+
+Current tests do not prove:
+
+- `PCM_1CH_8BIT` path
+- u-law decode path end-to-end to browser framing
+
+### Blind spot 5
+
+No automation for browser autoplay/suspended-context failures.
+
+This is exactly the kind of issue that can make "frames arrived" look healthy while playback is dead.
+
+## Acceptance checks before cutover
+
+Before the unified architecture becomes default, the migration should satisfy:
+
+1. Scenario B (`scope=false`, `audio=true`) has explicit automated coverage
+2. Layout switching does not restart or re-own transports
+3. `LIVE` mode has one tested controller path
+4. Receiver switching semantics are identical across layouts
+5. At least one manual hardware validation run confirms audio playback on the previously failing class of radio
+
+## Provisional conclusion
+
+The migration should be judged against parity of behavior slices, not against visual similarity.
+
+The most critical regression target is:
+
+- `scope=false + audio=true`
+
+because that is the scenario most likely to reveal whether the architecture is truly unified or only visually similar.

--- a/docs/plans/2026-04-11-presentation-architecture.md
+++ b/docs/plans/2026-04-11-presentation-architecture.md
@@ -1,0 +1,397 @@
+# Presentation Architecture For Skins, Themes, And Layout Variants
+
+**Date:** 2026-04-11
+**Status:** Draft for discussion
+**Issue:** `#646`
+**Depends on:** `#643`
+**Base commit:** `f0e78cc0ea0fcfbafdadbb4a20167ba0bc110d6a`
+
+## Objective
+
+Define the ideal presentation architecture above the shared runtime so the app can support:
+
+- standard `v2`
+- LCD
+- future skins
+- small theme changes
+- larger component-level visual swaps
+
+without reintroducing logic drift.
+
+## Core definitions
+
+### Runtime
+
+The stateful side-effect layer:
+
+- backend transport
+- audio/scope lifecycle
+- commands
+- capability normalization
+- optimistic updates
+
+Runtime must be presentation-agnostic.
+
+### View-model adapter
+
+A pure mapping layer:
+
+- runtime state -> semantic UI props
+- runtime actions -> semantic callbacks
+
+Adapters know what the UI means, but not how it looks.
+
+### Semantic component
+
+A component representing a radio concept with stable behavior contract.
+
+Examples:
+
+- `VfoDisplay`
+- `RxAudioControl`
+- `ScopeSurface`
+- `MeterPanel`
+- `TxControl`
+
+Semantic components receive semantic props and callbacks only.
+
+### Primitive component
+
+A low-level visual building block with no radio semantics.
+
+Examples:
+
+- button
+- segmented control
+- gauge
+- card
+- label/value row
+- LED indicator
+
+### Theme
+
+A token set for colors, typography, spacing, shadows, borders, motion.
+
+Theme changes appearance without changing component identity or layout structure.
+
+### Skin
+
+A mapping from semantic components to concrete visual implementations.
+
+Examples:
+
+- `industrial-v2`
+- `amber-lcd`
+- future `rack`, `retro`, `minimal`, `touch`
+
+A skin may swap component internals, but must preserve semantic component contracts.
+
+### Layout variant
+
+A screen composition over semantic components.
+
+Examples:
+
+- desktop standard
+- desktop LCD
+- mobile
+- compact monitor
+
+Layout variants choose placement and grouping, not runtime behavior.
+
+## Recommended layering
+
+Dependency direction should be one-way:
+
+`runtime -> adapters -> semantic components -> skin implementations -> primitives -> theme tokens`
+
+And separately:
+
+`layout variant -> semantic components`
+
+Important:
+
+- runtime must not import skins/themes/layouts
+- themes must not know about runtime
+- skin implementations must not talk to runtime directly
+- layout variants must compose semantic components, not transports
+
+## The three presentation knobs
+
+These should be first-class and separate.
+
+### 1. Theme = token switch
+
+Use theme when only visual language changes:
+
+- colors
+- font families
+- spacing scale
+- border radius
+- shadows
+- animation style
+
+Theme should be mostly CSS variables and token objects.
+
+### 2. Skin = semantic renderer switch
+
+Use skin when the same radio concept needs a different visual implementation:
+
+- classic seven-segment frequency vs industrial frequency strip
+- analog S-meter vs LCD bar meter
+- hardware-style buttons vs flat touch controls
+
+Skin swaps renderers, not behavior contracts.
+
+### 3. Layout variant = composition switch
+
+Use layout variants when the same semantic components need different arrangement:
+
+- sidebars vs stacked mobile panels
+- LCD center panel vs wide spectrum center panel
+- docked meters vs embedded meters
+
+Layout variants decide:
+
+- which semantic components appear
+- where they appear
+- in which slot/group they appear
+
+They must not decide:
+
+- how to connect to backend transports
+- how to decode audio
+- how to dispatch commands
+
+## Semantic component contract
+
+Each semantic component should expose:
+
+- semantic props only
+- semantic callbacks only
+- no transport knowledge
+- no backend endpoint knowledge
+- no concrete skin assumptions
+
+Example:
+
+`RxAudioControl` should receive:
+
+- `monitorMode`
+- `hasLiveAudio`
+- `level`
+- `onMonitorModeChange`
+- `onLevelChange`
+
+It should not know:
+
+- `audioManager`
+- `/api/v1/audio`
+- codec names
+- `sendCommand(...)`
+
+## Skin architecture
+
+Each skin should provide a component registry for semantic components.
+
+Example shape:
+
+- `skins/industrial-v2/registry.ts`
+- `skins/amber-lcd/registry.ts`
+
+Each registry maps semantic component ids to concrete implementations.
+
+Example:
+
+- `VfoDisplay -> IndustrialVfoDisplay`
+- `MeterPanel -> NeedleMeterPanel`
+- `RxAudioControl -> HardwareRxAudioPanel`
+
+Another skin might map:
+
+- `VfoDisplay -> AmberFrequencyDisplay`
+- `MeterPanel -> AmberMeterStrip`
+- `RxAudioControl -> LcdAudioStrip`
+
+The semantic API stays the same.
+
+## Primitive architecture
+
+Primitives should be reusable visual building blocks, not "business logic widgets".
+
+Good primitives:
+
+- `ControlButton`
+- `SegmentedControl`
+- `Gauge`
+- `Knob`
+- `PanelFrame`
+- `StatusPill`
+
+Bad primitives:
+
+- `WsAwareButton`
+- `ScopeConnectedIndicator` that reads transport state itself
+- `PttButton` that imports `audioManager`
+
+## Slots and composition
+
+Layouts should compose semantic components via named slots/zones.
+
+Recommended slot model:
+
+- `header`
+- `leftRail`
+- `centerPrimary`
+- `centerSecondary`
+- `rightRail`
+- `bottomDock`
+- `overlay`
+
+Each layout variant assigns semantic components into these slots.
+
+This keeps composition flexible without inventing new runtime paths.
+
+## How standard V2 and LCD should differ in the target system
+
+### Standard desktop
+
+- skin: `industrial-v2`
+- theme: one of the current token themes
+- layout: `desktop-standard`
+
+Composition:
+
+- `centerPrimary` -> `HardwareScopeSurface`
+- `header` -> `VfoHeader`
+- `leftRail` -> semantic control groups
+- `rightRail` -> semantic audio/DSP/TX groups
+- `bottomDock` -> compact summaries/meters
+
+### LCD desktop
+
+- skin: `amber-lcd`
+- theme: LCD token theme
+- layout: `desktop-lcd`
+
+Composition:
+
+- `centerPrimary` -> `LcdReceiverDisplay`
+- `centerSecondary` -> optional semantic scope surface if available
+- same semantic sidebars or LCD-specific semantic groups
+
+Important:
+
+Both layouts still consume the same:
+
+- `RxAudioControl` behavior contract
+- `ScopeSurface` runtime data
+- `TxControl` callbacks
+- capability-derived view models
+
+## Extension points that should be first-class
+
+These are worth designing for explicitly.
+
+### First-class
+
+- theme tokens
+- skin registry
+- layout slot composition
+- semantic component variants
+- renderer swapping for meters/frequency/status blocks
+
+### Deliberately not first-class
+
+- per-skin transport ownership
+- per-layout command dispatch
+- per-component capability policy
+- per-skin codec or audio lifecycle decisions
+
+If an extension point can fork behavior, it belongs below the presentation layer or should be forbidden.
+
+## Suggested directory model
+
+One reasonable end state:
+
+- `frontend/src/runtime/`
+- `frontend/src/adapters/`
+- `frontend/src/semantic/`
+- `frontend/src/skins/<skin-id>/`
+- `frontend/src/primitives/`
+- `frontend/src/themes/`
+- `frontend/src/layouts/`
+
+Meaning:
+
+- `runtime/` side effects and controllers
+- `adapters/` pure mappers
+- `semantic/` stable radio concepts
+- `skins/` concrete renderers
+- `primitives/` reusable low-level visuals
+- `themes/` tokens
+- `layouts/` screen composition
+
+## Anti-patterns to avoid
+
+### Anti-pattern 1
+
+Skin components importing runtime modules directly.
+
+That turns skins into hidden behavior forks.
+
+### Anti-pattern 2
+
+Theme objects containing behavior flags.
+
+Theme is for tokens, not feature semantics.
+
+### Anti-pattern 3
+
+Layout deciding transport ownership based on whether a panel is mounted.
+
+This is the current source of drift around scope/audio ownership.
+
+### Anti-pattern 4
+
+"Flexible" components that accept both semantic props and backend-specific escape hatches.
+
+That destroys the semantic boundary over time.
+
+### Anti-pattern 5
+
+Treating LCD as a special-case app instead of a skin/layout expression over shared runtime.
+
+## Design principles
+
+### Principle 1
+
+Optimize for correctness before flexibility.
+
+The architecture should make the wrong thing hard.
+
+### Principle 2
+
+Different visuals should reuse the same semantics.
+
+If two skins need different behavior contracts, the semantic component boundary is wrong.
+
+### Principle 3
+
+Presentation extensibility should come from composition, not from conditional logic spread across components.
+
+### Principle 4
+
+Model-assisted development needs hard boundaries.
+
+If a future model can solve a UI request by importing `sendCommand(...)` into a panel, the architecture is not strict enough.
+
+## Provisional conclusion
+
+The ideal frontend is not "one mega theme system". It is a layered system with three independent presentation controls:
+
+- theme changes tokens
+- skin changes semantic renderers
+- layout variant changes composition
+
+All three sit on top of one shared runtime and one semantic contract. That is the only shape that gives both visual freedom and behavioral stability.

--- a/docs/plans/2026-04-11-presentation-architecture.md
+++ b/docs/plans/2026-04-11-presentation-architecture.md
@@ -386,6 +386,312 @@ Model-assisted development needs hard boundaries.
 
 If a future model can solve a UI request by importing `sendCommand(...)` into a panel, the architecture is not strict enough.
 
+## Concrete TypeScript interfaces
+
+### FrontendRuntime
+
+```typescript
+interface FrontendRuntime {
+  // Reactive state (Svelte 5 $state under the hood)
+  readonly state: RadioState;
+  readonly capabilities: Capabilities;
+  readonly connection: ConnectionStatus;
+
+  // Controller facades
+  readonly audio: AudioController;
+  readonly scope: ScopeController;
+  readonly system: SystemController;
+
+  // Command dispatch (single entry point)
+  cmd(command: string, params?: Record<string, unknown>): void;
+}
+
+interface AudioController {
+  readonly rxEnabled: boolean;
+  readonly txEnabled: boolean;
+  readonly monitorMode: 'live' | 'radio' | 'mute';
+  readonly volume: number;          // 0..1, browser playback volume
+  readonly wsConnected: boolean;
+  readonly txSupported: boolean;
+
+  setMonitorMode(mode: 'live' | 'radio' | 'mute'): void;
+  setVolume(v: number): void;
+  startTx(): Promise<string | null>;
+  stopTx(): void;
+}
+
+interface ScopeController {
+  readonly hardwareScopeAvailable: boolean;
+  readonly audioScopeAvailable: boolean;
+  readonly activeScope: 'hardware' | 'audio-fft' | null;
+
+  // Parsed scope data, ready for rendering
+  readonly scopeFrame: ScopeFrame | null;
+  readonly audioScopeFrame: AudioScopeFrame | null;
+}
+
+interface SystemController {
+  powerOn(): Promise<void>;
+  powerOff(): Promise<void>;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  identifyFrequency(freqHz: number): Promise<EibiResult | null>;
+}
+```
+
+### View-model adapter contract
+
+```typescript
+// Adapters are pure functions — no side effects, no subscriptions.
+// They receive runtime state and return typed view-model objects.
+
+type Adapter<T> = (
+  state: RadioState,
+  caps: Capabilities,
+  audio: AudioController,
+  receiver?: 'main' | 'sub',
+) => T;
+
+// Example: VFO adapter
+interface VfoViewModel {
+  freqHz: number;
+  mode: string;
+  filter: number;
+  dataMode: boolean;
+  isActive: boolean;
+  badges: Badge[];
+  onFreqChange: (hz: number) => void;
+  onModeChange: (mode: string) => void;
+  onFilterChange: (filter: number) => void;
+}
+
+const toVfoProps: Adapter<VfoViewModel> = (state, caps, audio, receiver) => {
+  // pure derivation — no imports from transport, audio, or WS
+};
+
+// Example: RX audio adapter
+interface RxAudioViewModel {
+  monitorMode: 'live' | 'radio' | 'mute';
+  hasLiveAudio: boolean;
+  volume: number;
+  muted: boolean;
+  onMonitorModeChange: (mode: string) => void;
+  onVolumeChange: (v: number) => void;
+}
+```
+
+### Semantic component contract (Svelte 5)
+
+```svelte
+<!-- semantic/RxAudioControl.svelte -->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    monitorMode: 'live' | 'radio' | 'mute';
+    hasLiveAudio: boolean;
+    volume: number;
+    muted: boolean;
+    onMonitorModeChange: (mode: string) => void;
+    onVolumeChange: (v: number) => void;
+    // Skin provides rendering via snippet
+    children: Snippet;
+  }
+
+  let {
+    monitorMode, hasLiveAudio, volume, muted,
+    onMonitorModeChange, onVolumeChange, children,
+  }: Props = $props();
+</script>
+
+<!-- Semantic component provides behavioral context;
+     skin snippet provides visual rendering -->
+{@render children()}
+```
+
+## Svelte 5 skin mechanism
+
+### Why not a component registry
+
+Traditional component registries (map of string → component class) require dynamic component instantiation, which in Svelte 5 means `{@component}` or `svelte:component`. This adds complexity and loses static type checking.
+
+### Recommended: skin as a layout-level composition
+
+Each skin is a concrete Svelte component that:
+
+1. Imports the semantic components it needs
+2. Imports its own visual primitives
+3. Composes them into a layout using typed props
+
+```svelte
+<!-- skins/amber-lcd/LcdSkin.svelte -->
+<script lang="ts">
+  import type { FrontendRuntime } from '../../runtime/types';
+  import { toVfoProps, toRxAudioProps, toMeterProps } from '../../adapters';
+
+  // Skin-specific visual components
+  import AmberFrequency from './AmberFrequency.svelte';
+  import AmberMeter from './AmberMeter.svelte';
+  import AmberAudioStrip from './AmberAudioStrip.svelte';
+  import LcdFrame from './LcdFrame.svelte';
+
+  interface Props {
+    runtime: FrontendRuntime;
+  }
+  let { runtime }: Props = $props();
+
+  // Derive view-models from runtime (reactive via $derived)
+  const vfo = $derived(toVfoProps(runtime.state, runtime.capabilities, runtime.audio, 'main'));
+  const audio = $derived(toRxAudioProps(runtime.state, runtime.capabilities, runtime.audio));
+  const meter = $derived(toMeterProps(runtime.state, runtime.capabilities));
+</script>
+
+<LcdFrame>
+  <AmberFrequency freq={vfo.freqHz} mode={vfo.mode} />
+  <AmberMeter sMeter={meter.sMeter} />
+  <AmberAudioStrip
+    mode={audio.monitorMode}
+    volume={audio.volume}
+    onModeChange={audio.onMonitorModeChange}
+    onVolumeChange={audio.onVolumeChange}
+  />
+</LcdFrame>
+```
+
+### Skin resolution
+
+```typescript
+// skins/registry.ts
+import type { Component } from 'svelte';
+import type { FrontendRuntime } from '../runtime/types';
+
+export type SkinId = 'desktop-v2' | 'amber-lcd' | 'mobile';
+
+interface SkinResolution {
+  capabilities: Capabilities;
+  userPreference: 'auto' | 'lcd' | 'standard';
+  isMobile: boolean;
+}
+
+export function resolveSkinId(ctx: SkinResolution): SkinId {
+  if (ctx.isMobile) return 'mobile';
+  if (ctx.userPreference === 'lcd') return 'amber-lcd';
+  if (ctx.userPreference === 'standard') return 'desktop-v2';
+  // auto: use LCD when no hardware scope
+  return ctx.capabilities.scope ? 'desktop-v2' : 'amber-lcd';
+}
+
+// Lazy-load skin components to keep bundle size manageable
+const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component<{ runtime: FrontendRuntime }> }>> = {
+  'desktop-v2': () => import('./desktop-v2/DesktopSkin.svelte'),
+  'amber-lcd':  () => import('./amber-lcd/LcdSkin.svelte'),
+  'mobile':     () => import('./mobile/MobileSkin.svelte'),
+};
+
+export async function loadSkin(id: SkinId) {
+  return (await SKIN_LOADERS[id]()).default;
+}
+```
+
+### App entry point with skin resolution
+
+```svelte
+<!-- App.svelte (target state) -->
+<script lang="ts">
+  import { runtime } from './runtime';
+  import { resolveSkinId, loadSkin } from './skins/registry';
+
+  const skinId = $derived(resolveSkinId({
+    capabilities: runtime.capabilities,
+    userPreference: runtime.layoutPreference,
+    isMobile: runtime.isMobile,
+  }));
+
+  // Reactive skin loading — changes when skinId changes
+  let SkinComponent = $state<Component | null>(null);
+  $effect(() => {
+    loadSkin(skinId).then(c => { SkinComponent = c; });
+  });
+</script>
+
+{#if SkinComponent}
+  <SkinComponent {runtime} />
+{:else}
+  <div class="loading">Loading...</div>
+{/if}
+```
+
+## Layout slot model (concrete)
+
+Each skin's top-level layout should use named slots for composition:
+
+```typescript
+interface LayoutSlots {
+  header:           Component | null;  // VFO, status, connection
+  leftRail:         Component | null;  // control groups (mode, band, filter)
+  centerPrimary:    Component | null;  // scope surface or LCD display
+  centerSecondary:  Component | null;  // secondary scope or audio FFT
+  rightRail:        Component | null;  // audio, DSP, TX controls
+  bottomDock:       Component | null;  // meters, compact summaries
+  overlay:          Component | null;  // modals, freq entry, settings
+}
+```
+
+Skins are not obligated to fill all slots. LCD fills `centerPrimary` with `AmberLcdDisplay` and may leave `centerSecondary` empty. Desktop fills both with scope + waterfall. Mobile may collapse rails into tabbed panels.
+
+## Coexistence during migration
+
+During Phases 4-5, old and new code must coexist:
+
+### Strategy: parallel skin alongside existing layout
+
+1. New skin components live in `skins/` — no changes to existing `components-v2/`
+2. A feature flag (`?skin=unified`) enables the new path in `App.svelte`
+3. Old layout components remain the default until parity gate passes
+4. Once parity is confirmed, the flag defaults to `unified` and old layouts are deprecated
+5. Phase 6 removes old layout components
+
+### Import boundary enforcement
+
+```jsonc
+// .eslintrc (or eslint.config.js) — enforced from Phase 0
+{
+  "rules": {
+    "no-restricted-imports": ["error", {
+      "patterns": [
+        {
+          "group": ["$lib/transport/*", "$lib/audio/audio-manager"],
+          "importNames": ["sendCommand", "getChannel", "audioManager"],
+          "message": "Presentation components must not import runtime modules. Use adapter props instead."
+        }
+      ]
+    }]
+  },
+  "overrides": [
+    {
+      "files": ["src/runtime/**", "src/adapters/**", "src/components-v2/wiring/**"],
+      "rules": { "no-restricted-imports": "off" }
+    }
+  ]
+}
+```
+
+## Testing skin parity
+
+### Behavioral parity (automated)
+
+Semantic component tests verify that props → rendered output is correct regardless of which skin wraps them. These tests use the semantic component directly with mock props.
+
+### Visual parity (semi-automated)
+
+Skins are not expected to look identical. Visual testing should verify:
+
+1. All required props are consumed (TypeScript compilation catches this)
+2. Interaction callbacks fire correctly (component tests)
+3. No visual regressions within a single skin (Playwright screenshot diffing per skin)
+
+Cross-skin visual comparison is explicitly **not** a goal — skins exist to look different.
+
 ## Provisional conclusion
 
 The ideal frontend is not "one mega theme system". It is a layered system with three independent presentation controls:
@@ -395,3 +701,11 @@ The ideal frontend is not "one mega theme system". It is a layered system with t
 - layout variant changes composition
 
 All three sit on top of one shared runtime and one semantic contract. That is the only shape that gives both visual freedom and behavioral stability.
+
+The Svelte 5 implementation uses:
+
+- `$derived()` for reactive adapter-to-view-model binding
+- concrete skin components (not dynamic registries) for type safety
+- lazy `import()` for skin loading to manage bundle size
+- `$effect()` for reactive skin switching
+- eslint import boundaries for architectural enforcement

--- a/docs/plans/2026-04-11-rx-audio-trace.md
+++ b/docs/plans/2026-04-11-rx-audio-trace.md
@@ -1,0 +1,306 @@
+# RX Audio Path Trace
+
+**Date:** 2026-04-11
+**Status:** Research in progress
+**Issue:** `#642`
+**Base commit:** `f0e78cc0ea0fcfbafdadbb4a20167ba0bc110d6a` (`origin/main`)
+
+## Goal
+
+Trace the current RX audio path from `LIVE` UI selection to browser playback and identify concrete failure points for the symptom:
+
+- user can select `LIVE`
+- backend sends audio frames over `/api/v1/audio`
+- browser still produces no sound
+
+## End-to-end path on current `origin/main`
+
+### 1. UI presents `LIVE` only if capabilities include audio
+
+`frontend/src/components-v2/wiring/state-adapter.ts:440-460`
+
+- `toRxAudioProps(...)` sets `hasLiveAudio = hasCap(caps, 'audio')`
+- `monitorMode` becomes `'live'` only when `audioState.rxEnabled && hasLiveAudio`
+
+`frontend/src/components-v2/panels/RxAudioPanel.svelte:19-26`
+
+- `buildMonitorOptions(hasLiveAudio)` includes `LIVE` only when `hasLiveAudio === true`
+
+So if the UI shows `LIVE`, the frontend already believes runtime audio capability is present.
+
+### 2. Selecting `LIVE` starts browser RX audio
+
+`frontend/src/components-v2/wiring/command-bus.ts:536-547`
+
+- `onMonitorModeChange('live')`
+- clears mute state
+- restores AF level if needed
+- calls `audioManager.startRx()`
+
+### 3. `audioManager` opens `/api/v1/audio` and forwards every binary frame to `RxPlayer`
+
+`frontend/src/lib/audio/audio-manager.ts:79-85`
+
+- `startRx()` sets `rxEnabled = true`
+- starts `RxPlayer`
+- opens audio WS via `connect()`
+
+`frontend/src/lib/audio/audio-manager.ts:137-167`
+
+- opens `ws://.../api/v1/audio`
+- on open, sends `{ type: 'audio_start', direction: 'rx' }`
+- on every `ArrayBuffer`, calls `this.rxPlayer.feed(ev.data)`
+
+### 4. `RxPlayer` only understands two web transport codecs
+
+`frontend/src/lib/audio/rx-player.ts:68-78`
+
+- `CODEC_PCM16` -> `playPcm16(...)`
+- `CODEC_OPUS` -> `decodeOpus(...)`
+
+`frontend/src/lib/audio/constants.ts:3-10`
+
+- web transport codec space is only:
+  - `0x01` = Opus
+  - `0x02` = PCM16
+
+### 5. Backend maps radio codec to web codec before sending frames
+
+`src/icom_lan/web/handlers/audio.py:172-215`
+
+- radio codec is inspected via `radio.audio_codec`
+- web codec is normalized to:
+  - `AUDIO_CODEC_OPUS`
+  - `AUDIO_CODEC_PCM16`
+
+Important mappings:
+
+- `PCM_1CH_16BIT` -> `PCM16`
+- `PCM_2CH_16BIT` -> `PCM16`
+- `ULAW_*` -> `PCM16` with decode in relay loop
+- `PCM_1CH_8BIT` -> `PCM16` with comment `upcast in future`
+- `PCM_2CH_8BIT` -> `PCM16`
+
+### 6. Relay loop sends encoded web audio frames to browser clients
+
+`src/icom_lan/web/handlers/audio.py:226-270`
+
+- reads packets from the audio broadcaster subscription
+- optionally decodes u-law to PCM16
+- wraps payload with 8-byte web audio header
+- sends it to connected clients
+
+## Confirmed failure points
+
+### 1. `AudioContext` can remain suspended
+
+`frontend/src/lib/audio/rx-player.ts:35-52`
+
+- `start()` creates `AudioContext`
+- if suspended, it calls `resume()`
+- playback functions still bail out when `ctx.state === 'suspended'`
+
+`frontend/src/lib/audio/rx-player.ts:87-89`
+`frontend/src/lib/audio/rx-player.ts:107-110`
+
+Both PCM and Opus paths return immediately when the context is suspended.
+
+Current weakness:
+
+- no awaited resume confirmation
+- no state logging
+- no explicit user-gesture confirmation path
+
+This can produce the exact symptom "frames arrive, no sound".
+
+### 2. Opus decode silently depends on `AudioDecoder`
+
+`frontend/src/lib/audio/rx-player.ts:107-110`
+
+If `typeof AudioDecoder === 'undefined'`, Opus frames are ignored.
+
+Current weakness:
+
+- silent return
+- no fallback decoder
+- no user-visible error state
+
+If backend sends Opus and the browser/runtime lacks WebCodecs `AudioDecoder`, frames can arrive with zero playback.
+
+### 3. 8-bit PCM looks especially suspicious
+
+`src/icom_lan/web/handlers/audio.py:177-187`
+
+The backend explicitly maps `PCM_1CH_8BIT` and `PCM_2CH_8BIT` to web `PCM16`, but the comment says:
+
+- `PCM_1CH_8BIT: AUDIO_CODEC_PCM16,  # upcast in future`
+
+This is a strong red flag. The frontend `PCM16` path assumes signed 16-bit samples:
+
+`frontend/src/lib/audio/rx-player.ts:94-102`
+
+It reads payload using `new Int16Array(...)`.
+
+If the payload is still 8-bit PCM but labeled as PCM16, playback can be garbage or effectively silent.
+
+### 4. TX and RX paths are asymmetrical by design
+
+`frontend/src/lib/audio/constants.ts:13-23`
+
+Browser TX always sends Opus headers.
+
+`src/icom_lan/web/handlers/audio.py:482-499`
+
+Backend may transcode TX Opus to PCM for some radios, but RX path depends on radio codec normalization. So "TX works / RX fails" and "frames arrive / playback fails" are both plausible without a transport bug.
+
+## Current strongest suspects
+
+### Suspect A: AudioContext never reaches `running`
+
+This is the simplest browser-side explanation when:
+
+- `LIVE` is visible
+- `/api/v1/audio` is connected
+- frames arrive
+- no sound is heard
+
+### Suspect B: Browser receives Opus but lacks usable `AudioDecoder`
+
+This is likely if:
+
+- backend negotiates Opus on the radio side
+- browser/runtime lacks WebCodecs `AudioDecoder`
+- no console checks are in place
+
+### Suspect C: Radio codec is 8-bit PCM, but web path labels it as PCM16
+
+This is the strongest code-level mismatch currently visible in backend logic.
+
+It would also fit the timeline "it worked a few days ago" if:
+
+- the active radio/backend/codec changed
+- default codec negotiation changed
+- a different runtime path now feeds `PCM_1CH_8BIT`
+
+## Supporting context
+
+### Default codec preference is not Opus-first
+
+`src/icom_lan/types.py:191-200`
+
+Default preference order begins with:
+
+- `PCM_1CH_16BIT`
+- `PCM_2CH_16BIT`
+- `ULAW_*`
+- `PCM_*_8BIT`
+- only then `OPUS_*`
+
+So frontend behavior can differ substantially depending on which radio/backend is active, even though the WS API stays the same.
+
+### Capability gating is separate from playback success
+
+`src/icom_lan/web/runtime_helpers.py:17-58`
+
+Runtime capability logic determines whether frontend exposes `LIVE`, but once `LIVE` is shown and selected, playback success depends on the browser audio pipeline above, not only on the backend transport.
+
+## Next evidence needed
+
+To turn the current suspects into a proven root cause, the next step should capture:
+
+1. The first incoming RX frame header in the browser:
+   - codec
+   - sample rate
+   - channels
+2. `AudioContext.state` immediately after selecting `LIVE`
+3. Whether `AudioDecoder` exists in the failing browser
+4. The backend `radio.audio_codec` value on the failing radio/backend
+
+## Current test gaps
+
+Frontend coverage currently proves only the happy-path basics:
+
+- `frontend/src/lib/audio/__tests__/rx-player.test.ts`
+  covers `AudioContext` creation, suspended resume call, and PCM16 scheduling
+- `frontend/src/components-v2/panels/__tests__/RxAudioPanel.test.ts`
+  covers monitor option rendering
+
+Important gaps:
+
+- no tests for `audioManager` RX lifecycle or `/api/v1/audio` handling
+- no tests for Opus decode path in `RxPlayer`
+- no tests for `AudioDecoder === undefined`
+- no tests for `ctx.state === 'suspended'` during incoming frames
+- no tests for malformed or mislabeled PCM payloads
+- no backend tests around `PCM_1CH_8BIT -> web PCM16` normalization
+
+So the current code has multiple silent failure branches that are not guarded by tests.
+
+## Minimal instrumentation plan
+
+The next step should be a diagnostic-only patch, not a behavioral refactor.
+
+### Frontend instrumentation
+
+In `frontend/src/lib/audio/audio-manager.ts`:
+
+- log the first few RX frames:
+  - frame index
+  - codec
+  - sample rate
+  - channels
+  - payload length
+- log when `RxPlayer.feed(...)` throws
+
+In `frontend/src/lib/audio/rx-player.ts`:
+
+- log `AudioContext.state` on `start()`
+- log whether `resume()` was attempted and whether it resolved/rejected
+- log when PCM/Opus playback is skipped because context is still suspended
+- log when Opus playback is skipped because `AudioDecoder` is missing
+- log decoder creation and first decode attempts
+
+This proves whether the problem is:
+
+- transport only
+- browser audio unlock
+- codec mismatch
+- missing browser decoder support
+
+### Backend instrumentation
+
+Current backend already logs useful pieces in `src/icom_lan/web/handlers/audio.py`:
+
+- negotiated `radio codec -> web codec`
+- relay startup sample rate/channels
+- packet counts
+
+The missing piece is to make sure failing reports include those log lines from the same run.
+
+### Evidence threshold for decision-making
+
+After instrumentation, we should be able to classify the failure into one of these buckets:
+
+1. `LIVE` selected, but `AudioContext` never reaches `running`
+2. RX frames arrive as Opus, but browser lacks usable `AudioDecoder`
+3. RX frames arrive as web `PCM16`, but negotiated radio codec is 8-bit PCM
+4. RX frames never actually reach `audioManager` despite backend assumptions
+
+Only after that classification should we choose between:
+
+- browser playback fix
+- codec normalization fix
+- runtime architecture cleanup
+- or a combination of the above
+
+## Provisional conclusion
+
+On current `origin/main`, the statement "backend sends WS audio frames" is not enough to prove the frontend should produce sound.
+
+There are at least three plausible browser-side / codec-side failure points after transport:
+
+- suspended `AudioContext`
+- missing Opus decoder support
+- backend-side codec normalization mismatch, especially for 8-bit PCM
+
+The current code strongly suggests that the next step should be instrumentation, not speculative fixes.

--- a/docs/plans/2026-04-11-shared-frontend-runtime-contract.md
+++ b/docs/plans/2026-04-11-shared-frontend-runtime-contract.md
@@ -1,0 +1,314 @@
+# Shared Frontend Runtime Contract
+
+**Date:** 2026-04-11
+**Status:** Draft for discussion
+**Issue:** `#643`
+**Based on:** `#641`, `#642`
+**Base commit:** `f0e78cc0ea0fcfbafdadbb4a20167ba0bc110d6a`
+
+## Objective
+
+Define a strict frontend contract so:
+
+- `v2` main and LCD consume one shared runtime
+- layouts differ only in presentation and composition
+- audio, scope, commands, capability gating, and connection lifecycle do not fork by mounted component path
+
+## Why this contract is needed
+
+Current `origin/main` already has shared pieces:
+
+- one app bootstrap
+- shared stores
+- `state-adapter`
+- `command-bus`
+- shared sidebars
+
+But `#641` showed that runtime ownership still leaks into presentation:
+
+- WS channels opened by rendering components
+- `audioManager` used directly in UI components
+- direct `sendCommand(...)` in leaf components
+- direct backend `fetch(...)` in layout components
+- duplicated protocol parsing in UI surfaces
+
+That is enough to cause layout-dependent regressions even with one backend and one WS API.
+
+## Target architecture
+
+The frontend should be split into four layers.
+
+### 1. Runtime layer
+
+Owns all stateful side effects:
+
+- HTTP bootstrap
+- control WS lifecycle
+- scope/audio-scope WS lifecycle
+- audio WS lifecycle
+- browser playback lifecycle
+- TX microphone lifecycle
+- reconnect logic
+- capability normalization
+- command dispatch
+- optimistic state updates
+
+Examples of modules that belong here:
+
+- `app runtime shell`
+- `audio controller`
+- `scope controller`
+- `control controller`
+- shared stores
+
+### 2. Adapter layer
+
+Pure functions mapping runtime state into semantic view models.
+
+Responsibilities:
+
+- derive panel/view props
+- normalize per-radio/runtime quirks into stable semantic values
+- expose layout-independent callbacks supplied by runtime/controllers
+
+This is where "what does the UI mean?" lives, but not "how does it talk to the backend?".
+
+### 3. Semantic UI layer
+
+Presentation components for radio concepts, not transport details.
+
+Examples:
+
+- VFO display
+- RX audio controls
+- TX controls
+- meter panel
+- memory panel
+- scope surface
+
+These components render view models and call provided callbacks.
+
+### 4. Layout layer
+
+Composes semantic UI into concrete screens:
+
+- standard desktop
+- LCD desktop
+- mobile
+
+Layouts may decide placement, visibility, grouping, and composition.
+Layouts must not own runtime side effects.
+
+## Ownership rules
+
+### Runtime owns
+
+- `WebSocket` creation and teardown
+- endpoint paths like `/api/v1/ws`, `/api/v1/audio`, `/api/v1/scope`, `/api/v1/audio-scope`
+- `audioManager` or its replacement
+- browser `AudioContext` / decoder lifecycle
+- protocol parsing for binary frames
+- backend HTTP commands
+- optimistic patches to shared state
+
+### Adapters own
+
+- mapping `ServerState + Capabilities + UiState -> semantic props`
+- capability-based visibility decisions that affect behavior
+- semantic labels and normalized enums used by more than one layout
+
+### Presentation/layout owns
+
+- markup
+- CSS/theme classes
+- panel composition
+- local ephemeral UI state that does not affect shared behavior
+  - popover open/close
+  - drag reorder of panel positions
+  - temporary expanded/collapsed UI state
+
+## Allowed imports and forbidden imports
+
+### Allowed in presentational components
+
+- adapter-derived prop types
+- stateless formatting helpers
+- semantic callback props
+- theme tokens/styles
+- purely visual child components
+
+### Forbidden in presentational components
+
+- `$lib/transport/ws-client`
+- `sendCommand(...)`
+- `getChannel(...)`
+- `$lib/audio/audio-manager`
+- direct `fetch(...)` to backend endpoints
+- binary protocol parsers for scope/audio frames
+- capability stores when the check changes behavior rather than just visibility
+
+## Invariants
+
+These must hold after migration.
+
+### Invariant 1
+
+There is exactly one RX playback path for all layouts.
+
+Consequence:
+
+- `LIVE` in standard and LCD must route through the same audio controller
+- codec negotiation, WS subscription, decoding, volume, and mute logic are layout-independent
+
+### Invariant 2
+
+There is exactly one scope ownership path per scope type.
+
+Consequence:
+
+- hardware scope and audio FFT are mounted by runtime/controller ownership
+- layouts only choose whether and where to render the resulting view surface
+
+### Invariant 3
+
+`scope=false + audio=true` is a first-class supported state.
+
+Consequence:
+
+- absence of hardware scope must never alter audio behavior
+- LCD fallback and standard layout selection are presentation concerns, not audio runtime concerns
+
+### Invariant 4
+
+Capability gating for behavior happens before presentation.
+
+Consequence:
+
+- panels should not independently decide whether backend behavior exists
+- adapters/runtime expose stable booleans like `hasLiveAudio`, `hasHardwareScope`, `hasTx`
+
+### Invariant 5
+
+Mounted component choice must not change transport ownership.
+
+Consequence:
+
+- swapping layouts cannot change which WS is connected
+- mounting/unmounting a visual scope surface cannot be the thing that starts or stops the underlying scope stream
+
+## Proposed runtime shape
+
+## `FrontendRuntime`
+
+A single runtime shell should expose:
+
+- `state`
+- `capabilities`
+- `connectionStatus`
+- `audioState`
+- `scopeState`
+- `actions`
+
+### `actions`
+
+Runtime-level actions should include:
+
+- tuning actions
+- mode/filter actions
+- TX/PTT actions
+- RX audio monitor actions
+- scope actions
+- system actions
+
+These are the only callbacks adapters/layouts should receive.
+
+## Proposed controller split
+
+### `controlController`
+
+- owns `/api/v1/ws`
+- sends commands
+- applies optimistic updates
+
+### `audioController`
+
+- owns `/api/v1/audio`
+- owns browser playback and TX mic lifecycle
+- exposes monitor mode / volume / mute / tx-audio actions
+
+### `scopeController`
+
+- owns `/api/v1/scope` and `/api/v1/audio-scope`
+- parses binary frames once
+- exposes normalized scope models
+
+### `systemController`
+
+- owns power/connect/disconnect/eibi HTTP actions
+
+## Migration principles
+
+### Principle 1
+
+Move ownership before moving visuals.
+
+Do not rewrite layouts first. First extract transport/audio/command ownership into runtime/controllers.
+
+### Principle 2
+
+Keep adapters pure.
+
+If logic needs network, timers, browser APIs, or shared stores with side effects, it is not adapter logic.
+
+### Principle 3
+
+Replace direct imports with injected callbacks or view models.
+
+If a panel currently imports `sendCommand`, `audioManager`, or `getChannel`, that is a migration target.
+
+### Principle 4
+
+Migrate by behavior slice, not by file tree.
+
+Preferred order:
+
+1. audio ownership
+2. scope ownership
+3. system/backend HTTP actions
+4. remaining direct command dispatch
+
+### Principle 5
+
+Guardrails must enforce the contract.
+
+After migration, lint/tests should fail when presentational components import forbidden runtime modules.
+
+## Anti-drift rules for model-generated changes
+
+Any future change must answer:
+
+1. Which layer owns this behavior?
+2. Does this component need side effects, or only a view model?
+3. If a new layout is added, would this logic fork?
+
+If the answer implies layout-dependent behavior, the change belongs in runtime/controllers or adapters, not in a panel/layout component.
+
+## Out of scope
+
+This contract does not define:
+
+- skin/theme/token architecture
+- component composition flexibility across skins
+
+That belongs in `#646`.
+
+## Provisional conclusion
+
+The codebase does not need a second frontend rewrite. It needs strict completion of the architecture it already started:
+
+- one runtime shell
+- one controller-owned side-effect layer
+- pure adapters
+- presentational panels/layouts only
+
+That is the minimum contract required to keep `v2`, LCD, and future skins behaviorally identical while still allowing radically different presentation.

--- a/docs/plans/2026-04-11-v2-lcd-runtime-audit.md
+++ b/docs/plans/2026-04-11-v2-lcd-runtime-audit.md
@@ -1,0 +1,193 @@
+# V2/LCD Runtime Boundary Audit
+
+**Date:** 2026-04-11
+**Status:** Research in progress
+**Issue:** `#641`
+**Base commit:** `f0e78cc0ea0fcfbafdadbb4a20167ba0bc110d6a` (`origin/main`)
+
+## Goal
+
+Establish whether `v2` main and LCD are truly two presentations over one shared frontend runtime, or whether runtime responsibilities have leaked into layout and leaf components.
+
+## Current topology
+
+### Shared app entrypoint
+
+`frontend/src/App.svelte:24-52` initializes one frontend runtime path for `v2`:
+
+- polls `/api/v1/state` via `startPolling(...)`
+- loads `/api/v1/capabilities`
+- opens the control WebSocket `/api/v1/ws`
+- mounts `RadioLayoutV2` when `uiVersion === 'v2'`
+
+This means LCD is not a separate app in current `origin/main`; it is a layout variant inside `v2`.
+
+### V2 layout split
+
+`frontend/src/components-v2/layout/RadioLayout.svelte:191-195` chooses between:
+
+- `MobileRadioLayout`
+- `LcdLayout`
+- standard `RadioLayout` content
+
+`frontend/src/components-v2/layout/LcdLayout.svelte:47-67` reuses the same sidebars as standard layout:
+
+- `LeftSidebar`
+- `RightSidebar`
+- `StatusBar`
+- `KeyboardHandler`
+
+Only the center content changes:
+
+- standard layout renders `SpectrumPanel`
+- LCD layout renders `AmberLcdDisplay`
+
+### Shared state/command machinery already present
+
+The main shared abstraction is:
+
+- `frontend/src/components-v2/wiring/state-adapter.ts`
+- `frontend/src/components-v2/wiring/command-bus.ts`
+
+Example: `RightSidebar.svelte:56-85` derives props through `state-adapter` and binds UI events through `command-bus`. `RxAudioPanel.svelte:8-23` is mostly presentation-only and receives props/callbacks.
+
+This is the right architectural direction, but it is not yet the only path.
+
+## Confirmed boundary violations
+
+### 1. Presentation components still own transport connections
+
+These components open their own WS channels instead of consuming data from a shared runtime/controller:
+
+- `frontend/src/components/spectrum/SpectrumPanel.svelte:310-318`
+  Opens `/api/v1/scope` directly with `getChannel('scope')`.
+- `frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte:55-72`
+  Opens `/api/v1/audio-scope` directly with `getChannel('audio-scope')`.
+- `frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte:145-168`
+  Also opens `/api/v1/audio-scope` directly with `getChannel('audio-scope')`.
+
+Consequence: scope/audio-scope lifecycle is tied to which component happens to be mounted, not to one runtime owner.
+
+### 2. Leaf components still dispatch backend commands directly
+
+These components bypass `command-bus` and call `sendCommand(...)` themselves:
+
+- `frontend/src/components/spectrum/SpectrumPanel.svelte:287-298`
+  Sends `set_freq` during drag tuning.
+- `frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte:284`
+  Sends `set_tuner_status` directly.
+- `frontend/src/components-v2/panels/MemoryPanel.svelte:56-80`
+  Sends memory commands directly.
+
+Consequence: behavior can diverge by component even if state derivation is shared.
+
+### 3. TX audio lifecycle is split between command handlers and components
+
+RX audio is controlled in `command-bus`:
+
+- `frontend/src/components-v2/wiring/command-bus.ts:536-581`
+  `makeRxAudioHandlers()` owns `audioManager.startRx()`, `stopRx()`, and browser volume updates.
+
+TX audio is not centralized the same way. These presentation/layout components still call `audioManager` directly:
+
+- `frontend/src/components-v2/panels/TxPanel.svelte:55-80`
+  Calls `audioManager.startTx()` / `stopTx()` inside PTT logic.
+- `frontend/src/components-v2/layout/MobileRadioLayout.svelte:290-297`
+  Also calls `audioManager.startTx()` / `stopTx()` directly.
+
+Consequence: RX and TX do not share one consistent ownership model. Mobile and desktop TX can evolve differently.
+
+### 4. Layout/presentation components still own HTTP side effects
+
+These UI components call backend HTTP endpoints directly:
+
+- `frontend/src/components-v2/layout/LcdLayout.svelte:27-38`
+  Calls `/api/v1/radio/power`.
+- `frontend/src/components-v2/layout/StatusBar.svelte:47-78`
+  Calls connect/disconnect and power endpoints.
+- `frontend/src/components-v2/layout/StatusBar.svelte:87-108`
+  Calls `/api/v1/eibi/identify`.
+
+Consequence: system/runtime actions are not consistently routed through one orchestration layer.
+
+### 5. LCD still contains logic that is not expressed through shared view-models
+
+`frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte` contains custom derivation beyond presentation:
+
+- band lookup by frequency: `:38-64`
+- active meter source state and cycling: `:87-109`
+- LCD-specific DSP activity heuristics: `:111-121`
+- AGC label mapping: `:133-140`
+
+Some of this is valid presentation logic, but some of it is semantic UI/view-model logic that should be explicit in adapters if parity across skins matters.
+
+### 6. Scope frame parsing is duplicated across UI surfaces
+
+Equivalent `parseScopeFrame(...)` logic appears in:
+
+- `frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte:18-27`
+- `frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte:27-36`
+- `frontend/src/components/spectrum/spectrum-logic.ts`
+
+Consequence: protocol handling is duplicated in presentation surfaces.
+
+## What is actually shared today
+
+The current codebase is not "two separate frontends". It already shares meaningful core pieces:
+
+- one top-level app bootstrap (`App.svelte`)
+- one control WS path
+- one polling/state store path
+- one capabilities store path
+- one `state-adapter`
+- one `command-bus` for a large portion of controls
+- shared sidebars between standard and LCD layouts
+
+So the problem is not lack of any shared architecture. The problem is incomplete enforcement of that architecture.
+
+## Current assessment
+
+The code on `origin/main` is in an intermediate state:
+
+- directionally correct toward shared runtime + presentation adapters
+- not yet strict enough to guarantee parity
+- still vulnerable to model drift because transport, audio lifecycle, and commands can be reintroduced into UI components
+
+That explains how "same backend" can still produce different behavior by layout or mounted component path.
+
+## Implications for next issues
+
+### For `#642` (audio failure trace)
+
+Need to verify whether LCD audio failure is caused by:
+
+- a capability/UI gating mismatch
+- a decode/playback path issue in `audioManager` / `rx-player`
+- component-mount ownership of audio/scope side effects
+- a browser/user-gesture issue
+
+### For `#643` (target runtime contract)
+
+The target contract should make these ownership rules explicit:
+
+- layouts do not open WS connections
+- panels do not import `audioManager`
+- panels do not call `sendCommand(...)` directly
+- panels do not call backend HTTP endpoints directly
+- protocol parsing does not live in rendering components
+
+### For `#646` (presentation architecture)
+
+Need to separate:
+
+- presentation-only formatting/styling logic
+- semantic view-model derivation
+- runtime transport/command ownership
+
+Without that split, "skin" work will keep reintroducing behavioral forks.
+
+## Provisional conclusion
+
+On current `origin/main`, LCD and standard `v2` are partially unified, but not fully architecture-safe.
+
+The main architectural defect is not that LCD is a separate app; it is that runtime ownership is still distributed across layout and leaf components. That is enough to cause layout-dependent regressions even when backend transport is shared.

--- a/docs/plans/2026-04-12-architecture-presentation.html
+++ b/docs/plans/2026-04-12-architecture-presentation.html
@@ -1,0 +1,762 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>icom-lan Frontend Architecture</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --border: #30363d;
+    --text: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --green: #3fb950;
+    --red: #f85149;
+    --orange: #d29922;
+    --purple: #bc8cff;
+    --cyan: #39d2c0;
+    --pink: #f778ba;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    line-height: 1.6;
+    padding: 40px 20px;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+  h1 { font-size: 2em; margin-bottom: 8px; }
+  h2 { font-size: 1.5em; margin: 48px 0 16px; color: var(--accent); border-bottom: 1px solid var(--border); padding-bottom: 8px; }
+  h3 { font-size: 1.15em; margin: 24px 0 12px; color: var(--purple); }
+  p, li { color: var(--muted); margin-bottom: 8px; }
+  .subtitle { color: var(--muted); font-size: 0.95em; margin-bottom: 32px; }
+  code { background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; color: var(--cyan); }
+
+  /* Slide sections */
+  .slide { margin-bottom: 64px; }
+
+  /* Layer diagram */
+  .layers {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin: 24px 0;
+  }
+  .layer {
+    padding: 20px 24px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    position: relative;
+  }
+  .layer-num {
+    position: absolute;
+    right: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 2em;
+    font-weight: 700;
+    opacity: 0.15;
+  }
+  .layer h4 { font-size: 1.1em; margin-bottom: 4px; }
+  .layer p { margin: 0; font-size: 0.9em; }
+  .l-runtime { background: #1a2332; border-color: #264166; }
+  .l-runtime h4 { color: var(--accent); }
+  .l-adapter { background: #1a2825; border-color: #1f4a3a; }
+  .l-adapter h4 { color: var(--green); }
+  .l-semantic { background: #261a33; border-color: #3d2666; }
+  .l-semantic h4 { color: var(--purple); }
+  .l-presentation { background: #332218; border-color: #664422; }
+  .l-presentation h4 { color: var(--orange); }
+
+  .arrow-down {
+    text-align: center;
+    font-size: 1.5em;
+    color: var(--muted);
+    line-height: 1;
+    padding: 4px 0;
+  }
+
+  /* Three knobs */
+  .knobs {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    margin: 24px 0;
+  }
+  .knob-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px;
+  }
+  .knob-card h4 {
+    font-size: 1.05em;
+    margin-bottom: 8px;
+  }
+  .knob-card .what { color: var(--text); font-size: 0.95em; margin-bottom: 8px; }
+  .knob-card .how { color: var(--muted); font-size: 0.85em; }
+  .knob-theme h4 { color: var(--cyan); }
+  .knob-skin h4 { color: var(--pink); }
+  .knob-layout h4 { color: var(--orange); }
+
+  /* Comparison table */
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0;
+    font-size: 0.9em;
+  }
+  th, td {
+    padding: 10px 14px;
+    border: 1px solid var(--border);
+    text-align: left;
+  }
+  th {
+    background: var(--surface);
+    color: var(--text);
+    font-weight: 600;
+  }
+  td { color: var(--muted); }
+  tr:nth-child(even) td { background: rgba(255,255,255,0.02); }
+  .good { color: var(--green); }
+  .bad { color: var(--red); }
+
+  /* Flow diagrams */
+  .flow {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 16px 0;
+    flex-wrap: wrap;
+  }
+  .flow-box {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 14px;
+    font-size: 0.85em;
+    white-space: nowrap;
+  }
+  .flow-arrow { color: var(--muted); font-size: 1.2em; }
+  .flow-box.runtime { border-color: #264166; color: var(--accent); }
+  .flow-box.adapter { border-color: #1f4a3a; color: var(--green); }
+  .flow-box.semantic { border-color: #3d2666; color: var(--purple); }
+  .flow-box.skin { border-color: #664422; color: var(--orange); }
+  .flow-box.theme { border-color: #1a4040; color: var(--cyan); }
+
+  /* Skin comparison */
+  .skin-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 16px 0;
+  }
+  .skin-example {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+  }
+  .skin-example h5 {
+    font-size: 0.95em;
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  .skin-example pre {
+    font-size: 0.8em;
+    line-height: 1.5;
+    color: var(--muted);
+    overflow-x: auto;
+  }
+  .lcd-skin h5 { color: #f0a030; }
+  .v2-skin h5 { color: var(--accent); }
+
+  /* File tree */
+  .tree {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px 24px;
+    font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.82em;
+    line-height: 1.8;
+    color: var(--muted);
+    overflow-x: auto;
+    margin: 16px 0;
+  }
+  .tree .dir { color: var(--accent); font-weight: 600; }
+  .tree .file { color: var(--muted); }
+  .tree .comment { color: #484f58; }
+
+  /* Invariant cards */
+  .invariants {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 12px;
+    margin: 16px 0;
+  }
+  .inv-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+  }
+  .inv-card .inv-id {
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 0.85em;
+    margin-bottom: 4px;
+  }
+  .inv-card .inv-text {
+    color: var(--text);
+    font-size: 0.9em;
+    margin-bottom: 6px;
+  }
+  .inv-card .inv-why {
+    color: var(--muted);
+    font-size: 0.8em;
+  }
+
+  /* Phase timeline */
+  .phases {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin: 16px 0;
+  }
+  .phase {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 16px 0;
+    border-left: 2px solid var(--border);
+    margin-left: 16px;
+    padding-left: 24px;
+    position: relative;
+  }
+  .phase::before {
+    content: '';
+    position: absolute;
+    left: -7px;
+    top: 20px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--border);
+    border: 2px solid var(--bg);
+  }
+  .phase.active::before { background: var(--green); }
+  .phase-num {
+    color: var(--muted);
+    font-weight: 700;
+    font-size: 0.85em;
+    min-width: 24px;
+  }
+  .phase-content h5 { color: var(--text); font-size: 0.95em; margin-bottom: 4px; }
+  .phase-content p { font-size: 0.85em; margin: 0; }
+  .phase-gate {
+    display: inline-block;
+    background: rgba(59, 185, 80, 0.1);
+    border: 1px solid rgba(59, 185, 80, 0.3);
+    color: var(--green);
+    font-size: 0.75em;
+    padding: 2px 8px;
+    border-radius: 4px;
+    margin-top: 6px;
+  }
+
+  @media (max-width: 768px) {
+    .knobs { grid-template-columns: 1fr; }
+    .skin-grid { grid-template-columns: 1fr; }
+    .invariants { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<h1>icom-lan Frontend Architecture</h1>
+<p class="subtitle">ADR 2026-04-12 &mdash; Target architecture for unified V2/LCD runtime with skin/theme support</p>
+
+<!-- SLIDE 1: Problem -->
+<div class="slide">
+<h2>1. Проблема</h2>
+<p>V2 и LCD задумывались как две презентации над одним рантаймом. На практике runtime-ответственности утекли в компоненты.</p>
+
+<table>
+<tr><th>Нарушение</th><th>Где</th><th>Последствие</th></tr>
+<tr><td>Компоненты открывают WS-каналы</td><td>SpectrumPanel, AudioSpectrumPanel, AmberLcdDisplay</td><td>Transport lifecycle привязан к mount state</td></tr>
+<tr><td>Прямой <code>sendCommand()</code></td><td>AmberLcdDisplay, MemoryPanel</td><td>Команды обходят command bus</td></tr>
+<tr><td>Прямой <code>audioManager</code></td><td>TxPanel, MobileRadioLayout</td><td>TX audio не централизован</td></tr>
+<tr><td>Прямой <code>fetch()</code></td><td>StatusBar, LcdLayout</td><td>HTTP side effects в UI</td></tr>
+<tr><td>Дублирование парсинга</td><td>3 копии parseScopeFrame</td><td>Протокольная логика размазана</td></tr>
+</table>
+
+<p style="color: var(--red); margin-top: 16px;"><strong>Итого: 23 нарушения границ в 5 файлах.</strong> Достаточно для layout-зависимых регрессий даже при одном бэкенде.</p>
+</div>
+
+<!-- SLIDE 2: Target layers -->
+<div class="slide">
+<h2>2. Целевая архитектура: 4 слоя</h2>
+<p>Строгая однонаправленная зависимость. Каждый слой зависит только от слоя ниже.</p>
+
+<div class="layers">
+  <div class="layer l-presentation">
+    <h4>Skin + Layout + Theme</h4>
+    <p>Визуальная оболочка: amber-lcd, desktop-v2, mobile, будущие скины. CSS-темы.</p>
+    <span class="layer-num">4</span>
+  </div>
+  <div class="arrow-down">&darr;</div>
+  <div class="layer l-semantic">
+    <h4>Semantic Components</h4>
+    <p>Контракты поведения: VfoDisplay, MeterPanel, RxAudioControl, ScopeSurface. Типизированные props + callbacks.</p>
+    <span class="layer-num">3</span>
+  </div>
+  <div class="arrow-down">&darr;</div>
+  <div class="layer l-adapter">
+    <h4>View-Model Adapters</h4>
+    <p>Чистые функции: <code>(State, Caps) &rarr; Props</code>. Без side effects. Один адаптер на домен.</p>
+    <span class="layer-num">2</span>
+  </div>
+  <div class="arrow-down">&darr;</div>
+  <div class="layer l-runtime">
+    <h4>Runtime</h4>
+    <p>Singleton. Владеет: WS, audio, scope, state, commands, reconnect. Без DOM.</p>
+    <span class="layer-num">1</span>
+  </div>
+</div>
+</div>
+
+<!-- SLIDE 3: Runtime -->
+<div class="slide">
+<h2>3. Runtime: единый владелец side effects</h2>
+
+<h3>FrontendRuntime</h3>
+<div class="flow">
+  <div class="flow-box runtime">state</div>
+  <div class="flow-box runtime">capabilities</div>
+  <div class="flow-box runtime">connection</div>
+  <div class="flow-box runtime">cmd()</div>
+</div>
+
+<h3>Контроллеры</h3>
+<table>
+<tr><th>Контроллер</th><th>Владеет</th><th>Не владеет</th></tr>
+<tr>
+  <td><code>AudioController</code></td>
+  <td>/api/v1/audio WS, AudioContext, RxPlayer, TxMic, codec negotiation</td>
+  <td>AF level radio command (через cmd())</td>
+</tr>
+<tr>
+  <td><code>ScopeController</code></td>
+  <td>/api/v1/scope WS, /api/v1/audio-scope WS, binary frame parsing</td>
+  <td>Визуальный рендеринг (это skin)</td>
+</tr>
+<tr>
+  <td><code>SystemController</code></td>
+  <td>HTTP: power, connect/disconnect, EIBI identify</td>
+  <td>UI для этих действий</td>
+</tr>
+</table>
+
+<p style="margin-top: 16px;">Ключевое: runtime &mdash; чистый TypeScript, без Svelte, без DOM. Можно тестировать юнитами.</p>
+</div>
+
+<!-- SLIDE 4: Adapters -->
+<div class="slide">
+<h2>4. Адаптеры: чистый маппинг state &rarr; props</h2>
+
+<div class="flow">
+  <div class="flow-box runtime">RadioState</div>
+  <span class="flow-arrow">+</span>
+  <div class="flow-box runtime">Capabilities</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box adapter">toVfoProps()</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box semantic">VfoViewModel</div>
+</div>
+
+<p style="margin-top: 12px;">Каждый адаптер &mdash; чистая функция. Один файл на домен:</p>
+
+<table>
+<tr><th>Адаптер</th><th>Выход</th><th>Используется в</th></tr>
+<tr><td><code>vfo.ts</code></td><td>VfoViewModel (freq, mode, filter, badges, callbacks)</td><td>VfoDisplay</td></tr>
+<tr><td><code>audio.ts</code></td><td>RxAudioViewModel (monitorMode, volume, callbacks)</td><td>RxAudioControl</td></tr>
+<tr><td><code>meter.ts</code></td><td>MeterViewModel (sMeter, swr, power, alc)</td><td>MeterPanel</td></tr>
+<tr><td><code>scope.ts</code></td><td>ScopeViewModel (available, frame, callbacks)</td><td>ScopeSurface</td></tr>
+<tr><td><code>rf.ts</code></td><td>RfViewModel (att, preamp, nb, nr, callbacks)</td><td>RfFrontEnd</td></tr>
+<tr><td><code>tx.ts</code></td><td>TxViewModel (pttActive, txSupported, callbacks)</td><td>TxControl</td></tr>
+</table>
+
+<p style="margin-top: 12px;">Заменяет текущие <code>state-adapter.ts</code> + <code>command-bus.ts</code> &mdash; не дублирует, а рефакторит.</p>
+</div>
+
+<!-- SLIDE 5: Three knobs -->
+<div class="slide">
+<h2>5. Три независимые ручки оформления</h2>
+
+<div class="knobs">
+  <div class="knob-card knob-theme">
+    <h4>Theme</h4>
+    <div class="what">Меняет: цвета, шрифты, тени, радиусы</div>
+    <div class="how">Механизм: CSS custom properties через <code>data-theme</code><br>
+    Примеры: dracula, nord, crt-green, amoled-black<br>
+    <strong>20 тем уже есть &mdash; работают как есть</strong></div>
+  </div>
+  <div class="knob-card knob-skin">
+    <h4>Skin</h4>
+    <div class="what">Меняет: визуальную реализацию компонентов</div>
+    <div class="how">Механизм: конкретный Svelte-компонент для каждого semantic component<br>
+    Примеры: <code>AmberFrequency</code> vs <code>IndustrialFrequency</code><br>
+    <strong>Не меняет поведение &mdash; только рендер</strong></div>
+  </div>
+  <div class="knob-card knob-layout">
+    <h4>Layout</h4>
+    <div class="what">Меняет: расположение компонентов на экране</div>
+    <div class="how">Механизм: grid/flex в top-level компоненте skin-а<br>
+    Примеры: DesktopGrid, MobileTabs, LcdColumn<br>
+    <strong>Не меняет transport ownership</strong></div>
+  </div>
+</div>
+</div>
+
+<!-- SLIDE 6: How skins work -->
+<div class="slide">
+<h2>6. Как работает skin</h2>
+
+<p>Skin &mdash; это Svelte-компонент, который получает <code>FrontendRuntime</code> как единственный prop:</p>
+
+<div class="flow">
+  <div class="flow-box runtime">App.svelte</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box skin">resolveSkinId()</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box skin">loadSkin(id)</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box skin">&lt;SkinComponent runtime /&gt;</div>
+</div>
+
+<div class="skin-grid">
+  <div class="skin-example v2-skin">
+    <h5>Desktop V2 Skin</h5>
+    <pre>
+&lt;DesktopSkin {runtime}&gt;
+  &lt;VfoHeader&gt;
+    &lt;IndustrialFrequency {vfo.freqHz} /&gt;
+    &lt;NeedleSMeter {meter.sMeter} /&gt;
+  &lt;/VfoHeader&gt;
+  &lt;SpectrumCanvas {scope.frame} /&gt;
+  &lt;LeftSidebar&gt;
+    &lt;BandSelector ... /&gt;
+    &lt;ModeSelector ... /&gt;
+  &lt;/LeftSidebar&gt;
+  &lt;RightSidebar&gt;
+    &lt;HardwareRxAudioPanel ... /&gt;
+    &lt;DspPanel ... /&gt;
+  &lt;/RightSidebar&gt;
+&lt;/DesktopSkin&gt;</pre>
+  </div>
+  <div class="skin-example lcd-skin">
+    <h5>Amber LCD Skin</h5>
+    <pre>
+&lt;LcdSkin {runtime}&gt;
+  &lt;LcdFrame&gt;
+    &lt;AmberFrequency {vfo.freqHz} /&gt;
+    &lt;AmberSMeter {meter.sMeter} /&gt;
+    &lt;AmberAudioStrip
+      mode={audio.monitorMode}
+      onModeChange={audio.onModeChange}
+    /&gt;
+  &lt;/LcdFrame&gt;
+  &lt;LeftSidebar&gt;...&lt;/LeftSidebar&gt;
+  &lt;RightSidebar&gt;...&lt;/RightSidebar&gt;
+&lt;/LcdSkin&gt;</pre>
+  </div>
+</div>
+
+<p>Оба skin-а используют <strong>одни и те же адаптеры</strong> (<code>toVfoProps</code>, <code>toMeterProps</code>...) и <strong>один runtime</strong>. Различается только визуал.</p>
+</div>
+
+<!-- SLIDE 7: Data flow -->
+<div class="slide">
+<h2>7. Поток данных: от радио до пикселя</h2>
+
+<h3>RX Audio (пример)</h3>
+<div class="flow">
+  <div class="flow-box">IC-7610</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box runtime">AudioBus</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box runtime">AudioBroadcaster (backend)</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box runtime">/api/v1/audio WS</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box runtime">AudioController</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box runtime">RxPlayer &rarr; AudioContext</div>
+</div>
+
+<h3>User action (пример: смена режима мониторинга)</h3>
+<div class="flow">
+  <div class="flow-box skin">Click "LIVE"</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box adapter">onMonitorModeChange('live')</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box runtime">AudioController.setMonitorMode()</div>
+  <span class="flow-arrow">&rarr;</span>
+  <div class="flow-box runtime">startRx() + resume AudioContext</div>
+</div>
+
+<p style="margin-top: 12px;">UI-компонент <strong>не знает</strong> про WebSocket, AudioContext или codec. Он вызывает callback из props.</p>
+</div>
+
+<!-- SLIDE 8: File structure -->
+<div class="slide">
+<h2>8. Целевая структура файлов</h2>
+
+<div class="tree">
+<span class="dir">frontend/src/</span>
+<br><span class="dir">&boxvr;&boxh; runtime/</span> <span class="comment">&mdash; Layer 1: все side effects</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; index.ts</span> <span class="comment">&mdash; createRuntime(), singleton</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; types.ts</span> <span class="comment">&mdash; FrontendRuntime, controller interfaces</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; audio-controller.ts</span> <span class="comment">&mdash; AudioController (ex audio-manager)</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; scope-controller.ts</span> <span class="comment">&mdash; ScopeController</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; system-controller.ts</span> <span class="comment">&mdash; SystemController (HTTP calls)</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; command-dispatcher.ts</span> <span class="comment">&mdash; cmd() + optimistic patches</span>
+<br><span class="file">&boxv;  &boxur;&boxh; connection-monitor.ts</span>
+<br>
+<br><span class="dir">&boxvr;&boxh; adapters/</span> <span class="comment">&mdash; Layer 2: pure functions</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; vfo.ts, audio.ts, meter.ts, scope.ts</span>
+<br><span class="file">&boxv;  &boxur;&boxh; rf.ts, tx.ts, memory.ts, system.ts</span>
+<br>
+<br><span class="dir">&boxvr;&boxh; semantic/</span> <span class="comment">&mdash; Layer 3: behaviour contracts</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; VfoDisplay.svelte</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; RxAudioControl.svelte</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; MeterPanel.svelte, ScopeSurface.svelte</span>
+<br><span class="file">&boxv;  &boxur;&boxh; TxControl.svelte, ...</span>
+<br>
+<br><span class="dir">&boxvr;&boxh; primitives/</span> <span class="comment">&mdash; shared visual atoms</span>
+<br><span class="file">&boxv;  &boxur;&boxh; SegmentedButton, Knob, LinearMeter, SevenSegment, ...</span>
+<br>
+<br><span class="dir">&boxvr;&boxh; skins/</span> <span class="comment">&mdash; Layer 4: visual implementations</span>
+<br><span class="file">&boxv;  &boxvr;&boxh; registry.ts</span> <span class="comment">&mdash; resolveSkinId(), loadSkin()</span>
+<br><span class="dir">&boxv;  &boxvr;&boxh; desktop-v2/</span> <span class="comment">&mdash; DesktopSkin + visual components</span>
+<br><span class="dir">&boxv;  &boxvr;&boxh; amber-lcd/</span> <span class="comment">&mdash; LcdSkin + AmberFrequency, AmberMeter...</span>
+<br><span class="dir">&boxv;  &boxur;&boxh; mobile/</span> <span class="comment">&mdash; MobileSkin + CompactVfo...</span>
+<br>
+<br><span class="dir">&boxvr;&boxh; themes/</span> <span class="comment">&mdash; CSS tokens (20+ тем, as-is)</span>
+<br><span class="dir">&boxvr;&boxh; lib/</span> <span class="comment">&mdash; renderers, utils, gestures, data</span>
+<br><span class="file">&boxur;&boxh; App.svelte</span> <span class="comment">&mdash; skin resolver entry point</span>
+</div>
+</div>
+
+<!-- SLIDE 9: Invariants -->
+<div class="slide">
+<h2>9. Архитектурные инварианты</h2>
+<p>Нарушение любого = регрессия.</p>
+
+<div class="invariants">
+  <div class="inv-card">
+    <div class="inv-id">INV-1</div>
+    <div class="inv-text">Единый путь RX playback</div>
+    <div class="inv-why">Все лейауты проходят через один AudioController. Codec, WS, decode, volume &mdash; layout-независимы.</div>
+  </div>
+  <div class="inv-card">
+    <div class="inv-id">INV-2</div>
+    <div class="inv-text">Единое владение scope</div>
+    <div class="inv-why">ScopeController владеет WS-каналами. Лейаут решает где рендерить &mdash; но не подключаться ли.</div>
+  </div>
+  <div class="inv-card">
+    <div class="inv-id">INV-3</div>
+    <div class="inv-text">scope=false + audio=true &mdash; first class</div>
+    <div class="inv-why">Отсутствие scope не влияет на audio. LCD fallback &mdash; решение презентации, не рантайма.</div>
+  </div>
+  <div class="inv-card">
+    <div class="inv-id">INV-4</div>
+    <div class="inv-text">Capability gating до презентации</div>
+    <div class="inv-why">Панели не решают есть ли capability. Runtime/adapters дают hasLiveAudio, hasScope, hasTx.</div>
+  </div>
+  <div class="inv-card">
+    <div class="inv-id">INV-5</div>
+    <div class="inv-text">Mount/unmount не меняет transport</div>
+    <div class="inv-why">Переключение лейаута не перезапускает WS. Вмонтирование scope surface не стартует стрим.</div>
+  </div>
+  <div class="inv-card">
+    <div class="inv-id">INV-6</div>
+    <div class="inv-text">Нет runtime-импортов в презентации</div>
+    <div class="inv-why">Semantic, skins, primitives не импортируют transport/audio-manager. Enforced eslint-ом.</div>
+  </div>
+</div>
+</div>
+
+<!-- SLIDE 10: What this gives us -->
+<div class="slide">
+<h2>10. Что это даёт</h2>
+
+<table>
+<tr><th>Сценарий</th><th>Что менять</th><th>Что НЕ менять</th></tr>
+<tr>
+  <td><strong>Новый skin</strong> (например, Nixie Tube)</td>
+  <td>Новая папка <code>skins/nixie/</code></td>
+  <td class="good">Runtime, adapters, semantic &mdash; 0 изменений</td>
+</tr>
+<tr>
+  <td><strong>Новая capability радио</strong></td>
+  <td>Runtime + adapter</td>
+  <td class="good">Skins &mdash; 0 изменений (если semantic component есть)</td>
+</tr>
+<tr>
+  <td><strong>Audio bug</strong> (как #642)</td>
+  <td>Один файл: <code>runtime/audio-controller.ts</code></td>
+  <td class="good">Работает одинаково во всех скинах</td>
+</tr>
+<tr>
+  <td><strong>Новая тема</strong></td>
+  <td>Один CSS-файл в <code>themes/</code></td>
+  <td class="good">Всё остальное</td>
+</tr>
+<tr>
+  <td><strong>Behavioral parity</strong></td>
+  <td colspan="2" class="good">Гарантирована архитектурно: один runtime, одни адаптеры, enforce eslint</td>
+</tr>
+</table>
+</div>
+
+<!-- SLIDE 11: Current vs Target -->
+<div class="slide">
+<h2>11. Сейчас vs Target</h2>
+
+<table>
+<tr><th>Аспект</th><th>Сейчас</th><th>Target</th></tr>
+<tr>
+  <td>state-adapter + command-bus</td>
+  <td>Зачатки, не enforced</td>
+  <td class="good">Полноценные adapters, eslint enforcement</td>
+</tr>
+<tr>
+  <td>AudioManager</td>
+  <td class="bad">Синглтон, импортируется из 5 мест напрямую</td>
+  <td class="good">AudioController в runtime, доступен только через props</td>
+</tr>
+<tr>
+  <td>LCD layout</td>
+  <td class="bad">Отдельный путь с дублированием</td>
+  <td class="good">Skin над теми же semantic components</td>
+</tr>
+<tr>
+  <td>Scope ownership</td>
+  <td class="bad">getChannel() в 3 компонентах</td>
+  <td class="good">ScopeController, один WS, данные через props</td>
+</tr>
+<tr>
+  <td>Protocol parsing</td>
+  <td class="bad">3 копии parseScopeFrame</td>
+  <td class="good">Один раз в runtime controller</td>
+</tr>
+<tr>
+  <td>Темы</td>
+  <td>20 CSS тем, работают</td>
+  <td class="good">Остаются как есть</td>
+</tr>
+<tr>
+  <td>Boundary violations</td>
+  <td class="bad">23 нарушения</td>
+  <td class="good">0 &mdash; enforced eslint rules</td>
+</tr>
+</table>
+</div>
+
+<!-- SLIDE 12: Migration phases -->
+<div class="slide">
+<h2>12. Фазы миграции</h2>
+<p>Строго последовательно. Runtime first, presentation second.</p>
+
+<div class="phases">
+  <div class="phase active">
+    <div class="phase-content">
+      <div class="phase-num">#647</div>
+      <h5>Phase 0: Guardrails + диагностика</h5>
+      <p>eslint import boundaries, diagnostic logging для audio failure</p>
+      <div class="phase-gate">Gate: audio failure classified + guardrails active</div>
+    </div>
+  </div>
+  <div class="phase">
+    <div class="phase-content">
+      <div class="phase-num">#648</div>
+      <h5>Phase 1: Runtime shell + adapter boundary</h5>
+      <p>FrontendRuntime scaffold, controller interfaces, injected props</p>
+    </div>
+  </div>
+  <div class="phase">
+    <div class="phase-content">
+      <div class="phase-num">#649</div>
+      <h5>Phase 2: Centralize audio + scope</h5>
+      <p>AudioController, ScopeController &mdash; убрать getChannel из компонентов</p>
+      <div class="phase-gate">Gate: no presentation-owned WS connections</div>
+    </div>
+  </div>
+  <div class="phase">
+    <div class="phase-content">
+      <div class="phase-num">#650</div>
+      <h5>Phase 3: Semantic presentation layer</h5>
+      <p>Semantic component APIs, skin registry, layout slots</p>
+      <div class="phase-gate">Gate: semantic contracts stable for both desktop + LCD</div>
+    </div>
+  </div>
+  <div class="phase">
+    <div class="phase-content">
+      <div class="phase-num">#651</div>
+      <h5>Phase 4: Migrate V2 desktop</h5>
+      <p>Standard layout на unified architecture, feature flag</p>
+    </div>
+  </div>
+  <div class="phase">
+    <div class="phase-content">
+      <div class="phase-num">#652</div>
+      <h5>Phase 5: Migrate LCD</h5>
+      <p>LCD как skin + layout variant, validate scope=false+audio=true</p>
+    </div>
+  </div>
+  <div class="phase">
+    <div class="phase-content">
+      <div class="phase-num">#653</div>
+      <h5>Phase 6: Cutover + cleanup</h5>
+      <p>Удалить legacy paths, финальная проверка parity matrix</p>
+      <div class="phase-gate">Gate: all 4 capability scenarios pass + manual HW validation</div>
+    </div>
+  </div>
+</div>
+</div>
+
+<!-- SLIDE 13: Anti-patterns -->
+<div class="slide">
+<h2>13. Анти-паттерны (запрещено)</h2>
+
+<table>
+<tr><th>#</th><th>Анти-паттерн</th><th>Почему запрещён</th></tr>
+<tr><td class="bad">1</td><td>Skin импортирует runtime напрямую</td><td>Превращает skin в скрытый behavior fork</td></tr>
+<tr><td class="bad">2</td><td>Theme содержит behavior flags</td><td>Theme &mdash; только токены</td></tr>
+<tr><td class="bad">3</td><td>Layout решает transport по mount state</td><td>Текущий источник drift (scope/audio)</td></tr>
+<tr><td class="bad">4</td><td>Semantic component с escape hatches (<code>rawWsData</code>)</td><td>Разрушает semantic boundary</td></tr>
+<tr><td class="bad">5</td><td>LCD как special case с <code>if (isLcd)</code></td><td>LCD = skin, не отдельный code path</td></tr>
+<tr><td class="bad">6</td><td>Дублирование protocol parsing в UI</td><td>Парсинг &mdash; ответственность runtime</td></tr>
+</table>
+</div>
+
+<div class="slide" style="text-align: center; padding: 48px 0;">
+<h2 style="border: none;">Итог</h2>
+<p style="color: var(--text); font-size: 1.1em; max-width: 700px; margin: 0 auto;">
+Не нужен полный rewrite. Нужно строгое завершение архитектуры, которая уже частично существует:
+один runtime &rarr; чистые адаптеры &rarr; semantic components &rarr; skins/themes/layouts.
+</p>
+<p style="margin-top: 24px; font-size: 0.9em;">
+ADR: <code>docs/plans/2026-04-12-target-frontend-architecture.md</code>
+</p>
+</div>
+
+</body>
+</html>

--- a/docs/plans/2026-04-12-target-frontend-architecture.md
+++ b/docs/plans/2026-04-12-target-frontend-architecture.md
@@ -1,0 +1,633 @@
+# Target Frontend Architecture — ADR
+
+**Date:** 2026-04-12
+**Status:** Approved for implementation
+**Synthesizes:** `#643` (runtime contract), `#646` (presentation architecture)
+**Informed by:** `#641` (audit), `#642` (audio trace), `#644` (parity matrix), `#645` (migration plan)
+**Base commit:** `d87f50a` (`feat/642-audio-debug-logging`)
+
+## Purpose
+
+Single authoritative reference for the unified frontend architecture. All implementation issues (`#647`–`#653`) should be judged against this document.
+
+This ADR is executable: it contains concrete TypeScript interfaces, Svelte 5 patterns, file layout, and enforcement rules. It is not a vision doc — it is a build spec.
+
+---
+
+## Architecture overview
+
+Four layers, strict one-way dependency:
+
+```
+┌────────────��─────────────��──────────────────────────┐
+│  SKIN + LAYOUT + THEME                              │  ← visual shell
+│  (amber-lcd, desktop-v2, mobile, future skins)      │
+├─────────────────��───────────────────────────��───────┤
+│  SEMANTIC COMPONENTS                                │  ← behavior contracts
+│  (VfoDisplay, MeterPanel, RxAudioControl, ...)      │
+├───────────────���─────────────────────────��───────────┤
+│  VIEW-MODEL ADAPTERS                                │  ← pure functions
+│  (toVfoProps, toMeterProps, toRxAudioProps, ...)     │
+├───────────────────────────────────────────────���─────┤
+│  RUNTIME                                            │  ← singleton, no DOM
+│  (transport, audio, scope, state, commands)          │
+└─────────────────────────────────────────────────────┘
+```
+
+**Rule:** each layer depends only on the layer below. Never upward, never across.
+
+---
+
+## Layer 1: Runtime
+
+### What it owns
+
+All stateful side effects:
+
+- HTTP bootstrap (polling, capabilities fetch)
+- Control WebSocket (`/api/v1/ws`) lifecycle
+- Audio WebSocket (`/api/v1/audio`) lifecycle
+- Scope WebSocket (`/api/v1/scope`, `/api/v1/audio-scope`) lifecycle
+- Browser `AudioContext` and playback/mic lifecycle
+- Binary frame parsing (scope, audio)
+- Command dispatch and optimistic state patches
+- Reconnect logic and connection health
+- Capability normalization
+
+### What it must not do
+
+- Import Svelte components
+- Reference DOM elements
+- Know about skins, themes, or layouts
+- Contain presentation logic
+
+### FrontendRuntime interface
+
+```typescript
+interface FrontendRuntime {
+  // Reactive state (Svelte 5 $state internally)
+  readonly state: RadioState;
+  readonly capabilities: Capabilities;
+  readonly connection: ConnectionStatus;
+  readonly layoutPreference: 'auto' | 'lcd' | 'standard';
+  readonly isMobile: boolean;
+
+  // Controllers
+  readonly audio: AudioController;
+  readonly scope: ScopeController;
+  readonly system: SystemController;
+
+  // Single command dispatch entry point
+  cmd(command: string, params?: Record<string, unknown>): void;
+}
+```
+
+### AudioController
+
+```typescript
+interface AudioController {
+  readonly rxEnabled: boolean;
+  readonly txEnabled: boolean;
+  readonly monitorMode: 'live' | 'radio' | 'mute';
+  readonly volume: number;          // 0..1
+  readonly wsConnected: boolean;
+  readonly txSupported: boolean;
+
+  setMonitorMode(mode: 'live' | 'radio' | 'mute'): void;
+  setVolume(v: number): void;
+  startTx(): Promise<string | null>;
+  stopTx(): void;
+}
+```
+
+Owns: `/api/v1/audio` WS, `RxPlayer`, `TxMic`, codec negotiation, `AudioContext` lifecycle.
+
+Does not own: AF level radio command — that goes through `cmd()`.
+
+### ScopeController
+
+```typescript
+interface ScopeController {
+  readonly hardwareScopeAvailable: boolean;
+  readonly audioScopeAvailable: boolean;
+  readonly activeScope: 'hardware' | 'audio-fft' | null;
+
+  readonly scopeFrame: ScopeFrame | null;
+  readonly audioScopeFrame: AudioScopeFrame | null;
+}
+```
+
+Owns: `/api/v1/scope` and `/api/v1/audio-scope` WS connections, binary frame parsing.
+
+Presentation components consume `scopeFrame`/`audioScopeFrame` — they never open channels.
+
+### SystemController
+
+```typescript
+interface SystemController {
+  powerOn(): Promise<void>;
+  powerOff(): Promise<void>;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  identifyFrequency(freqHz: number): Promise<EibiResult | null>;
+}
+```
+
+Owns: all HTTP calls to backend (`/api/v1/radio/power`, `/api/v1/eibi/identify`, etc.).
+
+---
+
+## Layer 2: View-model adapters
+
+### Contract
+
+Adapters are **pure functions**. No side effects, no subscriptions, no imports from transport/audio/WS.
+
+```typescript
+type Adapter<T> = (
+  state: RadioState,
+  caps: Capabilities,
+  audio: AudioController,
+  receiver?: 'main' | 'sub',
+) => T;
+```
+
+Each adapter returns a typed view-model with:
+
+- derived display values
+- semantic callbacks (bound from runtime controllers)
+
+### Examples
+
+```typescript
+interface VfoViewModel {
+  freqHz: number;
+  mode: string;
+  filter: number;
+  dataMode: boolean;
+  isActive: boolean;
+  badges: Badge[];
+  onFreqChange: (hz: number) => void;
+  onModeChange: (mode: string) => void;
+  onFilterChange: (filter: number) => void;
+}
+
+interface RxAudioViewModel {
+  monitorMode: 'live' | 'radio' | 'mute';
+  hasLiveAudio: boolean;
+  volume: number;
+  muted: boolean;
+  onMonitorModeChange: (mode: string) => void;
+  onVolumeChange: (v: number) => void;
+}
+
+interface MeterViewModel {
+  sMeter: number;
+  swr: number | null;
+  power: number | null;
+  alc: number | null;
+  comp: number | null;
+  activeTxMeter: 'swr' | 'power' | 'alc' | 'comp';
+}
+
+interface ScopeViewModel {
+  available: boolean;
+  frame: ScopeFrame | null;
+  onTuneToFreq: (hz: number) => void;
+  onSpanChange: (span: number) => void;
+}
+```
+
+### Adapter location
+
+`frontend/src/adapters/` — one file per domain (vfo, audio, meter, scope, rf, tx, memory, system).
+
+### What adapters replace
+
+The existing `state-adapter.ts` and `command-bus.ts` are the embryonic form of this layer. Migration should refactor them into the adapter pattern, not duplicate alongside.
+
+---
+
+## Layer 3: Semantic components
+
+### Contract
+
+A semantic component represents a **radio concept** with a stable typed interface.
+
+Rules:
+
+- receives only semantic props and callbacks
+- no transport imports (`sendCommand`, `getChannel`, `audioManager`)
+- no backend endpoint knowledge
+- no concrete skin assumptions
+- framework-level logic only (event handling, conditional rendering, a11y)
+
+### Semantic component list
+
+| Component | Props (key fields) | Callbacks |
+|---|---|---|
+| `VfoDisplay` | freq, mode, filter, dataMode, badges | onFreqChange, onModeChange, onFilterChange |
+| `RxAudioControl` | monitorMode, hasLiveAudio, volume, muted | onMonitorModeChange, onVolumeChange |
+| `TxControl` | pttActive, txEnabled, txSupported | onPttToggle, onStartTx, onStopTx |
+| `MeterPanel` | sMeter, swr, power, alc, comp | — |
+| `ScopeSurface` | available, frame | onTuneToFreq, onSpanChange |
+| `BandSelector` | currentBand, bands | onBandChange |
+| `ModeSelector` | currentMode, modes | onModeChange |
+| `FilterSelector` | currentFilter, filters | onFilterChange |
+| `RfFrontEnd` | att, preamp, nb, nr, rfGain, squelch | onChange per field |
+| `DspControl` | notch, tpf, contour | onChange per field |
+| `MemoryControl` | channels, activeChannel | onRecall, onStore, onClear |
+| `StatusIndicator` | connected, radioReady, wsHealth | onReconnect |
+
+### Svelte 5 pattern
+
+Semantic components use `children: Snippet` or typed props — no `<slot>`. Skins provide concrete rendering.
+
+```svelte
+<!-- semantic/RxAudioControl.svelte -->
+<script lang="ts">
+  interface Props {
+    monitorMode: 'live' | 'radio' | 'mute';
+    hasLiveAudio: boolean;
+    volume: number;
+    muted: boolean;
+    onMonitorModeChange: (mode: string) => void;
+    onVolumeChange: (v: number) => void;
+  }
+  let { monitorMode, hasLiveAudio, volume, muted,
+        onMonitorModeChange, onVolumeChange }: Props = $props();
+</script>
+
+<!-- Semantic components can render directly or delegate to skin -->
+<!-- The key constraint: no runtime imports above -->
+```
+
+---
+
+## Layer 4: Presentation (Skin + Theme + Layout)
+
+### Three independent knobs
+
+| Knob | Changes | Mechanism | Example |
+|---|---|---|---|
+| **Theme** | Colors, fonts, spacing, shadows | CSS custom properties | `dracula.css`, `nord.css`, `crt-green.css` |
+| **Skin** | Visual implementation of semantic components | Concrete Svelte components | `AmberFrequency` vs `IndustrialFrequency` |
+| **Layout** | Spatial arrangement of components on screen | Grid/flex composition in skin top-level | `DesktopGrid` vs `MobileTabs` vs `LcdColumn` |
+
+**Theme** does not change component identity.
+**Skin** does not change behavior contracts.
+**Layout** does not change transport ownership.
+
+### Skin implementation (Svelte 5)
+
+Each skin is a concrete Svelte component receiving `FrontendRuntime` as its single prop:
+
+```svelte
+<!-- skins/amber-lcd/LcdSkin.svelte -->
+<script lang="ts">
+  import type { FrontendRuntime } from '../../runtime/types';
+  import { toVfoProps, toRxAudioProps, toMeterProps } from '../../adapters';
+
+  import AmberFrequency from './AmberFrequency.svelte';
+  import AmberMeter from './AmberMeter.svelte';
+  import AmberAudioStrip from './AmberAudioStrip.svelte';
+  import LcdFrame from './LcdFrame.svelte';
+
+  interface Props { runtime: FrontendRuntime }
+  let { runtime }: Props = $props();
+
+  const vfo = $derived(toVfoProps(runtime.state, runtime.capabilities, runtime.audio, 'main'));
+  const audio = $derived(toRxAudioProps(runtime.state, runtime.capabilities, runtime.audio));
+  const meter = $derived(toMeterProps(runtime.state, runtime.capabilities));
+</script>
+
+<LcdFrame>
+  <AmberFrequency freq={vfo.freqHz} mode={vfo.mode} />
+  <AmberMeter sMeter={meter.sMeter} />
+  <AmberAudioStrip
+    mode={audio.monitorMode}
+    volume={audio.volume}
+    onModeChange={audio.onMonitorModeChange}
+    onVolumeChange={audio.onVolumeChange}
+  />
+</LcdFrame>
+```
+
+### Skin resolution and lazy loading
+
+```typescript
+// skins/registry.ts
+type SkinId = 'desktop-v2' | 'amber-lcd' | 'mobile';
+
+function resolveSkinId(ctx: {
+  capabilities: Capabilities;
+  userPreference: 'auto' | 'lcd' | 'standard';
+  isMobile: boolean;
+}): SkinId {
+  if (ctx.isMobile) return 'mobile';
+  if (ctx.userPreference === 'lcd') return 'amber-lcd';
+  if (ctx.userPreference === 'standard') return 'desktop-v2';
+  return ctx.capabilities.scope ? 'desktop-v2' : 'amber-lcd';
+}
+
+const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
+  'desktop-v2': () => import('./desktop-v2/DesktopSkin.svelte'),
+  'amber-lcd':  () => import('./amber-lcd/LcdSkin.svelte'),
+  'mobile':     () => import('./mobile/MobileSkin.svelte'),
+};
+```
+
+### App entry point (target)
+
+```svelte
+<!-- App.svelte -->
+<script lang="ts">
+  import { runtime } from './runtime';
+  import { resolveSkinId, loadSkin } from './skins/registry';
+
+  const skinId = $derived(resolveSkinId({
+    capabilities: runtime.capabilities,
+    userPreference: runtime.layoutPreference,
+    isMobile: runtime.isMobile,
+  }));
+
+  let SkinComponent = $state(null);
+  $effect(() => {
+    loadSkin(skinId).then(c => { SkinComponent = c; });
+  });
+</script>
+
+{#if SkinComponent}
+  <SkinComponent {runtime} />
+{:else}
+  <div class="loading">Loading...</div>
+{/if}
+```
+
+### Layout slot model
+
+Each skin's layout arranges semantic components into named zones:
+
+| Slot | Desktop V2 | LCD | Mobile |
+|---|---|---|---|
+| `header` | VfoHeader + StatusBar | StatusBar | Compact VFO + status |
+| `leftRail` | Band, mode, filter, RF groups | LeftSidebar | — (tabbed) |
+| `centerPrimary` | Hardware scope | AmberLcdDisplay | Scope or LCD |
+| `centerSecondary` | Audio FFT / waterfall | Audio FFT (if available) | — |
+| `rightRail` | Audio, DSP, TX, CW groups | RightSidebar | — (tabbed) |
+| `bottomDock` | Meters, DX cluster | — | Bottom bar |
+| `overlay` | Modals, freq entry, settings | Same | Same |
+
+Skins are not required to fill all slots. Empty slots render nothing.
+
+### Theme architecture
+
+Unchanged from current system — 20+ CSS variable themes, applied via `data-theme` attribute:
+
+```css
+[data-theme="dracula"] {
+  --bg: #282a36;
+  --panel: #44475a;
+  --text: #f8f8f2;
+  --accent: #bd93f9;
+  /* ... */
+}
+```
+
+Themes are orthogonal to skins. Any theme can be applied to any skin (within reason — amber-lcd may have its own locked theme token set).
+
+---
+
+## Target file structure
+
+```
+frontend/src/
+├── runtime/                          # Layer 1
+│   ├── index.ts                      # createRuntime(), singleton export
+│   ├── types.ts                      # FrontendRuntime, controller interfaces
+│   ├── audio-controller.ts           # AudioController implementation
+│   ├── scope-controller.ts           # ScopeController implementation
+│   ├── system-controller.ts          # SystemController implementation
+│   ├── command-dispatcher.ts         # cmd() + optimistic patches
+│   ├── connection-monitor.ts         # health, reconnect, backoff
+│   └── capability-resolver.ts        # normalize caps into stable flags
+│
+├── adapters/                         # Layer 2
+│   ├── index.ts                      # re-export all adapters
+│   ├── vfo.ts
+│   ├── audio.ts
+│   ├── meter.ts
+│   ├── scope.ts
+│   ├── rf.ts
+│   ├── tx.ts
+│   ├── memory.ts
+│   └── system.ts
+│
+├── semantic/                         # Layer 3
+│   ├── VfoDisplay.svelte
+│   ├── RxAudioControl.svelte
+│   ├── TxControl.svelte
+│   ├── MeterPanel.svelte
+│   ├── ScopeSurface.svelte
+│   ├── BandSelector.svelte
+│   ├── ModeSelector.svelte
+│   ├── FilterSelector.svelte
+│   ├── RfFrontEnd.svelte
+│   ├── DspControl.svelte
+│   ├── MemoryControl.svelte
+│   └── StatusIndicator.svelte
+│
+├── primitives/                       # Shared visual atoms
+│   ├── SegmentedButton.svelte
+│   ├── Knob.svelte
+│   ├── LinearMeter.svelte
+│   ├── SevenSegment.svelte
+│   ├── FrequencyDigits.svelte
+│   ├── CanvasRenderer.svelte
+│   ├── PanelFrame.svelte
+│   └── StatusPill.svelte
+│
+├── skins/                            # Layer 4 — visual implementations
+│   ├── registry.ts                   # resolveSkinId(), loadSkin()
+│   ├── desktop-v2/
+│   │   ├── DesktopSkin.svelte
+│   │   ├── DesktopVfo.svelte
+│   │   ├── DesktopMeter.svelte
+│   │   └── ...
+│   ├── amber-lcd/
+│   │   ├── LcdSkin.svelte
+│   │   ├── AmberFrequency.svelte
+│   │   ├── AmberMeter.svelte
+│   │   └── ...
+│   └── mobile/
+│       ├── MobileSkin.svelte
+│       ├── CompactVfo.svelte
+│       └── ...
+│
+├── themes/                           # CSS tokens
+│   ├── tokens.css                    # base design tokens
+│   ├── dark.css
+│   ├── dracula.css
+│   ├── nord.css
+│   └── ...
+│
+├── stores/                           # Svelte 5 reactive stores (kept)
+│   └── ...                           # migrated into runtime/ over time
+│
+├── lib/                              # Shared utilities (non-runtime)
+│   ├── renderers/                    # Canvas engines (framework-agnostic)
+│   ├── utils/                        # Formatting, smoothing, etc.
+│   ├── data/                         # ARRL band plan, etc.
+│   └── gestures/                     # Touch gesture recognizers
+│
+└── App.svelte                        # Entry point → skin resolver
+```
+
+---
+
+## Architectural invariants
+
+These must hold at all times after migration. Violation = regression.
+
+### INV-1: Single RX playback path
+
+All layouts route through the same `AudioController`. Codec negotiation, WS subscription, decoding, volume, and mute are layout-independent.
+
+### INV-2: Single scope ownership per type
+
+Hardware scope and audio FFT are owned by `ScopeController`. Layouts choose whether and where to render — never whether to connect.
+
+### INV-3: `scope=false + audio=true` is first-class
+
+Absence of hardware scope must never alter audio behavior. LCD fallback is a presentation concern, not a runtime concern.
+
+### INV-4: Capability gating precedes presentation
+
+Panels do not independently decide whether backend capability exists. Runtime/adapters expose stable booleans (`hasLiveAudio`, `hasHardwareScope`, `hasTx`).
+
+### INV-5: Mount/unmount does not change transport
+
+Swapping layouts or mounting/unmounting visual components must not start or stop transports.
+
+### INV-6: No runtime imports in presentation
+
+Presentation components (semantic, skins, primitives) must not import from `runtime/`, `$lib/transport/`, or `$lib/audio/audio-manager`. Enforced by eslint.
+
+---
+
+## Import boundary rules
+
+### Allowed
+
+| Component type | May import from |
+|---|---|
+| Runtime | `$lib/transport`, `$lib/audio`, stores, types |
+| Adapters | Runtime types (read-only), utilities |
+| Semantic | Adapter types, primitives, Svelte, types |
+| Skins | Semantic, primitives, adapters, themes, Svelte |
+| Primitives | Themes, Svelte, types |
+
+### Forbidden
+
+| Component type | Must NOT import from |
+|---|---|
+| Semantic | `runtime/`, `$lib/transport/`, `$lib/audio/audio-manager` |
+| Skins | `runtime/` (except `FrontendRuntime` type via props), transport, audio |
+| Primitives | Runtime, adapters, transport, audio, stores |
+
+### eslint enforcement
+
+```jsonc
+{
+  "rules": {
+    "no-restricted-imports": ["error", {
+      "patterns": [{
+        "group": ["$lib/transport/*", "$lib/audio/audio-manager"],
+        "message": "Use adapter props. See ADR 2026-04-12."
+      }]
+    }]
+  },
+  "overrides": [{
+    "files": ["src/runtime/**", "src/adapters/**"],
+    "rules": { "no-restricted-imports": "off" }
+  }]
+}
+```
+
+---
+
+## Anti-patterns
+
+### 1. Skin imports runtime directly
+
+Turns skins into hidden behavior forks. Skin receives `FrontendRuntime` as a prop from `App.svelte` — it never imports the singleton.
+
+### 2. Theme contains behavior flags
+
+Theme is for tokens only. Feature decisions belong in runtime/adapters.
+
+### 3. Layout decides transport based on mount state
+
+This is the current root cause of drift. Runtime owns transport lifecycle; layout only renders data.
+
+### 4. Semantic component accepts escape hatches
+
+Props like `rawWsData` or `onRawCommand` destroy the semantic boundary. If a semantic component needs new behavior, extend the adapter.
+
+### 5. LCD treated as special case
+
+LCD is a skin + layout variant over shared runtime. It is not a separate code path. No `if (isLcd)` in runtime or adapters.
+
+### 6. Duplicated protocol parsing
+
+Scope frame parsing, audio header parsing — all binary protocol logic lives in runtime controllers. Never in rendering components.
+
+---
+
+## Migration coexistence
+
+During Phases 4-5, old and new code coexist:
+
+1. New skins live in `skins/` — existing `components-v2/` untouched initially
+2. Feature flag `?skin=unified` in `App.svelte` activates new path
+3. Old layouts remain default until parity gate passes
+4. Phase 6 removes old layouts after confirmation
+
+---
+
+## Evidence gates
+
+| After phase | Gate |
+|---|---|
+| Phase 0 | RX audio failure classified with evidence; eslint guardrails active |
+| Phase 2 | One controller-owned audio/scope path; no presentation-owned WS connections |
+| Phase 3 | Semantic component contracts stable for both desktop and LCD |
+| Before Phase 6 | All 4 capability scenarios pass; Scenario B (`scope=false + audio=true`) explicitly verified; manual hardware validation |
+
+---
+
+## Relationship to existing code
+
+| Current code | Target equivalent | Migration action |
+|---|---|---|
+| `lib/audio/audio-manager.ts` | `runtime/audio-controller.ts` | Refactor into controller with same internal logic |
+| `components-v2/wiring/state-adapter.ts` | `adapters/*.ts` | Split into per-domain adapters |
+| `components-v2/wiring/command-bus.ts` | `runtime/command-dispatcher.ts` + adapter callbacks | Extract command dispatch to runtime, bind callbacks in adapters |
+| `lib/stores/*.svelte.ts` | `runtime/` internal state | Stores become implementation detail of runtime |
+| `lib/transport/ws-client.ts` | `runtime/` internal | Transport is private to runtime |
+| `components-v2/layout/RadioLayout.svelte` | `skins/desktop-v2/DesktopSkin.svelte` | Rewrite as skin |
+| `components-v2/layout/LcdLayout.svelte` | `skins/amber-lcd/LcdSkin.svelte` | Rewrite as skin |
+| `components-v2/panels/*.svelte` | `semantic/*.svelte` + `skins/*/` visual parts | Split semantic contract from visual implementation |
+| `components-v2/theme/` | `themes/` | Move as-is |
+
+---
+
+## Summary
+
+This architecture guarantees:
+
+- **New skin** = new directory in `skins/`, zero changes to runtime/adapters/semantic
+- **New radio capability** = changes in runtime + adapter, zero changes to skins
+- **Audio bug** = fixed in one place (`runtime/audio-controller.ts`), works identically in all skins
+- **Behavioral parity** = enforced architecturally (one runtime, one adapter set) and by eslint
+- **No code duplication** = protocol parsing once in runtime, semantic logic once in adapters, visual variants only in skins

--- a/docs/plans/mypy-remaining-errors.md
+++ b/docs/plans/mypy-remaining-errors.md
@@ -1,0 +1,30 @@
+# Remaining mypy errors (post-P0 fix)
+
+After the 2026-03 mypy pass, the following categories of errors remain. Prefer real type fixes over broad `type: ignore`.
+
+## Summary
+
+- **Count:** 202 errors in 8 files (down from ~394 in 22 files).
+- **Strategy:** Extend `radio_protocol.Radio` / `AudioCapable` / `ScopeCapable` with missing method stubs, or narrow types at call sites (e.g. cast to `IcomRadio` where backend is known).
+
+## By file
+
+| File | Main issues |
+|------|-------------|
+| **radio.py** | `CivFrame \| None` passed to parsers; `no-any-return`; untyped `_scope_controls`; `int(object)` overload; protocol arg-type for `CivRuntime`/`ControlPhaseRuntime`. |
+| **cli.py** | `Radio` has no `__aenter__`/`__aexit__`; `AudioCapable` missing `start_audio_rx_pcm`, `stop_audio_rx_pcm`, `start_audio_tx_pcm`, `stop_audio_tx_pcm`, `push_audio_tx_pcm`, `get_audio_stats`; `Radio` missing many optional methods (antenna, date/time, dual_watch, tuner, attenuator, preamp, send_cw_text); `ScopeCapable` missing `capture_scope_frame`, `capture_scope_frames`. |
+| **web/radio_poller.py** | Same as cli: `AudioCapable`/`ScopeCapable`/`Radio` missing methods. |
+| **web/handlers.py** | `Radio` missing `get_system_date`, `get_system_time`, `get_dual_watch`, `get_tuner_status`, `set_tuner_status`. |
+| **audio_bridge.py** | `Radio` has no `audio_bus`; optional streams/subscription/decoder (`None`); `find_loopback_device` return; `_silence` annotation. |
+| **backends/icom7610/serial.py** | `SerialControlTransport`/`SerialCivTransport` assigned to `IcomTransport`; `Icom7610SerialRadio` missing mixin-style methods (`_advance_civ_generation`, `_start_civ_rx_pump`, etc.); task `None` check. |
+| **civ.py** | Assignment between `_PendingRequest` and `_AckWaiter`; `Future[CivFrame] \| None` attribute access. |
+| **scope_render.py** | `THEMES` / colormap values typed as `object`; index/cast for RGB tuples. |
+| **_control_phase.py** | — (fixed) |
+
+## Recommended next steps
+
+1. **radio_protocol:** Add optional method stubs to `Radio`, `AudioCapable`, `ScopeCapable` (and optionally a single “extended” protocol) for all IC-7610-specific methods used by web/cli/audio_bridge, so that `Radio`-typed call sites type-check when given `IcomRadio`.
+2. **Backends/serial:** Either make `Icom7610SerialRadio` inherit or compose the same control-phase/civ helpers as LAN (so it satisfies the same protocol), or introduce a shared protocol that both LAN and serial implement.
+3. **radio.py:** Add `assert frame is not None` or narrow types before calling parse_*; type `_scope_controls`; fix `int()` overload with explicit cast or guard.
+4. **civ.py:** Use a union type or separate variables for ack vs pending state so assignment is consistent.
+5. **scope_render:** Use typed dict or cast for THEMES/colormap entries (e.g. `tuple[int, int, int]`).

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -13,7 +13,6 @@ import { TxMic } from './tx-mic';
 import { setAudioConnected } from '../stores/connection.svelte';
 import { getRadioState } from '../stores/radio.svelte';
 import { setRxEnabled, setTxEnabled } from '../stores/audio.svelte';
-import { CODEC_OPUS, CODEC_PCM16, parseRxHeader } from './constants';
 
 const BACKOFF_MIN = 500;
 const BACKOFF_MAX = 10000;
@@ -27,7 +26,6 @@ class AudioManager {
   private backoff = BACKOFF_MIN;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private _listeners: Set<() => void> = new Set();
-  private rxHeaderLogCount = 0;
 
   // Reactive state (read externally)
   get rxEnabled(): boolean { return this._rxEnabled; }
@@ -144,7 +142,6 @@ class AudioManager {
 
     ws.onopen = () => {
       this.backoff = BACKOFF_MIN;
-      this.rxHeaderLogCount = 0;
       setAudioConnected(true);
       console.log('[audio-ws] connected');
       if (this._rxEnabled) {
@@ -157,31 +154,9 @@ class AudioManager {
       this.notify();
     };
 
-    let frameCount = 0;
     ws.onmessage = (ev) => {
       if (ev.data instanceof ArrayBuffer) {
-        frameCount++;
-        if (this.rxHeaderLogCount < 5) {
-          const hdr = parseRxHeader(ev.data);
-          if (!hdr) {
-            console.warn(`[audio-ws] RX frame #${frameCount} has invalid header bytes=${ev.data.byteLength}`);
-          } else {
-            const codecName = hdr.codec === CODEC_PCM16
-              ? 'PCM16'
-              : hdr.codec === CODEC_OPUS
-                ? 'OPUS'
-                : `0x${hdr.codec.toString(16).padStart(2, '0')}`;
-            console.info(
-              `[audio-ws] RX frame #${frameCount} codec=${codecName} sr=${hdr.sampleRate} ch=${hdr.channels} payload=${hdr.payload.byteLength}`,
-            );
-          }
-          this.rxHeaderLogCount++;
-        }
-        try {
-          this.rxPlayer.feed(ev.data);
-        } catch (e) {
-          if (frameCount <= 3) console.error(`[audio-ws] feed error on frame #${frameCount}:`, e);
-        }
+        this.rxPlayer.feed(ev.data);
       }
     };
 
@@ -191,7 +166,7 @@ class AudioManager {
     };
 
     ws.onclose = (ev) => {
-      console.warn(`[audio-ws] closed code=${ev.code} reason=${ev.reason} frames=${frameCount} rxEnabled=${this._rxEnabled}`);
+      console.warn(`[audio-ws] closed code=${ev.code} reason=${ev.reason}`);
       this.ws = null;
       setAudioConnected(false);
       this.notify();

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -13,6 +13,7 @@ import { TxMic } from './tx-mic';
 import { setAudioConnected } from '../stores/connection.svelte';
 import { getRadioState } from '../stores/radio.svelte';
 import { setRxEnabled, setTxEnabled } from '../stores/audio.svelte';
+import { CODEC_OPUS, CODEC_PCM16, parseRxHeader } from './constants';
 
 const BACKOFF_MIN = 500;
 const BACKOFF_MAX = 10000;
@@ -26,6 +27,7 @@ class AudioManager {
   private backoff = BACKOFF_MIN;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private _listeners: Set<() => void> = new Set();
+  private rxHeaderLogCount = 0;
 
   // Reactive state (read externally)
   get rxEnabled(): boolean { return this._rxEnabled; }
@@ -142,6 +144,7 @@ class AudioManager {
 
     ws.onopen = () => {
       this.backoff = BACKOFF_MIN;
+      this.rxHeaderLogCount = 0;
       setAudioConnected(true);
       console.log('[audio-ws] connected');
       if (this._rxEnabled) {
@@ -158,10 +161,26 @@ class AudioManager {
     ws.onmessage = (ev) => {
       if (ev.data instanceof ArrayBuffer) {
         frameCount++;
+        if (this.rxHeaderLogCount < 5) {
+          const hdr = parseRxHeader(ev.data);
+          if (!hdr) {
+            console.warn(`[audio-ws] RX frame #${frameCount} has invalid header bytes=${ev.data.byteLength}`);
+          } else {
+            const codecName = hdr.codec === CODEC_PCM16
+              ? 'PCM16'
+              : hdr.codec === CODEC_OPUS
+                ? 'OPUS'
+                : `0x${hdr.codec.toString(16).padStart(2, '0')}`;
+            console.info(
+              `[audio-ws] RX frame #${frameCount} codec=${codecName} sr=${hdr.sampleRate} ch=${hdr.channels} payload=${hdr.payload.byteLength}`,
+            );
+          }
+          this.rxHeaderLogCount++;
+        }
         try {
           this.rxPlayer.feed(ev.data);
         } catch (e) {
-          if (frameCount <= 3) console.error('[audio-ws] feed error:', e);
+          if (frameCount <= 3) console.error(`[audio-ws] feed error on frame #${frameCount}:`, e);
         }
       }
     };

--- a/frontend/src/lib/audio/rx-player.ts
+++ b/frontend/src/lib/audio/rx-player.ts
@@ -18,10 +18,6 @@ export class RxPlayer {
   private nextPlayTime = 0;
   private opusTs = 0;
   private _volume = 1.0;
-  private loggedSuspendedPcm = false;
-  private loggedSuspendedOpus = false;
-  private loggedMissingDecoder = false;
-  private loggedDecoderInit = false;
 
   get volume(): number {
     return this._volume;
@@ -38,40 +34,20 @@ export class RxPlayer {
 
   start(): void {
     if (this.ctx) {
-      if (this.ctx.state === 'suspended') {
-        console.info('[rx-player] reusing suspended AudioContext; attempting resume');
-        this.ctx.resume()
-          .then(() => {
-            console.info(`[rx-player] AudioContext resumed (state=${this.ctx?.state ?? 'none'})`);
-          })
-          .catch((err) => {
-            console.warn('[rx-player] AudioContext resume failed', err);
-          });
-      }
+      if (this.ctx.state === 'suspended') this.ctx.resume();
       return;
     }
     const Ctx = globalThis.AudioContext ?? (globalThis as any).webkitAudioContext;
     if (!Ctx) return;
     this.ctx = new Ctx({ sampleRate: SAMPLE_RATE });
-    this.ctx.onstatechange = () => {
-      console.info(`[rx-player] AudioContext state=${this.ctx?.state ?? 'none'}`);
-    };
     this.gain = this.ctx.createGain();
     this.gain.gain.value = this._volume;
     this.gain.connect(this.ctx.destination);
     this.nextPlayTime = 0;
-    console.info(`[rx-player] AudioContext created sampleRate=${this.ctx.sampleRate} state=${this.ctx.state}`);
     // Resume suspended context. When it transitions to 'running',
     // playPcm16/decodeOpus will start scheduling buffers automatically.
     if (this.ctx.state === 'suspended') {
-      console.info('[rx-player] initial AudioContext is suspended; attempting resume');
-      this.ctx.resume()
-        .then(() => {
-          console.info(`[rx-player] initial resume resolved state=${this.ctx?.state ?? 'none'}`);
-        })
-        .catch((err) => {
-          console.warn('[rx-player] initial AudioContext resume failed', err);
-        });
+      this.ctx.resume().catch(() => {});
     }
   }
 
@@ -87,10 +63,6 @@ export class RxPlayer {
     }
     this.nextPlayTime = 0;
     this.opusTs = 0;
-    this.loggedSuspendedPcm = false;
-    this.loggedSuspendedOpus = false;
-    this.loggedMissingDecoder = false;
-    this.loggedDecoderInit = false;
   }
 
   /** Feed a raw binary frame from WS */
@@ -114,15 +86,7 @@ export class RxPlayer {
 
   private playPcm16(payload: Uint8Array, sr: number, ch: number): void {
     if (!this.ctx || !this.gain) return;
-    if (this.ctx.state === 'suspended') {
-      if (!this.loggedSuspendedPcm) {
-        this.loggedSuspendedPcm = true;
-        console.warn(
-          `[rx-player] skipping PCM16 playback while AudioContext is suspended payload=${payload.byteLength} sr=${sr} ch=${ch}`,
-        );
-      }
-      return; // wait for resume
-    }
+    if (this.ctx.state === 'suspended') return; // wait for resume
     const channels = ch === 2 ? 2 : 1;
     const frameCount = Math.floor(payload.byteLength / (2 * channels));
     if (frameCount <= 0) return;
@@ -142,32 +106,12 @@ export class RxPlayer {
 
   private decodeOpus(payload: Uint8Array, sr: number, ch: number): void {
     if (!this.ctx || !this.gain) return;
-    if (this.ctx.state === 'suspended') {
-      if (!this.loggedSuspendedOpus) {
-        this.loggedSuspendedOpus = true;
-        console.warn(
-          `[rx-player] skipping Opus decode while AudioContext is suspended payload=${payload.byteLength} sr=${sr} ch=${ch}`,
-        );
-      }
-      return;
-    }
-    if (typeof AudioDecoder === 'undefined') {
-      if (!this.loggedMissingDecoder) {
-        this.loggedMissingDecoder = true;
-        console.warn(
-          `[rx-player] AudioDecoder unavailable; cannot play Opus payload=${payload.byteLength} sr=${sr} ch=${ch}`,
-        );
-      }
-      return;
-    }
+    if (this.ctx.state === 'suspended') return;
+    if (typeof AudioDecoder === 'undefined') return;
 
     if (!this.decoder) {
       const ctx = this.ctx;
       this.opusTs = 0;
-      if (!this.loggedDecoderInit) {
-        this.loggedDecoderInit = true;
-        console.info(`[rx-player] creating AudioDecoder sr=${sr > 0 ? sr : SAMPLE_RATE} ch=${ch === 2 ? 2 : 1}`);
-      }
       this.decoder = new AudioDecoder({
         output: (audioData: AudioData) => {
           const frames = audioData.numberOfFrames;

--- a/frontend/src/lib/audio/rx-player.ts
+++ b/frontend/src/lib/audio/rx-player.ts
@@ -18,6 +18,10 @@ export class RxPlayer {
   private nextPlayTime = 0;
   private opusTs = 0;
   private _volume = 1.0;
+  private loggedSuspendedPcm = false;
+  private loggedSuspendedOpus = false;
+  private loggedMissingDecoder = false;
+  private loggedDecoderInit = false;
 
   get volume(): number {
     return this._volume;
@@ -34,20 +38,40 @@ export class RxPlayer {
 
   start(): void {
     if (this.ctx) {
-      if (this.ctx.state === 'suspended') this.ctx.resume();
+      if (this.ctx.state === 'suspended') {
+        console.info('[rx-player] reusing suspended AudioContext; attempting resume');
+        this.ctx.resume()
+          .then(() => {
+            console.info(`[rx-player] AudioContext resumed (state=${this.ctx?.state ?? 'none'})`);
+          })
+          .catch((err) => {
+            console.warn('[rx-player] AudioContext resume failed', err);
+          });
+      }
       return;
     }
     const Ctx = globalThis.AudioContext ?? (globalThis as any).webkitAudioContext;
     if (!Ctx) return;
     this.ctx = new Ctx({ sampleRate: SAMPLE_RATE });
+    this.ctx.onstatechange = () => {
+      console.info(`[rx-player] AudioContext state=${this.ctx?.state ?? 'none'}`);
+    };
     this.gain = this.ctx.createGain();
     this.gain.gain.value = this._volume;
     this.gain.connect(this.ctx.destination);
     this.nextPlayTime = 0;
+    console.info(`[rx-player] AudioContext created sampleRate=${this.ctx.sampleRate} state=${this.ctx.state}`);
     // Resume suspended context. When it transitions to 'running',
     // playPcm16/decodeOpus will start scheduling buffers automatically.
     if (this.ctx.state === 'suspended') {
-      this.ctx.resume().catch(() => {});
+      console.info('[rx-player] initial AudioContext is suspended; attempting resume');
+      this.ctx.resume()
+        .then(() => {
+          console.info(`[rx-player] initial resume resolved state=${this.ctx?.state ?? 'none'}`);
+        })
+        .catch((err) => {
+          console.warn('[rx-player] initial AudioContext resume failed', err);
+        });
     }
   }
 
@@ -63,6 +87,10 @@ export class RxPlayer {
     }
     this.nextPlayTime = 0;
     this.opusTs = 0;
+    this.loggedSuspendedPcm = false;
+    this.loggedSuspendedOpus = false;
+    this.loggedMissingDecoder = false;
+    this.loggedDecoderInit = false;
   }
 
   /** Feed a raw binary frame from WS */
@@ -86,7 +114,15 @@ export class RxPlayer {
 
   private playPcm16(payload: Uint8Array, sr: number, ch: number): void {
     if (!this.ctx || !this.gain) return;
-    if (this.ctx.state === 'suspended') return; // wait for resume
+    if (this.ctx.state === 'suspended') {
+      if (!this.loggedSuspendedPcm) {
+        this.loggedSuspendedPcm = true;
+        console.warn(
+          `[rx-player] skipping PCM16 playback while AudioContext is suspended payload=${payload.byteLength} sr=${sr} ch=${ch}`,
+        );
+      }
+      return; // wait for resume
+    }
     const channels = ch === 2 ? 2 : 1;
     const frameCount = Math.floor(payload.byteLength / (2 * channels));
     if (frameCount <= 0) return;
@@ -106,12 +142,32 @@ export class RxPlayer {
 
   private decodeOpus(payload: Uint8Array, sr: number, ch: number): void {
     if (!this.ctx || !this.gain) return;
-    if (this.ctx.state === 'suspended') return;
-    if (typeof AudioDecoder === 'undefined') return;
+    if (this.ctx.state === 'suspended') {
+      if (!this.loggedSuspendedOpus) {
+        this.loggedSuspendedOpus = true;
+        console.warn(
+          `[rx-player] skipping Opus decode while AudioContext is suspended payload=${payload.byteLength} sr=${sr} ch=${ch}`,
+        );
+      }
+      return;
+    }
+    if (typeof AudioDecoder === 'undefined') {
+      if (!this.loggedMissingDecoder) {
+        this.loggedMissingDecoder = true;
+        console.warn(
+          `[rx-player] AudioDecoder unavailable; cannot play Opus payload=${payload.byteLength} sr=${sr} ch=${ch}`,
+        );
+      }
+      return;
+    }
 
     if (!this.decoder) {
       const ctx = this.ctx;
       this.opusTs = 0;
+      if (!this.loggedDecoderInit) {
+        this.loggedDecoderInit = true;
+        console.info(`[rx-player] creating AudioDecoder sr=${sr > 0 ? sr : SAMPLE_RATE} ch=${ch === 2 ? 2 : 1}`);
+      }
       this.decoder = new AudioDecoder({
         output: (audioData: AudioData) => {
           const frames = audioData.numberOfFrames;

--- a/src/icom_lan/usb_audio_resolve.py
+++ b/src/icom_lan/usb_audio_resolve.py
@@ -9,7 +9,8 @@ audio input/output device indices by correlating USB topology information.
 
 1. Parse the serial port's TTY suffix → find its ``locationID`` in IORegistry.
 2. Extract the upper 16 bits of ``locationID`` as the USB hub prefix.
-3. Find all ``USB Audio CODEC`` devices in IORegistry with their ``locationID``.
+3. Find all USB audio devices (``USB Audio CODEC``, ``USB Audio Device``) in
+   IORegistry with their ``locationID``.
 4. Match audio devices sharing the same hub prefix as the serial port.
 5. Map matched locations to ``sounddevice`` device indices by positional order.
 
@@ -230,11 +231,12 @@ def _run_ioreg() -> str | None:
         result = subprocess.run(
             ["/usr/sbin/ioreg", "-l"],
             capture_output=True,
-            text=True,
             timeout=10,
         )
         if result.returncode == 0:
-            return result.stdout
+            # ioreg may contain non-UTF-8 bytes (e.g. firmware blobs),
+            # decode leniently to avoid UnicodeDecodeError.
+            return result.stdout.decode("utf-8", errors="replace")
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
         logger.debug("usb-audio-resolve: ioreg failed: %s", exc)
     return None
@@ -258,14 +260,16 @@ def _find_serial_location(ioreg_text: str, tty_suffix: str) -> int | None:
 
 
 def _find_audio_codec_locations(ioreg_text: str) -> list[int]:
-    """Find all ``locationID`` values for ``USB Audio CODEC`` devices.
+    """Find all ``locationID`` values for USB audio devices.
 
-    Parses the IORegistry tree node addresses (e.g. ``USB Audio CODEC@20144000``)
-    to extract the location encoded in the node path, which is more reliable
-    than searching for nearby ``locationID`` properties.
+    Parses IORegistry tree node addresses to extract the location encoded
+    in the node path.  Supports multiple naming conventions:
+
+    - ``USB Audio CODEC@...`` — Icom (Burr-Brown/TI chip)
+    - ``USB Audio Device@...`` — Yaesu FTX-1 and similar
     """
     locations: list[int] = []
-    for m in re.finditer(r"USB Audio CODEC@([0-9a-fA-F]+)", ioreg_text):
+    for m in re.finditer(r"USB Audio (?:CODEC|Device)@([0-9a-fA-F]+)", ioreg_text):
         locations.append(int(m.group(1), 16))
     return sorted(locations)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -296,48 +296,54 @@ class TestMainEntryPoint:
             assert exc_info.value.code == 0
 
 
+def _run_main_serve(env_overrides: dict[str, str] | None = None) -> int:
+    """Run main() for 'serve' command, intercepting os._exit and the event loop.
+
+    main() uses asyncio.new_event_loop() + loop.run_until_complete() for serve,
+    then calls os._exit(). We must intercept os._exit to capture the exit code
+    and prevent process termination.
+    """
+    exit_code = -1
+
+    def fake_exit(code: int) -> None:
+        nonlocal exit_code
+        exit_code = code
+        raise SystemExit(code)
+
+    env = {"ICOM_PID_FILE": "", **(env_overrides or {})}
+    with patch.dict("os.environ", env, clear=False):
+        with patch("sys.argv", ["icom-lan", "--host", "127.0.0.1", "serve"]):
+            with patch("icom_lan.cli._run", new_callable=AsyncMock, return_value=0):
+                with patch("icom_lan.cli.os._exit", side_effect=fake_exit):
+                    with pytest.raises(SystemExit):
+                        main()
+    return exit_code
+
+
 class TestPidFile:
     """PID file is optional and only used for daemon-like commands (web, serve)."""
 
     def test_pid_file_not_created_when_icom_pid_file_unset(self):
         """Without ICOM_PID_FILE, Path.write_text is not called for PID."""
-        real_run = asyncio.run
-        with patch.dict("os.environ", {"ICOM_PID_FILE": ""}, clear=False):
-            with patch("sys.argv", ["icom-lan", "--host", "127.0.0.1", "serve"]):
-                with patch("icom_lan.cli._run", new_callable=AsyncMock, return_value=0):
-                    with patch("icom_lan.cli.asyncio.run") as mock_run:
-                        mock_run.side_effect = lambda coro: real_run(coro)
-                        with pytest.raises(SystemExit) as exc:
-                            main()
-                        assert exc.value.code == 0
-        # No Path.write_text for PID when ICOM_PID_FILE is empty
-        # (we did not patch Path, so no direct assertion; behavior is "no file path set")
+        code = _run_main_serve({"ICOM_PID_FILE": ""})
+        assert code == 0
 
     def test_pid_file_created_for_serve_when_icom_pid_file_set(self, tmp_path):
         """With ICOM_PID_FILE set, serve writes PID to that path and removes it on exit."""
         pid_path = tmp_path / "icom.pid"
-        real_run = asyncio.run
-        with patch.dict("os.environ", {"ICOM_PID_FILE": str(pid_path)}, clear=False):
-            with patch("sys.argv", ["icom-lan", "--host", "127.0.0.1", "serve"]):
-                with patch("icom_lan.cli._run", new_callable=AsyncMock, return_value=0):
-                    with patch("icom_lan.cli.asyncio.run") as mock_run:
-                        mock_run.side_effect = lambda coro: real_run(coro)
-                        with pytest.raises(SystemExit) as exc:
-                            main()
-                        assert exc.value.code == 0
-        assert not pid_path.exists()  # removed in finally
+        code = _run_main_serve({"ICOM_PID_FILE": str(pid_path)})
+        assert code == 0
+        assert not pid_path.exists()  # removed before os._exit
 
     def test_pid_file_not_created_for_status_even_when_icom_pid_file_set(
         self, tmp_path
     ):
         """With ICOM_PID_FILE set, status (non-daemon) does not write a PID file."""
         pid_path = tmp_path / "icom.pid"
-        real_run = asyncio.run
         with patch.dict("os.environ", {"ICOM_PID_FILE": str(pid_path)}, clear=False):
             with patch("sys.argv", ["icom-lan", "--host", "127.0.0.1", "status"]):
                 with patch("icom_lan.cli._run", new_callable=AsyncMock, return_value=0):
-                    with patch("icom_lan.cli.asyncio.run") as mock_run:
-                        mock_run.side_effect = lambda coro: real_run(coro)
+                    with patch("icom_lan.cli.os._exit", side_effect=lambda c: (_ for _ in ()).throw(SystemExit(c))):
                         with pytest.raises(SystemExit) as exc:
                             main()
                         assert exc.value.code == 0

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -841,20 +841,22 @@ def test_main_branches(monkeypatch, capsys: pytest.CaptureFixture[str]) -> None:
             main()
     sys_exit.assert_called_once_with(0)
 
-    def fake_interrupt(coro):
-        coro.close()
+    # Test KeyboardInterrupt handling — main() for 'status' uses
+    # loop.run_until_complete(_run(args)) → os._exit(), so we mock
+    # _run to raise KeyboardInterrupt and os._exit to capture the exit code.
+    async def _raise_interrupt(*a, **kw):
         raise KeyboardInterrupt
 
-    parser_run = DummyParser(SimpleNamespace(command="status"))
+    parser_run = DummyParser(SimpleNamespace(command="status", timeout=5))
+    captured_exit = []
     with (
         patch("icom_lan.cli._build_parser", return_value=parser_run),
-        patch("icom_lan.cli.asyncio.run", side_effect=fake_interrupt),
-        patch("icom_lan.cli.sys.exit", side_effect=SystemExit) as sys_exit,
+        patch("icom_lan.cli._run", side_effect=_raise_interrupt),
+        patch("icom_lan.cli.os._exit", side_effect=lambda c: captured_exit.append(c) or (_ for _ in ()).throw(SystemExit(c))),
     ):
         with pytest.raises(SystemExit):
             main()
-    sys_exit.assert_called_once_with(130)
-    assert "Interrupted, shutting down..." in capsys.readouterr().err
+    assert captured_exit == [130]
 
 
 @pytest.mark.asyncio

--- a/tests/test_usb_audio_resolve.py
+++ b/tests/test_usb_audio_resolve.py
@@ -84,6 +84,64 @@ IOREG_THREE_RADIOS = textwrap.dedent("""\
 """)
 
 
+# Yaesu FTX-1 ("USB Audio Device") alongside Icom IC-7610 ("USB Audio CODEC")
+# FTX-1: audio @ 0x20132200, serial HRI @ 0x20131000 (same hub prefix 0x2013)
+IOREG_YAESU_AND_ICOM = textwrap.dedent("""\
+    | +-o USB Audio Device@20132200  <class IOUSBHostDevice, id 0x1000d4711>
+    | |   "locationID" = 538124800
+    | |   "USB Product Name" = "USB Audio Device"
+    | +-o YAESU HRI USB I/F@20131000  <class IOUSBHostDevice, id 0x1000d470e>
+    | |   "locationID" = 538120192
+    | |   "USB Vendor Name" = "YAESUMUSEN"
+    | | +-o AppleUSBSLCOM
+    | |   | "IOTTYSuffix" = "01AE340D0"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbserial-01AE340D0"
+    | +-o USB Audio CODEC@01111400  <class IOUSBHostDevice, id 0x1000a9ab5>
+    | |   "locationID" = 17895424
+    | |   "USB Product Name" = "USB Audio CODEC"
+    | +-o CP2102 USB to UART Bridge Controller@01112000
+    | |   "locationID" = 17895936
+    | | +-o AppleUSBSLCOM
+    | |   | "IOTTYSuffix" = "111120"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbserial-111120"
+""")
+
+# Yaesu FTX-1 only (no Icom)
+# audio @ 0x20132200, serial HRI @ 0x20131000 (same hub prefix 0x2013)
+IOREG_YAESU_ONLY = textwrap.dedent("""\
+    | +-o USB Audio Device@20132200  <class IOUSBHostDevice, id 0x1000d4711>
+    | |   "locationID" = 538124800
+    | |   "USB Product Name" = "USB Audio Device"
+    | +-o YAESU HRI USB I/F@20131000  <class IOUSBHostDevice, id 0x1000d470e>
+    | |   "locationID" = 538120192
+    | | +-o AppleUSBSLCOM
+    | |   | "IOTTYSuffix" = "01AE340D0"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbserial-01AE340D0"
+""")
+
+
+def _make_mock_sd_mixed(
+    usb_codec_count: int = 1,
+    usb_device_count: int = 1,
+) -> MagicMock:
+    """Create a mock sounddevice with both "USB Audio CODEC" and "USB Audio Device" pairs."""
+    devices: list[dict[str, Any]] = [
+        {"name": "Built-in Speaker", "index": 0, "max_input_channels": 0, "max_output_channels": 2, "default_samplerate": 48000.0},
+    ]
+    for i in range(usb_device_count):
+        base_idx = len(devices)
+        devices.append({"name": "USB Audio Device", "index": base_idx, "max_input_channels": 0, "max_output_channels": 2, "default_samplerate": 48000.0})
+        devices.append({"name": "USB Audio Device", "index": base_idx + 1, "max_input_channels": 2, "max_output_channels": 0, "default_samplerate": 48000.0})
+    for i in range(usb_codec_count):
+        base_idx = len(devices)
+        devices.append({"name": "USB Audio CODEC", "index": base_idx, "max_input_channels": 0, "max_output_channels": 2, "default_samplerate": 48000.0})
+        devices.append({"name": "USB Audio CODEC", "index": base_idx + 1, "max_input_channels": 2, "max_output_channels": 0, "default_samplerate": 48000.0})
+    sd = MagicMock()
+    sd.query_devices.return_value = devices
+    sd.default.device = [-1, -1]
+    return sd
+
+
 def _make_mock_sd(
     usb_codec_count: int = 2,
 ) -> MagicMock:
@@ -165,6 +223,16 @@ class TestFindAudioCodecLocations:
     def test_three_radios(self) -> None:
         locs = _find_audio_codec_locations(IOREG_THREE_RADIOS)
         assert locs == [0x01111400, 0x20144000, 0x30144000]
+
+    def test_yaesu_usb_audio_device(self) -> None:
+        """Yaesu FTX-1 uses 'USB Audio Device' instead of 'USB Audio CODEC'."""
+        locs = _find_audio_codec_locations(IOREG_YAESU_ONLY)
+        assert locs == [0x20132200]
+
+    def test_mixed_yaesu_and_icom(self) -> None:
+        """Both Yaesu 'USB Audio Device' and Icom 'USB Audio CODEC' are found."""
+        locs = _find_audio_codec_locations(IOREG_YAESU_AND_ICOM)
+        assert locs == [0x01111400, 0x20132200]
 
 
 class TestFindSerialLocation:
@@ -296,6 +364,45 @@ class TestResolveMacos:
         assert result.location_prefix == 0x3014
         assert result.rx_device_index == 6  # input[2]
         assert result.tx_device_index == 5  # output[2]
+
+
+class TestResolveYaesu:
+    """Test resolution for Yaesu radios using 'USB Audio Device' naming."""
+
+    def test_yaesu_ftx1_alone(self) -> None:
+        sd = _make_mock_sd_mixed(usb_codec_count=0, usb_device_count=1)
+        result = _resolve_macos(
+            "/dev/cu.usbserial-01AE340D0",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_YAESU_ONLY,
+        )
+        assert result is not None
+        assert result.location_prefix == 0x2013
+        assert result.serial_port == "/dev/cu.usbserial-01AE340D0"
+
+    def test_yaesu_alongside_icom(self) -> None:
+        """Yaesu FTX-1 + Icom IC-7610 both resolved correctly."""
+        sd = _make_mock_sd_mixed(usb_codec_count=1, usb_device_count=1)
+        # Resolve Yaesu
+        result_yaesu = _resolve_macos(
+            "/dev/cu.usbserial-01AE340D0",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_YAESU_AND_ICOM,
+        )
+        assert result_yaesu is not None
+        assert result_yaesu.location_prefix == 0x2013
+
+        # Resolve Icom
+        result_icom = _resolve_macos(
+            "/dev/cu.usbserial-111120",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_YAESU_AND_ICOM,
+        )
+        assert result_icom is not None
+        assert result_icom.location_prefix == 0x0111
+
+        # Different devices
+        assert result_yaesu.rx_device_index != result_icom.rx_device_index
 
 
 class TestResolvePlatformDispatch:


### PR DESCRIPTION
## Summary

- **fix: Yaesu FTX-1 USB audio device not resolved** — IORegistry topology resolver only matched `USB Audio CODEC` (Icom); Yaesu FTX-1 registers as `USB Audio Device`. Expanded regex pattern to match both.
- **fix: `ioreg` UnicodeDecodeError** — IORegistry output may contain non-UTF-8 firmware blobs; now decoded with `errors='replace'`.
- **fix: TestPidFile hanging indefinitely** — `main()` uses `os._exit()` for serve/web commands, not `asyncio.run()`; tests now mock `os._exit` instead.
- **fix: 2 broken tests** — `test_main_branches` missing `timeout` attribute; `test_audio_broadcaster` struct unpack boundary on small packets.
- **docs: target frontend architecture ADR** (#646) — 4-layer architecture (runtime → adapters → semantic → skins), TypeScript interfaces, Svelte 5 skin mechanism, invariants, migration mapping. Visual HTML presentation included.
- **docs: track `docs/plans/` in repo** — research artifacts for epic #640.

## Root cause (#642)

FTX-1 audio was silent because the USB topology resolver (`usb_audio_resolve.py`) couldn't find the audio device in IORegistry — it only searched for `USB Audio CODEC@` but FTX-1 uses `USB Audio Device@`. The resolver fell through to a path that opened PortAudio with no device → zero-filled frames.

Secondary cause: macOS microphone permission must be granted to the terminal app (not just the radio app like WSJT-X). Documented for users.

## Test plan

- [x] `uv run pytest tests/test_usb_audio_resolve.py` — 34 passed (4 new Yaesu tests)
- [x] `uv run pytest tests/test_cli.py::TestPidFile` — 3 passed, no hang
- [x] `uv run pytest tests/test_cli_coverage.py::test_main_branches` — passed
- [x] `uv run pytest tests/test_handlers_coverage.py::test_audio_broadcaster_codec_and_frame_metadata` — passed
- [x] Frontend tests: 1437 passed
- [x] Frontend build: clean
- [x] Manual: FTX-1 audio plays in browser (confirmed peak>0 after permission grant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)