### PR TITLE
feat(#649): centralize audio/scope ownership — zero violations

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -47,7 +47,8 @@
     makeSystemHandlers, makeAntennaHandlers, makeScanHandlers,
   } from '../wiring/command-bus';
   import { getKeyboardConfig } from '$lib/stores/capabilities.svelte';
-  import { audioManager } from '$lib/audio/audio-manager';
+  import { getTxAudioControl } from '$lib/runtime/adapters/tx-adapter';
+  const txAudio = getTxAudioControl();
   import { onMount, onDestroy } from 'svelte';
 
   // ── State ──
@@ -289,12 +290,12 @@
 
   async function engageTx() {
     systemHandlers.onPttOn();
-    await audioManager.startTx();
+    await txAudio.startTx();
   }
 
   function disengageTx() {
     systemHandlers.onPttOff();
-    audioManager.stopTx();
+    txAudio.stopTx();
   }
 
   function pttDown() {

--- a/frontend/src/components-v2/panels/MemoryPanel.svelte
+++ b/frontend/src/components-v2/panels/MemoryPanel.svelte
@@ -6,7 +6,7 @@
    * so this panel tracks channel data locally (localStorage) and provides
    * controls for recall, store, clear, and channel selection.
    */
-  import { sendCommand } from '$lib/transport/ws-client';
+  import { runtime } from '$lib/runtime';
   import { radio } from '$lib/stores/radio.svelte';
   import { formatFrequencyString } from '../display/frequency-format';
 
@@ -54,8 +54,8 @@
   }
 
   function recallChannel(ch: number) {
-    sendCommand('set_memory_mode', { channel: ch });
-    sendCommand('memory_to_vfo', { channel: ch });
+    runtime.send('set_memory_mode', { channel: ch });
+    runtime.send('memory_to_vfo', { channel: ch });
     selectedChannel = ch;
   }
 
@@ -65,8 +65,8 @@
     const freq = rx?.freqHz ?? 0;
     const mode = rx?.mode ?? '';
 
-    sendCommand('set_memory_mode', { channel: ch });
-    sendCommand('memory_write', {});
+    runtime.send('set_memory_mode', { channel: ch });
+    runtime.send('memory_write', {});
 
     // Track locally
     const updated = new Map(channels);
@@ -77,7 +77,7 @@
   }
 
   function clearChannel(ch: number) {
-    sendCommand('memory_clear', { channel: ch });
+    runtime.send('memory_clear', { channel: ch });
 
     // Remove from local tracking
     const updated = new Map(channels);

--- a/frontend/src/components-v2/panels/TxPanel.svelte
+++ b/frontend/src/components-v2/panels/TxPanel.svelte
@@ -3,7 +3,8 @@
   import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
   import { hasTx, hasCapability } from '$lib/stores/capabilities.svelte';
   import { txStatusColor } from './tx-utils';
-  import { audioManager } from '$lib/audio/audio-manager';
+  import { getTxAudioControl } from '$lib/runtime/adapters/tx-adapter';
+  const txAudio = getTxAudioControl();
 
   interface Props {
     txActive: boolean;
@@ -54,7 +55,7 @@
 
   function startPttSafety() {
     clearPttSafety();
-    pttSafetyTimer = setTimeout(() => { pttMode = 'idle'; onPttOff?.(); audioManager.stopTx(); }, PTT_SAFETY_MS);
+    pttSafetyTimer = setTimeout(() => { pttMode = 'idle'; onPttOff?.(); txAudio.stopTx(); }, PTT_SAFETY_MS);
   }
   function clearPttSafety() {
     if (pttSafetyTimer) { clearTimeout(pttSafetyTimer); pttSafetyTimer = null; }
@@ -62,21 +63,21 @@
 
   function pttDown() {
     const now = Date.now();
-    if (pttMode === 'latched') { pttMode = 'idle'; onPttOff?.(); audioManager.stopTx(); clearPttSafety(); return; }
+    if (pttMode === 'latched') { pttMode = 'idle'; onPttOff?.(); txAudio.stopTx(); clearPttSafety(); return; }
     if (now - lastPttDown < PTT_DOUBLE_TAP_MS && pttMode === 'held') {
       pttMode = 'latched'; startPttSafety(); lastPttDown = 0; return;
     }
     lastPttDown = now;
     pttMode = 'held';
     onPttOn?.();
-    audioManager.startTx();
+    txAudio.startTx();
     startPttSafety();
   }
 
   function pttUp() {
     if (pttMode === 'held') {
       setTimeout(() => {
-        if (pttMode === 'held') { pttMode = 'idle'; onPttOff?.(); audioManager.stopTx(); clearPttSafety(); }
+        if (pttMode === 'held') { pttMode = 'idle'; onPttOff?.(); txAudio.stopTx(); clearPttSafety(); }
       }, PTT_DOUBLE_TAP_MS);
     }
   }

--- a/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
+++ b/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
@@ -2,29 +2,8 @@
   import { radio } from '$lib/stores/radio.svelte';
   import { resolveFilterModeConfig } from '../../wiring/state-adapter';
   import { getCapabilities } from '$lib/stores/capabilities.svelte';
-  import { getChannel } from '$lib/transport/ws-client';
-  import { markScopeFrame } from '$lib/stores/connection.svelte';
+  import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
   import AudioSpectrumCanvas from './AudioSpectrumCanvas.svelte';
-
-  // ── Scope frame parser (same as AmberLcdDisplay) ──
-
-  interface ScopeFrame {
-    receiver: number;
-    startFreq: number;
-    endFreq: number;
-    pixels: Uint8Array;
-  }
-
-  function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
-    const view = new DataView(buf);
-    if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
-    const receiver = view.getUint8(1);
-    const startFreq = view.getUint32(3, true);
-    const endFreq = view.getUint32(7, true);
-    const pixelCount = view.getUint16(14, true);
-    if (16 + pixelCount > view.byteLength) return null;
-    return { receiver, startFreq, endFreq, pixels: new Uint8Array(buf, 16, pixelCount) };
-  }
 
   // ── Radio state extraction ──
 
@@ -53,23 +32,14 @@
   let fftPush: ((data: Uint8Array) => void) | null = null;
 
   $effect(() => {
-    const scopeCh = getChannel('audio-scope');
-    scopeCh.connect('/api/v1/audio-scope');
-    const unsubBinary = scopeCh.onBinary((buf) => {
-      markScopeFrame();
-      const frame = parseScopeFrame(buf);
-      if (!frame) return;
+    const scope = createAudioScopeConnection((frame) => {
       fftPixels = frame.pixels;
       if (frame.endFreq > frame.startFreq) {
         fftBandwidth = frame.endFreq - frame.startFreq;
       }
       fftPush?.(frame.pixels);
     });
-
-    return () => {
-      unsubBinary();
-      scopeCh.disconnect();
-    };
+    return () => scope.disconnect();
   });
 </script>
 

--- a/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
@@ -9,31 +9,13 @@
   import AmberFrequency from './AmberFrequency.svelte';
   import AmberSmeter from './AmberSmeter.svelte';
   import AmberAfScope from './AmberAfScope.svelte';
-  import { getChannel, sendCommand } from '$lib/transport/ws-client';
-  import { markScopeFrame } from '$lib/stores/connection.svelte';
+  import { runtime } from '$lib/runtime';
+  import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
 
   // Command-bus handlers (singleton, no reactive deps)
   const vfoHandlers = makeVfoHandlers();
   const ritXitHandlers = makeRitXitHandlers();
   const cwHandlers = makeCwPanelHandlers();
-
-  interface ScopeFrame {
-    receiver: number;
-    startFreq: number;
-    endFreq: number;
-    pixels: Uint8Array;
-  }
-
-  function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
-    const view = new DataView(buf);
-    if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
-    const receiver = view.getUint8(1);
-    const startFreq = view.getUint32(3, true);
-    const endFreq = view.getUint32(7, true);
-    const pixelCount = view.getUint16(14, true);
-    if (16 + pixelCount > view.byteLength) return null;
-    return { receiver, startFreq, endFreq, pixels: new Uint8Array(buf, 16, pixelCount) };
-  }
 
   // Band lookup by frequency (LCD-specific)
   const BANDS: [string, number, number][] = [
@@ -140,32 +122,16 @@
   }
 
   // Scope WS connection — reactive to capabilities (may load after mount)
-  let scopeCleanup: (() => void) | null = null;
-
   $effect(() => {
-    const wantScope = hasAudioFft();
-    if (!wantScope) return;
+    if (!hasAudioFft()) return;
 
-    const scopeCh = getChannel('audio-scope');
-    scopeCh.connect('/api/v1/audio-scope');
-    const unsubBinary = scopeCh.onBinary((buf) => {
-      markScopeFrame();
-      const frame = parseScopeFrame(buf);
-      if (!frame) return;
+    const scope = createAudioScopeConnection((frame) => {
       fftPixels = frame.pixels;
       fftBandwidth = frame.endFreq > frame.startFreq ? frame.endFreq - frame.startFreq : undefined;
       fftPush?.(frame.pixels);
     });
 
-    scopeCleanup = () => {
-      unsubBinary();
-      scopeCh.disconnect();
-      scopeCleanup = null;
-    };
-
-    return () => {
-      scopeCleanup?.();
-    };
+    return () => scope.disconnect();
   });
 </script>
 
@@ -281,7 +247,7 @@
         <button class="lcd-btn" onclick={ritXitHandlers.onClear}>CLR</button>
       {/if}
       {#if hasCapability('tuner')}
-        <button class="lcd-btn" onclick={() => sendCommand('set_tuner_status', { value: 2 })}>TUNE</button>
+        <button class="lcd-btn" onclick={() => runtime.send('set_tuner_status', { value: 2 })}>TUNE</button>
       {/if}
       {#if isCwMode && hasCapability('cw')}
         <button class="lcd-btn" onclick={cwHandlers.onAutoTune}>AUTO</button>

--- a/frontend/src/lib/runtime/adapters/scope-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/scope-adapter.ts
@@ -1,0 +1,58 @@
+/**
+ * Scope adapter — encapsulates audio-scope WS channel lifecycle.
+ *
+ * Replaces direct getChannel('audio-scope') usage in AudioSpectrumPanel
+ * and AmberLcdDisplay. Parses binary scope frames in one place.
+ *
+ * Usage in a Svelte $effect:
+ *   const scope = createAudioScopeConnection(frame => { ... });
+ *   return () => scope.disconnect();
+ */
+
+import { getChannel } from '$lib/transport/ws-client';
+import { markScopeFrame } from '$lib/stores/connection.svelte';
+
+export interface ScopeFrame {
+  receiver: number;
+  startFreq: number;
+  endFreq: number;
+  pixels: Uint8Array;
+}
+
+export function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
+  const view = new DataView(buf);
+  if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
+  const receiver = view.getUint8(1);
+  const startFreq = view.getUint32(3, true);
+  const endFreq = view.getUint32(7, true);
+  const pixelCount = view.getUint16(14, true);
+  if (16 + pixelCount > view.byteLength) return null;
+  return { receiver, startFreq, endFreq, pixels: new Uint8Array(buf, 16, pixelCount) };
+}
+
+export interface AudioScopeHandle {
+  disconnect: () => void;
+}
+
+/**
+ * Open audio-scope WS channel and deliver parsed frames to the callback.
+ * Returns a handle with disconnect() for cleanup.
+ */
+export function createAudioScopeConnection(
+  onFrame: (frame: ScopeFrame) => void,
+): AudioScopeHandle {
+  const ch = getChannel('audio-scope');
+  ch.connect('/api/v1/audio-scope');
+  const unsubBinary = ch.onBinary((buf) => {
+    markScopeFrame();
+    const frame = parseScopeFrame(buf);
+    if (frame) onFrame(frame);
+  });
+
+  return {
+    disconnect: () => {
+      unsubBinary();
+      ch.disconnect();
+    },
+  };
+}

--- a/frontend/src/lib/runtime/adapters/tx-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/tx-adapter.ts
@@ -1,0 +1,14 @@
+/**
+ * TX adapter — provides audio TX lifecycle callbacks for PTT components.
+ *
+ * Replaces direct audioManager imports in TxPanel and MobileRadioLayout.
+ */
+
+import { runtime } from '../frontend-runtime';
+
+export function getTxAudioControl() {
+  return {
+    startTx: () => runtime.startTx(),
+    stopTx: () => runtime.stopTx(),
+  };
+}


### PR DESCRIPTION
## Summary

- **TX adapter** — TxPanel + MobileRadioLayout use `runtime.startTx()/stopTx()` instead of direct `audioManager`
- **Scope adapter** — AudioSpectrumPanel + AmberLcdDisplay use `createAudioScopeConnection()` instead of direct `getChannel('audio-scope')`
- **Command dispatch** — MemoryPanel + AmberLcdDisplay use `runtime.send()` instead of direct `sendCommand()`
- **Deduplicated** `parseScopeFrame` — was copied in 3 files, now lives in `scope-adapter.ts`

**eslint boundary violations: 5 → 0**

## Files

| New | Purpose |
|---|---|
| `lib/runtime/adapters/tx-adapter.ts` | TX audio lifecycle via runtime |
| `lib/runtime/adapters/scope-adapter.ts` | Audio-scope WS channel + shared frame parser |

| Migrated | Change |
|---|---|
| `TxPanel.svelte` | `audioManager` → `txAudio` adapter |
| `MobileRadioLayout.svelte` | `audioManager` → `txAudio` adapter |
| `MemoryPanel.svelte` | `sendCommand` → `runtime.send()` |
| `AudioSpectrumPanel.svelte` | `getChannel` + inline parser → scope adapter |
| `AmberLcdDisplay.svelte` | `getChannel` + `sendCommand` + inline parser → adapters |

## Test plan

- [x] `npx eslint src/components-v2/panels/ src/components-v2/layout/` — 0 errors
- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)