### PR TITLE
feat(#650): skin registry and presentation layer scaffolding

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -16,7 +16,8 @@
   import { getConnectionStatus, getRadioPowerOn } from '$lib/stores/connection.svelte';
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
   import { getCapabilities, getKeyboardConfig, hasDualReceiver, hasTx, hasAnyScope, hasSpectrum, hasAudioFft } from '$lib/stores/capabilities.svelte';
-  import { useLcdLayout } from '$lib/stores/layout.svelte';
+  import { getLayoutMode } from '$lib/stores/layout.svelte';
+  import { resolveSkinId, type SkinId } from '../../skins/registry';
   import SpectrumPanel from '../../components/spectrum/SpectrumPanel.svelte';
   import AudioSpectrumPanel from '../panels/audio-scope/AudioSpectrumPanel.svelte';
   import AmberLcdDisplay from '../panels/lcd/AmberLcdDisplay.svelte';
@@ -82,7 +83,14 @@
   let landscapeAutoLocked = $state(false);
   let spectrumLandscape = $derived(isMobile && isLandscape && !landscapeSpectrumDismissed && !landscapeAutoLocked);
   let connectionStatus = $derived(getConnectionStatus());
-  // (mobile activeTab removed — MobileRadioLayout handles its own state)
+
+  // Skin resolution — determines which layout to render
+  let skinId = $derived<SkinId>(resolveSkinId({
+    capabilities: caps,
+    layoutPreference: getLayoutMode(),
+    isMobile,
+    hasAnyScope: hasAnyScope(),
+  }));
 
   let isAudioFft = $derived(hasAudioFft());
   let activeReceiverLabel = $derived(radioState?.active === 'SUB' ? 'SUB' : 'MAIN');
@@ -188,9 +196,9 @@
   });
 </script>
 
-{#if isMobile}
+{#if skinId === 'mobile'}
   <MobileRadioLayout />
-{:else if useLcdLayout(hasAnyScope())}
+{:else if skinId === 'amber-lcd'}
   <LcdLayout />
 {:else}
 <div class="radio-layout">

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -8,9 +8,13 @@ vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
 
 vi.mock('$lib/stores/layout.svelte', () => ({
   useLcdLayout: vi.fn(() => false),
-  getLayoutMode: vi.fn(() => 'auto'),
+  getLayoutMode: vi.fn(() => 'standard'),
   cycleLayoutMode: vi.fn(),
   setLayoutMode: vi.fn(),
+}));
+
+vi.mock('../../../skins/registry', () => ({
+  resolveSkinId: vi.fn(() => 'desktop-v2'),
 }));
 
 vi.mock('$lib/stores/connection.svelte', () => ({

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
@@ -3,9 +3,13 @@ import { flushSync, mount, unmount } from 'svelte';
 
 vi.mock('$lib/stores/layout.svelte', () => ({
   useLcdLayout: vi.fn(() => false),
-  getLayoutMode: vi.fn(() => 'auto'),
+  getLayoutMode: vi.fn(() => 'standard'),
   cycleLayoutMode: vi.fn(),
   setLayoutMode: vi.fn(),
+}));
+
+vi.mock('../../../skins/registry', () => ({
+  resolveSkinId: vi.fn(() => 'desktop-v2'),
 }));
 
 vi.mock('$lib/stores/connection.svelte', () => ({

--- a/frontend/src/skins/amber-lcd/LcdSkin.svelte
+++ b/frontend/src/skins/amber-lcd/LcdSkin.svelte
@@ -1,0 +1,11 @@
+<!--
+  Amber LCD Skin — retro 7-segment display layout.
+
+  Delegation wrapper during migration. Phase 5 (#652) will express LCD
+  as a true skin composing semantic components with amber-themed renderers.
+-->
+<script lang="ts">
+  import LcdLayout from '../../components-v2/layout/LcdLayout.svelte';
+</script>
+
+<LcdLayout />

--- a/frontend/src/skins/desktop-v2/DesktopSkin.svelte
+++ b/frontend/src/skins/desktop-v2/DesktopSkin.svelte
@@ -1,0 +1,13 @@
+<!--
+  Desktop V2 Skin — standard layout with spectrum/waterfall.
+
+  This is a thin delegation wrapper during migration. It mounts the existing
+  RadioLayout internals. Once Phase 4 (#651) migrates all panels to the
+  runtime adapter pattern, this skin will compose semantic components directly
+  instead of delegating.
+-->
+<script lang="ts">
+  import RadioLayout from '../../components-v2/layout/RadioLayout.svelte';
+</script>
+
+<RadioLayout />

--- a/frontend/src/skins/mobile/MobileSkin.svelte
+++ b/frontend/src/skins/mobile/MobileSkin.svelte
@@ -1,0 +1,11 @@
+<!--
+  Mobile Skin — touch-optimized stacked layout.
+
+  Delegation wrapper during migration. Future phases will compose semantic
+  components with compact mobile-specific renderers.
+-->
+<script lang="ts">
+  import MobileRadioLayout from '../../components-v2/layout/MobileRadioLayout.svelte';
+</script>
+
+<MobileRadioLayout />

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -1,0 +1,54 @@
+/**
+ * Skin registry — resolves which skin to load based on capabilities and user preference.
+ *
+ * Each skin is a top-level Svelte component that composes semantic components
+ * into a layout. Skins are lazy-loaded to keep the initial bundle small.
+ *
+ * @see docs/plans/2026-04-12-target-frontend-architecture.md
+ */
+
+import type { Component } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { LayoutMode } from '$lib/stores/layout.svelte';
+
+export type SkinId = 'desktop-v2' | 'amber-lcd' | 'mobile';
+
+export interface SkinResolutionContext {
+  capabilities: Capabilities | null;
+  layoutPreference: LayoutMode;
+  isMobile: boolean;
+  hasAnyScope: boolean;
+}
+
+/**
+ * Determine which skin to use based on context.
+ *
+ * Rules:
+ * - Mobile viewport → mobile skin
+ * - User forced 'lcd' → amber-lcd
+ * - User forced 'standard' → desktop-v2
+ * - Auto: use desktop-v2 if any scope is available, amber-lcd otherwise
+ */
+export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
+  if (ctx.isMobile) return 'mobile';
+  if (ctx.layoutPreference === 'lcd') return 'amber-lcd';
+  if (ctx.layoutPreference === 'standard') return 'desktop-v2';
+  // auto: scope available → desktop, otherwise LCD
+  return ctx.hasAnyScope ? 'desktop-v2' : 'amber-lcd';
+}
+
+/**
+ * Lazy-load a skin component by ID.
+ *
+ * Returns the default export of the skin's entry Svelte component.
+ * Skins are code-split — only the active skin is loaded.
+ */
+const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
+  'desktop-v2': () => import('./desktop-v2/DesktopSkin.svelte'),
+  'amber-lcd': () => import('./amber-lcd/LcdSkin.svelte'),
+  'mobile': () => import('./mobile/MobileSkin.svelte'),
+};
+
+export async function loadSkin(id: SkinId): Promise<Component> {
+  return (await SKIN_LOADERS[id]).default;
+}


### PR DESCRIPTION
## Summary

- **Skin registry** (`skins/registry.ts`) — `resolveSkinId()` replaces inline layout branching. Lazy `loadSkin()` for code-split skin loading.
- **Three skin entry points** — `desktop-v2/DesktopSkin.svelte`, `amber-lcd/LcdSkin.svelte`, `mobile/MobileSkin.svelte`. Currently thin delegation wrappers; Phase 4/5 will compose semantic components.
- **RadioLayout refactored** — uses `skinId = $derived(resolveSkinId(...))` for layout selection instead of `isMobile`/`useLcdLayout` checks. Functionally equivalent.

## Architecture

```
skins/registry.ts
  resolveSkinId({ caps, layoutPref, isMobile, hasAnyScope })
    → 'desktop-v2' | 'amber-lcd' | 'mobile'

RadioLayout.svelte
  {#if skinId === 'mobile'} → MobileSkin
  {:else if skinId === 'amber-lcd'} → LcdSkin
  {:else} → inline desktop layout (DesktopSkin for future)
```

## Test plan

- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean
- [x] `npx eslint src/components-v2/ src/skins/` — 0 errors

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)