### PR TITLE
feat(#651): migrate V2 desktop to unified runtime path

### DIFF
--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { radio } from '$lib/stores/radio.svelte';
-  import { getCapabilities, hasCapability } from '$lib/stores/capabilities.svelte';
+  import { runtime } from '$lib/runtime';
+  import { hasCapability } from '$lib/stores/capabilities.svelte';
   import RfFrontEnd from '../panels/RfFrontEnd.svelte';
   import ModePanel from '../panels/ModePanel.svelte';
   import FilterPanel from '../panels/FilterPanel.svelte';
@@ -45,9 +45,9 @@
     makeSystemHandlers,
   } from '../wiring/command-bus';
 
-  // Reactive state + capabilities
-  let radioState = $derived(radio.current);
-  let caps = $derived(getCapabilities());
+  // Reactive state + capabilities — via runtime
+  let radioState = $derived(runtime.state);
+  let caps = $derived(runtime.caps);
 
   // --- Panel reorder (shared logic) ---
   const drag = createDragReorder({

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -12,10 +12,9 @@
     }
   }
   
-  import { radio } from '$lib/stores/radio.svelte';
-  import { getConnectionStatus, getRadioPowerOn } from '$lib/stores/connection.svelte';
+  import { runtime } from '$lib/runtime';
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
-  import { getCapabilities, getKeyboardConfig, hasDualReceiver, hasTx, hasAnyScope, hasSpectrum, hasAudioFft } from '$lib/stores/capabilities.svelte';
+  import { getKeyboardConfig, hasDualReceiver, hasTx, hasAnyScope, hasSpectrum, hasAudioFft } from '$lib/stores/capabilities.svelte';
   import { getLayoutMode } from '$lib/stores/layout.svelte';
   import { resolveSkinId, type SkinId } from '../../skins/registry';
   import SpectrumPanel from '../../components/spectrum/SpectrumPanel.svelte';
@@ -58,9 +57,9 @@
   import { HardwareButton } from '$lib/Button';
   import { Settings } from 'lucide-svelte';
 
-  // Reactive state + capabilities
-  let radioState = $derived(radio.current);
-  let caps = $derived(getCapabilities());
+  // Reactive state + capabilities — via runtime
+  let radioState = $derived(runtime.state);
+  let caps = $derived(runtime.caps);
   let keyboardConfig = $derived(getKeyboardConfig());
   let activeMode = $derived(radioState?.active === 'SUB' ? radioState?.sub?.mode : radioState?.main?.mode);
 
@@ -82,7 +81,7 @@
   let landscapeSpectrumDismissed = $state(false);
   let landscapeAutoLocked = $state(false);
   let spectrumLandscape = $derived(isMobile && isLandscape && !landscapeSpectrumDismissed && !landscapeAutoLocked);
-  let connectionStatus = $derived(getConnectionStatus());
+  let connectionStatus = $derived(runtime.connection.status);
 
   // Skin resolution — determines which layout to render
   let skinId = $derived<SkinId>(resolveSkinId({
@@ -300,7 +299,7 @@
 </div>
 {/if}
 
-{#if getRadioPowerOn() === false}
+{#if runtime.connection.radioPowerOn === false}
   <div class="power-off-overlay" aria-label="Radio is powered off">
     <div class="power-off-content">
       <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/src/components-v2/layout/RightSidebar.svelte
+++ b/frontend/src/components-v2/layout/RightSidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { radio } from '$lib/stores/radio.svelte';
-  import { getCapabilities, hasCapability } from '$lib/stores/capabilities.svelte';
+  import { runtime } from '$lib/runtime';
+  import { hasCapability } from '$lib/stores/capabilities.svelte';
   import RxAudioPanel from '../panels/RxAudioPanel.svelte';
   import DspPanel from '../panels/DspPanel.svelte';
   import TxPanel from '../panels/TxPanel.svelte';
@@ -45,9 +45,9 @@
     makeScanHandlers,
   } from '../wiring/command-bus';
 
-  // Reactive state + capabilities
-  let radioState = $derived(radio.current);
-  let caps = $derived(getCapabilities());
+  // Reactive state + capabilities — via runtime
+  let radioState = $derived(runtime.state);
+  let caps = $derived(runtime.caps);
 
   // Derived props via state adapter — native panels
   let dsp = $derived(toDspProps(radioState, caps));

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -17,6 +17,16 @@ vi.mock('../../../skins/registry', () => ({
   resolveSkinId: vi.fn(() => 'desktop-v2'),
 }));
 
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    state: null,
+    caps: null,
+    connection: { status: 'disconnected', radioPowerOn: null },
+    audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    send: vi.fn(),
+  },
+}));
+
 vi.mock('$lib/stores/connection.svelte', () => ({
   getConnectionStatus: vi.fn(() => ({ connected: false })),
   getRadioPowerOn: vi.fn(() => null),

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
@@ -12,6 +12,16 @@ vi.mock('../../../skins/registry', () => ({
   resolveSkinId: vi.fn(() => 'desktop-v2'),
 }));
 
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    state: null,
+    caps: null,
+    connection: { status: 'disconnected', radioPowerOn: null },
+    audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    send: vi.fn(),
+  },
+}));
+
 vi.mock('$lib/stores/connection.svelte', () => ({
   getConnectionStatus: vi.fn(() => ({ connected: false })),
   getRadioPowerOn: vi.fn(() => null),


### PR DESCRIPTION
## Summary

- **RadioLayout** reads state via `runtime.state`, `runtime.caps`, `runtime.connection` instead of direct store imports
- **LeftSidebar + RightSidebar** read state via `runtime.state`, `runtime.caps`
- Tests updated with `$lib/runtime` mocks

The entire V2 desktop layout chain now reads state through the FrontendRuntime singleton. State-adapter + command-bus remain as the adapter layer.

## Test plan

- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)