### PR TITLE
feat(#652): migrate LCD + mobile to unified runtime

### DIFF
--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -7,9 +7,8 @@
     setTheme(getTheme());
   }
 
-  import { radio } from '$lib/stores/radio.svelte';
+  import { runtime } from '$lib/runtime';
   import { getKeyboardConfig } from '$lib/stores/capabilities.svelte';
-  import { getRadioPowerOn } from '$lib/stores/connection.svelte';
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
   import AmberLcdDisplay from '../panels/lcd/AmberLcdDisplay.svelte';
   import LeftSidebar from './LeftSidebar.svelte';
@@ -18,13 +17,14 @@
   import StatusBar from './StatusBar.svelte';
   import { makeKeyboardHandlers } from '../wiring/command-bus';
 
-  let radioState = $derived(radio.current);
+  let radioState = $derived(runtime.state);
   let keyboardConfig = $derived(getKeyboardConfig());
   let activeMode = $derived(radioState?.active === 'SUB' ? radioState?.sub?.mode : radioState?.main?.mode);
 
   const keyboardHandlers = makeKeyboardHandlers();
 
   async function handlePowerOn() {
+    // TODO(#653): migrate to runtime.system.powerOn() when SystemController is implemented
     try {
       const resp = await fetch('/api/v1/radio/power', {
         method: 'POST',
@@ -69,7 +69,7 @@
 
 </div>
 
-{#if getRadioPowerOn() === false}
+{#if runtime.connection.radioPowerOn === false}
   <div class="power-off-overlay" aria-label="Radio is powered off">
     <div class="power-off-content">
       <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import { radio } from '$lib/stores/radio.svelte';
-  import { getCapabilities, hasTx, hasDualReceiver, hasAnyScope, hasSpectrum } from '$lib/stores/capabilities.svelte';
-  import { getConnectionStatus, getRadioPowerOn } from '$lib/stores/connection.svelte';
-  import { getAudioState } from '$lib/stores/audio.svelte';
+  import { runtime } from '$lib/runtime';
+  import { hasTx, hasDualReceiver, hasAnyScope, hasSpectrum } from '$lib/stores/capabilities.svelte';
   import { HardwareButton } from '$lib/Button';
   import SpectrumPanel from '../../components/spectrum/SpectrumPanel.svelte';
   import AmberLcdDisplay from '../panels/lcd/AmberLcdDisplay.svelte';
@@ -51,11 +49,11 @@
   const txAudio = getTxAudioControl();
   import { onMount, onDestroy } from 'svelte';
 
-  // ── State ──
-  let radioState = $derived(radio.current);
-  let caps = $derived(getCapabilities());
+  // ── State — via runtime ──
+  let radioState = $derived(runtime.state);
+  let caps = $derived(runtime.caps);
   let keyboardConfig = $derived(getKeyboardConfig());
-  let audioState = $derived(getAudioState());
+  let audioState = $derived(runtime.audio);
   let txCapable = $derived(hasTx());
 
   // ── VFO props ──


### PR DESCRIPTION
## Summary

- **LcdLayout** reads state via `runtime.state`, `runtime.connection` instead of direct store imports
- **MobileRadioLayout** reads state via `runtime.state`, `runtime.caps`, `runtime.audio`
- All 3 layout variants (desktop, LCD, mobile) now on the unified runtime path
- Also cleaned 7 stale agent worktrees that were interfering with vitest

## Test plan

- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)