### PR TITLE
chore(#653): cutover to unified frontend architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,15 @@ Never bare `python` or `pytest`. Worktrees: `uv sync --all-extras` first.
 - Keep-alive: ~500ms control, ~100ms audio — never weaken
 - MagicMock hides signature bugs — verify against real dataclasses
 
+**Frontend layering (enforce):**
+- `lib/runtime/` → singleton FrontendRuntime, wraps stores + transport + audio
+- `lib/runtime/adapters/` → pure functions mapping runtime state → component props
+- `components-v2/wiring/` → state-adapter + command-bus (adapter layer)
+- `components-v2/panels/` + `layout/` → presentation only, NO direct store/transport imports
+- `skins/` → skin registry + entry points (desktop-v2, amber-lcd, mobile)
+- eslint `no-restricted-imports` enforces: panels/layouts cannot import `$lib/transport/*` or `$lib/audio/audio-manager`
+- ADR: `docs/plans/2026-04-12-target-frontend-architecture.md`
+
 ---
 
 ## Testing

--- a/frontend/src/lib/stores/layout.svelte.ts
+++ b/frontend/src/lib/stores/layout.svelte.ts
@@ -43,13 +43,4 @@ export function cycleLayoutMode(hasAnyScope: boolean): void {
   }
 }
 
-/**
- * Resolve whether to use LCD layout given scope capabilities.
- * @param hasAnyScope — true if hardware spectrum OR audio FFT is available
- */
-export function useLcdLayout(hasAnyScope: boolean): boolean {
-  if (mode === 'lcd') return true;
-  if (mode === 'standard') return false;
-  // auto: standard layout when any scope is available, LCD otherwise
-  return !hasAnyScope;
-}
+// useLcdLayout() removed — layout resolution now handled by skins/registry.ts resolveSkinId()


### PR DESCRIPTION
## Summary

Final phase of epic #640. Removes obsolete code and documents the shipped architecture.

- Remove `useLcdLayout()` — superseded by `skins/registry.ts resolveSkinId()`
- Add frontend architecture section to `CLAUDE.md`

## Epic #640 completion summary

| Phase | PR | Issue | Status |
|---|---|---|---|
| — | #654 | #642 | Yaesu USB audio fix + ADR |
| 0 | #655 | #647 | eslint import boundary guardrails |
| 1 | #656 | #648 | FrontendRuntime shell + adapter boundary |
| 2 | #657 | #649 | Centralize audio/scope — 0 violations |
| 3 | #658 | #650 | Skin registry + presentation scaffolding |
| 4 | #659 | #651 | V2 desktop → unified runtime |
| 5 | #660 | #652 | LCD + mobile → unified runtime |
| 6 | #661 | #653 | Cutover + cleanup (this PR) |

## Final architecture

```
lib/runtime/          → FrontendRuntime singleton (state, caps, audio, commands)
lib/runtime/adapters/ → audio, vfo, tx, scope adapters
skins/registry.ts     → resolveSkinId() + lazy loadSkin()
skins/{desktop-v2,amber-lcd,mobile}/  → skin entry points
components-v2/wiring/ → state-adapter + command-bus (adapter layer)
components-v2/{panels,layout}/ → presentation only (eslint-enforced)
```

## Test plan

- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean
- [x] `npx eslint src/components-v2/ src/skins/` — 0 errors

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)