### PR TITLE
feat(#662): self-wire simple panels (Agc, Mode, Antenna)

### DIFF
--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -18,12 +18,9 @@
   import { createDragReorder } from '$lib/drag-reorder.svelte';
   import {
     toRfFrontEndProps,
-    toModeProps,
     toFilterProps,
-    toAgcProps,
     toRitXitProps,
     toBandSelectorProps,
-    toAntennaProps,
     toScanProps,
     toDspProps,
     toTxProps,
@@ -31,13 +28,10 @@
   } from '../wiring/state-adapter';
   import {
     makeRfFrontEndHandlers,
-    makeModeHandlers,
     makeFilterHandlers,
-    makeAgcHandlers,
     makeRitXitHandlers,
     makeBandHandlers,
     makePresetHandlers,
-    makeAntennaHandlers,
     makeScanHandlers,
     makeDspHandlers,
     makeTxHandlers,
@@ -56,28 +50,21 @@
     containerSelector: '.left-sidebar',
   });
 
-  // Derived props via state adapter — native panels
+  // Derived props via state adapter — panels not yet self-wiring
   let rfFrontEnd = $derived(toRfFrontEndProps(radioState, caps));
-  let mode = $derived(toModeProps(radioState, caps));
   let filter = $derived(toFilterProps(radioState, caps));
-  let agc = $derived(toAgcProps(radioState, caps));
   let ritXit = $derived(toRitXitProps(radioState, caps));
   let band = $derived(toBandSelectorProps(radioState));
-  let antenna = $derived(toAntennaProps(radioState, caps));
   let scan = $derived(toScanProps(radioState));
-  // Derived props — panels from right sidebar (for cross-sidebar rendering)
   let dsp = $derived(toDspProps(radioState, caps));
   let tx = $derived(toTxProps(radioState, caps));
   let cw = $derived(toCwProps(radioState, caps));
-  // Command handlers via command-bus
+  // Command handlers
   const rfHandlers = makeRfFrontEndHandlers();
-  const modeHandlers = makeModeHandlers();
   const filterHandlers = makeFilterHandlers();
-  const agcHandlers = makeAgcHandlers();
   const ritXitHandlers = makeRitXitHandlers();
   const bandHandlers = makeBandHandlers();
   const presetHandlers = makePresetHandlers();
-  const antennaHandlers = makeAntennaHandlers();
   const scanHandlers = makeScanHandlers();
   const dspHandlers = makeDspHandlers();
   const txHandlers = makeTxHandlers();
@@ -111,16 +98,7 @@
     <CollapsiblePanel title="MODE" panelId="mode"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('mode')}>
-      <ModePanel
-        currentMode={mode.currentMode}
-        modes={mode.modes}
-        dataMode={mode.dataMode}
-        hasDataMode={mode.hasDataMode}
-        dataModeCount={mode.dataModeCount}
-        dataModeLabels={mode.dataModeLabels}
-        onModeChange={modeHandlers.onModeChange}
-        onDataModeChange={modeHandlers.onDataModeChange}
-      />
+      <ModePanel />
     </CollapsiblePanel>
   {/if}
 
@@ -158,10 +136,7 @@
     <CollapsiblePanel title="AGC" panelId="agc"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('agc')}>
-      <AgcPanel
-        agcMode={agc.agcMode}
-        onAgcModeChange={agcHandlers.onAgcModeChange}
-      />
+      <AgcPanel />
     </CollapsiblePanel>
   {/if}
 
@@ -197,19 +172,11 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('antenna') && antenna.antennaCount > 1}
+  {#if drag.order.includes('antenna') && (caps?.antennas ?? 1) > 1}
     <CollapsiblePanel title="ANTENNA" panelId="antenna" dataPanel="antenna"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('antenna')}>
-      <AntennaPanel
-        txAntenna={antenna.txAntenna}
-        rxAnt={antenna.rxAnt}
-        antennaCount={antenna.antennaCount}
-        hasRxAntenna={antenna.hasRxAntenna}
-        onSelectAnt1={antennaHandlers.onSelectAnt1}
-        onSelectAnt2={antennaHandlers.onSelectAnt2}
-        onToggleRxAnt={antennaHandlers.onToggleRxAnt}
-      />
+      <AntennaPanel />
     </CollapsiblePanel>
   {/if}
 

--- a/frontend/src/components-v2/layout/RightSidebar.svelte
+++ b/frontend/src/components-v2/layout/RightSidebar.svelte
@@ -21,12 +21,9 @@
     toTxProps,
     toCwProps,
     toRfFrontEndProps,
-    toModeProps,
     toFilterProps,
-    toAgcProps,
     toRitXitProps,
     toBandSelectorProps,
-    toAntennaProps,
     toScanProps,
   } from '../wiring/state-adapter';
   import {
@@ -35,13 +32,10 @@
     makeCwPanelHandlers,
     makeSystemHandlers,
     makeRfFrontEndHandlers,
-    makeModeHandlers,
     makeFilterHandlers,
-    makeAgcHandlers,
     makeRitXitHandlers,
     makeBandHandlers,
     makePresetHandlers,
-    makeAntennaHandlers,
     makeScanHandlers,
   } from '../wiring/command-bus';
 
@@ -55,12 +49,9 @@
   let cw = $derived(toCwProps(radioState, caps));
   // Derived props — panels from left sidebar (for cross-sidebar rendering)
   let rfFrontEnd = $derived(toRfFrontEndProps(radioState, caps));
-  let modeProps = $derived(toModeProps(radioState, caps));
   let filter = $derived(toFilterProps(radioState, caps));
-  let agc = $derived(toAgcProps(radioState, caps));
   let ritXit = $derived(toRitXitProps(radioState, caps));
   let band = $derived(toBandSelectorProps(radioState));
-  let antenna = $derived(toAntennaProps(radioState, caps));
   let scan = $derived(toScanProps(radioState));
 
   // Command handlers via command-bus
@@ -69,13 +60,10 @@
   const cwHandlers = makeCwPanelHandlers();
   const systemHandlers = makeSystemHandlers();
   const rfHandlers = makeRfFrontEndHandlers();
-  const modeHandlers = makeModeHandlers();
   const filterHandlers = makeFilterHandlers();
-  const agcHandlers = makeAgcHandlers();
   const ritXitHandlers = makeRitXitHandlers();
   const bandHandlers = makeBandHandlers();
   const presetHandlers = makePresetHandlers();
-  const antennaHandlers = makeAntennaHandlers();
   const scanHandlers = makeScanHandlers();
 
   type RightSidebarMode = 'all' | 'rx' | 'tx';
@@ -212,16 +200,7 @@
   {#if drag.order.includes('mode')}
     <CollapsiblePanel title="MODE" panelId="mode"
       draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('mode')}>
-      <ModePanel
-        currentMode={modeProps.currentMode}
-        modes={modeProps.modes}
-        dataMode={modeProps.dataMode}
-        hasDataMode={modeProps.hasDataMode}
-        dataModeCount={modeProps.dataModeCount}
-        dataModeLabels={modeProps.dataModeLabels}
-        onModeChange={modeHandlers.onModeChange}
-        onDataModeChange={modeHandlers.onDataModeChange}
-      />
+      <ModePanel />
     </CollapsiblePanel>
   {/if}
 
@@ -257,10 +236,7 @@
   {#if drag.order.includes('agc')}
     <CollapsiblePanel title="AGC" panelId="agc"
       draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('agc')}>
-      <AgcPanel
-        agcMode={agc.agcMode}
-        onAgcModeChange={agcHandlers.onAgcModeChange}
-      />
+      <AgcPanel />
     </CollapsiblePanel>
   {/if}
 
@@ -294,18 +270,10 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('antenna') && antenna.antennaCount > 1}
+  {#if drag.order.includes('antenna') && (caps?.antennas ?? 1) > 1}
     <CollapsiblePanel title="ANTENNA" panelId="antenna" dataPanel="antenna"
       draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('antenna')}>
-      <AntennaPanel
-        txAntenna={antenna.txAntenna}
-        rxAnt={antenna.rxAnt}
-        antennaCount={antenna.antennaCount}
-        hasRxAntenna={antenna.hasRxAntenna}
-        onSelectAnt1={antennaHandlers.onSelectAnt1}
-        onSelectAnt2={antennaHandlers.onSelectAnt2}
-        onToggleRxAnt={antennaHandlers.onToggleRxAnt}
-      />
+      <AntennaPanel />
     </CollapsiblePanel>
   {/if}
 

--- a/frontend/src/components-v2/panels/AgcPanel.svelte
+++ b/frontend/src/components-v2/panels/AgcPanel.svelte
@@ -1,26 +1,21 @@
 <script lang="ts">
   import { HardwareButton } from '$lib/Button';
-  import { getAgcModes, getAgcLabels } from '$lib/stores/capabilities.svelte';
   import { buildAgcOptions } from './agc-utils';
+  import { deriveAgcProps, getAgcHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  interface Props {
-    agcMode: number;
-    onAgcModeChange: (v: number) => void;
-  }
-
-  let { agcMode, onAgcModeChange }: Props = $props();
-
-  let options = $derived(buildAgcOptions(getAgcModes(), getAgcLabels()));
+  const handlers = getAgcHandlers();
+  let props = $derived(deriveAgcProps());
+  let options = $derived(buildAgcOptions(props.agcModes, props.agcLabels));
 </script>
 
 <div class="panel-body">
   <div class="button-grid">
     {#each options as option}
       <HardwareButton
-        active={agcMode === option.value}
+        active={props.agcMode === option.value}
         indicator="edge-left"
         color="cyan"
-        onclick={() => onAgcModeChange(option.value)}
+        onclick={() => handlers.onAgcModeChange(option.value)}
       >
         {option.label}
       </HardwareButton>

--- a/frontend/src/components-v2/panels/AntennaPanel.svelte
+++ b/frontend/src/components-v2/panels/AntennaPanel.svelte
@@ -1,25 +1,17 @@
 <script lang="ts">
   import { HardwareButton } from '$lib/Button';
+  import { deriveAntennaProps, getAntennaHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  interface Props {
-    txAntenna: number;
-    rxAnt: boolean;
-    antennaCount: number;
-    hasRxAntenna: boolean;
-    onSelectAnt1: () => void;
-    onSelectAnt2: () => void;
-    onToggleRxAnt: () => void;
-  }
+  const handlers = getAntennaHandlers();
+  let p = $derived(deriveAntennaProps());
 
-  let {
-    txAntenna,
-    rxAnt,
-    antennaCount,
-    hasRxAntenna,
-    onSelectAnt1,
-    onSelectAnt2,
-    onToggleRxAnt,
-  }: Props = $props();
+  let txAntenna = $derived(p.txAntenna);
+  let rxAnt = $derived(p.rxAnt);
+  let antennaCount = $derived(p.antennaCount);
+  let hasRxAntenna = $derived(p.hasRxAntenna);
+  const onSelectAnt1 = handlers.onSelectAnt1;
+  const onSelectAnt2 = handlers.onSelectAnt2;
+  const onToggleRxAnt = handlers.onToggleRxAnt;
 </script>
 
 {#if antennaCount > 1}

--- a/frontend/src/components-v2/panels/ModePanel.svelte
+++ b/frontend/src/components-v2/panels/ModePanel.svelte
@@ -1,28 +1,20 @@
 <script lang="ts">
   import { HardwareButton } from '$lib/Button';
   import { getShortcutHint } from '../layout/shortcut-hints';
+  import { deriveModeProps, getModeHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  interface Props {
-    currentMode: string;
-    modes: string[];
-    dataMode: number;
-    hasDataMode: boolean;
-    dataModeCount?: number;
-    dataModeLabels?: Record<string, string>;
-    onModeChange: (mode: string) => void;
-    onDataModeChange: (mode: number) => void;
-  }
+  const handlers = getModeHandlers();
+  let p = $derived(deriveModeProps());
 
-  let {
-    currentMode,
-    modes,
-    dataMode,
-    hasDataMode,
-    dataModeCount = 0,
-    dataModeLabels = { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' },
-    onModeChange,
-    onDataModeChange,
-  }: Props = $props();
+  // Destructure for template readability
+  let currentMode = $derived(p.currentMode);
+  let modes = $derived(p.modes);
+  let dataMode = $derived(p.dataMode);
+  let hasDataMode = $derived(p.hasDataMode);
+  let dataModeCount = $derived(p.dataModeCount ?? 0);
+  let dataModeLabels = $derived(p.dataModeLabels ?? { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' });
+  const onModeChange = handlers.onModeChange;
+  const onDataModeChange = handlers.onDataModeChange;
 
   // Canonical display order — covers both IC-7610 and Yaesu naming conventions.
   const modeOrder = [

--- a/frontend/src/components-v2/panels/__tests__/ModePanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/ModePanel.test.ts
@@ -1,15 +1,34 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
-import type { ComponentProps } from 'svelte';
+
+const mockProps = {
+  currentMode: 'USB',
+  modes: ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
+  dataMode: 0,
+  hasDataMode: true,
+  dataModeCount: 3,
+  dataModeLabels: { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' } as Record<string, string>,
+};
+
+const mockHandlers = {
+  onModeChange: vi.fn(),
+  onDataModeChange: vi.fn(),
+};
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveModeProps: () => mockProps,
+  getModeHandlers: () => mockHandlers,
+}));
 
 import ModePanel from '../ModePanel.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(props: ComponentProps<typeof ModePanel>) {
+function mountPanel(overrides?: Partial<typeof mockProps>) {
+  if (overrides) Object.assign(mockProps, overrides);
   const target = document.createElement('div');
   document.body.appendChild(target);
-  const component = mount(ModePanel, { target, props });
+  const component = mount(ModePanel, { target });
   flushSync();
   components.push(component);
   return target;
@@ -17,6 +36,14 @@ function mountPanel(props: ComponentProps<typeof ModePanel>) {
 
 beforeEach(() => {
   components = [];
+  mockProps.currentMode = 'USB';
+  mockProps.modes = ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'];
+  mockProps.dataMode = 0;
+  mockProps.hasDataMode = true;
+  mockProps.dataModeCount = 3;
+  mockProps.dataModeLabels = { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' };
+  mockHandlers.onModeChange = vi.fn();
+  mockHandlers.onDataModeChange = vi.fn();
 });
 
 afterEach(() => {
@@ -24,57 +51,44 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-const baseProps: ComponentProps<typeof ModePanel> = {
-  currentMode: 'USB',
-  modes: ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
-  dataMode: 0,
-  hasDataMode: true,
-  dataModeCount: 3,
-  dataModeLabels: { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' },
-  onModeChange: vi.fn(),
-  onDataModeChange: vi.fn(),
-};
-
 describe('ModePanel', () => {
   it('renders mode buttons from capabilities', () => {
-    const target = mountPanel(baseProps);
+    const target = mountPanel();
     const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.mode-grid .v2-control-button')).map((button) => button.textContent?.trim());
     expect(buttons).toEqual(['USB', 'LSB', 'CW', 'CW-R', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R', 'AM', 'FM']);
   });
 
   it('highlights the active mode button', () => {
-    const target = mountPanel({ ...baseProps, currentMode: 'CW' });
+    const target = mountPanel({ currentMode: 'CW' });
     const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.mode-grid .v2-control-button'));
     const button = buttons.find((b) => b.textContent?.trim() === 'CW');
     expect(button?.dataset.active).toBe('true');
   });
 
   it('calls onModeChange when a mode button is clicked', () => {
-    const onModeChange = vi.fn();
-    const target = mountPanel({ ...baseProps, onModeChange });
+    const target = mountPanel();
     const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.mode-grid .v2-control-button'));
     buttons.find((b) => b.textContent?.trim() === 'LSB')?.click();
     flushSync();
-    expect(onModeChange).toHaveBeenCalledWith('LSB');
+    expect(mockHandlers.onModeChange).toHaveBeenCalledWith('LSB');
   });
 
   it('renders DATA mode controls when supported', () => {
-    const target = mountPanel(baseProps);
+    const target = mountPanel();
     const dataButtons = Array.from(target.querySelectorAll<HTMLButtonElement>('.data-grid .v2-control-button')).map((button) => button.textContent?.trim());
     expect(dataButtons).toEqual(['OFF', 'D1', 'D2', 'D3']);
   });
 
   it('does not render DATA mode controls when unsupported', () => {
-    const target = mountPanel({ ...baseProps, hasDataMode: false });
+    const target = mountPanel({ hasDataMode: false });
     expect(target.querySelector('.data-grid')).toBeNull();
   });
 
   it('calls onDataModeChange with numeric modes', () => {
-    const onDataModeChange = vi.fn();
-    const target = mountPanel({ ...baseProps, onDataModeChange });
+    const target = mountPanel();
     const dataButtons = Array.from(target.querySelectorAll<HTMLButtonElement>('.data-grid .v2-control-button'));
     dataButtons.find((b) => b.textContent?.trim() === 'D3')?.click();
     flushSync();
-    expect(onDataModeChange).toHaveBeenCalledWith(3);
+    expect(mockHandlers.onDataModeChange).toHaveBeenCalledWith(3);
   });
 });

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -1,0 +1,117 @@
+/**
+ * Panel adapters — derive props and handlers for self-wiring panels.
+ *
+ * Each panel calls its derive function inside $derived() and its
+ * handler function once at init. This replaces prop-passing from sidebars.
+ *
+ * Add new panel adapters here as panels are migrated to self-wiring.
+ */
+
+import { runtime } from '../frontend-runtime';
+import {
+  toAgcProps, toModeProps, toAntennaProps,
+  toRfFrontEndProps, toRitXitProps, toScanProps,
+  toMeterProps, toCwProps, toDspProps, toTxProps,
+  toFilterProps, toBandSelectorProps,
+} from '../../../components-v2/wiring/state-adapter';
+import {
+  makeAgcHandlers, makeModeHandlers, makeAntennaHandlers,
+  makeRfFrontEndHandlers, makeRitXitHandlers, makeScanHandlers,
+  makeMeterHandlers, makeCwPanelHandlers, makeDspHandlers,
+  makeTxHandlers, makeFilterHandlers, makeBandHandlers,
+  makePresetHandlers,
+} from '../../../components-v2/wiring/command-bus';
+
+// Re-export types for panel imports
+export type {
+  AgcProps, ModeProps, AntennaProps,
+  RfFrontEndProps, RitXitProps, ScanProps,
+  MeterProps, CwProps, DspProps, TxProps,
+  FilterProps, BandSelectorProps,
+} from '../../../components-v2/wiring/state-adapter';
+
+// ── AGC ──
+export function deriveAgcProps() {
+  return toAgcProps(runtime.state, runtime.caps);
+}
+const _agcHandlers = makeAgcHandlers();
+export function getAgcHandlers() { return _agcHandlers; }
+
+// ── Mode ──
+export function deriveModeProps() {
+  return toModeProps(runtime.state, runtime.caps);
+}
+const _modeHandlers = makeModeHandlers();
+export function getModeHandlers() { return _modeHandlers; }
+
+// ── Antenna ──
+export function deriveAntennaProps() {
+  return toAntennaProps(runtime.state, runtime.caps);
+}
+const _antennaHandlers = makeAntennaHandlers();
+export function getAntennaHandlers() { return _antennaHandlers; }
+
+// ── RF Front End ──
+export function deriveRfFrontEndProps() {
+  return toRfFrontEndProps(runtime.state, runtime.caps);
+}
+const _rfHandlers = makeRfFrontEndHandlers();
+export function getRfFrontEndHandlers() { return _rfHandlers; }
+
+// ── RIT/XIT ──
+export function deriveRitXitProps() {
+  return toRitXitProps(runtime.state, runtime.caps);
+}
+const _ritXitHandlers = makeRitXitHandlers();
+export function getRitXitHandlers() { return _ritXitHandlers; }
+
+// ── Scan ──
+export function deriveScanProps() {
+  return toScanProps(runtime.state);
+}
+const _scanHandlers = makeScanHandlers();
+export function getScanHandlers() { return _scanHandlers; }
+
+// ── Meter ──
+export function deriveMeterProps() {
+  return toMeterProps(runtime.state);
+}
+const _meterHandlers = makeMeterHandlers();
+export function getMeterHandlers() { return _meterHandlers; }
+
+// ── CW ──
+export function deriveCwProps() {
+  return toCwProps(runtime.state, runtime.caps);
+}
+const _cwHandlers = makeCwPanelHandlers();
+export function getCwHandlers() { return _cwHandlers; }
+
+// ── DSP ──
+export function deriveDspProps() {
+  return toDspProps(runtime.state, runtime.caps);
+}
+const _dspHandlers = makeDspHandlers();
+export function getDspHandlers() { return _dspHandlers; }
+
+// ── TX ──
+export function deriveTxProps() {
+  return toTxProps(runtime.state, runtime.caps);
+}
+const _txHandlers = makeTxHandlers();
+export function getTxHandlers() { return _txHandlers; }
+
+// ── Filter ──
+export function deriveFilterProps() {
+  return toFilterProps(runtime.state, runtime.caps);
+}
+const _filterHandlers = makeFilterHandlers();
+export function getFilterHandlers() { return _filterHandlers; }
+
+// ── Band Selector ──
+export function deriveBandSelectorProps() {
+  return toBandSelectorProps(runtime.state);
+}
+const _bandHandlers = makeBandHandlers();
+export function getBandHandlers() { return _bandHandlers; }
+const _presetHandlers = makePresetHandlers();
+export function getPresetHandlers() { return _presetHandlers; }


### PR DESCRIPTION
## Summary

- **New: panel-adapters.ts** — centralized adapter module with derive/handler pairs for all panels
- **Self-wired: AgcPanel, ModePanel, AntennaPanel** — derive props + handlers internally
- **Sidebars simplified** — removed 46 lines of prop-passing boilerplate
- **ModePanel test** updated to mock adapter

3 of 13 panels migrated. Adapters pre-wired for remaining 10.

## Test plan
- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)