### PR TITLE
feat(#663): self-wire 4 medium panels (RF, RitXit, Scan, CW)

### DIFF
--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -17,25 +17,17 @@
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
   import { createDragReorder } from '$lib/drag-reorder.svelte';
   import {
-    toRfFrontEndProps,
     toFilterProps,
-    toRitXitProps,
     toBandSelectorProps,
-    toScanProps,
     toDspProps,
     toTxProps,
-    toCwProps,
   } from '../wiring/state-adapter';
   import {
-    makeRfFrontEndHandlers,
     makeFilterHandlers,
-    makeRitXitHandlers,
     makeBandHandlers,
     makePresetHandlers,
-    makeScanHandlers,
     makeDspHandlers,
     makeTxHandlers,
-    makeCwPanelHandlers,
     makeSystemHandlers,
   } from '../wiring/command-bus';
 
@@ -51,24 +43,16 @@
   });
 
   // Derived props via state adapter — panels not yet self-wiring
-  let rfFrontEnd = $derived(toRfFrontEndProps(radioState, caps));
   let filter = $derived(toFilterProps(radioState, caps));
-  let ritXit = $derived(toRitXitProps(radioState, caps));
   let band = $derived(toBandSelectorProps(radioState));
-  let scan = $derived(toScanProps(radioState));
   let dsp = $derived(toDspProps(radioState, caps));
   let tx = $derived(toTxProps(radioState, caps));
-  let cw = $derived(toCwProps(radioState, caps));
   // Command handlers
-  const rfHandlers = makeRfFrontEndHandlers();
   const filterHandlers = makeFilterHandlers();
-  const ritXitHandlers = makeRitXitHandlers();
   const bandHandlers = makeBandHandlers();
   const presetHandlers = makePresetHandlers();
-  const scanHandlers = makeScanHandlers();
   const dspHandlers = makeDspHandlers();
   const txHandlers = makeTxHandlers();
-  const cwHandlers = makeCwPanelHandlers();
   const systemHandlers = makeSystemHandlers();
 </script>
 
@@ -77,20 +61,7 @@
     <CollapsiblePanel title="RF FRONT END" panelId="rf-front-end" dataPanel="rf-frontend"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('rf-front-end')}>
-      <RfFrontEnd
-        rfGain={rfFrontEnd.rfGain}
-        squelch={rfFrontEnd.squelch}
-        att={rfFrontEnd.att}
-        pre={rfFrontEnd.pre}
-        digiSel={rfFrontEnd.digiSel}
-        ipPlus={rfFrontEnd.ipPlus}
-        onRfGainChange={rfHandlers.onRfGainChange}
-        onSquelchChange={rfHandlers.onSquelchChange}
-        onAttChange={rfHandlers.onAttChange}
-        onPreChange={rfHandlers.onPreChange}
-        onDigiSelToggle={rfHandlers.onDigiSelToggle}
-        onIpPlusToggle={rfHandlers.onIpPlusToggle}
-      />
+      <RfFrontEnd />
     </CollapsiblePanel>
   {/if}
 
@@ -144,19 +115,7 @@
     <CollapsiblePanel title="RIT / XIT" panelId="rit-xit"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('rit-xit')}>
-      <RitXitPanel
-        ritActive={ritXit.ritActive}
-        ritOffset={ritXit.ritOffset}
-        xitActive={ritXit.xitActive}
-        xitOffset={ritXit.xitOffset}
-        hasRit={ritXit.hasRit}
-        hasXit={ritXit.hasXit}
-        onRitToggle={ritXitHandlers.onRitToggle}
-        onXitToggle={ritXitHandlers.onXitToggle}
-        onRitOffsetChange={ritXitHandlers.onRitOffsetChange}
-        onXitOffsetChange={ritXitHandlers.onXitOffsetChange}
-        onClear={ritXitHandlers.onClear}
-      />
+      <RitXitPanel />
     </CollapsiblePanel>
   {/if}
 
@@ -184,15 +143,7 @@
     <CollapsiblePanel title="SCAN" panelId="scan"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('scan')}>
-      <ScanPanel
-        scanning={scan.scanning}
-        scanType={scan.scanType}
-        scanResumeMode={scan.scanResumeMode}
-        onScanStart={scanHandlers.onScanStart}
-        onScanStop={scanHandlers.onScanStop}
-        onDfSpanChange={scanHandlers.onDfSpanChange}
-        onResumeChange={scanHandlers.onResumeChange}
-      />
+      <ScanPanel />
     </CollapsiblePanel>
   {/if}
 
@@ -261,23 +212,7 @@
 
   {#if drag.order.includes('cw') && hasCapability('cw')}
     <CollapsiblePanel title="CW" panelId="cw" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('cw')}>
-      <CwPanel
-        cwPitch={cw.cwPitch}
-        keySpeed={cw.keySpeed}
-        breakIn={cw.breakIn}
-        breakInDelay={cw.breakInDelay}
-        apfMode={cw.apfMode}
-        twinPeak={cw.twinPeak}
-        currentMode={cw.currentMode}
-        onCwPitchChange={cwHandlers.onCwPitchChange}
-        onKeySpeedChange={cwHandlers.onKeySpeedChange}
-        onBreakInToggle={cwHandlers.onBreakInToggle}
-        onBreakInModeChange={cwHandlers.onBreakInModeChange}
-        onBreakInDelayChange={cwHandlers.onBreakInDelayChange}
-        onApfChange={cwHandlers.onApfChange}
-        onTwinPeakToggle={cwHandlers.onTwinPeakToggle}
-        onAutoTune={cwHandlers.onAutoTune}
-      />
+      <CwPanel />
     </CollapsiblePanel>
   {/if}
 

--- a/frontend/src/components-v2/layout/RightSidebar.svelte
+++ b/frontend/src/components-v2/layout/RightSidebar.svelte
@@ -19,24 +19,16 @@
   import {
     toDspProps,
     toTxProps,
-    toCwProps,
-    toRfFrontEndProps,
     toFilterProps,
-    toRitXitProps,
     toBandSelectorProps,
-    toScanProps,
   } from '../wiring/state-adapter';
   import {
     makeDspHandlers,
     makeTxHandlers,
-    makeCwPanelHandlers,
     makeSystemHandlers,
-    makeRfFrontEndHandlers,
     makeFilterHandlers,
-    makeRitXitHandlers,
     makeBandHandlers,
     makePresetHandlers,
-    makeScanHandlers,
   } from '../wiring/command-bus';
 
   // Reactive state + capabilities — via runtime
@@ -46,25 +38,17 @@
   // Derived props via state adapter — native panels
   let dsp = $derived(toDspProps(radioState, caps));
   let tx = $derived(toTxProps(radioState, caps));
-  let cw = $derived(toCwProps(radioState, caps));
   // Derived props — panels from left sidebar (for cross-sidebar rendering)
-  let rfFrontEnd = $derived(toRfFrontEndProps(radioState, caps));
   let filter = $derived(toFilterProps(radioState, caps));
-  let ritXit = $derived(toRitXitProps(radioState, caps));
   let band = $derived(toBandSelectorProps(radioState));
-  let scan = $derived(toScanProps(radioState));
 
   // Command handlers via command-bus
   const dspHandlers = makeDspHandlers();
   const txHandlers = makeTxHandlers();
-  const cwHandlers = makeCwPanelHandlers();
   const systemHandlers = makeSystemHandlers();
-  const rfHandlers = makeRfFrontEndHandlers();
   const filterHandlers = makeFilterHandlers();
-  const ritXitHandlers = makeRitXitHandlers();
   const bandHandlers = makeBandHandlers();
   const presetHandlers = makePresetHandlers();
-  const scanHandlers = makeScanHandlers();
 
   type RightSidebarMode = 'all' | 'rx' | 'tx';
 
@@ -151,23 +135,7 @@
 
   {#if showTx && drag.order.includes('cw') && hasCapability('cw')}
     <CollapsiblePanel title="CW" panelId="cw" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('cw')}>
-      <CwPanel
-        cwPitch={cw.cwPitch}
-        keySpeed={cw.keySpeed}
-        breakIn={cw.breakIn}
-        breakInDelay={cw.breakInDelay}
-        apfMode={cw.apfMode}
-        twinPeak={cw.twinPeak}
-        currentMode={cw.currentMode}
-        onCwPitchChange={cwHandlers.onCwPitchChange}
-        onKeySpeedChange={cwHandlers.onKeySpeedChange}
-        onBreakInToggle={cwHandlers.onBreakInToggle}
-        onBreakInModeChange={cwHandlers.onBreakInModeChange}
-        onBreakInDelayChange={cwHandlers.onBreakInDelayChange}
-        onApfChange={cwHandlers.onApfChange}
-        onTwinPeakToggle={cwHandlers.onTwinPeakToggle}
-        onAutoTune={cwHandlers.onAutoTune}
-      />
+      <CwPanel />
     </CollapsiblePanel>
   {/if}
 
@@ -180,20 +148,7 @@
   {#if drag.order.includes('rf-front-end')}
     <CollapsiblePanel title="RF FRONT END" panelId="rf-front-end" dataPanel="rf-frontend"
       draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('rf-front-end')}>
-      <RfFrontEnd
-        rfGain={rfFrontEnd.rfGain}
-        squelch={rfFrontEnd.squelch}
-        att={rfFrontEnd.att}
-        pre={rfFrontEnd.pre}
-        digiSel={rfFrontEnd.digiSel}
-        ipPlus={rfFrontEnd.ipPlus}
-        onRfGainChange={rfHandlers.onRfGainChange}
-        onSquelchChange={rfHandlers.onSquelchChange}
-        onAttChange={rfHandlers.onAttChange}
-        onPreChange={rfHandlers.onPreChange}
-        onDigiSelToggle={rfHandlers.onDigiSelToggle}
-        onIpPlusToggle={rfHandlers.onIpPlusToggle}
-      />
+      <RfFrontEnd />
     </CollapsiblePanel>
   {/if}
 
@@ -243,19 +198,7 @@
   {#if drag.order.includes('rit-xit')}
     <CollapsiblePanel title="RIT / XIT" panelId="rit-xit"
       draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('rit-xit')}>
-      <RitXitPanel
-        ritActive={ritXit.ritActive}
-        ritOffset={ritXit.ritOffset}
-        xitActive={ritXit.xitActive}
-        xitOffset={ritXit.xitOffset}
-        hasRit={ritXit.hasRit}
-        hasXit={ritXit.hasXit}
-        onRitToggle={ritXitHandlers.onRitToggle}
-        onXitToggle={ritXitHandlers.onXitToggle}
-        onRitOffsetChange={ritXitHandlers.onRitOffsetChange}
-        onXitOffsetChange={ritXitHandlers.onXitOffsetChange}
-        onClear={ritXitHandlers.onClear}
-      />
+      <RitXitPanel />
     </CollapsiblePanel>
   {/if}
 
@@ -280,15 +223,7 @@
   {#if drag.order.includes('scan')}
     <CollapsiblePanel title="SCAN" panelId="scan"
       draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('scan')}>
-      <ScanPanel
-        scanning={scan.scanning}
-        scanType={scan.scanType}
-        scanResumeMode={scan.scanResumeMode}
-        onScanStart={scanHandlers.onScanStart}
-        onScanStop={scanHandlers.onScanStop}
-        onDfSpanChange={scanHandlers.onDfSpanChange}
-        onResumeChange={scanHandlers.onResumeChange}
-      />
+      <ScanPanel />
     </CollapsiblePanel>
   {/if}
 </aside>

--- a/frontend/src/components-v2/panels/CwPanel.svelte
+++ b/frontend/src/components-v2/panels/CwPanel.svelte
@@ -4,58 +4,26 @@
   import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
   import { hasCapability } from '$lib/stores/capabilities.svelte';
 
-  interface Props {
-    cwPitch?: number;
-    keySpeed?: number;
-    breakIn?: number;
-    breakInDelay?: number;
-    apfMode?: number;
-    twinPeak?: boolean;
-    currentMode?: string;
-    // Mobile CW panel props
-    wpm?: number;
-    breakInActive?: boolean;
-    sidetonePitch?: number;
-    sidetoneLevel?: number;
-    reversePaddle?: boolean;
-    keyerType?: number;
-    hasCw?: boolean;
-    onCwPitchChange?: (v: number) => void;
-    onKeySpeedChange?: (v: number) => void;
-    onBreakInToggle?: () => void;
-    onBreakInModeChange?: (mode: number) => void;
-    onBreakInDelayChange?: (v: number) => void;
-    onApfChange?: (mode: number) => void;
-    onTwinPeakToggle?: () => void;
-    onAutoTune?: () => void;
-    // Mobile CW handlers
-    onWpmChange?: (v: number) => void;
-    onSidetonePitchChange?: (v: number) => void;
-    onSidetoneLevelChange?: (v: number) => void;
-    onReversePaddleToggle?: () => void;
-    onKeyerTypeChange?: (v: number) => void;
-  }
+  import { deriveCwProps, getCwHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  const noop = () => {};
-  const noopN = (_v: number) => {};
+  const handlers = getCwHandlers();
+  let p = $derived(deriveCwProps());
 
-  let {
-    cwPitch = 600,
-    keySpeed = 12,
-    breakIn = 0,
-    breakInDelay = 0,
-    apfMode = 0,
-    twinPeak = false,
-    currentMode = 'CW',
-    onCwPitchChange = noopN,
-    onKeySpeedChange = noopN,
-    onBreakInToggle = noop,
-    onBreakInModeChange = noopN,
-    onBreakInDelayChange = noopN,
-    onApfChange = noopN,
-    onTwinPeakToggle = noop,
-    onAutoTune = noop,
-  }: Props = $props();
+  let cwPitch = $derived(p.cwPitch ?? 600);
+  let keySpeed = $derived(p.keySpeed ?? 12);
+  let breakIn = $derived(p.breakIn ?? 0);
+  let breakInDelay = $derived(p.breakInDelay ?? 0);
+  let apfMode = $derived(p.apfMode ?? 0);
+  let twinPeak = $derived(p.twinPeak ?? false);
+  let currentMode = $derived(p.currentMode ?? 'CW');
+  const onCwPitchChange = handlers.onCwPitchChange;
+  const onKeySpeedChange = handlers.onKeySpeedChange;
+  const onBreakInToggle = handlers.onBreakInToggle;
+  const onBreakInModeChange = handlers.onBreakInModeChange;
+  const onBreakInDelayChange = handlers.onBreakInDelayChange;
+  const onApfChange = handlers.onApfChange;
+  const onTwinPeakToggle = handlers.onTwinPeakToggle;
+  const onAutoTune = handlers.onAutoTune;
 
   let showBreakIn = $derived(hasCapability('break_in'));
   let showApf = $derived(hasCapability('apf'));

--- a/frontend/src/components-v2/panels/RfFrontEnd.svelte
+++ b/frontend/src/components-v2/panels/RfFrontEnd.svelte
@@ -7,35 +7,23 @@
   import { buildPreOptions, shouldShowPanel } from './rf-frontend-utils';
   import { getShortcutHint } from '../layout/shortcut-hints';
 
-  interface Props {
-    rfGain: number;
-    squelch: number;
-    att: number;
-    pre: number;
-    digiSel: boolean;
-    ipPlus: boolean;
-    onRfGainChange: (v: number) => void;
-    onSquelchChange: (v: number) => void;
-    onAttChange: (v: number) => void;
-    onPreChange: (v: number) => void;
-    onDigiSelToggle: (v: boolean) => void;
-    onIpPlusToggle: (v: boolean) => void;
-  }
+  import { deriveRfFrontEndProps, getRfFrontEndHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  let {
-    rfGain,
-    squelch,
-    att,
-    pre,
-    digiSel,
-    ipPlus,
-    onRfGainChange,
-    onSquelchChange,
-    onAttChange,
-    onPreChange,
-    onDigiSelToggle,
-    onIpPlusToggle,
-  }: Props = $props();
+  const handlers = getRfFrontEndHandlers();
+  let p = $derived(deriveRfFrontEndProps());
+
+  let rfGain = $derived(p.rfGain);
+  let squelch = $derived(p.squelch);
+  let att = $derived(p.att);
+  let pre = $derived(p.pre);
+  let digiSel = $derived(p.digiSel);
+  let ipPlus = $derived(p.ipPlus);
+  const onRfGainChange = handlers.onRfGainChange;
+  const onSquelchChange = handlers.onSquelchChange;
+  const onAttChange = handlers.onAttChange;
+  const onPreChange = handlers.onPreChange;
+  const onDigiSelToggle = handlers.onDigiSelToggle;
+  const onIpPlusToggle = handlers.onIpPlusToggle;
 
   let showRfGain = $derived(hasCapability('rf_gain'));
   let showSquelch = $derived(hasCapability('squelch'));

--- a/frontend/src/components-v2/panels/RitXitPanel.svelte
+++ b/frontend/src/components-v2/panels/RitXitPanel.svelte
@@ -4,33 +4,22 @@
   import { formatOffset, shouldShowPanel } from './rit-utils';
   import { getShortcutHint } from '../layout/shortcut-hints';
 
-  interface Props {
-    ritActive: boolean;
-    ritOffset: number;
-    xitActive: boolean;
-    xitOffset: number;
-    hasRit: boolean;
-    hasXit: boolean;
-    onRitToggle: () => void;
-    onXitToggle: () => void;
-    onRitOffsetChange: (v: number) => void;
-    onXitOffsetChange: (v: number) => void;
-    onClear: () => void;
-  }
+  import { deriveRitXitProps, getRitXitHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  let {
-    ritActive,
-    ritOffset,
-    xitActive,
-    xitOffset,
-    hasRit,
-    hasXit,
-    onRitToggle,
-    onXitToggle,
-    onRitOffsetChange,
-    onXitOffsetChange,
-    onClear,
-  }: Props = $props();
+  const handlers = getRitXitHandlers();
+  let p = $derived(deriveRitXitProps());
+
+  let ritActive = $derived(p.ritActive);
+  let ritOffset = $derived(p.ritOffset);
+  let xitActive = $derived(p.xitActive);
+  let xitOffset = $derived(p.xitOffset);
+  let hasRit = $derived(p.hasRit);
+  let hasXit = $derived(p.hasXit);
+  const onRitToggle = handlers.onRitToggle;
+  const onXitToggle = handlers.onXitToggle;
+  const onRitOffsetChange = handlers.onRitOffsetChange;
+  const onXitOffsetChange = handlers.onXitOffsetChange;
+  const onClear = handlers.onClear;
 
   let visible = $derived(shouldShowPanel(hasRit, hasXit));
   let offsetValue = $derived(xitActive && !ritActive ? xitOffset : ritOffset);

--- a/frontend/src/components-v2/panels/ScanPanel.svelte
+++ b/frontend/src/components-v2/panels/ScanPanel.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
   import { HardwareButton } from '$lib/Button';
 
-  interface Props {
-    scanning: boolean;
-    scanType: number;
-    scanResumeMode: number;
-    onScanStart: (type: number) => void;
-    onScanStop: () => void;
-    onDfSpanChange: (span: number) => void;
-    onResumeChange: (mode: number) => void;
-  }
+  import { deriveScanProps, getScanHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  let {
-    scanning,
-    scanType,
-    scanResumeMode,
-    onScanStart,
-    onScanStop,
-    onDfSpanChange,
-    onResumeChange,
-  }: Props = $props();
+  const handlers = getScanHandlers();
+  let p = $derived(deriveScanProps());
+
+  let scanning = $derived(p.scanning);
+  let scanType = $derived(p.scanType);
+  let scanResumeMode = $derived(p.scanResumeMode);
+  const onScanStart = handlers.onScanStart;
+  const onScanStop = handlers.onScanStop;
+  const onDfSpanChange = handlers.onDfSpanChange;
+  const onResumeChange = handlers.onResumeChange;
 
   const scanTypes = [
     { value: 0x01, label: 'PROG' },

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
@@ -1,33 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
-import type { ComponentProps } from 'svelte';
-import CwPanel from '../CwPanel.svelte';
 
-vi.mock('$lib/stores/capabilities.svelte', () => ({
-  hasCapability: vi.fn(() => true),
-}));
-
-let components: ReturnType<typeof mount>[] = [];
-
-function mountPanel(props: ComponentProps<typeof CwPanel>) {
-  const t = document.createElement('div');
-  document.body.appendChild(t);
-  const component = mount(CwPanel, { target: t, props });
-  flushSync();
-  components.push(component);
-  return t;
-}
-
-beforeEach(() => {
-  components = [];
-});
-
-afterEach(() => {
-  components.forEach((c) => unmount(c));
-  document.body.innerHTML = '';
-});
-
-const baseProps: ComponentProps<typeof CwPanel> = {
+const mockProps = {
   cwPitch: 600,
   keySpeed: 12,
   breakIn: 0,
@@ -35,63 +9,111 @@ const baseProps: ComponentProps<typeof CwPanel> = {
   apfMode: 0,
   twinPeak: false,
   currentMode: 'CW',
+  hasCw: true,
 };
+
+const mockHandlers = {
+  onCwPitchChange: vi.fn(),
+  onKeySpeedChange: vi.fn(),
+  onBreakInToggle: vi.fn(),
+  onBreakInModeChange: vi.fn(),
+  onBreakInDelayChange: vi.fn(),
+  onApfChange: vi.fn(),
+  onTwinPeakToggle: vi.fn(),
+  onAutoTune: vi.fn(),
+};
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveCwProps: () => mockProps,
+  getCwHandlers: () => mockHandlers,
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasCapability: vi.fn(() => true),
+}));
+
+import CwPanel from '../CwPanel.svelte';
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountPanel(overrides?: Partial<typeof mockProps>) {
+  if (overrides) Object.assign(mockProps, overrides);
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  const component = mount(CwPanel, { target: t });
+  flushSync();
+  components.push(component);
+  return t;
+}
+
+beforeEach(() => {
+  components = [];
+  Object.assign(mockProps, {
+    cwPitch: 600, keySpeed: 12, breakIn: 0, breakInDelay: 0,
+    apfMode: 0, twinPeak: false, currentMode: 'CW', hasCw: true,
+  });
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+});
 
 describe('CwPanel component rendering', () => {
   it('mounts without errors', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('.panel-body')).not.toBeNull();
   });
 
   it('renders RX mode line with current mode', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('.cw-mode-value')?.textContent).toBe('CW');
   });
 
   it('renders CW Pitch control', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const labels = Array.from(t.querySelectorAll('.vc-label'));
     expect(labels.some((el) => el.textContent === 'CW Pitch')).toBe(true);
   });
 
   it('renders Key Speed control', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const labels = Array.from(t.querySelectorAll('.vc-label'));
     expect(labels.some((el) => el.textContent === 'Key Speed')).toBe(true);
   });
 
   it('renders SEMI break-in button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim() === 'SEMI')).toBe(true);
   });
 
   it('renders FULL break-in button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim() === 'FULL')).toBe(true);
   });
 
   it('renders APF button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim() === 'APF')).toBe(true);
   });
 
   it('renders TPF (twin peak) button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim() === 'TPF')).toBe(true);
   });
 
   it('renders AUTO TUNE button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim() === 'AUTO TUNE')).toBe(true);
   });
 
   it('unmounts cleanly', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const comp = components.pop()!;
     unmount(comp);
     expect(t.innerHTML).toBe('');

--- a/frontend/src/components-v2/panels/__tests__/RitXitPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RitXitPanel.test.ts
@@ -1,15 +1,38 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
-import type { ComponentProps } from 'svelte';
-import RitXitPanel from '../RitXitPanel.svelte';
 import { formatOffset, shouldShowPanel } from '../rit-utils';
+
+const mockProps = {
+  ritActive: false,
+  ritOffset: 0,
+  xitActive: false,
+  xitOffset: 0,
+  hasRit: true,
+  hasXit: true,
+};
+
+const mockHandlers = {
+  onRitToggle: vi.fn(),
+  onXitToggle: vi.fn(),
+  onRitOffsetChange: vi.fn(),
+  onXitOffsetChange: vi.fn(),
+  onClear: vi.fn(),
+};
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveRitXitProps: () => mockProps,
+  getRitXitHandlers: () => mockHandlers,
+}));
+
+import RitXitPanel from '../RitXitPanel.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(props: ComponentProps<typeof RitXitPanel>) {
+function mountPanel(overrides?: Partial<typeof mockProps>) {
+  if (overrides) Object.assign(mockProps, overrides);
   const target = document.createElement('div');
   document.body.appendChild(target);
-  const component = mount(RitXitPanel, { target, props });
+  const component = mount(RitXitPanel, { target });
   flushSync();
   components.push(component);
   return target;
@@ -17,26 +40,21 @@ function mountPanel(props: ComponentProps<typeof RitXitPanel>) {
 
 beforeEach(() => {
   components = [];
+  Object.assign(mockProps, {
+    ritActive: false, ritOffset: 0, xitActive: false, xitOffset: 0,
+    hasRit: true, hasXit: true,
+  });
+  mockHandlers.onRitToggle = vi.fn();
+  mockHandlers.onXitToggle = vi.fn();
+  mockHandlers.onRitOffsetChange = vi.fn();
+  mockHandlers.onXitOffsetChange = vi.fn();
+  mockHandlers.onClear = vi.fn();
 });
 
 afterEach(() => {
   components.forEach((component) => unmount(component));
   document.body.innerHTML = '';
 });
-
-const baseProps: ComponentProps<typeof RitXitPanel> = {
-  ritActive: false,
-  ritOffset: 0,
-  xitActive: false,
-  xitOffset: 0,
-  hasRit: true,
-  hasXit: true,
-  onRitToggle: vi.fn(),
-  onXitToggle: vi.fn(),
-  onRitOffsetChange: vi.fn(),
-  onXitOffsetChange: vi.fn(),
-  onClear: vi.fn(),
-};
 
 // ---------------------------------------------------------------------------
 // formatOffset
@@ -117,25 +135,24 @@ describe('shouldShowPanel', () => {
 
 describe('CLEAR button', () => {
   it('renders a CLEAR action button', () => {
-    const target = mountPanel(baseProps);
+    const target = mountPanel();
     const btn = target.querySelector<HTMLButtonElement>('.clear-row button');
     expect(btn).not.toBeNull();
     expect(btn?.textContent?.trim()).toBe('CLEAR');
   });
 
   it('CLEAR button is never data-active="true" (action-button, not a toggle)', () => {
-    const target = mountPanel(baseProps);
+    const target = mountPanel();
     const btn = target.querySelector<HTMLButtonElement>('.clear-row button');
     expect(btn?.dataset.active).not.toBe('true');
   });
 
   it('calls onClear when CLEAR button is clicked', () => {
-    const onClear = vi.fn();
-    const target = mountPanel({ ...baseProps, onClear });
+    const target = mountPanel();
     const btn = target.querySelector<HTMLButtonElement>('.clear-row button');
     btn?.click();
     flushSync();
-    expect(onClear).toHaveBeenCalledOnce();
+    expect(mockHandlers.onClear).toHaveBeenCalledOnce();
   });
 });
 
@@ -150,39 +167,33 @@ describe('RitXitPanel component', () => {
   });
 
   it('renders the Offset slider when visible', () => {
-    const target = mountPanel(baseProps);
+    const target = mountPanel();
     const labels = Array.from(target.querySelectorAll('.vc-label')).map((el) => el.textContent);
     expect(labels).toContain('Offset');
   });
 
   it('uses the shared offset constraints', () => {
-    const target = mountPanel(baseProps);
+    const target = mountPanel();
     const slider = target.querySelector<HTMLElement>('[role="slider"]');
     expect(slider?.getAttribute('aria-valuemin')).toBe('-9999');
     expect(slider?.getAttribute('aria-valuemax')).toBe('9999');
   });
 
   it('calls onRitOffsetChange when the offset slider changes by default', () => {
-    const onRitOffsetChange = vi.fn();
-    const target = mountPanel({ ...baseProps, onRitOffsetChange });
+    const target = mountPanel();
     const slider = target.querySelector<HTMLElement>('[role="slider"]');
     slider!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     vi.advanceTimersByTime(60);
 
-    expect(onRitOffsetChange).toHaveBeenCalled();
+    expect(mockHandlers.onRitOffsetChange).toHaveBeenCalled();
   });
 
   it('calls onXitOffsetChange when only XIT is active', () => {
-    const onXitOffsetChange = vi.fn();
-    const target = mountPanel({
-      ...baseProps,
-      xitActive: true,
-      onXitOffsetChange,
-    });
+    const target = mountPanel({ xitActive: true });
     const slider = target.querySelector<HTMLElement>('[role="slider"]');
     slider!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     vi.advanceTimersByTime(60);
 
-    expect(onXitOffsetChange).toHaveBeenCalled();
+    expect(mockHandlers.onXitOffsetChange).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **Self-wired: RfFrontEnd, RitXitPanel, ScanPanel, CwPanel** via runtime adapters
- **Sidebars simplified**: -146 lines of prop-passing boilerplate
- **Tests updated**: CwPanel + RitXitPanel tests mock panel-adapters

8 of 13 panels now self-wiring. Net: -159 lines.

## Test plan
- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)