### PR TITLE
feat(#664): self-wire complex panels (DSP, TX, Filter, Band)

### DIFF
--- a/frontend/src/components-v2/controls/BandSelector.svelte
+++ b/frontend/src/components-v2/controls/BandSelector.svelte
@@ -5,14 +5,16 @@
   import { getShortcutHint } from '../layout/shortcut-hints';
   import { BROADCAST_SW_BANDS, BROADCAST_LW_MW_BANDS, findActiveBroadcastBand } from './broadcast-presets';
 
-  interface Props {
-    currentFreq: number;
-    onBandSelect: (bandName: string, freq: number, bsrCode?: number) => void;
-    onPresetSelect?: (freq: number, mode: string, filter?: number) => void;
-    onFreqPreset?: (freq: number, mode: string, filter?: number) => void;
-  }
+  import { deriveBandSelectorProps, getBandHandlers, getPresetHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  let { currentFreq, onBandSelect, onPresetSelect, onFreqPreset }: Props = $props();
+  const bandH = getBandHandlers();
+  const presetH = getPresetHandlers();
+  let bp = $derived(deriveBandSelectorProps());
+
+  let currentFreq = $derived(bp.currentFreq);
+  const onBandSelect = bandH.onBandSelect;
+  const onPresetSelect = presetH.onPresetSelect;
+  const onFreqPreset = presetH.onFreqPreset;
 
   let bandMode = $state<'ham' | 'broadcast' | 'lwmw'>('ham');
 

--- a/frontend/src/components-v2/controls/__tests__/BandSelector.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/BandSelector.test.ts
@@ -1,37 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
-import type { ComponentProps } from 'svelte';
-
-vi.mock('$lib/stores/capabilities.svelte', () => ({
-  getCapabilities: vi.fn(() => ({ freqRanges: HF_RANGES })),
-  getKeyboardConfig: vi.fn(() => null),
-}));
-
-import BandSelector from '../BandSelector.svelte';
 import { flattenBands, findActiveBand } from '../band-utils';
 import type { FreqRange } from '$lib/types/capabilities';
 
-let components: ReturnType<typeof mount>[] = [];
-
-function mountSelector(props: ComponentProps<typeof BandSelector>) {
-  const target = document.createElement('div');
-  document.body.appendChild(target);
-  const component = mount(BandSelector, { target, props });
-  flushSync();
-  components.push(component);
-  return target;
-}
-
-beforeEach(() => {
-  components = [];
-});
-
-afterEach(() => {
-  components.forEach((component) => unmount(component));
-  document.body.innerHTML = '';
-});
-
-// ── Fixtures ───────────────────────────────────────────────────────────────
+// ── Fixtures (must be declared before vi.mock factories) ──────────────────
 
 const HF_RANGES: FreqRange[] = [
   {
@@ -56,6 +28,57 @@ const HF_RANGES: FreqRange[] = [
     ],
   },
 ];
+
+const mockProps = {
+  currentFreq: 14_074_000,
+};
+
+const mockBandHandlers = {
+  onBandSelect: vi.fn(),
+};
+
+const mockPresetHandlers = {
+  onPresetSelect: vi.fn(),
+  onFreqPreset: vi.fn(),
+};
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => ({ freqRanges: HF_RANGES })),
+  getKeyboardConfig: vi.fn(() => null),
+}));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveBandSelectorProps: () => mockProps,
+  getBandHandlers: () => mockBandHandlers,
+  getPresetHandlers: () => mockPresetHandlers,
+}));
+
+import BandSelector from '../BandSelector.svelte';
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountPanel(overrides?: Partial<typeof mockProps>) {
+  if (overrides) Object.assign(mockProps, overrides);
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(BandSelector, { target });
+  flushSync();
+  components.push(component);
+  return target;
+}
+
+beforeEach(() => {
+  components = [];
+  mockProps.currentFreq = 14_074_000;
+  mockBandHandlers.onBandSelect = vi.fn();
+  mockPresetHandlers.onPresetSelect = vi.fn();
+  mockPresetHandlers.onFreqPreset = vi.fn();
+});
+
+afterEach(() => {
+  components.forEach((component) => unmount(component));
+  document.body.innerHTML = '';
+});
 
 const EMPTY_RANGES: FreqRange[] = [];
 
@@ -195,16 +218,12 @@ describe('BandSelector component', () => {
   }
 
   it('forwards bsrCode when a band is selected', () => {
-    const onBandSelect = vi.fn();
-    const target = mountSelector({
-      currentFreq: 14_074_000,
-      onBandSelect,
-    });
+    const target = mountPanel();
 
     const button = findButtonByText(target, '20m');
     button?.click();
     flushSync();
 
-    expect(onBandSelect).toHaveBeenCalledWith('20m', 14_225_000, 5);
+    expect(mockBandHandlers.onBandSelect).toHaveBeenCalledWith('20m', 14_225_000, 5);
   });
 });

--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -16,23 +16,8 @@
   import MemoryPanel from '../panels/MemoryPanel.svelte';
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
   import { createDragReorder } from '$lib/drag-reorder.svelte';
-  import {
-    toFilterProps,
-    toBandSelectorProps,
-    toDspProps,
-    toTxProps,
-  } from '../wiring/state-adapter';
-  import {
-    makeFilterHandlers,
-    makeBandHandlers,
-    makePresetHandlers,
-    makeDspHandlers,
-    makeTxHandlers,
-    makeSystemHandlers,
-  } from '../wiring/command-bus';
 
   // Reactive state + capabilities — via runtime
-  let radioState = $derived(runtime.state);
   let caps = $derived(runtime.caps);
 
   // --- Panel reorder (shared logic) ---
@@ -41,19 +26,6 @@
     defaults: ['rf-front-end', 'mode', 'filter', 'agc', 'rit-xit', 'band', 'antenna', 'scan'],
     containerSelector: '.left-sidebar',
   });
-
-  // Derived props via state adapter — panels not yet self-wiring
-  let filter = $derived(toFilterProps(radioState, caps));
-  let band = $derived(toBandSelectorProps(radioState));
-  let dsp = $derived(toDspProps(radioState, caps));
-  let tx = $derived(toTxProps(radioState, caps));
-  // Command handlers
-  const filterHandlers = makeFilterHandlers();
-  const bandHandlers = makeBandHandlers();
-  const presetHandlers = makePresetHandlers();
-  const dspHandlers = makeDspHandlers();
-  const txHandlers = makeTxHandlers();
-  const systemHandlers = makeSystemHandlers();
 </script>
 
 <aside class="left-sidebar" class:cross-drop-target={drag.isDropTarget}>
@@ -77,29 +49,7 @@
     <CollapsiblePanel title="FILTER" panelId="filter"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('filter')}>
-      <FilterPanel
-        currentMode={filter.currentMode}
-        currentFilter={filter.currentFilter}
-        filterShape={filter.filterShape}
-        filterLabels={filter.filterLabels}
-        filterWidth={filter.filterWidth}
-        filterWidthMin={filter.filterWidthMin}
-        filterWidthMax={filter.filterWidthMax}
-        filterConfig={filter.filterConfig}
-        ifShift={filter.ifShift}
-        hasPbt={filter.hasPbt}
-        pbtInner={filter.pbtInner}
-        pbtOuter={filter.pbtOuter}
-        onFilterChange={filterHandlers.onFilterChange}
-        onFilterWidthChange={filterHandlers.onFilterWidthChange}
-        onFilterShapeChange={filterHandlers.onFilterShapeChange}
-        onFilterPresetChange={filterHandlers.onFilterPresetChange}
-        onFilterDefaults={filterHandlers.onFilterDefaults}
-        onIfShiftChange={filterHandlers.onIfShiftChange}
-        onPbtInnerChange={filterHandlers.onPbtInnerChange}
-        onPbtOuterChange={filterHandlers.onPbtOuterChange}
-        onPbtReset={filterHandlers.onPbtReset}
-      />
+      <FilterPanel />
     </CollapsiblePanel>
   {/if}
 
@@ -123,11 +73,7 @@
     <CollapsiblePanel title="BAND" panelId="band"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('band')}>
-      <BandSelector
-        currentFreq={band.currentFreq}
-        onBandSelect={bandHandlers.onBandSelect}
-        onPresetSelect={presetHandlers.onPresetSelect}
-      />
+      <BandSelector />
     </CollapsiblePanel>
   {/if}
 
@@ -155,58 +101,13 @@
 
   {#if drag.order.includes('dsp')}
     <CollapsiblePanel title="DSP" panelId="dsp" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('dsp')}>
-      <DspPanel
-        nrMode={dsp.nrMode}
-        nrLevel={dsp.nrLevel}
-        nbActive={dsp.nbActive}
-        nbLevel={dsp.nbLevel}
-        nbDepth={dsp.nbDepth}
-        nbWidth={dsp.nbWidth}
-        notchMode={dsp.notchMode}
-        notchFreq={dsp.notchFreq}
-        manualNotchWidth={dsp.manualNotchWidth}
-        agcTimeConstant={dsp.agcTimeConstant}
-        onNrModeChange={dspHandlers.onNrModeChange}
-        onNrLevelChange={dspHandlers.onNrLevelChange}
-        onNbToggle={dspHandlers.onNbToggle}
-        onNbLevelChange={dspHandlers.onNbLevelChange}
-        onNbDepthChange={dspHandlers.onNbDepthChange}
-        onNbWidthChange={dspHandlers.onNbWidthChange}
-        onNotchModeChange={dspHandlers.onNotchModeChange}
-        onNotchFreqChange={dspHandlers.onNotchFreqChange}
-        onManualNotchWidthChange={dspHandlers.onManualNotchWidthChange}
-        onAgcTimeChange={dspHandlers.onAgcTimeChange}
-      />
+      <DspPanel />
     </CollapsiblePanel>
   {/if}
 
   {#if drag.order.includes('tx')}
     <CollapsiblePanel title="TX" panelId="tx" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('tx')}>
-      <TxPanel
-        txActive={tx.txActive}
-        rfPower={tx.rfPower}
-        micGain={tx.micGain}
-        atuActive={tx.atuActive}
-        atuTuning={tx.atuTuning}
-        voxActive={tx.voxActive}
-        compActive={tx.compActive}
-        compLevel={tx.compLevel}
-        monActive={tx.monActive}
-        monLevel={tx.monLevel}
-        driveGain={tx.driveGain}
-        onRfPowerChange={txHandlers.onRfPowerChange}
-        onMicGainChange={txHandlers.onMicGainChange}
-        onAtuToggle={txHandlers.onAtuToggle}
-        onAtuTune={txHandlers.onAtuTune}
-        onVoxToggle={txHandlers.onVoxToggle}
-        onCompToggle={txHandlers.onCompToggle}
-        onCompLevelChange={txHandlers.onCompLevelChange}
-        onMonToggle={txHandlers.onMonToggle}
-        onMonLevelChange={txHandlers.onMonLevelChange}
-        onDriveGainChange={txHandlers.onDriveGainChange}
-        onPttOn={systemHandlers.onPttOn}
-        onPttOff={systemHandlers.onPttOff}
-      />
+      <TxPanel />
     </CollapsiblePanel>
   {/if}
 

--- a/frontend/src/components-v2/layout/RightSidebar.svelte
+++ b/frontend/src/components-v2/layout/RightSidebar.svelte
@@ -16,39 +16,9 @@
   import BandSelector from '../controls/BandSelector.svelte';
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
   import { createDragReorder } from '$lib/drag-reorder.svelte';
-  import {
-    toDspProps,
-    toTxProps,
-    toFilterProps,
-    toBandSelectorProps,
-  } from '../wiring/state-adapter';
-  import {
-    makeDspHandlers,
-    makeTxHandlers,
-    makeSystemHandlers,
-    makeFilterHandlers,
-    makeBandHandlers,
-    makePresetHandlers,
-  } from '../wiring/command-bus';
 
   // Reactive state + capabilities — via runtime
-  let radioState = $derived(runtime.state);
   let caps = $derived(runtime.caps);
-
-  // Derived props via state adapter — native panels
-  let dsp = $derived(toDspProps(radioState, caps));
-  let tx = $derived(toTxProps(radioState, caps));
-  // Derived props — panels from left sidebar (for cross-sidebar rendering)
-  let filter = $derived(toFilterProps(radioState, caps));
-  let band = $derived(toBandSelectorProps(radioState));
-
-  // Command handlers via command-bus
-  const dspHandlers = makeDspHandlers();
-  const txHandlers = makeTxHandlers();
-  const systemHandlers = makeSystemHandlers();
-  const filterHandlers = makeFilterHandlers();
-  const bandHandlers = makeBandHandlers();
-  const presetHandlers = makePresetHandlers();
 
   type RightSidebarMode = 'all' | 'rx' | 'tx';
 
@@ -78,58 +48,13 @@
 
   {#if showRx && drag.order.includes('dsp')}
     <CollapsiblePanel title="DSP" panelId="dsp" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('dsp')}>
-      <DspPanel
-        nrMode={dsp.nrMode}
-        nrLevel={dsp.nrLevel}
-        nbActive={dsp.nbActive}
-        nbLevel={dsp.nbLevel}
-        nbDepth={dsp.nbDepth}
-        nbWidth={dsp.nbWidth}
-        notchMode={dsp.notchMode}
-        notchFreq={dsp.notchFreq}
-        manualNotchWidth={dsp.manualNotchWidth}
-        agcTimeConstant={dsp.agcTimeConstant}
-        onNrModeChange={dspHandlers.onNrModeChange}
-        onNrLevelChange={dspHandlers.onNrLevelChange}
-        onNbToggle={dspHandlers.onNbToggle}
-        onNbLevelChange={dspHandlers.onNbLevelChange}
-        onNbDepthChange={dspHandlers.onNbDepthChange}
-        onNbWidthChange={dspHandlers.onNbWidthChange}
-        onNotchModeChange={dspHandlers.onNotchModeChange}
-        onNotchFreqChange={dspHandlers.onNotchFreqChange}
-        onManualNotchWidthChange={dspHandlers.onManualNotchWidthChange}
-        onAgcTimeChange={dspHandlers.onAgcTimeChange}
-      />
+      <DspPanel />
     </CollapsiblePanel>
   {/if}
 
   {#if showTx && drag.order.includes('tx')}
     <CollapsiblePanel title="TX" panelId="tx" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('tx')}>
-      <TxPanel
-        txActive={tx.txActive}
-        rfPower={tx.rfPower}
-        micGain={tx.micGain}
-        atuActive={tx.atuActive}
-        atuTuning={tx.atuTuning}
-        voxActive={tx.voxActive}
-        compActive={tx.compActive}
-        compLevel={tx.compLevel}
-        monActive={tx.monActive}
-        monLevel={tx.monLevel}
-        driveGain={tx.driveGain}
-        onRfPowerChange={txHandlers.onRfPowerChange}
-        onMicGainChange={txHandlers.onMicGainChange}
-        onAtuToggle={txHandlers.onAtuToggle}
-        onAtuTune={txHandlers.onAtuTune}
-        onVoxToggle={txHandlers.onVoxToggle}
-        onCompToggle={txHandlers.onCompToggle}
-        onCompLevelChange={txHandlers.onCompLevelChange}
-        onMonToggle={txHandlers.onMonToggle}
-        onMonLevelChange={txHandlers.onMonLevelChange}
-        onDriveGainChange={txHandlers.onDriveGainChange}
-        onPttOn={systemHandlers.onPttOn}
-        onPttOff={systemHandlers.onPttOff}
-      />
+      <TxPanel />
     </CollapsiblePanel>
   {/if}
 
@@ -162,29 +87,7 @@
   {#if drag.order.includes('filter')}
     <CollapsiblePanel title="FILTER" panelId="filter"
       draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('filter')}>
-      <FilterPanel
-        currentMode={filter.currentMode}
-        currentFilter={filter.currentFilter}
-        filterShape={filter.filterShape}
-        filterLabels={filter.filterLabels}
-        filterWidth={filter.filterWidth}
-        filterWidthMin={filter.filterWidthMin}
-        filterWidthMax={filter.filterWidthMax}
-        filterConfig={filter.filterConfig}
-        ifShift={filter.ifShift}
-        hasPbt={filter.hasPbt}
-        pbtInner={filter.pbtInner}
-        pbtOuter={filter.pbtOuter}
-        onFilterChange={filterHandlers.onFilterChange}
-        onFilterWidthChange={filterHandlers.onFilterWidthChange}
-        onFilterShapeChange={filterHandlers.onFilterShapeChange}
-        onFilterPresetChange={filterHandlers.onFilterPresetChange}
-        onFilterDefaults={filterHandlers.onFilterDefaults}
-        onIfShiftChange={filterHandlers.onIfShiftChange}
-        onPbtInnerChange={filterHandlers.onPbtInnerChange}
-        onPbtOuterChange={filterHandlers.onPbtOuterChange}
-        onPbtReset={filterHandlers.onPbtReset}
-      />
+      <FilterPanel />
     </CollapsiblePanel>
   {/if}
 
@@ -205,11 +108,7 @@
   {#if drag.order.includes('band')}
     <CollapsiblePanel title="BAND" panelId="band"
       draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('band')}>
-      <BandSelector
-        currentFreq={band.currentFreq}
-        onBandSelect={bandHandlers.onBandSelect}
-        onPresetSelect={presetHandlers.onPresetSelect}
-      />
+      <BandSelector />
     </CollapsiblePanel>
   {/if}
 

--- a/frontend/src/components-v2/panels/DspPanel.svelte
+++ b/frontend/src/components-v2/panels/DspPanel.svelte
@@ -4,51 +4,31 @@
   import { hasCapability } from '$lib/stores/capabilities.svelte';
   import { buildNrOptions, buildNotchOptions } from './dsp-utils';
 
-  interface Props {
-    nrMode: number;
-    nrLevel: number;
-    nbActive: boolean;
-    nbLevel: number;
-    nbDepth: number;
-    nbWidth: number;
-    notchMode: 'off' | 'auto' | 'manual';
-    notchFreq: number;
-    manualNotchWidth: number;
-    agcTimeConstant: number;
-    onNrModeChange: (v: number) => void;
-    onNrLevelChange: (v: number) => void;
-    onNbToggle: (v: boolean) => void;
-    onNbLevelChange: (v: number) => void;
-    onNbDepthChange: (v: number) => void;
-    onNbWidthChange: (v: number) => void;
-    onNotchModeChange: (v: string) => void;
-    onNotchFreqChange: (v: number) => void;
-    onManualNotchWidthChange: (v: number) => void;
-    onAgcTimeChange: (v: number) => void;
-  }
+  import { deriveDspProps, getDspHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  let {
-    nrMode,
-    nrLevel,
-    nbActive,
-    nbLevel,
-    nbDepth = 0,
-    nbWidth = 0,
-    notchMode,
-    notchFreq,
-    manualNotchWidth = 0,
-    agcTimeConstant = 0,
-    onNrModeChange,
-    onNrLevelChange,
-    onNbToggle,
-    onNbLevelChange,
-    onNbDepthChange = () => {},
-    onNbWidthChange = () => {},
-    onNotchModeChange,
-    onNotchFreqChange,
-    onManualNotchWidthChange = () => {},
-    onAgcTimeChange = () => {},
-  }: Props = $props();
+  const handlers = getDspHandlers();
+  let p = $derived(deriveDspProps());
+
+  let nrMode = $derived(p.nrMode);
+  let nrLevel = $derived(p.nrLevel);
+  let nbActive = $derived(p.nbActive);
+  let nbLevel = $derived(p.nbLevel);
+  let nbDepth = $derived(p.nbDepth ?? 0);
+  let nbWidth = $derived(p.nbWidth ?? 0);
+  let notchMode = $derived(p.notchMode);
+  let notchFreq = $derived(p.notchFreq);
+  let manualNotchWidth = $derived(p.manualNotchWidth ?? 0);
+  let agcTimeConstant = $derived(p.agcTimeConstant ?? 0);
+  const onNrModeChange = handlers.onNrModeChange;
+  const onNrLevelChange = handlers.onNrLevelChange;
+  const onNbToggle = handlers.onNbToggle;
+  const onNbLevelChange = handlers.onNbLevelChange;
+  const onNbDepthChange = handlers.onNbDepthChange ?? (() => {});
+  const onNbWidthChange = handlers.onNbWidthChange ?? (() => {});
+  const onNotchModeChange = handlers.onNotchModeChange;
+  const onNotchFreqChange = handlers.onNotchFreqChange;
+  const onManualNotchWidthChange = handlers.onManualNotchWidthChange ?? (() => {});
+  const onAgcTimeChange = handlers.onAgcTimeChange ?? (() => {});
 
   const NOTCH_WIDTH_LABELS: Record<number, string> = { 0: 'WIDE', 1: 'MID', 2: 'NARROW' };
   const AGC_TIME_LABELS: Record<number, string> = {

--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -5,53 +5,32 @@
   import { formatFilterWidth } from './filter-utils';
   import { getShortcutHint, joinShortcutHints } from '../layout/shortcut-hints';
 
-  interface Props {
-    currentMode: string;
-    currentFilter: number;
-    filterShape: number;
-    filterLabels?: string[];
-    filterWidth: number;
-    filterWidthMin?: number;
-    filterWidthMax?: number;
-    filterConfig?: FilterModeConfig | null;
-    ifShift: number;
-    pbtInner?: number;
-    pbtOuter?: number;
-    hasPbt?: boolean;
-    onFilterChange?: (filter: number) => void;
-    onFilterWidthChange: (v: number) => void;
-    onFilterShapeChange?: (shape: number) => void;
-    onFilterPresetChange?: (filter: number, width: number) => void;
-    onFilterDefaults?: (defaults: number[]) => void;
-    onIfShiftChange: (v: number) => void;
-    onPbtInnerChange?: (v: number) => void;
-    onPbtOuterChange?: (v: number) => void;
-    onPbtReset?: () => void;
-  }
+  import { deriveFilterProps, getFilterHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  let {
-    currentMode,
-    currentFilter,
-    filterShape,
-    filterLabels = ['FIL1', 'FIL2', 'FIL3'],
-    filterWidth,
-    filterWidthMin = 50,
-    filterWidthMax = 9999,
-    filterConfig = null,
-    ifShift,
-    pbtInner = 0,
-    pbtOuter = 0,
-    hasPbt = false,
-    onFilterChange,
-    onFilterWidthChange,
-    onFilterShapeChange,
-    onFilterPresetChange,
-    onFilterDefaults,
-    onIfShiftChange,
-    onPbtInnerChange,
-    onPbtOuterChange,
-    onPbtReset,
-  }: Props = $props();
+  const handlers = getFilterHandlers();
+  let p = $derived(deriveFilterProps());
+
+  let currentMode = $derived(p.currentMode);
+  let currentFilter = $derived(p.currentFilter);
+  let filterShape = $derived(p.filterShape);
+  let filterLabels = $derived(p.filterLabels ?? ['FIL1', 'FIL2', 'FIL3']);
+  let filterWidth = $derived(p.filterWidth);
+  let filterWidthMin = $derived(p.filterWidthMin ?? 50);
+  let filterWidthMax = $derived(p.filterWidthMax ?? 9999);
+  let filterConfig = $derived(p.filterConfig ?? null);
+  let ifShift = $derived(p.ifShift);
+  let pbtInner = $derived(p.pbtInner ?? 0);
+  let pbtOuter = $derived(p.pbtOuter ?? 0);
+  let hasPbt = $derived(p.hasPbt ?? false);
+  const onFilterChange = handlers.onFilterChange;
+  const onFilterWidthChange = handlers.onFilterWidthChange;
+  const onFilterShapeChange = handlers.onFilterShapeChange;
+  const onFilterPresetChange = handlers.onFilterPresetChange;
+  const onFilterDefaults = handlers.onFilterDefaults;
+  const onIfShiftChange = handlers.onIfShiftChange;
+  const onPbtInnerChange = handlers.onPbtInnerChange;
+  const onPbtOuterChange = handlers.onPbtOuterChange;
+  const onPbtReset = handlers.onPbtReset;
 
   let modalOpen = $state(false);
   let draftWidths = $state<number[]>([]);

--- a/frontend/src/components-v2/panels/TxPanel.svelte
+++ b/frontend/src/components-v2/panels/TxPanel.svelte
@@ -4,44 +4,35 @@
   import { hasTx, hasCapability } from '$lib/stores/capabilities.svelte';
   import { txStatusColor } from './tx-utils';
   import { getTxAudioControl } from '$lib/runtime/adapters/tx-adapter';
+  import { deriveTxProps, getTxHandlers } from '$lib/runtime/adapters/panel-adapters';
+
   const txAudio = getTxAudioControl();
+  const handlers = getTxHandlers();
+  let p = $derived(deriveTxProps());
 
-  interface Props {
-    txActive: boolean;
-    rfPower: number;
-    micGain: number;
-    atuActive: boolean;
-    atuTuning: boolean;
-    voxActive: boolean;
-    compActive: boolean;
-    compLevel: number;
-    monActive: boolean;
-    monLevel: number;
-    driveGain: number;
-    onRfPowerChange: (v: number) => void;
-    onMicGainChange: (v: number) => void;
-    onAtuToggle: () => void;
-    onAtuTune: () => void;
-    onVoxToggle: () => void;
-    onCompToggle: () => void;
-    onCompLevelChange: (v: number) => void;
-    onMonToggle: () => void;
-    onMonLevelChange: (v: number) => void;
-    onDriveGainChange: (v: number) => void;
-    onPttOn?: () => void;
-    onPttOff?: () => void;
-  }
-
-  let {
-    txActive, rfPower, micGain,
-    atuActive, atuTuning, voxActive,
-    compActive, compLevel, monActive, monLevel, driveGain,
-    onRfPowerChange, onMicGainChange,
-    onAtuToggle, onAtuTune, onVoxToggle,
-    onCompToggle, onCompLevelChange,
-    onMonToggle, onMonLevelChange, onDriveGainChange,
-    onPttOn, onPttOff,
-  }: Props = $props();
+  let txActive = $derived(p.txActive);
+  let rfPower = $derived(p.rfPower);
+  let micGain = $derived(p.micGain);
+  let atuActive = $derived(p.atuActive);
+  let atuTuning = $derived(p.atuTuning);
+  let voxActive = $derived(p.voxActive);
+  let compActive = $derived(p.compActive);
+  let compLevel = $derived(p.compLevel);
+  let monActive = $derived(p.monActive);
+  let monLevel = $derived(p.monLevel);
+  let driveGain = $derived(p.driveGain);
+  const onRfPowerChange = handlers.onRfPowerChange;
+  const onMicGainChange = handlers.onMicGainChange;
+  const onAtuToggle = handlers.onAtuToggle;
+  const onAtuTune = handlers.onAtuTune;
+  const onVoxToggle = handlers.onVoxToggle;
+  const onCompToggle = handlers.onCompToggle;
+  const onCompLevelChange = handlers.onCompLevelChange;
+  const onMonToggle = handlers.onMonToggle;
+  const onMonLevelChange = handlers.onMonLevelChange;
+  const onDriveGainChange = handlers.onDriveGainChange;
+  const onPttOn = handlers.onPttOn;
+  const onPttOff = handlers.onPttOff;
 
   let tuneButtonColor = $derived(txStatusColor(atuActive, atuTuning));
   let showMon = $derived(hasCapability('monitor'));

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -1,18 +1,50 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
-import type { ComponentProps } from 'svelte';
-import DspPanel from '../DspPanel.svelte';
+
+const mockProps = {
+  nrMode: 0,
+  nrLevel: 5,
+  nbActive: false,
+  nbLevel: 128,
+  notchMode: 'off' as string,
+  notchFreq: 1000,
+  nbDepth: 0,
+  nbWidth: 0,
+  manualNotchWidth: 0,
+  agcTimeConstant: 0,
+};
+
+const mockHandlers = {
+  onNrModeChange: vi.fn(),
+  onNrLevelChange: vi.fn(),
+  onNbToggle: vi.fn(),
+  onNbLevelChange: vi.fn(),
+  onNotchModeChange: vi.fn(),
+  onNotchFreqChange: vi.fn(),
+  onNbDepthChange: vi.fn(),
+  onNbWidthChange: vi.fn(),
+  onManualNotchWidthChange: vi.fn(),
+  onAgcTimeChange: vi.fn(),
+};
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   hasCapability: vi.fn(() => true),
 }));
 
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveDspProps: () => mockProps,
+  getDspHandlers: () => mockHandlers,
+}));
+
+import DspPanel from '../DspPanel.svelte';
+
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(props: ComponentProps<typeof DspPanel>) {
+function mountPanel(overrides?: Partial<typeof mockProps>) {
+  if (overrides) Object.assign(mockProps, overrides);
   const t = document.createElement('div');
   document.body.appendChild(t);
-  const component = mount(DspPanel, { target: t, props });
+  const component = mount(DspPanel, { target: t });
   flushSync();
   components.push(component);
   return t;
@@ -20,6 +52,21 @@ function mountPanel(props: ComponentProps<typeof DspPanel>) {
 
 beforeEach(() => {
   components = [];
+  Object.assign(mockProps, {
+    nrMode: 0, nrLevel: 5, nbActive: false, nbLevel: 128,
+    notchMode: 'off', notchFreq: 1000, nbDepth: 0, nbWidth: 0,
+    manualNotchWidth: 0, agcTimeConstant: 0,
+  });
+  mockHandlers.onNrModeChange = vi.fn();
+  mockHandlers.onNrLevelChange = vi.fn();
+  mockHandlers.onNbToggle = vi.fn();
+  mockHandlers.onNbLevelChange = vi.fn();
+  mockHandlers.onNotchModeChange = vi.fn();
+  mockHandlers.onNotchFreqChange = vi.fn();
+  mockHandlers.onNbDepthChange = vi.fn();
+  mockHandlers.onNbWidthChange = vi.fn();
+  mockHandlers.onManualNotchWidthChange = vi.fn();
+  mockHandlers.onAgcTimeChange = vi.fn();
 });
 
 afterEach(() => {
@@ -27,67 +74,44 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-const baseProps: ComponentProps<typeof DspPanel> = {
-  nrMode: 0,
-  nrLevel: 5,
-  nbActive: false,
-  nbLevel: 128,
-  notchMode: 'off',
-  notchFreq: 1000,
-  onNrModeChange: vi.fn(),
-  onNrLevelChange: vi.fn(),
-  onNbToggle: vi.fn(),
-  onNbLevelChange: vi.fn(),
-  onNotchModeChange: vi.fn(),
-  onNotchFreqChange: vi.fn(),
-  nbDepth: 0,
-  nbWidth: 0,
-  manualNotchWidth: 0,
-  agcTimeConstant: 0,
-  onNbDepthChange: vi.fn(),
-  onNbWidthChange: vi.fn(),
-  onManualNotchWidthChange: vi.fn(),
-  onAgcTimeChange: vi.fn(),
-};
-
 describe('DspPanel component rendering', () => {
   it('mounts without errors', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('.dsp-panel')).not.toBeNull();
   });
 
   it('renders NB button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim().startsWith('NB'))).toBe(true);
   });
 
   it('renders NR button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim().startsWith('NR'))).toBe(true);
   });
 
   it('renders NOTCH button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim() === 'NOTCH')).toBe(true);
   });
 
   it('renders A-NOTCH button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim() === 'A-NOTCH')).toBe(true);
   });
 
   it('renders AGC-T button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
     expect(buttons.some((b) => b.textContent?.trim().startsWith('AGC-T'))).toBe(true);
   });
 
   it('unmounts cleanly', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const comp = components.pop()!;
     unmount(comp);
     expect(t.innerHTML).toBe('');

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.test.ts
@@ -1,12 +1,43 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
-import type { ComponentProps } from 'svelte';
-import DspPanel from '../DspPanel.svelte';
 import { buildNrOptions, buildNotchOptions } from '../dsp-utils';
+
+const mockProps = {
+  nrMode: 0,
+  nrLevel: 128,
+  nbActive: false,
+  nbLevel: 128,
+  notchMode: 'off' as string,
+  notchFreq: 1000,
+  nbDepth: 0,
+  nbWidth: 0,
+  manualNotchWidth: 0,
+  agcTimeConstant: 0,
+};
+
+const mockHandlers = {
+  onNrModeChange: vi.fn(),
+  onNrLevelChange: vi.fn(),
+  onNbToggle: vi.fn(),
+  onNbLevelChange: vi.fn(),
+  onNotchModeChange: vi.fn(),
+  onNotchFreqChange: vi.fn(),
+  onNbDepthChange: vi.fn(),
+  onNbWidthChange: vi.fn(),
+  onManualNotchWidthChange: vi.fn(),
+  onAgcTimeChange: vi.fn(),
+};
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   hasCapability: vi.fn(() => true),
 }));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveDspProps: () => mockProps,
+  getDspHandlers: () => mockHandlers,
+}));
+
+import DspPanel from '../DspPanel.svelte';
 
 // ---------------------------------------------------------------------------
 // buildNrOptions
@@ -58,10 +89,11 @@ describe('buildNotchOptions', () => {
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(props: ComponentProps<typeof DspPanel>) {
+function mountPanel(overrides?: Partial<typeof mockProps>) {
+  if (overrides) Object.assign(mockProps, overrides);
   const t = document.createElement('div');
   document.body.appendChild(t);
-  const component = mount(DspPanel, { target: t, props });
+  const component = mount(DspPanel, { target: t });
   flushSync();
   components.push(component);
   return t;
@@ -69,6 +101,21 @@ function mountPanel(props: ComponentProps<typeof DspPanel>) {
 
 beforeEach(() => {
   components = [];
+  Object.assign(mockProps, {
+    nrMode: 0, nrLevel: 128, nbActive: false, nbLevel: 128,
+    notchMode: 'off', notchFreq: 1000, nbDepth: 0, nbWidth: 0,
+    manualNotchWidth: 0, agcTimeConstant: 0,
+  });
+  mockHandlers.onNrModeChange = vi.fn();
+  mockHandlers.onNrLevelChange = vi.fn();
+  mockHandlers.onNbToggle = vi.fn();
+  mockHandlers.onNbLevelChange = vi.fn();
+  mockHandlers.onNotchModeChange = vi.fn();
+  mockHandlers.onNotchFreqChange = vi.fn();
+  mockHandlers.onNbDepthChange = vi.fn();
+  mockHandlers.onNbWidthChange = vi.fn();
+  mockHandlers.onManualNotchWidthChange = vi.fn();
+  mockHandlers.onAgcTimeChange = vi.fn();
 });
 
 afterEach(() => {
@@ -76,28 +123,13 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-const baseProps: ComponentProps<typeof DspPanel> = {
-  nrMode: 0,
-  nrLevel: 128,
-  nbActive: false,
-  nbLevel: 128,
-  notchMode: 'off',
-  notchFreq: 1000,
-  onNrModeChange: vi.fn(),
-  onNrLevelChange: vi.fn(),
-  onNbToggle: vi.fn(),
-  onNbLevelChange: vi.fn(),
-  onNotchModeChange: vi.fn(),
-  onNotchFreqChange: vi.fn(),
-};
-
 function getFillButtons(container: HTMLElement): HTMLButtonElement[] {
   return Array.from(container.querySelectorAll<HTMLButtonElement>('.dsp-btn-wrap button'));
 }
 
 describe('compact toggle row', () => {
   it('renders NR, NB, NOTCH labels in FillButtons', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const texts = getFillButtons(t).map((b) => b.textContent?.trim());
     expect(texts).toContain('NR');
     expect(texts).toContain('NB');
@@ -107,96 +139,89 @@ describe('compact toggle row', () => {
 
 describe('NR toggle', () => {
   it('calls onNrModeChange(1) when NR is off and toggle is clicked', () => {
-    const onNrModeChange = vi.fn();
-    const t = mountPanel({ ...baseProps, nrMode: 0, onNrModeChange });
+    const t = mountPanel({ nrMode: 0 });
     const nrBtn = getFillButtons(t).find((b) => b.textContent?.trim().startsWith('NR'));
     nrBtn?.click();
     flushSync();
-    expect(onNrModeChange).toHaveBeenCalledWith(1);
+    expect(mockHandlers.onNrModeChange).toHaveBeenCalledWith(1);
   });
 
   it('calls onNrModeChange(0) when NR is on and toggle is clicked', () => {
-    const onNrModeChange = vi.fn();
-    const t = mountPanel({ ...baseProps, nrMode: 1, onNrModeChange });
+    const t = mountPanel({ nrMode: 1 });
     const nrBtn = getFillButtons(t).find((b) => b.textContent?.trim().startsWith('NR'));
     nrBtn?.click();
     flushSync();
-    expect(onNrModeChange).toHaveBeenCalledWith(0);
+    expect(mockHandlers.onNrModeChange).toHaveBeenCalledWith(0);
   });
 });
 
 describe('NB toggle', () => {
   it('calls onNbToggle(true) when NB is off and toggle is clicked', () => {
-    const onNbToggle = vi.fn();
-    const t = mountPanel({ ...baseProps, nbActive: false, onNbToggle });
+    const t = mountPanel({ nbActive: false });
     const nbBtn = getFillButtons(t).find((b) => b.textContent?.trim().startsWith('NB'));
     nbBtn?.click();
     flushSync();
-    expect(onNbToggle).toHaveBeenCalledWith(true);
+    expect(mockHandlers.onNbToggle).toHaveBeenCalledWith(true);
   });
 
   it('calls onNbToggle(false) when NB is on and toggle is clicked', () => {
-    const onNbToggle = vi.fn();
-    const t = mountPanel({ ...baseProps, nbActive: true, onNbToggle });
+    const t = mountPanel({ nbActive: true });
     const nbBtn = getFillButtons(t).find((b) => b.textContent?.trim().startsWith('NB'));
     nbBtn?.click();
     flushSync();
-    expect(onNbToggle).toHaveBeenCalledWith(false);
+    expect(mockHandlers.onNbToggle).toHaveBeenCalledWith(false);
   });
 });
 
 describe('Notch toggle', () => {
   it('calls onNotchModeChange("auto") when notch is off and toggle is clicked', () => {
-    const onNotchModeChange = vi.fn();
-    const t = mountPanel({ ...baseProps, notchMode: 'off', onNotchModeChange });
+    const t = mountPanel({ notchMode: 'off' });
     const notchBtn = getFillButtons(t).find((b) => b.textContent?.trim() === 'NOTCH');
     notchBtn?.click();
     flushSync();
-    expect(onNotchModeChange).toHaveBeenCalledWith('auto');
+    expect(mockHandlers.onNotchModeChange).toHaveBeenCalledWith('auto');
   });
 
   it('calls onNotchModeChange("off") when notch is auto and toggle is clicked', () => {
-    const onNotchModeChange = vi.fn();
-    const t = mountPanel({ ...baseProps, notchMode: 'auto', onNotchModeChange });
+    const t = mountPanel({ notchMode: 'auto' });
     const notchBtn = getFillButtons(t).find((b) => b.textContent?.trim() === 'NOTCH');
     notchBtn?.click();
     flushSync();
-    expect(onNotchModeChange).toHaveBeenCalledWith('off');
+    expect(mockHandlers.onNotchModeChange).toHaveBeenCalledWith('off');
   });
 
   it('calls onNotchModeChange("off") when notch is manual and toggle is clicked', () => {
-    const onNotchModeChange = vi.fn();
-    const t = mountPanel({ ...baseProps, notchMode: 'manual', onNotchModeChange });
+    const t = mountPanel({ notchMode: 'manual' });
     const notchBtn = getFillButtons(t).find((b) => b.textContent?.trim() === 'NOTCH');
     notchBtn?.click();
     flushSync();
-    expect(onNotchModeChange).toHaveBeenCalledWith('off');
+    expect(mockHandlers.onNotchModeChange).toHaveBeenCalledWith('off');
   });
 });
 
 describe('modal initial state', () => {
   it('no backdrop when no modal is open', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('.menu-backdrop')).toBeNull();
   });
 
   it('no NR modal when no modal is open', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('[aria-label="Noise reduction settings"]')).toBeNull();
   });
 
   it('no NB modal when no modal is open', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('[aria-label="Noise blanker settings"]')).toBeNull();
   });
 
   it('no Notch modal when no modal is open', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('[aria-label="Notch filter settings"]')).toBeNull();
   });
 
   it('renders the A-NOTCH button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = getFillButtons(t);
     expect(buttons.some((b) => b.textContent?.trim() === 'A-NOTCH')).toBe(true);
   });
@@ -204,11 +229,10 @@ describe('modal initial state', () => {
 
 describe('NR mode via short-click cycle', () => {
   it('cycles NR mode: off → 1 → off on successive clicks', () => {
-    const onNrModeChange = vi.fn();
-    const t = mountPanel({ ...baseProps, nrMode: 0, onNrModeChange });
+    const t = mountPanel({ nrMode: 0 });
     const nrBtn = getFillButtons(t).find((b) => b.textContent?.trim().startsWith('NR'));
     nrBtn?.click();
     flushSync();
-    expect(onNrModeChange).toHaveBeenLastCalledWith(1);
+    expect(mockHandlers.onNrModeChange).toHaveBeenLastCalledWith(1);
   });
 });

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.test.ts
@@ -1,16 +1,52 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
-import type { ComponentProps } from 'svelte';
-import FilterPanel from '../FilterPanel.svelte';
 import { formatFilterWidth } from '../filter-utils';
 import { deriveIfShift } from '../filter-controls';
+
+const mockProps = {
+  currentMode: 'USB',
+  currentFilter: 2,
+  filterShape: 0,
+  filterLabels: ['FIL1', 'FIL2', 'FIL3'],
+  filterWidth: 2400,
+  filterConfig: {
+    defaults: [3000, 2400, 1800],
+    fixed: false,
+    minHz: 50,
+    maxHz: 3600,
+    stepHz: 50,
+  } as { defaults: number[]; fixed: boolean; minHz: number; maxHz: number; stepHz: number } | null,
+  ifShift: 0,
+  hasPbt: false,
+  pbtInner: 0,
+  pbtOuter: 0,
+};
+
+const mockHandlers = {
+  onFilterChange: vi.fn(),
+  onFilterWidthChange: vi.fn(),
+  onFilterShapeChange: vi.fn(),
+  onFilterPresetChange: vi.fn(),
+  onFilterDefaults: vi.fn(),
+  onIfShiftChange: vi.fn(),
+  onPbtInnerChange: vi.fn(),
+  onPbtOuterChange: vi.fn(),
+  onPbtReset: vi.fn(),
+};
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveFilterProps: () => mockProps,
+  getFilterHandlers: () => mockHandlers,
+}));
+
+import FilterPanel from '../FilterPanel.svelte';
 
 // ---------------------------------------------------------------------------
 // formatFilterWidth
 // ---------------------------------------------------------------------------
 
 describe('formatFilterWidth', () => {
-  
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -58,10 +94,11 @@ it('returns raw number string for values below 1000', () => {
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(props: ComponentProps<typeof FilterPanel>) {
+function mountPanel(overrides?: Partial<typeof mockProps>) {
+  if (overrides) Object.assign(mockProps, overrides);
   const t = document.createElement('div');
   document.body.appendChild(t);
-  const component = mount(FilterPanel, { target: t, props });
+  const component = mount(FilterPanel, { target: t });
   flushSync();
   components.push(component);
   return t;
@@ -69,6 +106,33 @@ function mountPanel(props: ComponentProps<typeof FilterPanel>) {
 
 beforeEach(() => {
   components = [];
+  Object.assign(mockProps, {
+    currentMode: 'USB',
+    currentFilter: 2,
+    filterShape: 0,
+    filterLabels: ['FIL1', 'FIL2', 'FIL3'],
+    filterWidth: 2400,
+    filterConfig: {
+      defaults: [3000, 2400, 1800],
+      fixed: false,
+      minHz: 50,
+      maxHz: 3600,
+      stepHz: 50,
+    },
+    ifShift: 0,
+    hasPbt: false,
+    pbtInner: 0,
+    pbtOuter: 0,
+  });
+  mockHandlers.onFilterChange = vi.fn();
+  mockHandlers.onFilterWidthChange = vi.fn();
+  mockHandlers.onFilterShapeChange = vi.fn();
+  mockHandlers.onFilterPresetChange = vi.fn();
+  mockHandlers.onFilterDefaults = vi.fn();
+  mockHandlers.onIfShiftChange = vi.fn();
+  mockHandlers.onPbtInnerChange = vi.fn();
+  mockHandlers.onPbtOuterChange = vi.fn();
+  mockHandlers.onPbtReset = vi.fn();
 });
 
 afterEach(() => {
@@ -76,31 +140,9 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-const baseProps: ComponentProps<typeof FilterPanel> = {
-  currentMode: 'USB',
-  currentFilter: 2,
-  filterShape: 0,
-  filterLabels: ['FIL1', 'FIL2', 'FIL3'],
-  filterWidth: 2400,
-  filterConfig: {
-    defaults: [3000, 2400, 1800],
-    fixed: false,
-    minHz: 50,
-    maxHz: 3600,
-    stepHz: 50,
-  },
-  ifShift: 0,
-  onFilterChange: vi.fn(),
-  onFilterWidthChange: vi.fn(),
-  onFilterShapeChange: vi.fn(),
-  onFilterPresetChange: vi.fn(),
-  onFilterDefaults: vi.fn(),
-  onIfShiftChange: vi.fn(),
-};
-
 describe('panel structure', () => {
   it('renders filter selector buttons', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button')).map((button) => button.textContent?.trim());
     expect(buttons).toContain('FIL1');
     expect(buttons).toContain('FIL2');
@@ -108,7 +150,7 @@ describe('panel structure', () => {
   });
 
   it('renders a read-only BW display instead of a Width slider', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('.bw-label')?.textContent).toBe('BW');
     expect(t.querySelector('.bw-value')?.textContent).toBe('2.4kHz');
     const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
@@ -116,18 +158,18 @@ describe('panel structure', () => {
   });
 
   it('renders the IF Shift slider', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const labels = Array.from(t.querySelectorAll('.vc-label'));
     expect(labels.some(el => el.textContent === 'IF Shift')).toBe(true);
   });
 
   it('renders the settings gear button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('.settings-button')?.textContent?.trim()).toBe('⚙');
   });
 
   it('IF Shift slider has min=-1200, max=1200, step=25', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const sliders = t.querySelectorAll<HTMLElement>('[role="slider"]');
     const ifShiftSlider = sliders[0];
     expect(ifShiftSlider.getAttribute('aria-valuemin')).toBe('-1200');
@@ -137,44 +179,44 @@ describe('panel structure', () => {
 
 describe('PBT sliders visibility', () => {
   it('does not render PBT sliders when hasPbt is false (default)', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const labels = Array.from(t.querySelectorAll('.vc-label')).map(el => el.textContent);
     expect(labels).not.toContain('PBT Inner');
     expect(labels).not.toContain('PBT Outer');
   });
 
   it('does not render PBT sliders when hasPbt=false explicitly', () => {
-    const t = mountPanel({ ...baseProps, hasPbt: false });
+    const t = mountPanel({ hasPbt: false });
     const labels = Array.from(t.querySelectorAll('.vc-label')).map(el => el.textContent);
     expect(labels).not.toContain('PBT Inner');
     expect(labels).not.toContain('PBT Outer');
   });
 
   it('renders PBT Inner slider when hasPbt=true', () => {
-    const t = mountPanel({ ...baseProps, hasPbt: true, pbtInner: 100, pbtOuter: -50 });
+    const t = mountPanel({ hasPbt: true, pbtInner: 100, pbtOuter: -50 });
     const labels = Array.from(t.querySelectorAll('.vc-label')).map(el => el.textContent);
     expect(labels).toContain('PBT Inner');
   });
 
   it('renders PBT Outer slider when hasPbt=true', () => {
-    const t = mountPanel({ ...baseProps, hasPbt: true, pbtInner: 100, pbtOuter: -50 });
+    const t = mountPanel({ hasPbt: true, pbtInner: 100, pbtOuter: -50 });
     const labels = Array.from(t.querySelectorAll('.vc-label')).map(el => el.textContent);
     expect(labels).toContain('PBT Outer');
   });
 
   it('renders Reset PBT button when hasPbt=true', () => {
-    const t = mountPanel({ ...baseProps, hasPbt: true, pbtInner: 100, pbtOuter: -50, onPbtReset: vi.fn() });
+    const t = mountPanel({ hasPbt: true, pbtInner: 100, pbtOuter: -50 });
     const buttons = Array.from(t.querySelectorAll('button')).map(el => el.textContent?.trim());
     expect(buttons).toContain('Reset');
   });
 
   it('renders 3 sliders total when hasPbt=true', () => {
-    const t = mountPanel({ ...baseProps, hasPbt: true, pbtInner: 0, pbtOuter: 0 });
+    const t = mountPanel({ hasPbt: true, pbtInner: 0, pbtOuter: 0 });
     expect(t.querySelectorAll('[role="slider"]').length).toBe(3);
   });
 
   it('renders 1 slider total when hasPbt=false', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelectorAll('[role="slider"]').length).toBe(1);
   });
 });
@@ -190,54 +232,48 @@ describe('callbacks', () => {
   });
 
   it('calls onFilterChange when a filter button is clicked', () => {
-    const onFilterChange = vi.fn();
-    const t = mountPanel({ ...baseProps, onFilterChange });
+    const t = mountPanel();
     const button = Array.from(t.querySelectorAll('button')).find(el => el.textContent?.trim() === 'FIL3') as HTMLButtonElement;
     button.click();
-    expect(onFilterChange).toHaveBeenCalledWith(3);
+    expect(mockHandlers.onFilterChange).toHaveBeenCalledWith(3);
   });
 
   it('calls onIfShiftChange when IF Shift slider changes', () => {
-    const onIfShiftChange = vi.fn();
-    const t = mountPanel({ ...baseProps, onIfShiftChange });
+    const t = mountPanel();
     const slider = t.querySelectorAll<HTMLElement>('[role="slider"]')[0];
     slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
     vi.advanceTimersByTime(60);
 
-    expect(onIfShiftChange).toHaveBeenCalled();
+    expect(mockHandlers.onIfShiftChange).toHaveBeenCalled();
   });
 
   it('calls onPbtInnerChange when PBT Inner slider changes', () => {
-    const onPbtInnerChange = vi.fn();
-    const t = mountPanel({ ...baseProps, hasPbt: true, pbtInner: 0, pbtOuter: 0, onPbtInnerChange });
+    const t = mountPanel({ hasPbt: true, pbtInner: 0, pbtOuter: 0 });
     const sliders = t.querySelectorAll<HTMLElement>('[role="slider"]');
     sliders[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     vi.advanceTimersByTime(60);
 
-    expect(onPbtInnerChange).toHaveBeenCalled();
+    expect(mockHandlers.onPbtInnerChange).toHaveBeenCalled();
   });
 
   it('calls onPbtOuterChange when PBT Outer slider changes', () => {
-    const onPbtOuterChange = vi.fn();
-    const t = mountPanel({ ...baseProps, hasPbt: true, pbtInner: 0, pbtOuter: 0, onPbtOuterChange });
+    const t = mountPanel({ hasPbt: true, pbtInner: 0, pbtOuter: 0 });
     const sliders = t.querySelectorAll<HTMLElement>('[role="slider"]');
     sliders[2].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
     vi.advanceTimersByTime(60);
 
-    expect(onPbtOuterChange).toHaveBeenCalled();
+    expect(mockHandlers.onPbtOuterChange).toHaveBeenCalled();
   });
 
   it('calls onPbtReset when the reset button is clicked', () => {
-    const onPbtReset = vi.fn();
-    const t = mountPanel({ ...baseProps, hasPbt: true, pbtInner: 100, pbtOuter: -100, onPbtReset });
+    const t = mountPanel({ hasPbt: true, pbtInner: 100, pbtOuter: -100 });
     const button = Array.from(t.querySelectorAll('button')).find(el => el.textContent?.trim() === 'Reset') as HTMLButtonElement;
     button.click();
-    expect(onPbtReset).toHaveBeenCalledOnce();
+    expect(mockHandlers.onPbtReset).toHaveBeenCalledOnce();
   });
 
   it('opens the settings modal and calls onFilterPresetChange from a modal slider', () => {
-    const onFilterPresetChange = vi.fn();
-    const t = mountPanel({ ...baseProps, onFilterPresetChange });
+    const t = mountPanel();
     const gear = t.querySelector('.settings-button') as HTMLButtonElement;
     gear.click();
     flushSync();
@@ -248,23 +284,22 @@ describe('callbacks', () => {
     const sliders = modal?.querySelectorAll<HTMLElement>('[role="slider"]') ?? [];
     sliders[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     vi.advanceTimersByTime(60);
-    expect(onFilterPresetChange).toHaveBeenCalled();
+    expect(mockHandlers.onFilterPresetChange).toHaveBeenCalled();
   });
 
   it('calls onFilterDefaults when restore defaults is clicked in the modal', () => {
-    const onFilterDefaults = vi.fn();
-    const t = mountPanel({ ...baseProps, onFilterDefaults });
+    const t = mountPanel();
     const gear = t.querySelector('.settings-button') as HTMLButtonElement;
     gear.click();
     flushSync();
 
     const button = Array.from(document.querySelectorAll('button')).find(el => el.textContent?.trim() === 'Restore Defaults') as HTMLButtonElement;
     button.click();
-    expect(onFilterDefaults).toHaveBeenCalledWith([3000, 2400, 1800]);
+    expect(mockHandlers.onFilterDefaults).toHaveBeenCalledWith([3000, 2400, 1800]);
   });
 
   it('shows SHARP and SOFT shape buttons in the modal', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const gear = t.querySelector('.settings-button') as HTMLButtonElement;
     gear.click();
     flushSync();
@@ -275,15 +310,14 @@ describe('callbacks', () => {
   });
 
   it('calls onFilterShapeChange when the SOFT button is clicked in the modal', () => {
-    const onFilterShapeChange = vi.fn();
-    const t = mountPanel({ ...baseProps, onFilterShapeChange });
+    const t = mountPanel();
     const gear = t.querySelector('.settings-button') as HTMLButtonElement;
     gear.click();
     flushSync();
 
     const button = Array.from(document.querySelectorAll('button')).find((el) => el.textContent?.trim() === 'SOFT') as HTMLButtonElement;
     button.click();
-    expect(onFilterShapeChange).toHaveBeenCalledWith(1);
+    expect(mockHandlers.onFilterShapeChange).toHaveBeenCalledWith(1);
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/TxPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/TxPanel.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
-import type { ComponentProps } from 'svelte';
-import TxPanel from '../TxPanel.svelte';
 import { txStatusColor } from '../tx-utils';
 
 // ---------------------------------------------------------------------------
@@ -45,20 +43,63 @@ it('returns danger red when tuning', () => {
 // TxPanel component
 // ---------------------------------------------------------------------------
 
+const mockProps = {
+  txActive: false,
+  rfPower: 128,
+  micGain: 128,
+  atuActive: false,
+  atuTuning: false,
+  voxActive: false,
+  compActive: false,
+  compLevel: 64,
+  monActive: false,
+  monLevel: 64,
+  driveGain: 128,
+};
+
+const mockHandlers = {
+  onRfPowerChange: vi.fn(),
+  onMicGainChange: vi.fn(),
+  onAtuToggle: vi.fn(),
+  onAtuTune: vi.fn(),
+  onVoxToggle: vi.fn(),
+  onCompToggle: vi.fn(),
+  onCompLevelChange: vi.fn(),
+  onMonToggle: vi.fn(),
+  onMonLevelChange: vi.fn(),
+  onDriveGainChange: vi.fn(),
+  onPttOn: vi.fn(),
+  onPttOff: vi.fn(),
+};
+
 // Mock hasTx so we can control its return value
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   hasTx: vi.fn(() => true),
   hasCapability: vi.fn(() => true),
 }));
 
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveTxProps: () => mockProps,
+  getTxHandlers: () => mockHandlers,
+}));
+
+vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
+  getTxAudioControl: () => ({
+    startTx: vi.fn(),
+    stopTx: vi.fn(),
+  }),
+}));
+
 import { hasTx } from '$lib/stores/capabilities.svelte';
+import TxPanel from '../TxPanel.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(props: ComponentProps<typeof TxPanel>) {
+function mountPanel(overrides?: Partial<typeof mockProps>) {
+  if (overrides) Object.assign(mockProps, overrides);
   const t = document.createElement('div');
   document.body.appendChild(t);
-  const component = mount(TxPanel, { target: t, props });
+  const component = mount(TxPanel, { target: t });
   flushSync();
   components.push(component);
   return t;
@@ -74,6 +115,23 @@ function openTxSettings(container: HTMLElement) {
 beforeEach(() => {
   components = [];
   vi.mocked(hasTx).mockReturnValue(true);
+  Object.assign(mockProps, {
+    txActive: false, rfPower: 128, micGain: 128, atuActive: false,
+    atuTuning: false, voxActive: false, compActive: false, compLevel: 64,
+    monActive: false, monLevel: 64, driveGain: 128,
+  });
+  mockHandlers.onRfPowerChange = vi.fn();
+  mockHandlers.onMicGainChange = vi.fn();
+  mockHandlers.onAtuToggle = vi.fn();
+  mockHandlers.onAtuTune = vi.fn();
+  mockHandlers.onVoxToggle = vi.fn();
+  mockHandlers.onCompToggle = vi.fn();
+  mockHandlers.onCompLevelChange = vi.fn();
+  mockHandlers.onMonToggle = vi.fn();
+  mockHandlers.onMonLevelChange = vi.fn();
+  mockHandlers.onDriveGainChange = vi.fn();
+  mockHandlers.onPttOn = vi.fn();
+  mockHandlers.onPttOff = vi.fn();
 });
 
 afterEach(() => {
@@ -81,76 +139,52 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-const baseProps: ComponentProps<typeof TxPanel> = {
-  txActive: false,
-  rfPower: 128,
-  micGain: 128,
-  atuActive: false,
-  atuTuning: false,
-  voxActive: false,
-  compActive: false,
-  compLevel: 64,
-  monActive: false,
-  monLevel: 64,
-  driveGain: 128,
-  onRfPowerChange: vi.fn(),
-  onMicGainChange: vi.fn(),
-  onAtuToggle: vi.fn(),
-  onAtuTune: vi.fn(),
-  onVoxToggle: vi.fn(),
-  onCompToggle: vi.fn(),
-  onCompLevelChange: vi.fn(),
-  onMonToggle: vi.fn(),
-  onMonLevelChange: vi.fn(),
-  onDriveGainChange: vi.fn(),
-};
-
 describe('panel structure', () => {
   it('renders TX IDLE badge when txActive is false', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const strip = t.querySelector('.tx-strip');
     expect(strip?.textContent?.trim()).toBe('○ RX');
   });
 
   it('renders TX ACTIVE badge when txActive is true', () => {
-    const t = mountPanel({ ...baseProps, txActive: true });
+    const t = mountPanel({ txActive: true });
     const strip = t.querySelector('.tx-strip');
     expect(strip?.textContent?.trim()).toBe('● TX');
   });
 
   it('renders Mic Gain slider', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     openTxSettings(t);
     const labels = Array.from(t.querySelectorAll('.vc-label'));
     expect(labels.some((el) => el.textContent === 'Mic Gain')).toBe(true);
   });
 
   it('renders ATU toggle', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('.v2-control-button'));
     expect(buttons.some((el) => el.textContent?.trim().startsWith('TUNE'))).toBe(true);
   });
 
   it('renders TUNE button', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('.v2-control-button'));
     expect(buttons.some((el) => el.textContent?.trim().startsWith('TUNE'))).toBe(true);
   });
 
   it('renders VOX toggle', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('.v2-control-button'));
     expect(buttons.some((el) => el.textContent?.trim() === 'VOX')).toBe(true);
   });
 
   it('renders COMP toggle', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('.v2-control-button'));
     expect(buttons.some((el) => el.textContent?.trim().startsWith('COMP'))).toBe(true);
   });
 
   it('renders MON toggle', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('.v2-control-button'));
     expect(buttons.some((el) => el.textContent?.trim().startsWith('MON'))).toBe(true);
   });
@@ -159,26 +193,26 @@ describe('panel structure', () => {
 describe('hasTx gating', () => {
   it('renders panel content when hasTx returns true', () => {
     vi.mocked(hasTx).mockReturnValue(true);
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('.tx-panel')).not.toBeNull();
   });
 
   it('hides panel content when hasTx returns false', () => {
     vi.mocked(hasTx).mockReturnValue(false);
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     expect(t.querySelector('.tx-panel')).toBeNull();
   });
 });
 
 describe('COMP slider visibility', () => {
   it('does not render Comp Level slider when compActive is false', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
     expect(labels).not.toContain('Comp Level');
   });
 
   it('renders Comp Level slider when compActive is true', () => {
-    const t = mountPanel({ ...baseProps, compActive: true });
+    const t = mountPanel({ compActive: true });
     openTxSettings(t);
     const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
     expect(labels).toContain('Comp Level');
@@ -187,13 +221,13 @@ describe('COMP slider visibility', () => {
 
 describe('MON slider visibility', () => {
   it('does not render Mon Level slider when monActive is false', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
     expect(labels).not.toContain('Mon Level');
   });
 
   it('renders Mon Level slider when monActive is true', () => {
-    const t = mountPanel({ ...baseProps, monActive: true });
+    const t = mountPanel({ monActive: true });
     openTxSettings(t);
     const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
     expect(labels).toContain('Mon Level');
@@ -202,13 +236,13 @@ describe('MON slider visibility', () => {
 
 describe('tuning state', () => {
   it('adds tuning class to TUNE button when atuTuning is true', () => {
-    const t = mountPanel({ ...baseProps, atuTuning: true });
+    const t = mountPanel({ atuTuning: true });
     const buttons = Array.from(t.querySelectorAll('.v2-control-button'));
     expect(buttons.some((el) => el.textContent?.trim().startsWith('TUNING'))).toBe(true);
   });
 
   it('does not add tuning class when atuTuning is false', () => {
-    const t = mountPanel(baseProps);
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('.v2-control-button'));
     expect(buttons.some((el) => el.textContent?.trim() === 'TUNE')).toBe(true);
   });
@@ -225,17 +259,15 @@ describe('callbacks', () => {
   });
 
   it('calls onAtuTune when TUNE button is clicked', () => {
-    const onAtuTune = vi.fn();
-    const t = mountPanel({ ...baseProps, onAtuTune });
+    const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll<HTMLElement>('.v2-control-button'));
     const tuneBtn = buttons.find((el) => el.textContent?.trim().startsWith('TUNE'));
     tuneBtn?.click();
-    expect(onAtuTune).toHaveBeenCalledOnce();
+    expect(mockHandlers.onAtuTune).toHaveBeenCalledOnce();
   });
 
   it('calls onMicGainChange when Mic Gain slider changes', () => {
-    const onMicGainChange = vi.fn();
-    const t = mountPanel({ ...baseProps, onMicGainChange });
+    const t = mountPanel();
     // Open the settings modal to reveal sliders
     const levelsBtn = Array.from(t.querySelectorAll<HTMLElement>('.v2-control-button'))
       .find((b) => b.textContent?.includes('LEVELS'));
@@ -249,6 +281,6 @@ describe('callbacks', () => {
     }
     vi.advanceTimersByTime(60);
 
-    expect(onMicGainChange).toHaveBeenCalled();
+    expect(mockHandlers.onMicGainChange).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **Self-wired: DspPanel, TxPanel, FilterPanel, BandSelector** via runtime adapters
- **Sidebars fully cleaned**: state-adapter + command-bus imports completely removed
- **5 test files** updated to mock panel-adapters
- Net: -115 lines

**All 13 panels now self-wiring.** Sidebars are pure render shells — zero wiring logic.

## Panel migration status: COMPLETE

| Panel | Status |
|---|---|
| RxAudioPanel | Self-wiring (Phase 1) |
| MemoryPanel | Self-wiring (Phase 2) |
| AgcPanel, ModePanel, AntennaPanel | Self-wiring (#662) |
| RfFrontEnd, RitXitPanel, ScanPanel, CwPanel | Self-wiring (#663) |
| DspPanel, TxPanel, FilterPanel, BandSelector | Self-wiring (#664, this PR) |

## Test plan
- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)