### PR TITLE
feat(#665): SystemController — zero direct fetch calls

### DIFF
--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -24,16 +24,10 @@
   const keyboardHandlers = makeKeyboardHandlers();
 
   async function handlePowerOn() {
-    // TODO(#653): migrate to runtime.system.powerOn() when SystemController is implemented
     try {
-      const resp = await fetch('/api/v1/radio/power', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ state: 'on' }),
-      });
-      if (!resp.ok) alert(`Failed to power on: ${await resp.text()}`);
+      await runtime.system.powerOn();
     } catch (err) {
-      alert(`Error: ${err}`);
+      alert(`Failed to power on: ${err}`);
     }
   }
 

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Radio, Cable, Activity, Volume2, ArrowDownUp, Power, Unplug, Palette, Monitor, Tv } from 'lucide-svelte';
   import ThemePicker from '../controls/ThemePicker.svelte';
+  import { runtime } from '$lib/runtime';
   import {
     getRadioStatus,
     getConnectionStatus,
@@ -49,31 +50,22 @@
     const action = isConnected ? 'Disconnect from' : 'Connect to';
     if (!confirm(`${action} radio?`)) return;
     try {
-      const endpoint = isConnected ? '/api/v1/radio/disconnect' : '/api/v1/radio/connect';
-      const response = await fetch(endpoint, { method: 'POST' });
-      if (!response.ok) {
-        const error = await response.text();
-        alert(`Failed to ${action.toLowerCase()}: ${error}`);
+      if (isConnected) {
+        await runtime.system.disconnect();
+      } else {
+        await runtime.system.connect();
       }
     } catch (err) {
-      alert(`Error: ${err}`);
+      alert(`Failed to ${action.toLowerCase()}: ${err}`);
     }
   }
 
   async function handlePowerOn() {
     if (!confirm('Turn ON the radio?')) return;
     try {
-      const response = await fetch('/api/v1/radio/power', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ state: 'on' }),
-      });
-      if (!response.ok) {
-        const error = await response.text();
-        alert(`Failed to turn on radio: ${error}`);
-      }
+      await runtime.system.powerOn();
     } catch (err) {
-      alert(`Error: ${err}`);
+      alert(`Failed to turn on radio: ${err}`);
     }
   }
 
@@ -94,17 +86,8 @@
     identifyTimer = setTimeout(async () => {
       if (nowPlayingExpanded) return;
       lastIdentifiedFreq = freq;
-      try {
-        const resp = await fetch(`/api/v1/eibi/identify?freq=${freq}`);
-        if (resp.ok) {
-          const data = await resp.json();
-          nowPlaying = data.stations?.length > 0 ? data.stations[0] : null;
-        } else {
-          nowPlaying = null;
-        }
-      } catch {
-        nowPlaying = null;
-      }
+      const result = await runtime.system.identifyFrequency(freq);
+      nowPlaying = result?.stations?.length ? result.stations[0] : null;
     }, 800);
 
     return () => {
@@ -115,17 +98,9 @@
   async function handlePowerOff() {
     if (!confirm('Turn OFF the radio?')) return;
     try {
-      const response = await fetch('/api/v1/radio/power', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ state: 'off' }),
-      });
-      if (!response.ok) {
-        const error = await response.text();
-        alert(`Failed to turn off radio: ${error}`);
-      }
+      await runtime.system.powerOff();
     } catch (err) {
-      alert(`Error: ${err}`);
+      alert(`Failed to turn off radio: ${err}`);
     }
   }
 </script>

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -27,6 +27,7 @@ import {
 import { getAudioState, setVolume, setMuted, toggleMute } from '$lib/stores/audio.svelte';
 import { sendCommand } from '$lib/transport/ws-client';
 import { audioManager } from '$lib/audio/audio-manager';
+import { systemController } from './system-controller';
 
 import type { ServerState, ReceiverState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
@@ -90,6 +91,13 @@ class FrontendRuntime {
   /** Whether the runtime has a radio connection. */
   get connected(): boolean {
     return isConnected();
+  }
+
+  // ── System controller ──
+
+  /** System actions (power, connect/disconnect, frequency identification). */
+  get system() {
+    return systemController;
   }
 
   // ── Command dispatch ──

--- a/frontend/src/lib/runtime/index.ts
+++ b/frontend/src/lib/runtime/index.ts
@@ -1,2 +1,3 @@
 export { runtime } from './frontend-runtime';
 export type { ConnectionSnapshot, AudioSnapshot } from './frontend-runtime';
+export type { EibiStation, EibiResult } from './system-controller';

--- a/frontend/src/lib/runtime/system-controller.ts
+++ b/frontend/src/lib/runtime/system-controller.ts
@@ -1,0 +1,60 @@
+/**
+ * SystemController — owns all HTTP system actions (power, connect, identify).
+ *
+ * Replaces direct fetch('/api/v1/...') calls in presentation components.
+ * All backend HTTP side effects go through this controller.
+ */
+
+export interface EibiStation {
+  name?: string;
+  freq?: number;
+  language?: string;
+  target?: string;
+  [key: string]: unknown;
+}
+
+export interface EibiResult {
+  stations: EibiStation[];
+}
+
+class SystemController {
+  async powerOn(): Promise<void> {
+    const resp = await fetch('/api/v1/radio/power', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'on' }),
+    });
+    if (!resp.ok) throw new Error(await resp.text());
+  }
+
+  async powerOff(): Promise<void> {
+    const resp = await fetch('/api/v1/radio/power', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'off' }),
+    });
+    if (!resp.ok) throw new Error(await resp.text());
+  }
+
+  async connect(): Promise<void> {
+    const resp = await fetch('/api/v1/radio/connect', { method: 'POST' });
+    if (!resp.ok) throw new Error(await resp.text());
+  }
+
+  async disconnect(): Promise<void> {
+    const resp = await fetch('/api/v1/radio/disconnect', { method: 'POST' });
+    if (!resp.ok) throw new Error(await resp.text());
+  }
+
+  async identifyFrequency(freqHz: number): Promise<EibiResult | null> {
+    try {
+      const resp = await fetch(`/api/v1/eibi/identify?freq=${freqHz}`);
+      if (!resp.ok) return null;
+      return await resp.json();
+    } catch {
+      return null;
+    }
+  }
+}
+
+export const systemController = new SystemController();


### PR DESCRIPTION
## Summary

- **New: SystemController** (`lib/runtime/system-controller.ts`) — `powerOn/Off()`, `connect/disconnect()`, `identifyFrequency()`
- **FrontendRuntime** exposes `system` property
- **StatusBar**: 4 fetch() calls → `runtime.system.*`
- **LcdLayout**: power-on TODO resolved → `runtime.system.powerOn()`
- **Zero** direct `fetch('/api/v1/')` calls remain in `components-v2/`

## Frontend migration status: COMPLETE

All architectural goals achieved:
- Runtime singleton owns all side effects
- 5 controllers: audio, scope, tx, system, command-dispatch
- 13 panels self-wiring via adapters
- Sidebars are pure render shells
- Skin registry drives layout selection
- 0 eslint boundary violations
- 0 direct fetch calls in presentation components

## Test plan
- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean
- [x] `grep -r "fetch('/api/v1/" src/components-v2/` — 0 matches

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)