### PR TITLE
fix: 5 code review findings (PTT bug, scope race, dead code, reactivity, USB match)

### DIFF
--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -63,7 +63,7 @@
 
 </div>
 
-{#if runtime.connection.radioPowerOn === false}
+{#if runtime.radioPowerOn === false}
   <div class="power-off-overlay" aria-label="Radio is powered off">
     <div class="power-off-content">
       <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -81,7 +81,7 @@
   let landscapeSpectrumDismissed = $state(false);
   let landscapeAutoLocked = $state(false);
   let spectrumLandscape = $derived(isMobile && isLandscape && !landscapeSpectrumDismissed && !landscapeAutoLocked);
-  let connectionStatus = $derived(runtime.connection.status);
+  let connectionStatus = $derived(runtime.connectionStatus);
 
   // Skin resolution — determines which layout to render
   let skinId = $derived<SkinId>(resolveSkinId({
@@ -299,7 +299,7 @@
 </div>
 {/if}
 
-{#if runtime.connection.radioPowerOn === false}
+{#if runtime.radioPowerOn === false}
   <div class="power-off-overlay" aria-label="Radio is powered off">
     <div class="power-off-content">
       <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/src/components-v2/layout/RightSidebar.svelte
+++ b/frontend/src/components-v2/layout/RightSidebar.svelte
@@ -1,24 +1,12 @@
 <script lang="ts">
-  import { runtime } from '$lib/runtime';
   import { hasCapability } from '$lib/stores/capabilities.svelte';
   import RxAudioPanel from '../panels/RxAudioPanel.svelte';
   import DspPanel from '../panels/DspPanel.svelte';
   import TxPanel from '../panels/TxPanel.svelte';
   import CwPanel from '../panels/CwPanel.svelte';
   import MemoryPanel from '../panels/MemoryPanel.svelte';
-  import RfFrontEnd from '../panels/RfFrontEnd.svelte';
-  import ModePanel from '../panels/ModePanel.svelte';
-  import FilterPanel from '../panels/FilterPanel.svelte';
-  import AgcPanel from '../panels/AgcPanel.svelte';
-  import RitXitPanel from '../panels/RitXitPanel.svelte';
-  import AntennaPanel from '../panels/AntennaPanel.svelte';
-  import ScanPanel from '../panels/ScanPanel.svelte';
-  import BandSelector from '../controls/BandSelector.svelte';
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
   import { createDragReorder } from '$lib/drag-reorder.svelte';
-
-  // Reactive state + capabilities — via runtime
-  let caps = $derived(runtime.caps);
 
   type RightSidebarMode = 'all' | 'rx' | 'tx';
 
@@ -70,61 +58,6 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('rf-front-end')}
-    <CollapsiblePanel title="RF FRONT END" panelId="rf-front-end" dataPanel="rf-frontend"
-      draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('rf-front-end')}>
-      <RfFrontEnd />
-    </CollapsiblePanel>
-  {/if}
-
-  {#if drag.order.includes('mode')}
-    <CollapsiblePanel title="MODE" panelId="mode"
-      draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('mode')}>
-      <ModePanel />
-    </CollapsiblePanel>
-  {/if}
-
-  {#if drag.order.includes('filter')}
-    <CollapsiblePanel title="FILTER" panelId="filter"
-      draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('filter')}>
-      <FilterPanel />
-    </CollapsiblePanel>
-  {/if}
-
-  {#if drag.order.includes('agc')}
-    <CollapsiblePanel title="AGC" panelId="agc"
-      draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('agc')}>
-      <AgcPanel />
-    </CollapsiblePanel>
-  {/if}
-
-  {#if drag.order.includes('rit-xit')}
-    <CollapsiblePanel title="RIT / XIT" panelId="rit-xit"
-      draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('rit-xit')}>
-      <RitXitPanel />
-    </CollapsiblePanel>
-  {/if}
-
-  {#if drag.order.includes('band')}
-    <CollapsiblePanel title="BAND" panelId="band"
-      draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('band')}>
-      <BandSelector />
-    </CollapsiblePanel>
-  {/if}
-
-  {#if drag.order.includes('antenna') && (caps?.antennas ?? 1) > 1}
-    <CollapsiblePanel title="ANTENNA" panelId="antenna" dataPanel="antenna"
-      draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('antenna')}>
-      <AntennaPanel />
-    </CollapsiblePanel>
-  {/if}
-
-  {#if drag.order.includes('scan')}
-    <CollapsiblePanel title="SCAN" panelId="scan"
-      draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('scan')}>
-      <ScanPanel />
-    </CollapsiblePanel>
-  {/if}
 </aside>
 
 <style>

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -21,6 +21,8 @@ vi.mock('$lib/runtime', () => ({
   runtime: {
     state: null,
     caps: null,
+    connectionStatus: 'disconnected',
+    radioPowerOn: null,
     connection: { status: 'disconnected', radioPowerOn: null },
     audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
     send: vi.fn(),

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
@@ -16,6 +16,8 @@ vi.mock('$lib/runtime', () => ({
   runtime: {
     state: null,
     caps: null,
+    connectionStatus: 'disconnected',
+    radioPowerOn: null,
     connection: { status: 'disconnected', radioPowerOn: null },
     audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
     send: vi.fn(),

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -526,6 +526,8 @@ export function makeTxHandlers() {
       patchRadioState({ driveGain: level });
       cmd('set_drive_gain', { level });
     },
+    onPttOn: () => cmd('ptt_on'),
+    onPttOff: () => cmd('ptt_off'),
   };
 }
 

--- a/frontend/src/lib/runtime/adapters/scope-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/scope-adapter.ts
@@ -12,6 +12,8 @@
 import { getChannel } from '$lib/transport/ws-client';
 import { markScopeFrame } from '$lib/stores/connection.svelte';
 
+let _scopeInstanceId = 0;
+
 export interface ScopeFrame {
   receiver: number;
   startFreq: number;
@@ -41,7 +43,9 @@ export interface AudioScopeHandle {
 export function createAudioScopeConnection(
   onFrame: (frame: ScopeFrame) => void,
 ): AudioScopeHandle {
-  const ch = getChannel('audio-scope');
+  // Each caller gets its own channel to avoid lifecycle conflicts
+  // when multiple components mount/unmount independently.
+  const ch = getChannel(`audio-scope-${++_scopeInstanceId}`);
   ch.connect('/api/v1/audio-scope');
   const unsubBinary = ch.onBinary((buf) => {
     markScopeFrame();

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -45,12 +45,6 @@ export interface ConnectionSnapshot {
   radioPowerOn: boolean | null;
 }
 
-export interface AudioSnapshot {
-  rxEnabled: boolean;
-  txEnabled: boolean;
-  volume: number;
-  muted: boolean;
-}
 
 // ── Runtime class ──
 
@@ -68,7 +62,23 @@ class FrontendRuntime {
     return getCapabilities();
   }
 
-  /** Connection health snapshot. */
+  /** Connection health — individual reactive getters to avoid object allocation. */
+  get connectionStatus(): 'connected' | 'partial' | 'disconnected' {
+    return getConnectionStatus();
+  }
+
+  get connectionHttp(): boolean { return getHttpConnected(); }
+  get connectionWs(): boolean { return getWsConnected(); }
+  get connectionAudio(): boolean { return isAudioConnected(); }
+  get connectionStale(): boolean { return isStale(); }
+  get connectionReconnecting(): boolean { return isReconnecting(); }
+  get radioStatus(): string { return getRadioStatus(); }
+  get radioPowerOn(): boolean | null { return getRadioPowerOn(); }
+
+  /**
+   * Connection snapshot (for contexts that need all fields at once).
+   * Prefer individual getters in $derived for better Svelte 5 reactivity.
+   */
   get connection(): ConnectionSnapshot {
     return {
       status: getConnectionStatus(),
@@ -82,10 +92,9 @@ class FrontendRuntime {
     };
   }
 
-  /** Audio UI state (volume, mute, rx/tx enabled). */
-  get audio(): AudioSnapshot {
-    const s = getAudioState();
-    return { rxEnabled: s.rxEnabled, txEnabled: s.txEnabled, volume: s.volume, muted: s.muted };
+  /** Audio UI state — returns the live $state object directly. */
+  get audio() {
+    return getAudioState();
   }
 
   /** Whether the runtime has a radio connection. */

--- a/frontend/src/lib/runtime/index.ts
+++ b/frontend/src/lib/runtime/index.ts
@@ -1,3 +1,3 @@
 export { runtime } from './frontend-runtime';
-export type { ConnectionSnapshot, AudioSnapshot } from './frontend-runtime';
+export type { ConnectionSnapshot } from './frontend-runtime';
 export type { EibiStation, EibiResult } from './system-controller';

--- a/src/icom_lan/usb_audio_resolve.py
+++ b/src/icom_lan/usb_audio_resolve.py
@@ -281,7 +281,7 @@ def _is_usb_audio_codec(name: str) -> bool:
     expose USB Audio Class devices.
     """
     lowered = name.lower()
-    return any(p in lowered for p in ("usb audio codec", "usb audio", "yaesu", "kenwood"))
+    return any(p in lowered for p in ("usb audio codec", "usb audio device", "yaesu", "kenwood"))
 
 
 def _safe_int(value: object, default: int = 0) -> int:


### PR DESCRIPTION
## Summary

Fixes 5 issues found during comprehensive code review of the session's 12 PRs.

### Critical
1. **Scope adapter shared channel race** — `createAudioScopeConnection()` returned a shared singleton WS channel. If two components used it, the first to unmount killed the other's connection. Now each caller gets a unique channel.
2. **PTT button never rendered** — `makeTxHandlers()` was missing `onPttOn`/`onPttOff`. TxPanel's `{#if onPttOn}` was always false. Tests masked this by mocking the handlers.

### Important
3. **`runtime.connection` getter** created a new object on every read, defeating Svelte 5 `$derived` equality. Added scalar getters (`connectionStatus`, `radioPowerOn`, etc.).
4. **67 lines dead code in RightSidebar** — 8 panel blocks with IDs not in `defaults` array, plus 8 unused imports.
5. **`_is_usb_audio_codec`** — `"usb audio"` substring matched generic USB headsets. Narrowed to `"usb audio device"`.

## Test plan
- [x] `npx vitest run` — 1437 passed
- [x] `npx vite build` — clean
- [x] `uv run pytest tests/test_usb_audio_resolve.py` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)