### PR TITLE
fix(#671): remove broken AUTO TUNE button

### DIFF
--- a/frontend/src/components-v2/panels/CwPanel.svelte
+++ b/frontend/src/components-v2/panels/CwPanel.svelte
@@ -23,7 +23,6 @@
   const onBreakInDelayChange = handlers.onBreakInDelayChange;
   const onApfChange = handlers.onApfChange;
   const onTwinPeakToggle = handlers.onTwinPeakToggle;
-  const onAutoTune = handlers.onAutoTune;
 
   let showBreakIn = $derived(hasCapability('break_in'));
   let showApf = $derived(hasCapability('apf'));
@@ -105,11 +104,8 @@
       />
     {/if}
 
-    <div class="toggle-row">
-      <button type="button" class="auto-tune-btn v2-control-button" onclick={onAutoTune}>
-        AUTO TUNE
-      </button>
-    </div>
+    <!-- AUTO TUNE: removed — was incorrectly triggering ATU.
+         Software CW auto-tune to be implemented in #671. -->
   </div>
 {/if}
 
@@ -151,8 +147,4 @@
     gap: 8px;
   }
 
-  .auto-tune-btn {
-    flex: 1;
-    background: transparent;
-  }
 </style>

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
@@ -106,10 +106,10 @@ describe('CwPanel component rendering', () => {
     expect(buttons.some((b) => b.textContent?.trim() === 'TPF')).toBe(true);
   });
 
-  it('renders AUTO TUNE button', () => {
+  it('does not render AUTO TUNE button (removed, see #671)', () => {
     const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
-    expect(buttons.some((b) => b.textContent?.trim() === 'AUTO TUNE')).toBe(true);
+    expect(buttons.some((b) => b.textContent?.trim() === 'AUTO TUNE')).toBe(false);
   });
 
   it('unmounts cleanly', () => {

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -423,10 +423,7 @@ export function makeCwPanelHandlers() {
       patchActiveReceiver({ twinPeakFilter: next }, true);
       cmd('set_twin_peak', { on: next, receiver });
     },
-    /** Same action as TX panel TUNE — starts ATU tuning when supported. */
-    onAutoTune: () => {
-      cmd('set_tuner_status', { value: 2 });
-    },
+    // onAutoTune: removed — was incorrectly triggering ATU. See #671.
     onWpmChange: (speed: number) => {
       patchRadioState({ keySpeed: speed });
       cmd('set_key_speed', { speed });


### PR DESCRIPTION
The AUTO TUNE button was sending ATU tune command instead of CW auto-tune.
CW auto-tune has no CI-V command — it's a DSP function that needs software
implementation. Button removed until the software CW auto-tune engine is built.

Refs #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)