### PR TITLE
feat(#675): CwAutoTuner engine — FFT peak detection module

### DIFF
--- a/src/icom_lan/cw_auto_tuner.py
+++ b/src/icom_lan/cw_auto_tuner.py
@@ -1,0 +1,154 @@
+"""CW Auto Tuner — FFT-based CW tone frequency detection.
+
+Collects PCM audio samples, runs an FFT, and detects the dominant
+CW tone frequency within the 200–1500 Hz band.
+
+Usage::
+
+    tuner = CwAutoTuner()
+    tuner.start_collection(lambda hz: print(f"Detected: {hz} Hz"))
+
+    # In audio callback:
+    tuner.feed_audio(pcm_bytes)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+__all__ = ["CwAutoTuner"]
+
+_log = logging.getLogger(__name__)
+
+_SAMPLE_RATE = 48000
+_COLLECT_SAMPLES = 24000  # 500 ms at 48 kHz
+_FFT_SIZE = 8192
+_MIN_HZ = 200
+_MAX_HZ = 1500
+_NOISE_FLOOR_DB = -50.0
+
+
+def _import_numpy() -> Any:
+    """Lazy-import numpy to avoid hard dependency at module level."""
+    try:
+        import numpy as np
+
+        return np
+    except ImportError:
+        raise ImportError(
+            "CwAutoTuner requires numpy. Install with: pip install numpy"
+        ) from None
+
+
+class CwAutoTuner:
+    """Detects CW tone frequency from PCM audio via FFT peak detection.
+
+    Call :meth:`start_collection` with a callback, then feed 16-bit signed
+    mono PCM audio via :meth:`feed_audio`.  After 500 ms of audio the
+    callback fires with the detected frequency in Hz, or ``None`` if no
+    tone was found above the noise floor.
+    """
+
+    def __init__(self) -> None:
+        self._callback: Callable[[int | None], None] | None = None
+        self._buffer: bytes = b""
+        self._active: bool = False
+
+    def start_collection(self, callback: Callable[[int | None], None]) -> None:
+        """Arm the tuner and begin collecting audio samples."""
+        self._callback = callback
+        self._buffer = b""
+        self._active = True
+
+    def feed_audio(self, pcm: bytes) -> None:
+        """Feed s16le mono PCM audio.  Triggers detection when enough data."""
+        if not self._active:
+            return
+        self._buffer += pcm
+        # 2 bytes per sample (int16)
+        if len(self._buffer) >= _COLLECT_SAMPLES * 2:
+            self._detect()
+
+    def cancel(self) -> None:
+        """Abort collection without firing the callback."""
+        self._active = False
+        self._callback = None
+        self._buffer = b""
+
+    @property
+    def active(self) -> bool:
+        """Whether the tuner is currently collecting audio."""
+        return self._active
+
+    def _detect(self) -> None:
+        """Run FFT peak detection and fire the callback."""
+        np = _import_numpy()
+        callback = self._callback
+
+        # Disarm before callback (one-shot)
+        self._active = False
+        self._callback = None
+
+        # Decode s16le → float64
+        samples = np.frombuffer(self._buffer, dtype=np.int16).astype(np.float64)
+        self._buffer = b""
+
+        # Take exactly _COLLECT_SAMPLES, then window with _FFT_SIZE
+        samples = samples[:_COLLECT_SAMPLES]
+
+        # Use the last _FFT_SIZE samples for FFT (zero-pad if short)
+        if len(samples) < _FFT_SIZE:
+            chunk = np.zeros(_FFT_SIZE, dtype=np.float64)
+            chunk[: len(samples)] = samples
+        else:
+            chunk = samples[-_FFT_SIZE:]
+
+        window = np.hanning(_FFT_SIZE)
+        windowed = chunk * window
+
+        # Real FFT (explicit n= guarantees bin-to-Hz mapping)
+        spectrum = np.fft.rfft(windowed, n=_FFT_SIZE)
+        magnitudes = np.abs(spectrum)
+
+        # Avoid log(0)
+        magnitudes = np.maximum(magnitudes, 1e-10)
+        db = 20.0 * np.log10(magnitudes / _FFT_SIZE)
+
+        # Bin range for 200–1500 Hz
+        bin_min = int(_MIN_HZ * _FFT_SIZE / _SAMPLE_RATE)
+        bin_max = int(_MAX_HZ * _FFT_SIZE / _SAMPLE_RATE) + 1
+
+        band_db = db[bin_min:bin_max]
+        peak_idx = int(np.argmax(band_db))
+        peak_db = band_db[peak_idx]
+
+        if peak_db < _NOISE_FLOOR_DB:
+            _log.debug("No CW tone above noise floor (peak %.1f dB)", peak_db)
+            if callback:
+                callback(None)
+            return
+
+        # Absolute bin index
+        k = bin_min + peak_idx
+
+        # Parabolic interpolation for sub-bin accuracy
+        if 0 < peak_idx < len(band_db) - 1:
+            y1 = db[k - 1]
+            y2 = db[k]
+            y3 = db[k + 1]
+            denom = 2.0 * (2.0 * y2 - y1 - y3)
+            if abs(denom) > 1e-10:
+                offset = (y3 - y1) / denom
+                k_refined = k + offset
+            else:
+                k_refined = float(k)
+        else:
+            k_refined = float(k)
+
+        freq_hz = k_refined * _SAMPLE_RATE / _FFT_SIZE
+        detected = int(round(freq_hz))
+        _log.debug("CW tone detected: %d Hz (%.1f dB)", detected, peak_db)
+
+        if callback:
+            callback(detected)

--- a/tests/test_cw_auto_tuner.py
+++ b/tests/test_cw_auto_tuner.py
@@ -1,0 +1,99 @@
+"""Tests for CwAutoTuner — FFT-based CW tone detection."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from icom_lan.cw_auto_tuner import CwAutoTuner
+
+_SAMPLE_RATE = 48000
+
+
+def _make_tone(freq_hz: float, duration_s: float = 0.5) -> bytes:
+    """Generate s16le mono PCM sine wave."""
+    t = np.arange(int(_SAMPLE_RATE * duration_s)) / _SAMPLE_RATE
+    samples = (np.sin(2 * np.pi * freq_hz * t) * 16000).astype(np.int16)
+    return samples.tobytes()
+
+
+def _make_silence(duration_s: float = 0.5) -> bytes:
+    """Generate s16le mono silence."""
+    n = int(_SAMPLE_RATE * duration_s)
+    return np.zeros(n, dtype=np.int16).tobytes()
+
+
+class TestCwAutoTuner:
+    """CwAutoTuner unit tests."""
+
+    def test_detect_700hz_tone(self) -> None:
+        """700 Hz sine → callback fires with ~700."""
+        tuner = CwAutoTuner()
+        result: list[int | None] = []
+        tuner.start_collection(result.append)
+        tuner.feed_audio(_make_tone(700.0))
+        assert len(result) == 1
+        assert result[0] is not None
+        assert abs(result[0] - 700) <= 6
+
+    def test_silence_returns_none(self) -> None:
+        """Silence → callback fires with None."""
+        tuner = CwAutoTuner()
+        result: list[int | None] = []
+        tuner.start_collection(result.append)
+        tuner.feed_audio(_make_silence())
+        assert len(result) == 1
+        assert result[0] is None
+
+    def test_inactive_before_start(self) -> None:
+        """Not active until start_collection called."""
+        tuner = CwAutoTuner()
+        assert tuner.active is False
+
+    def test_disarms_after_callback(self) -> None:
+        """Active becomes False after callback fires."""
+        tuner = CwAutoTuner()
+        tuner.start_collection(lambda _: None)
+        assert tuner.active is True
+        tuner.feed_audio(_make_tone(700.0))
+        assert tuner.active is False
+
+    def test_cancel_aborts(self) -> None:
+        """Cancel disarms and does not fire callback."""
+        tuner = CwAutoTuner()
+        result: list[int | None] = []
+        tuner.start_collection(result.append)
+        # Feed partial audio (less than 24000 samples)
+        tuner.feed_audio(_make_tone(700.0, duration_s=0.1))
+        tuner.cancel()
+        assert tuner.active is False
+        # Feed remaining — should be ignored
+        tuner.feed_audio(_make_tone(700.0, duration_s=0.4))
+        assert len(result) == 0
+
+    def test_feed_ignored_when_not_armed(self) -> None:
+        """feed_audio does nothing when not armed — no error."""
+        tuner = CwAutoTuner()
+        tuner.feed_audio(_make_tone(700.0))  # should not raise
+
+    def test_detect_1000hz_tone(self) -> None:
+        """1000 Hz sine → callback fires with ~1000."""
+        tuner = CwAutoTuner()
+        result: list[int | None] = []
+        tuner.start_collection(result.append)
+        tuner.feed_audio(_make_tone(1000.0))
+        assert len(result) == 1
+        assert result[0] is not None
+        assert abs(result[0] - 1000) <= 6
+
+    def test_incremental_feeding(self) -> None:
+        """Audio fed in small chunks still triggers detection."""
+        tuner = CwAutoTuner()
+        result: list[int | None] = []
+        tuner.start_collection(result.append)
+        pcm = _make_tone(800.0)
+        chunk_size = 1920  # 20ms frames (960 samples * 2 bytes)
+        for i in range(0, len(pcm), chunk_size):
+            tuner.feed_audio(pcm[i : i + chunk_size])
+        assert len(result) == 1
+        assert result[0] is not None
+        assert abs(result[0] - 800) <= 6


### PR DESCRIPTION
## Summary
- New `CwAutoTuner` class: standalone DSP module that detects CW tone frequency from PCM audio via FFT
- Collects 500ms of 48kHz s16le audio, runs 8192-point Hann-windowed rfft, finds peak in 200–1500 Hz band above -50 dB noise floor
- Parabolic interpolation for sub-bin accuracy (~6 Hz precision)
- One-shot pattern: arm → feed → callback fires → disarm

Closes #675
Parent: #671

## Test plan
- [x] 700 Hz tone detection within ±6 Hz
- [x] 1000 Hz tone detection within ±6 Hz
- [x] Silence returns None
- [x] Inactive before start, disarms after callback
- [x] Cancel aborts without firing callback
- [x] Feed ignored when not armed
- [x] Incremental feeding (20ms chunks) works
- [x] Full test suite: 4531 passed, 0 regressions
- [x] Ruff lint + format: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)