### PR TITLE
fix(#684): resolve audio WebSocket crash loop on PTT

### DIFF
--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -36,9 +36,9 @@ class AudioManager {
     let txFrames = 0;
     let droppedFrames = 0;
     this.txMic = new TxMic((data) => {
-      // Gate on local _txEnabled flag (set immediately on startTx) instead of
-      // getRadioState()?.ptt which requires a full round-trip before becoming true,
-      // causing all mic frames during that window to be silently dropped.
+      // Gate on local _txEnabled (set immediately on startTx), not
+      // getRadioState()?.ptt which has a full round-trip delay.
+      // IC-7610 LAN audio: RX stops during TX (not full-duplex).
       if (!this._txEnabled) {
         return;
       }

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -11,7 +11,6 @@
 import { RxPlayer } from './rx-player';
 import { TxMic } from './tx-mic';
 import { setAudioConnected } from '../stores/connection.svelte';
-import { getRadioState } from '../stores/radio.svelte';
 import { setRxEnabled, setTxEnabled } from '../stores/audio.svelte';
 
 const BACKOFF_MIN = 500;
@@ -37,14 +36,10 @@ class AudioManager {
     let txFrames = 0;
     let droppedFrames = 0;
     this.txMic = new TxMic((data) => {
-      // CRITICAL: Only send TX frames when PTT is active
-      // IC-7610 LAN audio cannot do full duplex (RX + TX simultaneously)
-      const ptt = getRadioState()?.ptt ?? false;
-      if (!ptt) {
-        droppedFrames++;
-        if (droppedFrames <= 3 || droppedFrames % 100 === 0) {
-          console.log(`[audio-ws] TX frame dropped (PTT OFF), total=${droppedFrames}`);
-        }
+      // Gate on local _txEnabled flag (set immediately on startTx) instead of
+      // getRadioState()?.ptt which requires a full round-trip before becoming true,
+      // causing all mic frames during that window to be silently dropped.
+      if (!this._txEnabled) {
         return;
       }
       

--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -416,6 +416,9 @@ class AudioHandler:
         finally:
             self._done.set()
             await self._stop_rx()
+            if self._tx_active:
+                self._tx_active = False
+                logger.info("audio: TX cleanup on handler exit")
             logger.info("audio: handler finished")
 
     async def _reader_loop(self) -> None:
@@ -448,7 +451,13 @@ class AudioHandler:
                 await self._start_rx()
             elif direction == "tx":
                 if self._radio and CAP_AUDIO in self._radio.capabilities:
-                    await self._radio.start_audio_tx_opus()  # type: ignore[attr-defined]
+                    try:
+                        await self._radio.start_audio_tx_opus()  # type: ignore[attr-defined]
+                    except RuntimeError as exc:
+                        if "Already transmitting" in str(exc):
+                            logger.info("audio: TX already started by poller, reusing")
+                        else:
+                            raise
                 self._tx_active = True
                 logger.info("audio: TX active")
         elif msg_type == "audio_stop":

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1290,6 +1290,54 @@ async def test_audio_handler_control_and_tx_guard_paths() -> None:
     assert handler._tx_active is False
 
 
+async def test_audio_handler_tx_already_transmitting_is_tolerated() -> None:
+    """_handle_control tolerates 'Already transmitting' from start_audio_tx_opus (#684)."""
+    from icom_lan.radio_protocol import AudioCapable
+
+    radio = MagicMock(spec=AudioCapable)
+    radio.capabilities = {"audio"}
+    radio.start_audio_tx_opus = AsyncMock(
+        side_effect=RuntimeError("Already transmitting")
+    )
+
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+    # Handler must survive and set _tx_active = True
+    assert handler._tx_active is True
+    radio.start_audio_tx_opus.assert_awaited_once()
+
+
+async def test_audio_handler_tx_other_runtime_error_propagates() -> None:
+    """Non-'Already transmitting' RuntimeError still propagates."""
+    from icom_lan.radio_protocol import AudioCapable
+
+    radio = MagicMock(spec=AudioCapable)
+    radio.capabilities = {"audio"}
+    radio.start_audio_tx_opus = AsyncMock(
+        side_effect=RuntimeError("Something else")
+    )
+
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+    with pytest.raises(RuntimeError, match="Something else"):
+        await handler._handle_control({"type": "audio_start", "direction": "tx"})
+
+
+async def test_audio_handler_run_resets_tx_active_on_exit() -> None:
+    """run() finally block must reset _tx_active when TX was active (#684)."""
+    ws = SimpleNamespace(
+        recv=AsyncMock(side_effect=[EOFError()]),
+        send_binary=AsyncMock(),
+        close=AsyncMock(),
+    )
+    handler = AudioHandler(ws, SimpleNamespace(push_audio_tx_opus=AsyncMock()), None)
+    handler._tx_active = True
+    await handler.run()
+    assert handler._done.is_set()
+    assert handler._tx_active is False
+
+
 async def test_audio_handler_run_calls_stop_rx_on_exit() -> None:
     ws = SimpleNamespace(
         recv=AsyncMock(side_effect=[EOFError()]), send_binary=AsyncMock()


### PR DESCRIPTION
## Summary

- Catch `RuntimeError("Already transmitting")` in `AudioHandler._handle_control()` when poller has already started TX audio stream — reuse existing stream instead of crashing
- Add TX cleanup (`_tx_active` reset) to `AudioHandler.run()` finally block so TX state doesn't leak on handler exit
- Frontend: gate mic frames on local `_txEnabled` flag instead of `getRadioState()?.ptt` to eliminate round-trip delay that silently dropped initial TX frames

Closes #684

## Test plan

- [x] `test_audio_handler_tx_already_transmitting_is_tolerated` — handler survives double TX start
- [x] `test_audio_handler_tx_other_runtime_error_propagates` — non-"Already transmitting" errors still propagate
- [x] `test_audio_handler_run_resets_tx_active_on_exit` — TX state cleaned up on handler exit
- [x] Existing audio handler tests pass unchanged
- [x] Full test suite: zero regressions
- [x] Ruff: zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)