### PR TITLE
fix(#691): TX transcoder uses radio's negotiated sample rate

### DIFF
--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -85,7 +85,11 @@ class AudioBroadcaster:
         self._legacy_tap_handle: TapHandle | None = None
         # Buffer pool for audio encoding/decoding operations
         # Pre-allocates buffers for common audio frame sizes (20ms @ 16kHz stereo = 1280 bytes)
-        self._buffer_pool = AudioBufferPool(buffer_size=1280, max_buffers=get_audio_buffer_pool_size(), name="audio-broadcaster")
+        self._buffer_pool = AudioBufferPool(
+            buffer_size=1280,
+            max_buffers=get_audio_buffer_pool_size(),
+            name="audio-broadcaster",
+        )
 
     async def subscribe(
         self, ws: WebSocketConnection | None = None
@@ -98,9 +102,7 @@ class AudioBroadcaster:
             if ws is not None:
                 self._client_ws[client_id] = ws
             # Start relay if no active subscription, or if relay task died
-            relay_alive = (
-                self._relay_task is not None and not self._relay_task.done()
-            )
+            relay_alive = self._relay_task is not None and not self._relay_task.done()
             if self._subscription is None or not relay_alive:
                 # Clean up stale subscription/task if needed
                 if self._subscription is not None and not relay_alive:
@@ -121,7 +123,11 @@ class AudioBroadcaster:
         async with self._lock:
             self._clients.pop(client_id, None)
             self._client_ws.pop(client_id, None)
-            if not self._clients and self._subscription is not None and not self._tap_registry.active:
+            if (
+                not self._clients
+                and self._subscription is not None
+                and not self._tap_registry.active
+            ):
                 await self._stop_relay()
         logger.info("audio-broadcaster: client removed (total=%d)", len(self._clients))
 
@@ -159,9 +165,7 @@ class AudioBroadcaster:
         that the PCM tap callback fires.
         """
         async with self._lock:
-            relay_alive = (
-                self._relay_task is not None and not self._relay_task.done()
-            )
+            relay_alive = self._relay_task is not None and not self._relay_task.done()
             if not relay_alive and self._radio:
                 await self._start_relay()
                 logger.info("audio-broadcaster: relay started for PCM tap")
@@ -170,15 +174,17 @@ class AudioBroadcaster:
         """Remove clients whose WebSocket is no longer alive. Returns count removed."""
         async with self._lock:
             dead_ids = [
-                cid
-                for cid, ws in list(self._client_ws.items())
-                if not ws.is_alive()
+                cid for cid, ws in list(self._client_ws.items()) if not ws.is_alive()
             ]
             for cid in dead_ids:
                 self._clients.pop(cid, None)
                 self._client_ws.pop(cid, None)
             # Stop relay if no clients remain (and no PCM tap active)
-            if not self._clients and self._subscription is not None and not self._tap_registry.active:
+            if (
+                not self._clients
+                and self._subscription is not None
+                and not self._tap_registry.active
+            ):
                 await self._stop_relay()
             remaining = len(self._clients)
         if dead_ids:
@@ -269,14 +275,15 @@ class AudioBroadcaster:
                     try:
                         audio_data = decode_ulaw_to_pcm16(audio_data)
                     except Exception as e:
-                        logger.warning(
-                            "audio: failed to decode ulaw data: %s", e
-                        )
+                        logger.warning("audio: failed to decode ulaw data: %s", e)
                         # Fall back to original data
                         audio_data = pkt.data
 
                 # Apply DSP pipeline if configured (operates on s16le PCM)
-                if self._dsp_pipeline is not None and self._web_codec == AUDIO_CODEC_PCM16:
+                if (
+                    self._dsp_pipeline is not None
+                    and self._web_codec == AUDIO_CODEC_PCM16
+                ):
                     try:
                         audio_data = self._dsp_pipeline.process_bytes(
                             audio_data, self._sample_rate
@@ -373,12 +380,11 @@ class AudioHandler:
             maxsize=self.HIGH_WATERMARK,
         )
         self._done = asyncio.Event()
-        # Opus decoder for TX when radio uses PCM codec
+        # Opus decoder for TX when radio uses PCM codec.
+        # Created lazily on TX start so we pass the radio's negotiated sample rate
+        # (otherwise a 24 kHz radio silently drops TX audio decoded at 48 kHz — #691).
         self._transcoder: PcmOpusTranscoder | None = None
-        try:
-            self._transcoder = create_pcm_opus_transcoder()
-        except Exception:
-            logger.debug("audio: TX transcoder unavailable (opus codec missing?)")
+        self._transcoder_rate: int = 0
 
     async def run(self) -> None:
         """Run the audio channel lifecycle.
@@ -398,7 +404,9 @@ class AudioHandler:
             for task in done:
                 exc = task.exception() if not task.cancelled() else None
                 if exc:
-                    logger.warning("audio: %s exited with error: %s", task.get_name(), exc)
+                    logger.warning(
+                        "audio: %s exited with error: %s", task.get_name(), exc
+                    )
                 else:
                     logger.debug("audio: %s exited normally", task.get_name())
             # Cancel the remaining task and close WS to unblock any stuck recv()
@@ -456,6 +464,7 @@ class AudioHandler:
                 await self._start_rx()
             elif direction == "tx":
                 if self._radio and CAP_AUDIO in self._radio.capabilities:
+                    self._ensure_tx_transcoder()
                     try:
                         await self._radio.start_audio_tx_opus()  # type: ignore[attr-defined]
                     except RuntimeError as exc:
@@ -473,6 +482,30 @@ class AudioHandler:
                     await self._radio.stop_audio_tx()  # type: ignore[attr-defined]
                 self._tx_active = False
                 logger.info("audio: TX stopped")
+
+    def _ensure_tx_transcoder(self) -> None:
+        """Create (or recreate) the TX Opus→PCM transcoder at the radio's rate.
+
+        TX-side fix for issue #691: previously the transcoder was constructed
+        in ``__init__`` before the radio's negotiated ``audio_sample_rate`` was
+        known, so the browser's 24 kHz Opus stream was decoded to 48 kHz PCM
+        and the radio silently dropped TX audio. Called on ``audio_start
+        direction=tx``, when the rate is guaranteed available.
+        """
+        sr = getattr(self._radio, "audio_sample_rate", None)
+        rate = (
+            sr if isinstance(sr, int) and not isinstance(sr, bool) and sr > 0 else 48000
+        )
+        if self._transcoder is not None and self._transcoder_rate == rate:
+            return
+        try:
+            self._transcoder = create_pcm_opus_transcoder(sample_rate=rate)
+            self._transcoder_rate = rate
+            logger.info("audio: TX transcoder ready at %d Hz", rate)
+        except Exception:
+            logger.debug("audio: TX transcoder unavailable (opus codec missing?)")
+            self._transcoder = None
+            self._transcoder_rate = 0
 
     async def _start_rx(self) -> None:
         """Subscribe to audio broadcaster for RX frames."""

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1351,6 +1351,60 @@ class TestAudioHandlerCodecDetection:
         assert frame[1] == AUDIO_CODEC_PCM16
 
 
+class TestAudioHandlerTxTranscoderRate:
+    """TX transcoder must use the radio's negotiated sample rate (issue #691).
+
+    Previously the transcoder was hard-coded to 48 kHz, which silently broke
+    TX on radios negotiated at a lower rate (e.g. 24 kHz) — PTT keyed up but
+    no RF power was emitted because the radio dropped the mismatched stream.
+    """
+
+    @staticmethod
+    def _make_handler(sample_rate: int | None) -> Any:
+        from icom_lan.radio_protocol import AudioCapable
+        from icom_lan.web.handlers import AudioBroadcaster, AudioHandler
+        from icom_lan.web.websocket import WebSocketConnection
+
+        mock_ws = MagicMock(spec=WebSocketConnection)
+        mock_radio = MagicMock(spec=AudioCapable)
+        mock_radio.capabilities = {"audio"}
+        if sample_rate is None:
+            # Simulate a radio that does not expose audio_sample_rate
+            del mock_radio.audio_sample_rate
+        else:
+            mock_radio.audio_sample_rate = sample_rate
+        mock_radio.start_audio_tx_opus = AsyncMock()
+
+        broadcaster = AudioBroadcaster(mock_radio)
+        handler = AudioHandler(mock_ws, mock_radio, broadcaster)
+        return handler
+
+    async def _start_tx(self, handler: Any) -> None:
+        await handler._handle_control({"type": "audio_start", "direction": "tx"})
+
+    async def test_tx_transcoder_uses_24khz_rate(self) -> None:
+        handler = self._make_handler(24000)
+        await self._start_tx(handler)
+        assert handler._transcoder is not None
+        assert handler._transcoder._fmt.sample_rate == 24000
+
+    async def test_tx_transcoder_uses_48khz_rate(self) -> None:
+        handler = self._make_handler(48000)
+        await self._start_tx(handler)
+        assert handler._transcoder is not None
+        assert handler._transcoder._fmt.sample_rate == 48000
+
+    async def test_tx_transcoder_falls_back_when_rate_missing(self) -> None:
+        handler = self._make_handler(None)
+        await self._start_tx(handler)
+        assert handler._transcoder is not None
+        assert handler._transcoder._fmt.sample_rate == 48000
+
+    async def test_tx_transcoder_not_created_before_tx_start(self) -> None:
+        handler = self._make_handler(24000)
+        assert handler._transcoder is None
+
+
 # ---------------------------------------------------------------------------
 # WebSocket keepalive (server-initiated pings)
 # ---------------------------------------------------------------------------
@@ -1385,9 +1439,9 @@ class TestWsKeepalive:
         # Ping frame: FIN|PING (0x89), payload len 2 ("ka")
         all_bytes = b"".join(written)
         ping_frame = make_frame(WS_OP_PING, b"ka")
-        assert (
-            ping_frame in all_bytes
-        ), f"Expected ping frame {ping_frame!r} in written data {all_bytes!r}"
+        assert ping_frame in all_bytes, (
+            f"Expected ping frame {ping_frame!r} in written data {all_bytes!r}"
+        )
 
     async def test_keepalive_cancels_cleanly(self) -> None:
         """Cancelling keepalive_loop raises no unhandled exceptions."""
@@ -1467,9 +1521,9 @@ class TestScopeLifecycle:
         from icom_lan.web.radio_poller import DisableScope
 
         cmds = server._command_queue.drain()
-        assert any(
-            isinstance(c, DisableScope) for c in cmds
-        ), "DisableScope should be in queue"
+        assert any(isinstance(c, DisableScope) for c in cmds), (
+            "DisableScope should be in queue"
+        )
         assert not server._scope_enabled
 
     async def test_scope_flag_reset_on_disable(self) -> None:
@@ -2123,9 +2177,9 @@ class TestSwitchScopeReceiver:
         poller.stop()
 
         scope_calls = [c for c in radio.send_civ.call_args_list if c[0][0] == 0x27]
-        assert not any(
-            c.kwargs.get("sub") == 0x12 for c in scope_calls
-        ), "Expected invalid receiver to be rejected without CI-V send"
+        assert not any(c.kwargs.get("sub") == 0x12 for c in scope_calls), (
+            "Expected invalid receiver to be rejected without CI-V send"
+        )
 
     async def test_select_vfo_sub_sends_swap(self) -> None:
         """SelectVfo("SUB") sends VFO swap (0x07 0xB0) when active=MAIN."""
@@ -2757,7 +2811,9 @@ class TestGetProfileRouting:
         """_get_profile() uses radio.model when radio has no .profile property."""
         from icom_lan.profiles import RadioProfile
 
-        radio = SimpleNamespace(model="FTX-1", capabilities={"audio", "scope"})  # no .profile attribute
+        radio = SimpleNamespace(
+            model="FTX-1", capabilities={"audio", "scope"}
+        )  # no .profile attribute
         srv = self._make_server(radio)
         profile = srv._get_profile()
 
@@ -2772,7 +2828,9 @@ class TestGetProfileRouting:
 
         ic7610_profile = resolve_radio_profile(model="IC-7610")
         # Simulate IcomRadio: has .profile (RadioProfile) but .model would differ
-        radio = SimpleNamespace(profile=ic7610_profile, model="WRONG", capabilities={"audio", "scope"})
+        radio = SimpleNamespace(
+            profile=ic7610_profile, model="WRONG", capabilities={"audio", "scope"}
+        )
         srv = self._make_server(radio)
         profile = srv._get_profile()
 
@@ -2799,7 +2857,9 @@ class TestGetMeterCalPayload:
 
     def test_profile_fallback_includes_calibrations(self):
         radio = SimpleNamespace(
-            model="IC-7610", capabilities=set(), radio_state=RadioState(),
+            model="IC-7610",
+            capabilities=set(),
+            radio_state=RadioState(),
         )
         srv = self._make_server(radio)
         payload = srv._get_meter_cal_payload()
@@ -2808,7 +2868,9 @@ class TestGetMeterCalPayload:
 
     def test_profile_fallback_includes_redlines(self):
         radio = SimpleNamespace(
-            model="IC-7610", capabilities=set(), radio_state=RadioState(),
+            model="IC-7610",
+            capabilities=set(),
+            radio_state=RadioState(),
         )
         srv = self._make_server(radio)
         payload = srv._get_meter_cal_payload()
@@ -2822,8 +2884,10 @@ class TestGetMeterCalPayload:
             meter_redlines={"power": 213},
         )
         radio = SimpleNamespace(
-            model="IC-7610", capabilities=set(),
-            radio_state=RadioState(), _config=fake_config,
+            model="IC-7610",
+            capabilities=set(),
+            radio_state=RadioState(),
+            _config=fake_config,
         )
         srv = self._make_server(radio)
         payload = srv._get_meter_cal_payload()


### PR DESCRIPTION
## Summary

- TX Opus→PCM transcoder was hard-coded to 48 kHz in `AudioHandler.__init__`, before the radio's negotiated `audio_sample_rate` was known.
- On radios negotiated at 24 kHz the browser's Opus stream was decoded to 48 kHz PCM and the radio silently dropped it — PTT keyed up but no RF was emitted.
- Moved transcoder creation into `_ensure_tx_transcoder()`, called from the TX-start branch where the rate is guaranteed available. Mirrors the RX-side pattern at `audio.py:231`.
- Falls back to 48000 Hz when `audio_sample_rate` is missing.

## Changes

- `src/icom_lan/web/handlers/audio.py` — remove eager transcoder from `__init__`; add `_ensure_tx_transcoder()`; call it on TX start. (Some surrounding reflows from `ruff format`.)
- `tests/test_web_server.py` — new class `TestAudioHandlerTxTranscoderRate` with 4 tests (24 kHz, 48 kHz, fallback, lazy-init).

## Test plan

- [x] `uv run pytest tests/test_web_server.py::TestAudioHandlerTxTranscoderRate` — 4 passed
- [x] Full suite: 4620 passed (was 4616 + 4 new), zero regressions
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy src/` clean

Closes #691