### PR TITLE
test(perf): suite speedup — 87.6s → 64s (−27%) on 4 targeted fixes

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import ExitStack, contextmanager
+from functools import partial
 from unittest.mock import Mock, patch
 
 import pytest
@@ -20,6 +22,30 @@ from icom_lan.discovery import (
     probe_serial_civ,
     probe_serial_yaesu_cat,
 )
+
+
+@contextmanager
+def _fast_probes():
+    """Patch probe_serial_civ / probe_serial_yaesu_cat to use a single baud and
+    tiny timeout. Cuts ~4 s (4 bauds × 1.0 s) per miss path to milliseconds.
+
+    Used by ``TestDiscoverSerialRadios`` — those tests only care about the
+    probe outcome, not about baud sweeping or real timeout values.
+    """
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "icom_lan.discovery.probe_serial_civ",
+                partial(probe_serial_civ, baud_rates=[19200], timeout=0.01),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "icom_lan.discovery.probe_serial_yaesu_cat",
+                partial(probe_serial_yaesu_cat, baud_rates=[38400], timeout=0.01),
+            )
+        )
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -615,7 +641,7 @@ class TestDiscoverSerialRadios:
         writer = _FakeWriter()
 
         port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=10C4:EA60")
-        with patch("serial.tools.list_ports.comports", return_value=[port]):
+        with _fast_probes(), patch("serial.tools.list_ports.comports", return_value=[port]):
             results = await discover_serial_radios(
                 _open_serial=_make_open(reader, writer),
             )
@@ -637,7 +663,7 @@ class TestDiscoverSerialRadios:
         yaesu_factory = _make_yaesu_factory("ID0840")
 
         port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=0403:6001")
-        with patch("serial.tools.list_ports.comports", return_value=[port]):
+        with _fast_probes(), patch("serial.tools.list_ports.comports", return_value=[port]):
             results = await discover_serial_radios(
                 _open_serial=_civ_open,
                 _yaesu_transport_factory=yaesu_factory,
@@ -657,7 +683,7 @@ class TestDiscoverSerialRadios:
         yaesu_factory = _make_yaesu_factory(None)
 
         port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=0403:6001")
-        with patch("serial.tools.list_ports.comports", return_value=[port]):
+        with _fast_probes(), patch("serial.tools.list_ports.comports", return_value=[port]):
             results = await discover_serial_radios(
                 _open_serial=_civ_open,
                 _yaesu_transport_factory=yaesu_factory,
@@ -687,7 +713,7 @@ class TestDiscoverSerialRadios:
             _make_port("/dev/ttyUSB0", "USB Serial"),
             _make_port("/dev/ttyUSB1", "USB Serial"),
         ]
-        with patch("serial.tools.list_ports.comports", return_value=ports):
+        with _fast_probes(), patch("serial.tools.list_ports.comports", return_value=ports):
             results = await discover_serial_radios(
                 _open_serial=_civ_open,
                 _yaesu_transport_factory=yaesu_factory,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -52,6 +52,7 @@ def _fast_probes():
 # Fake serial transport helpers for CI-V probe tests
 # ---------------------------------------------------------------------------
 
+
 class _FakeReader:
     def __init__(self, chunks: list[bytes]) -> None:
         self._queue: asyncio.Queue[bytes] = asyncio.Queue()
@@ -83,6 +84,7 @@ class _FakeWriter:
 def _make_open(reader: _FakeReader, writer: _FakeWriter):
     async def _open(*, url: str, baudrate: int, **_kw: object):
         return reader, writer
+
     return _open
 
 
@@ -93,6 +95,7 @@ _PROBE_CMD = bytes([0xFE, 0xFE, 0x00, 0xE0, 0x19, 0x00, 0xFD])
 # ---------------------------------------------------------------------------
 # CI-V probe tests
 # ---------------------------------------------------------------------------
+
 
 class TestProbeSerialCiv:
     @pytest.mark.asyncio
@@ -261,7 +264,9 @@ class TestIsCandidate:
 
     def test_usb_modem_included(self) -> None:
         # macOS USB CDC devices appear as /dev/tty.usbmodem*
-        port = _make_port("/dev/tty.usbmodem14101", "USB Modem", "USB VID:PID=0403:6001")
+        port = _make_port(
+            "/dev/tty.usbmodem14101", "USB Modem", "USB VID:PID=0403:6001"
+        )
         assert _is_candidate(port) is True
 
     def test_usb_upper_case_included(self) -> None:
@@ -351,7 +356,9 @@ class TestEnumerateSerialPorts:
 class TestDedupeRadios:
     def test_same_radio_lan_and_serial_grouped(self) -> None:
         lan = [{"model": "IC-7610", "address": 0x98, "host": "192.168.1.100"}]
-        serial = [{"model": "IC-7610", "address": 0x98, "port": "/dev/ttyUSB0", "baud": 19200}]
+        serial = [
+            {"model": "IC-7610", "address": 0x98, "port": "/dev/ttyUSB0", "baud": 19200}
+        ]
 
         result = dedupe_radios(lan, serial)
 
@@ -362,7 +369,9 @@ class TestDedupeRadios:
 
     def test_different_radios_stay_separate(self) -> None:
         lan = [{"model": "IC-7610", "address": 0x98, "host": "192.168.1.100"}]
-        serial = [{"model": "IC-705", "address": 0xA4, "port": "/dev/ttyUSB0", "baud": 19200}]
+        serial = [
+            {"model": "IC-705", "address": 0xA4, "port": "/dev/ttyUSB0", "baud": 19200}
+        ]
 
         result = dedupe_radios(lan, serial)
 
@@ -380,7 +389,9 @@ class TestDedupeRadios:
 
     def test_serial_only_no_lan_section(self) -> None:
         lan: list[dict] = []
-        serial = [{"model": "IC-705", "address": 0xA4, "port": "/dev/ttyUSB0", "baud": 19200}]
+        serial = [
+            {"model": "IC-705", "address": 0xA4, "port": "/dev/ttyUSB0", "baud": 19200}
+        ]
 
         result = dedupe_radios(lan, serial)
 
@@ -404,7 +415,9 @@ class TestDedupeRadios:
     def test_lan_without_model_not_merged_with_serial(self) -> None:
         # LAN entry has no model/address → cannot be deduped → stays separate
         lan = [{"host": "192.168.1.100"}]
-        serial = [{"model": "IC-7610", "address": 0x98, "port": "/dev/ttyUSB0", "baud": 19200}]
+        serial = [
+            {"model": "IC-7610", "address": 0x98, "port": "/dev/ttyUSB0", "baud": 19200}
+        ]
 
         result = dedupe_radios(lan, serial)
 
@@ -455,6 +468,7 @@ class _FakeCatTransport:
         self.queries.append(command)
         if self._response is None:
             from icom_lan.backends.yaesu_cat.transport import CatTimeoutError
+
             raise CatTimeoutError("timeout")
         return self._response
 
@@ -625,7 +639,9 @@ class TestProbeSerialYaesuCat:
             seen_bauds.append(int(str(kwargs["baudrate"])))
             return _FakeCatTransport(None)
 
-        await probe_serial_yaesu_cat("/dev/ttyUSB0", timeout=0.01, _transport_factory=factory)
+        await probe_serial_yaesu_cat(
+            "/dev/ttyUSB0", timeout=0.01, _transport_factory=factory
+        )
         assert seen_bauds == [38400, 9600, 115200]
 
 
@@ -641,7 +657,10 @@ class TestDiscoverSerialRadios:
         writer = _FakeWriter()
 
         port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=10C4:EA60")
-        with _fast_probes(), patch("serial.tools.list_ports.comports", return_value=[port]):
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+        ):
             results = await discover_serial_radios(
                 _open_serial=_make_open(reader, writer),
             )
@@ -663,7 +682,10 @@ class TestDiscoverSerialRadios:
         yaesu_factory = _make_yaesu_factory("ID0840")
 
         port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=0403:6001")
-        with _fast_probes(), patch("serial.tools.list_ports.comports", return_value=[port]):
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+        ):
             results = await discover_serial_radios(
                 _open_serial=_civ_open,
                 _yaesu_transport_factory=yaesu_factory,
@@ -683,7 +705,10 @@ class TestDiscoverSerialRadios:
         yaesu_factory = _make_yaesu_factory(None)
 
         port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=0403:6001")
-        with _fast_probes(), patch("serial.tools.list_ports.comports", return_value=[port]):
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+        ):
             results = await discover_serial_radios(
                 _open_serial=_civ_open,
                 _yaesu_transport_factory=yaesu_factory,
@@ -713,7 +738,10 @@ class TestDiscoverSerialRadios:
             _make_port("/dev/ttyUSB0", "USB Serial"),
             _make_port("/dev/ttyUSB1", "USB Serial"),
         ]
-        with _fast_probes(), patch("serial.tools.list_ports.comports", return_value=ports):
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=ports),
+        ):
             results = await discover_serial_radios(
                 _open_serial=_civ_open,
                 _yaesu_transport_factory=yaesu_factory,

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -252,9 +252,15 @@ class TestReceiveCivPort:
     def test_status_retry_pause_uses_reject_cooldown(self) -> None:
         radio = IcomRadio("192.168.1.100")
         radio._last_status_error = 0xFFFFFFFF
-        assert radio._control_phase._status_retry_pause() == radio._control_phase._STATUS_REJECT_COOLDOWN
+        assert (
+            radio._control_phase._status_retry_pause()
+            == radio._control_phase._STATUS_REJECT_COOLDOWN
+        )
         radio._last_status_error = 0
-        assert radio._control_phase._status_retry_pause() == radio._control_phase._STATUS_RETRY_PAUSE
+        assert (
+            radio._control_phase._status_retry_pause()
+            == radio._control_phase._STATUS_RETRY_PAUSE
+        )
 
 
 class TestSendOpenClose:
@@ -292,7 +298,9 @@ class TestWaitForPacket:
         mt = ConnectMockTransport()
         mt.queue_response(b"\x00" * 0x20)  # wrong size
         mt.queue_response(b"\x00" * 0x60)  # correct
-        result = await radio._control_phase._wait_for_packet(mt, size=0x60, label="test")
+        result = await radio._control_phase._wait_for_packet(
+            mt, size=0x60, label="test"
+        )
         assert len(result) == 0x60
 
     @pytest.mark.asyncio
@@ -316,7 +324,9 @@ class TestWaitForPacket:
         for _ in range(5):
             mt.queue_response(b"\x00" * 0x10)
         mt.queue_response(b"\xff" * 0x60)
-        result = await radio._control_phase._wait_for_packet(mt, size=0x60, label="test")
+        result = await radio._control_phase._wait_for_packet(
+            mt, size=0x60, label="test"
+        )
         assert result == b"\xff" * 0x60
 
 
@@ -393,7 +403,9 @@ class TestConnectReadiness:
                 "_receive_civ_port",
                 new=AsyncMock(return_value=50002),
             ),
-            patch.object(radio._control_phase, "_flush_queue", new=AsyncMock(return_value=0)),
+            patch.object(
+                radio._control_phase, "_flush_queue", new=AsyncMock(return_value=0)
+            ),
             patch.object(radio._control_phase, "_start_token_renewal"),
             patch.object(radio._control_phase, "_start_watchdog"),
             patch.object(radio._civ_runtime, "start_pump"),
@@ -467,7 +479,9 @@ class _FakeSocket:
 
 class TestWifiBindBehavior:
     @pytest.mark.asyncio
-    async def test_connect_uses_routed_local_bind_host_for_control_and_civ(self) -> None:
+    async def test_connect_uses_routed_local_bind_host_for_control_and_civ(
+        self,
+    ) -> None:
         radio = IcomRadio("192.168.2.1", username="u", password="p")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
@@ -510,7 +524,11 @@ class TestWifiBindBehavior:
             patch.object(radio._control_phase, "_start_token_renewal"),
             patch.object(radio._control_phase, "_start_watchdog"),
             patch.object(radio._control_phase, "_send_open_close", new=AsyncMock()),
-            patch.object(radio._control_phase, "_flush_queue", new=AsyncMock(side_effect=_mark_ready)),
+            patch.object(
+                radio._control_phase,
+                "_flush_queue",
+                new=AsyncMock(side_effect=_mark_ready),
+            ),
             patch.object(radio._civ_runtime, "start_pump"),
             patch.object(radio._civ_runtime, "start_data_watchdog"),
             patch.object(radio._civ_runtime, "start_worker"),
@@ -531,7 +549,9 @@ class TestWifiBindBehavior:
         }
 
     @pytest.mark.asyncio
-    async def test_connect_raises_on_persistent_civ_port_zero_without_error_flag(self) -> None:
+    async def test_connect_raises_on_persistent_civ_port_zero_without_error_flag(
+        self,
+    ) -> None:
         """civ_port=0 after all retries (no 0xFFFFFFFF flag) also raises ConnectionError."""
         radio = IcomRadio("192.168.1.100", username="u", password="p")
         mt = ConnectMockTransport()

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -515,6 +515,7 @@ class TestWifiBindBehavior:
             patch.object(radio._civ_runtime, "start_data_watchdog"),
             patch.object(radio._civ_runtime, "start_worker"),
             patch("icom_lan.transport.IcomTransport", return_value=fake_civ_transport),
+            patch.object(radio, "_fetch_initial_state", new=AsyncMock()),
         ):
             await radio.connect()
 

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -133,6 +133,13 @@ class TestBuildStateQueries:
 class TestFetchInitialState:
     """Tests for CoreRadio._fetch_initial_state method."""
 
+    @pytest.fixture(autouse=True)
+    def _no_real_pacing(self):
+        """Skip the 12ms inter-query sleep (~1.2s per test) — tests assert
+        call counts and flag state, not real pacing."""
+        with patch("icom_lan.radio.asyncio.sleep", new=AsyncMock()):
+            yield
+
     @pytest.fixture
     def radio(self):
         from icom_lan.radio import CoreRadio

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -80,9 +80,7 @@ class TestBuildStateQueries:
         """Serial backends should include ALC/comp/VD/Id meter queries."""
         profile = resolve_radio_profile(model="IC-7610")
         lan_queries = build_state_queries(profile, _ic7610_caps(), is_serial=False)
-        serial_queries = build_state_queries(
-            profile, _ic7610_caps(), is_serial=True
-        )
+        serial_queries = build_state_queries(profile, _ic7610_caps(), is_serial=True)
         # Serial should have more queries (the extra meters)
         assert len(serial_queries) > len(lan_queries)
         serial_cmds = {(q[0], q[1]) for q in serial_queries}
@@ -101,9 +99,7 @@ class TestBuildStateQueries:
         reduced_queries = build_state_queries(profile, reduced_caps)
         # NB queries (0x16/0x22 and 0x14/0x12) should be missing
         nb_in_full = [q for q in full_queries if q[0] == 0x16 and q[1] == 0x22]
-        nb_in_reduced = [
-            q for q in reduced_queries if q[0] == 0x16 and q[1] == 0x22
-        ]
+        nb_in_reduced = [q for q in reduced_queries if q[0] == 0x16 and q[1] == 0x22]
         assert len(nb_in_full) > 0
         assert len(nb_in_reduced) == 0
 
@@ -154,9 +150,7 @@ class TestFetchInitialState:
 
     @pytest.mark.asyncio
     async def test_dispatches_all_queries(self, radio) -> None:
-        queries = build_state_queries(
-            radio._profile, set(radio._profile.capabilities)
-        )
+        queries = build_state_queries(radio._profile, set(radio._profile.capabilities))
         await radio._fetch_initial_state()
         assert radio.send_civ.call_count == len(queries)
         assert radio._initial_state_fetched is True

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2007,12 +2007,12 @@ class TestRadioPoller:
         poller = RadioPoller(radio, cache, queue)
 
         poller.start()
-        # Initial state fetch runs ~60 queries × 12ms gap ≈ 0.7s before
-        # the main poll loop starts meter queries.
-        await asyncio.sleep(1.5)
+        # Initial state fetch is done by CoreRadio._fetch_initial_state() on
+        # connect; the poller just runs meter polls every _FAST_INTERVAL=25ms.
+        # 0.2s is plenty for ≥3 meter polls.
+        await asyncio.sleep(0.2)
         poller.stop()
 
-        # Initial fetch + interleaved meter/state queries.
         assert radio.send_civ.await_count >= 4
         meter_calls = [
             c for c in radio.send_civ.call_args_list if c[0][0] == 0x15
@@ -2047,7 +2047,7 @@ class TestRadioPoller:
 
         poller.start()
         queue.put(SetKeySpeed(24))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_key_speed.assert_awaited_once_with(24)
@@ -2066,7 +2066,7 @@ class TestRadioPoller:
 
         poller.start()
         queue.put(SetBreakIn(1))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_break_in.assert_awaited_once_with(1)
@@ -2127,7 +2127,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SwitchScopeReceiver(0))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         scope_calls = [c for c in radio.send_civ.call_args_list if c[0][0] == 0x27]
@@ -2150,7 +2150,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SwitchScopeReceiver(1))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         scope_calls = [c for c in radio.send_civ.call_args_list if c[0][0] == 0x27]
@@ -2173,7 +2173,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SwitchScopeReceiver(0xFF))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         scope_calls = [c for c in radio.send_civ.call_args_list if c[0][0] == 0x27]
@@ -2191,7 +2191,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SelectVfo("SUB"))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         swap_calls = [
@@ -2211,7 +2211,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SelectVfo("MAIN"))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         swap_calls = [
@@ -2232,7 +2232,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetSplit(True))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_split_mode.assert_awaited_once_with(True)
@@ -2251,7 +2251,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetRitStatus(True))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_rit_status.assert_awaited_once_with(True)
@@ -2270,7 +2270,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetRitTxStatus(True))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_rit_tx_status.assert_awaited_once_with(True)
@@ -2289,7 +2289,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetRitFrequency(-200))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_rit_frequency.assert_awaited_once_with(-200)
@@ -2308,7 +2308,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetPbtInner(150, receiver=0))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_pbt_inner.assert_awaited_once_with(150, receiver=0)
@@ -2327,7 +2327,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetPbtOuter(200, receiver=0))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_pbt_outer.assert_awaited_once_with(200, receiver=0)
@@ -2346,7 +2346,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetNRLevel(42, receiver=0))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_nr_level.assert_awaited_once_with(42, receiver=0)
@@ -2365,7 +2365,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetNBLevel(17, receiver=0))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_nb_level.assert_awaited_once_with(17, receiver=0)
@@ -2384,7 +2384,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetAutoNotch(True, receiver=0))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_auto_notch.assert_awaited_once_with(True, receiver=0)
@@ -2403,7 +2403,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetManualNotch(True, receiver=0))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_manual_notch.assert_awaited_once_with(True, receiver=0)
@@ -2422,7 +2422,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetNotchFilter(91))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_notch_filter.assert_awaited_once_with(91)
@@ -2445,7 +2445,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetAgcTimeConstant(9, receiver=0))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_agc_time_constant.assert_awaited_once_with(9, receiver=0)
@@ -2464,7 +2464,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetCwPitch(600))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_cw_pitch.assert_awaited_once_with(600)
@@ -2483,7 +2483,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetMicGain(123))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_mic_gain.assert_awaited_once_with(123)
@@ -2502,7 +2502,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetVox(True))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_vox.assert_awaited_once_with(True)
@@ -2525,7 +2525,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetCompressorLevel(88))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_compressor_level.assert_awaited_once_with(88)
@@ -2544,7 +2544,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetMonitor(True))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_monitor.assert_awaited_once_with(True)
@@ -2563,7 +2563,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetMonitorGain(55))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_monitor_gain.assert_awaited_once_with(55)
@@ -2582,7 +2582,7 @@ class TestSwitchScopeReceiver:
 
         poller.start()
         queue.put(SetDialLock(True))
-        await asyncio.sleep(0.15)
+        await asyncio.sleep(0.03)
         poller.stop()
 
         radio.set_dial_lock.assert_awaited_once_with(True)
@@ -2619,7 +2619,7 @@ class TestSwitchScopeReceiverCommand:
             assert resp["result"]["receiver"] == 1
 
             # Allow poller to execute the queued command
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(0.03)
 
             scope_calls = [
                 c for c in mock_radio.send_civ.call_args_list if c[0][0] == 0x27
@@ -2656,7 +2656,7 @@ class TestSwitchScopeReceiverCommand:
             assert resp["result"]["receiver"] == 0
 
             # Allow poller to execute the queued command
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(0.03)
 
             scope_calls = [
                 c for c in mock_radio.send_civ.call_args_list if c[0][0] == 0x27
@@ -2696,7 +2696,7 @@ class TestScopeAdvancedCommands:
             assert resp["ok"] is True
             assert resp["result"]["on"] is True
 
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(0.03)
             mock_radio.set_scope_during_tx.assert_called_once_with(True)
         finally:
             await _close_ws(writer)
@@ -2725,7 +2725,7 @@ class TestScopeAdvancedCommands:
             assert resp["ok"] is True
             assert resp["result"]["on"] is False
 
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(0.03)
             mock_radio.set_scope_during_tx.assert_called_once_with(False)
         finally:
             await _close_ws(writer)
@@ -2754,7 +2754,7 @@ class TestScopeAdvancedCommands:
             assert resp["ok"] is True
             assert resp["result"]["center_type"] == 2
 
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(0.03)
             mock_radio.set_scope_center_type.assert_called_once_with(2)
         finally:
             await _close_ws(writer)
@@ -2785,7 +2785,7 @@ class TestScopeAdvancedCommands:
             assert resp["result"]["start_hz"] == 14_000_000
             assert resp["result"]["end_hz"] == 15_000_000
 
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(0.03)
             mock_radio.set_scope_fixed_edge.assert_called_once_with(
                 edge=1,
                 start_hz=14_000_000,


### PR DESCRIPTION
## Summary

Suite runtime dropped from **87.6 s → 64.0 s (−23.6 s, −27 %)** on 4620 tests, based on the perf-plan audit (`.claude/workflow/perf-plan.md`). No behaviour changes.

## Items landed (in order of ROI)

| Commit | Item | File | Savings |
|--------|------|------|---------|
| `bb3ad88` | A — discovery probes | `test_discovery.py` | ~12 s |
| `c869676` | B — web_server poller-gap waits | `test_web_server.py` | ~5.4 s |
| `a8c825c` | C — state_queries autouse sleep-patch | `test_state_queries.py` | ~3.7 s |
| `d1244cf` | D — WifiBindBehavior mock `_fetch_initial_state` | `test_radio_connect.py` | ~3.4 s |
| `9ae9fd5` | — | formatter reflow on the three touched files | 0 |

## What each fix does

- **A:** `TestDiscoverSerialRadios` called `probe_serial_civ` through real defaults (4 bauds × 1 s timeout = 4 s per miss). New `_fast_probes()` context patches the probes to a single baud + 10 ms timeout. Tests assert the outcome (civ / yaesu / none), not the real sweep.
- **B:** 34× `await asyncio.sleep(0.15)` → `0.03` after `poller.start()` / `queue.put(...)`. `RadioPoller._FAST_INTERVAL` is 25 ms, so one tick comfortably fits in 30 ms. Plus 1× `sleep(1.5)` → `0.2` in `test_poller_broadcasts_meter_readings` — the initial state fetch moved to `CoreRadio._fetch_initial_state()` (see `radio_poller.py:566`), so the poller no longer pre-fetches.
- **C:** `TestFetchInitialState` (4 tests) hit the real `_fetch_initial_state` path (~100 queries × 12 ms = 1.2 s per test). Autouse fixture `AsyncMock`-patches `icom_lan.radio.asyncio.sleep`. Tests assert `call_count` + flag state, not pacing.
- **D:** `TestWifiBindBehavior::test_connect_uses_routed_local_bind_host_for_control_and_civ` ran real `_fetch_initial_state` after the mocked control phase (~3.5 s). One-line `patch.object(radio, "_fetch_initial_state", new=AsyncMock())` added to the existing patch block.

## Item E was reverted

Lowering the `test_radio_coverage.py::radio` fixture timeout from 0.05 → 0.02 (expected −2.5 s) caused `test_enable_scope_strict_sends_and_acks` to time out on the ACK roundtrip. Splitting into a separate `snapshot_radio` fixture was considered but would touch 8 test signatures — not worth the churn for 2.5 s. Left at 0.05 s.

## Test plan

- [x] Full suite: 4620 passed, 6 skipped, 2 deselected, 10 xfailed (zero regressions, same numbers as baseline)
- [x] Suite time: 87.6 s → 64.0 s (locally)
- [x] Affected files: `ruff check` / `ruff format --check` clean
- [x] `mypy src/` unaffected (no `src/` changes)

## Impact on CI

CI previously took ~2 min 27 s per matrix job after the earlier cache+uv work. Expected new CI time per job: **~1 min 40 s** (the test step dominated; 25 s of that step now eliminated).

Closes nothing (no linked issues — internal perf work).