### PR TITLE
test(perf): vitest thread pool + shared isolation — frontend suite 10.6s → 5.8s

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -51,5 +51,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     include: ['src/**/*.test.ts'],
+    pool: 'threads',
+    isolate: false,
   },
 })


### PR DESCRIPTION
## Summary

Two-line config change on \`frontend/vite.config.ts\`:

\`\`\`ts
test: {
  environment: 'jsdom',
  include: ['src/**/*.test.ts'],
  pool: 'threads',     // was default 'forks'
  isolate: false,      // share module / DOM state between files in a worker
}
\`\`\`

## Measured impact (local 10-core M-series, 3+ runs each)

| Config | Wall | CPU |
|---|---|---|
| Baseline (forks, isolate) | **10.60 s** | ~52 s |
| + \`pool: threads\` | 7.88 s | ~44 s |
| + \`isolate: false\` | **~5.82 s** | ~19 s |

Wall −45 %, CPU −64 %. On a 2–4 core CI runner, wall savings likely scale larger because parallelism headroom is tighter — expected CI test step drop: roughly 15 s → 9 s.

## Correctness

- 1470 tests pass — 5 consecutive runs 1470/1470, zero order-dependency flakiness.
- No stderr warnings, no TypeErrors.
- Threads share module cache; \`isolate: false\` shares DOM/module state between files in a worker. Today's tests tolerate this.

## Why CPU savings matter on CI

On 2–4 core CI runners, \`vitest\` + \`vite build\` + Python matrix can compete for cores. Cutting frontend CPU time ~60 % frees the runner for parallel work — often more valuable than the raw wall-clock delta for the test step itself.

## Risk — module-scope global mutations

Under \`isolate: false\`, a file that mutates \`globalThis\` at module scope leaks those mutations to any file that runs after it in the same worker. Verified today is clean, but future tests should \`beforeEach\`/\`afterEach\` + \`vi.spyOn(...).mockRestore()\` instead. Files that currently mutate at module scope (flagged for future cleanup, not blocking):

- \`src/components/spectrum/__tests__/SpectrumPanel.component.test.ts\`
- \`src/components-v2/layout/__tests__/LeftSidebar.test.ts\`
- \`src/components-v2/layout/__tests__/CollapsiblePanel.test.ts\`
- \`src/lib/utils/__tests__/battery.test.ts\`
- \`src/lib/media/__tests__/tx-mic.test.ts\`

## Test plan

- [x] Full vitest suite: 1470 passed, 79 files, ~5.8 s locally
- [x] 5× consecutive runs: 1470/1470 each, no variance in pass count
- [x] Clean stderr (no TypeError / deprecation leaks)
- [ ] CI matrix (3.11 / 3.12 / 3.13) — verified by PR checks

## Further opportunities (not in this PR)

- \`happy-dom\` (requires \`npm i -D happy-dom\`): estimated +2–4 s wall. Unmeasured, compat TBD.
- \`environmentMatchGlobs\` forcing \`environment: 'node'\` for ~44 logic tests that don't touch DOM: estimated +1–2 s wall, requires per-file audit.
- Replace \`vi.resetModules()\` pattern in 11 files with explicit \`__resetForTests()\` — modest additional win.

These can be tackled in a follow-up PR if further CI savings are needed.