### PR TITLE
fix(#717): split vfoLabel into receiverLabel + vfoSlotLabel

### DIFF
--- a/frontend/src/components/layout/DesktopLayout.svelte
+++ b/frontend/src/components/layout/DesktopLayout.svelte
@@ -23,7 +23,7 @@
   import SettingsPanel from '../settings/SettingsPanel.svelte';
 
   import { radio, patchActiveReceiver } from '../../lib/stores/radio.svelte';
-  import { hasDualReceiver, hasTx, vfoLabel } from '../../lib/stores/capabilities.svelte';
+  import { hasDualReceiver, hasTx, receiverLabel } from '../../lib/stores/capabilities.svelte';
   import { getConnectionStatus } from '../../lib/stores/connection.svelte';
   import { sendCommand } from '../../lib/transport/ws-client';
   import { setupKeyboard } from '../../lib/actions/keyboard';
@@ -36,8 +36,11 @@
 
   let isDualRx = $derived(hasDualReceiver());
   let isTx = $derived(hasTx());
-  let labelA = $derived(vfoLabel('A'));
-  let labelB = $derived(vfoLabel('B'));
+  // Intent: the two VfoDisplay panels are labelled by *receiver* identity
+  // (MAIN / SUB), not by VFO slot — the pair shows the two receivers, and
+  // each receiver can independently tune VFO A or B on IC-7610/9700.
+  let labelA = $derived(receiverLabel('MAIN'));
+  let labelB = $derived(receiverLabel('SUB'));
   let connectionStatus = $derived(getConnectionStatus());
   let isDisconnected = $derived(connectionStatus === 'disconnected');
   let isReconnecting = $derived(connectionStatus === 'partial');

--- a/frontend/src/lib/stores/__tests__/capabilities.test.ts
+++ b/frontend/src/lib/stores/__tests__/capabilities.test.ts
@@ -162,4 +162,65 @@ describe('capabilities store', () => {
       expect(store.getSmeterRedline()).toBe(120);
     });
   });
+
+  describe('receiverLabel', () => {
+    it('returns "MAIN" for MAIN receiver id', () => {
+      expect(store.receiverLabel('MAIN')).toBe('MAIN');
+    });
+
+    it('returns "SUB" for SUB receiver id', () => {
+      expect(store.receiverLabel('SUB')).toBe('SUB');
+    });
+
+    it('is independent of vfoScheme', () => {
+      store.setCapabilities(makeCaps({ vfoScheme: 'ab' }));
+      expect(store.receiverLabel('MAIN')).toBe('MAIN');
+      expect(store.receiverLabel('SUB')).toBe('SUB');
+    });
+  });
+
+  describe('vfoSlotLabel', () => {
+    it('returns "VFO A" for slot A', () => {
+      expect(store.vfoSlotLabel('A')).toBe('VFO A');
+    });
+
+    it('returns "VFO B" for slot B', () => {
+      expect(store.vfoSlotLabel('B')).toBe('VFO B');
+    });
+
+    it('is independent of vfoScheme', () => {
+      store.setCapabilities(makeCaps({ vfoScheme: 'main_sub' }));
+      expect(store.vfoSlotLabel('A')).toBe('VFO A');
+      expect(store.vfoSlotLabel('B')).toBe('VFO B');
+    });
+  });
+
+  describe('vfoLabel (deprecated shim)', () => {
+    it('preserves legacy main_sub behaviour', () => {
+      store.setCapabilities(makeCaps({ vfoScheme: 'main_sub' }));
+      expect(store.vfoLabel('A')).toBe('MAIN');
+      expect(store.vfoLabel('B')).toBe('SUB');
+    });
+
+    it('preserves legacy ab-scheme behaviour', () => {
+      store.setCapabilities(makeCaps({ vfoScheme: 'ab' }));
+      expect(store.vfoLabel('A')).toBe('VFO A');
+      expect(store.vfoLabel('B')).toBe('VFO B');
+    });
+
+    it('emits exactly one console.warn on first call', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        store.vfoLabel('A');
+        store.vfoLabel('B');
+        store.vfoLabel('A');
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledWith(
+          '[deprecated] vfoLabel(...) — use receiverLabel/vfoSlotLabel',
+        );
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
 });

--- a/frontend/src/lib/stores/capabilities.svelte.ts
+++ b/frontend/src/lib/stores/capabilities.svelte.ts
@@ -92,7 +92,41 @@ export function hasCapability(name: string): boolean {
   return capabilities?.capabilities.includes(name) ?? false;
 }
 
+/**
+ * Label for a receiver (MAIN / SUB).
+ *
+ * Use when the UI wants the *receiver* name — e.g. dual-RX panels that
+ * show which physical receiver is active. Independent of VFO slot: a
+ * single receiver can tune VFO A *or* VFO B.
+ */
+export function receiverLabel(id: 'MAIN' | 'SUB'): string {
+  return id;
+}
+
+/**
+ * Label for a VFO slot (VFO A / VFO B).
+ *
+ * Use when the UI wants the *VFO slot* name — e.g. split indicators,
+ * A/B swap buttons. Independent of receiver: MAIN receiver has both
+ * VFO A and VFO B on radios like IC-7610 / IC-9700.
+ */
+export function vfoSlotLabel(slot: 'A' | 'B'): string {
+  return slot === 'A' ? 'VFO A' : 'VFO B';
+}
+
+let _vfoLabelWarned = false;
+
+/**
+ * @deprecated Conflates receiver identity with VFO slot. Use
+ *   {@link receiverLabel} for MAIN/SUB or {@link vfoSlotLabel} for VFO A/B.
+ *   Scheduled for removal one minor version after 0.16.
+ */
 export function vfoLabel(slot: 'A' | 'B'): string {
+  if (!_vfoLabelWarned) {
+    _vfoLabelWarned = true;
+    // eslint-disable-next-line no-console
+    console.warn('[deprecated] vfoLabel(...) — use receiverLabel/vfoSlotLabel');
+  }
   const scheme = capabilities?.vfoScheme ?? 'main_sub';
   if (scheme === 'ab') return slot === 'A' ? 'VFO A' : 'VFO B';
   return slot === 'A' ? 'MAIN' : 'SUB';


### PR DESCRIPTION
## Summary
- Split the overloaded `vfoLabel(slot)` into `receiverLabel(id)` and `vfoSlotLabel(slot)` in `frontend/src/lib/stores/capabilities.svelte.ts`.
- Kept `vfoLabel` as a deprecation shim: identical return values, emits exactly one `console.warn` on first call.
- Migrated one representative caller (`DesktopLayout.svelte`) to `receiverLabel('MAIN' | 'SUB')` since its two VfoDisplay panels are labelled by receiver identity, not VFO slot.

## Why the old vfoLabel was ambiguous
`vfoLabel(slot: 'A' | 'B')` conflated two distinct concepts:
- receiver identity (MAIN vs SUB physical receiver)
- VFO slot identity (VFO A vs VFO B within a receiver)

On IC-7610/9700 the MAIN receiver has both VFO A and VFO B, so the `scheme='main_sub'` branch (mapping slot A to `'MAIN'`) was wrong. On ab-scheme rigs (IC-705), the function returned `'VFO A'/'VFO B'` when callers were actually rendering a receiver pair — a user-visible mislabel.

## Call sites migrated
- `frontend/src/components/layout/DesktopLayout.svelte` — dual VfoDisplay pair is labelled by receiver identity (MAIN/SUB). `labelA = receiverLabel('MAIN')`, `labelB = receiverLabel('SUB')`.

## Follow-ups (not in this PR to stay within the ≤3-file guardrail)
All remaining call sites are analogous (receiver-identity intent) and can migrate without behaviour change because the old `'main_sub'` branch coincidentally returned the right string for MAIN/SUB. The deprecation shim keeps them working until migrated.

- `frontend/src/components/layout/MobileLayout.svelte` — same pattern as DesktopLayout (`activeRx === 'MAIN' ? labelA : labelB`).
- `frontend/src/components-v2/vfo/VfoPanel.svelte` — receives `receiver: 'main' | 'sub'` prop and currently maps through slot A/B. Migrate to `receiverLabel(receiver.toUpperCase() as 'MAIN' | 'SUB')`. Will require updating the matching `VfoPanel.test.ts` integration block that asserts on `vfoLabel` calls.
- `vfoLabel` mocks in `components-v2/layout/__tests__/top-row-visual-regression.test.ts`, `components-v2/layout/__tests__/RadioLayout.test.ts`, `components-v2/layout/__tests__/MobileRadioLayout.component.test.ts`, `components-v2/vfo/__tests__/VfoOps.test.ts`, `VfoPanel.test.ts` — update alongside their production components.

## Test plan
- [x] `npx vitest run` — 1479 passed (was 1470 + 9 new tests for `receiverLabel`, `vfoSlotLabel`, and the deprecation shim).
- [x] `npm run build` — clean (no new type errors).
- [x] `console.warn` spy test: three `vfoLabel` calls produce exactly one warn.
- [x] Legacy behaviour preserved: `vfoLabel` returns identical values to before for both `main_sub` and `ab` schemes.
- [x] No visual regression — `DesktopLayout` MAIN/SUB labels unchanged (old code returned `'MAIN'`/`'SUB'` for slot A/B in the `main_sub` branch, which was the default).

Closes #717