### PR TITLE
refactor(#709): VfoSlotState + per-receiver active_slot

### DIFF
--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, runtime_checkable
 
-from .radio_state import RadioState
+from .radio_state import RadioState, VfoSlotState
 from .types import Mode
 
 if TYPE_CHECKING:
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "Radio",
+    "VfoSlotState",
     "AudioCapable",
     "CivCommandCapable",
     "ModeInfoCapable",

--- a/src/icom_lan/radio_state.py
+++ b/src/icom_lan/radio_state.py
@@ -11,11 +11,28 @@ This is intentionally additive: it runs *alongside* the existing
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any
 
 from .types import ScopeFixedEdge
 
-__all__ = ["ReceiverState", "ScopeControlsState", "TxBandEdge", "RadioState"]
+__all__ = [
+    "ReceiverState",
+    "ScopeControlsState",
+    "TxBandEdge",
+    "RadioState",
+    "VfoSlotState",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class VfoSlotState:
+    """Immutable per-VFO-slot (A or B) state within a receiver."""
+
+    freq_hz: int = 0
+    mode: str = "USB"
+    filter_num: int | None = None
+    data_mode: int = 0
 
 
 @dataclass(slots=True)
@@ -28,13 +45,18 @@ class TxBandEdge:
 
 @dataclass(slots=True)
 class ReceiverState:
-    """Per-receiver (MAIN or SUB) state."""
+    """Per-receiver (MAIN or SUB) state.
 
-    freq: int = 0
-    mode: str = "USB"
-    filter: int | None = None
+    Frequency, mode, filter and data_mode are stored per VFO slot
+    (``vfo_a`` / ``vfo_b``); the legacy ``freq`` / ``mode`` / ``filter`` /
+    ``data_mode`` attributes are derived properties reading and writing
+    the slot selected by :attr:`active_slot` (``"A"`` or ``"B"``).
+    """
+
+    vfo_a: VfoSlotState = field(default_factory=VfoSlotState)
+    vfo_b: VfoSlotState = field(default_factory=VfoSlotState)
+    active_slot: str = "A"  # "A" or "B"
     filter_width: int | None = None
-    data_mode: int = 0
     att: int = 0  # dB: 0, 3, 6, …, 45
     preamp: int = 0  # 0=off, 1=P1, 2=P2
     nb: bool = False
@@ -71,6 +93,102 @@ class ReceiverState:
     repeater_tsql: bool = False
     tone_freq: int = 0  # centihz, e.g. 8850 = 88.50 Hz
     tsql_freq: int = 0  # centihz, e.g. 8850 = 88.50 Hz
+
+    # --- VFO-slot-derived properties (legacy compat) ---------------------
+
+    @property
+    def _active(self) -> VfoSlotState:
+        return self.vfo_b if self.active_slot == "B" else self.vfo_a
+
+    def _replace_active(self, **kw: Any) -> None:
+        new_slot = replace(self._active, **kw)
+        if self.active_slot == "B":
+            self.vfo_b = new_slot
+        else:
+            self.vfo_a = new_slot
+
+    @property
+    def freq(self) -> int:
+        return self._active.freq_hz
+
+    @freq.setter
+    def freq(self, value: int) -> None:
+        self._replace_active(freq_hz=value)
+
+    @property
+    def mode(self) -> str:
+        return self._active.mode
+
+    @mode.setter
+    def mode(self, value: str) -> None:
+        self._replace_active(mode=value)
+
+    @property
+    def filter(self) -> int | None:
+        return self._active.filter_num
+
+    @filter.setter
+    def filter(self, value: int | None) -> None:
+        self._replace_active(filter_num=value)
+
+    @property
+    def data_mode(self) -> int:
+        return self._active.data_mode
+
+    @data_mode.setter
+    def data_mode(self, value: int) -> None:
+        self._replace_active(data_mode=value)
+
+
+# Wrap ReceiverState.__init__ to accept legacy kwargs (freq/mode/filter/
+# data_mode) and route them into vfo_a.  The dataclass-generated __init__
+# doesn't know about the derived properties, so we intercept the kwargs
+# before delegating.
+_ReceiverState_orig_init = ReceiverState.__init__
+
+
+def _receiver_state_init(
+    self: ReceiverState,
+    *args: Any,
+    freq: int | None = None,
+    mode: str | None = None,
+    filter: int | None = None,  # noqa: A002  (match legacy kwarg name)
+    data_mode: int | None = None,
+    **kwargs: Any,
+) -> None:
+    _ReceiverState_orig_init(self, *args, **kwargs)
+    legacy: dict[str, Any] = {}
+    if freq is not None:
+        legacy["freq_hz"] = freq
+    if mode is not None:
+        legacy["mode"] = mode
+    if filter is not None:
+        legacy["filter_num"] = filter
+    if data_mode is not None:
+        legacy["data_mode"] = data_mode
+    if legacy:
+        # Legacy kwargs always populate vfo_a (the default slot).
+        self.vfo_a = replace(self.vfo_a, **legacy)
+
+
+ReceiverState.__init__ = _receiver_state_init  # type: ignore[method-assign]
+
+
+def _receiver_to_dict(rx: ReceiverState) -> dict[str, Any]:
+    """Serialise a ReceiverState to a dict that keeps both the slot-shaped
+    (``vfo_a``/``vfo_b``/``active_slot``) view and the legacy top-level
+    ``freq``/``mode``/``filter``/``data_mode`` keys for backward-compat
+    with existing JSON consumers.
+    """
+    d = asdict(rx)
+    d["vfo_a"] = asdict(rx.vfo_a)
+    d["vfo_b"] = asdict(rx.vfo_b)
+    d["active_slot"] = rx.active_slot
+    d["freq"] = rx.freq
+    d["mode"] = rx.mode
+    d["filter"] = rx.filter
+    d["data_mode"] = rx.data_mode
+    return d
 
 
 @dataclass(slots=True)
@@ -218,9 +336,45 @@ class RadioState:
                 for e in self.tx_band_edges
             ],
             "scope_controls": asdict(self.scope_controls),
-            "main": asdict(self.main),
-            "sub": asdict(self.sub),
+            "main": _receiver_to_dict(self.main),
+            "sub": _receiver_to_dict(self.sub),
         }
+
+    @staticmethod
+    def _receiver_from_dict(d: dict[str, Any]) -> ReceiverState:
+        """Construct a :class:`ReceiverState` from a ``to_dict()`` payload.
+
+        Accepts both the slot-shaped view (``vfo_a``/``vfo_b``/``active_slot``)
+        and the legacy top-level ``freq``/``mode``/``filter``/``data_mode``
+        fallback.
+        """
+        slot_keys = {"freq_hz", "mode", "filter_num", "data_mode"}
+        plain: dict[str, Any] = {
+            k: v
+            for k, v in d.items()
+            if k not in {"vfo_a", "vfo_b", "active_slot",
+                          "freq", "mode", "filter", "data_mode"}
+        }
+        rx = ReceiverState(**plain)
+        if "vfo_a" in d and isinstance(d["vfo_a"], dict):
+            rx.vfo_a = VfoSlotState(
+                **{k: v for k, v in d["vfo_a"].items() if k in slot_keys}
+            )
+        if "vfo_b" in d and isinstance(d["vfo_b"], dict):
+            rx.vfo_b = VfoSlotState(
+                **{k: v for k, v in d["vfo_b"].items() if k in slot_keys}
+            )
+        if "active_slot" in d:
+            rx.active_slot = str(d["active_slot"])
+        if "vfo_a" not in d:
+            # Legacy fallback: top-level freq/mode/filter/data_mode → vfo_a.
+            rx.vfo_a = VfoSlotState(
+                freq_hz=int(d.get("freq", 0)),
+                mode=str(d.get("mode", "USB")),
+                filter_num=d.get("filter"),
+                data_mode=int(d.get("data_mode", 0)),
+            )
+        return rx
 
     def receiver(self, which: str) -> ReceiverState:
         """Return the :class:`ReceiverState` for *which* (``"MAIN"`` or ``"SUB"``)."""

--- a/tests/test_radio_state.py
+++ b/tests/test_radio_state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from icom_lan.radio_state import RadioState, ReceiverState
+from icom_lan.radio_state import RadioState, ReceiverState, VfoSlotState
 
 # ---------------------------------------------------------------------------
 # ReceiverState defaults
@@ -254,6 +254,9 @@ def test_to_dict_main_keys() -> None:
         "manual_notch_freq",
         "manual_notch_width",
         "narrow",
+        "vfo_a",
+        "vfo_b",
+        "active_slot",
     }
     assert set(main.keys()) == expected_keys
 
@@ -376,3 +379,74 @@ class TestTransceiverStatusState:
         assert d["comp_meter"] == 42
         assert d["vd_meter"] == 130
         assert d["id_meter"] == 55
+
+
+# --- VfoSlotState + per-receiver active_slot (#709) ------------------------
+
+
+class TestVfoSlotState:
+    """ReceiverState exposes per-VFO slot state with legacy-field fallback."""
+
+    def test_slot_defaults(self) -> None:
+        slot = VfoSlotState()
+        assert slot.freq_hz == 0
+        assert slot.mode == "USB"
+        assert slot.filter_num is None
+        assert slot.data_mode == 0
+
+    def test_legacy_freq_kwarg_populates_vfo_a(self) -> None:
+        rx = ReceiverState(freq=7_074_000)
+        assert rx.vfo_a.freq_hz == 7_074_000
+        assert rx.vfo_b.freq_hz == 0
+        assert rx.freq == 7_074_000  # property reads vfo_a (active by default)
+
+    def test_legacy_mode_filter_kwargs_populate_vfo_a(self) -> None:
+        rx = ReceiverState(freq=14_074_000, mode="CW", filter=2, data_mode=1)
+        assert rx.vfo_a.freq_hz == 14_074_000
+        assert rx.vfo_a.mode == "CW"
+        assert rx.vfo_a.filter_num == 2
+        assert rx.vfo_a.data_mode == 1
+        assert rx.mode == "CW"
+        assert rx.filter == 2
+        assert rx.data_mode == 1
+
+    def test_active_slot_b_reflects_vfo_b(self) -> None:
+        rx = ReceiverState(freq=14_074_000)
+        rx.vfo_b = VfoSlotState(freq_hz=7_000_000, mode="LSB")
+        rx.active_slot = "B"
+        assert rx.freq == 7_000_000
+        assert rx.mode == "LSB"
+        # Writing via property mutates vfo_b (the active slot), not vfo_a.
+        rx.freq = 3_573_000
+        assert rx.vfo_b.freq_hz == 3_573_000
+        assert rx.vfo_a.freq_hz == 14_074_000
+
+    def test_to_dict_from_dict_round_trip_preserves_both_slots(self) -> None:
+        rs = RadioState()
+        rs.main.vfo_a = VfoSlotState(freq_hz=14_074_000, mode="USB", filter_num=2)
+        rs.main.vfo_b = VfoSlotState(freq_hz=7_074_000, mode="CW", filter_num=1)
+        rs.main.active_slot = "B"
+        d = rs.to_dict()
+        assert d["main"]["vfo_a"]["freq_hz"] == 14_074_000
+        assert d["main"]["vfo_b"]["freq_hz"] == 7_074_000
+        assert d["main"]["active_slot"] == "B"
+        assert d["main"]["freq"] == 7_074_000  # legacy view = vfo_b
+
+        restored = RadioState._receiver_from_dict(d["main"])
+        assert restored.vfo_a.freq_hz == 14_074_000
+        assert restored.vfo_a.mode == "USB"
+        assert restored.vfo_a.filter_num == 2
+        assert restored.vfo_b.freq_hz == 7_074_000
+        assert restored.vfo_b.mode == "CW"
+        assert restored.vfo_b.filter_num == 1
+        assert restored.active_slot == "B"
+        assert restored.freq == 7_074_000
+
+    def test_from_dict_legacy_fallback_populates_vfo_a(self) -> None:
+        """A legacy dict without slot keys falls back to vfo_a via top-level freq/mode."""
+        legacy = {"freq": 7_074_000, "mode": "CW", "filter": 3, "data_mode": 0}
+        rx = RadioState._receiver_from_dict(legacy)
+        assert rx.vfo_a.freq_hz == 7_074_000
+        assert rx.vfo_a.mode == "CW"
+        assert rx.vfo_a.filter_num == 3
+        assert rx.active_slot == "A"


### PR DESCRIPTION
## Summary
- Add frozen `VfoSlotState` (freq_hz, mode, filter_num, data_mode) and extend `ReceiverState` with `vfo_a`, `vfo_b`, `active_slot` for independent per-slot state.
- Legacy `freq` / `mode` / `filter` / `data_mode` become derived read/write properties on `ReceiverState`, reading and writing the active slot via `dataclasses.replace` — v0.16.x call-sites (`rx.freq = X`, `ReceiverState(freq=...)`) are preserved via a post-decorator `__init__` wrapper.
- `to_dict()` now emits both the slot-shaped view and the legacy top-level keys, plus a symmetric `RadioState._receiver_from_dict` helper with legacy-payload fallback for round-trip.

## Files
- `src/icom_lan/radio_state.py`
- `src/icom_lan/radio_protocol.py`
- `tests/test_radio_state.py`

## Test plan
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4627 passed (3 pre-existing TX-transcoder failures unrelated, reproduced on clean main)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — only pre-existing `types-pyserial` missing-stub note; no new errors
- [x] Round-trip `to_dict` / `from_dict` preserves both slots; legacy-field fallback populates `vfo_a`; `active_slot='B'` makes `.freq` reflect `vfo_b`

Closes #709