### PR TITLE
refactor(#710): split vfo_scheme — swap_ab_code vs swap_main_sub_code

### DIFF
--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -266,13 +266,22 @@ defaults = [15000, 10000, 7000]
 
 ## `[vfo]` — VFO Configuration
 
-| Field         | Type   | Required    | Description                                       |
-|---------------|--------|-------------|---------------------------------------------------|
-| `scheme`      | string | yes         | VFO scheme (see below)                            |
-| `main_select` | int[]  | if main_sub | Wire bytes to select Main VFO (e.g. `[0xD0]`)    |
-| `sub_select`  | int[]  | if main_sub | Wire bytes to select Sub VFO (e.g. `[0xD1]`)     |
-| `swap`        | int[]  | no          | Wire bytes for VFO swap (e.g. `[0xB0]`)          |
-| `equal`       | int[]  | no          | Wire bytes for VFO equalize (e.g. `[0xB1]`)      |
+| Field             | Type   | Required    | Description                                                  |
+|-------------------|--------|-------------|--------------------------------------------------------------|
+| `scheme`          | string | yes         | VFO scheme (see below)                                       |
+| `main_select`     | int[]  | if main_sub | Wire bytes to select Main VFO (e.g. `[0xD0]`)                |
+| `sub_select`      | int[]  | if main_sub | Wire bytes to select Sub VFO (e.g. `[0xD1]`)                 |
+| `swap_ab`         | int[]  | no          | A↔B swap within the selected receiver (e.g. `[0x07, 0xB0]`)  |
+| `equal_ab`        | int[]  | no          | A=B equalize within the selected receiver                    |
+| `swap_main_sub`   | int[]  | no          | MAIN↔SUB swap across receivers (dual-RX rigs, e.g. `[0xB0]`) |
+| `equal_main_sub`  | int[]  | no          | MAIN=SUB equalize across receivers                           |
+| `swap` *(legacy)* | int[]  | no          | **Deprecated.** Maps to `swap_main_sub` if `scheme = "main_sub"`, else `swap_ab`. Emits a `DeprecationWarning` per load. |
+| `equal` *(legacy)*| int[]  | no          | **Deprecated.** Same mapping as `swap`.                      |
+
+The A↔B vs MAIN↔SUB split was introduced in issue #710: on dual-receiver rigs
+(IC-7610) `0x07 0xB0` swaps MAIN/SUB, while on single-receiver rigs (IC-7300)
+the same nibble swaps VFO A/B. The legacy `swap`/`equal` keys overloaded both
+meanings; prefer the explicit fields for new rig files.
 
 Valid VFO schemes:
 - **`ab`** — 2 VFOs (A/B), 1 receiver (IC-7300, X6100, TX-500)

--- a/src/icom_lan/profiles.py
+++ b/src/icom_lan/profiles.py
@@ -144,7 +144,13 @@ class RadioProfile:
     cmd29_routes: frozenset[tuple[int, int | None]]
     vfo_main_code: int | None = None
     vfo_sub_code: int | None = None
-    vfo_swap_code: int | None = None
+    # Explicit split (issue #710):
+    #   *_ab_code       → VFO A↔B within the currently-selected receiver
+    #   *_main_sub_code → MAIN↔SUB across receivers (dual-receiver rigs only)
+    swap_ab_code: int | None = None
+    equal_ab_code: int | None = None
+    swap_main_sub_code: int | None = None
+    equal_main_sub_code: int | None = None
     vfo_scheme: str = "main_sub"
     has_lan: bool = False
     freq_ranges: tuple[FreqRangeInfo, ...] = ()
@@ -172,6 +178,24 @@ class RadioProfile:
     scope_ref_min_db: float | None = None
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None
+
+    @property
+    def vfo_swap_code(self) -> int | None:
+        """Legacy alias — prefers ``swap_main_sub_code`` for dual-RX rigs.
+
+        Deprecated: use :attr:`swap_ab_code` or :attr:`swap_main_sub_code`
+        directly (issue #710).
+        """
+        return self.swap_main_sub_code or self.swap_ab_code
+
+    @property
+    def vfo_equal_code(self) -> int | None:
+        """Legacy alias — prefers ``equal_main_sub_code`` for dual-RX rigs.
+
+        Deprecated: use :attr:`equal_ab_code` or :attr:`equal_main_sub_code`
+        directly (issue #710).
+        """
+        return self.equal_main_sub_code or self.equal_ab_code
 
     def supports_capability(self, capability: str) -> bool:
         return capability in self.capabilities

--- a/src/icom_lan/rig_loader.py
+++ b/src/icom_lan/rig_loader.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 import tomllib
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -24,6 +26,8 @@ from .profiles import (
     RadioProfile,
     RuleSpec,
 )
+
+logger = logging.getLogger(__name__)
 
 VALID_VFO_SCHEMES = {"ab", "main_sub", "ab_shared", "single"}
 VALID_PROTOCOL_TYPES = {"civ", "kenwood_cat", "yaesu_cat"}
@@ -63,7 +67,10 @@ class RigConfig:
     vfo_scheme: str
     vfo_main_select: tuple[int, ...] | None
     vfo_sub_select: tuple[int, ...] | None
-    vfo_swap: tuple[int, ...] | None
+    vfo_swap_ab: tuple[int, ...] | None
+    vfo_equal_ab: tuple[int, ...] | None
+    vfo_swap_main_sub: tuple[int, ...] | None
+    vfo_equal_main_sub: tuple[int, ...] | None
     freq_ranges: tuple[dict[str, Any], ...]
     commands: dict[str, CommandSpec]
     cmd29_routes: tuple[tuple[int, int | None], ...]
@@ -98,7 +105,10 @@ class RigConfig:
         """Build a ``RadioProfile`` from this config."""
         vfo_main = self.vfo_main_select[0] if self.vfo_main_select else None
         vfo_sub = self.vfo_sub_select[0] if self.vfo_sub_select else None
-        vfo_swap = self.vfo_swap[0] if self.vfo_swap else None
+        swap_ab = self.vfo_swap_ab[0] if self.vfo_swap_ab else None
+        equal_ab = self.vfo_equal_ab[0] if self.vfo_equal_ab else None
+        swap_main_sub = self.vfo_swap_main_sub[0] if self.vfo_swap_main_sub else None
+        equal_main_sub = self.vfo_equal_main_sub[0] if self.vfo_equal_main_sub else None
 
         ranges = tuple(
             FreqRangeInfo(
@@ -128,7 +138,10 @@ class RigConfig:
             cmd29_routes=frozenset(self.cmd29_routes),
             vfo_main_code=vfo_main,
             vfo_sub_code=vfo_sub,
-            vfo_swap_code=vfo_swap,
+            swap_ab_code=swap_ab,
+            equal_ab_code=equal_ab,
+            swap_main_sub_code=swap_main_sub,
+            equal_main_sub_code=equal_main_sub,
             vfo_scheme=self.vfo_scheme,
             has_lan=self.has_lan,
             freq_ranges=ranges,
@@ -160,7 +173,7 @@ class RigConfig:
 
     def to_command_map(self) -> CommandMap:
         """Build a ``CommandMap`` from this config's CI-V commands.
-        
+
         Only CivCommandSpec entries are included; CatCommandSpec entries are ignored.
         """
         civ_commands: dict[str, tuple[int, ...]] = {}
@@ -291,19 +304,19 @@ def _parse_command_value(
     value: Any,
 ) -> CommandSpec:
     """Parse a single command value from TOML.
-    
+
     Supports two formats:
     1. CI-V wire bytes (list): [0x03] or [0x14, 0x01]
     2. CAT command spec (dict): { cat = { read = "FA;", parse = "FA{freq:09d};" } }
-    
+
     Args:
         filename: Source TOML filename (for error messages).
         command_name: Command name (for error messages).
         value: Raw TOML value to parse.
-    
+
     Returns:
         Parsed CommandSpec (either CivCommandSpec or CatCommandSpec).
-    
+
     Raises:
         RigLoadError: If the value format is invalid.
     """
@@ -324,7 +337,7 @@ def _parse_command_value(
                 f"got {value!r}"
             )
         return CivCommandSpec(bytes=tuple(value))
-    
+
     # Format 2: CAT command spec (dict with 'cat' key)
     if isinstance(value, dict):
         if "cat" not in value:
@@ -338,11 +351,11 @@ def _parse_command_value(
                 f"{filename}: [commands].{command_name}.cat must be a dict, "
                 f"got {type(cat_spec).__name__}"
             )
-        
+
         read_cmd = cat_spec.get("read")
         write_cmd = cat_spec.get("write")
         parse_template = cat_spec.get("parse")
-        
+
         # Validate types
         if read_cmd is not None and not isinstance(read_cmd, str):
             raise RigLoadError(
@@ -356,16 +369,16 @@ def _parse_command_value(
             raise RigLoadError(
                 f"{filename}: [commands].{command_name}.cat.parse must be a string"
             )
-        
+
         # At least one of read/write must be present
         if read_cmd is None and write_cmd is None:
             raise RigLoadError(
                 f"{filename}: [commands].{command_name}.cat must have "
                 f"at least one of 'read' or 'write'"
             )
-        
+
         return CatCommandSpec(read=read_cmd, write=write_cmd, parse=parse_template)
-    
+
     # Unknown format
     raise RigLoadError(
         f"{filename}: [commands].{command_name} must be a list (CI-V bytes) "
@@ -547,11 +560,11 @@ def load_rig(path: Path) -> RigConfig:
     if "commands" in data:
         commands_raw = dict(data["commands"])
         overrides = commands_raw.pop("overrides", {})
-        
+
         # Parse main commands
         for key, value in commands_raw.items():
             commands[key] = _parse_command_value(filename, key, value)
-        
+
         # Apply overrides
         for key, value in overrides.items():
             commands[key] = _parse_command_value(filename, key, value)
@@ -559,10 +572,38 @@ def load_rig(path: Path) -> RigConfig:
     # Parse freq_ranges
     freq_ranges_data = data.get("freq_ranges", {}).get("ranges", [])
 
-    # Parse VFO bytes
+    # Parse VFO bytes — explicit split (issue #710)
     vfo_main = tuple(vfo["main_select"]) if "main_select" in vfo else None
     vfo_sub = tuple(vfo["sub_select"]) if "sub_select" in vfo else None
-    vfo_swap_val = tuple(vfo["swap"]) if "swap" in vfo else None
+    vfo_swap_ab = tuple(vfo["swap_ab"]) if "swap_ab" in vfo else None
+    vfo_equal_ab = tuple(vfo["equal_ab"]) if "equal_ab" in vfo else None
+    vfo_swap_main_sub = tuple(vfo["swap_main_sub"]) if "swap_main_sub" in vfo else None
+    vfo_equal_main_sub = (
+        tuple(vfo["equal_main_sub"]) if "equal_main_sub" in vfo else None
+    )
+
+    # Legacy keys — map to new fields based on scheme; warn once per file.
+    has_legacy = "swap" in vfo or "equal" in vfo
+    if has_legacy:
+        legacy_swap = tuple(vfo["swap"]) if "swap" in vfo else None
+        legacy_equal = tuple(vfo["equal"]) if "equal" in vfo else None
+        if scheme == "main_sub":
+            if legacy_swap is not None and vfo_swap_main_sub is None:
+                vfo_swap_main_sub = legacy_swap
+            if legacy_equal is not None and vfo_equal_main_sub is None:
+                vfo_equal_main_sub = legacy_equal
+        else:
+            if legacy_swap is not None and vfo_swap_ab is None:
+                vfo_swap_ab = legacy_swap
+            if legacy_equal is not None and vfo_equal_ab is None:
+                vfo_equal_ab = legacy_equal
+        msg = (
+            f"{filename}: [vfo].swap/[vfo].equal are deprecated; "
+            "use swap_ab/equal_ab or swap_main_sub/equal_main_sub "
+            "(issue #710)."
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        logger.warning(msg)
 
     # Parse cmd29 routes
     cmd29_raw = data.get("cmd29", {}).get("routes", [])
@@ -582,9 +623,21 @@ def load_rig(path: Path) -> RigConfig:
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None
     if scope_section:
-        scope_ref_min_db = float(scope_section["ref_min_db"]) if "ref_min_db" in scope_section else None
-        scope_ref_max_db = float(scope_section["ref_max_db"]) if "ref_max_db" in scope_section else None
-        scope_ref_step_db = float(scope_section["ref_step_db"]) if "ref_step_db" in scope_section else None
+        scope_ref_min_db = (
+            float(scope_section["ref_min_db"])
+            if "ref_min_db" in scope_section
+            else None
+        )
+        scope_ref_max_db = (
+            float(scope_section["ref_max_db"])
+            if "ref_max_db" in scope_section
+            else None
+        )
+        scope_ref_step_db = (
+            float(scope_section["ref_step_db"])
+            if "ref_step_db" in scope_section
+            else None
+        )
 
     # Parse attenuator/preamp/agc (optional sections)
     att_section = data.get("attenuator", {})
@@ -655,8 +708,7 @@ def load_rig(path: Path) -> RigConfig:
         kind = rule.get("kind")
         if kind not in VALID_RULE_KINDS:
             raise RigLoadError(
-                f"{filename}: rule kind must be one of {VALID_RULE_KINDS}, "
-                f"got {kind!r}"
+                f"{filename}: rule kind must be one of {VALID_RULE_KINDS}, got {kind!r}"
             )
         rules.append(dict(rule))  # type: ignore[arg-type]
 
@@ -696,7 +748,10 @@ def load_rig(path: Path) -> RigConfig:
         vfo_scheme=scheme,
         vfo_main_select=vfo_main,
         vfo_sub_select=vfo_sub,
-        vfo_swap=vfo_swap_val,
+        vfo_swap_ab=vfo_swap_ab,
+        vfo_equal_ab=vfo_equal_ab,
+        vfo_swap_main_sub=vfo_swap_main_sub,
+        vfo_equal_main_sub=vfo_equal_main_sub,
         freq_ranges=tuple(freq_ranges_data),
         commands=commands,
         cmd29_routes=tuple(cmd29_routes),

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -191,13 +191,18 @@ fine = false
 
     def test_loads_default_keyboard_profile_with_file(self, tmp_path):
         import shutil
-        default_kb = Path(__file__).resolve().parent.parent / "rigs" / "_keyboard-default.toml"
+
+        default_kb = (
+            Path(__file__).resolve().parent.parent / "rigs" / "_keyboard-default.toml"
+        )
         if default_kb.exists():
             shutil.copy(default_kb, tmp_path / "_keyboard-default.toml")
             rig = load_rig(_write_toml(tmp_path, _MINIMAL_TOML))
             assert rig.keyboard is not None
             assert rig.keyboard.help_title == "Radio Keyboard"
-            assert any(binding.action == "toggle_help" for binding in rig.keyboard.bindings)
+            assert any(
+                binding.action == "toggle_help" for binding in rig.keyboard.bindings
+            )
 
 
 # ── RadioProfile building ───────────────────────────────────────
@@ -229,7 +234,11 @@ class TestToProfile:
         profile = load_rig(TEMPLATE_PATH).to_profile()
         assert profile.vfo_main_code == 0xD0
         assert profile.vfo_sub_code == 0xD1
+        # Legacy alias still works (issue #710)
         assert profile.vfo_swap_code == 0xB0
+        # IC-7610 template uses legacy [vfo].swap with scheme=main_sub
+        assert profile.swap_main_sub_code == 0xB0
+        assert profile.swap_ab_code is None
 
     def test_vfo_ab_codes(self, tmp_path):
         p = _write_toml(tmp_path, _MINIMAL_TOML)
@@ -298,6 +307,152 @@ class TestToProfile:
         assert any(
             binding.action == "toggle_help" for binding in profile.keyboard.bindings
         )
+
+
+# ── VFO scheme split (issue #710) ────────────────────────────────
+
+
+class TestVfoSchemeSplit:
+    """Explicit ``swap_ab`` / ``swap_main_sub`` fields + legacy mapping."""
+
+    _MAIN_SUB_SPLIT = """\
+    [radio]
+    id = "icom_ic7610_test"
+    model = "TEST-MAIN-SUB"
+    civ_addr = 0x98
+    receiver_count = 2
+    has_lan = true
+    has_wifi = false
+
+    [capabilities]
+    features = ["audio", "dual_rx"]
+
+    [modes]
+    list = ["USB"]
+
+    [filters]
+    list = ["FIL1"]
+
+    [vfo]
+    scheme = "main_sub"
+    main_select = [0xD0]
+    sub_select = [0xD1]
+    swap_main_sub = [0xB0]
+    equal_main_sub = [0xB1]
+    swap_ab = [0x07, 0xB0]
+    equal_ab = [0x07, 0xA0]
+
+    [[freq_ranges.ranges]]
+    label = "HF"
+    start_hz = 30000
+    end_hz = 60000000
+
+    [commands]
+    get_freq = [0x03]
+    """
+
+    def test_new_fields_loaded_into_profile(self, tmp_path):
+        p = _write_toml(tmp_path, self._MAIN_SUB_SPLIT)
+        profile = load_rig(p).to_profile()
+        assert profile.swap_main_sub_code == 0xB0
+        assert profile.equal_main_sub_code == 0xB1
+        assert profile.swap_ab_code == 0x07
+        assert profile.equal_ab_code == 0x07
+
+    def test_legacy_aliases_prefer_main_sub_when_dual(self, tmp_path):
+        p = _write_toml(tmp_path, self._MAIN_SUB_SPLIT)
+        profile = load_rig(p).to_profile()
+        # Legacy alias returns main_sub value when both are set
+        assert profile.vfo_swap_code == 0xB0
+        assert profile.vfo_equal_code == 0xB1
+
+    def test_legacy_swap_maps_to_main_sub_on_dual_scheme(self, tmp_path):
+        toml = """\
+        [radio]
+        id = "legacy_dual"
+        model = "LEGACY-DUAL"
+        civ_addr = 0x98
+        receiver_count = 2
+        has_lan = true
+        has_wifi = false
+
+        [capabilities]
+        features = ["audio", "dual_rx"]
+
+        [modes]
+        list = ["USB"]
+
+        [filters]
+        list = ["FIL1"]
+
+        [vfo]
+        scheme = "main_sub"
+        main_select = [0xD0]
+        sub_select = [0xD1]
+        swap = [0xB0]
+        equal = [0xB1]
+
+        [[freq_ranges.ranges]]
+        label = "HF"
+        start_hz = 30000
+        end_hz = 60000000
+        """
+        p = _write_toml(tmp_path, toml, name="legacy_dual.toml")
+        with pytest.warns(DeprecationWarning, match="issue #710"):
+            profile = load_rig(p).to_profile()
+        assert profile.swap_main_sub_code == 0xB0
+        assert profile.equal_main_sub_code == 0xB1
+        assert profile.swap_ab_code is None
+        assert profile.equal_ab_code is None
+        # Legacy alias still resolves
+        assert profile.vfo_swap_code == 0xB0
+
+    def test_legacy_swap_maps_to_ab_on_single_rx_scheme(self, tmp_path):
+        toml = """\
+        [radio]
+        id = "legacy_ab"
+        model = "LEGACY-AB"
+        civ_addr = 0x94
+        receiver_count = 1
+        has_lan = true
+        has_wifi = false
+
+        [capabilities]
+        features = ["audio"]
+
+        [modes]
+        list = ["USB"]
+
+        [filters]
+        list = ["FIL1"]
+
+        [vfo]
+        scheme = "ab"
+        swap = [0xB0]
+        equal = [0xA0]
+
+        [[freq_ranges.ranges]]
+        label = "HF"
+        start_hz = 30000
+        end_hz = 60000000
+        """
+        p = _write_toml(tmp_path, toml, name="legacy_ab.toml")
+        with pytest.warns(DeprecationWarning, match="issue #710"):
+            profile = load_rig(p).to_profile()
+        assert profile.swap_ab_code == 0xB0
+        assert profile.equal_ab_code == 0xA0
+        assert profile.swap_main_sub_code is None
+        assert profile.equal_main_sub_code is None
+        # Legacy alias still resolves to the ab code
+        assert profile.vfo_swap_code == 0xB0
+        assert profile.vfo_equal_code == 0xA0
+
+    def test_no_deprecation_when_only_new_keys(self, tmp_path, recwarn):
+        p = _write_toml(tmp_path, self._MAIN_SUB_SPLIT, name="new_only.toml")
+        load_rig(p)
+        assert not [
+            w for w in recwarn.list if issubclass(w.category, DeprecationWarning)
+        ]
 
 
 # ── CommandMap ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add four explicit fields to `RadioProfile` — `swap_ab_code` / `equal_ab_code` / `swap_main_sub_code` / `equal_main_sub_code` — so rig TOMLs can express A↔B (within a receiver) and MAIN↔SUB (across receivers) independently; the current `[vfo].swap` / `[vfo].equal` keys overload both meanings.
- Parse the new `[vfo].swap_ab` / `equal_ab` / `swap_main_sub` / `equal_main_sub` keys in `rig_loader`; keep legacy `[vfo].swap` / `equal` working by mapping them based on `[vfo].scheme` (`main_sub` → main_sub fields, everything else → ab fields).
- Document the new + legacy fields in `rigs/_schema.md`; mark legacy deprecated.

## Compatibility
- Legacy `vfo.swap` / `vfo.equal` still accepted; emits one `DeprecationWarning` per load (message includes filename so each rig gets its own warning, mirrored to the `icom_lan.rig_loader` logger at WARNING).
- `RadioProfile.vfo_swap_code` / `vfo_equal_code` remain as read-only `@property` aliases that prefer the main_sub value and fall back to ab.
- No existing TOML under `rigs/` changed in this PR — migrations land in the follow-up #713.

## Test plan
- [x] Full suite pytest green (4626 passed; 3 pre-existing failures in `TestAudioHandlerTxTranscoderRate`, unrelated to this change and present on `main`)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run mypy src/` clean on touched files (only pre-existing `types-pyserial` stub warning)
- [x] New `TestVfoSchemeSplit` covers new fields, legacy→main_sub mapping, legacy→ab mapping, `DeprecationWarning` emitted, and negative case (no warning when only new keys)

Closes #710