### PR TITLE
feat(protocol): ReceiverBankCapable + VfoSlotCapable protocols

### DIFF
--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -60,6 +60,8 @@ __all__ = [
     "ModeInfoCapable",
     "ScopeCapable",
     "DualReceiverCapable",
+    "ReceiverBankCapable",
+    "VfoSlotCapable",
     "StateCacheCapable",
     "RecoverableConnection",
     "AdvancedControlCapable",
@@ -543,6 +545,73 @@ class DualReceiverCapable(Protocol):
 
     async def get_main_sub_tracking(self) -> bool:
         """Get Main/Sub frequency tracking on/off state."""
+        ...
+
+
+@runtime_checkable
+class ReceiverBankCapable(Protocol):
+    """Radio exposes a bank of independent receivers.
+
+    Surfaces the ``Transceiver → Receiver → VFO`` hierarchy without breaking
+    the existing ``receiver: int = 0`` parameter convention used across the
+    codebase.  A *receiver* is a full signal chain (RF front-end, IF, demod)
+    that can be tuned independently; each receiver in turn owns a pair of
+    VFO slots (A/B) accessed via :class:`VfoSlotCapable`.
+
+    On a single-receiver radio ``receiver_count == 1`` and
+    :meth:`select_receiver` is a no-op for ``which == 0``.  On a dual-receiver
+    rig (e.g. IC-7610 Main/Sub) ``receiver_count == 2`` and the ``which``
+    argument accepts either the integer index (``0`` for Main, ``1`` for Sub)
+    or the case-insensitive name (``"main"`` / ``"sub"``).
+    """
+
+    @property
+    def receiver_count(self) -> int:
+        """Number of independent receivers exposed by this transceiver."""
+        ...
+
+    async def select_receiver(self, which: int | str) -> None:
+        """Make ``which`` the active receiver for subsequent commands.
+
+        Accepts an integer index (``0``-based) or a case-insensitive name
+        (``"main"`` / ``"sub"``).  Implementations may reject out-of-range
+        values with :class:`ValueError`.
+        """
+        ...
+
+    async def get_active_receiver(self) -> int:
+        """Return the index of the currently active receiver."""
+        ...
+
+
+@runtime_checkable
+class VfoSlotCapable(Protocol):
+    """Radio exposes VFO A/B slots per receiver.
+
+    Completes the ``Transceiver → Receiver → VFO`` hierarchy: each receiver
+    owns a pair of VFO slots (A and B) with independent state tracked by
+    :class:`~icom_lan.radio_state.VfoSlotState` (frequency, mode, filter,
+    etc.).  Operations take an explicit ``receiver`` index matching the
+    existing ``receiver: int = 0`` convention.
+
+    The slot parameter is always a single-character string (``"A"`` or
+    ``"B"``), case-insensitive on input and upper-case on output.
+    """
+
+    async def get_vfo_slot(self, receiver: int = 0) -> str:
+        """Return the active VFO slot (``"A"`` or ``"B"``) for ``receiver``."""
+        ...
+
+    async def set_vfo_slot(self, slot: str, receiver: int = 0) -> None:
+        """Make ``slot`` (``"A"`` or ``"B"``) the active VFO on ``receiver``."""
+        ...
+
+    async def swap_vfo_ab(self, receiver: int = 0) -> None:
+        """Swap VFO A and VFO B state on ``receiver`` (frequency, mode, …)."""
+        ...
+
+    async def equalize_vfo_ab(self, receiver: int = 0) -> None:
+        """Copy the active VFO's state to the inactive VFO on ``receiver``."""
         ...
 
 


### PR DESCRIPTION
## Summary

Add two `@runtime_checkable` capability protocols to `src/icom_lan/radio_protocol.py`:

- **`ReceiverBankCapable`** — `receiver_count`, `select_receiver(which)`, `get_active_receiver()`
- **`VfoSlotCapable`** — `get_vfo_slot / set_vfo_slot / swap_vfo_ab / equalize_vfo_ab` (all `receiver: int = 0`)

Together they surface the `Transceiver -> Receiver -> VFO` hierarchy (see `.claude/architecture/protocol.md`) without breaking the existing `receiver: int = 0` parameter signatures.

Type-only PR:
- No backend implementation
- No state changes
- `DualReceiverCapable.vfo_exchange` untouched — remains for backward compatibility
- Both protocols exported from `radio_protocol.__all__`
- Docstrings reference `VfoSlotState` (from #709) for the per-slot state model

Part of #708 (Phase 1.3).

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy --strict src/icom_lan/radio_protocol.py` — clean
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4632 passed; the 3 `TestAudioHandlerTxTranscoderRate` failures are pre-existing on `origin/main` (unrelated audio TX transcoder setup, not touched by this change)
- [x] LOC delta: +69 lines, 1 file (within ≤3 files / ≤200 LOC guardrail)

Closes #711