### PR TITLE
feat(ui): receiver focus selector on mobile skin

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { runtime } from '$lib/runtime';
-  import { hasTx, hasDualReceiver, hasAnyScope, hasSpectrum } from '$lib/stores/capabilities.svelte';
+  import { hasTx, hasDualReceiver, hasAnyScope, hasSpectrum, receiverLabel } from '$lib/stores/capabilities.svelte';
   import { HardwareButton } from '$lib/Button';
   import SpectrumPanel from '../../components/spectrum/SpectrumPanel.svelte';
   import AmberLcdDisplay from '../panels/lcd/AmberLcdDisplay.svelte';
@@ -97,6 +97,20 @@
   // ── VFO layout ──
   let receiverDeckElement = $state<HTMLElement | null>(null);
   let receiverDeckWidth = $state<number | null>(null);
+  let vfoFreqElement = $state<HTMLElement | null>(null);
+  let activeReceiver = $derived((radioState?.active ?? 'MAIN') as 'MAIN' | 'SUB');
+
+  function selectReceiver(target: 'MAIN' | 'SUB') {
+    if (target === 'MAIN') {
+      vfoHandlers.onMainVfoClick?.();
+    } else {
+      vfoHandlers.onSubVfoClick?.();
+    }
+    // Scroll the VFO display into view so the selection is visible to the user.
+    if (vfoFreqElement && typeof vfoFreqElement.scrollIntoView === 'function') {
+      vfoFreqElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }
   let vfoLayoutProfile = $derived(resolveVfoLayoutProfile(receiverDeckWidth));
   let receiverDeckStyle = $derived(vfoLayoutStyleVars(vfoLayoutProfile, {
     width: receiverDeckWidth,
@@ -438,9 +452,31 @@
 
   <!-- ═══ STICKY VFO HEADER ═══ -->
   <header class="m-vfo-bar" bind:this={receiverDeckElement} style={receiverDeckStyle}>
+    {#if hasDualReceiver()}
+      <div class="m-receiver-selector" role="group" aria-label="Receiver selector">
+        <button
+          type="button"
+          class="m-receiver-pill"
+          class:m-receiver-pill-active={activeReceiver === 'MAIN'}
+          aria-pressed={activeReceiver === 'MAIN'}
+          onclick={() => selectReceiver('MAIN')}
+        >
+          {receiverLabel('MAIN')}
+        </button>
+        <button
+          type="button"
+          class="m-receiver-pill"
+          class:m-receiver-pill-active={activeReceiver === 'SUB'}
+          aria-pressed={activeReceiver === 'SUB'}
+          onclick={() => selectReceiver('SUB')}
+        >
+          {receiverLabel('SUB')}
+        </button>
+      </div>
+    {/if}
     <div class="m-vfo-row">
       <span class="m-tx-indicator" style="background: {txIndicatorColor}" title={txPermit === 'allowed' ? 'TX allowed' : 'TX not allowed (out of band)'}></span>
-      <div class="m-vfo-freq">
+      <div class="m-vfo-freq" bind:this={vfoFreqElement}>
         <FrequencyDisplay freq={mainVfo.freq} compact active />
       </div>
       <button class="m-settings-btn" onclick={() => (settingsOpen = true)}>
@@ -1198,6 +1234,41 @@
     border-radius: 50%;
     flex-shrink: 0;
     transition: background 0.2s, box-shadow 0.2s;
+  }
+
+  .m-receiver-selector {
+    display: flex;
+    gap: 4px;
+    padding: 2px 0 4px;
+  }
+
+  .m-receiver-pill {
+    flex: 1 1 0;
+    min-height: 32px;
+    padding: 6px 10px;
+    border-radius: 4px;
+    border: 1px solid var(--v2-border-darker, #333);
+    background: var(--v2-bg-input, #1a1a2e);
+    color: var(--v2-text-secondary, #aaa);
+    font-family: 'Roboto Mono', monospace;
+    font-weight: 700;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+  }
+
+  .m-receiver-pill:focus-visible {
+    outline: 2px solid var(--v2-accent-cyan, #22d3ee);
+    outline-offset: 2px;
+  }
+
+  .m-receiver-pill-active {
+    background: var(--v2-accent-cyan, #22d3ee);
+    border-color: var(--v2-accent-cyan, #22d3ee);
+    color: var(--v2-bg-card, #111);
   }
 
   .m-vfo-row {

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.test.ts
@@ -39,7 +39,7 @@ vi.mock('./vfo-layout-tokens', () => ({
 }));
 
 // -- Store mocks --
-vi.mock('$lib/stores/radio.svelte', () => ({ radio: { current: null } }));
+vi.mock('$lib/stores/radio.svelte', () => ({ radio: { current: null as { active?: 'MAIN' | 'SUB' } | null } }));
 vi.mock('$lib/stores/connection.svelte', () => ({
   getConnectionStatus: vi.fn(() => ({ connected: false })),
   getRadioPowerOn: vi.fn(() => null),
@@ -56,7 +56,8 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
   hasTx: vi.fn(() => true), hasDualReceiver: vi.fn(() => false), hasAnyScope: vi.fn(() => false),
   hasSpectrum: vi.fn(() => false), getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
   getKeyboardConfig: vi.fn(() => null), setCapabilities: vi.fn(), hasCapability: vi.fn(() => false),
-  vfoLabel: vi.fn((s: string) => s === 'A' ? 'MAIN' : 'SUB'), isAudioFftScope: vi.fn(() => false),
+  vfoLabel: vi.fn((s: string) => s === 'A' ? 'MAIN' : 'SUB'),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id), isAudioFftScope: vi.fn(() => false),
   hasAudioFft: vi.fn(() => false), getScopeSource: vi.fn(() => null), hasAudio: vi.fn(() => false),
   getSmeterCalibration: vi.fn(() => null), getSmeterRedline: vi.fn(() => null),
   getMeterCalibration: vi.fn(() => null), getMeterRedline: vi.fn(() => null),
@@ -71,10 +72,17 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 
 // -- Wiring mocks --
-vi.mock('../wiring/command-bus', () => {
+const { onMainVfoClickSpy, onSubVfoClickSpy } = vi.hoisted(() => ({
+  onMainVfoClickSpy: vi.fn(),
+  onSubVfoClickSpy: vi.fn(),
+}));
+vi.mock('../../wiring/command-bus', () => {
   const n = vi.fn();
   return {
-    makeVfoHandlers: () => ({ onMainFreqChange: n, onSubFreqChange: n, onVfoSwap: n, onVfoEqual: n, onReceiverSelect: n }),
+    makeVfoHandlers: () => ({
+      onMainFreqChange: n, onSubFreqChange: n, onVfoSwap: n, onVfoEqual: n, onReceiverSelect: n,
+      onMainVfoClick: onMainVfoClickSpy, onSubVfoClick: onSubVfoClickSpy,
+    }),
     makeMeterHandlers: () => ({ onMeterSourceChange: n }), makeKeyboardHandlers: () => ({ dispatch: n }),
     makeModeHandlers: () => ({ onModeChange: n, onDataModeChange: n }),
     makeFilterHandlers: () => ({ onFilterChange: n, onFilterWidthChange: n }),
@@ -110,7 +118,8 @@ vi.mock('../wiring/state-adapter', () => {
 });
 
 import MobileRadioLayout from '../MobileRadioLayout.svelte';
-import { hasTx } from '$lib/stores/capabilities.svelte';
+import { hasTx, hasDualReceiver } from '$lib/stores/capabilities.svelte';
+import { radio } from '$lib/stores/radio.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
@@ -127,6 +136,10 @@ beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 390 });
   Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 844 });
   vi.mocked(hasTx).mockReturnValue(true);
+  vi.mocked(hasDualReceiver).mockReturnValue(false);
+  (radio as unknown as { current: { active?: 'MAIN' | 'SUB' } | null }).current = null;
+  onMainVfoClickSpy.mockClear();
+  onSubVfoClickSpy.mockClear();
 });
 
 afterEach(() => {
@@ -193,5 +206,93 @@ describe('MobileRadioLayout unmount', () => {
     const t = mountMobile();
     expect(t.querySelector('.m-layout')).not.toBeNull();
     expect(() => unmount(components.pop()!)).not.toThrow();
+  });
+});
+
+describe('MobileRadioLayout receiver selector (#719)', () => {
+  it('does not render selector on single-receiver radios', () => {
+    vi.mocked(hasDualReceiver).mockReturnValue(false);
+    expect(mountMobile().querySelector('.m-receiver-selector')).toBeNull();
+  });
+
+  it('renders MAIN/SUB pills when dual-RX', () => {
+    vi.mocked(hasDualReceiver).mockReturnValue(true);
+    const t = mountMobile();
+    const group = t.querySelector('.m-receiver-selector');
+    expect(group).not.toBeNull();
+    expect(group?.getAttribute('role')).toBe('group');
+    expect(group?.getAttribute('aria-label')).toBe('Receiver selector');
+    const pills = t.querySelectorAll<HTMLButtonElement>('.m-receiver-pill');
+    expect(pills.length).toBe(2);
+    expect(pills[0].textContent?.trim()).toBe('MAIN');
+    expect(pills[1].textContent?.trim()).toBe('SUB');
+  });
+
+  it('marks the active receiver with aria-pressed=true (MAIN default)', () => {
+    vi.mocked(hasDualReceiver).mockReturnValue(true);
+    const t = mountMobile();
+    const [mainPill, subPill] = Array.from(
+      t.querySelectorAll<HTMLButtonElement>('.m-receiver-pill'),
+    );
+    expect(mainPill.getAttribute('aria-pressed')).toBe('true');
+    expect(subPill.getAttribute('aria-pressed')).toBe('false');
+    expect(mainPill.classList.contains('m-receiver-pill-active')).toBe(true);
+  });
+
+  it('reflects SUB as active when radioState.active === SUB', () => {
+    vi.mocked(hasDualReceiver).mockReturnValue(true);
+    (radio as unknown as { current: { active?: 'MAIN' | 'SUB' } | null }).current = { active: 'SUB' };
+    const t = mountMobile();
+    const [mainPill, subPill] = Array.from(
+      t.querySelectorAll<HTMLButtonElement>('.m-receiver-pill'),
+    );
+    expect(mainPill.getAttribute('aria-pressed')).toBe('false');
+    expect(subPill.getAttribute('aria-pressed')).toBe('true');
+    expect(subPill.classList.contains('m-receiver-pill-active')).toBe(true);
+  });
+
+  it('pills are focusable buttons (keyboard a11y)', () => {
+    vi.mocked(hasDualReceiver).mockReturnValue(true);
+    const t = mountMobile();
+    const pills = t.querySelectorAll<HTMLButtonElement>('.m-receiver-pill');
+    pills.forEach((p) => {
+      expect(p.tagName).toBe('BUTTON');
+      expect(p.getAttribute('type')).toBe('button');
+    });
+    pills[0].focus();
+    expect(document.activeElement).toBe(pills[0]);
+    pills[1].focus();
+    expect(document.activeElement).toBe(pills[1]);
+  });
+
+  it('tapping MAIN pill dispatches onMainVfoClick', () => {
+    vi.mocked(hasDualReceiver).mockReturnValue(true);
+    const t = mountMobile();
+    const [mainPill] = Array.from(
+      t.querySelectorAll<HTMLButtonElement>('.m-receiver-pill'),
+    );
+    mainPill.click();
+    expect(onMainVfoClickSpy).toHaveBeenCalledTimes(1);
+    expect(onSubVfoClickSpy).not.toHaveBeenCalled();
+  });
+
+  it('tapping SUB pill dispatches onSubVfoClick and scrolls VFO display', () => {
+    vi.mocked(hasDualReceiver).mockReturnValue(true);
+    const scrollSpy = vi.fn();
+    // Patch Element.prototype.scrollIntoView for this test
+    const origScroll = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollSpy as unknown as typeof Element.prototype.scrollIntoView;
+    try {
+      const t = mountMobile();
+      const pills = Array.from(t.querySelectorAll<HTMLButtonElement>('.m-receiver-pill'));
+      pills[1].click();
+      expect(onSubVfoClickSpy).toHaveBeenCalledTimes(1);
+      expect(onMainVfoClickSpy).not.toHaveBeenCalled();
+      expect(scrollSpy).toHaveBeenCalled();
+      const arg = scrollSpy.mock.calls[0]?.[0];
+      expect(arg).toMatchObject({ behavior: 'smooth', block: 'center' });
+    } finally {
+      Element.prototype.scrollIntoView = origScroll;
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Add MAIN/SUB pill toggle in the mobile portrait header; visible only when `hasDualReceiver()` is true so IC-7300 / IC-705 layouts are unaffected.
- Active pill is `$derived` from `radioState.active` and reflects `aria-pressed`; pills are real `<button type="button">` with `focus-visible` outline and live inside a `role="group"` / `aria-label="Receiver selector"` wrapper.
- Tap routes through the existing `vfoHandlers.onMainVfoClick` / `onSubVfoClick` wiring (no changes to `command-bus.ts`), then smooth-scrolls the VFO frequency display into view via `scrollIntoView({ behavior: 'smooth', block: 'center' })` with a guard for missing `scrollIntoView`.

## Test plan

- [x] `npm run build` – clean
- [x] `npx vitest run` – 1486 / 1486 passing (7 new component tests in `MobileRadioLayout.component.test.ts` cover render gating, aria-pressed state for MAIN and SUB active, keyboard focus, and click → handler dispatch + scrollIntoView).
- [ ] Manual check on IC-7610 (dual-RX) confirms the pills appear and tapping SUB actually activates SUB receiver path.
- [ ] Manual check on a single-RX radio confirms no blank space / no selector.

Closes #719