### PR TITLE
fix: IC-9700 profile uses MAIN/SUB scheme with correct byte codes

### DIFF
--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -28,6 +28,8 @@ data_len_max = 475
 features = [
     # Receiver
     "audio",
+    "dual_rx",
+    "dual_watch",
     "af_level",
     "rf_gain",
     "squelch",
@@ -181,11 +183,18 @@ width_min_hz = 50
 width_max_hz = 9999
 
 [vfo]
-scheme = "ab"
-main_select = [0x00]  # VFO A
-sub_select = [0x01]   # VFO B
-swap = [0xB0]
-equal = [0xA0]
+# IC-9700 has two receivers (MAIN/SUB), not VFO A/B at the radio level.
+# CI-V 0x07 0xD0 = select MAIN receiver, 0x07 0xD1 = select SUB receiver.
+# CI-V 0x07 0xB0 = swap MAIN/SUB, 0x07 0xB1 = equal MAIN=SUB.
+# Bytes match the Icom CI-V dual-receiver convention also used by IC-7610.
+# (wfview IC-9700.rig exposes only "VFO Equal AB" = 0x07 0xA0; the 0x07 0xB1
+#  "Equal M/S" opcode is documented in the IC-9700 CI-V reference guide and
+#  mirrors IC-7610 behaviour — untested on hardware for this file.)
+scheme = "main_sub"
+main_select = [0xD0]
+sub_select = [0xD1]
+swap_main_sub = [0xB0]
+equal_main_sub = [0xB1]
 
 # ── Frequency Ranges ─────────────────────────────────────────────
 
@@ -275,11 +284,21 @@ end_hz = 54_000_000
 default_hz = 50_125_000
 bsr_code = 0x0A
 
+# ── Command 29 Routes ───────────────────────────────────────────
+# The IC-9700 uses the MAIN/SUB receiver-select scheme (0x07 0xD0/0xD1)
+# to target per-receiver commands, NOT the cmd29 prefix used by the
+# IC-7610 / IC-7760 / IC-785x. wfview's IC-9700.rig sets
+# `HasCommand29=false` at the file level and marks every individual
+# command `Command29=false`, matching the published CI-V reference
+# guide. Keep this list empty so supports_cmd29() returns False and
+# the command layer falls back to the MAIN/SUB receiver-switch path.
+
+[cmd29]
+routes = []
+
 # ── CI-V Commands ────────────────────────────────────────────────
 # Grouped by capability area. Wire bytes as integer arrays.
-# Source: IC-7300MK2 CI-V Reference Guide
-#
-# IC-7300 has NO Command29 support (single receiver).
+# Source: IC-9700 CI-V Reference Guide + wfview IC-9700.rig.
 
 [commands]
 
@@ -294,12 +313,19 @@ get_unselected_freq = [0x25, 0x01]        # Unselected VFO freq
 get_selected_mode = [0x26, 0x00]          # Selected VFO mode
 get_unselected_mode = [0x26, 0x01]        # Unselected VFO mode
 
-# ── VFO ──
+# ── VFO / Dual Receiver ──
 get_vfo = [0x07]
 set_vfo = [0x07]
 get_split = [0x0F]
 set_split = [0x0F]
-# NOTE: no dual_watch, no main/sub band select (single receiver)
+# Dual Watch on/off: 0x07 0xC2 = read state, 0x07 0xC1 = ON, 0x07 0xC0 = OFF.
+# (wfview IC-9700.rig exposes VFO Dual Watch via menu path 0x16 0x59;
+#  0x07 0xCx is the direct CI-V opcode per Icom CI-V reference guide.)
+get_dual_watch = [0x07, 0xC2]
+set_dual_watch_on = [0x07, 0xC1]
+set_dual_watch_off = [0x07, 0xC0]
+# 0x07 0xD2: read/write which band is bound to MAIN/SUB (0=MAIN, 1=SUB).
+get_main_sub_band = [0x07, 0xD2]
 
 # ── Tuning ──
 get_tuning_step = [0x10]
@@ -674,7 +700,8 @@ style = "toggle_and_level"
 style = "toggle_and_level"
 
 # Level control ranges — raw CI-V values and display mapping
-# IC-7300: single receiver, no cmd29, VFO A/B scheme
+# IC-9700: dual receiver (MAIN/SUB), no cmd29; receiver targeting via
+# 0x07 0xD0/0xD1 receiver-select before per-receiver commands.
 
 [controls.pbt_inner]
 raw_min = 0


### PR DESCRIPTION
Closes #713.

## Summary

`rigs/ic9700.toml` was a mis-labelled IC-7300 clone: `receiver_count=2` but `scheme="ab"`, VFO A/B byte codes, no dual-watch / main-sub-band commands. Rewritten to declare the correct MAIN/SUB scheme and commands per the IC-9700 CI-V reference guide and wfview's IC-9700.rig.

### Before / After

| Field | Before | After |
|---|---|---|
| `[vfo].scheme` | `"ab"` | `"main_sub"` |
| `[vfo].main_select` | `[0x00]` (VFO A) | `[0xD0]` |
| `[vfo].sub_select` | `[0x01]` (VFO B) | `[0xD1]` |
| `[vfo].swap_main_sub` | missing | `[0xB0]` |
| `[vfo].equal_main_sub` | `equal = [0xA0]` | `[0xB1]` |
| `[capabilities]` | — | `+ dual_rx, + dual_watch` |
| `get_dual_watch` | missing | `[0x07, 0xC2]` |
| `set_dual_watch_on` | missing | `[0x07, 0xC1]` |
| `set_dual_watch_off` | missing | `[0x07, 0xC0]` |
| `get_main_sub_band` | missing | `[0x07, 0xD2]` |
| `[cmd29].routes` | — | `[]` (see below) |
| stale "IC-7300: single receiver" / "IC-7300 has NO Command29" comments | — | replaced with IC-9700 semantics |

## cmd29 routes: 0 (not 30+)

Issue #713 anticipated ~30+ cmd29 routes mirroring `rigs/ic7610.toml`. Direct inspection of the authoritative source disagrees:

- wfview `references/wfview/rigs/IC-9700.rig` has **`HasCommand29=false`** at the file level
- Zero `Commands\N\Command29=true` entries (spot-checked ATT `0x11`, AF Gain `0x14 0x01`, RF Gain `0x14 0x02`, Squelch `0x14 0x03`, Preamp `0x16 0x02` — all `Command29=false`)
- IC-7610.rig by contrast has `HasCommand29=true` and 34 per-row entries

Per the issue's own cross-reference rule ("If wfview marks `Command29=false` for a specific row that's on IC-7610, OMIT that row"), applying it honestly yields zero routes. The IC-9700 targets per-receiver state via the MAIN/SUB receiver-select opcodes (`0x07 0xD0` / `0x07 0xD1`) before issuing per-receiver commands, rather than via the Command29 prefix used by the IC-7610 / IC-7760 / IC-785x. Empty `routes = []` keeps the schema slot and `supports_cmd29()` correctly returns `False`.

## Byte-code cross-reference vs wfview IC-9700.rig

| Opcode | Field | wfview IC-9700.rig | This PR | Note |
|---|---|---|---|---|
| `0x07 0xD0` | main_select | VFO Main Select | match | |
| `0x07 0xD1` | sub_select | VFO Sub Select | match | |
| `0x07 0xB0` | swap_main_sub | VFO Swap M/S | match | |
| `0x07 0xB1` | equal_main_sub | **not listed** (wfview exposes VFO Equal AB at `0x07 0xA0`) | `[0xB1]` | `0xB1` is the MAIN/SUB equal opcode per Icom CI-V reference + IC-7610.rig; the `0xA0` wfview exposes is VFO A=B. Issue #713 prescribed `0xB1` — we follow that. |
| `0x07 0xD2` | get_main_sub_band | VFO Main/Sub Band | match | |
| `0x07 0xC0 / 0xC1 / 0xC2` | Dual Watch off/on/read | **not listed** (wfview exposes Dual Watch only via menu path `0x16 0x59`) | `[0x07, 0xC0 / 0xC1 / 0xC2]` | Direct Dual Watch opcodes documented in the IC-9700 CI-V reference and match IC-7610.rig; per-issue prescription. |

All other byte codes that this PR changes are byte-for-byte identical to wfview IC-9700.rig.

## Verification

```
uv run ruff check src/ tests/       -> All checks passed!
uv run python -c "from icom_lan.profiles import resolve_radio_profile; p = resolve_radio_profile(model='IC-9700'); ..."
  scheme=main_sub, main=0xD0, sub=0xD1, swap_main_sub=0xB0, equal_main_sub=0xB1
  dual_rx=True, dual_watch=True, cmd29 routes=0, supports_cmd29(0x14,0x01)=False
```

Profile-adjacent tests:

```
uv run pytest tests/test_ic9700_backend.py tests/test_radios.py \
              tests/test_rig_loader.py tests/test_rig_multi_vendor.py \
              tests/test_supports_command.py -q
  122 passed
```

Full suite (excluding integration): 4632 passed, 3 pre-existing failures in `tests/test_web_server.py::TestAudioHandlerTxTranscoderRate` that are unrelated to this change (failures reproduce on the worktree even without my edits; tests pass on a fresh clone of main at the same sha — likely a stale environment artefact, not caused by this PR).

**Untested on hardware; verified against wfview IC-9700.rig.**

## Test plan
- [ ] Connect to an IC-9700 and confirm MAIN/SUB select, swap, equal, and Dual Watch operate per the new byte codes
- [ ] Confirm `get_main_sub_band` reads 0/1 correctly
- [ ] Confirm absence of cmd29 routes does not break per-receiver routing (receiver-select fall-through path)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>