### PR TITLE
feat(ui): DualVfoDisplay — show both MAIN+SUB on desktop skin for dual-RX radios

### DIFF
--- a/frontend/src/components-v2/layout/VfoHeader.svelte
+++ b/frontend/src/components-v2/layout/VfoHeader.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import VfoPanel from '../vfo/VfoPanel.svelte';
   import VfoOps from '../vfo/VfoOps.svelte';
+  import DualVfoDisplay from '../panels/vfo/DualVfoDisplay.svelte';
   import { hasDualReceiver } from '$lib/stores/capabilities.svelte';
+  import { patchRadioState } from '$lib/stores/radio.svelte';
   import { formatFrequency } from '../display/frequency-format';
   import type { VfoLayoutProfile } from './vfo-layout-tokens';
   import type { VfoStateProps } from './layout-utils';
@@ -76,15 +78,36 @@
 
 <span class="sr-only" aria-live="polite" aria-atomic="true">{announcedFrequency}</span>
 <div class="vfo-header" class:dual={dualReceiver}>
-  <div class="vfo-main-panel">
-    <VfoPanel
-      {...mainVfo}
+  {#if dualReceiver}
+    <DualVfoDisplay
+      main={mainVfo}
+      sub={subVfo}
+      active={mainVfo.isActive ? 'MAIN' : 'SUB'}
       {layoutProfile}
-      onVfoClick={onMainVfoClick}
-      onModeClick={onMainModeClick}
-      onFreqChange={onMainFreqChange}
+      onActivate={(receiver) => {
+        patchRadioState({ active: receiver });
+        if (receiver === 'MAIN') {
+          onMainVfoClick?.();
+        } else {
+          onSubVfoClick?.();
+        }
+      }}
+      onMainModeClick={onMainModeClick}
+      onSubModeClick={onSubModeClick}
+      onMainFreqChange={onMainFreqChange}
+      onSubFreqChange={onSubFreqChange}
     />
-  </div>
+  {:else}
+    <div class="vfo-main-panel">
+      <VfoPanel
+        {...mainVfo}
+        {layoutProfile}
+        onVfoClick={onMainVfoClick}
+        onModeClick={onMainModeClick}
+        onFreqChange={onMainFreqChange}
+      />
+    </div>
+  {/if}
 
   <div class="vfo-bridge-panel">
     <div class="vfo-bridge-stack">
@@ -114,18 +137,6 @@
       {/if}
     </div>
   </div>
-
-  {#if dualReceiver}
-    <div class="vfo-sub-panel">
-      <VfoPanel
-        {...subVfo}
-        {layoutProfile}
-        onVfoClick={onSubVfoClick}
-        onModeClick={onSubModeClick}
-        onFreqChange={onSubFreqChange}
-      />
-    </div>
-  {/if}
 </div>
 
 <style>
@@ -157,8 +168,13 @@
     align-items: stretch;
   }
 
-  .vfo-main-panel {
+  .vfo-header :global(.vfo-main-panel) {
     grid-area: main;
+    min-width: 0;
+  }
+
+  .vfo-header :global(.vfo-sub-panel) {
+    grid-area: sub;
     min-width: 0;
   }
 
@@ -249,11 +265,6 @@
 
   .speak-btn:active {
     background: rgba(0, 200, 220, 0.1);
-  }
-
-  .vfo-sub-panel {
-    grid-area: sub;
-    min-width: 0;
   }
 
   @media (max-width: 1024px) {

--- a/frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte
+++ b/frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte
@@ -1,0 +1,113 @@
+<!--
+  DualVfoDisplay — side-by-side MAIN + SUB VFO tiles for dual-RX radios.
+
+  Presentation-only: renders two VfoPanel tiles wrapped in keyboard/a11y
+  containers. The active tile is visually highlighted and announced via
+  aria-pressed. Clicking or pressing Enter/Space on an inactive tile fires
+  the onActivate callback with the receiver id.
+
+  Wiring (set_vfo + optimistic patchRadioState) lives at the VfoHeader
+  call-site.
+-->
+<script lang="ts">
+  import VfoPanel from '../../../components-v2/vfo/VfoPanel.svelte';
+  import type { VfoStateProps } from '../../../components-v2/layout/layout-utils';
+  import type { VfoLayoutProfile } from '../../../components-v2/layout/vfo-layout-tokens';
+
+  interface Props {
+    main: VfoStateProps;
+    sub: VfoStateProps;
+    active: 'MAIN' | 'SUB';
+    layoutProfile?: VfoLayoutProfile;
+    onActivate?: (receiver: 'MAIN' | 'SUB') => void;
+    onMainModeClick?: () => void;
+    onSubModeClick?: () => void;
+    onMainFreqChange?: (freq: number) => void;
+    onSubFreqChange?: (freq: number) => void;
+  }
+
+  let {
+    main,
+    sub,
+    active,
+    layoutProfile = 'baseline',
+    onActivate,
+    onMainModeClick,
+    onSubModeClick,
+    onMainFreqChange,
+    onSubFreqChange,
+  }: Props = $props();
+
+  function activate(receiver: 'MAIN' | 'SUB'): void {
+    if (active === receiver) return;
+    onActivate?.(receiver);
+  }
+
+  function handleKeydown(event: KeyboardEvent, receiver: 'MAIN' | 'SUB'): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      activate(receiver);
+    }
+  }
+</script>
+
+<div
+  class="dual-vfo-tile vfo-main-panel"
+  class:is-active={active === 'MAIN'}
+  role="button"
+  tabindex="0"
+  aria-pressed={active === 'MAIN'}
+  aria-label={active === 'MAIN' ? 'MAIN receiver (active)' : 'Activate MAIN receiver'}
+  data-receiver="main"
+  data-layout-profile={layoutProfile}
+  onclick={() => activate('MAIN')}
+  onkeydown={(e) => handleKeydown(e, 'MAIN')}
+>
+  <VfoPanel
+    {...main}
+    {layoutProfile}
+    onModeClick={onMainModeClick}
+    onFreqChange={onMainFreqChange}
+  />
+</div>
+
+<div
+  class="dual-vfo-tile vfo-sub-panel"
+  class:is-active={active === 'SUB'}
+  role="button"
+  tabindex="0"
+  aria-pressed={active === 'SUB'}
+  aria-label={active === 'SUB' ? 'SUB receiver (active)' : 'Activate SUB receiver'}
+  data-receiver="sub"
+  data-layout-profile={layoutProfile}
+  onclick={() => activate('SUB')}
+  onkeydown={(e) => handleKeydown(e, 'SUB')}
+>
+  <VfoPanel
+    {...sub}
+    {layoutProfile}
+    onModeClick={onSubModeClick}
+    onFreqChange={onSubFreqChange}
+  />
+</div>
+
+<style>
+  .dual-vfo-tile {
+    min-width: 0;
+    display: block;
+    cursor: pointer;
+    border-radius: 4px;
+    outline: none;
+    transition: box-shadow 150ms ease;
+  }
+
+  .dual-vfo-tile:focus-visible {
+    box-shadow: 0 0 0 2px var(--v2-accent-cyan, #00d4ff);
+  }
+
+  .dual-vfo-tile.is-active {
+    /* Active highlight is rendered by the inner VfoPanel.active class.
+       This selector exists so tests and external CSS can target the
+       outer tile without reaching into the panel. */
+  }
+</style>

--- a/frontend/src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts
+++ b/frontend/src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { ComponentProps } from 'svelte';
+
+// Mock capabilities for VfoPanel internals.
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  getCapabilities: vi.fn(() => ({
+    freqRanges: [
+      {
+        start: 14000000,
+        end: 14350000,
+        bands: [{ name: '20m', start: 14000000, end: 14350000, default: 14074000 }],
+      },
+    ],
+  })),
+  hasDualReceiver: vi.fn(() => true),
+  getSmeterCalibration: vi.fn(() => null),
+  getSmeterRedline: vi.fn(() => null),
+}));
+
+import DualVfoDisplay from '../DualVfoDisplay.svelte';
+import type { VfoStateProps } from '../../../layout/layout-utils';
+
+const mainVfo: VfoStateProps = {
+  receiver: 'main',
+  freq: 14074000,
+  mode: 'USB',
+  filter: 'FIL1',
+  sValue: 50,
+  isActive: true,
+  badges: {},
+};
+
+const subVfo: VfoStateProps = {
+  receiver: 'sub',
+  freq: 7074000,
+  mode: 'LSB',
+  filter: 'FIL1',
+  sValue: 30,
+  isActive: false,
+  badges: {},
+};
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountDisplay(props: ComponentProps<typeof DualVfoDisplay>) {
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  const component = mount(DualVfoDisplay, { target: t, props });
+  flushSync();
+  components.push(component);
+  return t;
+}
+
+beforeEach(() => {
+  components = [];
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+});
+
+describe('DualVfoDisplay', () => {
+  describe('structure', () => {
+    it('mounts with two tiles', () => {
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
+      const tiles = t.querySelectorAll('.dual-vfo-tile');
+      expect(tiles.length).toBe(2);
+    });
+
+    it('renders MAIN and SUB tiles with correct data-receiver', () => {
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
+      expect(t.querySelector('[data-receiver="main"]')).not.toBeNull();
+      expect(t.querySelector('[data-receiver="sub"]')).not.toBeNull();
+    });
+
+    it('both tiles are keyboard focusable (tabindex=0)', () => {
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
+      const tiles = t.querySelectorAll<HTMLElement>('.dual-vfo-tile');
+      tiles.forEach((tile) => {
+        expect(tile.getAttribute('tabindex')).toBe('0');
+      });
+    });
+
+    it('both tiles have role=button', () => {
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
+      const tiles = t.querySelectorAll('.dual-vfo-tile');
+      tiles.forEach((tile) => {
+        expect(tile.getAttribute('role')).toBe('button');
+      });
+    });
+  });
+
+  describe('active state', () => {
+    it('active tile has is-active class (MAIN active)', () => {
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
+      const mainTile = t.querySelector('[data-receiver="main"]');
+      const subTile = t.querySelector('[data-receiver="sub"]');
+      expect(mainTile?.classList.contains('is-active')).toBe(true);
+      expect(subTile?.classList.contains('is-active')).toBe(false);
+    });
+
+    it('active tile has is-active class (SUB active)', () => {
+      const t = mountDisplay({
+        main: { ...mainVfo, isActive: false },
+        sub: { ...subVfo, isActive: true },
+        active: 'SUB',
+      });
+      const mainTile = t.querySelector('[data-receiver="main"]');
+      const subTile = t.querySelector('[data-receiver="sub"]');
+      expect(mainTile?.classList.contains('is-active')).toBe(false);
+      expect(subTile?.classList.contains('is-active')).toBe(true);
+    });
+
+    it('aria-pressed reflects active receiver (MAIN)', () => {
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
+      expect(t.querySelector('[data-receiver="main"]')?.getAttribute('aria-pressed')).toBe('true');
+      expect(t.querySelector('[data-receiver="sub"]')?.getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('aria-pressed reflects active receiver (SUB)', () => {
+      const t = mountDisplay({
+        main: { ...mainVfo, isActive: false },
+        sub: { ...subVfo, isActive: true },
+        active: 'SUB',
+      });
+      expect(t.querySelector('[data-receiver="main"]')?.getAttribute('aria-pressed')).toBe('false');
+      expect(t.querySelector('[data-receiver="sub"]')?.getAttribute('aria-pressed')).toBe('true');
+    });
+  });
+
+  describe('onActivate callback', () => {
+    it('clicking inactive tile fires onActivate with the receiver id (SUB)', () => {
+      const onActivate = vi.fn();
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
+      t.querySelector<HTMLElement>('[data-receiver="sub"]')?.click();
+      expect(onActivate).toHaveBeenCalledOnce();
+      expect(onActivate).toHaveBeenCalledWith('SUB');
+    });
+
+    it('clicking inactive tile fires onActivate with the receiver id (MAIN)', () => {
+      const onActivate = vi.fn();
+      const t = mountDisplay({
+        main: { ...mainVfo, isActive: false },
+        sub: { ...subVfo, isActive: true },
+        active: 'SUB',
+        onActivate,
+      });
+      t.querySelector<HTMLElement>('[data-receiver="main"]')?.click();
+      expect(onActivate).toHaveBeenCalledOnce();
+      expect(onActivate).toHaveBeenCalledWith('MAIN');
+    });
+
+    it('clicking already-active tile does NOT fire onActivate', () => {
+      const onActivate = vi.fn();
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
+      t.querySelector<HTMLElement>('[data-receiver="main"]')?.click();
+      expect(onActivate).not.toHaveBeenCalled();
+    });
+
+    it('Enter key on inactive tile fires onActivate', () => {
+      const onActivate = vi.fn();
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
+      const tile = t.querySelector<HTMLElement>('[data-receiver="sub"]');
+      tile?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      expect(onActivate).toHaveBeenCalledWith('SUB');
+    });
+
+    it('Space key on inactive tile fires onActivate', () => {
+      const onActivate = vi.fn();
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
+      const tile = t.querySelector<HTMLElement>('[data-receiver="sub"]');
+      tile?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      expect(onActivate).toHaveBeenCalledWith('SUB');
+    });
+
+    it('other keys do not fire onActivate', () => {
+      const onActivate = vi.fn();
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
+      const tile = t.querySelector<HTMLElement>('[data-receiver="sub"]');
+      tile?.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+      expect(onActivate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -131,6 +131,24 @@ export function toVfoProps(
   };
 }
 
+/**
+ * Dual-VFO props — groups MAIN+SUB VfoStateProps with the active receiver id.
+ * Reuses the existing toVfoProps helper; no new adapter logic.
+ */
+export interface DualVfoProps {
+  main: VfoStateProps;
+  sub: VfoStateProps;
+  active: 'MAIN' | 'SUB';
+}
+
+export function toDualVfoProps(state: ServerState | null): DualVfoProps {
+  return {
+    main: toVfoProps(state, 'main'),
+    sub: toVfoProps(state, 'sub'),
+    active: state?.active === 'SUB' ? 'SUB' : 'MAIN',
+  };
+}
+
 /* ── RF Front End ────────────────────────────────────────────── */
 
 export interface RfFrontEndProps {


### PR DESCRIPTION
## Summary

- Adds `DualVfoDisplay` component (`components-v2/panels/vfo/`) that renders MAIN and SUB VFO tiles side-by-side for dual-RX radios (e.g. IC-7610). Active tile carries `is-active` + `aria-pressed=true`; both tiles are keyboard-focusable (`tabindex=0`, `role=button`) and activate on Enter/Space.
- Adds `toDualVfoProps(state)` to `wiring/state-adapter.ts` — grouping helper that reuses the existing `toVfoProps(state, 'main'|'sub')` and exposes the active receiver id.
- Wires `DualVfoDisplay` into `layout/VfoHeader.svelte` behind `hasDualReceiver()`. The single-VFO path (IC-7300/705) is preserved unchanged. `onActivate(receiver)` calls through the existing `onMainVfoClick` / `onSubVfoClick` wiring handlers (which fire `set_vfo`) and additionally applies an optimistic `patchRadioState({ active })` at the layout call-site so the UI flips immediately and the built-in optimistic TTL prevents a server revert.

## Screenshot description

On a dual-RX radio the top deck now shows two equally-sized VFO tiles (MAIN on the left, SUB on the right) flanking the existing bridge panel (SWAP / A=B / SPLIT / SPEAK). The active tile keeps the cyan `is-active` / `VfoPanel.active` border glow and reports `aria-pressed=true`; the inactive tile dims with a hover/focus ring. Clicking or keyboard-activating the inactive tile instantly flips the highlight and dispatches `set_vfo`. On single-RX radios (IC-7300/705) the layout is byte-identical to before.

## Deviation from task spec

The task described creating `DualVfoDisplay` and "branch at the `VfoHeader` (or single VFO tile) call site in `desktop-v2`". Doing that replacement at the `RadioLayout.svelte` call site would drop the VfoHeader bridge panel (SPLIT / SWAP / A=B / SPEAK) for dual-RX users — a regression against acceptance. Instead, `DualVfoDisplay` replaces the two inner `<VfoPanel>` calls inside `VfoHeader.svelte`, preserving the bridge. `RadioLayout.svelte` is untouched. Files touched: 3 source + 1 test = 4 total, within budget.

Also: `patchRadioState` in the current store takes only a patch (no second `lock` arg); optimistic locking is built-in via `OPTIMISTIC_TTL`, so `patchRadioState({ active: receiver })` is the correct call shape for the spec's intent.

## Test plan

- [x] `npx vitest run` — **1493 passed (80 test files)**, includes 14 new tests in `DualVfoDisplay.test.ts` covering: two-tile mount, `data-receiver` attributes, `tabindex=0` + `role=button`, `is-active` CSS toggle for both MAIN/SUB active states, `aria-pressed` reflection, click-to-activate with correct receiver id, no-op when clicking already-active tile, Enter + Space keyboard activation, other keys no-op. Pre-existing `top-row-visual-regression` test keeps passing (`.vfo-main-panel .panel` selector preserved via class reuse on the new tile wrapper).
- [x] `npm run build` — succeeds (2.74s).
- [x] `npx eslint` on touched files — clean; DualVfoDisplay imports no transport/audio modules (`no-restricted-imports` guard holds for panels).
- [ ] Manual smoke on IC-7610: both tiles render, clicking SUB activates it; on IC-7300/705 the layout is unchanged. (Requires hardware; not run in CI.)

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)