### PR TITLE
feat(protocol): TransceiverBankCapable for multi-transceiver radios (FTX-1)

### DIFF
--- a/src/icom_lan/profiles.py
+++ b/src/icom_lan/profiles.py
@@ -175,6 +175,7 @@ class RadioProfile:
     rules: tuple[RuleSpec, ...] = ()
     keyboard: KeyboardConfig | None = None
     antenna_tx_count: int = 1
+    transceiver_count: int = 1
     scope_ref_min_db: float | None = None
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -61,6 +61,7 @@ __all__ = [
     "ScopeCapable",
     "DualReceiverCapable",
     "ReceiverBankCapable",
+    "TransceiverBankCapable",
     "VfoSlotCapable",
     "StateCacheCapable",
     "RecoverableConnection",
@@ -581,6 +582,42 @@ class ReceiverBankCapable(Protocol):
 
     async def get_active_receiver(self) -> int:
         """Return the index of the currently active receiver."""
+        ...
+
+
+@runtime_checkable
+class TransceiverBankCapable(Protocol):
+    """Radio exposes a bank of independent transceivers.
+
+    Sits at the top of the ``Transceiver → Receiver → VFO`` hierarchy: a
+    *transceiver* is a fully independent RF stage (its own TX PA, antenna
+    port, and receiver chain) addressable as a distinct unit.  Examples are
+    the Yaesu FTX-1 family, where HF+50 MHz and 144+430 MHz are wired as two
+    separate transceivers sharing a single control head.
+
+    On a single-transceiver radio ``transceiver_count == 1`` and
+    :meth:`set_tx_source` is a no-op for ``xcvr == 0``.  On a multi-
+    transceiver rig the ``xcvr`` argument is a 0-based integer index
+    identifying which transceiver the operator is driving on TX; the radio
+    may expose additional receivers per transceiver via
+    :class:`ReceiverBankCapable`.
+    """
+
+    @property
+    def transceiver_count(self) -> int:
+        """Number of independent transceivers exposed by this rig."""
+        ...
+
+    async def get_tx_source(self) -> int:
+        """Return the 0-based index of the currently active TX transceiver."""
+        ...
+
+    async def set_tx_source(self, xcvr: int) -> None:
+        """Make ``xcvr`` the active TX transceiver.
+
+        Implementations may reject out-of-range values with
+        :class:`ValueError`.
+        """
         ...
 
 


### PR DESCRIPTION
## Summary

- Add `TransceiverBankCapable` protocol in `radio_protocol.py` to surface the top tier of the `Transceiver → Receiver → VFO` hierarchy. Targets multi-transceiver rigs such as the Yaesu FTX-1 (HF+50 / 144+430 as two independent transceivers).
- Add `transceiver_count: int = 1` field to `RadioProfile` so profiles can later declare multi-transceiver rigs.
- No backend implementation in this PR — type + profile field only, mirroring the pattern landed by #711.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy --strict src/icom_lan/radio_protocol.py` — clean
- [x] `uv run mypy src/` — only pre-existing `discovery.py` stub warning, unrelated
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4632 passed, 3 pre-existing `TestAudioHandlerTxTranscoderRate` failures on `origin/main` (unrelated)

Closes #712

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>