### PR TITLE
feat(backend/ic7610): swap_vfo_ab / swap_main_sub distinct methods

### DIFF
--- a/src/icom_lan/_dual_rx_runtime.py
+++ b/src/icom_lan/_dual_rx_runtime.py
@@ -17,7 +17,9 @@ else:
     _MixinBase = object
 
 from .commands import (
+    CONTROLLER_ADDR,
     RECEIVER_MAIN,
+    build_civ_frame,
     get_freq,
     get_mode,
     parse_frequency_response,
@@ -33,6 +35,9 @@ from .commands import parse_selected_freq_response as _parse_selected_freq_respo
 from .commands import parse_selected_mode_response as _parse_selected_mode_response
 from .exceptions import CommandError, TimeoutError
 from .types import Mode
+
+# CI-V command byte for VFO select / equal / swap (0x07).
+_CMD_VFO = 0x07
 
 logger = logging.getLogger(__name__)
 
@@ -247,3 +252,90 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         resp = await self._send_civ_expect(civ, label="get_unselected_mode")
         _rcvr, mode, _data_mode, filt = _parse_selected_mode_response(resp)
         return mode, filt
+
+    # ------------------------------------------------------------------
+    # Explicit swap/equalize — MAIN/SUB vs A/B (issue #714)
+    # ------------------------------------------------------------------
+
+    async def swap_main_sub(self) -> None:
+        """Swap MAIN and SUB VFO frequencies. Requires a dual-RX profile."""
+        self._check_connected()
+        if self._profile.receiver_count < 2:
+            raise CommandError(
+                f"swap_main_sub not supported by profile {self._profile.model}: "
+                "not dual-RX"
+            )
+        code = self._profile.swap_main_sub_code
+        if code is None:
+            raise CommandError(
+                f"swap_main_sub not supported by profile {self._profile.model}: "
+                "no swap_main_sub_code"
+            )
+        civ = build_civ_frame(
+            self._radio_addr, CONTROLLER_ADDR, _CMD_VFO, data=bytes([code])
+        )
+        await self._send_civ_raw(civ, wait_response=False)
+
+    async def equalize_main_sub(self) -> None:
+        """Copy MAIN VFO state to SUB. Requires a dual-RX profile."""
+        self._check_connected()
+        if self._profile.receiver_count < 2:
+            raise CommandError(
+                f"equalize_main_sub not supported by profile "
+                f"{self._profile.model}: not dual-RX"
+            )
+        code = self._profile.equal_main_sub_code
+        if code is None:
+            raise CommandError(
+                f"equalize_main_sub not supported by profile "
+                f"{self._profile.model}: no equal_main_sub_code"
+            )
+        civ = build_civ_frame(
+            self._radio_addr, CONTROLLER_ADDR, _CMD_VFO, data=bytes([code])
+        )
+        await self._send_civ_raw(civ, wait_response=False)
+
+    async def swap_vfo_ab(self, receiver: int = 0) -> None:
+        """Swap VFO A and VFO B within ``receiver``.
+
+        On dual-RX profiles the target receiver (MAIN/SUB) is selected
+        first so the swap opcode affects the intended receiver.  On
+        single-RX profiles the swap is issued directly.
+        """
+        self._check_connected()
+        self._require_receiver(receiver, operation="swap_vfo_ab")
+        # On IC-7610-style dual-RX rigs the A/B opcode and the MAIN/SUB
+        # opcode are the same byte (0xB0); if only swap_main_sub_code is
+        # declared in the profile, fall back to it so swap_vfo_ab still
+        # works per the hardware contract.
+        code = self._profile.swap_ab_code or self._profile.swap_main_sub_code
+        if code is None:
+            raise CommandError(
+                f"swap_vfo_ab not supported by profile {self._profile.model}: "
+                "no swap_ab_code"
+            )
+        if self._profile.receiver_count > 1:
+            target = "MAIN" if receiver == RECEIVER_MAIN else "SUB"
+            await self.set_vfo(target)
+        civ = build_civ_frame(
+            self._radio_addr, CONTROLLER_ADDR, _CMD_VFO, data=bytes([code])
+        )
+        await self._send_civ_raw(civ, wait_response=False)
+
+    async def equalize_vfo_ab(self, receiver: int = 0) -> None:
+        """Copy the active VFO's state to the inactive VFO on ``receiver``."""
+        self._check_connected()
+        self._require_receiver(receiver, operation="equalize_vfo_ab")
+        code = self._profile.equal_ab_code or self._profile.equal_main_sub_code
+        if code is None:
+            raise CommandError(
+                f"equalize_vfo_ab not supported by profile {self._profile.model}: "
+                "no equal_ab_code"
+            )
+        if self._profile.receiver_count > 1:
+            target = "MAIN" if receiver == RECEIVER_MAIN else "SUB"
+            await self.set_vfo(target)
+        civ = build_civ_frame(
+            self._radio_addr, CONTROLLER_ADDR, _CMD_VFO, data=bytes([code])
+        )
+        await self._send_civ_raw(civ, wait_response=False)

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -236,8 +236,6 @@ from .commands import (
     set_vox_gain,
     set_xfc_status,
     stop_cw,
-    vfo_a_equals_b,
-    vfo_swap,
 )
 from .commands import (
     get_attenuator as get_attenuator_cmd,  # Transceiver status family (#136); VFO / Dual Watch / Scanning (#132); Tone/TSQL (#134); System/Config commands (#135); Memory and band-stacking (#133)
@@ -2616,16 +2614,44 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._last_vfo = vfo.upper()
 
     async def vfo_equalize(self) -> None:
-        """Copy VFO A to VFO B (A=B)."""
-        self._check_connected()
-        civ = vfo_a_equals_b(to_addr=self._radio_addr)
-        await self._send_civ_raw(civ)
+        """Copy VFO state (deprecated — use ``equalize_main_sub`` or ``equalize_vfo_ab``).
+
+        On dual-RX profiles this delegates to :meth:`equalize_main_sub`; on
+        single-RX profiles it delegates to :meth:`equalize_vfo_ab` with
+        ``receiver=0``.
+        """
+        import warnings
+
+        warnings.warn(
+            "vfo_equalize() is deprecated; use equalize_main_sub() or "
+            "equalize_vfo_ab() explicitly",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self._profile.receiver_count > 1:
+            await self.equalize_main_sub()
+        else:
+            await self.equalize_vfo_ab(0)
 
     async def vfo_exchange(self) -> None:
-        """Swap VFO A and B."""
-        self._check_connected()
-        civ = vfo_swap(to_addr=self._radio_addr)
-        await self._send_civ_raw(civ)
+        """Swap VFO state (deprecated — use ``swap_main_sub`` or ``swap_vfo_ab``).
+
+        On dual-RX profiles this delegates to :meth:`swap_main_sub`; on
+        single-RX profiles it delegates to :meth:`swap_vfo_ab` with
+        ``receiver=0``.
+        """
+        import warnings
+
+        warnings.warn(
+            "vfo_exchange() is deprecated; use swap_main_sub() or "
+            "swap_vfo_ab() explicitly",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self._profile.receiver_count > 1:
+            await self.swap_main_sub()
+        else:
+            await self.swap_vfo_ab(0)
 
     async def set_split_mode(self, on: bool) -> None:
         """Enable or disable split mode."""

--- a/tests/test_vfo_dual_watch.py
+++ b/tests/test_vfo_dual_watch.py
@@ -1,5 +1,8 @@
 """Unit tests for VFO/dual-watch/scanning commands (Issue #132)."""
 
+import warnings
+from unittest.mock import patch
+
 import pytest
 
 from icom_lan import commands
@@ -9,6 +12,8 @@ from icom_lan.commands import (
     parse_bool_response,
     parse_level_response
 )
+from icom_lan.exceptions import CommandError
+from icom_lan.radio import IcomRadio
 from icom_lan.types import CivFrame
 from _command_test_helpers import bind_default_addr_globals
 
@@ -430,3 +435,147 @@ class TestCommandDistinctness:
     def test_scanning_distinct_from_tuning_step(self) -> None:
         """Scanning commands != tuning step commands."""
         assert commands.scan_start() != commands.get_tuning_step()
+
+
+# ---------------------------------------------------------------------------
+# swap_main_sub / swap_vfo_ab distinct methods (Issue #714)
+# ---------------------------------------------------------------------------
+
+
+def _make_radio(model: str) -> IcomRadio:
+    """Build a connected IcomRadio for ``model`` with a recording stub for sends."""
+    r = IcomRadio("127.0.0.1", model=model, timeout=0.05)
+    r._connected = True
+    r._check_connected = lambda: None  # type: ignore[method-assign]
+    return r
+
+
+class _RecordingSend:
+    """Stand-in for ``_send_civ_raw`` that captures CI-V payloads."""
+
+    def __init__(self) -> None:
+        self.frames: list[bytes] = []
+
+    async def __call__(self, civ: bytes, **_: object) -> None:
+        self.frames.append(civ)
+        return None
+
+
+class TestSwapMainSubVsSwapVfoAb:
+    """Issue #714 — distinct MAIN/SUB vs A/B swap/equalize methods."""
+
+    @pytest.mark.asyncio
+    async def test_ic7610_swap_main_sub_sends_0x07_0xb0(self) -> None:
+        r = _make_radio("IC-7610")
+        send = _RecordingSend()
+        with patch.object(r, "_send_civ_raw", send):
+            await r.swap_main_sub()
+        assert len(send.frames) == 1
+        # Frame tail is 07 B0 FD (command + data + terminator)
+        assert send.frames[0].endswith(b"\x07\xb0\xfd")
+
+    @pytest.mark.asyncio
+    async def test_ic7610_equalize_main_sub_sends_0x07_0xb1(self) -> None:
+        r = _make_radio("IC-7610")
+        send = _RecordingSend()
+        with patch.object(r, "_send_civ_raw", send):
+            await r.equalize_main_sub()
+        assert len(send.frames) == 1
+        assert send.frames[0].endswith(b"\x07\xb1\xfd")
+
+    @pytest.mark.asyncio
+    async def test_ic7610_swap_vfo_ab_selects_main_then_swaps(self) -> None:
+        """On dual-RX, swap_vfo_ab(0) first selects MAIN, then sends swap code."""
+        r = _make_radio("IC-7610")
+        set_vfo_calls: list[str] = []
+
+        async def _fake_set_vfo(vfo: str = "A") -> None:
+            set_vfo_calls.append(vfo.upper())
+
+        send = _RecordingSend()
+        with patch.object(r, "set_vfo", _fake_set_vfo), patch.object(
+            r, "_send_civ_raw", send
+        ):
+            await r.swap_vfo_ab(receiver=0)
+
+        assert set_vfo_calls == ["MAIN"]
+        # Falls back to swap_main_sub_code (0xB0) since ic7610.toml declares
+        # only the legacy ``swap`` key which maps to swap_main_sub_code.
+        assert len(send.frames) == 1
+        assert send.frames[0].endswith(b"\x07\xb0\xfd")
+
+    @pytest.mark.asyncio
+    async def test_ic7300_swap_main_sub_raises(self) -> None:
+        """Single-RX profile rejects swap_main_sub with CommandError."""
+        r = _make_radio("IC-7300")
+        with pytest.raises(CommandError, match="not dual-RX"):
+            await r.swap_main_sub()
+
+    @pytest.mark.asyncio
+    async def test_ic7300_equalize_main_sub_raises(self) -> None:
+        r = _make_radio("IC-7300")
+        with pytest.raises(CommandError, match="not dual-RX"):
+            await r.equalize_main_sub()
+
+    @pytest.mark.asyncio
+    async def test_ic7300_swap_vfo_ab_sends_directly(self) -> None:
+        """Single-RX: no receiver select, just the swap opcode."""
+        r = _make_radio("IC-7300")
+        set_vfo_calls: list[str] = []
+
+        async def _fake_set_vfo(vfo: str = "A") -> None:
+            set_vfo_calls.append(vfo.upper())
+
+        send = _RecordingSend()
+        with patch.object(r, "set_vfo", _fake_set_vfo), patch.object(
+            r, "_send_civ_raw", send
+        ):
+            await r.swap_vfo_ab(receiver=0)
+
+        # No receiver-select step on 1-Rx.
+        assert set_vfo_calls == []
+        assert len(send.frames) == 1
+        # IC-7300 profile declares swap_ab_code = 0xB0 via legacy mapping.
+        assert send.frames[0].endswith(b"\x07\xb0\xfd")
+
+    @pytest.mark.asyncio
+    async def test_ic7300_equalize_vfo_ab_sends_0x07_0xa0(self) -> None:
+        r = _make_radio("IC-7300")
+        send = _RecordingSend()
+        with patch.object(r, "_send_civ_raw", send):
+            await r.equalize_vfo_ab(receiver=0)
+        assert len(send.frames) == 1
+        # IC-7300 declares equal = [0xA0] in scheme=ab → equal_ab_code.
+        assert send.frames[0].endswith(b"\x07\xa0\xfd")
+
+    @pytest.mark.asyncio
+    async def test_vfo_exchange_alias_emits_deprecation_warning(self) -> None:
+        r = _make_radio("IC-7610")
+        send = _RecordingSend()
+        with patch.object(r, "_send_civ_raw", send):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                await r.vfo_exchange()
+        # DeprecationWarning raised once, pointing to caller (this test file).
+        dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(dep) == 1
+        assert "vfo_exchange" in str(dep[0].message)
+        assert dep[0].filename.endswith("test_vfo_dual_watch.py")
+        # Still dispatches to swap_main_sub under the hood.
+        assert len(send.frames) == 1
+        assert send.frames[0].endswith(b"\x07\xb0\xfd")
+
+    @pytest.mark.asyncio
+    async def test_vfo_equalize_alias_emits_deprecation_warning(self) -> None:
+        r = _make_radio("IC-7300")
+        send = _RecordingSend()
+        with patch.object(r, "_send_civ_raw", send):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                await r.vfo_equalize()
+        dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(dep) == 1
+        assert "vfo_equalize" in str(dep[0].message)
+        assert dep[0].filename.endswith("test_vfo_dual_watch.py")
+        assert len(send.frames) == 1
+        assert send.frames[0].endswith(b"\x07\xa0\xfd")


### PR DESCRIPTION
Closes #714.

## Summary
- `swap_main_sub()` / `equalize_main_sub()` on dual-RX profiles; raise `CommandError` on 1-Rx.
- `swap_vfo_ab(receiver=0)` / `equalize_vfo_ab(receiver=0)` — select MAIN/SUB first on dual-RX, direct send on 1-Rx.
- `vfo_exchange()` / `vfo_equalize()` retained as `DeprecationWarning` shims (`stacklevel=2` points to caller), dispatching per profile.

## Profile wiring
Uses `swap_ab_code` / `swap_main_sub_code` / `equal_*_code` from #710. For IC-7610 whose legacy TOML declares only the MAIN/SUB code under `swap = [0xB0]`, `swap_vfo_ab` falls back to `swap_main_sub_code` (same wire byte).

## Test plan
- [x] IC-7610: `swap_main_sub()` → `0x07 0xB0`; `equalize_main_sub()` → `0x07 0xB1`; `swap_vfo_ab(0)` → `set_vfo("MAIN")` then `0x07 0xB0`.
- [x] IC-7300: `swap_main_sub()` raises `CommandError("not dual-RX")`; `equalize_main_sub()` same. `swap_vfo_ab(0)` sends `0x07 0xB0` directly; `equalize_vfo_ab(0)` sends `0x07 0xA0`.
- [x] `vfo_exchange()` / `vfo_equalize()` emit `DeprecationWarning` whose `filename` points to the test file (caller), and still drive the correct wire bytes.
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4641 passed, 3 pre-existing failures unrelated (`test_web_server.py::TestAudioHandlerTxTranscoderRate`).
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run mypy src/icom_lan/_dual_rx_runtime.py src/icom_lan/radio.py` — no new errors vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)