### PR TITLE
feat(rigctld): full VFOA/VFOB protocol — route to MAIN/SUB on dual-RX, real slot switch on 1-Rx

### DIFF
--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -610,11 +610,58 @@ class RigctldHandler:
     # VFO commands
     # ------------------------------------------------------------------
 
+    def _profile_vfo_info(self) -> tuple[int, str] | None:
+        """Return (receiver_count, vfo_scheme) when the radio exposes a
+        real profile, else ``None``.
+
+        Safely handles mocked radios: ``AsyncMock.profile`` auto-generates
+        sub-attributes which are not usable integers/strings.
+        """
+        profile = getattr(self._radio, "profile", None)
+        if profile is None:
+            return None
+        rc = getattr(profile, "receiver_count", None)
+        scheme = getattr(profile, "vfo_scheme", None)
+        if isinstance(rc, int) and isinstance(scheme, str):
+            return rc, scheme
+        return None
+
+    def _active_vfo_name(self) -> str:
+        """Return ``"VFOA"`` or ``"VFOB"`` reflecting current radio state.
+
+        Dual-RX: maps ``radio_state.active`` (``MAIN``/``SUB``) → VFOA/VFOB.
+        1-Rx: maps ``radio_state.main.active_slot`` (``A``/``B``) → VFOA/VFOB.
+        Falls back to ``VFOA`` when state is missing or profile is unknown.
+        """
+        info = self._profile_vfo_info()
+        state = self._radio_state()
+        if info is None or state is None:
+            return "VFOA"
+        rc, _ = info
+        if rc >= 2:
+            return "VFOB" if state.active == "SUB" else "VFOA"
+        return "VFOB" if state.main.active_slot == "B" else "VFOA"
+
     async def _cmd_get_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
-        return RigctldResponse(values=["VFOA"])
+        return RigctldResponse(values=[self._active_vfo_name()])
 
     async def _cmd_set_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
-        # Accept any VFO name; single-VFO operation always uses VFOA
+        if not cmd.args:
+            return _err(HamlibError.EINVAL)
+        vfo = cmd.args[0].upper()
+        info = self._profile_vfo_info()
+        # Backwards-compat: unknown VFO names or profile-less radios → no-op
+        if vfo not in ("VFOA", "VFOB") or info is None:
+            return _ok()
+        rc, _ = info
+        set_vfo = getattr(self._radio, "set_vfo", None)
+        if set_vfo is None:
+            return _ok()
+        if rc >= 2:
+            target = "MAIN" if vfo == "VFOA" else "SUB"
+        else:
+            target = "A" if vfo == "VFOA" else "B"
+        await set_vfo(target)
         return _ok()
 
     # ------------------------------------------------------------------
@@ -800,9 +847,27 @@ class RigctldHandler:
     async def _cmd_get_split_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
         state = self._radio_state()
         split = state.split if state is not None else False
-        return RigctldResponse(values=[str(int(split)), "VFOA"])
+        return RigctldResponse(values=[str(int(split)), self._active_vfo_name()])
 
     async def _cmd_set_split_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
+        # Args: <split 0|1> <tx_vfo>
+        if len(cmd.args) < 2:
+            return _ok()
+        try:
+            on = bool(int(cmd.args[0]))
+        except ValueError:
+            return _err(HamlibError.EINVAL)
+        tx_vfo = cmd.args[1].upper()
+        info = self._profile_vfo_info()
+        set_split_mode = getattr(self._radio, "set_split_mode", None)
+        if set_split_mode is not None:
+            await set_split_mode(on)
+        # Dual-RX: when enabling split, ensure TX is routed to the requested
+        # receiver (WSJT-X sends VFOB as the split-TX source).
+        if on and info is not None and info[0] >= 2 and tx_vfo in ("VFOA", "VFOB"):
+            set_vfo = getattr(self._radio, "set_vfo", None)
+            if set_vfo is not None:
+                await set_vfo("SUB" if tx_vfo == "VFOB" else "MAIN")
         return _ok()
 
     # ------------------------------------------------------------------
@@ -834,7 +899,10 @@ class RigctldHandler:
         return RigctldResponse(values=[f"Icom {model} (icom-lan)"])
 
     async def _cmd_chk_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
-        return RigctldResponse(values=["0"])
+        info = self._profile_vfo_info()
+        # Dual-RX profiles advertise VFO-argument support to Hamlib.
+        dual = info is not None and info[0] >= 2
+        return RigctldResponse(values=["1" if dual else "0"])
 
     async def _cmd_get_powerstat(self, cmd: RigctldCommand) -> RigctldResponse:
         return RigctldResponse(values=["1"])

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -2099,3 +2099,199 @@ async def test_icom_dump_state_unchanged(
     resp = await handler.execute(get_cmd("dump_state"))
     assert resp.ok
     assert resp.values[1] == "3078"  # IC-7610 model
+
+
+# ---------------------------------------------------------------------------
+# Profile-aware VFO protocol (issue #722)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProfile:
+    """Minimal stand-in for ``icom_lan.profiles.RadioProfile`` for tests."""
+
+    def __init__(self, *, receiver_count: int, vfo_scheme: str) -> None:
+        self.receiver_count = receiver_count
+        self.vfo_scheme = vfo_scheme
+
+
+@pytest.fixture
+def dual_rx_radio() -> AsyncMock:
+    """IC-7610-style radio mock: dual-RX profile, main/sub VFO scheme."""
+    radio = AsyncMock()
+    radio.capabilities = set(FULL_ICOM_CAPS)
+    radio.profile = _FakeProfile(receiver_count=2, vfo_scheme="main_sub")
+    return radio
+
+
+@pytest.fixture
+def dual_rx_handler(
+    dual_rx_radio: AsyncMock, config: RigctldConfig
+) -> RigctldHandler:
+    return RigctldHandler(dual_rx_radio, config)
+
+
+@pytest.fixture
+def single_rx_radio() -> AsyncMock:
+    """IC-7300-style radio mock: single-RX profile, A/B VFO scheme."""
+    radio = AsyncMock()
+    radio.capabilities = set(FULL_ICOM_CAPS)
+    radio.profile = _FakeProfile(receiver_count=1, vfo_scheme="ab")
+    return radio
+
+
+@pytest.fixture
+def single_rx_handler(
+    single_rx_radio: AsyncMock, config: RigctldConfig
+) -> RigctldHandler:
+    return RigctldHandler(single_rx_radio, config)
+
+
+# -- chk_vfo ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chk_vfo_dual_rx_returns_1(dual_rx_handler: RigctldHandler) -> None:
+    resp = await dual_rx_handler.execute(get_cmd("chk_vfo"))
+    assert resp.ok
+    assert resp.values == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_chk_vfo_single_rx_returns_0(
+    single_rx_handler: RigctldHandler,
+) -> None:
+    resp = await single_rx_handler.execute(get_cmd("chk_vfo"))
+    assert resp.ok
+    assert resp.values == ["0"]
+
+
+# -- get_vfo reflects radio state ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_vfo_dual_rx_main_is_vfoa(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    state = RadioState()
+    state.active = "MAIN"
+    dual_rx_radio.radio_state = state
+    resp = await dual_rx_handler.execute(get_cmd("get_vfo"))
+    assert resp.values == ["VFOA"]
+
+
+@pytest.mark.asyncio
+async def test_get_vfo_dual_rx_sub_is_vfob(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    state = RadioState()
+    state.active = "SUB"
+    dual_rx_radio.radio_state = state
+    resp = await dual_rx_handler.execute(get_cmd("get_vfo"))
+    assert resp.values == ["VFOB"]
+
+
+@pytest.mark.asyncio
+async def test_get_vfo_single_rx_reflects_slot_b(
+    single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+) -> None:
+    state = RadioState()
+    state.main.active_slot = "B"
+    single_rx_radio.radio_state = state
+    resp = await single_rx_handler.execute(get_cmd("get_vfo"))
+    assert resp.values == ["VFOB"]
+
+
+# -- set_vfo sends correct CI-V selection -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_dual_rx_vfob_selects_sub(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    resp = await dual_rx_handler.execute(set_cmd("set_vfo", "VFOB"))
+    assert resp.ok
+    # SUB maps to CI-V 0x07 0xD1 via radio.set_vfo("SUB").
+    dual_rx_radio.set_vfo.assert_awaited_once_with("SUB")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_dual_rx_vfoa_selects_main(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    resp = await dual_rx_handler.execute(set_cmd("set_vfo", "VFOA"))
+    assert resp.ok
+    dual_rx_radio.set_vfo.assert_awaited_once_with("MAIN")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_single_rx_vfob_selects_slot_b(
+    single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+) -> None:
+    resp = await single_rx_handler.execute(set_cmd("set_vfo", "VFOB"))
+    assert resp.ok
+    # "B" maps to CI-V 0x07 0x01 via radio.set_vfo("B").
+    single_rx_radio.set_vfo.assert_awaited_once_with("B")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_single_rx_vfoa_selects_slot_a(
+    single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+) -> None:
+    resp = await single_rx_handler.execute(set_cmd("set_vfo", "VFOA"))
+    assert resp.ok
+    single_rx_radio.set_vfo.assert_awaited_once_with("A")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_unknown_name_is_backward_compat_ok(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    # Unknown VFO names from legacy clients should be silently accepted,
+    # never sent to the radio.
+    resp = await dual_rx_handler.execute(set_cmd("set_vfo", "VFO-C"))
+    assert resp.ok
+    dual_rx_radio.set_vfo.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_no_args_returns_einval(
+    dual_rx_handler: RigctldHandler,
+) -> None:
+    resp = await dual_rx_handler.execute(set_cmd("set_vfo"))
+    assert resp.error == HamlibError.EINVAL
+
+
+# -- set_split_vfo ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_split_vfo_dual_rx_enables_and_routes_to_sub(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    resp = await dual_rx_handler.execute(set_cmd("set_split_vfo", "1", "VFOB"))
+    assert resp.ok
+    dual_rx_radio.set_split_mode.assert_awaited_once_with(True)
+    dual_rx_radio.set_vfo.assert_awaited_once_with("SUB")
+
+
+@pytest.mark.asyncio
+async def test_set_split_vfo_dual_rx_disables_does_not_switch_receiver(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    resp = await dual_rx_handler.execute(set_cmd("set_split_vfo", "0", "VFOA"))
+    assert resp.ok
+    dual_rx_radio.set_split_mode.assert_awaited_once_with(False)
+    dual_rx_radio.set_vfo.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_split_vfo_dual_rx_reflects_active_sub(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    state = RadioState()
+    state.split = True
+    state.active = "SUB"
+    dual_rx_radio.radio_state = state
+    resp = await dual_rx_handler.execute(get_cmd("get_split_vfo"))
+    assert resp.ok
+    assert resp.values == ["1", "VFOB"]


### PR DESCRIPTION
Closes #722. Part of epic #708 (Phase 4.1).

## Summary

Implements the full Hamlib VFO protocol in `rigctld`, profile-aware, so third-party CAT clients (WSJT-X, fldigi, N1MM, DXLog) can drive both receivers correctly instead of silently failing on split-TX.

### Dual-RX profiles (`receiver_count == 2`, e.g. IC-7610)

- `chk_vfo` → `"1"` (advertises VFO-argument support to Hamlib)
- `get_vfo` → reflects `radio_state.active`: `MAIN` → `VFOA`, `SUB` → `VFOB`
- `set_vfo VFOA` → `radio.set_vfo("MAIN")` — CI-V `0x07 0xD0`
- `set_vfo VFOB` → `radio.set_vfo("SUB")` — CI-V `0x07 0xD1`
- `set_split_vfo 1 VFOB` → `set_split_mode(True)` + `set_vfo("SUB")` (routes TX to SUB — the pattern WSJT-X expects for split-on-TX-freq)
- `set_split_vfo 0 VFOA` → `set_split_mode(False)` (no receiver switch)
- `get_split_vfo` → `<split_bool> VFO<A|B>` from active receiver

### 1-Rx profiles (`receiver_count == 1`, e.g. IC-7300)

- `chk_vfo` → `"0"` (unchanged)
- `get_vfo` → reflects `radio_state.main.active_slot` (`A`/`B`) → VFOA/VFOB
- `set_vfo VFOA` → `radio.set_vfo("A")` — slot switch via CI-V `0x07 0x00`
- `set_vfo VFOB` → `radio.set_vfo("B")` — slot switch via CI-V `0x07 0x01`

### Backwards compatibility

- Unknown VFO names (e.g. `VFO-C`) and profile-less/mocked radios still return `RPRT 0` — legacy scripts don't crash.
- `_ok()` fallback preserved.
- All existing handler tests (215 total) continue to pass unchanged.

### dump_state note

`chk_vfo=1` is the canonical protocol-v0 mechanism for advertising VFO-argument support to Hamlib clients. The existing `_IC7610_DUMP_STATE` freq-range entries already include `0xf` (VFO A+B+… bitmask), so no changes to `_IC7610_DUMP_STATE` were needed — VFOB is already implicitly advertised there.

## Files changed

- `src/icom_lan/rigctld/handler.py` — profile-aware `chk_vfo`/`get_vfo`/`set_vfo`/`get_split_vfo`/`set_split_vfo` (+76 LOC)
- `tests/test_rigctld_handler.py` — 12 new tests covering dual-RX, 1-Rx, and backward-compat (+196 LOC)

Guardrails: 2 files, +272 LOC.

## Test plan

- [x] `uv run pytest tests/test_rigctld_handler.py` — 215 passed
- [x] `uv run pytest tests/ --ignore=tests/integration` — 4646 passed (3 pre-existing `test_web_server` TX-transcoder failures unrelated to rigctld, also fail on origin/main)
- [x] `uv run ruff check src/ tests/` — all clean
- [x] `uv run mypy src/` — only pre-existing `types-pyserial` import noise
- [ ] Integration: verify with live WSJT-X split-TX on IC-7610 (tracked by follow-up issue #723)

🤖 Generated with [Claude Code](https://claude.com/claude-code)