### PR TITLE
docs: transceiver/receiver/vfo model in protocol.md + schema

### DIFF
--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -311,6 +311,10 @@ IC-7610 parity matrix (issue #139, 2026-03-06): 134 implemented, 0 partial, 0 mi
   - **Documentation**: docs/AUDIO_STREAMING_PROFILE.md with detailed analysis
   - **Result:** Pipeline is production-ready; no optimizations needed
 
+### Phase 12 — Dual VFO / Dual Receiver architecture overhaul (#708) 🚧 IN PROGRESS
+
+**Goal:** Public `Radio` protocol expresses `Transceiver → Receiver → VFO` unambiguously across IC-7610, IC-9700, IC-7300, IC-705 and FTX-1, with no model-specific branches at call sites. Audit: `.claude/workflow/dual-vfo-audit.md`; architecture: `.claude/architecture/protocol.md` "Receiver tier"; schema: `rigs/_schema_v2.md`. Landed foundation: #709 (`VfoSlotState` + per-receiver `active_slot` on `ReceiverState`), #710 (split TOML `swap_ab`/`equal_ab` vs `swap_main_sub`/`equal_main_sub` with legacy `swap`/`equal` deprecation), #711 (`ReceiverBankCapable` + `VfoSlotCapable` runtime-checkable Protocols), #713 (IC-9700 profile rewritten as `scheme = "main_sub"` with empty `cmd29.routes` per wfview `HasCommand29=false`). Pending: #712 `TransceiverBankCapable` for FTX-1, plus the phase 2–4 backend, frontend and rigctld wiring tracked under epic #708.
+
 ### Reliability Test Expansion (2026-03-05)
 - Added extended integration coverage scaffolding for:
   - transport sequence wrap-around and ACK mixed stress,

--- a/rigs/_schema_v2.md
+++ b/rigs/_schema_v2.md
@@ -231,21 +231,66 @@ unit = "dBFS"
 
 ## VFO Schemes
 
+The public contract models a radio as `Transceiver → Receiver → VFO` (see
+`.claude/architecture/protocol.md` "Receiver tier"). The TOML `[vfo]` block
+declares how per-receiver and per-slot operations are routed on the wire.
+
 | Scheme | Receivers | VFOs | Radios |
 |--------|-----------|------|--------|
-| `main_sub` | 2 | 2 | IC-7610 (MAIN/SUB, cmd29) |
-| `ab` | 1 | 2 | IC-7300, TX-500 (A/B, select+send) |
+| `main_sub` | 2 | 2 (A/B each) | IC-7610 (cmd29), IC-9700 (receiver-select only) |
+| `ab` | 1 | 2 | IC-7300, IC-705, TX-500 (A/B, select+send) |
 | `ab_shared` | 2 | 1 | FTX-1 (2 rx share VFO set) |
 | `single` | 1 | 1 | RSPdx (SDR, tuner only) |
+
+### Fields
+
+Parsed by `src/icom_lan/rig_loader.py:575-605` into
+`RadioProfile` (`src/icom_lan/profiles.py:150-198`). Landed in #710.
+
+| Field | Type | Example | When required |
+|-------|------|---------|---------------|
+| `scheme` | `str` | `"main_sub"`, `"ab"`, `"ab_shared"`, `"single"` | always |
+| `main_select` | `list[int]` (CI-V bytes) | `[0xD0]` | `scheme = "main_sub"` |
+| `sub_select`  | `list[int]` | `[0xD1]` | `scheme = "main_sub"` |
+| `swap_main_sub`  | `list[int]` | `[0xB0]` | dual-RX rigs that support MAIN↔SUB swap |
+| `equal_main_sub` | `list[int]` | `[0xB1]` | dual-RX rigs that support MAIN=SUB equalize |
+| `swap_ab`  | `list[int]` | `[0xB0]` (single byte) or `[0x07, 0xB0]` | rigs with per-receiver VFO A↔B swap |
+| `equal_ab` | `list[int]` | `[0xA0]` or `[0x07, 0xA0]` | rigs with per-receiver VFO A=B equalize |
+
+### Example — dual-RX (IC-7610 / IC-9700 pattern)
 
 ```toml
 [vfo]
 scheme = "main_sub"
-main_select = [0xD0]    # CI-V specific
-sub_select = [0xD1]
-swap = [0xB0]
-equal = [0xB1]
+main_select   = [0xD0]
+sub_select    = [0xD1]
+swap_main_sub = [0xB0]   # MAIN ↔ SUB
+equal_main_sub = [0xB1]  # MAIN = SUB
+# A/B within the currently-selected receiver (optional, add when wiring VfoSlotCapable):
+# swap_ab  = [0x07, 0xB0]
+# equal_ab = [0x07, 0xA0]
 ```
+
+### Example — single-RX (IC-7300 / IC-705 pattern)
+
+```toml
+[vfo]
+scheme = "ab"
+swap_ab  = [0xB0]   # VFO A ↔ B
+equal_ab = [0xA0]   # VFO A = B
+```
+
+### Deprecated legacy keys
+
+The flat keys `swap` and `equal` conflate MAIN↔SUB with VFO A↔B — the same
+`0xB0` byte means different things depending on `scheme`.  They are still
+accepted:
+
+- When `scheme = "main_sub"`: `swap` → `swap_main_sub`, `equal` → `equal_main_sub`.
+- Otherwise: `swap` → `swap_ab`, `equal` → `equal_ab`.
+
+Loading a rig that uses them emits a `DeprecationWarning` once per file
+(`src/icom_lan/rig_loader.py:600-606`). Migrate to the explicit keys.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the `Transceiver → Receiver → VFO` hierarchy landed by the foundation PRs of epic #708:

- **`rigs/_schema_v2.md`** — document the new `[vfo]` fields `swap_main_sub` / `equal_main_sub` / `swap_ab` / `equal_ab` with types, examples and per-scheme required conditions. Cite `rig_loader.py:575-605` and `profiles.py:150-198`. Mark legacy `vfo.swap` / `vfo.equal` as deprecated (still accepted, emit a single `DeprecationWarning` per rig load via `rig_loader.py:600-606`). Add IC-9700 and IC-705 to the scheme table.
- **`docs/PROJECT.md`** — add a Phase 12 milestone entry for epic #708 listing landed PRs (#709 `VfoSlotState`, #710 split `vfo_scheme`, #711 `ReceiverBankCapable` + `VfoSlotCapable`, #713 IC-9700 profile fix) and remaining phase 2–4 work.

The internal doc `.claude/architecture/protocol.md` ("Receiver tier" section, landed separately) already carries the protocol-level hierarchy, per-model mapping and cross-reference for IC-9700 cmd29-absence. That file is outside `git` (`.gitignore:37`) so is not part of this PR.

Forward-looking fields called out in the issue brief but **not landed yet** (`vfo.vfo_a_select`, `vfo.vfo_b_select`, `radio.transceiver_count`) were deliberately omitted to keep the docs facts-only; they can be added once #712 and the A/B-select wiring land.

Closes #724

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mkdocs build --strict` — clean build
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4632 passed; the 3 pre-existing `test_web_server.py::TestAudioHandlerTxTranscoderRate` failures reproduce on `origin/main` and are unrelated to this docs-only change
- [ ] Visual review of rendered `rigs/_schema_v2.md` and `docs/PROJECT.md` on the MkDocs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)