### PR TITLE
feat(backend/ftx1): TransceiverBankCapable + tx_source wiring

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -7,6 +7,7 @@
 id = "yaesu_ftx1"
 model = "FTX-1"
 receiver_count = 2
+transceiver_count = 2
 has_lan = false
 has_wifi = false
 default_baud = 38400

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -960,6 +960,39 @@ class YaesuCatRadio:
         """Set TX function (0 = MAIN, 1 = SUB)."""
         await self._write("set_tx_func", vfo=str(vfo))
 
+    # -- TransceiverBankCapable --------------------------------------------
+
+    @property
+    def transceiver_count(self) -> int:
+        """Number of independent transceivers exposed by this rig.
+
+        FTX-1 is wired as two independent transceivers (HF+50 MHz and
+        144+430 MHz) sharing a single control head; other Yaesu CAT rigs
+        are single-transceiver.
+        """
+        return 2 if self._config.id == "yaesu_ftx1" else 1
+
+    async def set_tx_source(self, xcvr: int) -> None:
+        """Make ``xcvr`` the active TX transceiver (FTX-1 ``FT`` command).
+
+        Args:
+            xcvr: 0 = MAIN-side transmitter, 1 = SUB-side transmitter.
+        """
+        if xcvr not in (0, 1):
+            raise ValueError(
+                f"xcvr must be 0 or 1, got {xcvr!r} "
+                f"(transceiver_count={self.transceiver_count})"
+            )
+        await self._write("set_tx_func", vfo=str(xcvr))
+
+    async def get_tx_source(self) -> int:
+        """Return the 0-based index of the currently active TX transceiver.
+
+        Parses ``FT0;`` / ``FT1;`` from the radio (``FT`` command).
+        """
+        result = await self._query("get_tx_func")
+        return int(result["vfo"])
+
     async def get_split(self) -> bool:
         """Get split operation state."""
         result = await self._query("get_split")

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -592,6 +592,64 @@ async def test_get_tx_func(connected_radio):
     connected_radio._transport.query.assert_called_once_with("FT;")
 
 
+# ---------------------------------------------------------------------------
+# TransceiverBankCapable (FT command / tx_source)
+# ---------------------------------------------------------------------------
+
+
+def test_transceiver_count_ftx1(radio):
+    """FTX-1 exposes two independent transceivers (HF+50, 144+430)."""
+    assert radio.transceiver_count == 2
+
+
+def test_transceiver_count_non_ftx1(radio):
+    """Non-FTX-1 Yaesu CAT rigs default to a single transceiver."""
+    # FTX-1 is currently the only Yaesu CAT profile in-tree; simulate a
+    # non-FTX-1 rig by swapping the loaded config id.
+    object.__setattr__(radio._config, "id", "yaesu_other")
+    assert radio.transceiver_count == 1
+
+
+@pytest.mark.asyncio
+async def test_set_tx_source_main(connected_radio):
+    """set_tx_source(0) writes FT0; (MAIN-side transmitter)."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_tx_source(0)
+    connected_radio._transport.write.assert_called_once_with("FT0;")
+
+
+@pytest.mark.asyncio
+async def test_set_tx_source_sub(connected_radio):
+    """set_tx_source(1) writes FT1; (SUB-side transmitter)."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_tx_source(1)
+    connected_radio._transport.write.assert_called_once_with("FT1;")
+
+
+@pytest.mark.asyncio
+async def test_set_tx_source_rejects_out_of_range(connected_radio):
+    """set_tx_source rejects xcvr values other than 0 or 1."""
+    connected_radio._transport.write = AsyncMock()
+    with pytest.raises(ValueError):
+        await connected_radio.set_tx_source(2)
+    connected_radio._transport.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_tx_source_sub(connected_radio):
+    """get_tx_source parses FT1; and returns 1 (SUB-side active)."""
+    connected_radio._transport.query = AsyncMock(return_value="FT1")
+    assert await connected_radio.get_tx_source() == 1
+    connected_radio._transport.query.assert_called_once_with("FT;")
+
+
+@pytest.mark.asyncio
+async def test_get_tx_source_main(connected_radio):
+    """get_tx_source parses FT0; and returns 0 (MAIN-side active)."""
+    connected_radio._transport.query = AsyncMock(return_value="FT0")
+    assert await connected_radio.get_tx_source() == 0
+
+
 @pytest.mark.asyncio
 async def test_get_vfo_select(connected_radio):
     connected_radio._transport.query = AsyncMock(return_value="VS0")


### PR DESCRIPTION
## Summary

- Implement `TransceiverBankCapable` on `YaesuCatRadio`: `transceiver_count` property, `set_tx_source(xcvr)`, `get_tx_source()`.
- FTX-1 is two independent transceivers (HF+50 MHz / 144+430 MHz) sharing one control head; the Yaesu CAT `FT` command selects the TX chain (`FT0;` = MAIN-side transmitter, `FT1;` = SUB-side transmitter per FTX-1 CAT manual p.16).
- Declare `transceiver_count = 2` under `[radio]` in `rigs/ftx1.toml`.
- New methods delegate to the existing `FT` CAT command spec (no new TOML commands), with explicit range validation on `set_tx_source`.

## Test plan

- [x] `uv run pytest tests/test_ftx1_radio.py -q --tb=short` — 168 passed (7 new cases)
- [x] `uv run pytest tests/test_yaesu_cat*.py -q --tb=short` — 83 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] Full suite excluding integration: only 3 pre-existing `TestAudioHandlerTxTranscoderRate` failures (unrelated to this change, reproduce on `main`)

New tests:
- `test_transceiver_count_ftx1` — FTX-1 reports 2
- `test_transceiver_count_non_ftx1` — other Yaesu profiles default to 1
- `test_set_tx_source_main` / `test_set_tx_source_sub` — wire format `FT0;` / `FT1;`
- `test_set_tx_source_rejects_out_of_range` — `ValueError` on `xcvr ∉ {0,1}`
- `test_get_tx_source_main` / `test_get_tx_source_sub` — parse `FT0;` / `FT1;`

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)