### PR TITLE
fix(ui): DualVfoDisplay — dedicated activate button resolves WCAG 4.1.2

### DIFF
--- a/frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte
+++ b/frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte
@@ -1,10 +1,12 @@
 <!--
   DualVfoDisplay — side-by-side MAIN + SUB VFO tiles for dual-RX radios.
 
-  Presentation-only: renders two VfoPanel tiles wrapped in keyboard/a11y
-  containers. The active tile is visually highlighted and announced via
-  aria-pressed. Clicking or pressing Enter/Space on an inactive tile fires
-  the onActivate callback with the receiver id.
+  Presentation-only: renders two VfoPanel tiles. The active tile is visually
+  highlighted via the `.is-active` class. The inactive tile exposes a small
+  dedicated "Activate" button so screen-reader / keyboard users can switch
+  receivers without the tile container becoming a button that swallows its
+  interactive descendants (tuning digits, mode badge) — which would violate
+  WCAG 4.1.2 (no nested interactive content inside role="button").
 
   Wiring (set_vfo + optimistic patchRadioState) lives at the VfoHeader
   call-site.
@@ -42,26 +44,13 @@
     if (active === receiver) return;
     onActivate?.(receiver);
   }
-
-  function handleKeydown(event: KeyboardEvent, receiver: 'MAIN' | 'SUB'): void {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      activate(receiver);
-    }
-  }
 </script>
 
 <div
   class="dual-vfo-tile vfo-main-panel"
   class:is-active={active === 'MAIN'}
-  role="button"
-  tabindex="0"
-  aria-pressed={active === 'MAIN'}
-  aria-label={active === 'MAIN' ? 'MAIN receiver (active)' : 'Activate MAIN receiver'}
   data-receiver="main"
   data-layout-profile={layoutProfile}
-  onclick={() => activate('MAIN')}
-  onkeydown={(e) => handleKeydown(e, 'MAIN')}
 >
   <VfoPanel
     {...main}
@@ -69,19 +58,24 @@
     onModeClick={onMainModeClick}
     onFreqChange={onMainFreqChange}
   />
+  {#if active !== 'MAIN'}
+    <button
+      type="button"
+      class="activate-chip"
+      aria-label="Activate MAIN receiver"
+      data-activate="main"
+      onclick={() => activate('MAIN')}
+    >
+      Activate MAIN
+    </button>
+  {/if}
 </div>
 
 <div
   class="dual-vfo-tile vfo-sub-panel"
   class:is-active={active === 'SUB'}
-  role="button"
-  tabindex="0"
-  aria-pressed={active === 'SUB'}
-  aria-label={active === 'SUB' ? 'SUB receiver (active)' : 'Activate SUB receiver'}
   data-receiver="sub"
   data-layout-profile={layoutProfile}
-  onclick={() => activate('SUB')}
-  onkeydown={(e) => handleKeydown(e, 'SUB')}
 >
   <VfoPanel
     {...sub}
@@ -89,25 +83,63 @@
     onModeClick={onSubModeClick}
     onFreqChange={onSubFreqChange}
   />
+  {#if active !== 'SUB'}
+    <button
+      type="button"
+      class="activate-chip"
+      aria-label="Activate SUB receiver"
+      data-activate="sub"
+      onclick={() => activate('SUB')}
+    >
+      Activate SUB
+    </button>
+  {/if}
 </div>
 
 <style>
   .dual-vfo-tile {
     min-width: 0;
     display: block;
-    cursor: pointer;
+    position: relative;
     border-radius: 4px;
-    outline: none;
     transition: box-shadow 150ms ease;
-  }
-
-  .dual-vfo-tile:focus-visible {
-    box-shadow: 0 0 0 2px var(--v2-accent-cyan, #00d4ff);
   }
 
   .dual-vfo-tile.is-active {
     /* Active highlight is rendered by the inner VfoPanel.active class.
        This selector exists so tests and external CSS can target the
        outer tile without reaching into the panel. */
+  }
+
+  .activate-chip {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    z-index: 2;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--v2-accent-cyan, #00d4ff);
+    background: rgba(0, 0, 0, 0.55);
+    border: 1px solid var(--v2-accent-cyan, #00d4ff);
+    border-radius: 999px;
+    cursor: pointer;
+    opacity: 0.75;
+    transition:
+      opacity 150ms ease,
+      background-color 150ms ease;
+  }
+
+  .activate-chip:hover {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.75);
+  }
+
+  .activate-chip:focus-visible {
+    outline: none;
+    opacity: 1;
+    box-shadow: 0 0 0 2px var(--v2-accent-cyan, #00d4ff);
   }
 </style>

--- a/frontend/src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts
+++ b/frontend/src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts
@@ -76,19 +76,13 @@ describe('DualVfoDisplay', () => {
       expect(t.querySelector('[data-receiver="sub"]')).not.toBeNull();
     });
 
-    it('both tiles are keyboard focusable (tabindex=0)', () => {
-      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
-      const tiles = t.querySelectorAll<HTMLElement>('.dual-vfo-tile');
-      tiles.forEach((tile) => {
-        expect(tile.getAttribute('tabindex')).toBe('0');
-      });
-    });
-
-    it('both tiles have role=button', () => {
+    it('outer tiles are NOT role="button" (WCAG 4.1.2 — no nested interactive content)', () => {
       const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
       const tiles = t.querySelectorAll('.dual-vfo-tile');
       tiles.forEach((tile) => {
-        expect(tile.getAttribute('role')).toBe('button');
+        expect(tile.getAttribute('role')).toBeNull();
+        expect(tile.getAttribute('tabindex')).toBeNull();
+        expect(tile.getAttribute('aria-pressed')).toBeNull();
       });
     });
   });
@@ -113,34 +107,52 @@ describe('DualVfoDisplay', () => {
       expect(mainTile?.classList.contains('is-active')).toBe(false);
       expect(subTile?.classList.contains('is-active')).toBe(true);
     });
+  });
 
-    it('aria-pressed reflects active receiver (MAIN)', () => {
+  describe('activate button', () => {
+    it('inactive tile renders an activate button (SUB inactive)', () => {
       const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
-      expect(t.querySelector('[data-receiver="main"]')?.getAttribute('aria-pressed')).toBe('true');
-      expect(t.querySelector('[data-receiver="sub"]')?.getAttribute('aria-pressed')).toBe('false');
+      expect(t.querySelector('button[data-activate="sub"]')).not.toBeNull();
+      expect(t.querySelector('button[data-activate="main"]')).toBeNull();
     });
 
-    it('aria-pressed reflects active receiver (SUB)', () => {
+    it('inactive tile renders an activate button (MAIN inactive)', () => {
       const t = mountDisplay({
         main: { ...mainVfo, isActive: false },
         sub: { ...subVfo, isActive: true },
         active: 'SUB',
       });
-      expect(t.querySelector('[data-receiver="main"]')?.getAttribute('aria-pressed')).toBe('false');
-      expect(t.querySelector('[data-receiver="sub"]')?.getAttribute('aria-pressed')).toBe('true');
+      expect(t.querySelector('button[data-activate="main"]')).not.toBeNull();
+      expect(t.querySelector('button[data-activate="sub"]')).toBeNull();
+    });
+
+    it('activate button has descriptive aria-label', () => {
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
+      const btn = t.querySelector<HTMLButtonElement>('button[data-activate="sub"]');
+      expect(btn?.getAttribute('aria-label')).toBe('Activate SUB receiver');
+    });
+
+    it('activate button is a native <button> and keyboard-focusable by default', () => {
+      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
+      const btn = t.querySelector<HTMLButtonElement>('button[data-activate="sub"]');
+      expect(btn).not.toBeNull();
+      expect(btn?.tagName).toBe('BUTTON');
+      expect(btn?.getAttribute('type')).toBe('button');
+      // Native <button> is focusable without explicit tabindex.
+      expect(btn?.hasAttribute('disabled')).toBe(false);
     });
   });
 
   describe('onActivate callback', () => {
-    it('clicking inactive tile fires onActivate with the receiver id (SUB)', () => {
+    it('clicking activate button fires onActivate with the receiver id (SUB)', () => {
       const onActivate = vi.fn();
       const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
-      t.querySelector<HTMLElement>('[data-receiver="sub"]')?.click();
+      t.querySelector<HTMLButtonElement>('button[data-activate="sub"]')?.click();
       expect(onActivate).toHaveBeenCalledOnce();
       expect(onActivate).toHaveBeenCalledWith('SUB');
     });
 
-    it('clicking inactive tile fires onActivate with the receiver id (MAIN)', () => {
+    it('clicking activate button fires onActivate with the receiver id (MAIN)', () => {
       const onActivate = vi.fn();
       const t = mountDisplay({
         main: { ...mainVfo, isActive: false },
@@ -148,40 +160,28 @@ describe('DualVfoDisplay', () => {
         active: 'SUB',
         onActivate,
       });
-      t.querySelector<HTMLElement>('[data-receiver="main"]')?.click();
+      t.querySelector<HTMLButtonElement>('button[data-activate="main"]')?.click();
       expect(onActivate).toHaveBeenCalledOnce();
       expect(onActivate).toHaveBeenCalledWith('MAIN');
     });
 
-    it('clicking already-active tile does NOT fire onActivate', () => {
+    it('active tile does not render an activate button', () => {
       const onActivate = vi.fn();
       const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
-      t.querySelector<HTMLElement>('[data-receiver="main"]')?.click();
+      // No button on the active (MAIN) tile — nothing to click.
+      expect(t.querySelector('button[data-activate="main"]')).toBeNull();
       expect(onActivate).not.toHaveBeenCalled();
     });
 
-    it('Enter key on inactive tile fires onActivate', () => {
+    it('clicking the outer tile does NOT fire onActivate', () => {
+      // Outer tile is no longer interactive — only the activate button inside it is.
       const onActivate = vi.fn();
       const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
-      const tile = t.querySelector<HTMLElement>('[data-receiver="sub"]');
-      tile?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-      expect(onActivate).toHaveBeenCalledWith('SUB');
-    });
-
-    it('Space key on inactive tile fires onActivate', () => {
-      const onActivate = vi.fn();
-      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
-      const tile = t.querySelector<HTMLElement>('[data-receiver="sub"]');
-      tile?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
-      expect(onActivate).toHaveBeenCalledWith('SUB');
-    });
-
-    it('other keys do not fire onActivate', () => {
-      const onActivate = vi.fn();
-      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
-      const tile = t.querySelector<HTMLElement>('[data-receiver="sub"]');
-      tile?.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
-      expect(onActivate).not.toHaveBeenCalled();
+      const subTile = t.querySelector<HTMLElement>('[data-receiver="sub"]');
+      subTile?.click();
+      // The click bubbles from the tile itself (not the inner button), so no activation.
+      // Note: if the click originated on the button, it would fire — but that's covered above.
+      expect(onActivate).not.toHaveBeenCalledWith('MAIN');
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves a **P1 a11y finding** from the post-review audit of epic #708 (Web UI audit).

`DualVfoDisplay.svelte` previously marked each MAIN/SUB tile as `role="button"` + `tabindex="0"` with an `onclick` handler, wrapping `VfoPanel`'s interactive descendants (tuning digits inside `FrequencyDisplayInteractive`, mode badge button, etc.). This violates **WCAG 4.1.2 (Name, Role, Value)** and the ARIA `role="button"` contract, which forbid interactive descendants. NVDA and VoiceOver flatten the entire tile — frequency digits, mode, S-meter, badges — into the label of a single button, making the inner controls inaccessible to screen-reader users.

### Fix

- Remove `role="button"`, `tabindex="0"`, `aria-pressed`, `onclick`, `onkeydown` from the outer tile `<div>`.
- Introduce a dedicated **activate chip** — a small pill-shaped `<button type="button">` in the top-right corner of each tile, rendered only when that tile is **not** the active receiver. Label: `"Activate MAIN receiver"` / `"Activate SUB receiver"`.
- Native `<button>` is keyboard-focusable out of the box; Space/Enter are handled by the browser.
- The `is-active` visual highlight on the outer tile is preserved (border / inner `VfoPanel.active` styling untouched).
- Tuning digits and the mode badge inside `VfoPanel` remain fully interactive and individually reachable by AT.

### Files changed

- `frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte`
- `frontend/src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts`

## Test plan

- [x] `npx vitest run src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts` — 13/13 pass
- [x] `npx vitest run` — 1504/1504 pass (81 files)
- [x] `npm run build` — clean production build
- [x] Sanity: `rg 'role="button"' frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte` — only a doc comment referencing the prior violation remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)