### PR TITLE
fix: rig_loader parses transceiver_count from [radio] section

### DIFF
--- a/src/icom_lan/rig_loader.py
+++ b/src/icom_lan/rig_loader.py
@@ -97,6 +97,7 @@ class RigConfig:
     keyboard: KeyboardConfig | None = None
     antenna_tx_count: int = 1
     antenna_has_rx_ant: bool = False
+    transceiver_count: int = 1
     scope_ref_min_db: float | None = None
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None
@@ -166,6 +167,7 @@ class RigConfig:
             rules=self.rules,
             keyboard=self.keyboard,
             antenna_tx_count=self.antenna_tx_count,
+            transceiver_count=self.transceiver_count,
             scope_ref_min_db=self.scope_ref_min_db,
             scope_ref_max_db=self.scope_ref_max_db,
             scope_ref_step_db=self.scope_ref_step_db,
@@ -735,6 +737,7 @@ def load_rig(path: Path) -> RigConfig:
         model=radio["model"],
         civ_addr=civ_addr,
         receiver_count=radio["receiver_count"],
+        transceiver_count=int(radio.get("transceiver_count", 1)),
         has_lan=radio["has_lan"],
         has_wifi=radio["has_wifi"],
         default_baud=radio.get("default_baud", 19200),

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -224,6 +224,17 @@ class TestToProfile:
         profile = load_rig(TEMPLATE_PATH).to_profile()
         assert profile.receiver_count == 2
 
+    def test_transceiver_count_default(self):
+        """IC-7610 has no [radio].transceiver_count → defaults to 1."""
+        profile = load_rig(TEMPLATE_PATH).to_profile()
+        assert profile.transceiver_count == 1
+
+    def test_transceiver_count_ftx1(self):
+        """FTX-1 declares transceiver_count = 2 → must propagate to profile."""
+        ftx1_path = RIGS_DIR / "ftx1.toml"
+        profile = load_rig(ftx1_path).to_profile()
+        assert profile.transceiver_count == 2
+
     def test_capabilities_frozenset(self):
         profile = load_rig(TEMPLATE_PATH).to_profile()
         assert isinstance(profile.capabilities, frozenset)


### PR DESCRIPTION
## Summary

Addresses code-review finding on #737 — the profile field was wired to `RadioProfile` but not parsed from TOML.

PR #737 added `transceiver_count: int = 1` to `RadioProfile`, and `rigs/ftx1.toml` declares `transceiver_count = 2`, but `RigConfig` had no such field and `to_profile()` never passed it through. Every radio — including FTX-1 — silently received `transceiver_count = 1` at runtime.

- Add `transceiver_count: int = 1` field to `RigConfig` dataclass
- Parse `radio.get("transceiver_count", 1)` in `load_rig()` (mirrors `default_baud` pattern; kept optional for backward compatibility with single-transceiver rigs)
- Pass it through in `RigConfig.to_profile()` to `RadioProfile`
- Add two tests in `tests/test_rig_loader.py::TestToProfile`: IC-7610 (no TOML key) defaults to 1; FTX-1 propagates 2

## Test plan

- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run pytest tests/test_rig_loader.py` — 49 passed
- [x] Smoke: `resolve_radio_profile(model='FTX-1').transceiver_count == 2`, `model='IC-7610' == 1`
- [x] Full suite: 4675 passed (3 pre-existing `TestAudioHandlerTxTranscoderRate` failures on `origin/main`, unrelated)

Refs: #737

Generated with [Claude Code](https://claude.com/claude-code)