### PR TITLE
fix: post-review P1 findings — swap_vfo_ab safety + rigctld split rollback

### DIFF
--- a/src/icom_lan/_dual_rx_runtime.py
+++ b/src/icom_lan/_dual_rx_runtime.py
@@ -301,18 +301,22 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         On dual-RX profiles the target receiver (MAIN/SUB) is selected
         first so the swap opcode affects the intended receiver.  On
         single-RX profiles the swap is issued directly.
+
+        Raises ``CommandError`` when the profile does not declare a
+        dedicated ``swap_ab_code``.  We do NOT silently fall back to
+        ``swap_main_sub_code`` because on IC-7610 / IC-9700 that opcode
+        exchanges MAIN↔SUB — a different semantic than A↔B within a
+        single receiver.  Callers wanting MAIN↔SUB must use
+        ``swap_main_sub()`` explicitly.
         """
         self._check_connected()
         self._require_receiver(receiver, operation="swap_vfo_ab")
-        # On IC-7610-style dual-RX rigs the A/B opcode and the MAIN/SUB
-        # opcode are the same byte (0xB0); if only swap_main_sub_code is
-        # declared in the profile, fall back to it so swap_vfo_ab still
-        # works per the hardware contract.
-        code = self._profile.swap_ab_code or self._profile.swap_main_sub_code
+        code = self._profile.swap_ab_code
         if code is None:
             raise CommandError(
-                f"swap_vfo_ab not supported by profile {self._profile.model}: "
-                "no swap_ab_code"
+                f"swap_vfo_ab not supported by {self._profile.model}: "
+                "profile declares no swap_ab_code. "
+                "For MAIN↔SUB exchange use swap_main_sub()."
             )
         if self._profile.receiver_count > 1:
             target = "MAIN" if receiver == RECEIVER_MAIN else "SUB"
@@ -323,14 +327,21 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         await self._send_civ_raw(civ, wait_response=False)
 
     async def equalize_vfo_ab(self, receiver: int = 0) -> None:
-        """Copy the active VFO's state to the inactive VFO on ``receiver``."""
+        """Copy the active VFO's state to the inactive VFO on ``receiver``.
+
+        Raises ``CommandError`` when the profile does not declare a
+        dedicated ``equal_ab_code``.  We do NOT silently fall back to
+        ``equal_main_sub_code``: on dual-RX rigs that opcode copies
+        MAIN→SUB, not A→B within a receiver.
+        """
         self._check_connected()
         self._require_receiver(receiver, operation="equalize_vfo_ab")
-        code = self._profile.equal_ab_code or self._profile.equal_main_sub_code
+        code = self._profile.equal_ab_code
         if code is None:
             raise CommandError(
-                f"equalize_vfo_ab not supported by profile {self._profile.model}: "
-                "no equal_ab_code"
+                f"equalize_vfo_ab not supported by {self._profile.model}: "
+                "profile declares no equal_ab_code. "
+                "For MAIN→SUB copy use equalize_main_sub()."
             )
         if self._profile.receiver_count > 1:
             target = "MAIN" if receiver == RECEIVER_MAIN else "SUB"

--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -863,12 +863,63 @@ class RigctldHandler:
         if set_split_mode is not None:
             await set_split_mode(on)
         # Dual-RX: when enabling split, ensure TX is routed to the requested
-        # receiver (WSJT-X sends VFOB as the split-TX source).
+        # receiver (WSJT-X sends VFOB as the split-TX source).  If the
+        # receiver-select call fails we must roll back the split-enable —
+        # otherwise the radio is left in a half-configured state (split on
+        # but TX not routed to SUB), silently diverging from WSJT-X's
+        # expectations.
         if on and info is not None and info[0] >= 2 and tx_vfo in ("VFOA", "VFOB"):
             set_vfo = getattr(self._radio, "set_vfo", None)
             if set_vfo is not None:
-                await set_vfo("SUB" if tx_vfo == "VFOB" else "MAIN")
+                target = "SUB" if tx_vfo == "VFOB" else "MAIN"
+                try:
+                    await set_vfo(target)
+                except ConnectionError as exc:
+                    logger.warning(
+                        "set_split_vfo: set_vfo(%s) failed with "
+                        "ConnectionError (%s); rolling back split",
+                        target,
+                        exc,
+                    )
+                    await self._rollback_split(set_split_mode)
+                    return _err(HamlibError.EIO)
+                except TimeoutError as exc:
+                    logger.warning(
+                        "set_split_vfo: set_vfo(%s) timed out (%s); "
+                        "rolling back split",
+                        target,
+                        exc,
+                    )
+                    await self._rollback_split(set_split_mode)
+                    return _err(HamlibError.ETIMEOUT)
+                except Exception:
+                    logger.exception(
+                        "set_split_vfo: set_vfo(%s) failed unexpectedly; "
+                        "rolling back split",
+                        target,
+                    )
+                    await self._rollback_split(set_split_mode)
+                    return _err(HamlibError.EINTERNAL)
         return _ok()
+
+    async def _rollback_split(self, set_split_mode: Any) -> None:
+        """Best-effort rollback: disable split that was just enabled.
+
+        Called when the follow-up ``set_vfo`` in ``set_split_vfo`` fails,
+        so the radio does not end up with split-enabled but TX not
+        routed to SUB.  Rollback errors are logged and swallowed — the
+        original failure takes precedence in the response.
+        """
+        if set_split_mode is None:
+            return
+        try:
+            await set_split_mode(False)
+            logger.info("set_split_vfo: rollback disabled split successfully")
+        except Exception:
+            logger.exception(
+                "set_split_vfo: rollback set_split_mode(False) also failed; "
+                "radio may be in inconsistent state"
+            )
 
     # ------------------------------------------------------------------
     # RIT

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -2285,6 +2285,79 @@ async def test_set_split_vfo_dual_rx_disables_does_not_switch_receiver(
 
 
 @pytest.mark.asyncio
+async def test_set_split_vfo_rolls_back_split_on_set_vfo_connection_error(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    """If set_vfo fails with ConnectionError after set_split_mode(True),
+    the handler must roll back by calling set_split_mode(False) and
+    return EIO — never leaving the radio in split-on / TX-not-routed."""
+    dual_rx_radio.set_vfo.side_effect = IcomConnectionError("lost")
+
+    resp = await dual_rx_handler.execute(set_cmd("set_split_vfo", "1", "VFOB"))
+
+    assert resp.error == HamlibError.EIO
+    # Two calls: first to enable split, then rollback to disable.
+    assert dual_rx_radio.set_split_mode.await_args_list == [
+        ((True,), {}),
+        ((False,), {}),
+    ]
+    dual_rx_radio.set_vfo.assert_awaited_once_with("SUB")
+
+
+@pytest.mark.asyncio
+async def test_set_split_vfo_rolls_back_split_on_set_vfo_timeout(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    """TimeoutError on the follow-up set_vfo → rollback + ETIMEOUT."""
+    dual_rx_radio.set_vfo.side_effect = IcomTimeoutError("timeout")
+
+    resp = await dual_rx_handler.execute(set_cmd("set_split_vfo", "1", "VFOB"))
+
+    assert resp.error == HamlibError.ETIMEOUT
+    assert dual_rx_radio.set_split_mode.await_args_list == [
+        ((True,), {}),
+        ((False,), {}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_set_split_vfo_rolls_back_split_on_unexpected_error(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    """Unexpected exception → rollback + EINTERNAL."""
+    dual_rx_radio.set_vfo.side_effect = RuntimeError("boom")
+
+    resp = await dual_rx_handler.execute(set_cmd("set_split_vfo", "1", "VFOB"))
+
+    assert resp.error == HamlibError.EINTERNAL
+    assert dual_rx_radio.set_split_mode.await_args_list == [
+        ((True,), {}),
+        ((False,), {}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_set_split_vfo_rollback_swallows_rollback_failure(
+    dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+) -> None:
+    """If the rollback set_split_mode(False) itself fails, the handler
+    must still return the ORIGINAL failure code — not raise."""
+    dual_rx_radio.set_vfo.side_effect = IcomConnectionError("lost")
+    # set_split_mode succeeds on True, fails on False (the rollback).
+    dual_rx_radio.set_split_mode.side_effect = [
+        None,
+        IcomConnectionError("rollback failed too"),
+    ]
+
+    resp = await dual_rx_handler.execute(set_cmd("set_split_vfo", "1", "VFOB"))
+
+    assert resp.error == HamlibError.EIO
+    # Both calls were attempted — the rollback failure is swallowed
+    # (logged only); the original error code wins.
+    assert dual_rx_radio.set_split_mode.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_get_split_vfo_dual_rx_reflects_active_sub(
     dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
 ) -> None:

--- a/tests/test_vfo_dual_watch.py
+++ b/tests/test_vfo_dual_watch.py
@@ -484,8 +484,11 @@ class TestSwapMainSubVsSwapVfoAb:
         assert send.frames[0].endswith(b"\x07\xb1\xfd")
 
     @pytest.mark.asyncio
-    async def test_ic7610_swap_vfo_ab_selects_main_then_swaps(self) -> None:
-        """On dual-RX, swap_vfo_ab(0) first selects MAIN, then sends swap code."""
+    async def test_ic7610_swap_vfo_ab_raises_command_error(self) -> None:
+        """On IC-7610 ``swap_ab_code`` is ``None``; swap_vfo_ab must NOT
+        silently fall back to ``swap_main_sub_code`` — that would swap
+        MAIN↔SUB instead of A↔B within the receiver.  It must raise.
+        """
         r = _make_radio("IC-7610")
         set_vfo_calls: list[str] = []
 
@@ -496,13 +499,42 @@ class TestSwapMainSubVsSwapVfoAb:
         with patch.object(r, "set_vfo", _fake_set_vfo), patch.object(
             r, "_send_civ_raw", send
         ):
-            await r.swap_vfo_ab(receiver=0)
+            with pytest.raises(CommandError) as exc_info:
+                await r.swap_vfo_ab(receiver=0)
 
-        assert set_vfo_calls == ["MAIN"]
-        # Falls back to swap_main_sub_code (0xB0) since ic7610.toml declares
-        # only the legacy ``swap`` key which maps to swap_main_sub_code.
-        assert len(send.frames) == 1
-        assert send.frames[0].endswith(b"\x07\xb0\xfd")
+        msg = str(exc_info.value)
+        assert "swap_vfo_ab not supported" in msg
+        assert "IC-7610" in msg
+        assert "swap_ab_code" in msg
+        # Error message must point the caller at the correct alternative.
+        assert "swap_main_sub" in msg
+        # No receiver select or CI-V frame emitted on failure.
+        assert set_vfo_calls == []
+        assert send.frames == []
+
+    @pytest.mark.asyncio
+    async def test_ic7610_equalize_vfo_ab_raises_command_error(self) -> None:
+        """Same contract as swap_vfo_ab — no silent MAIN→SUB fallback."""
+        r = _make_radio("IC-7610")
+        set_vfo_calls: list[str] = []
+
+        async def _fake_set_vfo(vfo: str = "A") -> None:
+            set_vfo_calls.append(vfo.upper())
+
+        send = _RecordingSend()
+        with patch.object(r, "set_vfo", _fake_set_vfo), patch.object(
+            r, "_send_civ_raw", send
+        ):
+            with pytest.raises(CommandError) as exc_info:
+                await r.equalize_vfo_ab(receiver=0)
+
+        msg = str(exc_info.value)
+        assert "equalize_vfo_ab not supported" in msg
+        assert "IC-7610" in msg
+        assert "equal_ab_code" in msg
+        assert "equalize_main_sub" in msg
+        assert set_vfo_calls == []
+        assert send.frames == []
 
     @pytest.mark.asyncio
     async def test_ic7300_swap_main_sub_raises(self) -> None:


### PR DESCRIPTION
## Summary

Two P1 findings from code review of the #708 epic foundation work (#738, #739).

### 1. `swap_vfo_ab` silently performed MAIN↔SUB on IC-7610 / IC-9700

`DualRxRuntimeMixin.swap_vfo_ab` fell back from `swap_ab_code` to
`swap_main_sub_code` when the former was `None`. On IC-7610 / IC-9700
`swap_ab_code` is `None` and `swap_main_sub_code = 0xB0`, so
`swap_vfo_ab(receiver=0)` — expected to swap VFO A/B inside MAIN —
actually swapped MAIN and SUB. Same problem in `equalize_vfo_ab`.

**Fix:** drop the fallback; raise `CommandError` that names the correct
alternative (`swap_main_sub()` / `equalize_main_sub()`). IC-7300 /
IC-705 profiles (single-RX with `swap_ab_code` declared) continue to
work.

### 2. `set_split_vfo` left radio in partial state on `set_vfo` failure

`RigctldHandler._cmd_set_split_vfo` called `set_split_mode(True)` and
then `set_vfo("SUB")` without a try/except. If the second call raised
(connection drop, timeout, unsupported), split was left enabled but TX
was not routed to SUB — silent state divergence for WSJT-X.

**Fix:** wrap the receiver-select in try/except. On failure, best-effort
rollback via `set_split_mode(False)` (errors swallowed), then return
`EIO` / `ETIMEOUT` / `EINTERNAL` as appropriate.

Addresses code-review findings on #708 epic foundation PRs (#738, #739).

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest tests/test_vfo_dual_watch.py tests/test_rigctld_handler.py -v` — 300 passed
- [x] Full suite `uv run pytest tests/ -q --ignore=tests/integration` — 4678 passed (3 pre-existing `TestAudioHandlerTxTranscoderRate` failures unchanged on base)
- [x] Flipped `TestSwapMainSubVsSwapVfoAb::test_ic7610_swap_vfo_ab_*` — now asserts `CommandError`; added symmetric `equalize_vfo_ab` test
- [x] Added 4 rollback-path tests for `set_split_vfo` (ConnectionError, TimeoutError, unexpected exception, rollback-also-fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)