### PR TITLE
fix(ui): migrate VfoPanel to receiverLabel + vfoSlotLabel

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -250,6 +250,8 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
   getScopeSource: vi.fn(() => null),
   hasCapability: vi.fn(() => false),
   vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
   getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
   setCapabilities: vi.fn(),
   getAgcModes: vi.fn(() => [0, 1, 2, 3]),

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
@@ -51,6 +51,8 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
   getKeyboardConfig: vi.fn(() => null),
   getVfoScheme: vi.fn(() => 'main_sub'),
   vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
   getCapabilities: vi.fn(() => ({
     freqRanges: [
       {

--- a/frontend/src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts
+++ b/frontend/src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts
@@ -5,6 +5,8 @@ import type { ComponentProps } from 'svelte';
 // Mock capabilities for VfoPanel internals.
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
   getCapabilities: vi.fn(() => ({
     freqRanges: [
       {

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -2,7 +2,7 @@
   import LinearSMeter from '../meters/LinearSMeter.svelte';
   import FrequencyDisplayInteractive from '../display/FrequencyDisplayInteractive.svelte';
   import { StatusIndicator } from '$lib/Button';
-  import { getCapabilities, vfoLabel } from '$lib/stores/capabilities.svelte';
+  import { getCapabilities, receiverLabel, vfoSlotLabel } from '$lib/stores/capabilities.svelte';
   import { findActiveBand } from '../controls/band-utils';
   import { formatBadges, formatRitOffset } from './vfo-utils';
   import type { VfoLayoutProfile } from '../layout/vfo-layout-tokens';
@@ -38,8 +38,8 @@
   }: Props = $props();
 
   let slot = $derived<'A' | 'B'>(receiver === 'main' ? 'A' : 'B');
-  let label = $derived(vfoLabel(slot));
-  let slotTag = $derived(label.startsWith('VFO ') ? label.slice(4) : label);
+  let label = $derived(receiverLabel(receiver === 'main' ? 'MAIN' : 'SUB'));
+  let slotTag = $derived(vfoSlotLabel(slot).replace(/^VFO /, ''));
   let activeBand = $derived(findActiveBand(freq, getCapabilities()?.freqRanges ?? []));
   let badgeItems = $derived(formatBadges(badges, receiver));
   let meterVariant = $derived(layoutProfile === 'wide' ? 'vfo-wide' : 'vfo');

--- a/frontend/src/components-v2/vfo/__tests__/VfoPanel.test.ts
+++ b/frontend/src/components-v2/vfo/__tests__/VfoPanel.test.ts
@@ -105,7 +105,8 @@ describe('formatRitOffset', () => {
 // ---------------------------------------------------------------------------
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
-  vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
   getCapabilities: vi.fn(() => ({
     freqRanges: [
       {
@@ -125,7 +126,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
   getSmeterRedline: vi.fn(() => null),
 }));
 
-import { getCapabilities, vfoLabel } from '$lib/stores/capabilities.svelte';
+import { getCapabilities, receiverLabel, vfoSlotLabel } from '$lib/stores/capabilities.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
@@ -140,7 +141,8 @@ function mountPanel(props: ComponentProps<typeof VfoPanel>) {
 
 beforeEach(() => {
   components = [];
-  vi.mocked(vfoLabel).mockImplementation((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB'));
+  vi.mocked(receiverLabel).mockImplementation((id: 'MAIN' | 'SUB') => id);
+  vi.mocked(vfoSlotLabel).mockImplementation((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B'));
 });
 
 afterEach(() => {
@@ -202,7 +204,7 @@ describe('panel structure', () => {
     const t = mountPanel(baseProps);
     const tags = Array.from(t.querySelectorAll('.header-tag')).map((node) => node.textContent?.trim());
     expect(tags).toContain('BAR');
-    expect(tags).toContain('MAIN');
+    expect(tags).toContain('A');
   });
 
   it('renders the control strip even when badges are empty', () => {
@@ -214,7 +216,7 @@ describe('panel structure', () => {
     const t = mountPanel(baseProps);
     const indicators = Array.from(t.querySelectorAll('.control-strip .v2-status-indicator'));
     const slotIndicator = indicators.find((el) => el.getAttribute('data-color') === 'muted');
-    expect(slotIndicator?.textContent?.trim()).toBe('MAIN');
+    expect(slotIndicator?.textContent?.trim()).toBe('A');
   });
 });
 
@@ -332,21 +334,31 @@ describe('callbacks', () => {
   });
 });
 
-describe('vfoLabel integration', () => {
-  it('uses vfoLabel("A") for receiver=main', () => {
+describe('receiverLabel / vfoSlotLabel integration', () => {
+  it('uses receiverLabel("MAIN") for receiver=main', () => {
     mountPanel({ ...baseProps, receiver: 'main' });
-    expect(vi.mocked(vfoLabel)).toHaveBeenCalledWith('A');
+    expect(vi.mocked(receiverLabel)).toHaveBeenCalledWith('MAIN');
   });
 
-  it('uses vfoLabel("B") for receiver=sub', () => {
+  it('uses receiverLabel("SUB") for receiver=sub', () => {
     mountPanel({ ...baseProps, receiver: 'sub' });
-    expect(vi.mocked(vfoLabel)).toHaveBeenCalledWith('B');
+    expect(vi.mocked(receiverLabel)).toHaveBeenCalledWith('SUB');
   });
 
-  it('shows "VFO A" label when vfoScheme returns "VFO A"', () => {
-    vi.mocked(vfoLabel).mockReturnValue('VFO A');
+  it('uses vfoSlotLabel("A") for receiver=main', () => {
+    mountPanel({ ...baseProps, receiver: 'main' });
+    expect(vi.mocked(vfoSlotLabel)).toHaveBeenCalledWith('A');
+  });
+
+  it('uses vfoSlotLabel("B") for receiver=sub', () => {
+    mountPanel({ ...baseProps, receiver: 'sub' });
+    expect(vi.mocked(vfoSlotLabel)).toHaveBeenCalledWith('B');
+  });
+
+  it('renders the receiver label in the header', () => {
+    vi.mocked(receiverLabel).mockReturnValue('MAIN');
     const t = mountPanel({ ...baseProps, receiver: 'main' });
-    expect(t.querySelector('.vfo-label')?.textContent?.trim()).toBe('VFO A');
+    expect(t.querySelector('.vfo-label')?.textContent?.trim()).toBe('MAIN');
   });
 
   it('reads band ranges through getCapabilities()', () => {

--- a/frontend/src/components/layout/MobileLayout.svelte
+++ b/frontend/src/components/layout/MobileLayout.svelte
@@ -16,7 +16,7 @@
 
 
   import { radio } from '../../lib/stores/radio.svelte';
-  import { hasDualReceiver, getCapabilities, vfoLabel } from '../../lib/stores/capabilities.svelte';
+  import { hasDualReceiver, getCapabilities, receiverLabel } from '../../lib/stores/capabilities.svelte';
   import { getConnectionStatus } from '../../lib/stores/connection.svelte';
   import { sendCommand } from '../../lib/transport/ws-client';
   import { applyModeDefault } from '../../lib/stores/tuning.svelte';
@@ -26,8 +26,8 @@
   let active = $derived(radio.current?.active === 'SUB' ? (radio.current?.sub ?? null) : (radio.current?.main ?? null));
   let activeRx = $derived(radioState?.active ?? 'MAIN');
   let isDualRx = $derived(hasDualReceiver());
-  let labelA = $derived(vfoLabel('A'));
-  let labelB = $derived(vfoLabel('B'));
+  let labelA = $derived(receiverLabel('MAIN'));
+  let labelB = $derived(receiverLabel('SUB'));
 
   // Auto step based on mode
   let currentMode = $derived(active?.mode ?? '');


### PR DESCRIPTION
## Summary
Addresses post-merge code-review finding on PR #728 — production component `VfoPanel.svelte` was not migrated; deprecation shim was firing on every dual-RX page load.

`VfoPanel.svelte` still imported `vfoLabel` from the deprecation shim introduced by #728. Since the panel is rendered twice per dual-RX view (inside `DualVfoDisplay`), `console.warn('[deprecated] vfoLabel(...)')` was firing on every page load with dual-RX radios, and the label semantics worked only by coincidence for the `main_sub` scheme.

## Changes
- `VfoPanel.svelte` — header uses `receiverLabel('MAIN' | 'SUB')` (receiver identity); slot badge uses `vfoSlotLabel(slot)` (VFO A/B).
- `MobileLayout.svelte` — `labelA`/`labelB` now use `receiverLabel` (these denote the active receiver, not a VFO slot).
- Test-file mocks (`DualVfoDisplay.test.ts`, `RadioLayout.test.ts`, `top-row-visual-regression.test.ts`, `VfoPanel.test.ts`) updated to export the new symbols so the real `VfoPanel` rendered inside those tests can resolve them. The deprecated `vfoLabel` mock entries are left in place where they coexisted (no cost).

Scope expanded from 1 to 6 files: downstream test mocks that render `VfoPanel` crash without `receiverLabel` / `vfoSlotLabel` exports, so they could not be deferred.

## Test plan
- [x] `npx vitest run` — 1507 passed / 0 failed (up from 1479 post-#728; delta is test suite growth unrelated to this change).
- [x] `npm run build` — clean.
- [x] `rg 'vfoLabel\(' src --glob '!**/__tests__/**' --glob '!**/*.test.ts'` — only the deprecation shim's own definition remains; no production callers.