### PR TITLE
test: strengthen #726 coverage — SUB restore assertion + BCD payload check

### DIFF
--- a/tests/test_per_receiver_vfo_roundtrip.py
+++ b/tests/test_per_receiver_vfo_roundtrip.py
@@ -21,7 +21,7 @@ import pytest
 
 from icom_lan.exceptions import CommandError
 from icom_lan.radio import IcomRadio
-from icom_lan.types import Mode
+from icom_lan.types import Mode, bcd_encode
 
 from test_radio import MockTransport, _wrap_civ_in_udp
 
@@ -94,8 +94,12 @@ class TestPerReceiverFreq:
     ) -> None:
         await ic7610.set_freq(14_074_000, receiver=0)
         frames = _civ_bytes(mock_transport.sent_packets)
-        assert any(f[4:5] == b"\x05" for f in frames), (
+        freq_frame = next((f for f in frames if f[4:5] == b"\x05"), None)
+        assert freq_frame is not None, (
             f"expected a 0x05 set-freq frame; got {[f.hex() for f in frames]}"
+        )
+        assert freq_frame[5:-1] == bcd_encode(14_074_000), (
+            f"BCD payload mismatch: got {freq_frame[5:-1].hex()}"
         )
         assert not any(f == SEL_MAIN or f == SEL_SUB for f in frames), (
             "no 0x07 0xD0/D1 receiver-select expected for MAIN path"
@@ -111,16 +115,23 @@ class TestPerReceiverFreq:
         mock_transport.queue_response(ACK_IC7610)
         await ic7610.set_freq(7_074_000, receiver=1)
         frames = _civ_bytes(mock_transport.sent_packets)
-        cmds = [f[4:5] for f in frames]
-        # Expect: select SUB → 0x05 set-freq → restore MAIN (or equivalent).
-        assert b"\x07" in cmds, f"no receiver-select frame; got {cmds}"
-        assert b"\x05" in cmds, f"no set-freq frame; got {cmds}"
+        # Expect: select SUB → 0x05 set-freq → restore MAIN.
         first_select = next((i for i, f in enumerate(frames) if f == SEL_SUB), None)
         set_freq_idx = next(
             (i for i, f in enumerate(frames) if f[4:5] == b"\x05"), None
         )
         assert first_select is not None, "expected 0x07 0xD1 (select SUB)"
         assert set_freq_idx is not None and set_freq_idx > first_select
+        # Restore step: a SEL_MAIN must appear AFTER the set-freq frame.
+        restore_idx = next(
+            (i for i, f in enumerate(frames) if f == SEL_MAIN and i > set_freq_idx),
+            None,
+        )
+        assert restore_idx is not None, (
+            "expected 0x07 0xD0 (restore MAIN) after set-freq"
+        )
+        # BCD payload correctness.
+        assert frames[set_freq_idx][5:-1] == bcd_encode(7_074_000)
 
     @pytest.mark.asyncio
     async def test_ic7300_set_freq_direct(
@@ -128,7 +139,9 @@ class TestPerReceiverFreq:
     ) -> None:
         await ic7300.set_freq(14_074_000, receiver=0)
         frames = _civ_bytes(mock_transport.sent_packets)
-        assert any(f[4:5] == b"\x05" for f in frames)
+        freq_frame = next((f for f in frames if f[4:5] == b"\x05"), None)
+        assert freq_frame is not None
+        assert freq_frame[5:-1] == bcd_encode(14_074_000)
         assert not any(f == SEL_MAIN or f == SEL_SUB for f in frames), (
             "1-Rx profile must not send receiver-select"
         )
@@ -166,6 +179,14 @@ class TestPerReceiverMode:
         mode_idx = next((i for i, f in enumerate(frames) if f[4:5] == b"\x06"), None)
         assert sel_idx is not None, "expected 0x07 0xD1 (select SUB)"
         assert mode_idx is not None and mode_idx > sel_idx
+        # Restore step: a SEL_MAIN must appear AFTER the set-mode frame.
+        restore_idx = next(
+            (i for i, f in enumerate(frames) if f == SEL_MAIN and i > mode_idx),
+            None,
+        )
+        assert restore_idx is not None, (
+            "expected 0x07 0xD0 (restore MAIN) after set-mode"
+        )
 
     @pytest.mark.asyncio
     async def test_ic7300_set_mode_direct(


### PR DESCRIPTION
## Summary

Post-review P2 findings on PR #749 (issue #726).

## Changes

**`tests/test_per_receiver_vfo_roundtrip.py`:**

1. **SUB-fallback restore assertion.** Added `SEL_MAIN` restore-after-action check to `test_ic7610_set_freq_sub_uses_fallback_select_restore` and `test_ic7610_set_mode_sub_uses_fallback`. Without this, a regression that removed the `finally` block in `_run_with_receiver_vfo_fallback` would silently pass both tests — defeating the test name's promise.
2. **BCD payload equality.** Added `bcd_encode(freq_hz)` comparison to MAIN/direct set-freq tests. BCD is the non-obvious right-to-left digit-pair format explicitly flagged in `CLAUDE.md`; an encoding regression would otherwise only surface via integration tests.

## Test plan

- [x] 11/11 tests still pass in 0.24s
- [x] `ruff check` / `ruff format --check` clean