### PR TITLE
fix(poller): MAIN↔SUB flip on IC-7610 + silence Radio.__del__ test warnings

### DIFF
--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -1715,8 +1715,11 @@ class RadioPoller:
             return False
         if not self._profile.supports_receiver(receiver):
             return False
-        # Need a swap primitive to exchange A/B within the receiver.
-        if (self._profile.swap_ab_code or self._profile.swap_main_sub_code) is None:
+        # Need a true A/B-within-receiver swap primitive. swap_main_sub_code
+        # is NOT a fallback — on IC-7610 the 0x07 0xB0 byte toggles MAIN↔SUB,
+        # not A↔B inside a receiver, which would flip the radio's active-RX
+        # state on every slow-poll cycle.
+        if self._profile.swap_ab_code is None:
             return False
         return True
 
@@ -1736,8 +1739,8 @@ class RadioPoller:
         rx_name = "MAIN" if receiver == 0 else "SUB"
         rx_state = rs.receiver(rx_name)
         target_slot = "B" if rx_state.active_slot == "A" else "A"
-        swap_code = self._profile.swap_ab_code or self._profile.swap_main_sub_code
-        assert swap_code is not None  # gate guarantees
+        swap_code = self._profile.swap_ab_code
+        assert swap_code is not None  # gate guarantees (see _unselected_slot_gate)
         # Pre-select MAIN/SUB on dual-RX rigs so the swap hits the intended
         # receiver.  Restore after the read.
         pre_switched = False

--- a/tests/test_per_receiver_vfo_roundtrip.py
+++ b/tests/test_per_receiver_vfo_roundtrip.py
@@ -37,21 +37,23 @@ def mock_transport() -> MockTransport:
 
 
 @pytest.fixture
-def ic7610(mock_transport: MockTransport) -> IcomRadio:
+def ic7610(mock_transport: MockTransport):
     r = IcomRadio("192.168.1.100", model="IC-7610", timeout=0.05)
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True
-    return r
+    yield r
+    r._connected = False  # reset _conn_state so __del__ stays quiet
 
 
 @pytest.fixture
-def ic7300(mock_transport: MockTransport) -> IcomRadio:
+def ic7300(mock_transport: MockTransport):
     r = IcomRadio("192.168.1.101", model="IC-7300", timeout=0.05)
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True
-    return r
+    yield r
+    r._connected = False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -293,12 +293,16 @@ def mock_transport() -> MockTransport:
 
 
 @pytest.fixture
-def radio(mock_transport: MockTransport) -> IcomRadio:
+def radio(mock_transport: MockTransport):
+    """Shared radio fixture with explicit teardown to silence the
+    ``Radio collected with active connection/tasks`` __del__ warning
+    from tests that bypass the real connect/disconnect lifecycle."""
     r = IcomRadio("192.168.1.100", timeout=0.05)
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True
-    return r
+    yield r
+    r._connected = False  # reset _conn_state so __del__ stays quiet
 
 
 class TestContextManager:

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -107,12 +107,13 @@ def mock_transport() -> MockTransport:
 
 
 @pytest.fixture
-def radio(mock_transport: MockTransport) -> IcomRadio:
+def radio(mock_transport: MockTransport):
     r = IcomRadio("192.168.1.100", timeout=0.05)
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True
-    return r
+    yield r
+    r._connected = False  # reset _conn_state so __del__ stays quiet
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_selected_freq_mode.py
+++ b/tests/test_selected_freq_mode.py
@@ -192,12 +192,13 @@ def mock_transport() -> MockTransport:
 
 
 @pytest.fixture
-def radio(mock_transport: MockTransport) -> IcomRadio:
+def radio(mock_transport: MockTransport):
     r = IcomRadio("192.168.1.100", timeout=0.05)
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True
-    return r
+    yield r
+    r._connected = False  # reset _conn_state so __del__ stays quiet
 
 
 class TestRadioSelectedFreq:

--- a/tests/test_selected_freq_mode.py
+++ b/tests/test_selected_freq_mode.py
@@ -393,29 +393,18 @@ class TestPollerUnselectedSlotGate:
         return poller, radio, state
 
     @pytest.mark.asyncio
-    async def test_ic7610_polls_unselected_slot_both_receivers(self) -> None:
+    async def test_ic7610_skips_unselected_slot_poll_without_swap_ab(self) -> None:
+        """IC-7610 declares only swap_main_sub (0x07 0xB0 toggles MAIN↔SUB,
+        NOT A/B within a receiver). Without a true swap_ab_code, using the
+        MAIN↔SUB byte as a fallback would flip the radio's active-RX state
+        every slow-poll cycle — the bug reported against #743/#715. The gate
+        must skip the cycle entirely on such profiles.
+        """
         poller, radio, state = self._make_poller("IC-7610")
         await poller._poll_unselected_slot(0)
         await poller._poll_unselected_slot(1)
-        # Each receiver: (optional rx select) + swap + 0x03 + 0x04 + swap-back
-        # MAIN (active): swap + 0x03 + 0x04 + swap-back = 4
-        # SUB (needs switch): select SUB + swap + 0x03 + 0x04 + swap-back + select MAIN = 6
-        assert radio.send_civ.await_count >= 10
-        # Expect at least one swap (0x07, 0xB0) and one 0x03/0x04 pair
-        calls = [
-            (c.args, c.kwargs)
-            for c in radio.send_civ.await_args_list
-        ]
-        opcodes = [
-            (call[1].get("sub"), call[1].get("data", b"")[0] if call[1].get("data") else None)
-            for call in calls
-            if call[0] and call[0][0] == 0x07
-        ]
-        assert any(byte == 0xB0 for _sub, byte in opcodes)
-        # Freq/mode reads were issued
-        read_cmds = [call[0][0] for call in calls if call[0]]
-        assert 0x03 in read_cmds
-        assert 0x04 in read_cmds
+        # Gate rejects both: no CI-V traffic, no MAIN↔SUB flip.
+        assert radio.send_civ.await_count == 0
 
     @pytest.mark.asyncio
     async def test_ic7300_single_receiver_polls_vfo_b(self) -> None:


### PR DESCRIPTION
## P0 — Production bug: MAIN↔SUB flip every slow-poll cycle

**Symptom (from live IC-7610 at 192.168.55.40):**
After \`Connected\` + \`radio-poller: started\`, the radio flips MAIN ↔ SUB every few seconds. User-visible: active receiver switches spontaneously.

**Root cause:**
\`src/icom_lan/web/radio_poller.py::_unselected_slot_gate\` and \`_poll_unselected_slot\` from PR #743 (issue #715) fell back to \`swap_main_sub_code\` when \`swap_ab_code\` was \`None\`:

\`\`\`python
swap_code = self._profile.swap_ab_code or self._profile.swap_main_sub_code
\`\`\`

On IC-7610, \`swap_ab_code = None\` and \`swap_main_sub_code = 0xB0\`. The CI-V byte \`0x07 0xB0\` toggles **MAIN↔SUB**, not A↔B within a receiver. Every slow-poll cycle sent a MAIN↔SUB swap.

Same 0xB0-fallback bug that #746 fixed in \`_dual_rx_runtime.py::swap_vfo_ab\`. A duplicate copy of the pattern in \`radio_poller.py\` was missed.

**Fix:** \`_unselected_slot_gate\` now requires \`swap_ab_code\` specifically (no fallback). On IC-7610/9700 (declares only \`swap_main_sub\`) the cycle is skipped until the profile gains a true A/B-within-receiver primitive — future work: use \`0x07 0x00\` / \`0x07 0x01\` after \`0x07 0xD0/D1\` receiver-select. On IC-7300/IC-705 where \`swap_ab_code\` is declared (from #710 migration), behaviour is unchanged.

**Test flip:** \`test_ic7610_polls_unselected_slot_both_receivers\` previously asserted the buggy behaviour (≥10 CI-V sends including \`0x07 0xB0\`). Replaced with \`test_ic7610_skips_unselected_slot_poll_without_swap_ab\` asserting zero CI-V traffic.

## Secondary — silence Radio.__del__ warnings in 4 test fixtures

\`Radio.__del__\` (src/icom_lan/radio.py:748) emits \`Radio collected with active connection/tasks\` when GC reclaims an object with \`_conn_state == CONNECTED\`. Four fixtures set \`_connected = True\` to bypass real \`connect()\` then returned without teardown — 5-10 spurious warnings per full-suite run that obscured real signal.

Fix: \`yield r\` + \`r._connected = False\` on teardown. The \`_connected\` setter writes \`_conn_state\` back to DISCONNECTED, GC finds a clean object. Production warning path unchanged — still fires on real forgotten \`disconnect()\`.

Files: \`tests/test_radio.py\` (canonical \`radio\` fixture imported by others), \`tests/test_selected_freq_mode.py\`, \`tests/test_radio_coverage.py\`, \`tests/test_per_receiver_vfo_roundtrip.py\`.

## Test plan

- [x] Full suite: 4690 passed, 0 regressions
- [x] 0 \`Radio collected\` warnings (was 5-10)
- [x] \`ruff check\` / \`mypy\` clean