### PR TITLE
feat(#752): audio_config WS message + CI-V Phones L/R Mix routing

### DIFF
--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -24,6 +24,7 @@ from ..protocol import (
     MSG_TYPE_AUDIO_RX,
     decode_json,
     encode_audio_frame,
+    encode_json,
 )
 from ..websocket import WS_OP_BINARY, WS_OP_TEXT, WebSocketConnection
 
@@ -482,6 +483,88 @@ class AudioHandler:
                     await self._radio.stop_audio_tx()  # type: ignore[attr-defined]
                 self._tx_active = False
                 logger.info("audio: TX stopped")
+        elif msg_type == "audio_config":
+            await self._handle_audio_config(msg)
+
+    # --------------------------------------------------------------
+    # audio_config — MAIN/SUB focus + stereo split (issue #752)
+    # --------------------------------------------------------------
+    #
+    # IC-7610 CI-V Menu 0072 "Phones L/R Mix" bytes. Mapping from
+    # (focus, split_stereo) to the CI-V byte that Phones L/R Mix expects.
+    # Exact byte values may need tuning against hardware.
+    _PHONES_LR_MIX: dict[tuple[str, bool], int] = {
+        ("main", False): 0x00,  # L=MAIN, R=MAIN
+        ("main", True): 0x00,  # split has no effect — SUB silenced
+        ("sub", False): 0x03,  # L=SUB, R=SUB
+        ("sub", True): 0x03,
+        ("both", False): 0x02,  # L=mix, R=mix
+        ("both", True): 0x01,  # L=MAIN, R=SUB (true stereo split)
+    }
+    _VALID_AUDIO_FOCUS: frozenset[str] = frozenset({"main", "sub", "both"})
+
+    async def _handle_audio_config(self, msg: dict[str, Any]) -> None:
+        """Apply MAIN/SUB audio focus + stereo split via CI-V Phones L/R Mix.
+
+        Fire-and-forget on dual-RX profiles. Echoes the applied config back on
+        the WS so the client can confirm persistence. No-op on 1-Rx profiles.
+        """
+        focus = msg.get("focus", "")
+        split_stereo = bool(msg.get("split_stereo", False))
+
+        if focus not in self._VALID_AUDIO_FOCUS:
+            await self._send_error(
+                f"audio_config: invalid focus {focus!r}; "
+                f"expected one of {sorted(self._VALID_AUDIO_FOCUS)}"
+            )
+            return
+
+        if not self._radio:
+            return  # no radio attached — cannot apply
+        profile = getattr(self._radio, "profile", None)
+        rx_count = getattr(profile, "receiver_count", 1)
+        if rx_count < 2:
+            logger.debug("audio_config: ignored on 1-Rx profile")
+            return
+
+        phones_byte = self._PHONES_LR_MIX[(focus, split_stereo)]
+        try:
+            await self._radio.send_civ(  # type: ignore[attr-defined]
+                0x1A,
+                sub=0x05,
+                data=bytes([0x00, 0x72, phones_byte]),
+                wait_response=False,
+            )
+        except Exception:
+            logger.warning("audio_config: CI-V send failed", exc_info=True)
+            await self._send_error("audio_config: CI-V send failed")
+            return
+
+        logger.info(
+            "audio_config: focus=%s split_stereo=%s → phones=0x%02X",
+            focus,
+            split_stereo,
+            phones_byte,
+        )
+        await self._send_json(
+            {
+                "type": "audio_config",
+                "focus": focus,
+                "split_stereo": split_stereo,
+                "applied": True,
+            }
+        )
+
+    async def _send_json(self, obj: dict[str, Any]) -> None:
+        """Send a JSON message to the WS client."""
+        try:
+            await self._ws.send_text(encode_json(obj))
+        except Exception:
+            logger.debug("audio: _send_json failed", exc_info=True)
+
+    async def _send_error(self, message: str) -> None:
+        """Send an error message envelope to the WS client."""
+        await self._send_json({"type": "error", "message": message})
 
     def _ensure_tx_transcoder(self) -> None:
         """Create (or recreate) the TX Opus→PCM transcoder at the radio's rate.

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1405,6 +1405,105 @@ class TestAudioHandlerTxTranscoderRate:
         assert handler._transcoder is None
 
 
+class TestAudioConfigRouting:
+    """audio_config WS message → CI-V Phones L/R Mix (issue #752).
+
+    Each (focus, split_stereo) pair maps to a Menu 0072 byte emitted via
+    ``radio.send_civ(0x1A, sub=0x05, data=bytes([0x00, 0x72, byte]))``.
+    Gated on dual-RX profiles; 1-Rx radios silently no-op.
+    """
+
+    @staticmethod
+    def _make_handler(receiver_count: int = 2) -> Any:
+        from types import SimpleNamespace
+
+        from icom_lan.radio_protocol import AudioCapable
+        from icom_lan.web.handlers import AudioBroadcaster, AudioHandler
+        from icom_lan.web.websocket import WebSocketConnection
+
+        mock_ws = MagicMock(spec=WebSocketConnection)
+        mock_ws.send_text = AsyncMock()
+        mock_radio = MagicMock(spec=AudioCapable)
+        mock_radio.capabilities = {"audio"}
+        mock_radio.profile = SimpleNamespace(receiver_count=receiver_count)
+        mock_radio.send_civ = AsyncMock()
+
+        broadcaster = AudioBroadcaster(mock_radio)
+        handler = AudioHandler(mock_ws, mock_radio, broadcaster)
+        return handler, mock_radio, mock_ws
+
+    async def _apply(self, handler: Any, focus: str, split_stereo: bool) -> None:
+        await handler._handle_control(
+            {"type": "audio_config", "focus": focus, "split_stereo": split_stereo}
+        )
+
+    @staticmethod
+    def _expected_civ_call(phones_byte: int) -> dict[str, Any]:
+        return {
+            "args": (0x1A,),
+            "sub": 0x05,
+            "data": bytes([0x00, 0x72, phones_byte]),
+        }
+
+    async def test_focus_main_split_off_sends_phones_00(self) -> None:
+        handler, radio, _ = self._make_handler()
+        await self._apply(handler, "main", False)
+        radio.send_civ.assert_awaited_once_with(
+            0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x00]), wait_response=False
+        )
+
+    async def test_focus_sub_split_off_sends_phones_03(self) -> None:
+        handler, radio, _ = self._make_handler()
+        await self._apply(handler, "sub", False)
+        radio.send_civ.assert_awaited_once_with(
+            0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x03]), wait_response=False
+        )
+
+    async def test_focus_both_split_off_sends_phones_02(self) -> None:
+        handler, radio, _ = self._make_handler()
+        await self._apply(handler, "both", False)
+        radio.send_civ.assert_awaited_once_with(
+            0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x02]), wait_response=False
+        )
+
+    async def test_focus_both_split_on_sends_phones_01(self) -> None:
+        """Stereo split: L=MAIN, R=SUB — the headline feature."""
+        handler, radio, _ = self._make_handler()
+        await self._apply(handler, "both", True)
+        radio.send_civ.assert_awaited_once_with(
+            0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x01]), wait_response=False
+        )
+
+    async def test_invalid_focus_sends_error_no_civ(self) -> None:
+        handler, radio, ws = self._make_handler()
+        await self._apply(handler, "left", False)
+        radio.send_civ.assert_not_awaited()
+        assert ws.send_text.await_count >= 1
+        sent = ws.send_text.await_args_list[0].args[0]
+        assert "error" in sent
+        assert "invalid focus" in sent
+
+    async def test_single_rx_profile_noops(self) -> None:
+        handler, radio, ws = self._make_handler(receiver_count=1)
+        await self._apply(handler, "main", False)
+        radio.send_civ.assert_not_awaited()
+        ws.send_text.assert_not_awaited()
+
+    async def test_echo_includes_applied_true(self) -> None:
+        import json
+
+        handler, _, ws = self._make_handler()
+        await self._apply(handler, "both", True)
+        ws.send_text.assert_awaited_once()
+        echoed = json.loads(ws.send_text.await_args.args[0])
+        assert echoed == {
+            "type": "audio_config",
+            "focus": "both",
+            "split_stereo": True,
+            "applied": True,
+        }
+
+
 # ---------------------------------------------------------------------------
 # WebSocket keepalive (server-initiated pings)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part 1 of 3 in #721 decomposition (epic #708 — Dual VFO / Dual Receiver).

## Summary

Backend handles a new WS control message \`audio_config { focus, split_stereo }\` that lets the web client choose MAIN/SUB audio focus and enable stereo split.

## Mapping (focus × split_stereo) → Menu 0072 byte

| focus | split | byte | Effect |
|-------|:---:|:---:|---|
| main  | any | 0x00 | L=MAIN, R=MAIN |
| sub   | any | 0x03 | L=SUB,  R=SUB |
| both  | off | 0x02 | L=mix, R=mix (both receivers to both ears) |
| both  | on  | 0x01 | L=MAIN, R=SUB (true stereo split) |

Byte values may need tuning against real hardware — documented in the code.

## Behaviour

- Invalid \`focus\` → WS error envelope returned; no CI-V emission.
- \`receiver_count < 2\` (IC-7300, IC-705) → silent no-op.
- Valid dual-RX → fire-and-forget \`radio.send_civ(0x1A, sub=0x05, data=bytes([0x00, 0x72, byte]), wait_response=False)\` + echo \`{type: audio_config, focus, split_stereo, applied: true}\` back on the WS.

## Files

- \`src/icom_lan/web/handlers/audio.py\` — new \`_handle_audio_config\`, \`_send_json\`, \`_send_error\` helpers; branch in \`_handle_control\`.
- \`tests/test_web_server.py\` — new \`TestAudioConfigRouting\` class, 7 cases.

## Test plan

- [x] 7/7 new tests pass (4 mapping cases + invalid-focus + 1-Rx no-op + echo shape)
- [x] Full suite: 4697 passed (was 4690), 0 regressions
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy src/\` clean

## Not in scope (other parts)

- #753 — frontend \`AudioRoutingControl\` component + WebAudio gain/pan pipeline
- #754 — integration tests verifying PCM channel correctness end-to-end

Closes #752