### PR TITLE
fix(#765): broadcaster reports real frame_ms derived from payload (Option B)

### DIFF
--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -296,13 +296,23 @@ class AudioBroadcaster:
                 if self._tap_registry.active and self._web_codec == AUDIO_CODEC_PCM16:
                     self._tap_registry.feed(audio_data)
 
+                # frame_ms is derived from the actual payload size (issue #765).
+                # The hardcoded 20 ms here was the root cause of the 2026-04-16
+                # companion crash (epic #764): IC-7610 dispatches 1364-byte PCM16
+                # mono packets ~= 14.2 ms, not 20 ms, and downstream consumers
+                # trusted the label.  Browser ignores frame_ms (rx-player.ts
+                # sizes buffers from payload); companion + native clients need
+                # the header to match reality.  See protocol.py docstring.
+                _bytes_per_sample = 2
+                _denom = max(1, self._sample_rate * self._channels * _bytes_per_sample)
+                _frame_ms = max(1, min((len(audio_data) * 1000) // _denom, 255))
                 frame = encode_audio_frame(
                     MSG_TYPE_AUDIO_RX,
                     self._web_codec,
                     self._seq,
                     self._sample_rate // 100,
                     self._channels,
-                    20,
+                    _frame_ms,
                     audio_data,
                 )
                 self._seq = (self._seq + 1) & 0xFFFF

--- a/src/icom_lan/web/protocol.py
+++ b/src/icom_lan/web/protocol.py
@@ -96,7 +96,12 @@ def encode_audio_frame(
         sequence: Wrapping sequence counter (uint16).
         sample_rate: Sample rate / 100 as uint16 (e.g. 480 for 48000).
         channels: 1 = mono, 2 = stereo.
-        frame_ms: Frame duration in ms (typically 20).
+        frame_ms: Frame duration in ms. **Advisory** — consumers MUST
+            compute buffer sizes from ``len(payload) / (sample_rate *
+            channels * bytes_per_sample)`` directly and not trust this
+            label for allocator decisions. The broadcaster derives the
+            value from the actual payload on emit (see epic #764 / #765);
+            packed as uint8 (1-255).
         payload: Codec-specific audio data.
 
     Returns:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1351,6 +1351,97 @@ class TestAudioHandlerCodecDetection:
         assert frame[1] == AUDIO_CODEC_PCM16
 
 
+class TestBroadcasterFrameMsInvariant:
+    """Wire-header ``frame_ms`` must match the actual payload size (issue #765).
+
+    Regression guard for the 2026-04-16 companion crash (epic #764): the
+    broadcaster previously hardcoded ``frame_ms=20`` regardless of the radio's
+    real packet size, causing downstream consumers to allocate mis-sized
+    ring buffers. The fix derives the value from ``len(audio_data)`` on emit.
+    """
+
+    async def _capture_with_payload(
+        self, audio_codec: object, sample_rate: int, payload_size: int, channels: int
+    ) -> bytes:
+        from icom_lan.audio_bus import AudioBus
+        from icom_lan.radio_protocol import AudioCapable
+        from icom_lan.web.handlers import AudioBroadcaster, AudioHandler
+        from icom_lan.web.websocket import WebSocketConnection
+
+        mock_ws = MagicMock(spec=WebSocketConnection)
+        mock_radio = MagicMock(spec=AudioCapable)
+        mock_radio.capabilities = {"audio"}
+        mock_radio.audio_codec = audio_codec
+        mock_radio.audio_sample_rate = sample_rate
+        mock_radio.start_audio_rx_opus = AsyncMock()
+        mock_radio.stop_audio_rx_opus = AsyncMock()
+
+        bus = AudioBus(mock_radio)
+        mock_radio.audio_bus = bus
+
+        broadcaster = AudioBroadcaster(mock_radio)
+        handler = AudioHandler(mock_ws, mock_radio, broadcaster)
+        await handler._start_rx()
+
+        # Force the broadcaster's channel count — some codecs imply stereo,
+        # some mono; this test explicitly controls payload shape.
+        broadcaster._channels = channels
+
+        mock_pkt = MagicMock()
+        mock_pkt.data = b"\x00\x01" * (payload_size // 2)
+        bus._on_opus_packet(mock_pkt)
+        await asyncio.sleep(0.1)
+
+        return handler._frame_queue.get_nowait()
+
+    @staticmethod
+    def _parse_header(frame: bytes) -> tuple[int, int, int, int]:
+        """Return (sr_hz, channels, frame_ms, payload_len)."""
+        import struct
+
+        from icom_lan.web.protocol import AUDIO_HEADER_SIZE
+
+        _, _, _seq, sr100, ch, frame_ms = struct.unpack_from("<BBHHBB", frame, 0)
+        return sr100 * 100, ch, frame_ms, len(frame) - AUDIO_HEADER_SIZE
+
+    async def test_frame_ms_matches_1364_byte_ic7610_packet(self) -> None:
+        """IC-7610 real-world: 1364 B @ 48 kHz mono PCM16 → 14 ms (was 20)."""
+        from icom_lan.types import AudioCodec
+
+        frame = await self._capture_with_payload(
+            AudioCodec.PCM_1CH_16BIT, 48000, 1364, channels=1
+        )
+        sr, ch, frame_ms, payload_len = self._parse_header(frame)
+        expected = (payload_len * 1000) // (sr * ch * 2)
+        assert frame_ms == expected, (
+            f"header lies: declared {frame_ms}ms but payload={payload_len}B "
+            f"@ {sr}Hz × {ch}ch needs {expected}ms"
+        )
+        assert frame_ms == 14
+
+    async def test_frame_ms_matches_1920_byte_exact_20ms_packet(self) -> None:
+        """Exactly 20 ms @ 48 kHz mono PCM16 = 1920 B → frame_ms == 20."""
+        from icom_lan.types import AudioCodec
+
+        frame = await self._capture_with_payload(
+            AudioCodec.PCM_1CH_16BIT, 48000, 1920, channels=1
+        )
+        _, _, frame_ms, _ = self._parse_header(frame)
+        assert frame_ms == 20
+
+    async def test_frame_ms_matches_3840_byte_stereo_20ms_packet(self) -> None:
+        """Stereo: 3840 B @ 48 kHz × 2ch × 2bytes = 20 ms."""
+        from icom_lan.types import AudioCodec
+
+        frame = await self._capture_with_payload(
+            AudioCodec.PCM_2CH_16BIT, 48000, 3840, channels=2
+        )
+        sr, ch, frame_ms, payload_len = self._parse_header(frame)
+        expected = (payload_len * 1000) // (sr * ch * 2)
+        assert frame_ms == expected
+        assert frame_ms == 20
+
+
 class TestAudioHandlerTxTranscoderRate:
     """TX transcoder must use the radio's negotiated sample rate (issue #691).
 


### PR DESCRIPTION
Primary fix for the 2026-04-16 companion crash (epic #764). Ships **Option B** per re-review (\`.claude/workflow/audio-arch-re-review.md\`).

## Root cause

\`src/icom_lan/web/handlers/audio.py:305\` hardcoded \`frame_ms=20\` regardless of payload size. IC-7610 sends 1364-byte PCM16 mono @ 48 kHz packets ≈ 14.2 ms, not 20 ms. Downstream consumers that trust the label (companion's PortAudio \`blocksize=960\`) received 682-sample partial writes, tripping the glibc \`sysmalloc\` assertion on aarch64 via PipeWire's ALSA shim.

## Fix

Compute \`frame_ms\` from actual payload on send:

\`\`\`python
_bytes_per_sample = 2
_denom = max(1, self._sample_rate * self._channels * _bytes_per_sample)
_frame_ms = max(1, min((len(audio_data) * 1000) // _denom, 255))
\`\`\`

5 LOC. No state machine, no ring buffer, no seq-semantics change, no stereo-interleave risk for the in-flight #721 split-stereo work, no doubled copy on the ulaw path.

## Why Option B over Option A

Full argument in the re-review doc. Key points:
- Only in-tree consumer that reads \`frame_ms\` was this buggy site lying to itself.
- Frontend (\`rx-player.ts:163-179\`) derives duration from \`payload.byteLength\` and ignores \`frame_ms\`.
- Companion fix is tracked separately in \`icom-lan-pro#76\` and is required regardless for future robustness (IC-705 Opus, 24 kHz rates, stereo under #721).
- Option A added a state machine + ring buffer + seq semantics change for zero real-world benefit.

## Changes

- **\`src/icom_lan/web/handlers/audio.py\`** — payload-derived \`frame_ms\`; comment documents the history.
- **\`src/icom_lan/web/protocol.py\`** — \`encode_audio_frame\` docstring marks \`frame_ms\` **advisory**; consumers MUST derive buffer sizes from payload length, not header.
- **\`tests/test_web_server.py\`** — new \`TestBroadcasterFrameMsInvariant\` class with three cases:
  1. IC-7610 1364 B mono → 14 ms
  2. Exact 20 ms @ 1920 B mono → 20 ms
  3. Stereo 3840 B → 20 ms

Invariant: \`frame_ms == len(payload) × 1000 / (sample_rate × channels × 2)\`.

## Test plan

- [x] New 3-case invariant test passes.
- [x] Full pytest suite: 4700 passed (+3), 0 regressions.
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy src/\` clean.
- [ ] Validate on Linux aarch64 per \`icom-lan-pro\`'s playbook §6–§8 — after the companion's belt-and-braces fix also lands.

## Follow-ups (separate PRs / issues)

- Cleanup PR: delete \`AudioBufferPool\` module + its tests + \`get_audio_buffer_pool_size\` in env_config + remove PCM-8 dead mapping at \`handlers/audio.py:213-214\`. All pure deletions. ~5 files, net LOC reduction.
- **#766** — codec/channel change detection, blocking for #721 split-stereo toggle.

Partially closes #765 (primary fix; cleanup tracks remainder).