### PR TITLE
fix(#766): broadcaster picks up mid-stream codec/channel/sample_rate changes

### DIFF
--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -82,6 +82,10 @@ class AudioBroadcaster:
         # Multi-consumer PCM tap registry (replaces single _pcm_tap)
         self._tap_registry = TapRegistry()
         self._legacy_tap_handle: TapHandle | None = None
+        # Flag raised by invalidate_codec_state(); checked at top of each
+        # _relay_loop iteration to pick up mid-stream mono↔stereo switches
+        # driven by the audio_config WS handler (issue #766, unblocks #721).
+        self._codec_stale: bool = False
 
     async def subscribe(
         self, ws: WebSocketConnection | None = None
@@ -187,45 +191,59 @@ class AudioBroadcaster:
             )
         return len(dead_ids)
 
-    async def _start_relay(self) -> None:
-        if not self._radio or CAP_AUDIO not in self._radio.capabilities:
-            return
+    def invalidate_codec_state(self) -> None:
+        """Mark broadcaster's cached codec state as stale.
 
+        The next ``_relay_loop`` iteration will call ``_refresh_codec_state``
+        to pick up any radio-side codec / channel / sample-rate changes.
+        Called by ``AudioHandler._handle_audio_config`` after a successful
+        CI-V Phones L/R Mix set, since that can flip the radio from mono
+        to stereo output (issue #766, unblocks #721).
+        """
+        self._codec_stale = True
+
+    def _refresh_codec_state(self, *, first: bool = False) -> None:
+        """Read radio's current codec / channels / sample rate into cache.
+
+        Called from ``_start_relay`` (``first=True``) and from ``_relay_loop``
+        whenever ``invalidate_codec_state`` has been called since the last
+        refresh. Behavior-preserving extraction of the block previously
+        inlined in ``_start_relay``.
+        """
         # Negotiate web codec from radio's actual audio codec
         _codec = getattr(self._radio, "audio_codec", None)
         if isinstance(_codec, AudioCodec):
-            # Map radio codec → web transport codec
-            # For ulaw codecs, we transcode to PCM16 in _relay_loop
-            # NOTE: PCM_1CH_8BIT / PCM_2CH_8BIT intentionally NOT mapped.  No
-            # tested backend negotiates 8-bit PCM; a speculative "upcast in
-            # future" map previously existed but the upcast was never wired,
-            # so any 8-bit payload was shipped under a 16-bit label and
-            # garbled by consumers.  Removed per #765; unknown codec falls
-            # through to the PCM16 default + logs the value.
+            # Map radio codec → web transport codec.
+            # For ulaw codecs, we transcode to PCM16 in _relay_loop.
+            # NOTE: PCM_1CH_8BIT / PCM_2CH_8BIT intentionally NOT mapped
+            # (see #765); unknown codec falls through to PCM16 default.
             _CODEC_MAP = {
                 AudioCodec.OPUS_1CH: AUDIO_CODEC_OPUS,
                 AudioCodec.OPUS_2CH: AUDIO_CODEC_OPUS,
                 AudioCodec.PCM_1CH_16BIT: AUDIO_CODEC_PCM16,
                 AudioCodec.PCM_2CH_16BIT: AUDIO_CODEC_PCM16,
-                AudioCodec.ULAW_1CH: AUDIO_CODEC_PCM16,  # decoded in _relay_loop
-                AudioCodec.ULAW_2CH: AUDIO_CODEC_PCM16,  # decoded in _relay_loop
+                AudioCodec.ULAW_1CH: AUDIO_CODEC_PCM16,
+                AudioCodec.ULAW_2CH: AUDIO_CODEC_PCM16,
             }
             self._web_codec = _CODEC_MAP.get(_codec, AUDIO_CODEC_PCM16)
-            # Store original codec for decoding logic
             self._radio_codec = _codec
-            if _codec in (
-                AudioCodec.PCM_2CH_16BIT,
-                AudioCodec.ULAW_2CH,
-                AudioCodec.OPUS_2CH,
-            ):
-                self._channels = 2
+            self._channels = (
+                2
+                if _codec
+                in (
+                    AudioCodec.PCM_2CH_16BIT,
+                    AudioCodec.ULAW_2CH,
+                    AudioCodec.OPUS_2CH,
+                )
+                else 1
+            )
             logger.info(
                 "audio-broadcaster: radio codec=%s (0x%02x) → web_codec=0x%02x",
                 _codec.name,
                 int(_codec),
                 self._web_codec,
             )
-        else:
+        elif first:
             logger.warning(
                 "audio-broadcaster: no radio codec info, defaulting to PCM16"
             )
@@ -233,11 +251,18 @@ class AudioBroadcaster:
         if isinstance(_sr, int) and not isinstance(_sr, bool) and _sr > 0:
             self._sample_rate = _sr
         logger.info(
-            "audio-broadcaster: starting relay codec=0x%02x sr=%d ch=%d",
+            "audio-broadcaster: %s codec=0x%02x sr=%d ch=%d",
+            "starting relay" if first else "codec state refreshed",
             self._web_codec,
             self._sample_rate,
             self._channels,
         )
+
+    async def _start_relay(self) -> None:
+        if not self._radio or CAP_AUDIO not in self._radio.capabilities:
+            return
+
+        self._refresh_codec_state(first=True)
 
         try:
             bus = self._radio.audio_bus  # type: ignore[attr-defined]
@@ -256,6 +281,9 @@ class AudioBroadcaster:
             async for pkt in self._subscription:
                 if pkt is None:
                     continue
+                if self._codec_stale:
+                    self._refresh_codec_state()
+                    self._codec_stale = False
                 if self._seq < 3 or self._seq % 500 == 0:
                     logger.info(
                         "audio: rx packet #%d, web_codec=0x%02x, data=%d bytes",
@@ -550,6 +578,11 @@ class AudioHandler:
             split_stereo,
             phones_byte,
         )
+        # Radio may switch mono↔stereo output after this CI-V; broadcaster's
+        # cached codec/channels must be refreshed on the next relay iteration
+        # (issue #766, unblocks #721 stereo toggle).
+        if self._broadcaster is not None:
+            self._broadcaster.invalidate_codec_state()
         await self._send_json(
             {
                 "type": "audio_config",

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -19,7 +19,7 @@ import json
 import struct
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1440,6 +1440,90 @@ class TestBroadcasterFrameMsInvariant:
         expected = (payload_len * 1000) // (sr * ch * 2)
         assert frame_ms == expected
         assert frame_ms == 20
+
+
+class TestBroadcasterCodecInvalidation:
+    """Broadcaster picks up mid-stream codec/channel changes via
+    ``invalidate_codec_state`` (issue #766, unblocks #721 split-stereo)."""
+
+    @staticmethod
+    def _setup(audio_codec: object, sample_rate: int) -> tuple[Any, Any, Any]:
+        from types import SimpleNamespace
+
+        from icom_lan.audio_bus import AudioBus
+        from icom_lan.radio_protocol import AudioCapable
+        from icom_lan.web.handlers import AudioBroadcaster, AudioHandler
+        from icom_lan.web.websocket import WebSocketConnection
+
+        mock_ws = MagicMock(spec=WebSocketConnection)
+        mock_ws.send_text = AsyncMock()
+        mock_radio = MagicMock(spec=AudioCapable)
+        mock_radio.capabilities = {"audio"}
+        mock_radio.audio_codec = audio_codec
+        mock_radio.audio_sample_rate = sample_rate
+        mock_radio.start_audio_rx_opus = AsyncMock()
+        mock_radio.stop_audio_rx_opus = AsyncMock()
+        mock_radio.send_civ = AsyncMock()
+        mock_radio.profile = SimpleNamespace(receiver_count=2)
+
+        bus = AudioBus(mock_radio)
+        mock_radio.audio_bus = bus
+
+        broadcaster = AudioBroadcaster(mock_radio)
+        handler = AudioHandler(mock_ws, mock_radio, broadcaster)
+        return handler, broadcaster, mock_radio
+
+    async def test_invalidate_flag_triggers_refresh_on_next_packet(self) -> None:
+        from icom_lan.types import AudioCodec
+
+        handler, broadcaster, mock_radio = self._setup(AudioCodec.PCM_1CH_16BIT, 48000)
+        await handler._start_rx()
+
+        pkt_mono = MagicMock()
+        pkt_mono.data = b"\x00\x01" * 960
+        mock_radio.audio_bus._on_opus_packet(pkt_mono)
+        await asyncio.sleep(0.05)
+        handler._frame_queue.get_nowait()
+        assert broadcaster._channels == 1
+
+        mock_radio.audio_codec = AudioCodec.PCM_2CH_16BIT
+        broadcaster.invalidate_codec_state()
+        assert broadcaster._codec_stale is True
+
+        pkt_stereo = MagicMock()
+        pkt_stereo.data = b"\x00\x01" * 1920
+        mock_radio.audio_bus._on_opus_packet(pkt_stereo)
+        await asyncio.sleep(0.05)
+
+        assert broadcaster._channels == 2
+        assert broadcaster._codec_stale is False
+
+    async def test_handler_invalidates_on_audio_config(self) -> None:
+        from icom_lan.types import AudioCodec
+
+        handler, broadcaster, _ = self._setup(AudioCodec.PCM_1CH_16BIT, 48000)
+        assert broadcaster._codec_stale is False
+        await handler._handle_control(
+            {"type": "audio_config", "focus": "both", "split_stereo": True}
+        )
+        assert broadcaster._codec_stale is True
+
+    async def test_static_codec_refreshes_only_on_start(self) -> None:
+        from icom_lan.types import AudioCodec
+
+        handler, broadcaster, mock_radio = self._setup(AudioCodec.PCM_1CH_16BIT, 48000)
+        with patch.object(
+            broadcaster,
+            "_refresh_codec_state",
+            wraps=broadcaster._refresh_codec_state,
+        ) as spy:
+            await handler._start_rx()
+            for _ in range(5):
+                pkt = MagicMock()
+                pkt.data = b"\x00\x01" * 100
+                mock_radio.audio_bus._on_opus_packet(pkt)
+                await asyncio.sleep(0.02)
+            assert spy.call_count == 1
 
 
 class TestAudioHandlerTxTranscoderRate:


### PR DESCRIPTION
Unblocks #721 split-stereo toggle. Part of epic #764.

## Problem

\`AudioBroadcaster._start_relay\` read \`audio_codec\` / \`audio_sample_rate\` / \`_channels\` **once** at relay start and cached forever.  When #721 UI toggles split_stereo, the backend \`audio_config\` handler (#755) emits CI-V Phones L/R Mix → radio switches output mono↔stereo, but the broadcaster kept stale cache.  Wire-header \`channels\` and the payload-derived \`frame_ms\` (from #767) stayed wrong for the rest of the session.

## Fix (Option 2 — invalidate-from-handler)

- Extracted the codec-init block out of \`_start_relay\` into \`_refresh_codec_state(first: bool = False)\`.  Behavior-preserving on \`first=True\` path; distinct log line on mid-stream refresh.
- Added public \`invalidate_codec_state()\` that sets a \`_codec_stale\` flag.
- \`_relay_loop\` checks the flag at the top of each iteration and refreshes when set.  Zero cost on the happy path (one bool read per packet).
- \`AudioHandler._handle_audio_config\` calls \`broadcaster.invalidate_codec_state()\` after the CI-V send succeeds.

Rejected Option 1 (re-read every packet) — the two getattrs are cheap but there's no reason to pay for them when the relay knows exactly when a change can happen.

## Tests — \`TestBroadcasterCodecInvalidation\` (3 cases)

1. Invalidate flag + next packet → channels/codec picked up mid-stream.
2. \`audio_config\` WS message raises the flag.
3. Static codec: \`_refresh_codec_state\` called exactly once at start, not per packet.

## Test plan

- [x] Full suite: 4682 passed (+3), 0 regressions.
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy src/\` clean.
- [ ] Manual validation on live IC-7610 after #756 (UI) lands.

Closes #766.