### PR TITLE
feat(#756): AudioRoutingControl — MAIN/SUB focus, stereo split, per-channel gain

### DIFF
--- a/frontend/src/components-v2/panels/AudioRoutingControl.svelte
+++ b/frontend/src/components-v2/panels/AudioRoutingControl.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { makeAudioRoutingHandlers } from '../wiring/command-bus';
+  import { receiverLabel } from '$lib/stores/capabilities.svelte';
+
+  type AudioFocus = 'main' | 'sub' | 'both';
+
+  const handlers = makeAudioRoutingHandlers();
+
+  let focus: AudioFocus = $state('both');
+  let splitStereo = $state(false);
+  let mainGainDb = $state(0);
+  let subGainDb = $state(0);
+
+  onMount(() => {
+    const restored = handlers.restoreFromStorage();
+    focus = restored.focus;
+    splitStereo = restored.split_stereo;
+    mainGainDb = restored.main_gain_db;
+    subGainDb = restored.sub_gain_db;
+  });
+
+  function setFocus(next: AudioFocus) {
+    focus = next;
+    handlers.onFocusChange(next);
+  }
+
+  function toggleSplit() {
+    splitStereo = !splitStereo;
+    handlers.onSplitStereoChange(splitStereo);
+  }
+
+  function updateGain(channel: 'main' | 'sub', value: number) {
+    if (channel === 'main') mainGainDb = value;
+    else subGainDb = value;
+    handlers.onChannelGainChange(channel, value);
+  }
+
+  const FOCUS_OPTIONS: Array<{ value: AudioFocus; label: string }> = [
+    { value: 'main', label: receiverLabel('MAIN') },
+    { value: 'sub', label: receiverLabel('SUB') },
+    { value: 'both', label: 'Both' },
+  ];
+</script>
+
+<div class="audio-routing" aria-label="Audio routing">
+  <div class="focus-row" role="radiogroup" aria-label="Audio focus">
+    {#each FOCUS_OPTIONS as opt (opt.value)}
+      <button
+        type="button"
+        role="radio"
+        aria-checked={focus === opt.value}
+        class:active={focus === opt.value}
+        onclick={() => setFocus(opt.value)}
+      >
+        {opt.label}
+      </button>
+    {/each}
+  </div>
+
+  <button
+    type="button"
+    class="split-toggle"
+    class:active={splitStereo}
+    aria-pressed={splitStereo}
+    onclick={toggleSplit}
+    title="Route MAIN to left channel, SUB to right channel"
+  >
+    Stereo split
+  </button>
+
+  <label class="gain-row">
+    <span class="gain-label">{receiverLabel('MAIN')}</span>
+    <input
+      type="range"
+      min="-60"
+      max="12"
+      step="1"
+      aria-label="MAIN gain in decibels"
+      value={mainGainDb}
+      oninput={(e) => updateGain('main', Number((e.target as HTMLInputElement).value))}
+    />
+    <span class="gain-value">{mainGainDb} dB</span>
+  </label>
+
+  <label class="gain-row">
+    <span class="gain-label">{receiverLabel('SUB')}</span>
+    <input
+      type="range"
+      min="-60"
+      max="12"
+      step="1"
+      aria-label="SUB gain in decibels"
+      value={subGainDb}
+      oninput={(e) => updateGain('sub', Number((e.target as HTMLInputElement).value))}
+    />
+    <span class="gain-value">{subGainDb} dB</span>
+  </label>
+</div>
+
+<style>
+  .audio-routing {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 7px 8px;
+    border-top: 1px solid var(--v2-border-subtle, rgba(255, 255, 255, 0.08));
+  }
+  .focus-row {
+    display: flex;
+    gap: 4px;
+  }
+  .focus-row > button {
+    flex: 1 1 0;
+    min-width: 0;
+    padding: 4px 6px;
+    background: transparent;
+    border: 1px solid var(--v2-border-subtle, rgba(255, 255, 255, 0.15));
+    color: var(--v2-text-primary, #e5e7eb);
+    border-radius: 3px;
+    font-size: 10px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .focus-row > button.active {
+    background: var(--v2-accent-cyan-alt, rgba(34, 211, 238, 0.22));
+    border-color: var(--v2-accent-cyan, #22d3ee);
+  }
+  .split-toggle {
+    padding: 4px 8px;
+    background: transparent;
+    border: 1px solid var(--v2-border-subtle, rgba(255, 255, 255, 0.15));
+    color: var(--v2-text-primary, #e5e7eb);
+    border-radius: 3px;
+    font-size: 10px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .split-toggle.active {
+    background: var(--v2-accent-cyan-alt, rgba(34, 211, 238, 0.22));
+    border-color: var(--v2-accent-cyan, #22d3ee);
+  }
+  .gain-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 10px;
+  }
+  .gain-label {
+    flex: 0 0 48px;
+    color: var(--v2-text-muted, #9ca3af);
+  }
+  .gain-row input {
+    flex: 1 1 0;
+  }
+  .gain-value {
+    flex: 0 0 42px;
+    text-align: right;
+    font-family: 'Roboto Mono', monospace;
+    color: var(--v2-text-primary, #e5e7eb);
+  }
+</style>

--- a/frontend/src/components-v2/panels/RxAudioPanel.svelte
+++ b/frontend/src/components-v2/panels/RxAudioPanel.svelte
@@ -5,6 +5,8 @@
   import { buildMonitorOptions, formatMonitorStatus } from './audio-utils';
   import { getShortcutHint } from '../layout/shortcut-hints';
   import { isAudioConnected } from '$lib/stores/connection.svelte';
+  import { hasDualReceiver } from '$lib/stores/capabilities.svelte';
+  import AudioRoutingControl from './AudioRoutingControl.svelte';
 
   const handlers = getRxAudioHandlers();
   let props = $derived(deriveRxAudioProps());
@@ -51,6 +53,9 @@
       <div class="output-indicator" class:audio-disconnected={showDisconnected}>
         {#if showDisconnected}Audio link lost — reconnecting…{:else}{statusText}{/if}
       </div>
+      {#if hasDualReceiver()}
+        <AudioRoutingControl />
+      {/if}
     </div>
 {/if}
 

--- a/frontend/src/components-v2/panels/__tests__/AudioRoutingControl.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/AudioRoutingControl.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+
+// Mock audio-manager so we can spy on setAudioConfig calls.
+const setAudioConfigSpy = vi.fn();
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    setAudioConfig: (...args: unknown[]) => setAudioConfigSpy(...args),
+    getAudioConfig: () => ({
+      focus: 'both',
+      split_stereo: false,
+      main_gain_db: 0,
+      sub_gain_db: 0,
+    }),
+  },
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  receiverLabel: (id: 'MAIN' | 'SUB') => id,
+}));
+
+import AudioRoutingControl from '../AudioRoutingControl.svelte';
+
+let target: HTMLElement;
+let component: ReturnType<typeof mount>;
+let originalLocalStorage: Storage | undefined;
+
+// Install a fresh, in-memory localStorage for each test.  Under vitest's
+// shared-context config (isolate: false) some earlier tests stub out
+// globals; this guarantees a clean slate regardless of sibling files.
+function installLocalStorage(): Map<string, string> {
+  const store = new Map<string, string>();
+  const stub: Storage = {
+    get length() { return store.size; },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+  };
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: stub, writable: true, configurable: true,
+  });
+  return store;
+}
+
+beforeEach(() => {
+  setAudioConfigSpy.mockClear();
+  originalLocalStorage = (globalThis as any).localStorage;
+  installLocalStorage();
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  if (target && target.parentNode) target.parentNode.removeChild(target);
+  if (originalLocalStorage !== undefined) {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: originalLocalStorage, writable: true, configurable: true,
+    });
+  }
+});
+
+function mountControl() {
+  component = mount(AudioRoutingControl, { target });
+  flushSync();
+}
+
+describe('AudioRoutingControl', () => {
+  it('renders three focus buttons with radiogroup a11y', () => {
+    mountControl();
+    const radiogroup = target.querySelector('[role="radiogroup"]');
+    expect(radiogroup).not.toBeNull();
+    const radios = target.querySelectorAll('[role="radio"]');
+    expect(radios.length).toBe(3);
+  });
+
+  it('click on MAIN fires setAudioConfig({focus: "main"}) and persists', async () => {
+    mountControl();
+    const radios = Array.from(target.querySelectorAll('[role="radio"]')) as HTMLButtonElement[];
+    const mainBtn = radios[0];
+    mainBtn.click();
+    flushSync();
+    expect(setAudioConfigSpy).toHaveBeenCalledWith({ focus: 'main' });
+    expect(localStorage.getItem('icom.audio.focus')).toBe('main');
+    // aria-checked reflects new state
+    expect(mainBtn.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('split toggle flips aria-pressed and fires setAudioConfig', () => {
+    mountControl();
+    const toggle = target.querySelector('.split-toggle') as HTMLButtonElement;
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    toggle.click();
+    flushSync();
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(setAudioConfigSpy).toHaveBeenCalledWith({ split_stereo: true });
+    expect(localStorage.getItem('icom.audio.split_stereo')).toBe('1');
+  });
+
+  it('MAIN slider dispatches setAudioConfig({main_gain_db: …}) and persists', () => {
+    mountControl();
+    const sliders = target.querySelectorAll('input[type="range"]');
+    const mainSlider = sliders[0] as HTMLInputElement;
+    mainSlider.value = '-12';
+    mainSlider.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(setAudioConfigSpy).toHaveBeenCalledWith({ main_gain_db: -12 });
+    expect(localStorage.getItem('icom.audio.main_gain_db')).toBe('-12');
+  });
+
+  it('SUB slider dispatches setAudioConfig({sub_gain_db: …})', () => {
+    mountControl();
+    const sliders = target.querySelectorAll('input[type="range"]');
+    const subSlider = sliders[1] as HTMLInputElement;
+    subSlider.value = '-3';
+    subSlider.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(setAudioConfigSpy).toHaveBeenCalledWith({ sub_gain_db: -3 });
+  });
+
+  it('rehydrates from localStorage on mount', () => {
+    localStorage.setItem('icom.audio.focus', 'sub');
+    localStorage.setItem('icom.audio.split_stereo', '1');
+    localStorage.setItem('icom.audio.main_gain_db', '-6');
+    localStorage.setItem('icom.audio.sub_gain_db', '2');
+
+    mountControl();
+
+    // setAudioConfig called once by restoreFromStorage with the stored values.
+    const restoreCall = setAudioConfigSpy.mock.calls.find((c) =>
+      c[0] && typeof c[0] === 'object'
+      && 'focus' in c[0] && 'split_stereo' in c[0]
+      && 'main_gain_db' in c[0] && 'sub_gain_db' in c[0]
+    );
+    expect(restoreCall).toBeDefined();
+    expect(restoreCall?.[0]).toEqual({
+      focus: 'sub',
+      split_stereo: true,
+      main_gain_db: -6,
+      sub_gain_db: 2,
+    });
+
+    // UI reflects restored values.
+    const radios = Array.from(target.querySelectorAll('[role="radio"]')) as HTMLButtonElement[];
+    const subRadio = radios[1];
+    expect(subRadio.getAttribute('aria-checked')).toBe('true');
+
+    const toggle = target.querySelector('.split-toggle') as HTMLButtonElement;
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+
+    const sliders = target.querySelectorAll('input[type="range"]');
+    expect((sliders[0] as HTMLInputElement).value).toBe('-6');
+    expect((sliders[1] as HTMLInputElement).value).toBe('2');
+  });
+});

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -611,6 +611,84 @@ export function makeRxAudioHandlers() {
   };
 }
 
+/* ── Dual-RX audio routing (#756) ────────────────────────────────
+ * UI surface for the pipeline plumbed in #755 (audio_config WS +
+ * CI-V Phones L/R Mix) and #757 (RxPlayer routing graph).  Three
+ * widgets: focus selector, stereo split toggle, per-channel gain.
+ */
+
+const LS_FOCUS = 'icom.audio.focus';
+const LS_SPLIT = 'icom.audio.split_stereo';
+const LS_MAIN_DB = 'icom.audio.main_gain_db';
+const LS_SUB_DB = 'icom.audio.sub_gain_db';
+
+type AudioFocus = 'main' | 'sub' | 'both';
+
+function _ls<T>(key: string, parse: (raw: string) => T | null): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return null;
+    return parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function _lsSet(key: string, value: string): void {
+  try { localStorage.setItem(key, value); } catch { /* quota / private mode — ignore */ }
+}
+
+export function makeAudioRoutingHandlers() {
+  return {
+    onFocusChange: (focus: AudioFocus) => {
+      audioManager.setAudioConfig({ focus });
+      _lsSet(LS_FOCUS, focus);
+    },
+    onSplitStereoChange: (on: boolean) => {
+      audioManager.setAudioConfig({ split_stereo: on });
+      _lsSet(LS_SPLIT, on ? '1' : '0');
+    },
+    onChannelGainChange: (channel: 'main' | 'sub', db: number) => {
+      const safe = Number.isFinite(db) ? db : 0;
+      if (channel === 'main') {
+        audioManager.setAudioConfig({ main_gain_db: safe });
+        _lsSet(LS_MAIN_DB, String(safe));
+      } else {
+        audioManager.setAudioConfig({ sub_gain_db: safe });
+        _lsSet(LS_SUB_DB, String(safe));
+      }
+    },
+    restoreFromStorage: () => {
+      const focus = _ls<AudioFocus>(LS_FOCUS, (r) =>
+        r === 'main' || r === 'sub' || r === 'both' ? r : null
+      );
+      const split = _ls<boolean>(LS_SPLIT, (r) => r === '1');
+      const mainDb = _ls<number>(LS_MAIN_DB, (r) => {
+        const n = Number(r);
+        return Number.isFinite(n) ? n : null;
+      });
+      const subDb = _ls<number>(LS_SUB_DB, (r) => {
+        const n = Number(r);
+        return Number.isFinite(n) ? n : null;
+      });
+      const cfg: Record<string, unknown> = {};
+      if (focus !== null) cfg.focus = focus;
+      if (split !== null) cfg.split_stereo = split;
+      if (mainDb !== null) cfg.main_gain_db = mainDb;
+      if (subDb !== null) cfg.sub_gain_db = subDb;
+      if (Object.keys(cfg).length > 0) {
+        audioManager.setAudioConfig(cfg);
+      }
+      return {
+        focus: focus ?? 'both' as AudioFocus,
+        split_stereo: split ?? false,
+        main_gain_db: mainDb ?? 0,
+        sub_gain_db: subDb ?? 0,
+      };
+    },
+  };
+}
+
 /* ── Band Selector Handlers ──────────────────────────────────── */
 
 export function makePresetHandlers() {


### PR DESCRIPTION
UI surface for dual-RX audio routing. Part of #721 / epic #708.

## Widgets

1. **Focus selector** — MAIN / SUB / Both (\`role=\"radiogroup\"\`, \`aria-checked\`).
2. **Stereo split toggle** — button with \`aria-pressed\`; when on, MAIN → L, SUB → R.
3. **Two independent gain sliders** — MAIN and SUB, range -60..+12 dB, \`aria-label\`.

All gated behind \`hasDualReceiver()\` — hidden on 1-Rx radios.

## Stack

- Backend \`audio_config\` WS + CI-V Phones L/R Mix: #755 (landed).
- \`RxPlayer\` routing graph + \`AudioManager.setAudioConfig(...)\` API: #757 (landed).
- Codec/channel change detection on toggle: #766 → #769 (landed).
- **This PR:** UI + wiring + localStorage persistence.

## localStorage keys

- \`icom.audio.focus\` — \`'main' | 'sub' | 'both'\`
- \`icom.audio.split_stereo\` — \`'1' | '0'\`
- \`icom.audio.main_gain_db\` — number as string
- \`icom.audio.sub_gain_db\` — number as string

Component rehydrates on mount and dispatches restored config to \`audioManager.setAudioConfig()\`.

## Files

- \`frontend/src/components-v2/wiring/command-bus.ts\` — new \`makeAudioRoutingHandlers()\` factory with \`restoreFromStorage\` helper.
- \`frontend/src/components-v2/panels/AudioRoutingControl.svelte\` (new).
- \`frontend/src/components-v2/panels/RxAudioPanel.svelte\` — mounts the control when dual-RX.
- \`frontend/src/components-v2/panels/__tests__/AudioRoutingControl.test.ts\` (new) — 6 vitest cases.

## Tests

1. Focus row has 3 buttons in a radiogroup with correct a11y.
2. Click MAIN → \`setAudioConfig({focus: 'main'})\` + localStorage write + \`aria-checked\`.
3. Split toggle flips \`aria-pressed\` + setAudioConfig.
4. MAIN slider change → \`setAudioConfig({main_gain_db: N})\` + persist.
5. SUB slider change → \`setAudioConfig({sub_gain_db: N})\`.
6. Rehydrate from localStorage: pre-set keys → mount → setAudioConfig called with restored values + UI reflects them.

Test notes: component installs a fresh in-memory localStorage stub per test. Under the vitest shared-context config (\`isolate: false\` from PR #707), some sibling suites stub globals at module scope; the local installer guarantees deterministic isolation regardless of sibling test order.

## Test plan

- [x] New 6 tests pass.
- [x] Frontend vitest: 1522 passed (+6), 0 regressions.
- [x] Backend pytest: 4682 passed, unchanged.
- [x] \`npm run build\` clean.
- [ ] Manual validation on live IC-7610: toggle split → L/R audible separately; focus switch silences the other RX.

Closes #756.
Unblocks #754 (end-to-end integration tests).