### PR TITLE
fix(web): VFO MAIN/SUB buttons emit receiver-select, not swap

### DIFF
--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -1274,29 +1274,41 @@ class RadioPoller:
                         logger.warning("set_band: unknown bsr_code=%d", band)
             case SelectVfo(vfo=vfo):
                 self._last_user_write_ts = time.monotonic()
-                # IC-7610 LAN audio is always from MAIN receiver (mono).
-                # To "switch" audio to SUB, we SWAP MAIN↔SUB (0x07 0xB0).
-                # This exchanges frequencies, modes, and all params between
-                # MAIN and SUB — audio, scope, everything follows MAIN.
+                # Select the target receiver via 0x07 0xD0 (MAIN) or 0xD1
+                # (SUB).  Pre-#771 this used a MAIN↔SUB swap (0x07 0xB0)
+                # as a hack so that LAN audio (MAIN-only at the time)
+                # would "follow" the selected receiver.  After #721/#755
+                # introduced Phones L/R Mix + audio_config, audio routing
+                # is independent of which receiver is selected, and the
+                # swap hack actively corrupted user state on every click
+                # (frequencies/modes traded places).  Now uses the proper
+                # CI-V receiver-select primitive.  Idempotent: re-clicking
+                # the active receiver emits no CI-V (the state event still
+                # fires so UI listeners can refresh).
                 vfo_upper = vfo.upper()
                 is_sub = vfo_upper in ("SUB", "B")
                 if is_sub:
                     self._ensure_receiver_supported(1, operation="select_vfo")
                 current = self._current_active()
-                need_swap = (is_sub and current == "MAIN") or (
-                    not is_sub and current == "SUB"
-                )
-                if need_swap:
-                    if self._profile.vfo_swap_code is None:
+                target = "SUB" if is_sub else "MAIN"
+                if target != current:
+                    code = (
+                        self._profile.vfo_sub_code
+                        if is_sub
+                        else self._profile.vfo_main_code
+                    )
+                    if code is None:
                         raise CommandError(
-                            f"select_vfo({vfo}) is unsupported by profile {self._profile.model}: "
-                            "no VFO swap code"
+                            f"select_vfo({vfo}) is unsupported by profile "
+                            f"{self._profile.model}: no MAIN/SUB select code"
                         )
-                    await self._civ(0x07, data=bytes([self._profile.vfo_swap_code]))
-                    logger.info("radio-poller: VFO swap (Main<>Sub)")
+                    await self._civ(0x07, data=bytes([code]))
+                    logger.info(
+                        "radio-poller: select VFO=%s (0x07 0x%02X)", target, code
+                    )
                     rs = getattr(self._radio, "_radio_state", None)
                     if rs is not None and hasattr(rs, "active"):
-                        rs.active = "SUB" if current == "MAIN" else "MAIN"
+                        rs.active = target
                 if self._on_state_event:
                     self._on_state_event("vfo_changed", {"vfo": vfo})
             case VfoSwap():

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -218,8 +218,16 @@ async def test_execute_event_emitting_commands_and_vfo_paths() -> None:
 
     await poller._execute(SelectVfo("SUB"))  # noqa: SLF001
     assert radio._radio_state.active == "SUB"
+    radio.send_civ.assert_any_await(0x07, sub=None, data=bytes([0xD1]), wait_response=False)
     await poller._execute(SelectVfo("MAIN"))  # noqa: SLF001
-    assert radio.send_civ.await_count >= 2
+    assert radio._radio_state.active == "MAIN"
+    radio.send_civ.assert_any_await(0x07, sub=None, data=bytes([0xD0]), wait_response=False)
+    # Re-clicking the active receiver is a no-op CI-V-wise but still emits
+    # the state event so UI listeners can refresh.
+    civ_calls_before = radio.send_civ.await_count
+    await poller._execute(SelectVfo("MAIN"))  # noqa: SLF001
+    assert radio.send_civ.await_count == civ_calls_before
+    assert any(name == "vfo_changed" for name, _ in events)
 
     await poller._execute(VfoSwap())  # noqa: SLF001
     assert any(name == "vfo_swapped" for name, _ in events)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2455,8 +2455,8 @@ class TestSwitchScopeReceiver:
             "Expected invalid receiver to be rejected without CI-V send"
         )
 
-    async def test_select_vfo_sub_sends_swap(self) -> None:
-        """SelectVfo("SUB") sends VFO swap (0x07 0xB0) when active=MAIN."""
+    async def test_select_vfo_sub_sends_receiver_select(self) -> None:
+        """SelectVfo("SUB") sends receiver-select (0x07 0xD1) when active=MAIN."""
         from icom_lan.web.radio_poller import CommandQueue, RadioPoller, SelectVfo
 
         radio = self._make_radio()
@@ -2468,15 +2468,23 @@ class TestSwitchScopeReceiver:
         await asyncio.sleep(0.03)
         poller.stop()
 
+        sub_select_calls = [
+            c
+            for c in radio.send_civ.call_args_list
+            if c[0][0] == 0x07 and c.kwargs.get("data") == bytes([0xD1])
+        ]
+        assert len(sub_select_calls) >= 1, (
+            "Expected SUB receiver-select (0x07 0xD1) on SelectVfo SUB"
+        )
         swap_calls = [
             c
             for c in radio.send_civ.call_args_list
             if c[0][0] == 0x07 and c.kwargs.get("data") == bytes([0xB0])
         ]
-        assert len(swap_calls) >= 1, "Expected VFO swap (0x07 0xB0) on SelectVfo SUB"
+        assert len(swap_calls) == 0, "Must NOT emit swap (0x07 0xB0) on SelectVfo"
 
-    async def test_select_vfo_main_no_swap_when_already_main(self) -> None:
-        """SelectVfo("MAIN") does NOT swap when already on MAIN."""
+    async def test_select_vfo_main_noop_when_already_main(self) -> None:
+        """SelectVfo("MAIN") emits no CI-V when already on MAIN."""
         from icom_lan.web.radio_poller import CommandQueue, RadioPoller, SelectVfo
 
         radio = self._make_radio()
@@ -2488,12 +2496,13 @@ class TestSwitchScopeReceiver:
         await asyncio.sleep(0.03)
         poller.stop()
 
-        swap_calls = [
+        select_calls = [
             c
             for c in radio.send_civ.call_args_list
-            if c[0][0] == 0x07 and c.kwargs.get("data") == bytes([0xB0])
+            if c[0][0] == 0x07
+            and c.kwargs.get("data") in (bytes([0xD0]), bytes([0xD1]), bytes([0xB0]))
         ]
-        assert len(swap_calls) == 0, "Should NOT swap when already on MAIN"
+        assert len(select_calls) == 0, "Should NOT emit 0x07 select when already MAIN"
 
     async def test_set_split_updates_radio_and_state(self) -> None:
         """SetSplit(on) calls radio.set_split_mode and updates RadioState.split."""


### PR DESCRIPTION
## Summary

- The web UI MAIN/SUB VFO buttons were using **MAIN↔SUB swap (0x07 0xB0)** as a proxy for receiver selection. This was a pre-#721 hack from when LAN audio was MAIN-only — swapping made the audio "follow" the selected receiver.
- After #721/#755 introduced Phones L/R Mix routing + `audio_config`, audio is independent of which receiver is selected, and the swap hack began **actively corrupting state**: clicking SUB exchanged MAIN/SUB frequencies and modes on the radio; clicking the already-active receiver emitted no CI-V at all.
- Live report from IC-7610: *"Кнопки управления MAIN/SUB VFO не работают. 1. Нет изменений на радио. 2. Бессмысленные изменения в веб."*

## Fix

Use the proper CI-V receiver-select primitive instead of swap:
- `SelectVfo("MAIN")` → `0x07 0xD0` (from `profile.vfo_main_code`, `rigs/ic7610.toml main_select=[0xD0]`)
- `SelectVfo("SUB")` → `0x07 0xD1` (from `profile.vfo_sub_code`, `rigs/ic7610.toml sub_select=[0xD1]`)
- Idempotent: re-clicking the already-active receiver emits no CI-V; state event still fires so UI listeners refresh.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4682 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/icom_lan/web/radio_poller.py` — clean
- [x] Unit tests updated to assert exact CI-V bytes (0xD0 / 0xD1) and that 0xB0 is **never** emitted on SelectVfo
- [ ] Manual verification on live IC-7610: click MAIN, click SUB, click MAIN again, confirm no freq/mode exchange and radio's selected receiver matches UI

## Behavior change (visible to users)

- **BEFORE:** click SUB → MAIN/SUB frequencies exchange on the radio (jarring).
- **AFTER:** click SUB → radio simply selects SUB receiver; frequencies stay where they are. Audio routing is driven independently by `audio_config`, aligned with the architecture established in #721/#755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)