### PR TITLE
feat(web-ui/#777): VfoOps rewire — 4 buttons + read-only TX indicator

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -217,11 +217,11 @@
       dualWatchActive={vfoOps.dualWatch}
       txVfo={vfoOps.txVfo}
       onSwap={vfoHandlers.onSwap}
-      onCopy={vfoHandlers.onCopy}
       onEqual={vfoHandlers.onEqual}
       onSplitToggle={vfoHandlers.onSplitToggle}
-      onDualWatchToggle={() => vfoHandlers.onDualWatchToggle(!vfoOps.dualWatch)}
-      onTxVfoChange={vfoHandlers.onTxVfoChange}
+      onQuickSplit={vfoHandlers.onQuickSplit}
+      onDualWatchToggle={vfoHandlers.onDualWatchToggle}
+      onQuickDw={vfoHandlers.onQuickDw}
       onMainVfoClick={vfoHandlers.onMainVfoClick}
       onSubVfoClick={vfoHandlers.onSubVfoClick}
       onMainModeClick={vfoHandlers.onMainModeClick}

--- a/frontend/src/components-v2/layout/VfoHeader.svelte
+++ b/frontend/src/components-v2/layout/VfoHeader.svelte
@@ -14,13 +14,14 @@
     layoutProfile?: VfoLayoutProfile;
     splitActive: boolean;
     dualWatchActive: boolean;
+    /** Read-only indicator: which receiver currently transmits. */
     txVfo: 'main' | 'sub';
     onSwap?: () => void;
-    onCopy?: () => void;
     onEqual?: () => void;
     onSplitToggle?: () => void;
-    onDualWatchToggle?: () => void;
-    onTxVfoChange?: (v: string) => void;
+    onQuickSplit?: () => void;
+    onDualWatchToggle?: (on: boolean) => void;
+    onQuickDw?: () => void;
     onMainVfoClick?: () => void;
     onSubVfoClick?: () => void;
     onMainModeClick?: () => void;
@@ -38,11 +39,11 @@
     dualWatchActive,
     txVfo,
     onSwap = () => {},
-    onCopy = () => {},
     onEqual = () => {},
     onSplitToggle = () => {},
-    onDualWatchToggle = () => {},
-    onTxVfoChange = () => {},
+    onQuickSplit = () => {},
+    onDualWatchToggle = (_on: boolean) => {},
+    onQuickDw = () => {},
     onMainVfoClick,
     onSubVfoClick,
     onMainModeClick,
@@ -116,11 +117,11 @@
         {dualWatchActive}
         {txVfo}
         {onSwap}
-        {onCopy}
         {onEqual}
         {onSplitToggle}
-        {onDualWatchToggle}
-        {onTxVfoChange}
+        {onQuickSplit}
+        onDualWatchToggle={() => onDualWatchToggle(!dualWatchActive)}
+        {onQuickDw}
       />
 
       {#if dualReceiver}

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
@@ -230,21 +230,6 @@ describe('VfoHeader visual regression', () => {
           {
             "active": "false",
             "color": "muted",
-            "label": "M=S",
-          },
-          {
-            "active": "true",
-            "color": "orange",
-            "label": "TX→M",
-          },
-          {
-            "active": "false",
-            "color": "orange",
-            "label": "TX→S",
-          },
-          {
-            "active": "false",
-            "color": "muted",
             "label": "M↔S",
           },
         ],
@@ -303,21 +288,6 @@ describe('VfoHeader visual regression', () => {
             "active": "false",
             "color": "green",
             "label": "DW",
-          },
-          {
-            "active": "false",
-            "color": "muted",
-            "label": "M=S",
-          },
-          {
-            "active": "true",
-            "color": "orange",
-            "label": "TX→M",
-          },
-          {
-            "active": "false",
-            "color": "orange",
-            "label": "TX→S",
           },
           {
             "active": "false",

--- a/frontend/src/components-v2/vfo/VfoOps.svelte
+++ b/frontend/src/components-v2/vfo/VfoOps.svelte
@@ -1,18 +1,24 @@
 <script lang="ts">
   import '../controls/control-button.css';
   import { hasDualReceiver, getVfoScheme } from '$lib/stores/capabilities.svelte';
-  import { vfoSwapLabel, vfoCopyLabel, vfoEqualLabel, vfoTxLabel } from './vfo-ops-utils';
+  import { vfoSwapLabel, vfoCopyLabel, vfoTxLabel } from './vfo-ops-utils';
+  import { withDoubleClick } from '../wiring/double-click';
 
   interface Props {
     splitActive: boolean;
     dualWatchActive: boolean;
+    /** Read-only indicator: which receiver transmits right now.
+     *  Derived from split flag — see `toVfoOpsProps`. */
     txVfo: 'main' | 'sub';
     onSwap: () => void;
-    onCopy: () => void;
+    /** Equalize MAIN→SUB (copy). Backend sends `0x07 0xB1`. */
     onEqual: () => void;
+    /** Toggle SPLIT on/off. Double-click = Quick Split (equalize + ON). */
     onSplitToggle: () => void;
+    onQuickSplit: () => void;
+    /** Toggle Dual Watch on/off. Double-click = Quick DW (equalize + ON). */
     onDualWatchToggle: () => void;
-    onTxVfoChange: (v: string) => void;
+    onQuickDw: () => void;
   }
 
   let {
@@ -20,30 +26,42 @@
     dualWatchActive,
     txVfo,
     onSwap,
-    onCopy,
     onEqual,
     onSplitToggle,
+    onQuickSplit,
     onDualWatchToggle,
-    onTxVfoChange,
+    onQuickDw,
   }: Props = $props();
 
   let scheme = $derived(getVfoScheme());
   let swapLabel = $derived(vfoSwapLabel(scheme));
   let copyLabel = $derived(vfoCopyLabel(scheme));
-  let equalLabel = $derived(vfoEqualLabel(scheme));
-  let txMainLabel = $derived(vfoTxLabel(scheme, 'main'));
-  let txSubLabel = $derived(vfoTxLabel(scheme, 'sub'));
+  let txBadgeLabel = $derived(vfoTxLabel(scheme, txVfo));
   let dualRx = $derived(hasDualReceiver());
+
+  // Double-click wiring: short tap = toggle, double tap = Quick action.
+  // The inner handlers are rebuilt on each prop change so that stale
+  // closures don't point at the previous handler identity.
+  let dwClick = $derived(withDoubleClick(onDualWatchToggle, onQuickDw));
+  let splitClick = $derived(withDoubleClick(onSplitToggle, onQuickSplit));
 </script>
 
 <div class:dual={dualRx} class="vfo-ops">
-  <button type="button" class="bridge-button v2-control-button" data-active="false" data-color="muted" onclick={onCopy}>{copyLabel}</button>
+  <button
+    type="button"
+    class="bridge-button v2-control-button"
+    data-active="false"
+    data-color="muted"
+    onclick={onEqual}
+    title="Equalize — copy MAIN to SUB"
+  >{copyLabel}</button>
   <button
     type="button"
     class="bridge-button v2-control-button"
     data-active={splitActive}
     data-color="cyan"
-    onclick={onSplitToggle}
+    onclick={splitClick}
+    title="SPLIT — single click toggles, double click = Quick Split (equalize + ON)"
   >SPLIT</button>
   {#if dualRx}
     <button
@@ -51,27 +69,28 @@
       class="bridge-button v2-control-button"
       data-active={dualWatchActive}
       data-color="green"
-      onclick={() => onDualWatchToggle(!dualWatchActive)}
+      onclick={dwClick}
+      title="DUAL WATCH — single click toggles, double click = Quick DW (equalize + ON)"
     >DW</button>
   {/if}
-  <button type="button" class="bridge-button v2-control-button" data-active="false" data-color="muted" onclick={onEqual}>{equalLabel}</button>
+  <button
+    type="button"
+    class="bridge-button v2-control-button"
+    data-active="false"
+    data-color="muted"
+    onclick={onSwap}
+    title="Exchange — swap MAIN and SUB"
+  >{swapLabel}</button>
   {#if dualRx}
-    <button
-      type="button"
-      class="bridge-button v2-control-button"
-      data-active={txVfo === 'main'}
-      data-color="orange"
-      onclick={() => onTxVfoChange('main')}
-    >{txMainLabel}</button>
-    <button
-      type="button"
-      class="bridge-button v2-control-button"
-      data-active={txVfo === 'sub'}
-      data-color="orange"
-      onclick={() => onTxVfoChange('sub')}
-    >{txSubLabel}</button>
+    <!-- Read-only TX indicator; derives from split flag via state adapter. -->
+    <div
+      class="tx-indicator"
+      data-testid="tx-indicator"
+      data-tx={txVfo}
+      aria-live="polite"
+      title="Transmit receiver (read-only; follows SPLIT flag)"
+    >{txBadgeLabel}</div>
   {/if}
-  <button type="button" class="bridge-button v2-control-button" data-active="false" data-color="muted" onclick={onSwap}>{swapLabel}</button>
 </div>
 
 <style>
@@ -105,25 +124,34 @@
     --control-active-text: var(--v2-text-bright);
   }
 
-  .bridge-button[data-color='orange'] {
-    --control-accent: var(--v2-accent-orange-alt);
-    --control-active-text: var(--v2-text-bright);
+  .tx-indicator {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--vfo-ops-badge-height, 18px);
+    padding: 4px var(--vfo-ops-badge-padding-x, 6px);
+    border-radius: var(--vfo-ops-badge-radius, 4px);
+    font-size: var(--vfo-ops-badge-font-size, 10px);
+    font-weight: 600;
+    color: var(--v2-accent-orange-alt, #ffa500);
+    background: var(--v2-surface-muted, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--v2-border-muted, rgba(255, 255, 255, 0.08));
+    user-select: none;
+    cursor: default;
   }
 
   .vfo-ops:not(.dual) {
     grid-auto-flow: row;
   }
 
-  /* Dual-rx layout: COPY | SPLIT | DW | = | TX-M | TX-S | SWAP
-     Row 1: COPY, SPLIT
-     Row 2: DW, =
-     Row 3: TX-M, TX-S
-     Row 4: SWAP (span 2) */
-  .vfo-ops.dual .bridge-button:nth-child(1) { grid-column: 1; grid-row: 1; }  /* COPY */
+  /* Dual-rx layout:
+     Row 1: COPY   | SPLIT
+     Row 2: DW     | SWAP
+     Row 3: TX-indicator (span 2) */
+  .vfo-ops.dual .bridge-button:nth-child(1) { grid-column: 1; grid-row: 1; }  /* COPY  (M→S) */
   .vfo-ops.dual .bridge-button:nth-child(2) { grid-column: 2; grid-row: 1; }  /* SPLIT */
   .vfo-ops.dual .bridge-button:nth-child(3) { grid-column: 1; grid-row: 2; }  /* DW */
-  .vfo-ops.dual .bridge-button:nth-child(4) { grid-column: 2; grid-row: 2; }  /* = */
-  .vfo-ops.dual .bridge-button:nth-child(5) { grid-column: 1; grid-row: 3; }  /* TX-M */
-  .vfo-ops.dual .bridge-button:nth-child(6) { grid-column: 2; grid-row: 3; }  /* TX-S */
-  .vfo-ops.dual .bridge-button:nth-child(7) { grid-column: 1 / -1; grid-row: 4; }  /* SWAP */
+  .vfo-ops.dual .bridge-button:nth-child(4) { grid-column: 2; grid-row: 2; }  /* SWAP (M↔S) */
+  .vfo-ops.dual .tx-indicator { grid-row: 3; }
 </style>

--- a/frontend/src/components-v2/vfo/__tests__/VfoOps.test.ts
+++ b/frontend/src/components-v2/vfo/__tests__/VfoOps.test.ts
@@ -33,6 +33,8 @@ describe('vfoCopyLabel', () => {
 });
 
 describe('vfoEqualLabel', () => {
+  // Retained for backward-compat of the utility; no longer rendered
+  // in VfoOps (the M=S duplicate button was removed in epic #774).
   it('returns A=B for ab scheme', () => {
     expect(vfoEqualLabel('ab')).toBe('A=B');
   });
@@ -88,11 +90,11 @@ const baseProps: ComponentProps<typeof VfoOps> = {
   dualWatchActive: false,
   txVfo: 'main',
   onSwap: vi.fn(),
-  onCopy: vi.fn(),
   onEqual: vi.fn(),
   onSplitToggle: vi.fn(),
+  onQuickSplit: vi.fn(),
   onDualWatchToggle: vi.fn(),
-  onTxVfoChange: vi.fn(),
+  onQuickDw: vi.fn(),
 };
 
 beforeEach(() => {
@@ -121,14 +123,14 @@ describe('always-visible buttons (ab scheme)', () => {
     expect(getButtonLabels(t)).toContain('A→B');
   });
 
-  it('renders A=B equal button', () => {
-    const t = mountComponent(baseProps);
-    expect(getButtonLabels(t)).toContain('A=B');
-  });
-
-  it('renders SPLIT badge', () => {
+  it('renders SPLIT button', () => {
     const t = mountComponent(baseProps);
     expect(getButtonLabels(t)).toContain('SPLIT');
+  });
+
+  it('does NOT render the removed A=B duplicate', () => {
+    const t = mountComponent(baseProps);
+    expect(getButtonLabels(t)).not.toContain('A=B');
   });
 });
 
@@ -147,9 +149,9 @@ describe('always-visible buttons (main_sub scheme)', () => {
     expect(getButtonLabels(t)).toContain('M→S');
   });
 
-  it('renders M=S equal button', () => {
+  it('does NOT render the removed M=S duplicate', () => {
     const t = mountComponent(baseProps);
-    expect(getButtonLabels(t)).toContain('M=S');
+    expect(getButtonLabels(t)).not.toContain('M=S');
   });
 });
 
@@ -171,111 +173,145 @@ describe('SPLIT button state', () => {
   });
 });
 
-describe('TX routing (dual receiver)', () => {
+describe('TX indicator (dual receiver, read-only)', () => {
   beforeEach(() => {
     vi.mocked(hasDualReceiver).mockReturnValue(true);
   });
 
-  it('shows TX→A and TX→B when hasDualReceiver is true (ab scheme)', () => {
+  it('renders the TX indicator with TX→A label when txVfo=main (ab scheme)', () => {
     const t = mountComponent(baseProps);
-    const labels = getButtonLabels(t);
-    expect(labels).toContain('TX→A');
-    expect(labels).toContain('TX→B');
+    const indicator = t.querySelector('[data-testid="tx-indicator"]');
+    expect(indicator?.textContent?.trim()).toBe('TX→A');
+    expect(indicator?.getAttribute('data-tx')).toBe('main');
   });
 
-  it('shows TX→M and TX→S when hasDualReceiver is true (main_sub scheme)', () => {
+  it('renders the TX indicator with TX→B when txVfo=sub (ab scheme)', () => {
+    const t = mountComponent({ ...baseProps, txVfo: 'sub' });
+    const indicator = t.querySelector('[data-testid="tx-indicator"]');
+    expect(indicator?.textContent?.trim()).toBe('TX→B');
+    expect(indicator?.getAttribute('data-tx')).toBe('sub');
+  });
+
+  it('renders TX→M / TX→S labels under main_sub scheme', () => {
     vi.mocked(getVfoScheme).mockReturnValue('main_sub');
-    const t = mountComponent(baseProps);
-    const labels = getButtonLabels(t);
-    expect(labels).toContain('TX→M');
-    expect(labels).toContain('TX→S');
+    let t = mountComponent(baseProps);
+    expect(t.querySelector('[data-testid="tx-indicator"]')?.textContent?.trim()).toBe('TX→M');
+    t = mountComponent({ ...baseProps, txVfo: 'sub' });
+    expect(t.querySelector('[data-testid="tx-indicator"]')?.textContent?.trim()).toBe('TX→S');
   });
 
-  it('hides TX badges when hasDualReceiver is false', () => {
+  it('TX indicator is NOT rendered when hasDualReceiver is false', () => {
     vi.mocked(hasDualReceiver).mockReturnValue(false);
     const t = mountComponent(baseProps);
-    const labels = getButtonLabels(t);
-    expect(labels).not.toContain('TX→A');
-    expect(labels).not.toContain('TX→B');
+    expect(t.querySelector('[data-testid="tx-indicator"]')).toBeNull();
   });
 
-  it('TX→A button is active when txVfo is main', () => {
-    const t = mountComponent({ ...baseProps, txVfo: 'main' });
-    const txA = Array.from(t.querySelectorAll('.bridge-button')).find(
-      (el) => el.textContent?.trim() === 'TX→A',
+  it('does NOT render removed TX→A / TX→B buttons (only the indicator)', () => {
+    const t = mountComponent(baseProps);
+    const buttons = Array.from(t.querySelectorAll('button.bridge-button'));
+    const txButton = buttons.find(
+      (el) => el.textContent?.trim() === 'TX→A' || el.textContent?.trim() === 'TX→B',
     );
-    expect(txA?.getAttribute('data-active')).toBe('true');
-  });
-
-  it('TX→B button is active when txVfo is sub', () => {
-    const t = mountComponent({ ...baseProps, txVfo: 'sub' });
-    const txB = Array.from(t.querySelectorAll('.bridge-button')).find(
-      (el) => el.textContent?.trim() === 'TX→B',
-    );
-    expect(txB?.getAttribute('data-active')).toBe('true');
+    expect(txButton).toBeUndefined();
   });
 });
 
-describe('callbacks', () => {
+describe('single-click callbacks', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('calls onSwap when swap button is clicked', () => {
     const onSwap = vi.fn();
     const t = mountComponent({ ...baseProps, onSwap });
-    const badge = Array.from(t.querySelectorAll('.bridge-button')).find(
+    const btn = Array.from(t.querySelectorAll('.bridge-button')).find(
       (el) => el.textContent?.trim() === 'A↔B',
     ) as HTMLElement | undefined;
-    badge?.click();
+    btn?.click();
     expect(onSwap).toHaveBeenCalledOnce();
   });
 
-  it('calls onCopy when copy button is clicked', () => {
-    const onCopy = vi.fn();
-    const t = mountComponent({ ...baseProps, onCopy });
-    const badge = Array.from(t.querySelectorAll('.bridge-button')).find(
-      (el) => el.textContent?.trim() === 'A→B',
-    ) as HTMLElement | undefined;
-    badge?.click();
-    expect(onCopy).toHaveBeenCalledOnce();
-  });
-
-  it('calls onEqual when equal button is clicked', () => {
+  it('calls onEqual when M→S/A→B copy button is clicked', () => {
     const onEqual = vi.fn();
     const t = mountComponent({ ...baseProps, onEqual });
-    const badge = Array.from(t.querySelectorAll('.bridge-button')).find(
-      (el) => el.textContent?.trim() === 'A=B',
+    const btn = Array.from(t.querySelectorAll('.bridge-button')).find(
+      (el) => el.textContent?.trim() === 'A→B',
     ) as HTMLElement | undefined;
-    badge?.click();
+    btn?.click();
     expect(onEqual).toHaveBeenCalledOnce();
   });
 
-  it('calls onSplitToggle when SPLIT button is clicked', () => {
+  it('SPLIT single-click fires onSplitToggle after the double-click window closes', () => {
     const onSplitToggle = vi.fn();
-    const t = mountComponent({ ...baseProps, onSplitToggle });
-    const badge = Array.from(t.querySelectorAll('.bridge-button')).find(
+    const onQuickSplit = vi.fn();
+    const t = mountComponent({ ...baseProps, onSplitToggle, onQuickSplit });
+    const btn = Array.from(t.querySelectorAll('.bridge-button')).find(
       (el) => el.textContent?.trim() === 'SPLIT',
     ) as HTMLElement | undefined;
-    badge?.click();
+    btn?.click();
+    expect(onSplitToggle).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
     expect(onSplitToggle).toHaveBeenCalledOnce();
+    expect(onQuickSplit).not.toHaveBeenCalled();
   });
 
-  it('calls onTxVfoChange("sub") when TX→B is clicked', () => {
+  it('DW single-click fires onDualWatchToggle after the double-click window closes', () => {
     vi.mocked(hasDualReceiver).mockReturnValue(true);
-    const onTxVfoChange = vi.fn();
-    const t = mountComponent({ ...baseProps, onTxVfoChange });
-    const badge = Array.from(t.querySelectorAll('.bridge-button')).find(
-      (el) => el.textContent?.trim() === 'TX→B',
+    const onDualWatchToggle = vi.fn();
+    const onQuickDw = vi.fn();
+    const t = mountComponent({ ...baseProps, onDualWatchToggle, onQuickDw });
+    const btn = Array.from(t.querySelectorAll('.bridge-button')).find(
+      (el) => el.textContent?.trim() === 'DW',
     ) as HTMLElement | undefined;
-    badge?.click();
-    expect(onTxVfoChange).toHaveBeenCalledWith('sub');
+    btn?.click();
+    expect(onDualWatchToggle).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(onDualWatchToggle).toHaveBeenCalledOnce();
+    expect(onQuickDw).not.toHaveBeenCalled();
+  });
+});
+
+describe('double-click callbacks', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
   });
 
-  it('calls onTxVfoChange("main") when TX→A is clicked', () => {
-    vi.mocked(hasDualReceiver).mockReturnValue(true);
-    const onTxVfoChange = vi.fn();
-    const t = mountComponent({ ...baseProps, txVfo: 'sub', onTxVfoChange });
-    const badge = Array.from(t.querySelectorAll('.bridge-button')).find(
-      (el) => el.textContent?.trim() === 'TX→A',
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('SPLIT double-click fires onQuickSplit (not onSplitToggle)', () => {
+    const onSplitToggle = vi.fn();
+    const onQuickSplit = vi.fn();
+    const t = mountComponent({ ...baseProps, onSplitToggle, onQuickSplit });
+    const btn = Array.from(t.querySelectorAll('.bridge-button')).find(
+      (el) => el.textContent?.trim() === 'SPLIT',
     ) as HTMLElement | undefined;
-    badge?.click();
-    expect(onTxVfoChange).toHaveBeenCalledWith('main');
+    btn?.click();
+    vi.advanceTimersByTime(100);
+    btn?.click();
+    expect(onQuickSplit).toHaveBeenCalledOnce();
+    vi.advanceTimersByTime(500);
+    expect(onSplitToggle).not.toHaveBeenCalled();
+  });
+
+  it('DW double-click fires onQuickDw (not onDualWatchToggle)', () => {
+    vi.mocked(hasDualReceiver).mockReturnValue(true);
+    const onDualWatchToggle = vi.fn();
+    const onQuickDw = vi.fn();
+    const t = mountComponent({ ...baseProps, onDualWatchToggle, onQuickDw });
+    const btn = Array.from(t.querySelectorAll('.bridge-button')).find(
+      (el) => el.textContent?.trim() === 'DW',
+    ) as HTMLElement | undefined;
+    btn?.click();
+    vi.advanceTimersByTime(100);
+    btn?.click();
+    expect(onQuickDw).toHaveBeenCalledOnce();
+    vi.advanceTimersByTime(500);
+    expect(onDualWatchToggle).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
@@ -186,14 +186,25 @@ describe('resolveFilterModeConfig', () => {
 });
 
 describe('toVfoOpsProps', () => {
-  it('derives txVfo as opposite receiver when split is active', () => {
-    const mainActive = toVfoOpsProps(
+  // IC-7610: TX = MAIN always, except in Split where TX = SUB.
+  // See manual p. 3-2, 4-9 — TX does not follow the "active"
+  // (selected) receiver, only the split flag.  Epic #774.
+  it('derives txVfo purely from the split flag, ignoring active receiver', () => {
+    const mainActiveSplit = toVfoOpsProps(
       { active: 'MAIN', split: true, dualWatch: false, mainSubTracking: false } as any, null);
-    expect(mainActive.txVfo).toBe('sub');
+    expect(mainActiveSplit.txVfo).toBe('sub');
 
-    const subActive = toVfoOpsProps(
+    const subActiveSplit = toVfoOpsProps(
       { active: 'SUB', split: true, dualWatch: false, mainSubTracking: false } as any, null);
-    expect(subActive.txVfo).toBe('main');
+    expect(subActiveSplit.txVfo).toBe('sub');
+
+    const mainActiveNoSplit = toVfoOpsProps(
+      { active: 'MAIN', split: false, dualWatch: false, mainSubTracking: false } as any, null);
+    expect(mainActiveNoSplit.txVfo).toBe('main');
+
+    const subActiveNoSplit = toVfoOpsProps(
+      { active: 'SUB', split: false, dualWatch: false, mainSubTracking: false } as any, null);
+    expect(subActiveNoSplit.txVfo).toBe('main');
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/vfo-wiring.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-wiring.test.ts
@@ -19,56 +19,40 @@ import { makeBandHandlers, makeFilterHandlers, makeModeHandlers, makeRitXitHandl
 const originalDocumentQuerySelector = document.querySelector.bind(document);
 
 describe('toVfoOpsProps', () => {
-  it('uses the active VFO as TX VFO when split is off', () => {
+  // TX follows split, not the active receiver.  IC-7610 manual p. 3-2:
+  // "you can transmit on only the Main band (except in Split
+  // Frequency operation)."  Under split RX=MAIN, TX=SUB.  This is
+  // independent of which receiver is currently "selected".
+  it('reports txVfo=main when split is off regardless of active receiver', () => {
     expect(
       toVfoOpsProps(
-        {
-          active: 'MAIN',
-          split: false,
-          dualWatch: false,
-          mainSubTracking: false,
-        } as any,
+        { active: 'MAIN', split: false, dualWatch: false, mainSubTracking: false } as any,
         null,
       ).txVfo,
     ).toBe('main');
 
     expect(
       toVfoOpsProps(
-        {
-          active: 'SUB',
-          split: false,
-          dualWatch: false,
-          mainSubTracking: false,
-        } as any,
+        { active: 'SUB', split: false, dualWatch: false, mainSubTracking: false } as any,
         null,
       ).txVfo,
-    ).toBe('sub');
+    ).toBe('main');
   });
 
-  it('uses the opposite VFO as TX VFO when split is on', () => {
+  it('reports txVfo=sub when split is on regardless of active receiver', () => {
     expect(
       toVfoOpsProps(
-        {
-          active: 'MAIN',
-          split: true,
-          dualWatch: false,
-          mainSubTracking: false,
-        } as any,
+        { active: 'MAIN', split: true, dualWatch: false, mainSubTracking: false } as any,
         null,
       ).txVfo,
     ).toBe('sub');
 
     expect(
       toVfoOpsProps(
-        {
-          active: 'SUB',
-          split: true,
-          dualWatch: false,
-          mainSubTracking: false,
-        } as any,
+        { active: 'SUB', split: true, dualWatch: false, mainSubTracking: false } as any,
         null,
       ).txVfo,
-    ).toBe('main');
+    ).toBe('sub');
   });
 });
 
@@ -80,33 +64,6 @@ describe('makeVfoHandlers', () => {
 
   afterEach(() => {
     document.querySelector = originalDocumentQuerySelector;
-  });
-
-  it('maps TX→MAIN to SUB active receiver when split is on', () => {
-    vi.mocked(getRadioState).mockReturnValue({ split: true } as any);
-
-    makeVfoHandlers().onTxVfoChange('main');
-
-    expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
-    expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
-  });
-
-  it('maps TX→SUB to MAIN active receiver when split is on', () => {
-    vi.mocked(getRadioState).mockReturnValue({ split: true } as any);
-
-    makeVfoHandlers().onTxVfoChange('sub');
-
-    expect(patchRadioState).toHaveBeenCalledWith({ active: 'MAIN' });
-    expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'MAIN' });
-  });
-
-  it('maps TX target directly when split is off', () => {
-    vi.mocked(getRadioState).mockReturnValue({ split: false } as any);
-
-    makeVfoHandlers().onTxVfoChange('sub');
-
-    expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
-    expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
   });
 
   it('sends explicit split=false when toggling from active split state', () => {

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -79,26 +79,12 @@ function focusModePanel(vfo: 'MAIN' | 'SUB'): void {
 export function makeVfoHandlers() {
   return {
     onSwap: () => cmd('vfo_swap'),
-    // IC-7610: A→B and A=B are the same CI-V command (0x07 0xA0)
-    onCopy: () => cmd('vfo_equalize'),
+    // IC-7610: M→S (copy/equalize) = 0x07 0xB1.  One semantic, one handler.
     onEqual: () => cmd('vfo_equalize'),
     onSplitToggle: () => {
       const next = !(getRadioState()?.split ?? false);
       patchRadioState({ split: next });
       cmd('set_split', { on: next });
-    },
-    onTxVfoChange: (v: string) => {
-      const state = getRadioState();
-      const splitActive = state?.split ?? false;
-      const targetVfo = splitActive
-        ? v === 'main'
-          ? 'SUB'
-          : 'MAIN'
-        : v === 'main'
-          ? 'MAIN'
-          : 'SUB';
-      patchRadioState({ active: targetVfo });
-      cmd('set_vfo', { vfo: targetVfo });
     },
     onMainVfoClick: () => cmd('set_vfo', { vfo: 'MAIN' }),
     onSubVfoClick: () => cmd('set_vfo', { vfo: 'SUB' }),

--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -551,15 +551,15 @@ export function toVfoOpsProps(
   state: ServerState | null,
   caps: Capabilities | null,
 ): VfoOpsProps {
-  const activeVfo = state?.active === 'SUB' ? 'sub' : 'main';
-  const txVfo = state?.split
-    ? activeVfo === 'main'
-      ? 'sub'
-      : 'main'
-    : activeVfo;
+  // IC-7610: TX is always MAIN, except in Split where TX is SUB
+  // (cross-band: RX on MAIN, TX on SUB).  Manual p. 3-2, 4-9.
+  // The previously-active-receiver based derivation was wrong: TX
+  // does not follow the selected receiver, only the split flag.
+  const split = state?.split ?? false;
+  const txVfo: 'main' | 'sub' = split ? 'sub' : 'main';
 
   return {
-    splitActive: state?.split ?? false,
+    splitActive: split,
     txVfo,
     dualWatch: state?.dualWatch ?? false,
     mainSubTracking: state?.mainSubTracking ?? false,


### PR DESCRIPTION
Part C of epic #774. Previously #780 (auto-closed after its base #779 was merged; reopened here after rebase onto main).

## Summary

Aligns the desktop-v2 VfoOps panel with the IC-7610's actual physical architecture.

**Panel now:**

| Button | Single click | Double-click |
|--------|--------------|--------------|
| **M↔S** (swap) | Exchange | — |
| **M→S** (copy) | Equalize M→S | — |
| **DW** | Toggle DW | Quick-DW (equalize + DW ON) |
| **SPLIT** | Toggle SPLIT | Quick-SPLIT (equalize + SPLIT ON) |

Plus a **read-only TX indicator** showing TX→M / TX→S — derives from split flag only.

## Removed

- **M=S** button — same CI-V as M→S (duplicate).
- **TX→M / TX→S** clickable buttons — the IC-7610 has no \"pick TX receiver\" command. TX is MAIN normally, SUB in split.
- \`onCopy\` and \`onTxVfoChange\` handlers in \`command-bus\` (no remaining consumers).

## Fixed

- \`toVfoOpsProps.txVfo\` — previously derived from \`active × split\` with an inverse formula that gave wrong results under SUB+split. Corrected to \`split ? 'sub' : 'main'\`.

## Test plan

- [x] \`npx vitest run src/components-v2/vfo src/components-v2/wiring\` — 53 tests 5×/5× green
- [x] \`npx svelte-check\` — 0 errors, 0 warnings
- [x] \`npm run build\` — clean
- [ ] Live smoke test on IC-7610 after this merges

Closes #777. Part of epic #774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)