### PR TITLE
fix(test/#771): split vitest into fast + isolated projects

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -49,9 +49,50 @@ export default defineConfig({
     target: ['es2020', 'safari14'],
   },
   test: {
-    environment: 'jsdom',
-    include: ['src/**/*.test.ts'],
-    pool: 'threads',
-    isolate: false,
+    // Split the test suite into two projects to contain the cost
+    // of test-file isolation.  Under ``isolate: false`` (PR #707 —
+    // ~10× faster) modules are cached across test files; any file
+    // that does module-scope ``vi.mock(...)`` is vulnerable to load
+    // ordering — a sibling file that imports the real module first
+    // pins it in the cache and the hoisted mock becomes a no-op.
+    // Rather than fixing each affected file (treadmill, and any
+    // new test file that uses ``vi.mock`` becomes a future flake),
+    // route the known-sensitive files through a small isolated pool
+    // and keep the rest fast.  Issue #771.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'fast',
+          environment: 'jsdom',
+          include: ['src/**/*.test.ts'],
+          exclude: [
+            'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
+            'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
+            'src/components-v2/wiring/__tests__/focus-mode-race.test.ts',
+            'src/components-v2/panels/__tests__/AudioRoutingControl.test.ts',
+            'src/lib/stores/radio.svelte.test.ts',
+          ],
+          pool: 'threads',
+          isolate: false,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'isolated',
+          environment: 'jsdom',
+          include: [
+            'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
+            'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
+            'src/components-v2/wiring/__tests__/focus-mode-race.test.ts',
+            'src/components-v2/panels/__tests__/AudioRoutingControl.test.ts',
+            'src/lib/stores/radio.svelte.test.ts',
+          ],
+          pool: 'threads',
+          isolate: true,
+        },
+      },
+    ],
   },
 })


### PR DESCRIPTION
## Root cause (broader than #771 title suggested)

Under \`isolate: false\` (PR #707, ~10× faster) modules are cached across test files. Any file that uses module-scope \`vi.mock(...)\` is vulnerable to load ordering: if a sibling file imports the real module first, the hoisted mock factories never run and become no-ops.

**Empirically 5 files trip this** across the full suite:
- \`components-v2/wiring/__tests__/keyboard-wiring.test.ts\` (the reported one)
- \`components-v2/wiring/__tests__/vfo-wiring.test.ts\`
- \`components-v2/wiring/__tests__/focus-mode-race.test.ts\`
- \`components-v2/panels/__tests__/AudioRoutingControl.test.ts\`
- \`lib/stores/radio.svelte.test.ts\`

Different victim each run depending on scheduler order. Baseline: **2/10 green**.

## Why not the stashed per-file fixes

Previous attempts (\`vi.resetModules()\` + dynamic imports; \`vi.doMock\` variant) reached 3–6/10 green. Both fix one file's hit rate without addressing the other four, so overall CI green-rate barely moves. And every new test file using module-scope \`vi.mock\` becomes a future flake — whack-a-mole.

## Fix

Split the suite into two vitest 4 projects:

- **\`fast\`** — \`isolate: false\`, excludes the 5 sensitive files (~1525 tests, unchanged speed).
- **\`isolated\`** — \`isolate: true\`, runs only the 5 sensitive files (~0.3s added cost).

Single maintenance point (\`vite.config.ts\`). If a 6th file starts flaking, add it to the \`isolated\` list.

## Test plan

- [x] 10/10 consecutive full-suite runs green on my machine (baseline 2/10)
- [x] Total duration ~6s (same as \`isolate: false\` alone — no regression vs PR #707 speedup)
- [x] No test file edits required

## Scope

1 file, +45/-4 LOC. Within guardrail.

Closes #771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)