### PR TITLE
fix(audio/#762): document Opus DSP/tap gate + one-shot warning

### DIFF
--- a/docs/internals/rfc-audio-v1-mini.md
+++ b/docs/internals/rfc-audio-v1-mini.md
@@ -146,3 +146,29 @@ Mitigation:
 2. Keep current ambiguous names as low-level aliases or add hard warnings immediately?
 3. Should `--stats` print periodic stream stats (live) or end-of-run summary by default?
 4. Is `opuslib` optional dependency acceptable as the default high-level backend?
+
+## 10) DSP pipeline + PCM tap gate on Opus-native radios (issue #762)
+
+**Behavior:** the web audio broadcaster's DSP pipeline (noise gate,
+limiter, etc.) and the PCM tap registry (used by the FFT / waterfall
+scope and audio analyzers) both operate on decoded PCM16.  When the
+radio's native audio codec is Opus (IC-705 and any future Opus-only
+model), the broadcaster passes the Opus frame through without
+decoding, so DSP and taps **do not run**.
+
+**Why we don't decode + re-encode on the hot path:** Opus re-encode
+would introduce quality loss on every frame.  Users of IC-705 have
+not reported needing DSP or scope through the web UI, so the gate
+is documented rather than closed.
+
+**Observability:** the broadcaster emits a one-shot `WARNING` log
+entry when it detects an active DSP pipeline on an Opus-native
+codec — fires at `set_dsp_pipeline()` or at `_refresh_codec_state()`
+(in case the codec flips mid-stream), whichever happens first.
+
+**Upgrade path if demand arrives:** issue #762 §"Option A" — decode
+Opus once in `_relay_loop`, run DSP + feed taps on the PCM buffer,
+then re-encode before fan-out.  `_audio_transcoder.PcmOpusTranscoder`
+already exists and can be reused.  Quality loss is negligible for
+AM/FM ham audio but non-zero on SSB; flag behind a config toggle if
+implemented.

--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -77,8 +77,18 @@ class AudioBroadcaster:
         self._sample_rate: int = 48000
         self._channels: int = 1
         self._lock = asyncio.Lock()
-        # Optional DSP pipeline (inserted between codec decode and tap/distribute)
+        # Optional DSP pipeline (inserted between codec decode and tap/distribute).
+        # NOTE: the DSP pipeline and the tap registry both operate on decoded
+        # PCM16.  When the radio's native codec is Opus (IC-705 and future
+        # Opus-only models) we pass the frame through un-decoded to preserve
+        # wire quality, so neither DSP nor taps run.  See ``_refresh_codec_state``
+        # for the one-shot warning that fires when this combination is detected,
+        # and ``docs/internals/rfc-audio-v1-mini.md`` for the user-facing note.
+        # Issue #762.
         self._dsp_pipeline: DSPPipeline | None = None
+        # One-shot flag so the Opus-DSP warning log fires at most once per
+        # broadcaster lifetime, regardless of whether DSP or codec is set first.
+        self._dsp_opus_warned: bool = False
         # Multi-consumer PCM tap registry (replaces single _pcm_tap)
         self._tap_registry = TapRegistry()
         self._legacy_tap_handle: TapHandle | None = None
@@ -150,8 +160,36 @@ class AudioBroadcaster:
         When set, every decoded PCM16 frame is passed through
         :meth:`DSPPipeline.process_bytes` before tap distribution and
         client encoding.  Pass ``None`` to remove the pipeline.
+
+        NOTE: DSP (and the PCM tap registry used by the FFT scope) are
+        silently skipped when the radio's native codec is Opus.  Issue
+        #762 — a one-shot WARNING is logged the first time this
+        combination is observed; see :meth:`_maybe_warn_dsp_opus_gate`.
         """
         self._dsp_pipeline = pipeline
+        if pipeline is not None:
+            self._maybe_warn_dsp_opus_gate()
+
+    def _maybe_warn_dsp_opus_gate(self) -> None:
+        """Fire a one-shot WARNING if DSP is active on an Opus-native radio.
+
+        Safe to call from either order: ``set_dsp_pipeline`` call site,
+        or from codec refresh when the codec flips to Opus mid-stream.
+        Issue #762.
+        """
+        if self._dsp_opus_warned:
+            return
+        if self._dsp_pipeline is None:
+            return
+        if self._web_codec != AUDIO_CODEC_OPUS:
+            return
+        logger.warning(
+            "audio-broadcaster: DSP pipeline is configured but the radio's "
+            "native codec is Opus — DSP and FFT-scope tap dispatch are "
+            "skipped to preserve wire quality.  See issue #762 / "
+            "docs/internals/rfc-audio-v1-mini.md."
+        )
+        self._dsp_opus_warned = True
 
     async def ensure_relay(self) -> None:
         """Ensure the relay loop is running (for PCM tap consumers like FFT scope).
@@ -257,6 +295,9 @@ class AudioBroadcaster:
             self._sample_rate,
             self._channels,
         )
+        # Re-check DSP-on-Opus after the codec may have just flipped.
+        # Issue #762.
+        self._maybe_warn_dsp_opus_gate()
 
     async def _start_relay(self) -> None:
         if not self._radio or CAP_AUDIO not in self._radio.capabilities:
@@ -302,7 +343,11 @@ class AudioBroadcaster:
                         # Fall back to original data
                         audio_data = pkt.data
 
-                # Apply DSP pipeline if configured (operates on s16le PCM)
+                # Apply DSP pipeline if configured (operates on s16le PCM).
+                # Opus-native radios bypass DSP to avoid decode + re-encode
+                # quality loss on the wire; see issue #762 for the design
+                # note and ``_maybe_warn_dsp_opus_gate`` for the one-shot
+                # warning that surfaces this asymmetry to the operator.
                 if (
                     self._dsp_pipeline is not None
                     and self._web_codec == AUDIO_CODEC_PCM16
@@ -314,7 +359,9 @@ class AudioBroadcaster:
                     except Exception:
                         logger.debug("audio: dsp pipeline error", exc_info=True)
 
-                # Fan out PCM data to all registered taps (FFT scope, analyzers, etc.)
+                # Fan out PCM data to all registered taps (FFT scope, analyzers, etc.).
+                # Opus-native radios do not feed taps — consumers get silence.
+                # Same rationale as the DSP gate above.  Issue #762.
                 if self._tap_registry.active and self._web_codec == AUDIO_CODEC_PCM16:
                     self._tap_registry.feed(audio_data)
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1526,6 +1526,99 @@ class TestBroadcasterCodecInvalidation:
             assert spy.call_count == 1
 
 
+class TestDspOpusGateWarning:
+    """Issue #762: DSP pipeline + PCM tap registry are gated on PCM16.
+
+    When a radio's native codec is Opus (IC-705), DSP and tap dispatch
+    silently don't run.  The broadcaster logs a one-shot WARNING when
+    this combination is detected so operators aren't mystified.
+    """
+
+    def _pcm_broadcaster(self):
+        from icom_lan.types import AudioCodec
+        from icom_lan.web.handlers import AudioBroadcaster
+        from icom_lan.web.protocol import AUDIO_CODEC_PCM16
+        b = AudioBroadcaster(None)
+        b._radio_codec = AudioCodec.PCM_1CH_16BIT
+        b._web_codec = AUDIO_CODEC_PCM16
+        return b
+
+    def _opus_broadcaster(self):
+        from icom_lan.types import AudioCodec
+        from icom_lan.web.handlers import AudioBroadcaster
+        from icom_lan.web.protocol import AUDIO_CODEC_OPUS
+        b = AudioBroadcaster(None)
+        b._radio_codec = AudioCodec.OPUS_1CH
+        b._web_codec = AUDIO_CODEC_OPUS
+        return b
+
+    def test_no_warning_when_dsp_set_on_pcm_broadcaster(self, caplog) -> None:
+        import logging
+        b = self._pcm_broadcaster()
+        with caplog.at_level(logging.WARNING, logger="icom_lan.web.handlers.audio"):
+            b.set_dsp_pipeline(MagicMock())
+        assert not any(
+            "native codec is Opus" in r.message for r in caplog.records
+        )
+        assert b._dsp_opus_warned is False
+
+    def test_warning_fires_when_dsp_set_on_opus_broadcaster(self, caplog) -> None:
+        import logging
+        b = self._opus_broadcaster()
+        with caplog.at_level(logging.WARNING, logger="icom_lan.web.handlers.audio"):
+            b.set_dsp_pipeline(MagicMock())
+        matching = [r for r in caplog.records if "native codec is Opus" in r.message]
+        assert len(matching) == 1, (
+            f"Expected exactly one DSP-Opus warning; got {len(matching)}"
+        )
+        assert b._dsp_opus_warned is True
+
+    def test_warning_fires_at_most_once_per_lifetime(self, caplog) -> None:
+        import logging
+        b = self._opus_broadcaster()
+        with caplog.at_level(logging.WARNING, logger="icom_lan.web.handlers.audio"):
+            b.set_dsp_pipeline(MagicMock())
+            b.set_dsp_pipeline(MagicMock())
+            b._maybe_warn_dsp_opus_gate()
+        matching = [r for r in caplog.records if "native codec is Opus" in r.message]
+        assert len(matching) == 1
+
+    def test_warning_fires_when_codec_flips_to_opus_mid_stream(self, caplog) -> None:
+        """Operator sets DSP while radio is on PCM; radio later flips to Opus.
+
+        The warning must fire on the codec refresh, not stay silent because
+        the order was unfavourable.
+        """
+        import logging
+        from icom_lan.types import AudioCodec
+        from icom_lan.web.protocol import AUDIO_CODEC_OPUS
+
+        b = self._pcm_broadcaster()
+        b.set_dsp_pipeline(MagicMock())
+        # No warning yet — we're on PCM.
+        assert b._dsp_opus_warned is False
+
+        # Simulate a codec flip to Opus (e.g. config change mid-stream).
+        b._radio_codec = AudioCodec.OPUS_1CH
+        b._web_codec = AUDIO_CODEC_OPUS
+        with caplog.at_level(logging.WARNING, logger="icom_lan.web.handlers.audio"):
+            b._maybe_warn_dsp_opus_gate()
+        matching = [r for r in caplog.records if "native codec is Opus" in r.message]
+        assert len(matching) == 1
+        assert b._dsp_opus_warned is True
+
+    def test_no_warning_when_dsp_is_none(self, caplog) -> None:
+        import logging
+        b = self._opus_broadcaster()
+        with caplog.at_level(logging.WARNING, logger="icom_lan.web.handlers.audio"):
+            b.set_dsp_pipeline(None)
+            b._maybe_warn_dsp_opus_gate()
+        assert b._dsp_opus_warned is False
+        assert not any(
+            "native codec is Opus" in r.message for r in caplog.records
+        )
+
+
 class TestAudioHandlerTxTranscoderRate:
     """TX transcoder must use the radio's negotiated sample rate (issue #691).
 


### PR DESCRIPTION
## Problem

The web audio broadcaster's DSP pipeline and PCM tap registry (FFT scope) operate on decoded PCM16. When the radio's native codec is Opus (IC-705 and any future Opus-only model), the broadcaster passes Opus through un-decoded to preserve wire quality — so DSP and taps silently don't run. Users enabling DSP on an Opus radio see no effect and no explanation.

## Fix — Option C per #762

Document the gate rather than close it. No IC-705 demand currently justifies the Opus decode + re-encode cost of Option A.

- Clarifying comments at both gate sites in \`_relay_loop\` (DSP conditional, tap-registry feed).
- One-shot \`WARNING\` log when an active DSP pipeline is observed on an Opus-native codec. Fires from either \`set_dsp_pipeline()\` or \`_refresh_codec_state()\`, whichever reaches the combination first (either order works).
- New §10 in \`docs/internals/rfc-audio-v1-mini.md\` — behavior, rationale, observability, upgrade path.
- 5 focused tests in a new \`TestDspOpusGateWarning\` class.

## Test plan

- [x] \`uv run pytest tests/ -q --tb=short --ignore=tests/integration\` — 4691 passed
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [x] New tests cover both orderings (DSP-first-then-codec-flip, codec-first-then-DSP) and idempotency

## Scope

3 files, +169 LOC. Within guardrail.

Closes #762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)