### PR TITLE
fix(web): scope follows active receiver on MAIN/SUB select

### DIFF
--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -1313,6 +1313,28 @@ class RadioPoller:
                     rs = getattr(self._radio, "_radio_state", None)
                     if rs is not None and hasattr(rs, "active"):
                         rs.active = target
+                    # Scope follows the selected receiver: emit 0x27 0x12 so
+                    # the spectrum/waterfall flips to the new band.  In
+                    # dual-scope mode this still updates the "selected"
+                    # receiver marker; in single-scope mode the displayed
+                    # band changes.  Capability-gated so single-RX profiles
+                    # (IC-7300/705) are unaffected.
+                    if CAP_SCOPE in self._caps and CAP_DUAL_RX in self._caps:
+                        scope_rx = 1 if is_sub else 0
+                        try:
+                            await self._civ(
+                                0x27, sub=0x12, data=bytes([scope_rx])
+                            )
+                            logger.info(
+                                "radio-poller: scope receiver → %s "
+                                "(follows select_vfo)",
+                                target,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "radio-poller: scope follow failed",
+                                exc_info=True,
+                            )
                 if self._on_state_event:
                     self._on_state_event("vfo_changed", {"vfo": vfo})
             case VfoSwap():

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -224,9 +224,12 @@ async def test_execute_event_emitting_commands_and_vfo_paths() -> None:
     await poller._execute(SelectVfo("SUB"))  # noqa: SLF001
     assert radio._radio_state.active == "SUB"
     radio.send_civ.assert_any_await(0x07, sub=None, data=bytes([0xD1]), wait_response=False)
+    # Scope follows the selected receiver (0x27 0x12 0x01 = SUB).
+    radio.send_civ.assert_any_await(0x27, sub=0x12, data=bytes([0x01]), wait_response=False)
     await poller._execute(SelectVfo("MAIN"))  # noqa: SLF001
     assert radio._radio_state.active == "MAIN"
     radio.send_civ.assert_any_await(0x07, sub=None, data=bytes([0xD0]), wait_response=False)
+    radio.send_civ.assert_any_await(0x27, sub=0x12, data=bytes([0x00]), wait_response=False)
     # Re-clicking the active receiver is a no-op CI-V-wise but still emits
     # the state event so UI listeners can refresh.
     civ_calls_before = radio.send_civ.await_count

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2575,6 +2575,17 @@ class TestSwitchScopeReceiver:
             if c[0][0] == 0x07 and c.kwargs.get("data") == bytes([0xB0])
         ]
         assert len(swap_calls) == 0, "Must NOT emit swap (0x07 0xB0) on SelectVfo"
+        # Scope follows the selected receiver: 0x27 0x12 0x01 for SUB.
+        scope_calls = [
+            c
+            for c in radio.send_civ.call_args_list
+            if c[0][0] == 0x27
+            and c.kwargs.get("sub") == 0x12
+            and c.kwargs.get("data") == bytes([0x01])
+        ]
+        assert len(scope_calls) >= 1, (
+            "Expected scope to follow selected receiver (0x27 0x12 0x01)"
+        )
 
     async def test_select_vfo_main_noop_when_already_main(self) -> None:
         """SelectVfo("MAIN") emits no CI-V when already on MAIN."""


### PR DESCRIPTION
## Problem

After PR #773 the MAIN/SUB buttons correctly select the receiver (\`0x07 0xD0/D1\`), but the spectrum/waterfall stays on whatever the toolbar toggle last set. User switching to SUB sees SUB's audio, MAIN's scope.

## Fix

In the \`SelectVfo\` handler, after emitting the receiver-select frame, also emit \`0x27 0x12 0x00/01\` (scope receiver) when the profile has both \`dual_rx\` and \`scope\` capabilities. On single-RX profiles (IC-7300/705) the gate is false and nothing changes.

- Dual-scope mode (\`0x27 0x13 = 0x01\`): still updates the \"selected\" receiver marker.
- Single-scope mode: displayed band changes.

A transient scope-CI-V error is demoted to DEBUG + swallowed so it cannot block the primary receiver select.

## Test plan

- [x] Full pytest suite — 4691 passed
- [x] ruff + mypy clean
- [x] New assertions in \`test_radio_poller_coverage.py\` and \`test_web_server.py\` verify exact CI-V bytes
- [ ] Live verification on IC-7610: clicking MAIN / SUB → scope flips to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)