### PR TITLE
fix(web-ui): optimistic equalize/swap + audio focus follows ACTIVATE

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/vfo-wiring.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-wiring.test.ts
@@ -9,10 +9,24 @@ vi.mock('$lib/stores/radio.svelte', () => ({
   getRadioState: vi.fn(() => null),
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
+  patchReceiver: vi.fn(),
+}));
+
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    setAudioConfig: vi.fn(),
+    startRx: vi.fn(),
+    stopRx: vi.fn(),
+    setRxVolume: vi.fn(),
+    rxEnabled: false,
+  },
 }));
 
 import { sendCommand } from '$lib/transport/ws-client';
-import { getActiveReceiver, getRadioState, patchActiveReceiver, patchRadioState } from '$lib/stores/radio.svelte';
+import {
+  getActiveReceiver, getRadioState, patchActiveReceiver, patchRadioState, patchReceiver,
+} from '$lib/stores/radio.svelte';
+import { audioManager } from '$lib/audio/audio-manager';
 import { toVfoOpsProps } from '../state-adapter';
 import { makeBandHandlers, makeFilterHandlers, makeModeHandlers, makeRitXitHandlers, makeVfoHandlers } from '../command-bus';
 
@@ -136,6 +150,70 @@ describe('makeVfoHandlers', () => {
 
     makeVfoHandlers().onTrackingToggle(false);
     expect(sendCommand).toHaveBeenCalledWith('set_main_sub_tracking', { on: false });
+  });
+
+  // Optimistic updates + audio focus follow for live MAIN/SUB UX.
+  describe('optimistic updates + audio focus', () => {
+    beforeEach(() => {
+      vi.mocked(patchReceiver).mockClear();
+      vi.mocked(audioManager.setAudioConfig).mockClear();
+    });
+
+    it('onEqual optimistically copies MAIN freq/mode/filter to SUB before the poll', () => {
+      vi.mocked(getRadioState).mockReturnValue({
+        main: { freqHz: 14_074_000, mode: 'USB', filter: 2 },
+        sub: { freqHz: 28_500_000, mode: 'AM', filter: 3 },
+      } as any);
+
+      makeVfoHandlers().onEqual();
+
+      expect(patchReceiver).toHaveBeenCalledWith(
+        1,
+        { freqHz: 14_074_000, mode: 'USB', filter: 2 },
+      );
+      expect(sendCommand).toHaveBeenCalledWith('vfo_equalize', {});
+    });
+
+    it('onSwap optimistically exchanges freq/mode/filter between MAIN and SUB', () => {
+      vi.mocked(getRadioState).mockReturnValue({
+        main: { freqHz: 14_074_000, mode: 'USB', filter: 2 },
+        sub: { freqHz: 28_500_000, mode: 'AM', filter: 3 },
+      } as any);
+
+      makeVfoHandlers().onSwap();
+
+      // MAIN gets SUB's former values; SUB gets MAIN's former values.
+      expect(patchReceiver).toHaveBeenCalledWith(
+        0,
+        { freqHz: 28_500_000, mode: 'AM', filter: 3 },
+      );
+      expect(patchReceiver).toHaveBeenCalledWith(
+        1,
+        { freqHz: 14_074_000, mode: 'USB', filter: 2 },
+      );
+      expect(sendCommand).toHaveBeenCalledWith('vfo_swap', {});
+    });
+
+    it('onEqual without state does nothing optimistic but still fires command', () => {
+      vi.mocked(getRadioState).mockReturnValue(null);
+      makeVfoHandlers().onEqual();
+      expect(patchReceiver).not.toHaveBeenCalled();
+      expect(sendCommand).toHaveBeenCalledWith('vfo_equalize', {});
+    });
+
+    it('onMainVfoClick couples audio focus to MAIN', () => {
+      makeVfoHandlers().onMainVfoClick();
+      expect(patchRadioState).toHaveBeenCalledWith({ active: 'MAIN' });
+      expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'MAIN' });
+      expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'main' });
+    });
+
+    it('onSubVfoClick couples audio focus to SUB', () => {
+      makeVfoHandlers().onSubVfoClick();
+      expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
+      expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
+      expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'sub' });
+    });
   });
 });
 

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -76,18 +76,66 @@ function focusModePanel(vfo: 'MAIN' | 'SUB'): void {
 
 /* ── VFO Handlers ────────────────────────────────────────────── */
 
+/** Fields that ``0x07 0xB1`` (equalize) and ``0x07 0xB0`` (exchange)
+ *  propagate between MAIN and SUB on the radio.  Frequency + mode are
+ *  the two observable ones the user cares about; backend poll refreshes
+ *  the rest within one cycle.  Keep the list minimal. */
+const _MAIN_SUB_EQUALIZE_FIELDS = ['freqHz', 'mode', 'filter'] as const;
+
+function _activateReceiver(target: 'MAIN' | 'SUB'): void {
+  // Optimistic UI + WS command to select the receiver.
+  patchRadioState({ active: target });
+  cmd('set_vfo', { vfo: target });
+  // Couple audio focus to the selected receiver so operator hears the
+  // band they're now tuning.  In Dual-Watch mode the radio broadcasts
+  // both receivers' audio, and the web layer decides which channel to
+  // render via the Phones L/R Mix (#752/#755).  Without this coupling,
+  // clicking MAIN/SUB updated state + scope but left the audio focus
+  // untouched, so the user heard MAIN while tuning SUB.
+  audioManager.setAudioConfig({ focus: target === 'SUB' ? 'sub' : 'main' });
+}
+
 export function makeVfoHandlers() {
   return {
-    onSwap: () => cmd('vfo_swap'),
-    // IC-7610: M→S (copy/equalize) = 0x07 0xB1.  One semantic, one handler.
-    onEqual: () => cmd('vfo_equalize'),
+    onSwap: () => {
+      // IC-7610 ``0x07 0xB0`` swaps freq+mode+params between MAIN and SUB.
+      // Optimistically swap the two in the store so the UI reflects the
+      // change within one tick rather than waiting for the next poll.
+      const s = getRadioState();
+      if (s?.main && s?.sub) {
+        const mainSnap: Record<string, unknown> = {};
+        const subSnap: Record<string, unknown> = {};
+        for (const f of _MAIN_SUB_EQUALIZE_FIELDS) {
+          mainSnap[f] = (s.sub as any)[f];
+          subSnap[f] = (s.main as any)[f];
+        }
+        patchReceiver(0, mainSnap as any);
+        patchReceiver(1, subSnap as any);
+      }
+      cmd('vfo_swap');
+    },
+    onEqual: () => {
+      // IC-7610 ``0x07 0xB1`` copies MAIN state to SUB.  Optimistically
+      // mirror that in the store so the SUB readouts snap to MAIN's
+      // values immediately — previously users had to wait for the next
+      // poll cycle (~250ms) to see the change.
+      const s = getRadioState();
+      if (s?.main) {
+        const snap: Record<string, unknown> = {};
+        for (const f of _MAIN_SUB_EQUALIZE_FIELDS) {
+          snap[f] = (s.main as any)[f];
+        }
+        patchReceiver(1, snap as any);
+      }
+      cmd('vfo_equalize');
+    },
     onSplitToggle: () => {
       const next = !(getRadioState()?.split ?? false);
       patchRadioState({ split: next });
       cmd('set_split', { on: next });
     },
-    onMainVfoClick: () => cmd('set_vfo', { vfo: 'MAIN' }),
-    onSubVfoClick: () => cmd('set_vfo', { vfo: 'SUB' }),
+    onMainVfoClick: () => _activateReceiver('MAIN'),
+    onSubVfoClick: () => _activateReceiver('SUB'),
     onMainModeClick: () => focusModePanel('MAIN'),
     onSubModeClick: () => focusModePanel('SUB'),
     onMainFreqChange: (freq: number) => {


### PR DESCRIPTION
## Problems (live IC-7610 feedback after epic #774)

1. **M→S (equalize)** — SUB readout updated only on next poll (~250ms lag). Looked broken.
2. **M↔S (swap)** — same poll lag + reported as \"doesn't work\" because effect invisible until catch-up.
3. **ACTIVATE on SUB panel (DW on)** — radio actually switched (user saw S-meter respond on SUB), waterfall followed, but audio stayed on MAIN. Audio is controlled by the decoupled \`audio_config.focus\` (Phones L/R Mix from #755); user expected ACTIVATE to couple audio too.

## Fixes

1. **Optimistic M→S copy:** \`onEqual\` patches \`sub\` := \`main\` (freq/mode/filter) before firing \`vfo_equalize\`.
2. **Optimistic swap:** \`onSwap\` exchanges freq/mode/filter between \`main\` and \`sub\` in the store, then fires \`vfo_swap\`.
3. **Audio follow:** a new private \`_activateReceiver(target)\` helper runs \`patchRadioState({ active })\` + \`cmd('set_vfo')\` + \`audioManager.setAudioConfig({ focus })\`. Called from both \`onMainVfoClick\` and \`onSubVfoClick\`.

Operators who want decoupled audio (monitor MAIN while tuning SUB) use the AudioRoutingControl panel explicitly after the click.

## Test plan

- [x] 8 new assertions in \`vfo-wiring.test.ts\` covering optimistic patches + audio-focus coupling
- [x] \`npx vitest run\` — 5/5 runs green
- [x] \`npx svelte-check\` — clean
- [ ] Live smoke on IC-7610 after merge + server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)