### PR TITLE
fix(audio): queue audio_config WS send when socket not yet open

### DIFF
--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -104,6 +104,13 @@ class AudioManager {
    * ``audio_config`` message to the backend so it can set CI-V Phones L/R
    * Mix accordingly (handled server-side in #752/#755).  Gain values are
    * applied locally only; the backend does not receive them.
+   *
+   * WS-delivery semantics: if the audio WS is not yet open (user hasn't
+   * started RX audio in the browser) we eagerly open it and queue the
+   * pending focus/split pair; ``_flushPendingAudioConfig`` fires the
+   * message once the socket is open.  Without this, clicking ACTIVATE on
+   * MAIN/SUB was a no-op on the radio's own Phones L/R Mix because the
+   * CI-V command never left the browser.
    */
   setAudioConfig(cfg: Partial<AudioRoutingConfig>): void {
     if (cfg.focus !== undefined) this.rxPlayer.setFocus(cfg.focus);
@@ -111,16 +118,27 @@ class AudioManager {
     if (cfg.main_gain_db !== undefined) this.rxPlayer.setChannelGainDb('main', cfg.main_gain_db);
     if (cfg.sub_gain_db !== undefined) this.rxPlayer.setChannelGainDb('sub', cfg.sub_gain_db);
     // Only the focus + split_stereo pair maps to CI-V; gain is local.
-    if (
-      (cfg.focus !== undefined || cfg.split_stereo !== undefined)
-      && this.ws?.readyState === WebSocket.OPEN
-    ) {
-      this.ws.send(JSON.stringify({
-        type: 'audio_config',
-        focus: this.rxPlayer.focus,
-        split_stereo: this.rxPlayer.splitStereo,
-      }));
+    if (cfg.focus === undefined && cfg.split_stereo === undefined) return;
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this._flushPendingAudioConfig();
+      return;
     }
+    // WS not open — remember that the next open should flush the config,
+    // and kick off the connect.  ``onopen`` will call the flush.
+    this._audioConfigPending = true;
+    this.connect();
+  }
+
+  private _audioConfigPending: boolean = false;
+
+  private _flushPendingAudioConfig(): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({
+      type: 'audio_config',
+      focus: this.rxPlayer.focus,
+      split_stereo: this.rxPlayer.splitStereo,
+    }));
+    this._audioConfigPending = false;
   }
 
   /** Current config snapshot — useful for UI state rehydration. */
@@ -188,6 +206,13 @@ class AudioManager {
       }
       if (this._txEnabled) {
         ws.send(JSON.stringify({ type: 'audio_start', direction: 'tx' }));
+      }
+      // If setAudioConfig was called before the WS was open, push the
+      // cached focus/split pair now so the backend can update CI-V
+      // Phones L/R Mix.  Keeps ACTIVATE on MAIN/SUB consistent regardless
+      // of whether the user has started RX audio in the browser.
+      if (this._audioConfigPending) {
+        this._flushPendingAudioConfig();
       }
       this.rxPlayer.flush();
       this.notify();


### PR DESCRIPTION
## Problem

User report: clicking ACTIVATE on SUB (with DW on) should set the radio's Phones L/R Mix to SUB so both the web audio stream and the physical radio phones/speakers follow.  In practice both stayed on MAIN.

Root cause: \`audioManager.setAudioConfig({ focus })\` only sent the \`audio_config\` WS message when \`this.ws?.readyState === WebSocket.OPEN\`.  The audio WS is only opened lazily on \`startRx\` / \`startTx\` — operators who hadn't started RX audio in the browser had no WS, so the CI-V Phones L/R Mix was never updated.

PR #785 added the frontend call but relied on the WS being open.  This completes the fix.

## Fix

- Cache the pending focus/split_stereo pair (\`_audioConfigPending\`).
- Eagerly call \`connect()\` if the WS isn't open.
- Flush the cached config from \`onopen\`.

Already-open WS path is unchanged.

## Test plan

- [x] \`npx svelte-check\` — clean (0 errors, 0 warnings)
- [x] \`npx vitest run\` — 1532 passed
- [ ] Live verify: click ACTIVATE on SUB before touching web RX — radio's phones output should now switch to SUB

🤖 Generated with [Claude Code](https://claude.com/claude-code)