### PR TITLE
fix(#788 #792): stereo-first codec + Phones L/R Mix locked OFF for dual-RX

### DIFF
--- a/src/icom_lan/types.py
+++ b/src/icom_lan/types.py
@@ -189,14 +189,18 @@ _AUDIO_CODEC_CHANNELS: dict[AudioCodec, int] = {
     AudioCodec.OPUS_2CH: 2,
 }
 _DEFAULT_CODEC_PREFERENCE: tuple[AudioCodec, ...] = (
-    AudioCodec.PCM_1CH_16BIT,
+    # Preferred: stereo PCM16 so dual-RX radios deliver L=MAIN + R=SUB in the
+    # LAN stream (epic #787).  Single-RX radios' firmware downgrades to mono
+    # during handshake; the broadcaster's ``_refresh_codec_state`` reads the
+    # actual negotiated codec back, so downstream logic tracks reality.
     AudioCodec.PCM_2CH_16BIT,
-    AudioCodec.ULAW_1CH,
+    AudioCodec.PCM_1CH_16BIT,
     AudioCodec.ULAW_2CH,
-    AudioCodec.PCM_1CH_8BIT,
+    AudioCodec.ULAW_1CH,
     AudioCodec.PCM_2CH_8BIT,
-    AudioCodec.OPUS_1CH,
+    AudioCodec.PCM_1CH_8BIT,
     AudioCodec.OPUS_2CH,
+    AudioCodec.OPUS_1CH,
 )
 
 

--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -566,20 +566,26 @@ class AudioHandler:
             await self._handle_audio_config(msg)
 
     # --------------------------------------------------------------
-    # audio_config — MAIN/SUB focus + stereo split (issue #752)
+    # audio_config — MAIN/SUB focus + stereo split (issue #752, revised in #788)
     # --------------------------------------------------------------
     #
-    # IC-7610 CI-V Menu 0072 "Phones L/R Mix" bytes. Mapping from
-    # (focus, split_stereo) to the CI-V byte that Phones L/R Mix expects.
-    # Exact byte values may need tuning against hardware.
-    _PHONES_LR_MIX: dict[tuple[str, bool], int] = {
-        ("main", False): 0x00,  # L=MAIN, R=MAIN
-        ("main", True): 0x00,  # split has no effect — SUB silenced
-        ("sub", False): 0x03,  # L=SUB, R=SUB
-        ("sub", True): 0x03,
-        ("both", False): 0x02,  # L=mix, R=mix
-        ("both", True): 0x01,  # L=MAIN, R=SUB (true stereo split)
-    }
+    # IC-7610 CI-V ``0x1A 05 00 72`` "Connectors > Phones > L/R Mix" —
+    # per official CI-V reference p. 5: **data is 00 or 01 only**.
+    # Earlier revisions of this mapping sent 0x02 / 0x03 which the
+    # radio silently ignored, leaving LAN audio on MAIN regardless of
+    # the web UI's focus choice.  Epic #787 corrects this:
+    #
+    #   0x00 = Mix OFF → L=MAIN, R=SUB separated (true stereo split)
+    #   0x01 = Mix ON  → summed to both channels (mono on both L/R)
+    #
+    # The UI flag ``split_stereo=True`` means "I want separated L/R
+    # channels", which is **Mix OFF = 0x00**.  ``split_stereo=False``
+    # accepts the summed/mono routing, which is **Mix ON = 0x01**.
+    #
+    # The ``focus`` selector is a pure frontend concern (part B / #789) —
+    # it routes the stereo L/R pair through WebAudio gain nodes, not
+    # through CI-V.  The handler still accepts + validates + echoes
+    # ``focus`` so the client can persist it.
     _VALID_AUDIO_FOCUS: frozenset[str] = frozenset({"main", "sub", "both"})
 
     async def _handle_audio_config(self, msg: dict[str, Any]) -> None:
@@ -606,7 +612,7 @@ class AudioHandler:
             logger.debug("audio_config: ignored on 1-Rx profile")
             return
 
-        phones_byte = self._PHONES_LR_MIX[(focus, split_stereo)]
+        phones_byte = 0x00 if split_stereo else 0x01
         try:
             await self._radio.send_civ(  # type: ignore[attr-defined]
                 0x1A,

--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -299,10 +299,41 @@ class AudioBroadcaster:
         # Issue #762.
         self._maybe_warn_dsp_opus_gate()
 
+    async def _apply_phones_mix_off(self) -> None:
+        """Force Phones L/R Mix = OFF so the LAN stream is separated stereo.
+
+        Dual-RX routing contract (#792, epic #787): the frontend recovers
+        ``focus`` × ``split_stereo`` by gating the splitter's L=MAIN /
+        R=SUB outputs.  If the radio was left in Mix ON from a prior
+        session or from the physical menu, it pre-sums the receivers
+        before LAN transmission and the frontend can no longer isolate
+        a single receiver.  Send 0x1A 05 00 72 00 once per relay start
+        so new sessions always begin in a predictable state.  No-op on
+        single-RX profiles where the setting is irrelevant.
+        """
+        if not self._radio:
+            return
+        profile = getattr(self._radio, "profile", None)
+        rx_count = getattr(profile, "receiver_count", 1)
+        if rx_count < 2:
+            return
+        try:
+            await self._radio.send_civ(  # type: ignore[attr-defined]
+                0x1A,
+                sub=0x05,
+                data=bytes([0x00, 0x72, 0x00]),
+                wait_response=False,
+            )
+        except Exception:
+            logger.debug(
+                "audio-broadcaster: Phones L/R Mix init failed", exc_info=True
+            )
+
     async def _start_relay(self) -> None:
         if not self._radio or CAP_AUDIO not in self._radio.capabilities:
             return
 
+        await self._apply_phones_mix_off()
         self._refresh_codec_state(first=True)
 
         try:
@@ -571,21 +602,25 @@ class AudioHandler:
     #
     # IC-7610 CI-V ``0x1A 05 00 72`` "Connectors > Phones > L/R Mix" —
     # per official CI-V reference p. 5: **data is 00 or 01 only**.
-    # Earlier revisions of this mapping sent 0x02 / 0x03 which the
-    # radio silently ignored, leaving LAN audio on MAIN regardless of
-    # the web UI's focus choice.  Epic #787 corrects this:
     #
-    #   0x00 = Mix OFF → L=MAIN, R=SUB separated (true stereo split)
-    #   0x01 = Mix ON  → summed to both channels (mono on both L/R)
+    #   0x00 = Mix OFF → L=MAIN, R=SUB separated in the LAN stream.
+    #   0x01 = Mix ON  → radio pre-sums MAIN + SUB to both channels
+    #                    before transmission (LAN output becomes mono).
     #
-    # The UI flag ``split_stereo=True`` means "I want separated L/R
-    # channels", which is **Mix OFF = 0x00**.  ``split_stereo=False``
-    # accepts the summed/mono routing, which is **Mix ON = 0x01**.
+    # Contract for dual-RX routing (epic #787, #792): the backend must
+    # **always** keep Mix OFF while a 2-channel codec is active.  The
+    # frontend recovers ``focus`` × ``split_stereo`` purely via WebAudio
+    # gain/pan on the separated L=MAIN / R=SUB pair (#789).  If Mix is
+    # ON the radio has already mixed the receivers, so ``focus=main`` /
+    # ``focus=sub`` can no longer isolate a single receiver — the
+    # frontend would play the summed signal instead.
     #
-    # The ``focus`` selector is a pure frontend concern (part B / #789) —
-    # it routes the stereo L/R pair through WebAudio gain nodes, not
-    # through CI-V.  The handler still accepts + validates + echoes
-    # ``focus`` so the client can persist it.
+    # Both ``focus`` and ``split_stereo`` stay on the wire so the client
+    # can persist + echo them, but neither round-trips to CI-V anymore.
+    # Broadcaster start-up also forces Mix OFF once per session via
+    # :meth:`AudioBroadcaster._apply_phones_mix_off` so the LAN stream
+    # is separated from the first packet, independent of prior radio
+    # state.
     _VALID_AUDIO_FOCUS: frozenset[str] = frozenset({"main", "sub", "both"})
 
     async def _handle_audio_config(self, msg: dict[str, Any]) -> None:
@@ -612,7 +647,10 @@ class AudioHandler:
             logger.debug("audio_config: ignored on 1-Rx profile")
             return
 
-        phones_byte = 0x00 if split_stereo else 0x01
+        # Phones L/R Mix is always kept OFF (0x00) on dual-RX radios; see
+        # class-level comment above and #792.  ``focus`` / ``split_stereo``
+        # echo back for client-side persistence but don't drive CI-V.
+        phones_byte = 0x00
         try:
             await self._radio.send_civ(  # type: ignore[attr-defined]
                 0x1A,

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -32,7 +32,7 @@ class TestAudioCodecEnum:
 class TestRadioAudioConfig:
     def test_default_codec(self) -> None:
         r = IcomRadio("192.168.1.100")
-        assert r.audio_codec == AudioCodec.PCM_1CH_16BIT
+        assert r.audio_codec == AudioCodec.PCM_2CH_16BIT
         assert r.audio_sample_rate == 48000
 
     def test_custom_codec(self) -> None:
@@ -63,9 +63,9 @@ class TestAudioCapabilities:
 
     def test_default_selection_is_deterministic(self) -> None:
         caps = get_audio_capabilities()
-        assert caps.default_codec == AudioCodec.PCM_1CH_16BIT
+        assert caps.default_codec == AudioCodec.PCM_2CH_16BIT
         assert caps.default_sample_rate_hz == 48000
-        assert caps.default_channels == 1
+        assert caps.default_channels == 2
 
     def test_default_values_are_supported(self) -> None:
         caps = get_audio_capabilities()
@@ -82,6 +82,6 @@ class TestAudioCapabilities:
         assert "supported_codecs" in data
         assert "supported_sample_rates_hz" in data
         assert "supported_channels" in data
-        assert data["default_codec"] == {"name": "PCM_1CH_16BIT", "value": 0x04}
+        assert data["default_codec"] == {"name": "PCM_2CH_16BIT", "value": 0x10}
         assert data["default_sample_rate_hz"] == 48000
-        assert data["default_channels"] == 1
+        assert data["default_channels"] == 2

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -171,7 +171,7 @@ class TestCmdAudioCaps:
         out = capsys.readouterr().out
         assert "Supported codecs:" in out
         assert "Defaults:" in out
-        assert "PCM_1CH_16BIT" in out
+        assert "PCM_2CH_16BIT" in out
         assert "48000" in out
 
     @pytest.mark.asyncio
@@ -180,9 +180,9 @@ class TestCmdAudioCaps:
         rc = await _cmd_audio_caps(args)
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
-        assert data["default_codec"]["name"] == "PCM_1CH_16BIT"
+        assert data["default_codec"]["name"] == "PCM_2CH_16BIT"
         assert data["default_sample_rate_hz"] == 48000
-        assert data["default_channels"] == 1
+        assert data["default_channels"] == 2
         assert any(c["name"] == "OPUS_1CH" for c in data["supported_codecs"])
 
     @pytest.mark.asyncio
@@ -529,7 +529,7 @@ class TestRunErrorHandling:
         rc = await _run(args)
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
-        assert data["default_channels"] == 1
+        assert data["default_channels"] == 2
 
     @pytest.mark.asyncio
     async def test_run_audio_caps_with_stats_connects(self, capsys) -> None:

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -429,7 +429,7 @@ class TestCliAudioCapsE2E:
         data = json.loads(capsys.readouterr().out)
         assert "supported_codecs" in data
         assert data["default_sample_rate_hz"] == 48000
-        assert data["default_channels"] == 1
+        assert data["default_channels"] == 2
 
     @pytest.mark.asyncio
     async def test_caps_text_format(self, capsys) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -68,9 +68,9 @@ class TestSyncAudioNaming:
 
     def test_audio_capabilities(self) -> None:
         caps = IcomRadio.audio_capabilities()
-        assert caps.default_codec.name == "PCM_1CH_16BIT"
+        assert caps.default_codec.name == "PCM_2CH_16BIT"
         assert caps.default_sample_rate_hz == 48000
-        assert caps.default_channels == 1
+        assert caps.default_channels == 2
 
     def test_get_audio_stats_delegates(self) -> None:
         r = IcomRadio("192.168.1.100")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1674,11 +1674,13 @@ class TestAudioHandlerTxTranscoderRate:
 
 
 class TestAudioConfigRouting:
-    """audio_config WS message → CI-V Phones L/R Mix (issue #752).
+    """audio_config WS message → CI-V Phones L/R Mix (issue #752 / #788 / #792).
 
-    Each (focus, split_stereo) pair maps to a Menu 0072 byte emitted via
-    ``radio.send_civ(0x1A, sub=0x05, data=bytes([0x00, 0x72, byte]))``.
-    Gated on dual-RX profiles; 1-Rx radios silently no-op.
+    Contract (#792): Phones L/R Mix is always kept OFF (0x00) on dual-RX
+    radios so the LAN stream stays separated L=MAIN / R=SUB.  ``focus``
+    and ``split_stereo`` travel on the WS payload for client-side
+    persistence but do not round-trip to CI-V.  Gated on dual-RX profiles;
+    1-Rx radios silently no-op.
     """
 
     @staticmethod
@@ -1713,42 +1715,37 @@ class TestAudioConfigRouting:
             "data": bytes([0x00, 0x72, phones_byte]),
         }
 
-    async def test_split_stereo_off_sends_phones_mix_on(self) -> None:
-        """split_stereo=False → Phones L/R Mix ON (0x01 = summed), any focus.
+    async def test_any_focus_split_combo_sends_phones_mix_off(self) -> None:
+        """Every (focus, split_stereo) combination → Phones L/R Mix OFF (0x00).
 
-        Per IC-7610 CI-V reference, ``0x1A 05 00 72`` is a boolean toggle
-        (Mix OFF = 0x00 = separated L/R, Mix ON = 0x01 = summed to both).
-        When the user does NOT request stereo separation we enable the
-        radio's L/R mix so both ears hear the same summed signal.
-        Focus routing is a pure frontend concern (#789).  Issue #788.
+        #792 contract: the backend must keep Mix OFF whenever a 2-channel
+        codec is active so the LAN stream stays separated L=MAIN/R=SUB.
+        If the radio pre-sums the receivers, the frontend can no longer
+        isolate MAIN or SUB via WebAudio gain — both channels would carry
+        the summed signal.  ``focus`` / ``split_stereo`` now round-trip
+        only as echo-back for client-side persistence.
         """
         for focus in ("main", "sub", "both"):
-            handler, radio, _ = self._make_handler()
-            await self._apply(handler, focus, False)
-            radio.send_civ.assert_awaited_once_with(
-                0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x01]), wait_response=False
-            )
-
-    async def test_split_stereo_on_sends_phones_mix_off(self) -> None:
-        """split_stereo=True → Phones L/R Mix OFF (0x00 = separated), any focus.
-
-        True stereo split means L=MAIN, R=SUB kept independent, which is
-        Mix OFF = 0x00 on the IC-7610.  Issue #788.
-        """
-        for focus in ("main", "sub", "both"):
-            handler, radio, _ = self._make_handler()
-            await self._apply(handler, focus, True)
-            radio.send_civ.assert_awaited_once_with(
-                0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x00]), wait_response=False
-            )
+            for split in (False, True):
+                handler, radio, _ = self._make_handler()
+                await self._apply(handler, focus, split)
+                radio.send_civ.assert_awaited_once_with(
+                    0x1A,
+                    sub=0x05,
+                    data=bytes([0x00, 0x72, 0x00]),
+                    wait_response=False,
+                )
 
     async def test_only_valid_phones_bytes_are_emitted(self) -> None:
-        """Invariant: Phones L/R Mix only ever receives 0x00 or 0x01.
+        """Invariant: Phones L/R Mix only ever receives 0x00.
 
         Per IC-7610 CI-V reference p. 5, command ``0x1A 05 00 72``
         accepts only ``{0x00, 0x01}``.  Previous revisions sent
-        ``0x02`` and ``0x03``, which the radio silently rejected
-        (epic #787).
+        ``0x02`` and ``0x03`` (silently rejected by the radio — epic
+        #787) and the #788 pass briefly drove the byte from
+        ``split_stereo``.  Post-#792 the backend is locked to ``0x00``
+        so the frontend graph can always recover the per-receiver
+        channels it needs.
         """
         for focus in ("main", "sub", "both"):
             for split in (False, True):
@@ -1759,7 +1756,7 @@ class TestAudioConfigRouting:
                 assert data[:2] == b"\x00\x72", (
                     f"unexpected Phones sub-command: {data.hex()}"
                 )
-                assert data[2] in (0x00, 0x01), (
+                assert data[2] == 0x00, (
                     f"out-of-spec phones byte: 0x{data[2]:02X} for "
                     f"focus={focus} split={split}"
                 )
@@ -1792,6 +1789,47 @@ class TestAudioConfigRouting:
             "split_stereo": True,
             "applied": True,
         }
+
+
+class TestBroadcasterPhonesMixInit:
+    """AudioBroadcaster._apply_phones_mix_off — #792.
+
+    Broadcaster must force Phones L/R Mix = OFF on relay start so the LAN
+    stream begins in separated-stereo state regardless of prior radio
+    configuration.  Dual-RX only; no-op on 1-Rx profiles.
+    """
+
+    @staticmethod
+    def _make_broadcaster(receiver_count: int = 2) -> Any:
+        from types import SimpleNamespace
+
+        from icom_lan.radio_protocol import AudioCapable
+        from icom_lan.web.handlers import AudioBroadcaster
+
+        mock_radio = MagicMock(spec=AudioCapable)
+        mock_radio.capabilities = {"audio"}
+        mock_radio.profile = SimpleNamespace(receiver_count=receiver_count)
+        mock_radio.send_civ = AsyncMock()
+        return AudioBroadcaster(mock_radio), mock_radio
+
+    async def test_dual_rx_sends_mix_off(self) -> None:
+        broadcaster, radio = self._make_broadcaster(receiver_count=2)
+        await broadcaster._apply_phones_mix_off()
+        radio.send_civ.assert_awaited_once_with(
+            0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x00]), wait_response=False
+        )
+
+    async def test_single_rx_is_noop(self) -> None:
+        broadcaster, radio = self._make_broadcaster(receiver_count=1)
+        await broadcaster._apply_phones_mix_off()
+        radio.send_civ.assert_not_awaited()
+
+    async def test_civ_error_is_swallowed(self) -> None:
+        broadcaster, radio = self._make_broadcaster(receiver_count=2)
+        radio.send_civ.side_effect = RuntimeError("boom")
+        # Must not raise — relay start-up continues even if the init fails.
+        await broadcaster._apply_phones_mix_off()
+        radio.send_civ.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1713,34 +1713,56 @@ class TestAudioConfigRouting:
             "data": bytes([0x00, 0x72, phones_byte]),
         }
 
-    async def test_focus_main_split_off_sends_phones_00(self) -> None:
-        handler, radio, _ = self._make_handler()
-        await self._apply(handler, "main", False)
-        radio.send_civ.assert_awaited_once_with(
-            0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x00]), wait_response=False
-        )
+    async def test_split_stereo_off_sends_phones_mix_on(self) -> None:
+        """split_stereo=False → Phones L/R Mix ON (0x01 = summed), any focus.
 
-    async def test_focus_sub_split_off_sends_phones_03(self) -> None:
-        handler, radio, _ = self._make_handler()
-        await self._apply(handler, "sub", False)
-        radio.send_civ.assert_awaited_once_with(
-            0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x03]), wait_response=False
-        )
+        Per IC-7610 CI-V reference, ``0x1A 05 00 72`` is a boolean toggle
+        (Mix OFF = 0x00 = separated L/R, Mix ON = 0x01 = summed to both).
+        When the user does NOT request stereo separation we enable the
+        radio's L/R mix so both ears hear the same summed signal.
+        Focus routing is a pure frontend concern (#789).  Issue #788.
+        """
+        for focus in ("main", "sub", "both"):
+            handler, radio, _ = self._make_handler()
+            await self._apply(handler, focus, False)
+            radio.send_civ.assert_awaited_once_with(
+                0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x01]), wait_response=False
+            )
 
-    async def test_focus_both_split_off_sends_phones_02(self) -> None:
-        handler, radio, _ = self._make_handler()
-        await self._apply(handler, "both", False)
-        radio.send_civ.assert_awaited_once_with(
-            0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x02]), wait_response=False
-        )
+    async def test_split_stereo_on_sends_phones_mix_off(self) -> None:
+        """split_stereo=True → Phones L/R Mix OFF (0x00 = separated), any focus.
 
-    async def test_focus_both_split_on_sends_phones_01(self) -> None:
-        """Stereo split: L=MAIN, R=SUB — the headline feature."""
-        handler, radio, _ = self._make_handler()
-        await self._apply(handler, "both", True)
-        radio.send_civ.assert_awaited_once_with(
-            0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x01]), wait_response=False
-        )
+        True stereo split means L=MAIN, R=SUB kept independent, which is
+        Mix OFF = 0x00 on the IC-7610.  Issue #788.
+        """
+        for focus in ("main", "sub", "both"):
+            handler, radio, _ = self._make_handler()
+            await self._apply(handler, focus, True)
+            radio.send_civ.assert_awaited_once_with(
+                0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x00]), wait_response=False
+            )
+
+    async def test_only_valid_phones_bytes_are_emitted(self) -> None:
+        """Invariant: Phones L/R Mix only ever receives 0x00 or 0x01.
+
+        Per IC-7610 CI-V reference p. 5, command ``0x1A 05 00 72``
+        accepts only ``{0x00, 0x01}``.  Previous revisions sent
+        ``0x02`` and ``0x03``, which the radio silently rejected
+        (epic #787).
+        """
+        for focus in ("main", "sub", "both"):
+            for split in (False, True):
+                handler, radio, _ = self._make_handler()
+                await self._apply(handler, focus, split)
+                call = radio.send_civ.call_args
+                data = call.kwargs.get("data") or call.args[-1]
+                assert data[:2] == b"\x00\x72", (
+                    f"unexpected Phones sub-command: {data.hex()}"
+                )
+                assert data[2] in (0x00, 0x01), (
+                    f"out-of-spec phones byte: 0x{data[2]:02X} for "
+                    f"focus={focus} split={split}"
+                )
 
     async def test_invalid_focus_sends_error_no_civ(self) -> None:
         handler, radio, ws = self._make_handler()


### PR DESCRIPTION
## Summary

Combined fix for **#788** (stereo-first codec default + boolean Phones L/R Mix byte) and **#792** (routing-contract fix — Mix must stay OFF whenever a 2ch codec is active).  Together these complete epic **#787** for dual-RX LAN audio; the frontend graph described in #789 was already implemented in #753/#755/#757/#770 and now works correctly against this backend.

## Why a combined PR

The #788 pass alone would have shipped a subtle live bug: tying Phones L/R Mix to `split_stereo` means the radio pre-sums MAIN+SUB whenever the user doesn't request a stereo split, which makes `focus=main` / `focus=sub` broken on real hardware (both channels carry the summed signal; WebAudio gain can't recover per-receiver audio).  The problem only surfaces on a live IC-7610, never in unit tests.  Rather than ship the known-broken mapping, #792 was scoped alongside and folded here.

## Changes

### 1. `src/icom_lan/types.py` — stereo-first codec default (#788)
`_DEFAULT_CODEC_PREFERENCE` now leads with `PCM_2CH_16BIT`.  Dual-RX radios deliver `L=MAIN, R=SUB` in the LAN stream; single-RX firmware downgrades to mono during handshake, and `_refresh_codec_state` reads the negotiated codec back.

### 2. `src/icom_lan/web/handlers/audio.py` — Mix OFF always (#788 + #792)
- `_PHONES_LR_MIX` dict removed.
- `_handle_audio_config` now sends `0x1A 05 00 72 00` unconditionally for dual-RX profiles.  `focus` + `split_stereo` still travel on the WS payload for client-side persistence but no longer drive CI-V.
- New `AudioBroadcaster._apply_phones_mix_off()` fires once on every relay start so the LAN stream is separated stereo from the first packet, independent of the radio's prior state.  Single-RX no-op; CI-V errors swallowed so start-up continues.

### 3. `tests/test_web_server.py` — rewritten contract tests
- Old 4-row byte-matrix tests (which also asserted invalid 0x02/0x03) replaced with one "any (focus, split_stereo) → 0x00" contract test.
- Invariant test tightened from `byte in {0x00, 0x01}` to `byte == 0x00`.
- New `TestBroadcasterPhonesMixInit` covers the dual-RX hook, the single-RX no-op, and the swallowed-error path.

### 4. Test-fallout files (single-fact flip)
`tests/test_audio_codec.py`, `tests/test_cli_async.py`, `tests/test_cli_e2e.py`, `tests/test_sync.py` — each flips the default codec assertion from `PCM_1CH_16BIT` / `channels=1` to `PCM_2CH_16BIT` / `channels=2`.  Single-assertion edits, no behavior changes.

## Scope note — 7 files, not 3

Originally planned at 3 files per #788's guardrail.  The extra 4 are test-fallout from the global default flip — every test that asserts the default codec name or channel count has to move in lockstep.  No unrelated edits.

## Out of scope (follow-ups)

- **#789** — already implemented in `frontend/src/lib/audio/rx-player.ts` + `audio-manager.ts` + `AudioRoutingControl.svelte` (landed in #753/#755/#757/#770, 21 vitest tests covering the focus × split_stereo table).  Recommend closing as already-done after this PR merges.
- **#790** — `tests/integration/test_audio_routing.py:63-68` still parametrizes against the pre-#788 byte matrix (`0x02` / `0x03`).  Skipped by `--ignore=tests/integration` in the acceptance command; refresh alongside RFC §11 there.

## Test plan

- [x] `uv run pytest tests/ -q --tb=line --ignore=tests/integration` → 4692 passed, 0 failures, 6 skipped, 10 xfailed (baseline unchanged)
- [x] `uv run ruff check src/ tests/` → clean
- [x] `uv run mypy src/icom_lan/web/handlers/audio.py src/icom_lan/types.py` → clean
- [x] `TestAudioConfigRouting` — 5/5 pass, contract is "always 0x00"
- [x] `TestBroadcasterPhonesMixInit` — 3/3 pass, dual-RX hook + single-RX no-op + error swallow
- [ ] Live smoke test (requires radio): `focus=main` → MAIN only; `focus=sub` → SUB only; `focus=both` + `split_stereo=true` → true stereo MAIN→L, SUB→R

Closes #788.  Closes #792.  Completes epic #787 backend side; unblocks #790 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)