### PR TITLE
chore(#790): cleanup integration test + document LAN routing in RFC §11

### DIFF
--- a/docs/internals/rfc-audio-v1-mini.md
+++ b/docs/internals/rfc-audio-v1-mini.md
@@ -172,3 +172,61 @@ then re-encode before fan-out.  `_audio_transcoder.PcmOpusTranscoder`
 already exists and can be reused.  Quality loss is negligible for
 AM/FM ham audio but non-zero on SSB; flag behind a config toggle if
 implemented.
+
+## 11) LAN MAIN/SUB audio routing (epic #787)
+
+**Wire format.**  On dual-RX radios the LAN audio stream is **stereo
+PCM16 with L=MAIN and R=SUB** whenever a 2-channel codec is
+negotiated.  `_DEFAULT_CODEC_PREFERENCE` in `types.py` leads with
+`PCM_2CH_16BIT` (0x10); single-RX firmware downgrades to mono during
+handshake, and the broadcaster's `_refresh_codec_state` reads the
+negotiated codec back so downstream logic tracks reality rather than
+the requested codec.
+
+**Phones L/R Mix is always OFF.**  CI-V `0x1A 05 00 72` is a boolean
+toggle — `0x00` = Mix OFF (separated stereo), `0x01` = Mix ON (summed
+to both channels).  The backend keeps it locked at `0x00` via two
+paths:
+
+- `AudioHandler._handle_audio_config` — every `audio_config` WS
+  message emits `0x00`, independent of the `split_stereo` payload.
+- `AudioBroadcaster._apply_phones_mix_off` — fires once on every
+  relay start (guarded on `receiver_count >= 2`) so the LAN stream
+  begins in separated-stereo state regardless of the radio's prior
+  menu state.  Errors are swallowed so start-up continues on radios
+  where the command is unsupported.
+
+If Mix were ON the radio would pre-sum MAIN + SUB before transmission
+and the frontend graph could no longer isolate a single receiver —
+`focus=main` and `focus=sub` would both play the summed signal.
+
+**`focus` and `split_stereo` live on the frontend.**  The WebAudio
+graph in `frontend/src/lib/audio/rx-player.ts` routes the stereo
+pair through `ChannelSplitter(2) → GainNode×2 → StereoPanner×2 →
+destination`:
+
+| `focus` | `split_stereo` | L gain | R gain | L pan | R pan |
+|---------|----------------|--------|--------|-------|-------|
+| main    | any            | 1.0    | 0.0    | 0     | 0     |
+| sub     | any            | 0.0    | 1.0    | 0     | 0     |
+| both    | false          | 1.0    | 1.0    | 0     | 0     |
+| both    | true           | 1.0    | 1.0    | −1    | +1    |
+
+Per-channel dB sliders (`mainGainDb` / `subGainDb`) multiply into the
+L/R gains respectively.
+
+**Why the WS message still exists.**  `audio_config` is retained as
+a bidirectional echo channel so the client can persist its `focus` +
+`split_stereo` choice and the backend confirms via `applied: true`.
+The CI-V round-trip it used to drive (the broken `_PHONES_LR_MIX`
+dict pre-#788) is gone — the message now only raises the
+broadcaster's `_codec_stale` flag so a mid-stream codec/channel
+change triggers a fresh `_refresh_codec_state` pass (issue #766).
+
+**Historical context.**  Revisions before #788 sent `0x02` / `0x03`
+on this sub-command for `focus=sub` / `focus=both` — values the radio
+silently ignored per the CI-V reference (only `{0x00, 0x01}` valid).
+#788 briefly tied the byte to `split_stereo`; #792 corrected that to
+the lock-at-`0x00` contract above.  The dead-code mapping is
+documented here rather than in a deleted source comment so future
+contributors don't rediscover the same trap.

--- a/tests/integration/test_audio_routing.py
+++ b/tests/integration/test_audio_routing.py
@@ -58,29 +58,41 @@ class TestAudioConfigEndToEnd:
     codec-cache invalidation."""
 
     @pytest.mark.parametrize(
-        "focus,split_stereo,expected_byte",
+        "focus,split_stereo",
         [
-            ("main", False, 0x00),
-            ("main", True, 0x00),
-            ("sub", False, 0x03),
-            ("sub", True, 0x03),
-            ("both", False, 0x02),
-            ("both", True, 0x01),
+            ("main", False),
+            ("main", True),
+            ("sub", False),
+            ("sub", True),
+            ("both", False),
+            ("both", True),
         ],
     )
-    async def test_focus_split_matrix_emits_correct_phones_lr_mix(
-        self, focus: str, split_stereo: bool, expected_byte: int
+    async def test_focus_split_matrix_emits_mix_off(
+        self, focus: str, split_stereo: bool
     ) -> None:
+        """Any (focus, split_stereo) → Phones L/R Mix OFF (0x00).
+
+        Post-#792 contract (epic #787): the radio always sends separated
+        L=MAIN/R=SUB stereo whenever a 2ch codec is active, so the backend
+        unconditionally keeps Mix OFF.  ``focus`` × ``split_stereo``
+        resolve on the frontend via WebAudio gain + pan (rx-player.ts).
+
+        Earlier revisions sent ``0x02`` / ``0x03`` for ``focus=sub`` /
+        ``focus=both`` — values the radio silently ignored per the CI-V
+        reference.  Those dead bytes are gone; this test pins the
+        replacement contract.
+        """
         handler, broadcaster, mock_radio = _build()
         await handler._handle_control(
             {"type": "audio_config", "focus": focus, "split_stereo": split_stereo}
         )
 
-        # CI-V byte correct.
+        # CI-V byte is always Mix OFF.
         mock_radio.send_civ.assert_awaited_once_with(
             0x1A,
             sub=0x05,
-            data=bytes([0x00, 0x72, expected_byte]),
+            data=bytes([0x00, 0x72, 0x00]),
             wait_response=False,
         )
 


### PR DESCRIPTION
## Summary

Final cleanup for epic #787 (part C).  Two files, zero \`src/\` changes, zero behavior changes.

1. **\`tests/integration/test_audio_routing.py\`** — collapsed the parametrize matrix from the pre-#788 4-value byte table (\`0x00\` / \`0x01\` / \`0x02\` / \`0x03\`) down to the post-#792 single-value contract (every \`(focus, split_stereo)\` pair emits \`0x00\`).  Test renamed from \`..._emits_correct_phones_lr_mix\` to \`..._emits_mix_off\` so the name matches the assertion.  Docstring documents why the old bytes were dead code.
2. **\`docs/internals/rfc-audio-v1-mini.md\`** — appended \`## 11) LAN MAIN/SUB audio routing (epic #787)\` with five sub-sections:
   - Wire format (stereo PCM16 L=MAIN/R=SUB on 2ch codec)
   - Phones L/R Mix lock invariant (always \`0x00\`, via handler + \`AudioBroadcaster._apply_phones_mix_off\`)
   - Frontend routing table (\`focus\` × \`split_stereo\` → L/R gain / pan)
   - Why the \`audio_config\` WS message still exists (echo-back for client persistence + \`_codec_stale\` invalidation)
   - Historical context for the \`0x02\` / \`0x03\` trap (#788 partial fix → #792 final contract)

The dead-code \`_PHONES_LR_MIX\` dict mentioned in the issue body was already removed in #791 — grep finds only stale \`__pycache__\`.

## Scope

- 2 files (guardrail ≤3)
- +81 / -11 lines (guardrail ≤100)
- No code changes
- No protocol changes

## Test plan

- [x] \`uv run pytest tests/integration/test_audio_routing.py -q\` → 9/9 pass
- [x] \`uv run pytest tests/ -q --tb=line --ignore=tests/integration\` → 4692 passed, 0 failures
- [x] \`uv run ruff check tests/\` → clean
- [x] Live smoke test of the end-to-end routing confirmed post-#791 merge (USB backend, IC-7610 dual-RX): \`focus=main\` → MAIN only, \`focus=sub\` → SUB only, \`focus=both + split_stereo=true\` → true stereo L=MAIN / R=SUB

Closes #790.  Closes epic #787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)