### PR TITLE
fix(#794): decouple tx_codec from rx_codec — restore IC-7610 stereo LAN

### DIFF
--- a/src/icom_lan/_control_phase.py
+++ b/src/icom_lan/_control_phase.py
@@ -19,6 +19,7 @@ from ._connection_state import RadioConnectionState
 from .exceptions import AuthenticationError, ConnectionError, TimeoutError
 from .startup_checks import wait_for_radio_startup_ready
 from .transport import ConnectionState, IcomTransport
+from .types import AudioCodec
 
 if TYPE_CHECKING:
     from ._runtime_protocols import ControlPhaseHost
@@ -477,6 +478,17 @@ class ControlPhaseRuntime:
         audio_local_port: int = 0,
     ) -> None:
         h = self._host
+        # TX codec must always be mono for IC-7610 (and all Icom LAN radios
+        # we target): the mic path through the transceiver is 1-channel, and
+        # the stock firmware rejects conninfo with ``error=0xFFFFFFFF`` when
+        # ``txcodec`` is a 2ch value (0x08 / 0x10 / 0x20 / 0x41).  wfview
+        # enforces the same constraint in its UI by only offering mono TX
+        # codecs (``settingswidget.cpp:118-124``).  Our Python client used to
+        # mirror the RX codec into TX, which broke stereo RX on LAN.  See
+        # issue #794.  We force ``PCM_1CH_16BIT`` so stereo RX works without
+        # any user-visible tradeoff — the radio uses its own separately
+        # configured TX modulation source regardless of this byte.
+        tx_codec = int(AudioCodec.PCM_1CH_16BIT)
         conninfo = build_conninfo_packet(
             sender_id=h._ctrl_transport.my_id,
             receiver_id=h._ctrl_transport.remote_id,
@@ -488,7 +500,7 @@ class ControlPhaseRuntime:
             auth_seq=h._auth_seq,
             guid=guid,
             rx_codec=int(h._audio_codec),
-            tx_codec=int(h._audio_codec),
+            tx_codec=tx_codec,
             rx_sample_rate=h._audio_sample_rate,
             tx_sample_rate=h._audio_sample_rate,
             civ_local_port=civ_local_port,

--- a/src/icom_lan/types.py
+++ b/src/icom_lan/types.py
@@ -192,7 +192,14 @@ _DEFAULT_CODEC_PREFERENCE: tuple[AudioCodec, ...] = (
     # Preferred: stereo PCM16 so dual-RX radios deliver L=MAIN + R=SUB in the
     # LAN stream (epic #787).  Single-RX radios' firmware downgrades to mono
     # during handshake; the broadcaster's ``_refresh_codec_state`` reads the
-    # actual negotiated codec back, so downstream logic tracks reality.
+    # actual negotiated codec back.
+    #
+    # NOTE: the stereo value (0x10) is safe in the conninfo ``rxcodec`` field
+    # *only* because ``_control_phase._send_conninfo`` explicitly forces the
+    # ``txcodec`` field to a mono value — IC-7610 stock firmware rejects the
+    # session with ``error=0xFFFFFFFF`` if ``txcodec`` itself is stereo (its
+    # mic path is mono-only, same constraint wfview enforces via its UI at
+    # ``settingswidget.cpp:118-124``).  Issue #794.
     AudioCodec.PCM_2CH_16BIT,
     AudioCodec.PCM_1CH_16BIT,
     AudioCodec.ULAW_2CH,

--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -316,6 +316,10 @@ class AudioBroadcaster:
         profile = getattr(self._radio, "profile", None)
         rx_count = getattr(profile, "receiver_count", 1)
         if rx_count < 2:
+            logger.info(
+                "audio-broadcaster: Phones L/R Mix skipped (rx_count=%d < 2)",
+                rx_count,
+            )
             return
         try:
             await self._radio.send_civ(  # type: ignore[attr-defined]
@@ -324,8 +328,11 @@ class AudioBroadcaster:
                 data=bytes([0x00, 0x72, 0x00]),
                 wait_response=False,
             )
+            logger.info(
+                "audio-broadcaster: Phones L/R Mix = OFF sent (1A 05 00 72 00)"
+            )
         except Exception:
-            logger.debug(
+            logger.warning(
                 "audio-broadcaster: Phones L/R Mix init failed", exc_info=True
             )
 

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -185,6 +185,38 @@ class TestSendConninfo:
         await radio._control_phase._send_conninfo(None)
         assert len(mt.sent_packets) == 1
 
+    @pytest.mark.asyncio
+    async def test_tx_codec_is_mono_even_when_rx_codec_is_stereo(self) -> None:
+        """Issue #794: IC-7610 stock firmware rejects conninfo with stereo
+        ``txcodec`` (mic path is mono-only).  Regardless of the requested RX
+        codec, the conninfo ``txcodec`` byte at offset 0x73 must be mono
+        (PCM_1CH_16BIT = 0x04).
+        """
+        from icom_lan.types import AudioCodec
+
+        radio = IcomRadio(
+            "192.168.1.100",
+            username="u",
+            password="p",
+            audio_codec=AudioCodec.PCM_2CH_16BIT,
+        )
+        mt = ConnectMockTransport()
+        radio._ctrl_transport = mt
+        radio._token = 0x12345678
+        radio._tok_request = 0xABCD
+        await radio._control_phase._send_conninfo(b"\x00" * 16)
+        assert len(mt.sent_packets) == 1
+        packet = mt.sent_packets[0]
+        # Conninfo layout: rxcodec at byte 0x72, txcodec at byte 0x73
+        # (see ``src/icom_lan/auth.py`` ``build_conninfo_packet``).
+        assert packet[0x72] == int(AudioCodec.PCM_2CH_16BIT), (
+            f"rxcodec should reflect requested codec 0x10, got 0x{packet[0x72]:02X}"
+        )
+        assert packet[0x73] == int(AudioCodec.PCM_1CH_16BIT), (
+            f"txcodec must be mono 0x04 even for stereo RX, "
+            f"got 0x{packet[0x73]:02X}"
+        )
+
 
 class TestReceiveCivPort:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR #791 broke LAN connection to IC-7610 stock firmware. Root cause: our Python conninfo builder blindly mirrored \`rx_codec\` into \`tx_codec\`, and #791 changed the default codec preference to \`PCM_2CH_16BIT (0x10)\`. IC-7610's stock firmware rejects conninfo with \`error=0xFFFFFFFF\` when \`tx_codec\` is a 2-channel value (the transceiver's mic path is mono-only). Confirmed by bisecting v0.16.4 (works) vs main post-#791 (rejects) vs main post-#791 with manual \`tx_codec\` override (works).

wfview enforces the same constraint in its UI: the TX codec combobox only offers mono values \`{0x01, 0x02, 0x04, 0x40, 0x80}\`. There's no way for a wfview user to request a stereo TX codec. Our Python client inherited the RX choice uncritically. See issue #794 for the full bisection.

## Changes

- **\`src/icom_lan/_control_phase.py\`** — \`_send_conninfo\` now hardcodes \`tx_codec = PCM_1CH_16BIT (0x04)\`. The comment references the IC-7610 mic-path constraint, wfview's matching UI restriction, and issue #794.
- **\`src/icom_lan/types.py\`** — updated the \`_DEFAULT_CODEC_PREFERENCE\` docstring to note that stereo in this tuple is safe only because \`_send_conninfo\` forces mono \`tx_codec\`.
- **\`src/icom_lan/web/handlers/audio.py\`** — \`AudioBroadcaster._apply_phones_mix_off\` success path goes from silent to \`INFO\` so operators can confirm Mix OFF actually fired (the first thing I needed while investigating this issue). Failure path goes from \`DEBUG exc_info\` to \`WARNING exc_info\` so swallowed errors stop being invisible.
- **\`tests/test_radio_connect.py\`** — added \`TestSendConninfo.test_tx_codec_is_mono_even_when_rx_codec_is_stereo\`. Pins the conninfo byte at offset \`0x73\` to \`0x04\` even when the client requests \`rx_codec = 0x10\`. Blocks future "just mirror rx to tx" refactors from silently reintroducing the bug.

## Live verification (IC-7610 @ 192.168.55.40, stock firmware, LAN)

\`\`\`
22:56:30 Status: civ_port=50002, audio_port=50003, error=0x00000000
22:56:34 initial state fetch done (96/96 ok)
22:56:41 audio-broadcaster: Phones L/R Mix = OFF sent (1A 05 00 72 00)
22:56:41 audio-broadcaster: radio codec=PCM_2CH_16BIT (0x10) → web_codec=0x02
22:56:41 audio-broadcaster: starting relay codec=0x02 sr=48000 ch=2
\`\`\`

Plus end-to-end UI smoke — all 4 cells of the #789 routing matrix (focus={main, sub, both} × split={on, off}) produce the expected per-channel audio: \`focus=main\` → MAIN only, \`focus=sub\` → SUB only, \`focus=both + split=on\` → true stereo L=MAIN, R=SUB.

## Scope

- 4 files changed, 61+ / 3− lines, all guardrails satisfied.
- No architectural changes.
- The 4 test files that tracked the default codec (\`test_audio_codec.py\`, \`test_cli_async.py\`, \`test_cli_e2e.py\`, \`test_sync.py\`) are **untouched** — main already has them pointing at stereo defaults and that stays correct.

## Test plan

- [x] \`uv run pytest tests/ -q --tb=short --ignore=tests/integration\` → 4698 passed, 0 failures
- [x] \`uv run ruff check src/ tests/\` → clean
- [x] IC-7610 LAN session opens (\`error=0x00000000\`), stereo codec negotiated, frontend routing verified live
- [x] New regression test locks the \`tx_codec\` mono invariant

Closes #794.

🤖 Generated with [Claude Code](https://claude.com/claude-code)