### PR TITLE
fix(web-ui): CollapsiblePanel phantom-collapse on plain hover

### DIFF
--- a/frontend/src/components-v2/controls/CollapsiblePanel.svelte
+++ b/frontend/src/components-v2/controls/CollapsiblePanel.svelte
@@ -57,18 +57,24 @@
 
   // --- Swipe gesture tracking ---
   const SWIPE_THRESHOLD = 30;
+  let swipeActive = false;
   let swipeStartY = 0;
   let swipeStartX = 0;
   let swipeHandled = false;
 
   function onHeaderPointerDown(e: PointerEvent) {
+    swipeActive = true;
     swipeStartX = e.clientX;
     swipeStartY = e.clientY;
     swipeHandled = false;
   }
 
   function onHeaderPointerMove(e: PointerEvent) {
-    if (!collapsible || swipeHandled) return;
+    // Only track swipe distance while a pointer is actively held down.
+    // Without this gate, plain hover movement reads ``swipeStartY = 0`` and
+    // the first frame computes ``dy = e.clientY`` (hundreds of pixels),
+    // instantly tripping the swipe-to-collapse threshold on mouse-over.
+    if (!swipeActive || !collapsible || swipeHandled) return;
     const dy = e.clientY - swipeStartY;
     const dx = e.clientX - swipeStartX;
     const absDy = Math.abs(dy);
@@ -86,6 +92,15 @@
         toggle();
       }
     }
+  }
+
+  function onHeaderPointerUp() {
+    swipeActive = false;
+  }
+
+  function onHeaderPointerCancel() {
+    swipeActive = false;
+    swipeHandled = false;
   }
 
   function onHeaderClick(e: MouseEvent) {
@@ -114,6 +129,9 @@
       onclick={onHeaderClick}
       onpointerdown={onHeaderPointerDown}
       onpointermove={onHeaderPointerMove}
+      onpointerup={onHeaderPointerUp}
+      onpointercancel={onHeaderPointerCancel}
+      onpointerleave={onHeaderPointerUp}
       disabled={!collapsible}
     >
       {#if collapsible}

--- a/frontend/src/components-v2/controls/__tests__/CollapsiblePanel.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/CollapsiblePanel.test.ts
@@ -394,5 +394,51 @@ describe('CollapsiblePanel', () => {
       // Should remain collapsed (click was suppressed by swipeHandled flag)
       expect(chevron?.textContent).toBe('▸');
     });
+
+    it('hover motion without pointerdown does not collapse the panel', () => {
+      // Regression for the phantom-swipe bug: pointermove fires during plain
+      // mouse-over, and the handler used to compute ``dy = clientY - 0`` on
+      // uninitialised swipe state, tripping the collapse threshold on the
+      // first frame.  Now pointermove is gated on ``swipeActive``.
+      const target = mountPanel({ title: 'Test', panelId: 'hover-test' });
+      const header = target.querySelector('.panel-header') as HTMLElement;
+      const chevron = target.querySelector('.chevron');
+
+      expect(chevron?.textContent).toBe('▾');
+
+      // Hover: several pointermove events at varying Y, no pointerdown.
+      for (const y of [100, 150, 200, 400, 600]) {
+        header.dispatchEvent(
+          new PointerEvent('pointermove', { clientX: 50, clientY: y, bubbles: true }),
+        );
+      }
+      flushSync();
+
+      // Must still be expanded — hover must not toggle.
+      expect(chevron?.textContent).toBe('▾');
+    });
+
+    it('pointerup clears swipe state so next hover is inert', () => {
+      const target = mountPanel({ title: 'Test', panelId: 'reset-test' });
+      const header = target.querySelector('.panel-header') as HTMLElement;
+      const chevron = target.querySelector('.chevron');
+
+      // Complete a successful swipe (down → collapse)
+      simulateSwipe(header, 40);
+      header.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      flushSync();
+      expect(chevron?.textContent).toBe('▸');
+
+      // Now hover: moves should not expand the collapsed panel.
+      for (const y of [20, 60, 120, 300]) {
+        header.dispatchEvent(
+          new PointerEvent('pointermove', { clientX: 50, clientY: y, bubbles: true }),
+        );
+      }
+      flushSync();
+
+      // Still collapsed — hover did not re-toggle.
+      expect(chevron?.textContent).toBe('▸');
+    });
   });
 });


### PR DESCRIPTION
## Bug

Hovering (no click) over panel headers in the left sidebar would randomly collapse or expand them. Observed on every panel in the left column; right column unaffected in practice (fewer panels, less cursor travel — not an immunity).

## Root cause

\`onHeaderPointerMove\` in \`CollapsiblePanel.svelte\` fires during plain hover, not just during an active drag. The swipe state variables (\`swipeStartX\`, \`swipeStartY\`) were initialised to \`0\` at component mount and only written in \`onHeaderPointerDown\`.

If the user hovers without clicking first, \`pointermove\` computes \`dy = e.clientY - 0\` — which is the raw viewport Y of the cursor, often hundreds of pixels — and trips the 30 px swipe threshold on the very first frame. The handler then calls \`toggle()\`.

The \`absDy > absDx * 2\` guard didn't gate anything useful either: with \`startX = 0\` too, any cursor position with \`Y > 2 * X\` triggers (roughly the bottom 2/3 of a normal window). So the collapse looked random but was actually "fires on most \`pointermove\` events within the header before any \`pointerdown\`".

## Fix

Gate \`onHeaderPointerMove\` on a fresh \`swipeActive\` boolean. \`pointerdown\` flips it true; \`pointerup\` / \`pointerleave\` / \`pointercancel\` clear it. This mirrors the standard touch-gesture pattern and removes the entire false-positive path without changing the accepted-swipe behaviour (the three existing swipe-down / swipe-up / threshold tests still pass unchanged).

## Regression tests

Two new cases in \`CollapsiblePanel.test.ts\`:

- **\`hover motion without pointerdown does not collapse the panel\`** — dispatches several \`pointermove\` events across a wide Y range without any \`pointerdown\`; asserts the panel stays expanded. Fails on the old code (collapses on the first move); passes on the fix.
- **\`pointerup clears swipe state so next hover is inert\`** — runs a legitimate swipe-down + \`pointerup\`, then a series of plain hover moves; asserts the panel does not re-toggle. Locks the state-reset behaviour.

## Scope

- 2 files (\`CollapsiblePanel.svelte\` + its test file)
- +65 / −1 lines
- No behaviour change for legitimate swipe gestures or click-to-toggle
- No protocol / backend changes

## Test plan

- [x] \`npx vitest run\` → 1534 passed across 83 files (+2 new cases)
- [x] \`npx svelte-check --threshold error\` → 217 files, 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)