### PR TITLE
fix(review): sync.py default codec + RFC §11 routing-table accuracy

### DIFF
--- a/docs/internals/rfc-audio-v1-mini.md
+++ b/docs/internals/rfc-audio-v1-mini.md
@@ -207,10 +207,20 @@ destination`:
 
 | `focus` | `split_stereo` | L gain | R gain | L pan | R pan |
 |---------|----------------|--------|--------|-------|-------|
-| main    | any            | 1.0    | 0.0    | 0     | 0     |
-| sub     | any            | 0.0    | 1.0    | 0     | 0     |
+| main    | false          | 1.0    | 0.0    | 0     | 0     |
+| main    | true           | 1.0    | 0.0    | −1    | +1    |
+| sub     | false          | 0.0    | 1.0    | 0     | 0     |
+| sub     | true           | 0.0    | 1.0    | −1    | +1    |
 | both    | false          | 1.0    | 1.0    | 0     | 0     |
 | both    | true           | 1.0    | 1.0    | −1    | +1    |
+
+Panning depends **only** on `split_stereo` (see
+`rx-player.ts::_applyGraphState`, lines 247-257) — when on,
+`mainPanner` hard-pans to −1 and `subPanner` to +1 regardless of
+`focus`.  For single-receiver focus (`focus=main` or `focus=sub`) the
+opposing gain is already 0 so the pan on the silenced channel is
+inaudible, but the setting still applies to the active channel — e.g.
+`focus=main` + `split_stereo=true` routes MAIN to the left ear only.
 
 Per-channel dB sliders (`mainGainDb` / `subGainDb`) multiply into the
 L/R gains respectively.

--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -21,7 +21,7 @@ from .ic705 import (
     prepare_ic705_data_profile as _prepare_ic705_data_profile,
     restore_ic705_data_profile as _restore_ic705_data_profile,
 )
-from .radio import IcomRadio as _AsyncIcomRadio  # noqa: TID251
+from .radio import IcomRadio as _AsyncIcomRadio, _DEFAULT_AUDIO_CODEC  # noqa: TID251
 from .capabilities import CAP_METERS, CAP_POWER_CONTROL
 from .types import AudioCapabilities, AudioCodec, Mode, ScopeCompletionPolicy
 
@@ -43,7 +43,9 @@ class IcomRadio:
         password: Authentication password.
         radio_addr: CI-V address of the radio (default IC-7610 = 0x98).
         timeout: Operation timeout in seconds.
-        audio_codec: Audio codec (default PCM 1ch 16-bit).
+        audio_codec: Audio codec (default: stereo PCM 2ch 16-bit on dual-RX
+            radios, auto-negotiated down to mono on single-RX firmware — see
+            ``_DEFAULT_CODEC_PREFERENCE`` in ``types.py``).
         audio_sample_rate: Audio sample rate in Hz.
     """
 
@@ -55,7 +57,7 @@ class IcomRadio:
         password: str = "",
         radio_addr: int = 0x98,
         timeout: float = 5.0,
-        audio_codec: AudioCodec | int = AudioCodec.PCM_1CH_16BIT,
+        audio_codec: AudioCodec | int = _DEFAULT_AUDIO_CODEC,
         audio_sample_rate: int = 48000,
     ) -> None:
         self._loop = asyncio.new_event_loop()


### PR DESCRIPTION
## Summary

Post-merge review follow-ups from PRs #791 / #795 / #796 / #793. Two MEDIUM findings, zero behaviour changes in the hot path — docs + single-line API default.

## Changes

### 1. \`src/icom_lan/sync.py\` — drift with the rest of the codebase

\`sync.py::IcomRadio.__init__\` still hardcoded \`audio_codec = PCM_1CH_16BIT\`, with a docstring repeating the mono claim. Every other constructor (\`radio.py\`, \`backends/config.py\`, \`_icom_serial_base.py\`) already pulls from \`_AUDIO_CAPABILITIES.default_codec\` which #791 flipped to stereo. Result: sync users silently got mono, async users got stereo.

Switched to \`_DEFAULT_AUDIO_CODEC\` imported from \`radio.py\` so both surfaces track the global default. Docstring updated.

### 2. \`docs/internals/rfc-audio-v1-mini.md\` §11 — table contradicts code

The post-#793 table in §11 claimed \`L pan = 0, R pan = 0\` for every \`focus=main\` / \`focus=sub\` row regardless of \`split_stereo\`. Actual behaviour at \`rx-player.ts:247-257\`:

\`\`\`ts
this.mainPanner.pan.value = this._splitStereo ? -1 : 0;
this.subPanner.pan.value  = this._splitStereo ? +1 : 0;
\`\`\`

Pan depends **only** on \`split_stereo\`. So \`focus=main\` + \`split_stereo=true\` hard-pans MAIN to −1 — inaudible today (SUB is muted by gain) but misleading for future contributors.

Expanded the table to six explicit rows that mirror the code one-to-one, plus a short paragraph explaining the pan/gain independence.

## Out of scope

Filed as **follow-up #797**: per-profile codec preference override for single-RX radios (IC-7300 / IC-705 / IC-9700, all hardware-blocked). The stereo-first default may fail conninfo on those radios; needs testing when hardware surfaces.

Not touched in this PR (matter of taste, not bugs):

- \`_handle_audio_config\` still re-sends Mix OFF on every WS message even though \`_apply_phones_mix_off\` already covered it at relay start. Wire traffic waste, not a regression.
- \`_apply_phones_mix_off\` INFO log on every relay start. Arguably noisy; leaving.

## Test plan

- [x] \`uv run pytest tests/ -q --ignore=tests/integration\` → 4698 passed, 0 failures
- [x] \`uv run ruff check src/ tests/\` → clean
- [x] RFC table cross-checked against \`rx-player.ts:247-257\` line by line
- [x] Both surfaces (sync + async) now return the same default codec

🤖 Generated with [Claude Code](https://claude.com/claude-code)