### PR TITLE
fix(#799): gate Phones L/R Mix on capability, not receiver_count

### DIFF
--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -35,6 +35,10 @@ features = [
     "audio",
     "dual_rx",
     "dual_watch",
+    # LAN audio stereo routing via Phones L/R Mix (0x1A 05 00 72).
+    # IC-7610-only menu item — do NOT add to IC-9700 or FTX-1 even though
+    # they also have receiver_count=2 (#787 / #792 / #794).
+    "lan_dual_rx_audio_routing",
     "af_level",
     "rf_gain",
     "squelch",

--- a/src/icom_lan/capabilities.py
+++ b/src/icom_lan/capabilities.py
@@ -39,6 +39,18 @@ CAP_AF_LEVEL = "af_level"
 CAP_RF_GAIN = "rf_gain"
 CAP_SQUELCH = "squelch"
 
+# LAN audio stereo routing via the ``0x1A 05 00 72`` "Phones L/R Mix" CI-V
+# sub-command (IC-7610 menu path: Connectors → Phones → L/R Mix).  Declaring
+# this capability authorises the web audio broadcaster to (a) force Mix OFF
+# once per relay start so the LAN stream stays separated L=MAIN / R=SUB, and
+# (b) echo the frontend ``audio_config`` message's ``focus`` / ``split_stereo``
+# payload back to the client.  Both paths are dual-RX contract (#787 / #792 /
+# #794).  Do NOT add this tag to rigs that don't expose this menu item — IC-
+# 9700 also has ``receiver_count=2`` but its menu layout does not include
+# ``0x1A 05 00 72``, and FTX-1 runs on Yaesu CAT which has no ``send_civ``
+# at all.
+CAP_LAN_DUAL_RX_AUDIO_ROUTING = "lan_dual_rx_audio_routing"
+
 # RF front-end
 CAP_ATTENUATOR = "attenuator"
 CAP_PREAMP = "preamp"
@@ -126,6 +138,7 @@ KNOWN_CAPABILITIES: frozenset[str] = frozenset(
         CAP_AUDIO,
         CAP_DUAL_RX,
         CAP_DUAL_WATCH,
+        CAP_LAN_DUAL_RX_AUDIO_ROUTING,
         CAP_AF_LEVEL,
         CAP_RF_GAIN,
         CAP_SQUELCH,

--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from ...dsp.pipeline import DSPPipeline
     from ...radio_protocol import Radio
 
-from ...capabilities import CAP_AUDIO
+from ...capabilities import CAP_AUDIO, CAP_LAN_DUAL_RX_AUDIO_ROUTING
 
 __all__ = ["AudioBroadcaster", "AudioHandler"]
 
@@ -308,18 +308,18 @@ class AudioBroadcaster:
         session or from the physical menu, it pre-sums the receivers
         before LAN transmission and the frontend can no longer isolate
         a single receiver.  Send 0x1A 05 00 72 00 once per relay start
-        so new sessions always begin in a predictable state.  No-op on
-        single-RX profiles where the setting is irrelevant.
+        so new sessions always begin in a predictable state.
+
+        Gated on the ``lan_dual_rx_audio_routing`` capability.  Declared
+        only on IC-7610 — IC-9700 also has ``receiver_count=2`` but its
+        menu layout does not include ``0x1A 05 00 72``, and FTX-1 runs
+        on Yaesu CAT which has no ``send_civ`` at all.  Sending this
+        CI-V on either would silent-NAK (IC-9700) or raise AttributeError
+        (FTX-1).  Issue #799.
         """
         if not self._radio:
             return
-        profile = getattr(self._radio, "profile", None)
-        rx_count = getattr(profile, "receiver_count", 1)
-        if rx_count < 2:
-            logger.info(
-                "audio-broadcaster: Phones L/R Mix skipped (rx_count=%d < 2)",
-                rx_count,
-            )
+        if CAP_LAN_DUAL_RX_AUDIO_ROUTING not in self._radio.capabilities:
             return
         try:
             await self._radio.send_civ(  # type: ignore[attr-defined]
@@ -633,8 +633,13 @@ class AudioHandler:
     async def _handle_audio_config(self, msg: dict[str, Any]) -> None:
         """Apply MAIN/SUB audio focus + stereo split via CI-V Phones L/R Mix.
 
-        Fire-and-forget on dual-RX profiles. Echoes the applied config back on
-        the WS so the client can confirm persistence. No-op on 1-Rx profiles.
+        Fire-and-forget on radios declaring the
+        ``lan_dual_rx_audio_routing`` capability (IC-7610 only today —
+        see ``capabilities.CAP_LAN_DUAL_RX_AUDIO_ROUTING``).  Echoes the
+        applied config back on the WS so the client can confirm
+        persistence.  Silent no-op on radios that don't declare the
+        capability — e.g. IC-9700 (dual-RX but different menu layout)
+        and FTX-1 (Yaesu CAT, no ``send_civ`` at all).  Issue #799.
         """
         focus = msg.get("focus", "")
         split_stereo = bool(msg.get("split_stereo", False))
@@ -648,10 +653,10 @@ class AudioHandler:
 
         if not self._radio:
             return  # no radio attached — cannot apply
-        profile = getattr(self._radio, "profile", None)
-        rx_count = getattr(profile, "receiver_count", 1)
-        if rx_count < 2:
-            logger.debug("audio_config: ignored on 1-Rx profile")
+        if CAP_LAN_DUAL_RX_AUDIO_ROUTING not in self._radio.capabilities:
+            logger.debug(
+                "audio_config: ignored — radio lacks lan_dual_rx_audio_routing"
+            )
             return
 
         # Phones L/R Mix is always kept OFF (0x00) on dual-RX radios; see

--- a/tests/integration/test_audio_routing.py
+++ b/tests/integration/test_audio_routing.py
@@ -33,11 +33,19 @@ pytestmark = [pytest.mark.integration, pytest.mark.mock_integration]
 
 def _build(receiver_count: int = 2) -> tuple[AudioHandler, AudioBroadcaster, Any]:
     """Construct the full AudioHandler + AudioBroadcaster + AudioBus chain
-    against a MagicMock radio. Returns (handler, broadcaster, mock_radio)."""
+    against a MagicMock radio. Returns (handler, broadcaster, mock_radio).
+
+    Default shape is an IC-7610-like dual-RX profile: declares both the
+    ``audio`` and ``lan_dual_rx_audio_routing`` capabilities so the
+    handler actually exercises the Phones L/R Mix CI-V path.  Issue #799.
+    """
     mock_ws = MagicMock(spec=WebSocketConnection)
     mock_ws.send_text = AsyncMock()
     mock_radio = MagicMock(spec=AudioCapable)
-    mock_radio.capabilities = {"audio"}
+    caps = {"audio"}
+    if receiver_count >= 2:
+        caps.add("lan_dual_rx_audio_routing")
+    mock_radio.capabilities = caps
     mock_radio.audio_codec = AudioCodec.PCM_1CH_16BIT
     mock_radio.audio_sample_rate = 48000
     mock_radio.start_audio_rx_opus = AsyncMock()

--- a/tests/test_rig_ic7610.py
+++ b/tests/test_rig_ic7610.py
@@ -59,6 +59,7 @@ class TestProfileParity:
                 "audio",
                 "dual_rx",
                 "dual_watch",
+                "lan_dual_rx_audio_routing",
                 "af_level",
                 "rf_gain",
                 "squelch",
@@ -121,7 +122,7 @@ class TestProfileParity:
         assert profile.capabilities == expected
 
     def test_capabilities_count(self, profile):
-        assert len(profile.capabilities) == 47
+        assert len(profile.capabilities) == 48
 
     def test_cmd29_routes_exact(self, profile):
         expected = frozenset(

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1458,7 +1458,7 @@ class TestBroadcasterCodecInvalidation:
         mock_ws = MagicMock(spec=WebSocketConnection)
         mock_ws.send_text = AsyncMock()
         mock_radio = MagicMock(spec=AudioCapable)
-        mock_radio.capabilities = {"audio"}
+        mock_radio.capabilities = {"audio", "lan_dual_rx_audio_routing"}
         mock_radio.audio_codec = audio_codec
         mock_radio.audio_sample_rate = sample_rate
         mock_radio.start_audio_rx_opus = AsyncMock()
@@ -1684,7 +1684,11 @@ class TestAudioConfigRouting:
     """
 
     @staticmethod
-    def _make_handler(receiver_count: int = 2) -> Any:
+    def _make_handler(
+        receiver_count: int = 2,
+        *,
+        supports_routing: bool = True,
+    ) -> Any:
         from types import SimpleNamespace
 
         from icom_lan.radio_protocol import AudioCapable
@@ -1694,7 +1698,10 @@ class TestAudioConfigRouting:
         mock_ws = MagicMock(spec=WebSocketConnection)
         mock_ws.send_text = AsyncMock()
         mock_radio = MagicMock(spec=AudioCapable)
-        mock_radio.capabilities = {"audio"}
+        caps = {"audio"}
+        if supports_routing:
+            caps.add("lan_dual_rx_audio_routing")
+        mock_radio.capabilities = caps
         mock_radio.profile = SimpleNamespace(receiver_count=receiver_count)
         mock_radio.send_civ = AsyncMock()
 
@@ -1771,7 +1778,20 @@ class TestAudioConfigRouting:
         assert "invalid focus" in sent
 
     async def test_single_rx_profile_noops(self) -> None:
-        handler, radio, ws = self._make_handler(receiver_count=1)
+        # IC-7300 / IC-705 / X6100 shape: receiver_count=1, capability absent.
+        handler, radio, ws = self._make_handler(
+            receiver_count=1, supports_routing=False
+        )
+        await self._apply(handler, "main", False)
+        radio.send_civ.assert_not_awaited()
+        ws.send_text.assert_not_awaited()
+
+    async def test_dual_rx_without_routing_capability_is_noop(self) -> None:
+        # IC-9700 shape: receiver_count=2 but menu layout lacks Phones L/R Mix,
+        # so it must NOT receive 0x1A 05 00 72.  Issue #799.
+        handler, radio, ws = self._make_handler(
+            receiver_count=2, supports_routing=False
+        )
         await self._apply(handler, "main", False)
         radio.send_civ.assert_not_awaited()
         ws.send_text.assert_not_awaited()
@@ -1800,32 +1820,53 @@ class TestBroadcasterPhonesMixInit:
     """
 
     @staticmethod
-    def _make_broadcaster(receiver_count: int = 2) -> Any:
+    def _make_broadcaster(
+        receiver_count: int = 2,
+        *,
+        supports_routing: bool = True,
+    ) -> Any:
         from types import SimpleNamespace
 
         from icom_lan.radio_protocol import AudioCapable
         from icom_lan.web.handlers import AudioBroadcaster
 
         mock_radio = MagicMock(spec=AudioCapable)
-        mock_radio.capabilities = {"audio"}
+        caps = {"audio"}
+        if supports_routing:
+            caps.add("lan_dual_rx_audio_routing")
+        mock_radio.capabilities = caps
         mock_radio.profile = SimpleNamespace(receiver_count=receiver_count)
         mock_radio.send_civ = AsyncMock()
         return AudioBroadcaster(mock_radio), mock_radio
 
-    async def test_dual_rx_sends_mix_off(self) -> None:
-        broadcaster, radio = self._make_broadcaster(receiver_count=2)
+    async def test_routing_capable_sends_mix_off(self) -> None:
+        # IC-7610 shape: capability declared, Mix OFF CI-V emitted.
+        broadcaster, radio = self._make_broadcaster(supports_routing=True)
         await broadcaster._apply_phones_mix_off()
         radio.send_civ.assert_awaited_once_with(
             0x1A, sub=0x05, data=bytes([0x00, 0x72, 0x00]), wait_response=False
         )
 
     async def test_single_rx_is_noop(self) -> None:
-        broadcaster, radio = self._make_broadcaster(receiver_count=1)
+        # IC-7300 / IC-705 / X6100 shape: no routing capability, no CI-V.
+        broadcaster, radio = self._make_broadcaster(
+            receiver_count=1, supports_routing=False
+        )
+        await broadcaster._apply_phones_mix_off()
+        radio.send_civ.assert_not_awaited()
+
+    async def test_dual_rx_without_routing_capability_is_noop(self) -> None:
+        # IC-9700 shape: receiver_count=2 but the Phones L/R Mix menu item
+        # does NOT exist on that radio — we must not send 0x1A 05 00 72.
+        # Issue #799.
+        broadcaster, radio = self._make_broadcaster(
+            receiver_count=2, supports_routing=False
+        )
         await broadcaster._apply_phones_mix_off()
         radio.send_civ.assert_not_awaited()
 
     async def test_civ_error_is_swallowed(self) -> None:
-        broadcaster, radio = self._make_broadcaster(receiver_count=2)
+        broadcaster, radio = self._make_broadcaster(supports_routing=True)
         radio.send_civ.side_effect = RuntimeError("boom")
         # Must not raise — relay start-up continues even if the init fails.
         await broadcaster._apply_phones_mix_off()


### PR DESCRIPTION
## Bug

After #791 + #795 the dual-RX audio routing path in \`src/icom_lan/web/handlers/audio.py\` gated on \`profile.receiver_count >= 2\`. The assumption "two receivers ⇔ IC-7610" is wrong: **three** profiles declare \`receiver_count=2\`:

| Rig | \`receiver_count\` | \`scheme\` | Backend |
|-----|-------------------|-----------|---------|
| IC-7610 | 2 | \`main_sub\` | CoreRadio (LAN/serial) |
| **IC-9700** | 2 | \`main_sub\` | Ic9700CoreRadio ⊂ CoreRadio |
| **FTX-1** | 2 | \`ab_shared\` | YaesuCatRadio (no \`send_civ\`!) |

With the old gate:

- **IC-9700** — wfview's rig file contains zero \`0x1A\`-family commands; the Phones L/R Mix menu item does not exist on that radio. Our code sent \`0x1A 05 00 72 00\` anyway on every relay start — silent NAK at best, mutated unrelated setting at worst.
- **FTX-1** — \`YaesuCatRadio\` has no \`send_civ\` method at all. First \`audio_config\` WS message raised \`AttributeError\`, swallowed by the broad \`except Exception\` and surfaced as the misleading \`"audio_config: CI-V send failed"\` error to the client.

Both radios are hardware-blocked in CI (per project memory) so the bug was latent, but would have fired the moment either one plugged in for the first time.

## Fix

Replace the \`receiver_count >= 2\` gate with an explicit capability tag. The capability describes the thing we actually use (radio has Phones L/R Mix at CI-V \`0x1A 05 00 72\`), not a side-effect proxy (channel count).

### Changes

- **\`src/icom_lan/capabilities.py\`** — new \`CAP_LAN_DUAL_RX_AUDIO_ROUTING = "lan_dual_rx_audio_routing"\` constant, registered in \`KNOWN_CAPABILITIES\`. Docstring explains exactly why it exists and why it is *not* on IC-9700 / FTX-1.
- **\`rigs/ic7610.toml\`** — declares the capability (only profile today).
- **\`src/icom_lan/web/handlers/audio.py\`** — \`AudioBroadcaster._apply_phones_mix_off\` and \`AudioHandler._handle_audio_config\` both now gate on the capability instead of \`receiver_count\`. Silent no-op path for IC-9700 / FTX-1. Docstrings updated.

### Tests

- **\`tests/test_web_server.py\`** — \`_make_handler\` / \`_make_broadcaster\` grow a \`supports_routing\` kwarg (default True, IC-7610 shape). Two new tests cover the IC-9700 shape (\`receiver_count=2\` + capability absent → no-op): \`test_dual_rx_without_routing_capability_is_noop\` on both handler and broadcaster fixtures.
- **\`tests/test_rig_ic7610.py\`** — parity test asserts the new capability is present; count bumped 47 → 48.
- **\`tests/integration/test_audio_routing.py\`** — \`_build\` auto-adds the capability for dual-RX mocks so the integration tests still exercise the CI-V path.

## Verification

- [x] \`uv run pytest tests/ -q --ignore=tests/integration\` → **4700 passed**, 0 failures
- [x] \`uv run pytest tests/integration/test_audio_routing.py -q\` → 9/9 passed
- [x] \`uv run ruff check src/ tests/\` → clean
- [x] \`uv run mypy src/icom_lan/capabilities.py src/icom_lan/web/handlers/audio.py\` → clean

Live-validated on IC-7610 (LAN) in prior sessions — no behaviour change for the currently supported stereo-capable radio.

## Scope

- 6 files (3 src, 3 tests)
- +101 / −29 lines
- No architectural change — reuses existing string-keyed capability pattern

Closes #799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)