### PR TITLE
style(#830): spectrum toolbar grouping + separators + visual spec

### DIFF
--- a/frontend/src/components/spectrum/SpectrumToolbar.svelte
+++ b/frontend/src/components/spectrum/SpectrumToolbar.svelte
@@ -6,7 +6,7 @@
   import { hasCapability, hasDualReceiver } from '../../lib/stores/capabilities.svelte';
   import ScopeSettingsPopover from './ScopeSettingsPopover.svelte';
   import {
-    SPAN_LABELS, SPEED_LABELS, MODE_BUTTONS,
+    SPAN_LABELS, SPEED_LABELS, SPEED_STATIC_LABEL, MODE_BUTTONS,
     toggleLayer as toggleLayerFn, isLayerVisible,
     isSpanApplicable, isEdgeApplicable,
     clampSpan, clampSpeed, clampBrt, clampRef,
@@ -128,6 +128,7 @@
 </script>
 
 <div class="spectrum-toolbar">
+  <!-- Group A: Tuning (no wash) -->
   <div class="toolbar-group step-group">
     <button
       class="toolbar-btn small step-arrow"
@@ -150,98 +151,102 @@
       title="Increase tuning step"
     >▶</button>
   </div>
-  <div class="toolbar-separator"></div>
-  <div class="toolbar-group">
-    <button class="toolbar-btn" class:active={enableAvg} onclick={() => (enableAvg = !enableAvg)}>AVG</button>
-    <button class="toolbar-btn" class:active={enablePeakHold} onclick={() => (enablePeakHold = !enablePeakHold)}>PEAK</button>
-  </div>
-  <div class="toolbar-separator"></div>
-  <div class="toolbar-group">
-    <span class="toolbar-label">BRT</span>
-    <button class="toolbar-btn small" onclick={() => (brtLevel = clampBrt(brtLevel, -5))}>−</button>
-    <span class="toolbar-value ref-value">{brtLevel > 0 ? '+' : ''}{brtLevel}</span>
-    <button class="toolbar-btn small" onclick={() => (brtLevel = clampBrt(brtLevel, 5))}>+</button>
-  </div>
   {#if hasCapability('scope')}
     <div class="toolbar-separator"></div>
-    <div class="toolbar-group">
-      <span class="toolbar-label">REF</span>
-      <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: clampRef(scopeControls?.refDb ?? 0, -5) })}>−</button>
-      <span class="toolbar-value ref-value">{(scopeControls?.refDb ?? 0) > 0 ? '+' : ''}{scopeControls?.refDb ?? 0}</span>
-      <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: clampRef(scopeControls?.refDb ?? 0, 5) })}>+</button>
-    </div>
-    <div class="toolbar-separator"></div>
-    <div class="toolbar-group">
-      {#each MODE_BUTTONS as [m, label]}
-        <button
-          class="toolbar-btn small"
-          class:active={scopeControls?.mode === m}
-          onclick={() => sendCommand('set_scope_mode', { mode: m })}
-          title="Scope mode: {label}"
-        >{label}</button>
-      {/each}
-    </div>
-    {#if edgeApplicable}
-      <div class="toolbar-separator"></div>
+    <!-- Group B: Scope mode (cyan wash) -->
+    <div class="toolbar-group-b">
       <div class="toolbar-group">
-        <span class="toolbar-label">EDGE</span>
-        {#each [1, 2, 3, 4] as e}
+        {#each MODE_BUTTONS as [m, label]}
           <button
             class="toolbar-btn small"
-            class:active={scopeControls?.edge === e}
-            onclick={() => sendCommand('set_scope_edge', { edge: e })}
-          >{e}</button>
+            class:active={scopeControls?.mode === m}
+            onclick={() => sendCommand('set_scope_mode', { mode: m })}
+            title="Scope mode: {label}"
+          >{label}</button>
         {/each}
       </div>
-    {/if}
-    {#if spanApplicable}
-      <div class="toolbar-separator"></div>
-      <div class="toolbar-group step-group">
-        <button class="toolbar-btn small step-arrow" onclick={() => cycleSpan(-1)} title="Decrease span">◀</button>
-        <button class="toolbar-btn step-control" onclick={() => cycleSpan(1)} title="Scope span">
-          <span class="toolbar-label">SPAN</span>
-          <span class="toolbar-value">{SPAN_LABELS[scopeControls?.span ?? 3] ?? '±25k'}</span>
-        </button>
-        <button class="toolbar-btn small step-arrow" onclick={() => cycleSpan(1)} title="Increase span">▶</button>
-      </div>
-    {/if}
-    <div class="toolbar-separator"></div>
-    <div class="toolbar-group step-group">
-      <button class="toolbar-btn small step-arrow" onclick={() => cycleSpeed(-1)} title="Decrease speed">◀</button>
-      <button class="toolbar-btn step-control" onclick={() => cycleSpeed(1)} title="Scope sweep speed">
-        <span class="toolbar-label">SPD</span>
-        <span class="toolbar-value">{SPEED_LABELS[scopeControls?.speed ?? 1] ?? 'MID'}</span>
-      </button>
-      <button class="toolbar-btn small step-arrow" onclick={() => cycleSpeed(1)} title="Increase speed">▶</button>
-      <button class="toolbar-btn" class:active={scopeControls?.hold ?? false} onclick={toggleHold} title="Scope hold">HOLD</button>
+      {#if edgeApplicable}
+        <div class="toolbar-sub-separator"></div>
+        <div class="toolbar-group">
+          <span class="toolbar-label">EDGE</span>
+          {#each [1, 2, 3, 4] as e}
+            <button
+              class="toolbar-btn small"
+              class:active={scopeControls?.edge === e}
+              onclick={() => sendCommand('set_scope_edge', { edge: e })}
+            >{e}</button>
+          {/each}
+        </div>
+      {/if}
     </div>
-    {#if hasDualReceiver()}
-      <div class="toolbar-separator"></div>
-      <div class="toolbar-group">
-        <button class="toolbar-btn" class:active={scopeControls?.dual ?? false} onclick={toggleDual} title="Dual scope">DUAL</button>
-        <button class="toolbar-btn" onclick={switchReceiver} title="Switch scope receiver">
-          {scopeControls?.receiver === 1 ? 'SUB' : 'MAIN'}
-        </button>
-      </div>
-    {/if}
     <div class="toolbar-separator"></div>
-    <div class="toolbar-group settings-group">
-      <button class="toolbar-btn small" onclick={() => showSettings = !showSettings} title="Scope settings">&#9881;</button>
-      {#if showSettings}
-        <ScopeSettingsPopover onClose={() => showSettings = false} />
+    <!-- Group C: Scope data (cyan wash) -->
+    <div class="toolbar-group-c">
+      {#if spanApplicable}
+        <div class="toolbar-group step-group">
+          <button class="toolbar-btn small step-arrow" onclick={() => cycleSpan(-1)} title="Decrease span">◀</button>
+          <button class="toolbar-btn step-control" onclick={() => cycleSpan(1)} title="Scope span">
+            <span class="toolbar-label">SPAN</span>
+            <span class="toolbar-value">{SPAN_LABELS[scopeControls?.span ?? 3] ?? '±25k'}</span>
+          </button>
+          <button class="toolbar-btn small step-arrow" onclick={() => cycleSpan(1)} title="Increase span">▶</button>
+        </div>
+        <div class="toolbar-sub-separator"></div>
+      {/if}
+      <div class="toolbar-group step-group">
+        <button class="toolbar-btn small step-arrow" onclick={() => cycleSpeed(-1)} title="Decrease speed">◀</button>
+        <button class="toolbar-btn step-control" onclick={() => cycleSpeed(1)} title="Scope sweep speed">
+          <span class="toolbar-label">{SPEED_STATIC_LABEL}</span>
+          <span class="toolbar-value">{SPEED_LABELS[scopeControls?.speed ?? 1] ?? 'MID'}</span>
+        </button>
+        <button class="toolbar-btn small step-arrow" onclick={() => cycleSpeed(1)} title="Increase speed">▶</button>
+      </div>
+      <div class="toolbar-sub-separator"></div>
+      <div class="toolbar-group">
+        <button class="toolbar-btn" class:active={scopeControls?.hold ?? false} onclick={toggleHold} title="Scope hold">HOLD</button>
+      </div>
+      <div class="toolbar-sub-separator"></div>
+      <div class="toolbar-group">
+        <span class="toolbar-label">REF</span>
+        <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: clampRef(scopeControls?.refDb ?? 0, -5) })}>−</button>
+        <span class="toolbar-value ref-value">{(scopeControls?.refDb ?? 0) > 0 ? '+' : ''}{scopeControls?.refDb ?? 0}</span>
+        <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: clampRef(scopeControls?.refDb ?? 0, 5) })}>+</button>
+      </div>
+      {#if hasDualReceiver()}
+        <div class="toolbar-sub-separator"></div>
+        <div class="toolbar-group">
+          <button class="toolbar-btn" class:active={scopeControls?.dual ?? false} onclick={toggleDual} title="Dual scope">DUAL</button>
+          <button class="toolbar-btn" onclick={switchReceiver} title="Switch scope receiver">
+            {scopeControls?.receiver === 1 ? 'SUB' : 'MAIN'}
+          </button>
+        </div>
       {/if}
     </div>
   {/if}
   <div class="toolbar-separator"></div>
-  <div class="toolbar-group">
-    <select class="toolbar-select" bind:value={colorScheme}>
-      <option value="classic">Classic</option>
-      <option value="thermal">Thermal</option>
-      <option value="grayscale">Gray</option>
-    </select>
-  </div>
-  <div class="toolbar-separator"></div>
-  <div class="toolbar-group bands-group">
+  <!-- Group D: Display (neutral wash) -->
+  <div class="toolbar-group-d">
+    <div class="toolbar-group">
+      <button class="toolbar-btn" class:active={enableAvg} onclick={() => (enableAvg = !enableAvg)}>AVG</button>
+      <button class="toolbar-btn" class:active={enablePeakHold} onclick={() => (enablePeakHold = !enablePeakHold)}>PEAK</button>
+    </div>
+    <div class="toolbar-sub-separator"></div>
+    <div class="toolbar-group">
+      <span class="toolbar-label">BRT</span>
+      <button class="toolbar-btn small" onclick={() => (brtLevel = clampBrt(brtLevel, -5))}>−</button>
+      <span class="toolbar-value ref-value">{brtLevel > 0 ? '+' : ''}{brtLevel}</span>
+      <button class="toolbar-btn small" onclick={() => (brtLevel = clampBrt(brtLevel, 5))}>+</button>
+    </div>
+    <div class="toolbar-sub-separator"></div>
+    <div class="toolbar-group">
+      <select class="toolbar-select" bind:value={colorScheme}>
+        <option value="classic">Classic</option>
+        <option value="thermal">Thermal</option>
+        <option value="grayscale">Gray</option>
+      </select>
+    </div>
+    <div class="toolbar-sub-separator"></div>
+    <div class="toolbar-group bands-group">
     <button class="toolbar-btn" class:active={showBandPlan} onclick={() => (showBandPlan = !showBandPlan)} title="Show/hide band plan overlay">
       BANDS
     </button>
@@ -289,8 +294,20 @@
         </div>
       {/if}
     {/if}
+    </div>
   </div>
+  {#if hasCapability('scope')}
+    <div class="toolbar-separator"></div>
+    <!-- Group E: Settings (no wash) -->
+    <div class="toolbar-group settings-group">
+      <button class="toolbar-btn small" onclick={() => showSettings = !showSettings} title="Scope settings">&#9881;</button>
+      {#if showSettings}
+        <ScopeSettingsPopover onClose={() => showSettings = false} />
+      {/if}
+    </div>
+  {/if}
   <div class="toolbar-spacer"></div>
+  <!-- Group F: Actions (no wash) -->
   <button class="toolbar-btn icon-btn" onclick={() => (fullscreen = !fullscreen)} title="Toggle fullscreen">
     {fullscreen ? '✕' : '⛶'}
   </button>
@@ -300,27 +317,58 @@
   .spectrum-toolbar {
     display: flex;
     align-items: center;
-    height: 28px;
+    height: 32px;
     padding: 0 8px;
     background: linear-gradient(180deg, #2a2a2a 0%, #1e1e1e 100%);
     border-bottom: 1px solid var(--panel-border);
     gap: 4px;
     flex-shrink: 0;
     font-family: 'Roboto Mono', monospace;
-    font-size: 10px;
+    font-size: 11px;
     user-select: none;
   }
 
   .toolbar-group {
     display: flex;
     align-items: center;
-    gap: 2px;
+    gap: 3px;
+  }
+
+  /* Group containers with wash backgrounds (visual grouping) */
+  .toolbar-group-b,
+  .toolbar-group-c,
+  .toolbar-group-d {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    padding: 0 4px;
+    border-radius: 3px;
+    height: 24px;
+  }
+
+  .toolbar-group-b,
+  .toolbar-group-c {
+    /* Scope state — cyan wash */
+    background: rgba(0, 212, 255, 0.03);
+  }
+
+  .toolbar-group-d {
+    /* Display only — neutral wash */
+    background: rgba(255, 255, 255, 0.02);
   }
 
   .toolbar-separator {
-    width: 1px;
-    height: 16px;
+    width: 2px;
+    height: 20px;
     background: var(--panel-border);
+    margin: 0 6px;
+  }
+
+  .toolbar-sub-separator {
+    width: 1px;
+    height: 14px;
+    background: var(--panel-border);
+    opacity: 0.5;
     margin: 0 4px;
   }
 
@@ -366,11 +414,13 @@
     color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 0.05em;
+    font-weight: 500;
   }
 
   .toolbar-value {
     color: var(--text);
     font-variant-numeric: tabular-nums;
+    font-weight: 600;
   }
 
   .ref-value {

--- a/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
@@ -103,11 +103,23 @@ describe('SpectrumToolbar component', () => {
     expect(spanLabel).toBeDefined();
   });
 
-  it('renders speed selector', () => {
+  it('renders speed selector with SPEED label', () => {
     const target = mountToolbar();
     const labels = Array.from(target.querySelectorAll('.toolbar-label'));
-    const spdLabel = labels.find((el) => el.textContent?.trim() === 'SPD');
-    expect(spdLabel).toBeDefined();
+    const speedLabel = labels.find((el) => el.textContent?.trim() === 'SPEED');
+    expect(speedLabel).toBeDefined();
+  });
+
+  it('renders wash-background group containers (B, C, D)', () => {
+    const target = mountToolbar();
+    expect(target.querySelector('.toolbar-group-b')).not.toBeNull();
+    expect(target.querySelector('.toolbar-group-c')).not.toBeNull();
+    expect(target.querySelector('.toolbar-group-d')).not.toBeNull();
+  });
+
+  it('renders 1px sub-separator inside group containers', () => {
+    const target = mountToolbar();
+    expect(target.querySelector('.toolbar-sub-separator')).not.toBeNull();
   });
 
   it('renders STEP control', () => {

--- a/frontend/src/components/spectrum/__tests__/spectrum-toolbar.test.ts
+++ b/frontend/src/components/spectrum/__tests__/spectrum-toolbar.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
-  SPAN_LABELS, SPEED_LABELS, MODE_BUTTONS,
+  SPAN_LABELS, SPEED_LABELS, SPEED_STATIC_LABEL, MODE_BUTTONS,
   toggleLayer, isLayerVisible,
   isSpanApplicable, isEdgeApplicable,
   clampSpan, clampSpeed, clampBrt, clampRef,
@@ -31,6 +31,10 @@ describe('SpectrumToolbar constants', () => {
     expect(SPEED_LABELS[0]).toBe('FST');
     expect(SPEED_LABELS[1]).toBe('MID');
     expect(SPEED_LABELS[2]).toBe('SLO');
+  });
+
+  it('SPEED_STATIC_LABEL is the expanded "SPEED" (renamed from SPD)', () => {
+    expect(SPEED_STATIC_LABEL).toBe('SPEED');
   });
 
   it('MODE_BUTTONS has 4 entries with correct labels', () => {

--- a/frontend/src/components/spectrum/spectrum-toolbar-logic.ts
+++ b/frontend/src/components/spectrum/spectrum-toolbar-logic.ts
@@ -5,6 +5,12 @@
 
 /* ── Constants ── */
 
+/**
+ * Static label for the sweep-speed stepper.
+ * Renamed from "SPD" → "SPEED" per design plan 2026-04-18-spectrum-controls §9.
+ */
+export const SPEED_STATIC_LABEL = 'SPEED';
+
 export const SPAN_LABELS: Record<number, string> = {
   0: '\u00b12.5k', 1: '\u00b15k', 2: '\u00b110k', 3: '\u00b125k',
   4: '\u00b150k', 5: '\u00b1100k', 6: '\u00b1250k', 7: '\u00b1500k',


### PR DESCRIPTION
## Summary
- Wraps spectrum toolbar into `.toolbar-group-b` / `-c` / `-d` containers with cyan + neutral wash backgrounds per design plan `docs/plans/2026-04-18-spectrum-controls.md` §§3-4, §7.
- 2 px group separators + 1 px in-group sub-separators; height 28 -> 32 px; font 10 -> 11 px; label/value weight split 500/600.
- Renames `SPD` -> `SPEED` (new `SPEED_STATIC_LABEL` constant).
- No behavior change — every control keeps its existing handler/bindings.

Closes #830.

## Test plan
- [x] `npx vitest run src/components/spectrum/` — 187/187 pass
- [x] ESLint clean on the 4 touched files
- [ ] Manual smoke: open desktop skin, verify new wash groups + SPEED label render and all buttons still dispatch the same `sendCommand` payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)