### PR TITLE
feat(#820): add MetersDockPanel with Po/SWR/ALC/S tiles

### DIFF
--- a/frontend/src/components-v2/panels/MetersDockPanel.svelte
+++ b/frontend/src/components-v2/panels/MetersDockPanel.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+  import {
+    formatAlc,
+    formatPowerWatts,
+    formatSMeter,
+    formatSwr,
+    normalize,
+    normalizePower,
+  } from './meter-utils';
+
+  /**
+   * Unified TX / station-health meters dashboard for the desktop-v2 bottom
+   * dock. Renders an auto-fit grid of tiles for each meter whose raw value
+   * is defined on the runtime state (capability gating by `!== undefined`).
+   *
+   * Scope: issue #820 ships Po / SWR / ALC / S tiles. Id / Vd / COMP land
+   * with #822; peak-hold and fault highlighting land with #823.
+   *
+   * The panel is pure presentation — no store / transport imports.
+   */
+  interface Props {
+    sValue?: number;
+    powerMeter?: number;
+    swrMeter?: number;
+    alcMeter?: number;
+    txActive: boolean;
+  }
+
+  let { sValue, powerMeter, swrMeter, alcMeter, txActive }: Props = $props();
+
+  interface Tile {
+    key: 'po' | 'swr' | 'alc' | 's';
+    label: string;
+    display: string;
+    fillPct: number;
+    fill: string;
+    track: string;
+    relevant: boolean;
+  }
+
+  // Priority order (plan §3): Po → SWR → ALC → S. Tiles with undefined
+  // source values are omitted entirely so the grid re-flows.
+  let tiles = $derived.by<Tile[]>(() => {
+    const out: Tile[] = [];
+    if (powerMeter !== undefined) {
+      out.push({
+        key: 'po',
+        label: 'Po',
+        display: formatPowerWatts(powerMeter),
+        fillPct: normalizePower(powerMeter) * 100,
+        fill: 'var(--v2-meter-power-fill)',
+        track: 'var(--v2-meter-power-track)',
+        relevant: txActive,
+      });
+    }
+    if (swrMeter !== undefined) {
+      out.push({
+        key: 'swr',
+        label: 'SWR',
+        display: formatSwr(swrMeter),
+        fillPct: normalize(swrMeter) * 100,
+        fill: 'var(--v2-meter-swr-fill)',
+        track: 'var(--v2-meter-swr-track)',
+        relevant: txActive,
+      });
+    }
+    if (alcMeter !== undefined) {
+      out.push({
+        key: 'alc',
+        label: 'ALC',
+        display: formatAlc(alcMeter),
+        fillPct: normalize(alcMeter) * 100,
+        fill: 'var(--v2-meter-alc-fill)',
+        track: 'var(--v2-meter-alc-track)',
+        relevant: txActive,
+      });
+    }
+    if (sValue !== undefined) {
+      out.push({
+        key: 's',
+        label: 'S',
+        display: formatSMeter(sValue),
+        fillPct: normalize(sValue) * 100,
+        fill: 'var(--v2-meter-s-fill)',
+        track: 'var(--v2-meter-s-track)',
+        relevant: !txActive,
+      });
+    }
+    return out;
+  });
+</script>
+
+<article class="meters-dock-panel" data-testid="meters-dock-panel">
+  <header class="dock-header">
+    <span class="dock-title">STATION METERS</span>
+    <span class="dock-tx-state" data-active={txActive}>{txActive ? 'TX' : 'RX'}</span>
+  </header>
+
+  <div class="dock-grid">
+    {#each tiles as tile (tile.key)}
+      <div class="dock-tile" data-meter={tile.key} data-relevant={tile.relevant}>
+        <div class="tile-header">
+          <span class="tile-label">{tile.label}</span>
+        </div>
+        <div class="tile-value">{tile.display}</div>
+        <div class="tile-bar" style:background={tile.track}>
+          <div
+            class="tile-bar-fill"
+            style:width={`${Math.max(0, Math.min(100, tile.fillPct))}%`}
+            style:background={tile.fill}
+          ></div>
+        </div>
+      </div>
+    {/each}
+  </div>
+</article>
+
+<style>
+  .meters-dock-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--v2-border-darker);
+    border-radius: 4px;
+    background: linear-gradient(180deg, var(--v2-bg-gradient-start) 0%, var(--v2-bg-darkest) 100%);
+    box-sizing: border-box;
+    width: 100%;
+  }
+
+  .dock-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-family: 'Roboto Mono', monospace;
+  }
+
+  .dock-title {
+    color: var(--v2-text-light);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+  }
+
+  .dock-tx-state {
+    color: var(--v2-text-muted);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+  }
+
+  .dock-tx-state[data-active='true'] {
+    color: var(--v2-accent-red, #ff4040);
+  }
+
+  .dock-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+    gap: 8px;
+  }
+
+  .dock-tile {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 12px;
+    border: 1px solid var(--v2-border);
+    border-radius: 4px;
+    background: var(--v2-bg-card, transparent);
+    font-family: 'Roboto Mono', monospace;
+    transition: opacity 200ms ease, border-color 150ms ease;
+  }
+
+  .dock-tile[data-relevant='false'] {
+    opacity: 0.35;
+  }
+
+  .tile-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .tile-label {
+    color: var(--v2-text-light);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+  }
+
+  .tile-value {
+    color: var(--v2-text-white);
+    font-size: 22px;
+    font-weight: 700;
+    line-height: 1.1;
+  }
+
+  .tile-bar {
+    position: relative;
+    height: 6px;
+    border-radius: 1px;
+    overflow: hidden;
+  }
+
+  .tile-bar-fill {
+    height: 100%;
+  }
+</style>

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import MetersDockPanel from '../MetersDockPanel.svelte';
+import {
+  formatAmps,
+  formatVolts,
+  formatCompDb,
+  updatePeakHold,
+} from '../meter-utils';
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasTx: vi.fn(() => true),
+  getMeterCalibration: vi.fn(() => null),
+  getMeterRedline: vi.fn(() => null),
+}));
+
+// ---------------------------------------------------------------------------
+// New formatters
+// ---------------------------------------------------------------------------
+
+describe('formatAmps', () => {
+  it('returns 0.0 A for raw 0', () => {
+    expect(formatAmps(0)).toBe('0.0 A');
+  });
+  it('returns 10.0 A at knot raw=151', () => {
+    expect(formatAmps(151)).toBe('10.0 A');
+  });
+  it('returns 15.0 A at knot raw=195', () => {
+    expect(formatAmps(195)).toBe('15.0 A');
+  });
+  it('clamps raw 300 to last knot (25.0 A)', () => {
+    expect(formatAmps(300)).toBe('25.0 A');
+  });
+});
+
+describe('formatVolts', () => {
+  it('returns 0.0 V for raw 0', () => {
+    expect(formatVolts(0)).toBe('0.0 V');
+  });
+  it('returns 10.0 V at knot raw=13', () => {
+    expect(formatVolts(13)).toBe('10.0 V');
+  });
+  it('returns 16.0 V at knot raw=241', () => {
+    expect(formatVolts(241)).toBe('16.0 V');
+  });
+});
+
+describe('formatCompDb', () => {
+  it('returns 0 dB for raw 0', () => {
+    expect(formatCompDb(0)).toBe('0 dB');
+  });
+  it('returns 15 dB at knot raw=75', () => {
+    expect(formatCompDb(75)).toBe('15 dB');
+  });
+  it('returns 30 dB at knot raw=150', () => {
+    expect(formatCompDb(150)).toBe('30 dB');
+  });
+});
+
+describe('updatePeakHold', () => {
+  it('initializes state when undefined', () => {
+    const s = updatePeakHold(undefined, 42, 1000);
+    expect(s).toEqual({ peak: 42, peakAt: 1000 });
+  });
+  it('latches a new higher peak and updates timestamp', () => {
+    const s = updatePeakHold({ peak: 10, peakAt: 1000 }, 20, 1500);
+    expect(s).toEqual({ peak: 20, peakAt: 1500 });
+  });
+  it('keeps peak unchanged when current is lower and decay not elapsed', () => {
+    const s = updatePeakHold({ peak: 100, peakAt: 1000 }, 50, 1000);
+    expect(s.peak).toBe(100);
+    expect(s.peakAt).toBe(1000);
+  });
+  it('linearly decays toward current mid-window', () => {
+    // halfway through 2s decay: peak 100, current 0 -> 50
+    const s = updatePeakHold({ peak: 100, peakAt: 0 }, 0, 1000);
+    expect(s.peak).toBeCloseTo(50, 5);
+    expect(s.peakAt).toBe(0);
+  });
+  it('collapses to current once decay window elapses', () => {
+    const s = updatePeakHold({ peak: 100, peakAt: 0 }, 25, 2000);
+    expect(s).toEqual({ peak: 25, peakAt: 2000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MetersDockPanel component
+// ---------------------------------------------------------------------------
+
+let components: ReturnType<typeof mount>[] = [];
+let roots: HTMLElement[] = [];
+
+function mountPanel(props: ComponentProps<typeof MetersDockPanel>) {
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  roots.push(t);
+  const component = mount(MetersDockPanel, { target: t, props });
+  flushSync();
+  components.push(component);
+  return t;
+}
+
+beforeEach(() => {
+  components = [];
+  roots = [];
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  roots.forEach((r) => r.remove());
+  components = [];
+  roots = [];
+});
+
+const fullProps: ComponentProps<typeof MetersDockPanel> = {
+  sValue: 120,
+  powerMeter: 143,
+  swrMeter: 48,
+  alcMeter: 60,
+  txActive: false,
+};
+
+describe('MetersDockPanel structure', () => {
+  it('renders the STATION METERS header', () => {
+    const t = mountPanel(fullProps);
+    expect(t.querySelector('.dock-title')?.textContent).toBe('STATION METERS');
+  });
+
+  it('renders four tiles when all four state fields are defined', () => {
+    const t = mountPanel(fullProps);
+    expect(t.querySelectorAll('.dock-tile')).toHaveLength(4);
+  });
+
+  it('renders tiles in fixed priority order Po, SWR, ALC, S', () => {
+    const t = mountPanel(fullProps);
+    const keys = Array.from(t.querySelectorAll('.dock-tile')).map((el) =>
+      el.getAttribute('data-meter'),
+    );
+    expect(keys).toEqual(['po', 'swr', 'alc', 's']);
+  });
+
+  it('shows RX state label when txActive is false', () => {
+    const t = mountPanel(fullProps);
+    const state = t.querySelector('.dock-tx-state');
+    expect(state?.textContent).toBe('RX');
+    expect(state?.getAttribute('data-active')).toBe('false');
+  });
+
+  it('shows TX state label when txActive is true', () => {
+    const t = mountPanel({ ...fullProps, txActive: true });
+    const state = t.querySelector('.dock-tx-state');
+    expect(state?.textContent).toBe('TX');
+    expect(state?.getAttribute('data-active')).toBe('true');
+  });
+});
+
+describe('MetersDockPanel capability gating', () => {
+  it('hides Po tile when powerMeter is undefined', () => {
+    const t = mountPanel({ ...fullProps, powerMeter: undefined });
+    expect(t.querySelector('[data-meter="po"]')).toBeNull();
+    expect(t.querySelectorAll('.dock-tile')).toHaveLength(3);
+  });
+
+  it('hides SWR tile when swrMeter is undefined', () => {
+    const t = mountPanel({ ...fullProps, swrMeter: undefined });
+    expect(t.querySelector('[data-meter="swr"]')).toBeNull();
+  });
+
+  it('hides ALC tile when alcMeter is undefined', () => {
+    const t = mountPanel({ ...fullProps, alcMeter: undefined });
+    expect(t.querySelector('[data-meter="alc"]')).toBeNull();
+  });
+
+  it('hides S tile when sValue is undefined', () => {
+    const t = mountPanel({ ...fullProps, sValue: undefined });
+    expect(t.querySelector('[data-meter="s"]')).toBeNull();
+  });
+
+  it('renders no tiles when all state fields are undefined', () => {
+    const t = mountPanel({
+      sValue: undefined,
+      powerMeter: undefined,
+      swrMeter: undefined,
+      alcMeter: undefined,
+      txActive: false,
+    });
+    expect(t.querySelectorAll('.dock-tile')).toHaveLength(0);
+  });
+
+  it('still renders the header when every tile is hidden', () => {
+    const t = mountPanel({
+      sValue: undefined,
+      powerMeter: undefined,
+      swrMeter: undefined,
+      alcMeter: undefined,
+      txActive: false,
+    });
+    expect(t.querySelector('.dock-title')?.textContent).toBe('STATION METERS');
+  });
+});
+
+describe('MetersDockPanel relevance dimming', () => {
+  it('marks TX tiles as relevant when txActive=true', () => {
+    const t = mountPanel({ ...fullProps, txActive: true });
+    expect(t.querySelector('[data-meter="po"]')?.getAttribute('data-relevant')).toBe('true');
+    expect(t.querySelector('[data-meter="swr"]')?.getAttribute('data-relevant')).toBe('true');
+    expect(t.querySelector('[data-meter="alc"]')?.getAttribute('data-relevant')).toBe('true');
+    expect(t.querySelector('[data-meter="s"]')?.getAttribute('data-relevant')).toBe('false');
+  });
+
+  it('marks S tile as relevant when txActive=false', () => {
+    const t = mountPanel({ ...fullProps, txActive: false });
+    expect(t.querySelector('[data-meter="s"]')?.getAttribute('data-relevant')).toBe('true');
+    expect(t.querySelector('[data-meter="po"]')?.getAttribute('data-relevant')).toBe('false');
+  });
+});
+
+describe('MetersDockPanel formatted values', () => {
+  it('displays Po in watts', () => {
+    const t = mountPanel(fullProps);
+    expect(t.querySelector('[data-meter="po"] .tile-value')?.textContent).toBe('50W');
+  });
+
+  it('displays SWR ratio', () => {
+    const t = mountPanel(fullProps);
+    expect(t.querySelector('[data-meter="swr"] .tile-value')?.textContent).toBe('1.5');
+  });
+
+  it('displays ALC percentage', () => {
+    const t = mountPanel(fullProps);
+    expect(t.querySelector('[data-meter="alc"] .tile-value')?.textContent).toBe('50%');
+  });
+
+  it('displays S-meter as S-units', () => {
+    const t = mountPanel(fullProps);
+    expect(t.querySelector('[data-meter="s"] .tile-value')?.textContent).toBe('S9');
+  });
+});

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -151,6 +151,89 @@ export function formatSMeter(raw: number): string {
  * Returns needle gauge mark positions and labels for the given meter source.
  * Uses capabilities calibration data when available, IC-7610 defaults otherwise.
  */
+/**
+ * Formats raw Id (drain current) value as amps string.
+ * IC-7610 CI-V Reference p.4: 00 00=0 A, 00 97=10 A, 01 43=15 A, 02 12=25 A.
+ * Falls back to capabilities calibration when present.
+ */
+const ID_KNOTS: [number, number][] = [
+  [0, 0],
+  [151, 10],
+  [195, 15],
+  [212, 25],
+];
+
+export function formatAmps(raw: number): string {
+  const knots = getKnots('id', ID_KNOTS);
+  const amps = piecewise(raw, knots);
+  return `${amps.toFixed(1)} A`;
+}
+
+/**
+ * Formats raw Vd (drain voltage) value as volts string.
+ * IC-7610 CI-V Reference p.4: 00 00=0 V, 00 13=10 V, 02 41=16 V.
+ * Nominal reading on-air is ~13.8 V.
+ */
+const VD_KNOTS: [number, number][] = [
+  [0, 0],
+  [13, 10],
+  [241, 16],
+];
+
+export function formatVolts(raw: number): string {
+  const knots = getKnots('vd', VD_KNOTS);
+  const volts = piecewise(raw, knots);
+  return `${volts.toFixed(1)} V`;
+}
+
+/**
+ * Formats raw COMP (speech compressor) value as dB string.
+ * IC-7610 CI-V Reference p.4: 00 00=0 dB, 00 75=15 dB, 01 50=30 dB.
+ */
+const COMP_KNOTS: [number, number][] = [
+  [0, 0],
+  [75, 15],
+  [150, 30],
+];
+
+export function formatCompDb(raw: number): string {
+  const knots = getKnots('comp', COMP_KNOTS);
+  const db = Math.round(piecewise(raw, knots));
+  return `${db} dB`;
+}
+
+/**
+ * Peak-hold state tracker (stub for M-D / #823).
+ * Retains the highest value seen within `decayMs`; decays linearly toward
+ * `current` after the last peak update.
+ *
+ * This is a pure function over state and does not schedule timers. Callers
+ * step it on each render tick. Full decay + double-click reset behavior
+ * lands with issue #823.
+ */
+export interface PeakHoldState {
+  peak: number;
+  peakAt: number;
+}
+
+export function updatePeakHold(
+  state: PeakHoldState | undefined,
+  current: number,
+  now: number,
+  decayMs = 2000,
+): PeakHoldState {
+  if (!state || current >= state.peak) {
+    return { peak: current, peakAt: now };
+  }
+  const elapsed = now - state.peakAt;
+  if (elapsed >= decayMs) {
+    return { peak: current, peakAt: now };
+  }
+  const t = elapsed / decayMs;
+  const decayed = state.peak + (current - state.peak) * t;
+  return { peak: decayed, peakAt: state.peakAt };
+}
+
 export function getNeedleMarks(source: MeterSource): Mark[] {
   switch (source) {
     case 'S': {


### PR DESCRIPTION
## Summary

Scaffolds the unified station-meters dashboard per design plan `docs/plans/2026-04-18-desktop-meters-panel.md` §9 Issue A. Closes #820.

- New `MetersDockPanel.svelte` — auto-fit grid (132 px min) of Po / SWR / ALC / S tiles, rendered in fixed priority order per plan §3.
- Tiles are capability-gated by `state.<field> !== undefined`. Missing meters disappear and the grid re-flows — no "N/A" placeholders.
- `meter-utils.ts` gains `formatAmps`, `formatVolts`, `formatCompDb` (used by M-C / #822) and a pure `updatePeakHold` helper stub (used by M-D / #823).
- No integration into `RadioLayout` yet — that is M-B / #821. No new CSS tokens — reuses existing `--v2-meter-*-fill` / `-track`.

## Test plan

- [x] `npx vitest run src/components-v2/panels/__tests__/MetersDockPanel.test.ts` — 32 pass
- [x] Existing `MeterPanel.test.ts` + `meter-utils.test.ts` still pass (no regressions)
- [x] `npx eslint` on changed files — clean
- [x] `npx svelte-check` — 0 errors, 0 warnings
- [x] `uv run ruff check src/ tests/` — clean
- [x] Guardrails: 3 files changed, component 208 LOC (incl. ~100 CSS), +83 in meter-utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)