### PR TITLE
refactor(#824): remove panel-wide click-to-activate + STANDBY/ACTIVE pill

### DIFF
--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -50,20 +50,15 @@
   });
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   class="panel"
   class:active={isActive}
-  onclick={onVfoClick}
-  role={onVfoClick ? 'button' : undefined}
   data-layout-profile={layoutProfile}
   style={Object.entries(receiverChromeVars).map(([key, value]) => `${key}:${value}`).join(';')}
 >
   <div class="panel-header">
     <div class="header-title-group">
       <span class="vfo-label">{label}</span>
-      <span class="receiver-state" data-active={isActive}>{isActive ? 'ACTIVE' : 'STANDBY'}</span>
     </div>
 
     <div class="header-badges">
@@ -167,26 +162,6 @@
     font-weight: 700;
     letter-spacing: 0.14em;
     text-transform: uppercase;
-  }
-
-  .receiver-state {
-    display: inline-flex;
-    align-items: center;
-    min-height: var(--vfo-header-badge-height, 12px);
-    padding: 0 var(--vfo-header-badge-padding-x, 5px);
-    border: 1px solid var(--v2-vfo-badge-active-border);
-    border-radius: var(--vfo-panel-badge-radius, 3px);
-    color: var(--v2-accent-green-bright);
-    background: var(--v2-vfo-badge-active-bg);
-    font-size: var(--vfo-header-badge-font-size, 7px);
-    font-weight: 700;
-    letter-spacing: 0.08em;
-  }
-
-  .receiver-state[data-active='false'] {
-    border-color: var(--v2-vfo-badge-standby-border);
-    color: var(--v2-text-subdued);
-    background: var(--v2-vfo-badge-standby-bg);
   }
 
   .header-badges {

--- a/frontend/src/components-v2/vfo/__tests__/VfoPanel.test.ts
+++ b/frontend/src/components-v2/vfo/__tests__/VfoPanel.test.ts
@@ -317,11 +317,11 @@ describe('badge rendering', () => {
 });
 
 describe('callbacks', () => {
-  it('calls onVfoClick when panel is clicked', () => {
+  it('does not call onVfoClick when panel is clicked (panel-wide activation removed)', () => {
     const onVfoClick = vi.fn();
     const t = mountPanel({ ...baseProps, onVfoClick });
     t.querySelector<HTMLElement>('.panel')?.click();
-    expect(onVfoClick).toHaveBeenCalledOnce();
+    expect(onVfoClick).not.toHaveBeenCalled();
   });
 
   it('calls onModeClick when mode badge is clicked', () => {


### PR DESCRIPTION
## Summary
- Remove panel-wide `onclick={onVfoClick}` / `role="button"` from `VfoPanel.svelte`. Panel click no longer toggles the active receiver — activation now flows exclusively through the M/S segmented control (#825, Act-B).
- Remove the `ACTIVE / STANDBY` pill from the panel header (and its associated CSS). The `.panel.active` border/glow remains as the sole visual feedback for active state.
- Update the `calls onVfoClick when panel is clicked` test to assert the handler is **not** called (the prop stays plumbed for Act-B repurposing per the downscoped plan).

Per design plan `docs/plans/2026-04-18-receiver-activation.md` §9 Issue A. Removal-only per issue scope; `onVfoClick` plumbing in state-adapter / command-bus intentionally left untouched.

## Test plan
- [x] `npx vitest run src/components-v2/vfo/__tests__/VfoPanel.test.ts` — 44/44 pass
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest tests/ -q --ignore=tests/integration` — only 2 pre-existing failures on main (`test_root_returns_html`, `test_static_index_has_cache_control`) which require a built `frontend/dist/` and are unrelated to this change
- [ ] Visual: panel click no longer activates; M/S segmented control still switches receiver; active panel still shows border/glow

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)