### PR TITLE
fix(#807): move settings gear button into StatusBar

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -55,7 +55,6 @@
   import RitXitPanel from '../panels/RitXitPanel.svelte';
   import CwPanel from '../panels/CwPanel.svelte';
   import { HardwareButton } from '$lib/Button';
-  import { Settings } from 'lucide-svelte';
 
   // Reactive state + capabilities — via runtime
   let radioState = $derived(runtime.state);
@@ -201,10 +200,7 @@
   <LcdLayout />
 {:else}
 <div class="radio-layout">
-  <StatusBar />
-  <button class="settings-button" onclick={() => (settingsOpen = true)} title="Settings">
-    <Settings size={20} />
-  </button>
+  <StatusBar onSettings={() => (settingsOpen = true)} />
   <KeyboardHandler config={keyboardConfig} onAction={keyboardHandlers.dispatch} />
 
   <section class="receiver-deck" bind:this={receiverDeckElement} style={receiverDeckStyle}>
@@ -803,35 +799,6 @@
   @keyframes pulse-dim {
     0%, 100% { opacity: 0.6; }
     50% { opacity: 1; }
-  }
-
-  /* ── Settings Button ── */
-  .settings-button {
-    position: fixed;
-    top: 36px;
-    right: 16px;
-    z-index: 100;
-    width: 40px;
-    height: 40px;
-    border: 1px solid var(--v2-border-panel, #333);
-    border-radius: 6px;
-    background: var(--v2-bg-card, #1a1a2e);
-    color: var(--v2-text-secondary, #aaa);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 150ms;
-  }
-
-  .settings-button:hover {
-    background: var(--v2-bg-panel, #252540);
-    color: var(--v2-accent-cyan, #00d4ff);
-    border-color: var(--v2-accent-cyan, #00d4ff);
-  }
-
-  .settings-button:active {
-    transform: scale(0.95);
   }
 
   /* ── Settings Modal ── */

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Radio, Cable, Activity, Volume2, ArrowDownUp, Power, Unplug, Palette, Monitor, Tv } from 'lucide-svelte';
+  import { Radio, Cable, Activity, Volume2, ArrowDownUp, Power, Unplug, Palette, Monitor, Tv, Settings } from 'lucide-svelte';
   import ThemePicker from '../controls/ThemePicker.svelte';
   import { runtime } from '$lib/runtime';
   import {
@@ -13,6 +13,11 @@
   import { getFrequency } from '$lib/stores/radio.svelte';
   import { hasAnyScope, hasAudio, hasSpectrum } from '$lib/stores/capabilities.svelte';
   import { getLayoutMode, cycleLayoutMode } from '$lib/stores/layout.svelte';
+
+  interface Props {
+    onSettings?: () => void;
+  }
+  let { onSettings }: Props = $props();
 
   let layoutMode = $derived(getLayoutMode());
   let hasAnyScopeAvail = $derived(hasAnyScope());
@@ -217,6 +222,15 @@
     >
       <Power size={14} strokeWidth={2} />
       <span class="btn-label">OFF</span>
+    </button>
+    <button
+      type="button"
+      class="control-btn settings-btn"
+      onclick={() => onSettings?.()}
+      title="Settings"
+      aria-label="Settings"
+    >
+      <Settings size={14} strokeWidth={2} />
     </button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Removes `position: fixed` settings gear from `RadioLayout.svelte` (was colliding with VFO header).
- Adds a Settings gear button to `StatusBar.svelte`'s control row, next to ON/OFF.
- Wires it via a new optional `onSettings` prop so `settingsOpen` state stays in `RadioLayout`.

Closes #807.

## Test plan
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 2 pre-existing failures in `test_web_server.py` (missing `frontend/dist` build; unrelated to change; confirmed to also fail on main).
- [x] `uv run ruff check src/ tests/` — zero violations.
- [x] `npm run lint:boundaries` — clean.
- [x] `npm run check` — no new Svelte/TS errors introduced by the diff.
- [ ] Manual: open Web UI, confirm gear icon appears in StatusBar (rightmost), clicking it opens the Settings modal, and no fixed-position button overlaps the VFO header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)