### PR TITLE
fix: CI-V watchdog self-cancel + patient OpenClose recovery

### DIFF
--- a/src/icom_lan/_civ_rx.py
+++ b/src/icom_lan/_civ_rx.py
@@ -265,8 +265,15 @@ class CivRuntime:
     # ------------------------------------------------------------------
 
     async def _civ_data_watchdog_loop(self) -> None:
-        """Monitor CI-V data flow; recover with open_close then soft_reconnect."""
-        _OPENCLOSE_DEADLINE = 5.0
+        """Monitor CI-V data flow; recover with open_close then soft_reconnect.
+
+        OpenClose is retried patiently (wfview icomudpcivdata.cpp:31 pattern —
+        never escalates). icom-lan keeps a safety-net deadline at
+        _OPENCLOSE_DEADLINE before handing recovery off to a detached
+        reconnect task. The task is detached so its cooldown sleep survives
+        the watchdog loop exiting.
+        """
+        _OPENCLOSE_DEADLINE = 60.0
         _MAX_RECONNECTS = 3
         _RECONNECT_BACKOFF = (45.0, 60.0, 60.0)
         recovering = False
@@ -310,7 +317,8 @@ class CivRuntime:
                             await self._host._send_open_close(open_stream=True)
                         except (ConnectionError, TimeoutError, OSError) as exc:
                             logger.debug(
-                                "civ-data-watchdog: open_close failed: %s", exc,
+                                "civ-data-watchdog: open_close failed: %s",
+                                exc,
                             )
                         except Exception:
                             logger.warning(
@@ -322,28 +330,21 @@ class CivRuntime:
                         reconnect_pause = _RECONNECT_BACKOFF[
                             min(reconnect_count - 1, len(_RECONNECT_BACKOFF) - 1)
                         ]
+                        # Recovery runs in a detached task so its cooldown
+                        # sleep is honored even when this watchdog task
+                        # exits. The prior inline `await stop_data_watchdog()`
+                        # cancelled this task and caused the cooldown to be
+                        # skipped entirely (self-cancel bug).
                         if reconnect_count > _MAX_RECONNECTS:
                             logger.warning(
                                 "civ-data-watchdog: %d soft reconnects failed, "
                                 "attempting full reconnect",
                                 reconnect_count - 1,
                             )
-                            try:
-                                await self.stop_data_watchdog()
-                                await self._host._force_cleanup_civ()
-                                await self._host.disconnect()
-                                await asyncio.sleep(reconnect_pause)
-                                await self._host.connect()
-                            except (ConnectionError, TimeoutError, OSError):
-                                logger.error(
-                                    "civ-data-watchdog: full reconnect failed",
-                                    exc_info=True,
-                                )
-                            except Exception:
-                                logger.error(
-                                    "civ-data-watchdog: unexpected error in full reconnect",
-                                    exc_info=True,
-                                )
+                            asyncio.create_task(
+                                self._watchdog_full_reconnect(reconnect_pause),
+                                name="civ-watchdog-full-reconnect",
+                            )
                             return
                         logger.warning(
                             "civ-data-watchdog: OpenClose failed for %.1fs, "
@@ -353,36 +354,10 @@ class CivRuntime:
                             _MAX_RECONNECTS,
                             reconnect_pause,
                         )
-                        try:
-                            await self.stop_data_watchdog()
-                            await self._host._force_cleanup_civ()
-                            await asyncio.sleep(reconnect_pause)
-                            await self._host.soft_reconnect()
-                        except (ConnectionError, TimeoutError, OSError):
-                            logger.error(
-                                "civ-data-watchdog: soft_reconnect failed, "
-                                "falling back to full reconnect",
-                                exc_info=True,
-                            )
-                            try:
-                                await self._host.disconnect()
-                                await asyncio.sleep(reconnect_pause)
-                                await self._host.connect()
-                            except (ConnectionError, TimeoutError, OSError):
-                                logger.error(
-                                    "civ-data-watchdog: full reconnect also failed",
-                                    exc_info=True,
-                                )
-                            except Exception:
-                                logger.error(
-                                    "civ-data-watchdog: unexpected error in full reconnect fallback",
-                                    exc_info=True,
-                                )
-                        except Exception:
-                            logger.error(
-                                "civ-data-watchdog: unexpected error in soft_reconnect",
-                                exc_info=True,
-                            )
+                        asyncio.create_task(
+                            self._watchdog_soft_reconnect(reconnect_pause),
+                            name="civ-watchdog-soft-reconnect",
+                        )
                         return
                 else:
                     if recovering:
@@ -392,6 +367,60 @@ class CivRuntime:
                         self._host._civ_stream_ready = True
         except asyncio.CancelledError:
             pass
+
+    async def _watchdog_soft_reconnect(self, cooldown: float) -> None:
+        """Detached recovery: force_cleanup → sleep(cooldown) → soft_reconnect.
+
+        Runs outside the watchdog loop so the cooldown sleep survives the
+        watchdog task exiting. Falls back to full reconnect on failure.
+        """
+        try:
+            await self._host._force_cleanup_civ()
+            await asyncio.sleep(cooldown)
+            await self._host.soft_reconnect()
+        except (ConnectionError, TimeoutError, OSError):
+            logger.error(
+                "civ-data-watchdog: soft_reconnect failed, "
+                "falling back to full reconnect",
+                exc_info=True,
+            )
+            try:
+                await self._host.disconnect()
+                await asyncio.sleep(cooldown)
+                await self._host.connect()
+            except (ConnectionError, TimeoutError, OSError):
+                logger.error(
+                    "civ-data-watchdog: full reconnect also failed",
+                    exc_info=True,
+                )
+            except Exception:
+                logger.error(
+                    "civ-data-watchdog: unexpected error in full reconnect fallback",
+                    exc_info=True,
+                )
+        except Exception:
+            logger.error(
+                "civ-data-watchdog: unexpected error in soft_reconnect",
+                exc_info=True,
+            )
+
+    async def _watchdog_full_reconnect(self, cooldown: float) -> None:
+        """Detached full reconnect after max soft_reconnect attempts exceeded."""
+        try:
+            await self._host._force_cleanup_civ()
+            await self._host.disconnect()
+            await asyncio.sleep(cooldown)
+            await self._host.connect()
+        except (ConnectionError, TimeoutError, OSError):
+            logger.error(
+                "civ-data-watchdog: full reconnect failed",
+                exc_info=True,
+            )
+        except Exception:
+            logger.error(
+                "civ-data-watchdog: unexpected error in full reconnect",
+                exc_info=True,
+            )
 
     def _ensure_civ_runtime(self) -> None:
         """Ensure CI-V transport exists (tests may bypass connect())."""
@@ -1091,7 +1120,12 @@ class CivRuntime:
                         rs.tx_band_edges.append(tx_edge)
 
         except (ValueError, IndexError, KeyError, AttributeError, TypeError) as exc:
-            logger.debug("civ-rx: state update failed for cmd=0x%02x sub=0x%02x: %s", frame.command or 0, frame.sub or 0, exc)
+            logger.debug(
+                "civ-rx: state update failed for cmd=0x%02x sub=0x%02x: %s",
+                frame.command or 0,
+                frame.sub or 0,
+                exc,
+            )
         except Exception:
             logger.warning("civ-rx: unexpected error in state update", exc_info=True)
 
@@ -1177,7 +1211,8 @@ class CivRuntime:
                                 await self._host.soft_reconnect()
                             except (ConnectionError, TimeoutError, OSError) as exc:
                                 logger.debug(
-                                    "Fast CI-V soft_reconnect attempt failed: %s", exc,
+                                    "Fast CI-V soft_reconnect attempt failed: %s",
+                                    exc,
                                 )
                             except Exception:
                                 logger.warning(
@@ -1189,7 +1224,8 @@ class CivRuntime:
                         await self._host.soft_reconnect()
                     except (ConnectionError, TimeoutError, OSError) as exc:
                         logger.debug(
-                            "Fast CI-V soft_reconnect attempt failed: %s", exc,
+                            "Fast CI-V soft_reconnect attempt failed: %s",
+                            exc,
                         )
                     except Exception:
                         logger.warning(

--- a/src/icom_lan/_civ_rx.py
+++ b/src/icom_lan/_civ_rx.py
@@ -142,6 +142,11 @@ class CivRuntime:
 
     def __init__(self, host: "CivRuntimeHost") -> None:
         self._host = host
+        # Detached reconnect task spawned from the watchdog escalation path.
+        # Tracked here so stop_data_watchdog() can cancel it and prevent a
+        # late soft_reconnect from firing after an explicit disconnect
+        # (Codex P1 on PR #851).
+        self._reconnect_task: asyncio.Task[None] | None = None
 
     # ------------------------------------------------------------------
     # Public API (design doc)
@@ -178,7 +183,13 @@ class CivRuntime:
         logger.info("civ-data-watchdog: started")
 
     async def stop_data_watchdog(self) -> None:
-        """Stop CI-V data watchdog."""
+        """Stop CI-V data watchdog and any in-flight detached reconnect task.
+
+        The reconnect helper (spawned from the escalation path as a detached
+        task) is cancelled alongside the watchdog loop so an explicit
+        disconnect during the cooldown cannot be undone by a late
+        soft_reconnect.
+        """
         task = getattr(self._host, "_civ_data_watchdog_task", None)
         if task is not None and not task.done():
             task.cancel()
@@ -187,6 +198,15 @@ class CivRuntime:
             except asyncio.CancelledError:
                 pass
         self._host._civ_data_watchdog_task = None
+
+        rc_task = self._reconnect_task
+        if rc_task is not None and not rc_task.done():
+            rc_task.cancel()
+            try:
+                await rc_task
+            except asyncio.CancelledError:
+                pass
+        self._reconnect_task = None
 
     def advance_generation(self, reason: str) -> None:
         """Advance CI-V request generation and fail stale waiters."""
@@ -341,7 +361,7 @@ class CivRuntime:
                                 "attempting full reconnect",
                                 reconnect_count - 1,
                             )
-                            asyncio.create_task(
+                            self._reconnect_task = asyncio.create_task(
                                 self._watchdog_full_reconnect(reconnect_pause),
                                 name="civ-watchdog-full-reconnect",
                             )
@@ -354,7 +374,7 @@ class CivRuntime:
                             _MAX_RECONNECTS,
                             reconnect_pause,
                         )
-                        asyncio.create_task(
+                        self._reconnect_task = asyncio.create_task(
                             self._watchdog_soft_reconnect(reconnect_pause),
                             name="civ-watchdog-soft-reconnect",
                         )

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -280,16 +280,21 @@ async def test_watchdog_loop_phase1_open_close_exception_ignored(
         patch("asyncio.sleep", side_effect=mock_sleep),
         patch.object(radio, "_send_open_close", side_effect=failing_open_close),
     ):
-        await radio._civ_runtime._civ_data_watchdog_loop()  # should complete without raising
+        await (
+            radio._civ_runtime._civ_data_watchdog_loop()
+        )  # should complete without raising
 
 
 async def test_watchdog_loop_phase2_uses_long_reconnect_cooldown(
     radio: IcomRadio,
 ) -> None:
-    """Phase 2 uses a long cooldown before reconnect to avoid reconnect churn."""
+    """Phase 2 uses a long cooldown before reconnect to avoid reconnect churn.
+
+    After the OpenClose deadline, the watchdog spawns a detached reconnect
+    task that sleeps for the cooldown BEFORE calling soft_reconnect.
+    """
     radio._last_civ_data_received = 0.0
     radio._civ_recovering = False
-    radio._civ_runtime.stop_data_watchdog = AsyncMock()
     radio._force_cleanup_civ = AsyncMock()
     radio.soft_reconnect = AsyncMock()
 
@@ -297,16 +302,14 @@ async def test_watchdog_loop_phase2_uses_long_reconnect_cooldown(
 
     async def fake_sleep(delay: float) -> None:
         delays.append(delay)
-        if delay >= 10.0:
-            raise asyncio.CancelledError()
 
-    monotonic_values = iter([200.0, 200.0, 206.0, 206.1])
+    monotonic_values = iter([200.0, 200.0, 265.0, 265.1, 265.2])
 
     def _mono() -> float:
         try:
             return next(monotonic_values)
         except StopIteration:
-            return 206.1
+            return 265.2
 
     with (
         patch("asyncio.sleep", side_effect=fake_sleep),
@@ -314,8 +317,87 @@ async def test_watchdog_loop_phase2_uses_long_reconnect_cooldown(
         patch.object(radio, "_send_open_close", new=AsyncMock()),
     ):
         await radio._civ_runtime._civ_data_watchdog_loop()
+        # Await the spawned reconnect task explicitly so its cooldown sleep
+        # runs inside the patched scope.
+        spawned = [
+            t for t in asyncio.all_tasks() if t.get_name().startswith("civ-watchdog-")
+        ]
+        for task in spawned:
+            await task
 
+    # 45s cooldown was observed in the spawned task (first backoff entry).
     assert any(d >= 45.0 for d in delays)
+    radio.soft_reconnect.assert_awaited_once()
+
+
+async def test_watchdog_soft_reconnect_task_sleeps_before_reconnect(
+    radio: IcomRadio,
+) -> None:
+    """Detached soft_reconnect task sleeps for the cooldown BEFORE calling
+    soft_reconnect — regression guard for the self-cancel bug where the
+    watchdog cancelled itself and the cooldown sleep never ran.
+    """
+    order: list[str] = []
+
+    async def record_force_cleanup() -> None:
+        order.append("force_cleanup")
+
+    async def record_sleep(delay: float) -> None:
+        order.append(f"sleep({delay})")
+
+    async def record_soft_reconnect() -> None:
+        order.append("soft_reconnect")
+
+    radio._force_cleanup_civ = record_force_cleanup
+    radio.soft_reconnect = record_soft_reconnect
+
+    with patch("asyncio.sleep", side_effect=record_sleep):
+        await radio._civ_runtime._watchdog_soft_reconnect(cooldown=45.0)
+
+    assert order == ["force_cleanup", "sleep(45.0)", "soft_reconnect"]
+
+
+async def test_watchdog_patient_openclose_before_escalation(
+    radio: IcomRadio,
+) -> None:
+    """Watchdog sends open_close for a patient period before escalating to
+    soft_reconnect. Matches wfview's recovery pattern (icomudpcivdata.cpp:31):
+    persistent OpenClose every 100ms rather than aggressive escalation.
+    """
+    radio._last_civ_data_received = 0.0
+    radio._civ_recovering = False
+    radio.soft_reconnect = AsyncMock()
+    radio._force_cleanup_civ = AsyncMock()
+
+    # Monotonic advances 1 sec per call; recovery_start captured on 2nd call,
+    # then each elapsed_recovery check stays under the 60-sec deadline for
+    # well past the old 5-sec cutoff.
+    mono_time = [200.0]
+
+    def _mono() -> float:
+        mono_time[0] += 1.0
+        return mono_time[0]
+
+    sleep_count = [0]
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_count[0] += 1
+        if sleep_count[0] >= 30:
+            raise asyncio.CancelledError()
+
+    oc_mock = AsyncMock()
+
+    with (
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        patch("time.monotonic", side_effect=_mono),
+        patch.object(radio, "_send_open_close", new=oc_mock),
+    ):
+        await radio._civ_runtime._civ_data_watchdog_loop()
+
+    # Crossed the old 5-sec deadline many times but NOT escalated.
+    radio.soft_reconnect.assert_not_awaited()
+    # open_close called repeatedly during the patient period.
+    assert oc_mock.await_count >= 10
 
 
 # ---------------------------------------------------------------------------
@@ -835,7 +917,9 @@ def test_update_radio_state_cmd12_antenna_ant1(radio_with_state: IcomRadio) -> N
     assert rs.rx_antenna_1 is False
 
 
-def test_update_radio_state_cmd12_antenna_ant2_rx_on(radio_with_state: IcomRadio) -> None:
+def test_update_radio_state_cmd12_antenna_ant2_rx_on(
+    radio_with_state: IcomRadio,
+) -> None:
     """cmd 0x12 sub 0x01 selects ANT2 with RX ANT ON."""
     rs = radio_with_state._radio_state
     frame = _make_frame(cmd=0x12, sub=0x01, data=bytes([0x01]))

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -357,6 +357,36 @@ async def test_watchdog_soft_reconnect_task_sleeps_before_reconnect(
     assert order == ["force_cleanup", "sleep(45.0)", "soft_reconnect"]
 
 
+async def test_stop_data_watchdog_cancels_pending_reconnect_task(
+    radio: IcomRadio,
+) -> None:
+    """stop_data_watchdog() must cancel any pending detached reconnect task
+    spawned by watchdog escalation, so disconnect during cooldown does not
+    trigger a late soft_reconnect (Codex P1 on PR #851).
+    """
+    radio._force_cleanup_civ = AsyncMock()
+    radio.soft_reconnect = AsyncMock()
+
+    # Spawn the reconnect helper the same way the watchdog does, and
+    # register it on the runtime so stop_data_watchdog can find it.
+    task = asyncio.create_task(
+        radio._civ_runtime._watchdog_soft_reconnect(cooldown=5.0),
+        name="civ-watchdog-soft-reconnect",
+    )
+    radio._civ_runtime._reconnect_task = task
+
+    # Let the task enter its cooldown sleep.
+    await asyncio.sleep(0.01)
+    assert not task.done(), "task should still be sleeping in cooldown"
+
+    # Explicit disconnect during cooldown.
+    await radio._civ_runtime.stop_data_watchdog()
+
+    assert task.done()
+    radio.soft_reconnect.assert_not_awaited()
+    assert radio._civ_runtime._reconnect_task is None
+
+
 async def test_watchdog_patient_openclose_before_escalation(
     radio: IcomRadio,
 ) -> None:


### PR DESCRIPTION
## Summary

- **Self-cancel bug**: watchdog called `await self.stop_data_watchdog()` on itself before the cooldown sleep — `CancelledError` propagated at the next `await`, so `asyncio.sleep(45)` and `soft_reconnect()` never ran even though the log said `cooldown=45s`.
- **Aggressive escalation**: `_OPENCLOSE_DEADLINE = 5.0` tore down the CI-V session after just 5 seconds of silence; wfview (`icomudpcivdata.cpp:31`) retries OpenClose every 100 ms indefinitely with no escalation at all and runs reliably on the same hardware for days. Result: every ~7 seconds `force_cleanup → soft_reconnect → 96/96 fetch ok → 2 s silence → 5 s OpenClose cutoff → tear down again`, never giving the radio time to re-engage broadcast.

### Fix

- Recovery (`_watchdog_soft_reconnect`, `_watchdog_full_reconnect`) runs as detached `asyncio.create_task`s so the cooldown sleep is honored even when the watchdog loop exits via `return`.
- `_OPENCLOSE_DEADLINE` raised from 5.0 s to 60.0 s. Still bounded as a safety net (unlike wfview), but 12× more patient.

### Regression guards

- `test_watchdog_soft_reconnect_task_sleeps_before_reconnect` — asserts `force_cleanup → sleep(cooldown) → soft_reconnect` in that exact order.
- `test_watchdog_patient_openclose_before_escalation` — asserts OpenClose is retried for well over the old 5-second cutoff without triggering any reconnect.
- `test_watchdog_loop_phase2_uses_long_reconnect_cooldown` — updated to await the spawned task so its cooldown sleep runs inside the patched scope.

### Observed on live hardware

On an IC-7610 that had been stuck in the flap for hours, restarting with this patch let broadcast resume immediately and stay quiet for the duration of the test session.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4719 passed, 0 failed (Python 3.11)
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run ruff format src/ tests/` — no changes
- [x] Live IC-7610: broadcast resumed immediately after restart on a previously flapping session
- [ ] 8+ hour soak test on live IC-7610 to confirm the original hang cannot recur
- [ ] If the radio does enter the "deaf" state again, logs should show `civ-data-watchdog: CI-V data resumed` after patient OpenClose (no `soft_reconnect`) — the success criterion for the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)