### PR TITLE
feat(#839): mobile chip-scroll IA + ESSENTIALS panel

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -20,6 +20,8 @@
   import ScanPanel from '../panels/ScanPanel.svelte';
   import CwPanel from '../panels/CwPanel.svelte';
   import DockMeterPanel from '../panels/DockMeterPanel.svelte';
+  import EssentialsPanel from '../panels/EssentialsPanel.svelte';
+  import MobileChipBar from './mobile-chip-bar.svelte';
   import KeyboardHandler from './KeyboardHandler.svelte';
   import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
   import {
@@ -101,6 +103,16 @@
     width: receiverDeckWidth,
     overrides: {},
   }));
+
+  // ── Mobile IA chip navigation ──
+  const MOBILE_CHIPS = $derived([
+    { id: 'essentials', label: 'ESSENTIALS' },
+    { id: 'band', label: 'BAND' },
+    { id: 'scan', label: 'SCAN' },
+    { id: 'rf', label: 'RF' },
+    ...(txCapable ? [{ id: 'tx', label: 'TX' }] : []),
+  ]);
+  let activeChip = $state<string>('essentials');
 
   // ── Modals ──
   let settingsOpen = $state(false);
@@ -475,20 +487,39 @@
       </section>
     {/if}
 
-    <!-- Band -->
-    <section class="m-section">
-      <CollapsiblePanel title="BAND" panelId="m-band" collapsible={true}>
+    <!-- ═══ CHIP-SCROLL NAV ═══ -->
+    <MobileChipBar chips={MOBILE_CHIPS} active={activeChip} onSelect={(id) => (activeChip = id)} />
+
+    <!-- ═══ ACTIVE CHIP CONTENT ═══ -->
+    <section class="m-chip-content">
+      {#if activeChip === 'essentials'}
+        <EssentialsPanel
+          {vfoOps}
+          {mode}
+          quickModes={QUICK_MODES}
+          {filter}
+          {rxAudio}
+          {dsp}
+          onSplitToggle={vfoHandlers.onSplitToggle}
+          onSwap={vfoHandlers.onSwap}
+          onEqual={vfoHandlers.onEqual}
+          onModeChange={modeHandlers.onModeChange}
+          onMoreModes={() => (modeModalOpen = true)}
+          onFilterChange={(idx) => filterHandlers.onFilterChange?.(idx)}
+          onMoreFilters={() => (filterModalOpen = true)}
+          onMonitorModeChange={rxAudioHandlers.onMonitorModeChange}
+          onAfLevelChange={rxAudioHandlers.onAfLevelChange}
+          onNbToggle={dspHandlers.onNbToggle}
+          onNrModeChange={dspHandlers.onNrModeChange}
+          onNotchModeChange={dspHandlers.onNotchModeChange}
+        />
+      {:else if activeChip === 'band'}
         <BandSelector
           currentFreq={band.currentFreq}
           onBandSelect={bandHandlers.onBandSelect}
           onPresetSelect={presetHandlers.onPresetSelect}
         />
-      </CollapsiblePanel>
-    </section>
-
-    <!-- Scan -->
-    <section class="m-section">
-      <CollapsiblePanel title="SCAN" panelId="m-scan" collapsible={true}>
+      {:else if activeChip === 'scan'}
         <ScanPanel
           scanning={scan.scanning}
           scanType={scan.scanType}
@@ -498,120 +529,7 @@
           onDfSpanChange={scanHandlers.onDfSpanChange}
           onResumeChange={scanHandlers.onResumeChange}
         />
-      </CollapsiblePanel>
-    </section>
-
-    <!-- Mode (quick: LSB USB CW AM + More) -->
-    <section class="m-section">
-      <CollapsiblePanel title="MODE" panelId="m-mode" collapsible={true}>
-        <div class="m-quick-grid">
-          {#each QUICK_MODES as m}
-            <HardwareButton
-              active={mode.currentMode === m}
-              indicator="edge-left"
-              color="cyan"
-              onclick={() => modeHandlers.onModeChange(m)}
-            >
-              {m}
-            </HardwareButton>
-          {/each}
-          <HardwareButton
-            indicator="edge-left"
-            color="muted"
-            onclick={() => (modeModalOpen = true)}
-          >
-            More…
-          </HardwareButton>
-        </div>
-      </CollapsiblePanel>
-    </section>
-
-    <!-- Filter (quick: FIL1 FIL2 FIL3 + More) -->
-    <section class="m-section">
-      <CollapsiblePanel title="FILTER" panelId="m-filter" collapsible={true}>
-        <div class="m-quick-grid">
-          {#each (filter.filterLabels ?? ['FIL1', 'FIL2', 'FIL3']) as label, idx}
-            <HardwareButton
-              active={filter.currentFilter === idx + 1}
-              indicator="edge-left"
-              color="cyan"
-              onclick={() => filterHandlers.onFilterChange?.(idx + 1)}
-            >
-              {label}
-            </HardwareButton>
-          {/each}
-          <HardwareButton
-            indicator="edge-left"
-            color="muted"
-            onclick={() => (filterModalOpen = true)}
-          >
-            More…
-          </HardwareButton>
-        </div>
-      </CollapsiblePanel>
-    </section>
-
-    <!-- Audio (AF + monitor mode + DSP toggles) -->
-    <section class="m-section">
-      <CollapsiblePanel title="AUDIO" panelId="m-audio" collapsible={true}>
-        <div class="m-audio-content">
-          <div class="m-audio-buttons">
-            {#each ['local', 'live', 'mute'] as opt}
-              <HardwareButton
-                active={rxAudio.monitorMode === opt}
-                indicator="edge-left"
-                color={opt === 'mute' ? 'red' : 'cyan'}
-                onclick={() => rxAudioHandlers.onMonitorModeChange(opt)}
-              >
-                {opt === 'local' ? 'LOCAL' : opt === 'live' ? 'LIVE' : 'MUTE'}
-              </HardwareButton>
-            {/each}
-          </div>
-          <ValueControl
-            label="AF Level"
-            value={rxAudio.afLevel}
-            min={0}
-            max={255}
-            step={1}
-            renderer="hbar"
-            displayFn={rawToPercentDisplay}
-            accentColor="var(--v2-accent-cyan-alt)"
-            onChange={rxAudioHandlers.onAfLevelChange}
-            variant="hardware-illuminated"
-          />
-          <div class="m-dsp-toggles">
-            <HardwareButton
-              active={dsp.nbActive}
-              indicator="edge-left"
-              color={dsp.nbActive ? 'green' : 'muted'}
-              onclick={() => dspHandlers.onNbToggle(!dsp.nbActive)}
-            >
-              NB
-            </HardwareButton>
-            <HardwareButton
-              active={dsp.nrMode > 0}
-              indicator="edge-left"
-              color={dsp.nrMode > 0 ? 'green' : 'muted'}
-              onclick={() => dspHandlers.onNrModeChange(dsp.nrMode > 0 ? 0 : 1)}
-            >
-              NR
-            </HardwareButton>
-            <HardwareButton
-              active={dsp.notchMode !== 'off'}
-              indicator="edge-left"
-              color={dsp.notchMode !== 'off' ? 'green' : 'muted'}
-              onclick={() => dspHandlers.onNotchModeChange(dsp.notchMode !== 'off' ? 'off' : 'auto')}
-            >
-              NOTCH
-            </HardwareButton>
-          </div>
-        </div>
-      </CollapsiblePanel>
-    </section>
-
-    <!-- RF Front End (ATT / PRE / DIGI-SEL / IP+) -->
-    <section class="m-section">
-      <CollapsiblePanel title="RF" panelId="m-rf-quick" collapsible={true}>
+      {:else if activeChip === 'rf'}
         <RfFrontEnd
           rfGain={rfFrontEnd.rfGain}
           squelch={rfFrontEnd.squelch}
@@ -626,81 +544,67 @@
           onDigiSelToggle={rfHandlers.onDigiSelToggle}
           onIpPlusToggle={rfHandlers.onIpPlusToggle}
         />
-      </CollapsiblePanel>
-    </section>
-
-    <!-- TX (compact: PTT + Power readout + ATU) -->
-    {#if txCapable}
-      <section class="m-section">
-        <CollapsiblePanel title="TX" panelId="m-tx" collapsible={true}>
-          <div class="m-tx-compact">
-            <!-- Power readout (tap → power modal) -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <div class="m-tx-info" onclick={() => (powerModalOpen = true)}>
-              <span class="m-tx-power-value">{formatPower(tx.rfPower)}</span>
-              {#if tx.txActive || pttActive}
-                <span class="m-tx-swr-value">SWR {meter.swr > 0 ? (meter.swr / 10).toFixed(1) : '—'}</span>
-              {/if}
-            </div>
-
-            <!-- ATU -->
-            <button
-              class="m-atu-btn"
-              class:m-atu-on={atuStatus === 'on'}
-              class:m-atu-tuning={atuStatus === 'tuning'}
-              ontouchstart={atuTouchStart}
-              ontouchend={atuTouchEnd}
-              ontouchcancel={atuTouchEnd}
-              onmousedown={atuTouchStart}
-              onmouseup={atuTouchEnd}
-            >
-              ATU
-            </button>
-
-            <!-- TX settings -->
-            <button class="m-tx-settings-btn" onclick={() => (txSettingsOpen = true)}>
-              <Sliders size={14} />
-            </button>
-
-            <!-- PTT (wider) -->
-            <button
-              class="m-ptt-btn"
-              class:m-ptt-held={pttMode === 'held'}
-              class:m-ptt-latched={pttMode === 'latched'}
-              ontouchstart={(e) => { e.preventDefault(); pttDown(); }}
-              ontouchend={(e) => { e.preventDefault(); pttUp(); }}
-              ontouchcancel={() => pttUp()}
-              onmousedown={pttDown}
-              onmouseup={pttUp}
-              onmouseleave={() => { if (pttMode === 'held') pttUp(); }}
-            >
-              {#if pttMode === 'latched'}
-                <MicOff size={18} />
-                TX LOCK
-              {:else if pttMode === 'held'}
-                TX
-              {:else}
-                <Mic size={18} />
-                PTT
-              {/if}
-            </button>
+      {:else if activeChip === 'tx' && txCapable}
+        <div class="m-tx-compact">
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div class="m-tx-info" onclick={() => (powerModalOpen = true)}>
+            <span class="m-tx-power-value">{formatPower(tx.rfPower)}</span>
+            {#if tx.txActive || pttActive}
+              <span class="m-tx-swr-value">SWR {meter.swr > 0 ? (meter.swr / 10).toFixed(1) : '—'}</span>
+            {/if}
           </div>
-          {#if tx.txActive || pttActive}
-            <div class="m-tx-meter">
-              <DockMeterPanel
-                sValue={mainVfo.sValue}
-                rfPower={meter.rfPower ?? 0}
-                swr={meter.swr}
-                alc={meter.alc ?? 0}
-                txActive={true}
-                meterSource="po"
-                onMeterSourceChange={() => {}}
-              />
-            </div>
-          {/if}
-        </CollapsiblePanel>
-      </section>
-    {/if}
+          <button
+            class="m-atu-btn"
+            class:m-atu-on={atuStatus === 'on'}
+            class:m-atu-tuning={atuStatus === 'tuning'}
+            ontouchstart={atuTouchStart}
+            ontouchend={atuTouchEnd}
+            ontouchcancel={atuTouchEnd}
+            onmousedown={atuTouchStart}
+            onmouseup={atuTouchEnd}
+          >
+            ATU
+          </button>
+          <button class="m-tx-settings-btn" onclick={() => (txSettingsOpen = true)}>
+            <Sliders size={14} />
+          </button>
+          <button
+            class="m-ptt-btn"
+            class:m-ptt-held={pttMode === 'held'}
+            class:m-ptt-latched={pttMode === 'latched'}
+            ontouchstart={(e) => { e.preventDefault(); pttDown(); }}
+            ontouchend={(e) => { e.preventDefault(); pttUp(); }}
+            ontouchcancel={() => pttUp()}
+            onmousedown={pttDown}
+            onmouseup={pttUp}
+            onmouseleave={() => { if (pttMode === 'held') pttUp(); }}
+          >
+            {#if pttMode === 'latched'}
+              <MicOff size={18} />
+              TX LOCK
+            {:else if pttMode === 'held'}
+              TX
+            {:else}
+              <Mic size={18} />
+              PTT
+            {/if}
+          </button>
+        </div>
+        {#if tx.txActive || pttActive}
+          <div class="m-tx-meter">
+            <DockMeterPanel
+              sValue={mainVfo.sValue}
+              rfPower={meter.rfPower ?? 0}
+              swr={meter.swr}
+              alc={meter.alc ?? 0}
+              txActive={true}
+              meterSource="po"
+              onMeterSourceChange={() => {}}
+            />
+          </div>
+        {/if}
+      {/if}
+    </section>
 
     <!-- Spacer for tuning strip -->
     <div class="m-bottom-spacer"></div>
@@ -1328,60 +1232,10 @@
     box-shadow: none;
   }
 
-  /* ── Sections ── */
-  .m-section {
+  /* ── Active chip content ── */
+  .m-chip-content {
     display: flex;
     flex-direction: column;
-  }
-
-  .m-section :global(.collapsible-panel) {
-    border-radius: 0;
-    border-left: none;
-    border-right: none;
-  }
-
-  /* ── Quick grid (mode, filter quick buttons) ── */
-  .m-quick-grid {
-    display: flex;
-    gap: 4px;
-    padding: 7px 8px;
-    flex-wrap: wrap;
-  }
-
-  .m-quick-grid > :global(button) {
-    flex: 1 1 auto;
-    min-width: 52px;
-    min-height: 40px;
-  }
-
-  /* ── Audio content ── */
-  .m-audio-content {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 7px 8px;
-  }
-
-  .m-audio-buttons {
-    display: flex;
-    gap: 4px;
-  }
-
-  .m-audio-buttons > :global(button) {
-    flex: 1 1 0;
-    min-width: 0;
-    min-height: 36px;
-  }
-
-  .m-dsp-toggles {
-    display: flex;
-    gap: 4px;
-  }
-
-  .m-dsp-toggles > :global(button) {
-    flex: 1 1 0;
-    min-width: 0;
-    min-height: 36px;
   }
 
   /* ── TX compact section ── */

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.test.ts
@@ -163,8 +163,12 @@ describe('MobileRadioLayout structure', () => {
     expect(mountMobile().querySelector('.m-tuning-strip')).not.toBeNull();
   });
 
-  it('renders section panels inside m-content', () => {
-    expect(mountMobile().querySelectorAll('.m-content .m-section').length).toBeGreaterThan(0);
+  it('renders chip-bar nav inside m-content', () => {
+    expect(mountMobile().querySelector('.m-content .m-chip-bar')).not.toBeNull();
+  });
+
+  it('renders active chip content area', () => {
+    expect(mountMobile().querySelector('.m-content .m-chip-content')).not.toBeNull();
   });
 
   it('renders TX indicator', () => {
@@ -177,14 +181,27 @@ describe('MobileRadioLayout structure', () => {
 });
 
 describe('MobileRadioLayout TX gating', () => {
-  it('renders PTT button when hasTx is true', () => {
+  it('exposes TX chip when hasTx is true', () => {
     vi.mocked(hasTx).mockReturnValue(true);
-    expect(mountMobile().querySelector('.m-ptt-btn')).not.toBeNull();
+    const chips = Array.from(mountMobile().querySelectorAll('.m-chip')) as HTMLButtonElement[];
+    expect(chips.some((c) => c.textContent?.trim() === 'TX')).toBe(true);
   });
 
-  it('hides PTT button when hasTx is false', () => {
+  it('hides TX chip when hasTx is false', () => {
     vi.mocked(hasTx).mockReturnValue(false);
-    expect(mountMobile().querySelector('.m-ptt-btn')).toBeNull();
+    const chips = Array.from(mountMobile().querySelectorAll('.m-chip')) as HTMLButtonElement[];
+    expect(chips.some((c) => c.textContent?.trim() === 'TX')).toBe(false);
+  });
+
+  it('renders PTT button when TX chip selected', () => {
+    vi.mocked(hasTx).mockReturnValue(true);
+    const root = mountMobile();
+    const txChip = Array.from(root.querySelectorAll('.m-chip')).find(
+      (c) => c.textContent?.trim() === 'TX',
+    ) as HTMLButtonElement | undefined;
+    txChip?.click();
+    flushSync();
+    expect(root.querySelector('.m-ptt-btn')).not.toBeNull();
   });
 });
 

--- a/frontend/src/components-v2/layout/mobile-chip-bar.svelte
+++ b/frontend/src/components-v2/layout/mobile-chip-bar.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  // Horizontal chip-scroll navigation for mobile IA.
+  // Renders a row of section chips; one is active at a time.
+  interface Chip {
+    id: string;
+    label: string;
+  }
+
+  interface Props {
+    chips: Chip[];
+    active: string;
+    onSelect: (id: string) => void;
+  }
+
+  let { chips, active, onSelect }: Props = $props();
+</script>
+
+<nav class="m-chip-bar" aria-label="Mobile sections">
+  {#each chips as chip}
+    <button
+      type="button"
+      class="m-chip"
+      class:m-chip-active={chip.id === active}
+      aria-pressed={chip.id === active}
+      onclick={() => onSelect(chip.id)}
+    >
+      {chip.label}
+    </button>
+  {/each}
+</nav>
+
+<style>
+  .m-chip-bar {
+    display: flex;
+    gap: 6px;
+    padding: 6px 8px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+    background: var(--v2-bg-darker, #0a0a14);
+    border-bottom: 1px solid var(--v2-border-darker, #1a1a2e);
+    flex-shrink: 0;
+  }
+
+  .m-chip-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .m-chip {
+    flex: 0 0 auto;
+    min-height: 32px;
+    padding: 4px 14px;
+    border-radius: 16px;
+    border: 1px solid var(--v2-border-panel, #333);
+    background: var(--v2-bg-input, #1a1a2e);
+    color: var(--v2-text-muted, #888);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    white-space: nowrap;
+  }
+
+  .m-chip:active {
+    background: var(--v2-bg-card, #222);
+  }
+
+  .m-chip-active {
+    background: rgba(34, 211, 238, 0.12);
+    border-color: var(--v2-accent-cyan, #22d3ee);
+    color: var(--v2-accent-cyan, #22d3ee);
+  }
+</style>

--- a/frontend/src/components-v2/panels/EssentialsPanel.svelte
+++ b/frontend/src/components-v2/panels/EssentialsPanel.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  // ESSENTIALS panel — default mobile chip content.
+  // Compact: VFO ops (SPLIT / A<->B / A=B), MODE quick, FILTER quick,
+  // AUDIO (monitor mode + AF), DSP toggles (NB / NR / NOTCH).
+  import { HardwareButton } from '$lib/Button';
+  import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
+
+  interface Props {
+    vfoOps: { splitActive: boolean };
+    mode: { currentMode: string };
+    quickModes: string[];
+    filter: { currentFilter: number; filterLabels?: string[] };
+    rxAudio: { monitorMode: string; afLevel: number };
+    dsp: { nbActive: boolean; nrMode: number; notchMode: string };
+    onSplitToggle: () => void;
+    onSwap: () => void;
+    onEqual: () => void;
+    onModeChange: (m: string) => void;
+    onMoreModes: () => void;
+    onFilterChange: (idx: number) => void;
+    onMoreFilters: () => void;
+    onMonitorModeChange: (m: string) => void;
+    onAfLevelChange: (v: number) => void;
+    onNbToggle: (v: boolean) => void;
+    onNrModeChange: (m: number) => void;
+    onNotchModeChange: (m: string) => void;
+  }
+
+  let {
+    vfoOps, mode, quickModes, filter, rxAudio, dsp,
+    onSplitToggle, onSwap, onEqual,
+    onModeChange, onMoreModes,
+    onFilterChange, onMoreFilters,
+    onMonitorModeChange, onAfLevelChange,
+    onNbToggle, onNrModeChange, onNotchModeChange,
+  }: Props = $props();
+</script>
+
+<div class="ess">
+  <div class="ess-group">
+    <div class="ess-label">VFO</div>
+    <div class="ess-row">
+      <HardwareButton active={vfoOps.splitActive} indicator="edge-left" color={vfoOps.splitActive ? 'yellow' : 'muted'} onclick={onSplitToggle}>SPLIT</HardwareButton>
+      <HardwareButton indicator="edge-left" color="cyan" onclick={onSwap}>A↔B</HardwareButton>
+      <HardwareButton indicator="edge-left" color="cyan" onclick={onEqual}>A=B</HardwareButton>
+    </div>
+  </div>
+
+  <div class="ess-group">
+    <div class="ess-label">MODE</div>
+    <div class="ess-row">
+      {#each quickModes as m}
+        <HardwareButton active={mode.currentMode === m} indicator="edge-left" color="cyan" onclick={() => onModeChange(m)}>{m}</HardwareButton>
+      {/each}
+      <HardwareButton indicator="edge-left" color="muted" onclick={onMoreModes}>More…</HardwareButton>
+    </div>
+  </div>
+
+  <div class="ess-group">
+    <div class="ess-label">FILTER</div>
+    <div class="ess-row">
+      {#each (filter.filterLabels ?? ['FIL1', 'FIL2', 'FIL3']) as label, idx}
+        <HardwareButton active={filter.currentFilter === idx + 1} indicator="edge-left" color="cyan" onclick={() => onFilterChange(idx + 1)}>{label}</HardwareButton>
+      {/each}
+      <HardwareButton indicator="edge-left" color="muted" onclick={onMoreFilters}>More…</HardwareButton>
+    </div>
+  </div>
+
+  <div class="ess-group">
+    <div class="ess-label">AUDIO</div>
+    <div class="ess-row">
+      {#each ['local', 'live', 'mute'] as opt}
+        <HardwareButton active={rxAudio.monitorMode === opt} indicator="edge-left" color={opt === 'mute' ? 'red' : 'cyan'} onclick={() => onMonitorModeChange(opt)}>
+          {opt === 'local' ? 'LOCAL' : opt === 'live' ? 'LIVE' : 'MUTE'}
+        </HardwareButton>
+      {/each}
+    </div>
+    <ValueControl
+      label="AF Level"
+      value={rxAudio.afLevel}
+      min={0}
+      max={255}
+      step={1}
+      renderer="hbar"
+      displayFn={rawToPercentDisplay}
+      accentColor="var(--v2-accent-cyan-alt)"
+      onChange={onAfLevelChange}
+      variant="hardware-illuminated"
+    />
+  </div>
+
+  <div class="ess-group">
+    <div class="ess-label">DSP</div>
+    <div class="ess-row">
+      <HardwareButton active={dsp.nbActive} indicator="edge-left" color={dsp.nbActive ? 'green' : 'muted'} onclick={() => onNbToggle(!dsp.nbActive)}>NB</HardwareButton>
+      <HardwareButton active={dsp.nrMode > 0} indicator="edge-left" color={dsp.nrMode > 0 ? 'green' : 'muted'} onclick={() => onNrModeChange(dsp.nrMode > 0 ? 0 : 1)}>NR</HardwareButton>
+      <HardwareButton active={dsp.notchMode !== 'off'} indicator="edge-left" color={dsp.notchMode !== 'off' ? 'green' : 'muted'} onclick={() => onNotchModeChange(dsp.notchMode !== 'off' ? 'off' : 'auto')}>NOTCH</HardwareButton>
+    </div>
+  </div>
+</div>
+
+<style>
+  .ess {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px 8px;
+  }
+
+  .ess-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .ess-label {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: var(--v2-text-dim, #555);
+    text-transform: uppercase;
+  }
+
+  .ess-row {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+
+  .ess-row > :global(button) {
+    flex: 1 1 0;
+    min-width: 52px;
+    min-height: 40px;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Replace stacked `m-section` list in mobile portrait with a horizontal chip-scroll nav (`mobile-chip-bar.svelte`) and a single active-chip content region. Default active chip = ESSENTIALS.
- New `EssentialsPanel.svelte` consolidates compact VFO ops (SPLIT / A↔B / A=B), MODE quick-picks, FILTER quick-picks, AUDIO (monitor mode + AF), and DSP toggles (NB / NR / NOTCH).
- Other chips: BAND, SCAN, RF, TX (TX chip only when `hasTx()`). All other mobile features — Wake Lock, fullscreen, PTT safety timer, sticky VFO header, S-meter bar, tuning strip, spectrum, MORE bottom sheet, landscape branch — preserved unchanged.

Foundation for issues #840 / #841 / #843 under mobile IA epic #818.

## Test plan
- [x] `frontend/npx vitest run` — 1467 pass (15 layout-structure tests updated for chip-bar)
- [x] `uv run pytest tests/ --ignore=tests/integration` — 4612 pass (2 pre-existing web-server failures unchanged from baseline; require built frontend)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `frontend/npx svelte-check` — 126 errors on MobileRadioLayout (identical baseline count; pre-existing panel prop type inference issues shared with RadioLayout)
- [ ] Manual: open mobile layout on device, verify default ESSENTIALS chip, cycle through BAND/SCAN/RF/TX chips, confirm Wake Lock + landscape still work