### PR TITLE
feat(#839): mobile chip-scroll IA + ESSENTIALS panel

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -136,6 +136,14 @@
     ...(txCapable ? [{ id: 'tx', label: 'TX' }] : []),
   ]);
 
+  // Reset to ESSENTIALS if the active chip disappears from the list
+  // (e.g., capability refresh after reconnecting to a non-TX radio).
+  $effect(() => {
+    if (!mobileChips.some((c) => c.id === activeChipId)) {
+      activeChipId = 'essentials';
+    }
+  });
+
   // ── Tuning strip ──
   let availableSteps = $derived(getStepsForMode(mode.currentMode));
   let tuningStep = $state(1000); // Hz

--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -21,6 +21,8 @@
   import CwPanel from '../panels/CwPanel.svelte';
   import DockMeterPanel from '../panels/DockMeterPanel.svelte';
   import KeyboardHandler from './KeyboardHandler.svelte';
+  import MobileChipBar from './mobile-chip-bar.svelte';
+  import EssentialsPanel from '../panels/EssentialsPanel.svelte';
   import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
   import {
     Settings, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Mic, MicOff,
@@ -123,6 +125,16 @@
   let filterModalOpen = $state(false);
   let txSettingsOpen = $state(false);
   let powerModalOpen = $state(false);
+
+  // ── Chip-scroll IA (#839) ──
+  let activeChipId = $state('essentials');
+  const mobileChips = $derived([
+    { id: 'essentials', label: 'ESSENTIALS' },
+    { id: 'band', label: 'BAND' },
+    { id: 'scan', label: 'SCAN' },
+    { id: 'rf', label: 'RF' },
+    ...(txCapable ? [{ id: 'tx', label: 'TX' }] : []),
+  ]);
 
   // ── Tuning strip ──
   let availableSteps = $derived(getStepsForMode(mode.currentMode));
@@ -512,164 +524,83 @@
       </section>
     {/if}
 
-    <!-- Band -->
-    <section class="m-section">
-      <CollapsiblePanel title="BAND" panelId="m-band" collapsible={true}>
-        <BandSelector
-          currentFreq={band.currentFreq}
-          onBandSelect={bandHandlers.onBandSelect}
-          onPresetSelect={presetHandlers.onPresetSelect}
+    <!-- Chip-scroll IA nav (#839) -->
+    <MobileChipBar
+      chips={mobileChips}
+      activeId={activeChipId}
+      onSelect={(id) => (activeChipId = id)}
+    />
+
+    <!-- Active-chip content area (single panel mounted at a time) -->
+    {#if activeChipId === 'essentials'}
+      <section class="m-section" id="m-chip-panel-essentials" role="tabpanel">
+        <EssentialsPanel
+          vfoOps={vfoOps}
+          mode={mode}
+          filter={filter}
+          rxAudio={rxAudio}
+          dsp={dsp}
+          quickModes={QUICK_MODES}
+          onSplitToggle={vfoHandlers.onSplitToggle}
+          onSwap={vfoHandlers.onSwap}
+          onEqual={vfoHandlers.onEqual}
+          onModeChange={modeHandlers.onModeChange}
+          onModeMore={() => (modeModalOpen = true)}
+          onFilterChange={(n) => filterHandlers.onFilterChange?.(n)}
+          onFilterMore={() => (filterModalOpen = true)}
+          onMonitorModeChange={rxAudioHandlers.onMonitorModeChange}
+          onAfLevelChange={rxAudioHandlers.onAfLevelChange}
+          onNbToggle={dspHandlers.onNbToggle}
+          onNrModeChange={dspHandlers.onNrModeChange}
+          onNotchModeChange={dspHandlers.onNotchModeChange}
         />
-      </CollapsiblePanel>
-    </section>
-
-    <!-- Scan -->
-    <section class="m-section">
-      <CollapsiblePanel title="SCAN" panelId="m-scan" collapsible={true}>
-        <ScanPanel
-          scanning={scan.scanning}
-          scanType={scan.scanType}
-          scanResumeMode={scan.scanResumeMode}
-          onScanStart={scanHandlers.onScanStart}
-          onScanStop={scanHandlers.onScanStop}
-          onDfSpanChange={scanHandlers.onDfSpanChange}
-          onResumeChange={scanHandlers.onResumeChange}
-        />
-      </CollapsiblePanel>
-    </section>
-
-    <!-- Mode (quick: LSB USB CW AM + More) -->
-    <section class="m-section">
-      <CollapsiblePanel title="MODE" panelId="m-mode" collapsible={true}>
-        <div class="m-quick-grid">
-          {#each QUICK_MODES as m}
-            <HardwareButton
-              active={mode.currentMode === m}
-              indicator="edge-left"
-              color="cyan"
-              onclick={() => modeHandlers.onModeChange(m)}
-            >
-              {m}
-            </HardwareButton>
-          {/each}
-          <HardwareButton
-            indicator="edge-left"
-            color="muted"
-            onclick={() => (modeModalOpen = true)}
-          >
-            More…
-          </HardwareButton>
-        </div>
-      </CollapsiblePanel>
-    </section>
-
-    <!-- Filter (quick: FIL1 FIL2 FIL3 + More) -->
-    <section class="m-section">
-      <CollapsiblePanel title="FILTER" panelId="m-filter" collapsible={true}>
-        <div class="m-quick-grid">
-          {#each (filter.filterLabels ?? ['FIL1', 'FIL2', 'FIL3']) as label, idx}
-            <HardwareButton
-              active={filter.currentFilter === idx + 1}
-              indicator="edge-left"
-              color="cyan"
-              onclick={() => filterHandlers.onFilterChange?.(idx + 1)}
-            >
-              {label}
-            </HardwareButton>
-          {/each}
-          <HardwareButton
-            indicator="edge-left"
-            color="muted"
-            onclick={() => (filterModalOpen = true)}
-          >
-            More…
-          </HardwareButton>
-        </div>
-      </CollapsiblePanel>
-    </section>
-
-    <!-- Audio (AF + monitor mode + DSP toggles) -->
-    <section class="m-section">
-      <CollapsiblePanel title="AUDIO" panelId="m-audio" collapsible={true}>
-        <div class="m-audio-content">
-          <div class="m-audio-buttons">
-            {#each ['local', 'live', 'mute'] as opt}
-              <HardwareButton
-                active={rxAudio.monitorMode === opt}
-                indicator="edge-left"
-                color={opt === 'mute' ? 'red' : 'cyan'}
-                onclick={() => rxAudioHandlers.onMonitorModeChange(opt)}
-              >
-                {opt === 'local' ? 'LOCAL' : opt === 'live' ? 'LIVE' : 'MUTE'}
-              </HardwareButton>
-            {/each}
-          </div>
-          <ValueControl
-            label="AF Level"
-            value={rxAudio.afLevel}
-            min={0}
-            max={255}
-            step={1}
-            renderer="hbar"
-            displayFn={rawToPercentDisplay}
-            accentColor="var(--v2-accent-cyan-alt)"
-            onChange={rxAudioHandlers.onAfLevelChange}
-            variant="hardware-illuminated"
+      </section>
+    {:else if activeChipId === 'band'}
+      <section class="m-section" id="m-chip-panel-band" role="tabpanel">
+        <CollapsiblePanel title="BAND" panelId="m-band" collapsible={false}>
+          <BandSelector
+            currentFreq={band.currentFreq}
+            onBandSelect={bandHandlers.onBandSelect}
+            onPresetSelect={presetHandlers.onPresetSelect}
           />
-          <div class="m-dsp-toggles">
-            <HardwareButton
-              active={dsp.nbActive}
-              indicator="edge-left"
-              color={dsp.nbActive ? 'green' : 'muted'}
-              onclick={() => dspHandlers.onNbToggle(!dsp.nbActive)}
-            >
-              NB
-            </HardwareButton>
-            <HardwareButton
-              active={dsp.nrMode > 0}
-              indicator="edge-left"
-              color={dsp.nrMode > 0 ? 'green' : 'muted'}
-              onclick={() => dspHandlers.onNrModeChange(dsp.nrMode > 0 ? 0 : 1)}
-            >
-              NR
-            </HardwareButton>
-            <HardwareButton
-              active={dsp.notchMode !== 'off'}
-              indicator="edge-left"
-              color={dsp.notchMode !== 'off' ? 'green' : 'muted'}
-              onclick={() => dspHandlers.onNotchModeChange(dsp.notchMode !== 'off' ? 'off' : 'auto')}
-            >
-              NOTCH
-            </HardwareButton>
-          </div>
-        </div>
-      </CollapsiblePanel>
-    </section>
-
-    <!-- RF Front End (ATT / PRE / DIGI-SEL / IP+) -->
-    <section class="m-section">
-      <CollapsiblePanel title="RF" panelId="m-rf-quick" collapsible={true}>
-        <RfFrontEnd
-          rfGain={rfFrontEnd.rfGain}
-          squelch={rfFrontEnd.squelch}
-          att={rfFrontEnd.att}
-          pre={rfFrontEnd.pre}
-          digiSel={rfFrontEnd.digiSel}
-          ipPlus={rfFrontEnd.ipPlus}
-          onRfGainChange={rfHandlers.onRfGainChange}
-          onSquelchChange={rfHandlers.onSquelchChange}
-          onAttChange={rfHandlers.onAttChange}
-          onPreChange={rfHandlers.onPreChange}
-          onDigiSelToggle={rfHandlers.onDigiSelToggle}
-          onIpPlusToggle={rfHandlers.onIpPlusToggle}
-        />
-      </CollapsiblePanel>
-    </section>
-
-    <!-- TX (compact: PTT + Power readout + ATU) -->
-    {#if txCapable}
-      <section class="m-section">
-        <CollapsiblePanel title="TX" panelId="m-tx" collapsible={true}>
+        </CollapsiblePanel>
+      </section>
+    {:else if activeChipId === 'scan'}
+      <section class="m-section" id="m-chip-panel-scan" role="tabpanel">
+        <CollapsiblePanel title="SCAN" panelId="m-scan" collapsible={false}>
+          <ScanPanel
+            scanning={scan.scanning}
+            scanType={scan.scanType}
+            scanResumeMode={scan.scanResumeMode}
+            onScanStart={scanHandlers.onScanStart}
+            onScanStop={scanHandlers.onScanStop}
+            onDfSpanChange={scanHandlers.onDfSpanChange}
+            onResumeChange={scanHandlers.onResumeChange}
+          />
+        </CollapsiblePanel>
+      </section>
+    {:else if activeChipId === 'rf'}
+      <section class="m-section" id="m-chip-panel-rf" role="tabpanel">
+        <CollapsiblePanel title="RF" panelId="m-rf-quick" collapsible={false}>
+          <RfFrontEnd
+            rfGain={rfFrontEnd.rfGain}
+            squelch={rfFrontEnd.squelch}
+            att={rfFrontEnd.att}
+            pre={rfFrontEnd.pre}
+            digiSel={rfFrontEnd.digiSel}
+            ipPlus={rfFrontEnd.ipPlus}
+            onRfGainChange={rfHandlers.onRfGainChange}
+            onSquelchChange={rfHandlers.onSquelchChange}
+            onAttChange={rfHandlers.onAttChange}
+            onPreChange={rfHandlers.onPreChange}
+            onDigiSelToggle={rfHandlers.onDigiSelToggle}
+            onIpPlusToggle={rfHandlers.onIpPlusToggle}
+          />
+        </CollapsiblePanel>
+      </section>
+    {:else if activeChipId === 'tx' && txCapable}
+      <section class="m-section" id="m-chip-panel-tx" role="tabpanel">
+        <CollapsiblePanel title="TX" panelId="m-tx" collapsible={false}>
           <div class="m-tx-compact">
             <!-- Power readout (tap → power modal) -->
             <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -1414,50 +1345,6 @@
     border-radius: 0;
     border-left: none;
     border-right: none;
-  }
-
-  /* ── Quick grid (mode, filter quick buttons) ── */
-  .m-quick-grid {
-    display: flex;
-    gap: 4px;
-    padding: 7px 8px;
-    flex-wrap: wrap;
-  }
-
-  .m-quick-grid > :global(button) {
-    flex: 1 1 auto;
-    min-width: 52px;
-    min-height: 40px;
-  }
-
-  /* ── Audio content ── */
-  .m-audio-content {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 7px 8px;
-  }
-
-  .m-audio-buttons {
-    display: flex;
-    gap: 4px;
-  }
-
-  .m-audio-buttons > :global(button) {
-    flex: 1 1 0;
-    min-width: 0;
-    min-height: 44px;
-  }
-
-  .m-dsp-toggles {
-    display: flex;
-    gap: 4px;
-  }
-
-  .m-dsp-toggles > :global(button) {
-    flex: 1 1 0;
-    min-width: 0;
-    min-height: 44px;
   }
 
   /* ── TX compact section ── */

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -215,6 +215,34 @@ describe('MobileRadioLayout TX gating', () => {
     // And the TX-only PTT is not mounted on cold-open (ESSENTIALS active by default).
     expect(t.querySelector('.m-ptt-btn')).toBeNull();
   });
+
+  it('auto-resets active chip to ESSENTIALS when TX capability drops at runtime (#839)', () => {
+    // Back the hasTx mock with a reactive $state so the component's $derived
+    // txCapable re-evaluates when we flip capability mid-session.
+    const txState = $state({ on: true });
+    vi.mocked(hasTx).mockImplementation(() => txState.on);
+
+    const t = mountMobile();
+    // Select TX chip while TX-capable.
+    const txChip = Array.from(t.querySelectorAll<HTMLButtonElement>('.m-chip')).find(
+      (b) => b.textContent?.trim() === 'TX',
+    );
+    expect(txChip, 'TX chip should be present when hasTx=true').toBeDefined();
+    txChip!.click();
+    flushSync();
+    expect(t.querySelector('#m-chip-panel-tx')).not.toBeNull();
+
+    // Simulate capability refresh: TX disappears.
+    txState.on = false;
+    flushSync();
+
+    // Guard $effect must reset activeChipId back to ESSENTIALS, so no panel goes blank.
+    expect(t.querySelector('#m-chip-panel-tx')).toBeNull();
+    expect(t.querySelector('#m-chip-panel-essentials')).not.toBeNull();
+    // ESSENTIALS chip should now be the active one in the chip bar.
+    const active = t.querySelector('.m-chip-bar .m-chip-active');
+    expect(active?.textContent?.trim()).toBe('ESSENTIALS');
+  });
 });
 
 describe('MobileRadioLayout chip-scroll IA (#839)', () => {

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.test.ts
@@ -24,6 +24,8 @@ vi.mock('../panels/ScanPanel.svelte', () => ({ default: function S() { return {}
 vi.mock('../panels/CwPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/DockMeterPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('./KeyboardHandler.svelte', () => ({ default: function S() { return {}; } }));
+// Note: ../panels/EssentialsPanel.svelte and ./mobile-chip-bar.svelte are intentionally
+// NOT mocked — the chip-scroll IA contract (#839) is part of what these tests cover.
 vi.mock('$lib/Button', () => ({ HardwareButton: function S() { return {}; } }));
 vi.mock('lucide-svelte', () => {
   const S = function () { return {}; };
@@ -190,14 +192,45 @@ describe('MobileRadioLayout structure', () => {
 });
 
 describe('MobileRadioLayout TX gating', () => {
-  it('renders PTT button when hasTx is true', () => {
+  it('renders TX chip when hasTx is true (#839)', () => {
     vi.mocked(hasTx).mockReturnValue(true);
-    expect(mountMobile().querySelector('.m-ptt-btn')).not.toBeNull();
+    const t = mountMobile();
+    const chipBar = t.querySelector('.m-chip-bar');
+    expect(chipBar).not.toBeNull();
+    const labels = Array.from(chipBar?.querySelectorAll('.m-chip') ?? []).map(
+      (b) => b.textContent?.trim(),
+    );
+    expect(labels).toContain('TX');
   });
 
-  it('hides PTT button when hasTx is false', () => {
+  it('omits TX chip when hasTx is false (#839)', () => {
     vi.mocked(hasTx).mockReturnValue(false);
-    expect(mountMobile().querySelector('.m-ptt-btn')).toBeNull();
+    const t = mountMobile();
+    const chipBar = t.querySelector('.m-chip-bar');
+    expect(chipBar).not.toBeNull();
+    const labels = Array.from(chipBar?.querySelectorAll('.m-chip') ?? []).map(
+      (b) => b.textContent?.trim(),
+    );
+    expect(labels).not.toContain('TX');
+    // And the TX-only PTT is not mounted on cold-open (ESSENTIALS active by default).
+    expect(t.querySelector('.m-ptt-btn')).toBeNull();
+  });
+});
+
+describe('MobileRadioLayout chip-scroll IA (#839)', () => {
+  it('renders chip bar inside m-content with ESSENTIALS default-active', () => {
+    const t = mountMobile();
+    const bar = t.querySelector('.m-content .m-chip-bar');
+    expect(bar).not.toBeNull();
+    const active = bar?.querySelector('.m-chip-active');
+    expect(active?.textContent?.trim()).toBe('ESSENTIALS');
+    expect(t.querySelector('#m-chip-panel-essentials')).not.toBeNull();
+  });
+
+  it('renders exactly one active chip panel at a time', () => {
+    const t = mountMobile();
+    const panels = t.querySelectorAll('[id^="m-chip-panel-"]');
+    expect(panels.length).toBe(1);
   });
 });
 

--- a/frontend/src/components-v2/layout/mobile-chip-bar.svelte
+++ b/frontend/src/components-v2/layout/mobile-chip-bar.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  /**
+   * Horizontal chip-scroll navigation bar for mobile portrait IA (#839).
+   * One active chip at a time. Horizontal scroll (touch) for overflow.
+   */
+  type ChipItem = { id: string; label: string };
+
+  interface Props {
+    chips: ChipItem[];
+    activeId: string;
+    onSelect: (id: string) => void;
+  }
+
+  let { chips, activeId, onSelect }: Props = $props();
+</script>
+
+<div class="m-chip-bar" role="tablist" aria-label="Mobile sections">
+  {#each chips as chip (chip.id)}
+    <button
+      type="button"
+      role="tab"
+      class="m-chip"
+      class:m-chip-active={chip.id === activeId}
+      aria-selected={chip.id === activeId}
+      aria-controls="m-chip-panel-{chip.id}"
+      onclick={() => onSelect(chip.id)}
+    >
+      {chip.label}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .m-chip-bar {
+    display: flex;
+    flex-shrink: 0;
+    gap: 4px;
+    padding: 6px 8px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+    background: var(--v2-bg-darker, #0a0a14);
+    border-bottom: 1px solid var(--v2-border-darker, #1a1a2e);
+  }
+
+  .m-chip-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .m-chip {
+    flex: 0 0 auto;
+    min-width: 56px;
+    min-height: 44px;
+    padding: 6px 14px;
+    border-radius: 22px;
+    border: 1px solid var(--v2-border-darker, #333);
+    background: var(--v2-bg-input, #1a1a2e);
+    color: var(--v2-text-secondary, #aaa);
+    font-family: 'Roboto Mono', monospace;
+    font-weight: 700;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+    white-space: nowrap;
+  }
+
+  .m-chip:focus-visible {
+    outline: 2px solid var(--v2-accent-cyan, #22d3ee);
+    outline-offset: 2px;
+  }
+
+  .m-chip-active {
+    background: var(--v2-accent-cyan, #22d3ee);
+    border-color: var(--v2-accent-cyan, #22d3ee);
+    color: var(--v2-bg-card, #111);
+  }
+</style>

--- a/frontend/src/components-v2/panels/EssentialsPanel.svelte
+++ b/frontend/src/components-v2/panels/EssentialsPanel.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  /**
+   * ESSENTIALS panel — mobile IA chip-scroll default-active content (#839).
+   * 90%-of-the-time controls: VFO ops, MODE quick, FILTER quick, AUDIO, DSP toggles.
+   */
+  import { HardwareButton } from '$lib/Button';
+  import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
+
+  interface Props {
+    vfoOps: { splitActive?: boolean };
+    mode: { currentMode: string; modes: string[] };
+    filter: { currentFilter: number; filterLabels?: string[] };
+    rxAudio: { monitorMode: string; afLevel: number };
+    dsp: { nbActive: boolean; nrMode: number; notchMode: string };
+    quickModes: string[];
+    onSplitToggle: () => void;
+    onSwap: () => void;
+    onEqual: () => void;
+    onModeChange: (m: string) => void;
+    onModeMore: () => void;
+    onFilterChange: (n: number) => void;
+    onFilterMore: () => void;
+    onMonitorModeChange: (m: string) => void;
+    onAfLevelChange: (v: number) => void;
+    onNbToggle: (v: boolean) => void;
+    onNrModeChange: (v: number) => void;
+    onNotchModeChange: (v: string) => void;
+  }
+
+  let {
+    vfoOps,
+    mode,
+    filter,
+    rxAudio,
+    dsp,
+    quickModes,
+    onSplitToggle,
+    onSwap,
+    onEqual,
+    onModeChange,
+    onModeMore,
+    onFilterChange,
+    onFilterMore,
+    onMonitorModeChange,
+    onAfLevelChange,
+    onNbToggle,
+    onNrModeChange,
+    onNotchModeChange,
+  }: Props = $props();
+</script>
+
+<div class="m-essentials">
+  <!-- VFO ops -->
+  <div class="m-row m-vfo-ops">
+    <HardwareButton
+      active={vfoOps.splitActive ?? false}
+      indicator="edge-left"
+      color={vfoOps.splitActive ? 'yellow' : 'muted'}
+      onclick={onSplitToggle}
+    >
+      SPLIT
+    </HardwareButton>
+    <HardwareButton indicator="edge-left" color="cyan" onclick={onSwap}>
+      A↔B
+    </HardwareButton>
+    <HardwareButton indicator="edge-left" color="cyan" onclick={onEqual}>
+      A=B
+    </HardwareButton>
+  </div>
+
+  <!-- MODE quick -->
+  <div class="m-row">
+    {#each quickModes as m}
+      <HardwareButton
+        active={mode.currentMode === m}
+        indicator="edge-left"
+        color="cyan"
+        onclick={() => onModeChange(m)}
+      >
+        {m}
+      </HardwareButton>
+    {/each}
+    <HardwareButton indicator="edge-left" color="muted" onclick={onModeMore}>
+      More…
+    </HardwareButton>
+  </div>
+
+  <!-- FILTER quick -->
+  <div class="m-row">
+    {#each (filter.filterLabels ?? ['FIL1', 'FIL2', 'FIL3']) as label, idx}
+      <HardwareButton
+        active={filter.currentFilter === idx + 1}
+        indicator="edge-left"
+        color="cyan"
+        onclick={() => onFilterChange(idx + 1)}
+      >
+        {label}
+      </HardwareButton>
+    {/each}
+    <HardwareButton indicator="edge-left" color="muted" onclick={onFilterMore}>
+      More…
+    </HardwareButton>
+  </div>
+
+  <!-- AUDIO monitor mode -->
+  <div class="m-row">
+    {#each ['local', 'live', 'mute'] as opt}
+      <HardwareButton
+        active={rxAudio.monitorMode === opt}
+        indicator="edge-left"
+        color={opt === 'mute' ? 'red' : 'cyan'}
+        onclick={() => onMonitorModeChange(opt)}
+      >
+        {opt === 'local' ? 'LOCAL' : opt === 'live' ? 'LIVE' : 'MUTE'}
+      </HardwareButton>
+    {/each}
+  </div>
+
+  <!-- AF level -->
+  <ValueControl
+    label="AF Level"
+    value={rxAudio.afLevel}
+    min={0}
+    max={255}
+    step={1}
+    renderer="hbar"
+    displayFn={rawToPercentDisplay}
+    accentColor="var(--v2-accent-cyan-alt)"
+    onChange={onAfLevelChange}
+    variant="hardware-illuminated"
+  />
+
+  <!-- DSP toggles -->
+  <div class="m-row">
+    <HardwareButton
+      active={dsp.nbActive}
+      indicator="edge-left"
+      color={dsp.nbActive ? 'green' : 'muted'}
+      onclick={() => onNbToggle(!dsp.nbActive)}
+    >
+      NB
+    </HardwareButton>
+    <HardwareButton
+      active={dsp.nrMode > 0}
+      indicator="edge-left"
+      color={dsp.nrMode > 0 ? 'green' : 'muted'}
+      onclick={() => onNrModeChange(dsp.nrMode > 0 ? 0 : 1)}
+    >
+      NR
+    </HardwareButton>
+    <HardwareButton
+      active={dsp.notchMode !== 'off'}
+      indicator="edge-left"
+      color={dsp.notchMode !== 'off' ? 'green' : 'muted'}
+      onclick={() => onNotchModeChange(dsp.notchMode !== 'off' ? 'off' : 'auto')}
+    >
+      NOTCH
+    </HardwareButton>
+  </div>
+</div>
+
+<style>
+  .m-essentials {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+  }
+
+  .m-row {
+    display: flex;
+    gap: 4px;
+  }
+
+  .m-row > :global(button) {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 44px;
+  }
+
+  .m-vfo-ops > :global(button) {
+    min-height: 36px;
+  }
+</style>


### PR DESCRIPTION
Closes #839.

Implements Option D from `docs/plans/2026-04-18-mobile-ia.md` §10.1 — replaces the stacked collapsible `m-section` accordion in the portrait `m-content` region with a horizontal chip-scroll nav + single-active chip content area.

## Summary
- New `mobile-chip-bar.svelte` — horizontal scrolling pill chips with `role="tablist"` / `aria-selected` semantics.
- New `EssentialsPanel.svelte` — default-active "90% panel" hosting VFO ops (SPLIT/A↔B/A=B), MODE quick-picks (LSB/USB/CW/AM + More), FILTER quick-picks (FIL1/2/3 + More), AUDIO monitor (LOCAL/LIVE/MUTE) + AF level, and DSP toggles (NB/NR/NOTCH).
- `MobileRadioLayout.svelte` portrait region rewired to chip bar + single active `.m-section` (ESSENTIALS | BAND | SCAN | RF | TX, last gated on `hasTx()`).

## Preservation (byte-for-byte where feasible)
- Landscape branch (`.m-landscape`) — untouched.
- `m-receiver-pill` segmented MAIN/SUB selector (#774) — untouched.
- Wake Lock + iOS video fallback path — untouched.
- Fullscreen logic + `checkOrientation` — untouched.
- PTT state machine (held / latched / double-tap / 3-min safety timer) — untouched (still lives in the TX chip body for this issue; #840 will relocate to a FAB).
- ATU long-press, sticky VFO header, S-meter bar, tuning strip — untouched.
- All bottom sheets (SETTINGS / MODE / FILTER / POWER / TX SETTINGS) — untouched.

## Test file update — justification
The structural selector contract changed: `.m-ptt-btn` is no longer mounted on cold-open because ESSENTIALS is the default chip. The two existing "TX gating" tests were updated to assert on chip-bar labels; new tests assert chip-scroll IA invariants (chip bar inside `m-content`, ESSENTIALS active by default, exactly one chip panel mounted at a time). This pushes the file count to 4 and is flagged in the issue as acceptable with justification.

## Test plan
- [x] `npx vitest run` — 1571/1571 pass (84 test files).
- [x] `uv run ruff check src/ tests/` — zero violations.
- [x] `uv run pytest -q --ignore=tests/integration` — baseline failures only (4 pre-existing in `test_per_receiver_vfo_roundtlip.py` and `test_web_server.py`; unrelated to frontend).
- [ ] Manual smoke on a phone or Chrome mobile emulation: cold-open shows ESSENTIALS; tapping BAND/SCAN/RF/TX chips swaps the active panel; landscape flip still enters fullscreen + Wake Lock; PTT still works from TX chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)