### PR TITLE
feat(#825): remove activate-chip + toActiveReceiverProps adapter (PR 2/2)

### DIFF
--- a/frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte
+++ b/frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte
@@ -2,14 +2,12 @@
   DualVfoDisplay — side-by-side MAIN + SUB VFO tiles for dual-RX radios.
 
   Presentation-only: renders two VfoPanel tiles. The active tile is visually
-  highlighted via the `.is-active` class. The inactive tile exposes a small
-  dedicated "Activate" button so screen-reader / keyboard users can switch
-  receivers without the tile container becoming a button that swallows its
-  interactive descendants (tuning digits, mode badge) — which would violate
-  WCAG 4.1.2 (no nested interactive content inside role="button").
+  highlighted via the `.is-active` class. Receiver activation is performed
+  via the segmented [M|S] toggle in VfoOps (see `ActiveReceiverToggle.svelte`,
+  issue #825 Option B) — a single primary affordance, no duplicate UX.
 
-  Wiring (set_vfo + optimistic patchRadioState) lives at the VfoHeader
-  call-site.
+  The `onActivate` prop is retained for API compatibility and is used by
+  tests, but is no longer wired to any in-tile control.
 -->
 <script lang="ts">
   import VfoPanel from '../../../components-v2/vfo/VfoPanel.svelte';
@@ -28,22 +26,19 @@
     onSubFreqChange?: (freq: number) => void;
   }
 
+  // `onActivate` is retained in the Props type for API compatibility
+  // but is no longer wired to any in-tile control. Receiver activation
+  // lives in the segmented [M|S] toggle (ActiveReceiverToggle) in VfoOps.
   let {
     main,
     sub,
     active,
     layoutProfile = 'baseline',
-    onActivate,
     onMainModeClick,
     onSubModeClick,
     onMainFreqChange,
     onSubFreqChange,
   }: Props = $props();
-
-  function activate(receiver: 'MAIN' | 'SUB'): void {
-    if (active === receiver) return;
-    onActivate?.(receiver);
-  }
 </script>
 
 <div
@@ -58,17 +53,6 @@
     onModeClick={onMainModeClick}
     onFreqChange={onMainFreqChange}
   />
-  {#if active !== 'MAIN'}
-    <button
-      type="button"
-      class="activate-chip"
-      aria-label="Activate MAIN receiver"
-      data-activate="main"
-      onclick={() => activate('MAIN')}
-    >
-      Activate MAIN
-    </button>
-  {/if}
 </div>
 
 <div
@@ -83,17 +67,6 @@
     onModeClick={onSubModeClick}
     onFreqChange={onSubFreqChange}
   />
-  {#if active !== 'SUB'}
-    <button
-      type="button"
-      class="activate-chip"
-      aria-label="Activate SUB receiver"
-      data-activate="sub"
-      onclick={() => activate('SUB')}
-    >
-      Activate SUB
-    </button>
-  {/if}
 </div>
 
 <style>
@@ -109,37 +82,5 @@
     /* Active highlight is rendered by the inner VfoPanel.active class.
        This selector exists so tests and external CSS can target the
        outer tile without reaching into the panel. */
-  }
-
-  .activate-chip {
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    z-index: 2;
-    padding: 2px 8px;
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--v2-accent-cyan, #00d4ff);
-    background: rgba(0, 0, 0, 0.55);
-    border: 1px solid var(--v2-accent-cyan, #00d4ff);
-    border-radius: 999px;
-    cursor: pointer;
-    opacity: 0.75;
-    transition:
-      opacity 150ms ease,
-      background-color 150ms ease;
-  }
-
-  .activate-chip:hover {
-    opacity: 1;
-    background: rgba(0, 0, 0, 0.75);
-  }
-
-  .activate-chip:focus-visible {
-    outline: none;
-    opacity: 1;
-    box-shadow: 0 0 0 2px var(--v2-accent-cyan, #00d4ff);
   }
 </style>

--- a/frontend/src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts
+++ b/frontend/src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts
@@ -111,79 +111,32 @@ describe('DualVfoDisplay', () => {
     });
   });
 
-  describe('activate button', () => {
-    it('inactive tile renders an activate button (SUB inactive)', () => {
+  describe('activate-chip removal (issue #825 Option B)', () => {
+    it('no activate-chip button is rendered on either tile when MAIN is active', () => {
       const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
-      expect(t.querySelector('button[data-activate="sub"]')).not.toBeNull();
       expect(t.querySelector('button[data-activate="main"]')).toBeNull();
-    });
-
-    it('inactive tile renders an activate button (MAIN inactive)', () => {
-      const t = mountDisplay({
-        main: { ...mainVfo, isActive: false },
-        sub: { ...subVfo, isActive: true },
-        active: 'SUB',
-      });
-      expect(t.querySelector('button[data-activate="main"]')).not.toBeNull();
       expect(t.querySelector('button[data-activate="sub"]')).toBeNull();
+      expect(t.querySelector('.activate-chip')).toBeNull();
     });
 
-    it('activate button has descriptive aria-label', () => {
-      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
-      const btn = t.querySelector<HTMLButtonElement>('button[data-activate="sub"]');
-      expect(btn?.getAttribute('aria-label')).toBe('Activate SUB receiver');
-    });
-
-    it('activate button is a native <button> and keyboard-focusable by default', () => {
-      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN' });
-      const btn = t.querySelector<HTMLButtonElement>('button[data-activate="sub"]');
-      expect(btn).not.toBeNull();
-      expect(btn?.tagName).toBe('BUTTON');
-      expect(btn?.getAttribute('type')).toBe('button');
-      // Native <button> is focusable without explicit tabindex.
-      expect(btn?.hasAttribute('disabled')).toBe(false);
-    });
-  });
-
-  describe('onActivate callback', () => {
-    it('clicking activate button fires onActivate with the receiver id (SUB)', () => {
-      const onActivate = vi.fn();
-      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
-      t.querySelector<HTMLButtonElement>('button[data-activate="sub"]')?.click();
-      expect(onActivate).toHaveBeenCalledOnce();
-      expect(onActivate).toHaveBeenCalledWith('SUB');
-    });
-
-    it('clicking activate button fires onActivate with the receiver id (MAIN)', () => {
-      const onActivate = vi.fn();
+    it('no activate-chip button is rendered on either tile when SUB is active', () => {
       const t = mountDisplay({
         main: { ...mainVfo, isActive: false },
         sub: { ...subVfo, isActive: true },
         active: 'SUB',
-        onActivate,
       });
-      t.querySelector<HTMLButtonElement>('button[data-activate="main"]')?.click();
-      expect(onActivate).toHaveBeenCalledOnce();
-      expect(onActivate).toHaveBeenCalledWith('MAIN');
-    });
-
-    it('active tile does not render an activate button', () => {
-      const onActivate = vi.fn();
-      const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
-      // No button on the active (MAIN) tile — nothing to click.
       expect(t.querySelector('button[data-activate="main"]')).toBeNull();
-      expect(onActivate).not.toHaveBeenCalled();
+      expect(t.querySelector('button[data-activate="sub"]')).toBeNull();
+      expect(t.querySelector('.activate-chip')).toBeNull();
     });
 
     it('clicking the outer tile does NOT fire onActivate', () => {
-      // Outer tile is no longer interactive — only the activate button inside it is.
+      // Outer tile has never been interactive, and the inner chip is gone.
       const onActivate = vi.fn();
       const t = mountDisplay({ main: mainVfo, sub: subVfo, active: 'MAIN', onActivate });
       const subTile = t.querySelector<HTMLElement>('[data-receiver="sub"]');
       subTile?.click();
-      // The click bubbles from the tile itself (not the inner button), so no activation.
-      // Note: if the click originated on the button, it would fire — but that's covered above.
-      expect(onActivate).not.toHaveBeenCalledWith('MAIN');
+      expect(onActivate).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -149,6 +149,24 @@ export function toDualVfoProps(state: ServerState | null): DualVfoProps {
   };
 }
 
+/* ── Active Receiver ─────────────────────────────────────────── */
+
+export interface ActiveReceiverProps {
+  active: 'MAIN' | 'SUB';
+}
+
+/**
+ * Props for the segmented [M|S] ActiveReceiverToggle (issue #825).
+ * Reads `state.active` directly — no caps dependency.
+ */
+export function toActiveReceiverProps(
+  state: ServerState | null,
+): ActiveReceiverProps {
+  return {
+    active: state?.active === 'SUB' ? 'SUB' : 'MAIN',
+  };
+}
+
 /* ── RF Front End ────────────────────────────────────────────── */
 
 export interface RfFrontEndProps {


### PR DESCRIPTION
## Summary
Part 2 of 2 for #825 (Option B). Paired with #856.

- Removes the per-tile `activate-chip` markup and CSS from `DualVfoDisplay.svelte`. The segmented `[M|S]` `ActiveReceiverToggle` (PR #856) becomes the single primary affordance for switching the active receiver from the UI.
- Adds `toActiveReceiverProps(state)` in `wiring/state-adapter.ts` for future consumers that want `{ active }` without pulling the full dual-VFO props.
- Updates `DualVfoDisplay.test.ts` to assert the chip is gone and the outer tile remains non-interactive.

The `onActivate` prop is retained on the `DualVfoDisplay` Props type for backward compatibility — no current caller relies on it firing, but dropping it would cascade into `VfoHeader` and expand the change beyond 3 files.

## Paired PR
Must land together with #856 — merge #856 first so the toggle exists before the chip is removed, otherwise dual-RX users lose the ability to switch receivers from the UI in the window between merges.

## Test plan
- [x] `npx vitest run src/components-v2/panels/vfo/ src/components-v2/wiring/` — 60 tests pass
- [x] Full frontend suite: 1564 tests pass
- [x] `eslint` — clean on changed files
- [ ] Manual: verify no `.activate-chip` in DOM on dual-RX skin
- [ ] Manual: confirm tile visual highlight still follows `state.active`

Part of Issue B in `docs/plans/2026-04-18-receiver-activation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)