### PR TITLE
fix(#807): move settings gear into StatusBar

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -55,7 +55,6 @@
   import RitXitPanel from '../panels/RitXitPanel.svelte';
   import CwPanel from '../panels/CwPanel.svelte';
   import { HardwareButton } from '$lib/Button';
-  import { Settings } from 'lucide-svelte';
   import Toast from '../../components/shared/Toast.svelte';
 
   // Reactive state + capabilities — via runtime
@@ -202,10 +201,7 @@
   <LcdLayout />
 {:else}
 <div class="radio-layout">
-  <StatusBar />
-  <button class="settings-button" onclick={() => (settingsOpen = true)} title="Settings">
-    <Settings size={20} />
-  </button>
+  <StatusBar onSettings={() => (settingsOpen = true)} />
   <KeyboardHandler config={keyboardConfig} onAction={keyboardHandlers.dispatch} />
 
   <section class="receiver-deck" bind:this={receiverDeckElement} style={receiverDeckStyle}>
@@ -814,35 +810,6 @@
     .power-off-content {
       animation: none;
     }
-  }
-
-  /* ── Settings Button ── */
-  .settings-button {
-    position: fixed;
-    top: 36px;
-    right: 16px;
-    z-index: 100;
-    width: 40px;
-    height: 40px;
-    border: 1px solid var(--v2-border-panel, #333);
-    border-radius: 6px;
-    background: var(--v2-bg-card, #1a1a2e);
-    color: var(--v2-text-secondary, #aaa);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 150ms;
-  }
-
-  .settings-button:hover {
-    background: var(--v2-bg-panel, #252540);
-    color: var(--v2-accent-cyan, #00d4ff);
-    border-color: var(--v2-accent-cyan, #00d4ff);
-  }
-
-  .settings-button:active {
-    transform: scale(0.95);
   }
 
   /* ── Settings Modal ── */

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Radio, Cable, Activity, Volume2, ArrowDownUp, Power, Unplug, Palette, Monitor, Tv } from 'lucide-svelte';
+  import { Radio, Cable, Activity, Volume2, ArrowDownUp, Power, Unplug, Palette, Monitor, Tv, Settings } from 'lucide-svelte';
   import ThemePicker from '../controls/ThemePicker.svelte';
   import { runtime } from '$lib/runtime';
   import {
@@ -14,6 +14,11 @@
   import { getFrequency } from '$lib/stores/radio.svelte';
   import { hasAnyScope, hasAudio, hasSpectrum } from '$lib/stores/capabilities.svelte';
   import { getLayoutMode, cycleLayoutMode } from '$lib/stores/layout.svelte';
+
+  interface Props {
+    onSettings?: () => void;
+  }
+  let { onSettings }: Props = $props();
 
   let layoutMode = $derived(getLayoutMode());
   let hasAnyScopeAvail = $derived(hasAnyScope());
@@ -185,6 +190,17 @@
   </div>
 
   <div class="status-controls">
+    {#if onSettings}
+      <button
+        type="button"
+        class="control-btn settings-btn"
+        onclick={onSettings}
+        title="Settings"
+        aria-label="Settings"
+      >
+        <Settings size={14} strokeWidth={2} />
+      </button>
+    {/if}
     <button
       type="button"
       class="control-btn layout-btn"


### PR DESCRIPTION
## Summary
- Remove fixed-positioned settings gear (top:36px right:16px) from `RadioLayout.svelte` — it visually collided with the VFO header.
- Add gear `control-btn` to `StatusBar.svelte` at the start of the `.status-controls` row, alongside STD / ThemePicker / Disconnect / Power toggle.
- New optional `onSettings` prop on StatusBar; `RadioLayout` wires it to `settingsOpen = true`.
- Uses `Settings` icon from `lucide-svelte`.

Closes #807. Supersedes closed PR #850.

## Test plan
- [x] `npx vitest run src/components-v2/layout/__tests__/` — 152/152 passed
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run pytest tests/ -q --ignore=tests/integration` — 4 pre-existing failures unrelated to diff (same failures on main without changes)
- [ ] Manual: gear in StatusBar opens settings modal; no fixed-position gear overlapping VFO header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)