### PR TITLE
feat(#822): Id/Vd/COMP tiles with capability gating

### DIFF
--- a/frontend/src/components-v2/panels/MetersDockPanel.svelte
+++ b/frontend/src/components-v2/panels/MetersDockPanel.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import {
     formatAlc,
+    formatAmps,
+    formatCompDb,
     formatPowerWatts,
     formatSMeter,
     formatSwr,
+    formatVolts,
     normalize,
     normalizePower,
   } from './meter-utils';
@@ -13,8 +16,9 @@
    * dock. Renders an auto-fit grid of tiles for each meter whose raw value
    * is defined on the runtime state (capability gating by `!== undefined`).
    *
-   * Scope: issue #820 ships Po / SWR / ALC / S tiles. Id / Vd / COMP land
-   * with #822; peak-hold and fault highlighting land with #823.
+   * Scope: issue #820 shipped Po / SWR / ALC / S tiles. Issue #822 adds
+   * Id / Vd / COMP (COMP additionally gated on `compressorOn === true`).
+   * Peak-hold and fault highlighting land with #823.
    *
    * The panel is pure presentation — no store / transport imports.
    */
@@ -23,13 +27,27 @@
     powerMeter?: number;
     swrMeter?: number;
     alcMeter?: number;
+    idMeter?: number;
+    vdMeter?: number;
+    compMeter?: number;
+    compressorOn?: boolean;
     txActive: boolean;
   }
 
-  let { sValue, powerMeter, swrMeter, alcMeter, txActive }: Props = $props();
+  let {
+    sValue,
+    powerMeter,
+    swrMeter,
+    alcMeter,
+    idMeter,
+    vdMeter,
+    compMeter,
+    compressorOn,
+    txActive,
+  }: Props = $props();
 
   interface Tile {
-    key: 'po' | 'swr' | 'alc' | 's';
+    key: 'po' | 'swr' | 'alc' | 's' | 'id' | 'vd' | 'comp';
     label: string;
     display: string;
     fillPct: number;
@@ -72,6 +90,39 @@
         fillPct: normalize(alcMeter) * 100,
         fill: 'var(--v2-meter-alc-fill)',
         track: 'var(--v2-meter-alc-track)',
+        relevant: txActive,
+      });
+    }
+    if (idMeter !== undefined) {
+      out.push({
+        key: 'id',
+        label: 'Id',
+        display: formatAmps(idMeter),
+        fillPct: normalize(idMeter) * 100,
+        fill: 'var(--v2-meter-id-fill)',
+        track: 'var(--v2-meter-id-track)',
+        relevant: txActive,
+      });
+    }
+    if (vdMeter !== undefined) {
+      out.push({
+        key: 'vd',
+        label: 'Vd',
+        display: formatVolts(vdMeter),
+        fillPct: normalize(vdMeter) * 100,
+        fill: 'var(--v2-meter-vd-fill)',
+        track: 'var(--v2-meter-vd-track)',
+        relevant: txActive,
+      });
+    }
+    if (compMeter !== undefined && compressorOn === true) {
+      out.push({
+        key: 'comp',
+        label: 'COMP',
+        display: formatCompDb(compMeter),
+        fillPct: normalize(compMeter) * 100,
+        fill: 'var(--v2-meter-comp-fill)',
+        track: 'var(--v2-meter-comp-track)',
         relevant: txActive,
       });
     }

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
@@ -198,6 +198,67 @@ describe('MetersDockPanel capability gating', () => {
     });
     expect(t.querySelector('.dock-title')?.textContent).toBe('STATION METERS');
   });
+
+  it('renders Id tile when idMeter is defined', () => {
+    const t = mountPanel({ ...fullProps, idMeter: 151 });
+    const tile = t.querySelector('[data-meter="id"]');
+    expect(tile).not.toBeNull();
+    expect(tile?.querySelector('.tile-value')?.textContent).toBe('10.0 A');
+  });
+
+  it('hides Id tile when idMeter is undefined', () => {
+    const t = mountPanel({ ...fullProps, idMeter: undefined });
+    expect(t.querySelector('[data-meter="id"]')).toBeNull();
+  });
+
+  it('renders Vd tile when vdMeter is defined', () => {
+    const t = mountPanel({ ...fullProps, vdMeter: 13 });
+    const tile = t.querySelector('[data-meter="vd"]');
+    expect(tile).not.toBeNull();
+    expect(tile?.querySelector('.tile-value')?.textContent).toBe('10.0 V');
+  });
+
+  it('hides Vd tile when vdMeter is undefined', () => {
+    const t = mountPanel({ ...fullProps, vdMeter: undefined });
+    expect(t.querySelector('[data-meter="vd"]')).toBeNull();
+  });
+
+  it('renders COMP tile when compMeter is defined and compressorOn=true', () => {
+    const t = mountPanel({ ...fullProps, compMeter: 75, compressorOn: true });
+    const tile = t.querySelector('[data-meter="comp"]');
+    expect(tile).not.toBeNull();
+    expect(tile?.querySelector('.tile-value')?.textContent).toBe('15 dB');
+  });
+
+  it('hides COMP tile when compressorOn is false', () => {
+    const t = mountPanel({ ...fullProps, compMeter: 75, compressorOn: false });
+    expect(t.querySelector('[data-meter="comp"]')).toBeNull();
+  });
+
+  it('hides COMP tile when compressorOn is undefined (gating)', () => {
+    const t = mountPanel({ ...fullProps, compMeter: 75 });
+    expect(t.querySelector('[data-meter="comp"]')).toBeNull();
+  });
+
+  it('hides COMP tile when compMeter is undefined even with compressorOn=true', () => {
+    const t = mountPanel({ ...fullProps, compMeter: undefined, compressorOn: true });
+    expect(t.querySelector('[data-meter="comp"]')).toBeNull();
+  });
+
+  it('renders all seven tiles when all state fields are defined', () => {
+    const t = mountPanel({
+      ...fullProps,
+      idMeter: 100,
+      vdMeter: 13,
+      compMeter: 75,
+      compressorOn: true,
+    });
+    expect(t.querySelectorAll('.dock-tile')).toHaveLength(7);
+    const keys = Array.from(t.querySelectorAll('.dock-tile')).map((el) =>
+      el.getAttribute('data-meter'),
+    );
+    expect(keys).toEqual(['po', 'swr', 'alc', 'id', 'vd', 'comp', 's']);
+  });
 });
 
 describe('MetersDockPanel relevance dimming', () => {

--- a/frontend/src/components-v2/theme/tokens.css
+++ b/frontend/src/components-v2/theme/tokens.css
@@ -178,6 +178,12 @@
   --v2-meter-swr-track: linear-gradient(90deg, rgba(15, 90, 55, 0.35) 0%, rgba(24, 195, 111, 0.22) 52%, rgba(164, 135, 18, 0.16) 68%, rgba(126, 24, 15, 0.2) 100%);
   --v2-meter-alc-fill: linear-gradient(90deg, #0d4b31 0%, #3e8b29 32%, #e1b43c 58%, #9e2710 100%);
   --v2-meter-alc-track: linear-gradient(90deg, rgba(13, 75, 49, 0.34) 0%, rgba(62, 139, 41, 0.2) 32%, rgba(225, 180, 60, 0.17) 58%, rgba(158, 39, 16, 0.2) 100%);
+  --v2-meter-id-fill: linear-gradient(90deg, #5a2a08 0%, #d07a1a 55%, #f7c357 100%);
+  --v2-meter-id-track: linear-gradient(90deg, rgba(90, 42, 8, 0.32) 0%, rgba(208, 122, 26, 0.2) 55%, rgba(247, 195, 87, 0.14) 100%);
+  --v2-meter-vd-fill: linear-gradient(90deg, #0c4a6e 0%, #2fa5d6 55%, #8fe8ff 100%);
+  --v2-meter-vd-track: linear-gradient(90deg, rgba(12, 74, 110, 0.32) 0%, rgba(47, 165, 214, 0.2) 55%, rgba(143, 232, 255, 0.14) 100%);
+  --v2-meter-comp-fill: linear-gradient(90deg, #0f5a37 0%, #2fbd6b 55%, #b7f0a8 100%);
+  --v2-meter-comp-track: linear-gradient(90deg, rgba(15, 90, 55, 0.32) 0%, rgba(47, 189, 107, 0.2) 55%, rgba(183, 240, 168, 0.14) 100%);
 
   /* Meter Source Tags */
   --v2-meter-source-s-bg: rgba(12, 54, 76, 0.52);


### PR DESCRIPTION
## Summary
- Extends `MetersDockPanel` from #820 with Id (drain current), Vd (drain voltage), and COMP (speech compressor) tiles.
- Capability-gated: each tile renders only when its `*Meter` prop is `!== undefined`. COMP is additionally gated on `compressorOn === true` per the design plan.
- Adds 3 new gradient token pairs (`--v2-meter-{id,vd,comp}-{fill,track}`) to `tokens.css`; reuses `formatAmps` / `formatVolts` / `formatCompDb` already landed in `meter-utils.ts` by #820.

All three new tiles are TX-relevant (dimmed on RX). No store/transport imports; pure presentation per the v2 panels layering rules. Out of scope: peak-hold (#823), RadioLayout mount (#821).

Closes #822.

## Test plan
- [x] `npx vitest run src/components-v2/panels/__tests__/MetersDockPanel.test.ts` — 41 tests pass, including new capability-matrix cases for Id/Vd/COMP and a 7-tile ordering case (`po, swr, alc, id, vd, comp, s`).
- [x] `npx eslint` on changed files — clean.
- [x] Grid reflows correctly when tiles are hidden (asserted via existing `dock-tile` count tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)