### PR TITLE
style(#826): strengthen active/inactive VFO panel treatment

### DIFF
--- a/frontend/src/components-v2/theme/tokens.css
+++ b/frontend/src/components-v2/theme/tokens.css
@@ -146,8 +146,10 @@
   --v2-receiver-sub-accent: #FF6A00;    /* orange */
   --v2-vfo-main-control-border: rgba(0, 212, 255, 0.48);
   --v2-vfo-main-control-glow: rgba(0, 212, 255, 0.12);
+  --v2-vfo-main-panel-glow-outer: rgba(0, 212, 255, 0.35);
   --v2-vfo-sub-control-border: rgba(255, 106, 0, 0.48);
   --v2-vfo-sub-control-glow: rgba(255, 106, 0, 0.12);
+  --v2-vfo-sub-panel-glow-outer: rgba(255, 106, 0, 0.35);
 
   /* VFO Indicators */
   --v2-vfo-active-glow: rgba(0, 212, 255, 0.08);

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -47,6 +47,7 @@
     '--receiver-accent': `var(--v2-receiver-${receiver}-accent)`,
     '--receiver-control-border': `var(--v2-vfo-${receiver}-control-border)`,
     '--receiver-control-glow': `var(--v2-vfo-${receiver}-control-glow)`,
+    '--receiver-panel-glow-outer': `var(--v2-vfo-${receiver}-panel-glow-outer)`,
   });
 </script>
 
@@ -130,12 +131,24 @@
     border-radius: 4px;
     overflow: hidden;
     font-family: 'Roboto Mono', monospace;
-    transition: border-color 150ms ease;
+    transition: border-color 150ms ease, box-shadow 150ms ease;
   }
 
   .panel.active {
     border-color: var(--receiver-control-border);
-    box-shadow: inset 0 0 0 1px var(--receiver-control-glow);
+    box-shadow:
+      inset 0 0 0 1px var(--receiver-control-glow),
+      0 0 12px 1px var(--receiver-panel-glow-outer);
+  }
+
+  .panel-meter,
+  .control-strip {
+    transition: filter 150ms ease;
+  }
+
+  .panel:not(.active) .panel-meter,
+  .panel:not(.active) .control-strip {
+    filter: saturate(0.4) brightness(0.85);
   }
 
   .panel-header {


### PR DESCRIPTION
## Summary

- Widen `.panel.active` glow in `VfoPanel.svelte` by adding an outer
  colored box-shadow on top of the existing inset line, so the active
  receiver reads as visibly lit.
- Desaturate `.panel-meter` and `.control-strip` on the inactive panel
  (`filter: saturate(0.4) brightness(0.85)`) so the idle side looks
  dimmed, not just "missing its glow".
- Introduce new receiver-scoped tokens `--v2-vfo-main-panel-glow-outer`
  (cyan) and `--v2-vfo-sub-panel-glow-outer` (orange) in `tokens.css`,
  wired through `receiverChromeVars`.

Implements Issue C of `docs/plans/2026-04-18-receiver-activation.md`.
Pure CSS — no markup or behavior change. Closes #826.

## Test plan

- [x] `npx vitest run` — 1592/1592 tests pass (VfoPanel 46/46)
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Visually verify MAIN active: cyan outer glow, SUB meter/controls desaturate
- [ ] Visually verify SUB active: orange outer glow, MAIN meter/controls desaturate
- [ ] Visually verify transition between active/inactive is smooth (150ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)