### PR TITLE
refactor(#832): move SCOPE status to VfoHeader bridge

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -14,7 +14,7 @@
   
   import { runtime } from '$lib/runtime';
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
-  import { getKeyboardConfig, hasDualReceiver, hasTx, hasAnyScope, hasSpectrum, hasAudioFft } from '$lib/stores/capabilities.svelte';
+  import { getKeyboardConfig, hasCapability, hasDualReceiver, hasTx, hasAnyScope, hasSpectrum, hasAudioFft } from '$lib/stores/capabilities.svelte';
   import { getLayoutMode } from '$lib/stores/layout.svelte';
   import { resolveSkinId, type SkinId } from '../../skins/registry';
   import SpectrumPanel from '../../components/spectrum/SpectrumPanel.svelte';
@@ -61,6 +61,29 @@
   // Reactive state + capabilities — via runtime
   let radioState = $derived(runtime.state);
   let caps = $derived(runtime.caps);
+
+  // Scope digest for VfoHeader bridge (issue #832).  Gate on `scope` capability;
+  // VfoHeader treats null as "hide the block".
+  let scopeStatus = $derived.by(() => {
+    if (!hasCapability('scope')) return null;
+    const sc = (radioState as { scopeControls?: { dual?: boolean; receiver?: number; span?: number; speed?: number } } | null)?.scopeControls;
+    if (!sc) return null;
+    return {
+      dual: sc.dual ?? false,
+      receiver: sc.receiver ?? 0,
+      span: sc.span ?? 3,
+      speed: sc.speed ?? 1,
+    };
+  });
+
+  function handleScopeDualToggle(): void {
+    const current = (radioState as { scopeControls?: { dual?: boolean } } | null)?.scopeControls?.dual ?? false;
+    runtime.send('set_scope_dual', { dual: !current });
+  }
+
+  function handleScopeReceiverChange(receiver: 0 | 1): void {
+    runtime.send('switch_scope_receiver', { receiver });
+  }
   let keyboardConfig = $derived(getKeyboardConfig());
   let activeMode = $derived(radioState?.active === 'SUB' ? radioState?.sub?.mode : radioState?.main?.mode);
 
@@ -229,6 +252,9 @@
       onSubFreqChange={vfoHandlers.onSubFreqChange}
       onSubModeClick={vfoHandlers.onSubModeClick}
       onSpeak={systemHandlers.onSpeak}
+      {scopeStatus}
+      onScopeDualToggle={handleScopeDualToggle}
+      onScopeReceiverChange={handleScopeReceiverChange}
     />
   </section>
 

--- a/frontend/src/components-v2/layout/VfoHeader.svelte
+++ b/frontend/src/components-v2/layout/VfoHeader.svelte
@@ -1,3 +1,13 @@
+<script module lang="ts">
+  /** Subset of ScopeControls consumed by the bridge SCOPE-status block (issue #832). */
+  export interface ScopeStatusProps {
+    dual: boolean;
+    receiver: number;
+    span: number;
+    speed: number;
+  }
+</script>
+
 <script lang="ts">
   import VfoPanel from '../vfo/VfoPanel.svelte';
   import VfoOps from '../vfo/VfoOps.svelte';
@@ -8,6 +18,15 @@
   import type { VfoLayoutProfile } from './vfo-layout-tokens';
   import type { VfoStateProps } from './layout-utils';
 
+  // Labels duplicated from spectrum-toolbar-logic.ts to avoid a reverse
+  // dependency from layout/ → components/spectrum/. These are small and
+  // stable (Icom IC-7610 scope constants).
+  const SPAN_LABELS: Record<number, string> = {
+    0: '\u00b12.5k', 1: '\u00b15k', 2: '\u00b110k', 3: '\u00b125k',
+    4: '\u00b150k', 5: '\u00b1100k', 6: '\u00b1250k', 7: '\u00b1500k',
+  };
+  const SPEED_LABELS: Record<number, string> = { 0: 'FST', 1: 'MID', 2: 'SLO' };
+
   interface Props {
     mainVfo: VfoStateProps;
     subVfo: VfoStateProps;
@@ -16,6 +35,8 @@
     dualWatchActive: boolean;
     /** Read-only indicator: which receiver currently transmits. */
     txVfo: 'main' | 'sub';
+    /** Scope digest shown in the bridge (issue #832). Omit to hide. */
+    scopeStatus?: ScopeStatusProps | null;
     onSwap?: () => void;
     onEqual?: () => void;
     onSplitToggle?: () => void;
@@ -29,6 +50,8 @@
     onMainFreqChange?: (freq: number) => void;
     onSubFreqChange?: (freq: number) => void;
     onSpeak?: () => void;
+    onScopeDualToggle?: () => void;
+    onScopeReceiverChange?: (receiver: 0 | 1) => void;
   }
 
   let {
@@ -38,6 +61,7 @@
     splitActive,
     dualWatchActive,
     txVfo,
+    scopeStatus = null,
     onSwap = () => {},
     onEqual = () => {},
     onSplitToggle = () => {},
@@ -51,6 +75,8 @@
     onMainFreqChange,
     onSubFreqChange,
     onSpeak,
+    onScopeDualToggle,
+    onScopeReceiverChange,
   }: Props = $props();
 
   let dualReceiver = $derived(hasDualReceiver());
@@ -140,6 +166,40 @@
         onDualWatchToggle={() => onDualWatchToggle(!dualWatchActive)}
         {onQuickDw}
       />
+
+      {#if scopeStatus}
+        <div class="scope-status" data-testid="scope-status">
+          <span class="scope-status-title">SCOPE</span>
+          {#if dualReceiver}
+            <div class="scope-status-row scope-pills" role="group" aria-label="Scope source">
+              <button
+                type="button"
+                class="scope-pill"
+                class:active={scopeStatus.receiver !== 1}
+                onclick={() => onScopeReceiverChange?.(0)}
+                title="Scope source: MAIN"
+              >MAIN</button>
+              <button
+                type="button"
+                class="scope-pill"
+                class:active={scopeStatus.receiver === 1}
+                onclick={() => onScopeReceiverChange?.(1)}
+                title="Scope source: SUB"
+              >SUB</button>
+            </div>
+            <button
+              type="button"
+              class="scope-dual"
+              class:active={scopeStatus.dual}
+              onclick={() => onScopeDualToggle?.()}
+              title="Dual scope"
+            >DUAL</button>
+          {/if}
+          <span class="scope-status-row scope-digest">
+            {SPAN_LABELS[scopeStatus.span] ?? '\u00b125k'} {SPEED_LABELS[scopeStatus.speed] ?? 'MID'}
+          </span>
+        </div>
+      {/if}
 
       {#if dualReceiver}
         <div class:inactive={!splitActive} class="split-status">
@@ -261,6 +321,71 @@
     letter-spacing: 0.08em;
   }
 
+  .scope-status {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    margin-top: auto;
+    padding:
+      var(--vfo-ops-secondary-padding-top, 4px)
+      0
+      0;
+    border-top: 1px solid var(--v2-vfo-header-border);
+    font-family: 'Roboto Mono', monospace;
+    text-transform: uppercase;
+    align-items: center;
+  }
+
+  .scope-status-title {
+    color: var(--v2-text-muted);
+    font-size: 7px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+  }
+
+  .scope-status-row {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    color: var(--v2-text-secondary);
+    font-size: 7px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+  }
+
+  .scope-pill,
+  .scope-dual {
+    padding: 1px 6px;
+    border: 1px solid var(--v2-border, #2a2a3e);
+    border-radius: 3px;
+    background: transparent;
+    color: var(--v2-text-muted);
+    font-family: inherit;
+    font-size: 7px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    line-height: 1.2;
+  }
+
+  .scope-pill:hover,
+  .scope-dual:hover {
+    color: var(--v2-accent-cyan, #00d4ff);
+    border-color: var(--v2-accent-cyan, #00d4ff);
+  }
+
+  .scope-pill.active,
+  .scope-dual.active {
+    color: var(--v2-accent-cyan, #00d4ff);
+    border-color: rgba(0, 212, 255, 0.4);
+    background: rgba(0, 212, 255, 0.1);
+  }
+
+  .scope-digest {
+    font-variant-numeric: tabular-nums;
+  }
+
   .speak-btn {
     margin-top: 4px;
     padding: 3px 6px;
@@ -299,8 +424,15 @@
       flex-wrap: wrap;
     }
 
-    .split-status {
+    .split-status,
+    .scope-status {
       align-items: flex-start;
+    }
+
+    .scope-status {
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: 6px;
     }
   }
 </style>

--- a/frontend/src/components-v2/layout/__tests__/vfo-header.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/vfo-header.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for the SCOPE status block in VfoHeader bridge (issue #832).
+ *
+ * The block renders only when `scopeStatus` prop is non-null, shows the
+ * MAIN/SUB source pills + DUAL toggle only when dual receiver is available,
+ * and always shows the SPAN/SPEED read-only digest.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasDualReceiver: vi.fn(() => true),
+  hasTx: vi.fn(() => true),
+  hasSpectrum: vi.fn(() => false),
+  hasAnyScope: vi.fn(() => false),
+  hasAudioFft: vi.fn(() => false),
+  hasCapability: vi.fn(() => false),
+  getScopeSource: vi.fn(() => null),
+  vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
+  getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
+  getVfoScheme: vi.fn(() => 'main_sub'),
+  getAgcModes: vi.fn(() => [0, 1, 2, 3]),
+  getAgcLabels: vi.fn(() => ({ 0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW' })),
+  getSupportedModes: vi.fn(() => ['USB', 'LSB', 'CW', 'AM', 'FM']),
+  getSupportedFilters: vi.fn(() => ['FIL1', 'FIL2', 'FIL3']),
+  getAttValues: vi.fn(() => [0, 10, 20]),
+  getAttLabels: vi.fn(() => ({ 0: '0dB', 10: '10dB', 20: '20dB' })),
+  getPreValues: vi.fn(() => [0, 1, 2]),
+  getPreLabels: vi.fn(() => ({ 0: 'OFF', 1: 'PRE1', 2: 'PRE2' })),
+  getAntennaCount: vi.fn(() => 1),
+  getSmeterCalibration: vi.fn(() => null),
+  getSmeterRedline: vi.fn(() => null),
+  getMeterCalibration: vi.fn(() => null),
+  getMeterRedline: vi.fn(() => null),
+  getControlRange: vi.fn(() => ({ min: 0, max: 255 })),
+}));
+
+vi.mock('$lib/stores/radio.svelte', () => ({
+  patchRadioState: vi.fn(),
+}));
+
+import VfoHeader, { type ScopeStatusProps } from '../VfoHeader.svelte';
+import { hasDualReceiver } from '$lib/stores/capabilities.svelte';
+import type { VfoStateProps } from '../layout-utils';
+
+const mainVfo: VfoStateProps = {
+  receiver: 'main',
+  freq: 14074000,
+  mode: 'USB',
+  filter: 'FIL1',
+  sValue: 0,
+  isActive: true,
+  badges: {},
+};
+
+const subVfo: VfoStateProps = {
+  receiver: 'sub',
+  freq: 7074000,
+  mode: 'LSB',
+  filter: 'FIL1',
+  sValue: 0,
+  isActive: false,
+  badges: {},
+};
+
+let components: ReturnType<typeof mount>[] = [];
+const mountedTargets: HTMLElement[] = [];
+
+function mountHeader(props: Record<string, unknown> = {}) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  mountedTargets.push(target);
+  const component = mount(VfoHeader, {
+    target,
+    props: {
+      mainVfo,
+      subVfo,
+      splitActive: false,
+      dualWatchActive: false,
+      txVfo: 'main',
+      ...props,
+    },
+  });
+  flushSync();
+  components.push(component);
+  return target;
+}
+
+beforeEach(() => {
+  components = [];
+  mountedTargets.length = 0;
+  vi.clearAllMocks();
+  vi.mocked(hasDualReceiver).mockReturnValue(true);
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  for (const t of mountedTargets) {
+    t.remove();
+  }
+  mountedTargets.length = 0;
+});
+
+describe('VfoHeader SCOPE status block', () => {
+  it('hides the block when scopeStatus is null', () => {
+    const target = mountHeader({ scopeStatus: null });
+    expect(target.querySelector('[data-testid="scope-status"]')).toBeNull();
+  });
+
+  it('renders SCOPE title when scopeStatus is provided', () => {
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus });
+    const block = target.querySelector('[data-testid="scope-status"]');
+    expect(block).not.toBeNull();
+    expect(block!.textContent).toContain('SCOPE');
+  });
+
+  it('renders MAIN and SUB pills when dual receiver', () => {
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus });
+    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
+    const labels = pills.map((p) => p.textContent?.trim());
+    expect(labels).toEqual(['MAIN', 'SUB']);
+  });
+
+  it('marks the active scope source pill as active (receiver=0 → MAIN)', () => {
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus });
+    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
+    expect(pills[0].classList.contains('active')).toBe(true);
+    expect(pills[1].classList.contains('active')).toBe(false);
+  });
+
+  it('marks SUB pill active when receiver=1', () => {
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 1, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus });
+    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
+    expect(pills[0].classList.contains('active')).toBe(false);
+    expect(pills[1].classList.contains('active')).toBe(true);
+  });
+
+  it('renders DUAL toggle with active state when scopeStatus.dual is true', () => {
+    const scopeStatus: ScopeStatusProps = { dual: true, receiver: 0, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus });
+    const dualBtn = target.querySelector<HTMLButtonElement>('.scope-dual');
+    expect(dualBtn).not.toBeNull();
+    expect(dualBtn!.textContent?.trim()).toBe('DUAL');
+    expect(dualBtn!.classList.contains('active')).toBe(true);
+  });
+
+  it('hides MAIN/SUB pills and DUAL toggle when dual receiver is not available', () => {
+    vi.mocked(hasDualReceiver).mockReturnValue(false);
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus });
+    expect(target.querySelector('.scope-pill')).toBeNull();
+    expect(target.querySelector('.scope-dual')).toBeNull();
+    // Digest still present
+    expect(target.querySelector('.scope-digest')).not.toBeNull();
+  });
+
+  it('renders SPAN/SPEED digest from scopeStatus', () => {
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus });
+    const digest = target.querySelector('.scope-digest');
+    expect(digest).not.toBeNull();
+    const text = digest!.textContent!.replace(/\s+/g, ' ').trim();
+    expect(text).toBe('\u00b125k MID');
+  });
+
+  it('renders correct digest values for different span/speed indices', () => {
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 5, speed: 0 };
+    const target = mountHeader({ scopeStatus });
+    const digest = target.querySelector('.scope-digest');
+    const text = digest!.textContent!.replace(/\s+/g, ' ').trim();
+    expect(text).toBe('\u00b1100k FST');
+  });
+
+  it('falls back to default digest labels for out-of-range indices', () => {
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 99, speed: 99 };
+    const target = mountHeader({ scopeStatus });
+    const digest = target.querySelector('.scope-digest');
+    const text = digest!.textContent!.replace(/\s+/g, ' ').trim();
+    expect(text).toBe('\u00b125k MID');
+  });
+
+  it('invokes onScopeReceiverChange with 1 when SUB pill is clicked', () => {
+    const onScopeReceiverChange = vi.fn();
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus, onScopeReceiverChange });
+    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
+    pills[1].click();
+    flushSync();
+    expect(onScopeReceiverChange).toHaveBeenCalledWith(1);
+  });
+
+  it('invokes onScopeReceiverChange with 0 when MAIN pill is clicked', () => {
+    const onScopeReceiverChange = vi.fn();
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 1, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus, onScopeReceiverChange });
+    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
+    pills[0].click();
+    flushSync();
+    expect(onScopeReceiverChange).toHaveBeenCalledWith(0);
+  });
+
+  it('invokes onScopeDualToggle when DUAL is clicked', () => {
+    const onScopeDualToggle = vi.fn();
+    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
+    const target = mountHeader({ scopeStatus, onScopeDualToggle });
+    const dualBtn = target.querySelector<HTMLButtonElement>('.scope-dual');
+    dualBtn!.click();
+    flushSync();
+    expect(onScopeDualToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/spectrum/SpectrumToolbar.svelte
+++ b/frontend/src/components/spectrum/SpectrumToolbar.svelte
@@ -3,7 +3,7 @@
   import { type ColorSchemeName } from '../../lib/renderers/waterfall-renderer';
   import { radio } from '../../lib/stores/radio.svelte';
   import { sendCommand } from '../../lib/transport/ws-client';
-  import { hasCapability, hasDualReceiver } from '../../lib/stores/capabilities.svelte';
+  import { hasCapability } from '../../lib/stores/capabilities.svelte';
   import ScopeSettingsPopover from './ScopeSettingsPopover.svelte';
   import {
     SPAN_LABELS, SPEED_LABELS, SPEED_STATIC_LABEL, MODE_BUTTONS,
@@ -116,15 +116,6 @@
   function toggleHold() {
     sendCommand('set_scope_hold', { on: !(scopeControls?.hold ?? false) });
   }
-
-  function toggleDual() {
-    sendCommand('set_scope_dual', { dual: !(scopeControls?.dual ?? false) });
-  }
-
-  function switchReceiver() {
-    const next = (scopeControls?.receiver ?? 0) === 1 ? 0 : 1;
-    sendCommand('switch_scope_receiver', { receiver: next });
-  }
 </script>
 
 <div class="spectrum-toolbar">
@@ -212,15 +203,6 @@
         <span class="toolbar-value ref-value">{(scopeControls?.refDb ?? 0) > 0 ? '+' : ''}{scopeControls?.refDb ?? 0}</span>
         <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: clampRef(scopeControls?.refDb ?? 0, 5) })}>+</button>
       </div>
-      {#if hasDualReceiver()}
-        <div class="toolbar-sub-separator"></div>
-        <div class="toolbar-group">
-          <button class="toolbar-btn" class:active={scopeControls?.dual ?? false} onclick={toggleDual} title="Dual scope">DUAL</button>
-          <button class="toolbar-btn" onclick={switchReceiver} title="Switch scope receiver">
-            {scopeControls?.receiver === 1 ? 'SUB' : 'MAIN'}
-          </button>
-        </div>
-      {/if}
     </div>
   {/if}
   <div class="toolbar-separator"></div>

--- a/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
@@ -151,12 +151,12 @@ describe('SpectrumToolbar component', () => {
     expect(holdBtn).toBeDefined();
   });
 
-  it('renders DUAL and receiver buttons when dual receiver available', () => {
+  it('does not render DUAL/MAIN scope-source buttons (moved to VfoHeader bridge in #832)', () => {
     const target = mountToolbar();
     const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.toolbar-btn'));
     const labels = buttons.map((b) => b.textContent?.trim());
-    expect(labels).toContain('DUAL');
-    expect(labels).toContain('MAIN');
+    expect(labels).not.toContain('DUAL');
+    expect(labels).not.toContain('MAIN');
   });
 
   it('renders color scheme selector', () => {


### PR DESCRIPTION
## Summary

Per design plan `docs/plans/2026-04-18-spectrum-controls.md` Issue C (rescoped audit 2026-04-19).

- Moves the `DUAL` toggle and `MAIN | SUB` scope-source pills out of the spectrum toolbar into a new inline **SCOPE** status block in `VfoHeader`'s bridge column, alongside a read-only `SPAN / SPEED` digest.
- `SpectrumToolbar` keeps its interactive `SPAN` and `SPEED` steppers (§5d of the plan); only the scope-source + DUAL block is removed.
- Preserves the `components-v2/layout/` layering rule — `VfoHeader` never imports `$lib/transport/*`. `scopeStatus` + two handlers (`onScopeDualToggle`, `onScopeReceiverChange`) are threaded as props from `RadioLayout`, and commands are dispatched via `runtime.send(...)` (which already wraps `sendCommand`).
- Visibility gating: the whole block is hidden unless `hasCapability('scope')`. MAIN/SUB pills + DUAL toggle are hidden when `!hasDualReceiver()`; the SPAN/SPEED digest still shows.
- `SPAN_LABELS` / `SPEED_LABELS` are duplicated locally in `VfoHeader.svelte` to avoid a reverse `layout/ → components/spectrum/` dependency.

## Files

- `frontend/src/components-v2/layout/VfoHeader.svelte` — add `ScopeStatus` block inline + styles + responsive ≤1024px bridge-horizontal tweak.
- `frontend/src/components-v2/layout/RadioLayout.svelte` — derive `scopeStatus` from `runtime.state?.scopeControls`; wire handlers via `runtime.send`.
- `frontend/src/components/spectrum/SpectrumToolbar.svelte` — remove DUAL + MAIN/SUB block + `toggleDual` / `switchReceiver`.
- `frontend/src/components-v2/layout/__tests__/vfo-header.test.ts` — new: 13 tests covering visibility gates, digest labels, active pill, and handler dispatch.
- `frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts` — invert the DUAL/MAIN assertion.

## Test plan

- [x] `npx vitest run` — 86 files, 1605 tests passing
- [x] `npx eslint` on changed files — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] 4 pre-existing Python test failures unrelated to this change (verified on clean main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)