### PR TITLE
fix(#860): VFO digit/badge collision — subgrid layout

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
@@ -236,10 +236,12 @@
       <div class="vfo-freq">
         <AmberFrequency {freqHz} size="large" />
       </div>
-      <span class="vfo-mode-box">{mode}{filter ? ` ${filter}` : ''}</span>
-      {#if bandLabel}
-        <span class="vfo-band-box">{bandLabel}</span>
-      {/if}
+      <div class="vfo-badges">
+        <span class="vfo-mode-box">{mode}{filter ? ` ${filter}` : ''}</span>
+        {#if bandLabel}
+          <span class="vfo-band-box">{bandLabel}</span>
+        {/if}
+      </div>
     </div>
 
     <!-- ═══ VFO B — compact form preserved (peer promotion is #845) ═══ -->
@@ -449,9 +451,23 @@
   }
 
   .lcd-vfo-main {
+    /* issue #860: use explicit 3-col grid so freq digits (DSEG7 fixed metrics)
+       cannot overflow into mode/band badges. Column 2 `minmax(0,1fr)` lets the
+       freq cell shrink; `overflow:hidden` on `.vfo-freq` clips digits rather
+       than overlapping siblings. */
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 10px;
     flex: 1;
     min-height: 0;
     align-items: center;
+  }
+
+  .vfo-badges {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
   }
 
   .vfo-tag {
@@ -479,6 +495,7 @@
     display: flex;
     align-items: center;
     min-width: 0;
+    overflow: hidden;
   }
 
   .vfo-band-box {
@@ -491,7 +508,6 @@
     border: 2px solid rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.4));
     border-radius: 4px;
     padding: 2px 8px;
-    margin-left: 6px;
     background: rgba(26, 16, 0, var(--lcd-alpha-ghost));
   }
 
@@ -505,7 +521,6 @@
     border: 2px solid rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.4));
     border-radius: 4px;
     padding: 2px 8px;
-    margin-left: 6px;
   }
 
   .vfo-mode-sub {


### PR DESCRIPTION
## Summary
- **P0 ship-blocker** (reported 2026-04-19): VFO A frequency digits overlap `LSB 2` / `40m` mode+band badges in the amber LCD skin. Layout regression from #844 scaffold.
- Convert `.lcd-vfo-main` from flex to explicit 3-col grid (`auto | minmax(0,1fr) | auto`): row-tag, freq, new `.vfo-badges` wrapper.
- Add `overflow: hidden` to `.vfo-freq` so DSEG7 digits clip-before-overlap at extreme narrow widths (dual-RX 6u column).
- `.lcd-vfo-sub` keeps its flex layout (unchanged; peer promotion is #845).

## Root cause
`.lcd-vfo-row` was flex with `gap: 10px`. `AmberFrequency size="large"` has fixed intrinsic DSEG7 metrics that overflow rightward into sibling badges. `min-width: 0` let the container shrink but child paint still overlapped.

Plan: [`docs/plans/2026-04-19-lcd-layout-fixup.md` §A](../blob/main/docs/plans/2026-04-19-lcd-layout-fixup.md)

## Scope
- Single file, 21 insertions / 6 deletions.
- Does NOT touch contrast (#861), VFO B (#845), or aux row (#862).

## Test plan
- [x] `npx vitest run src/components-v2/panels/lcd/` — 33/33 pass
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Visual: VFO A digits no longer overlap mode/band badges at single-RX width
- [ ] Visual: at dual-RX (6u column) width, digits clip via `overflow:hidden` while badges stay intact
- [ ] Visual: badge spacing looks consistent (margin-left removed from boxes; `.vfo-badges` owns the `gap`)

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)