### PR TITLE
fix(#822): Vd tile stays readable in RX idle

### DIFF
--- a/frontend/src/components-v2/panels/MetersDockPanel.svelte
+++ b/frontend/src/components-v2/panels/MetersDockPanel.svelte
@@ -112,7 +112,9 @@
         fillPct: normalize(vdMeter) * 100,
         fill: 'var(--v2-meter-vd-fill)',
         track: 'var(--v2-meter-vd-track)',
-        relevant: txActive,
+        // Vd (drain voltage) is a continuous supply/PSU health metric,
+        // readable in both RX and TX — unlike TX-only Po/SWR/ALC/Id/COMP.
+        relevant: true,
       });
     }
     if (compMeter !== undefined && compressorOn === true) {

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
@@ -275,6 +275,16 @@ describe('MetersDockPanel relevance dimming', () => {
     expect(t.querySelector('[data-meter="s"]')?.getAttribute('data-relevant')).toBe('true');
     expect(t.querySelector('[data-meter="po"]')?.getAttribute('data-relevant')).toBe('false');
   });
+
+  it('keeps Vd tile relevant in RX idle (supply voltage is always readable)', () => {
+    const t = mountPanel({ ...fullProps, vdMeter: 180, txActive: false });
+    expect(t.querySelector('[data-meter="vd"]')?.getAttribute('data-relevant')).toBe('true');
+  });
+
+  it('keeps Vd tile relevant during TX as well', () => {
+    const t = mountPanel({ ...fullProps, vdMeter: 180, txActive: true });
+    expect(t.querySelector('[data-meter="vd"]')?.getAttribute('data-relevant')).toBe('true');
+  });
 });
 
 describe('MetersDockPanel formatted values', () => {


### PR DESCRIPTION
## Summary
- Vd (drain voltage) is a continuous supply/PSU health metric — it reads ~13.8V in both RX and TX, unlike the TX-only Po/SWR/ALC/Id/COMP tiles.
- Previously marked `relevant: txActive`, which rendered the tile dimmed (opacity 0.35) whenever the radio was idle, hiding supply-voltage visibility at a glance.
- Fix: mark Vd as always-relevant. Po/SWR/ALC/Id/COMP stay TX-relevant; S stays RX-relevant.

Addresses a P2 codex review finding on already-merged PR #866.

## Test plan
- [x] `npx vitest run src/components-v2/panels/__tests__/MetersDockPanel.test.ts` — 43/43 pass, including two new assertions that Vd reports `data-relevant=true` in both RX-idle and TX states.
- [x] `uv run ruff check src/ tests/` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)