### PR TITLE
fix(#832): restore scope source/dual controls on mobile layout

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -263,7 +263,10 @@
       {#if hasSpectrum()}
         <div class="spectrum-slot">
           <div class="spectrum-frame">
-            <SpectrumPanel />
+            <!-- Desktop: VfoHeader bridge owns DUAL + MAIN/SUB (#832); hide
+                 the toolbar duplicate. Mobile/v1 layouts omit the prop so
+                 the toolbar retains them (#832 fallback). -->
+            <SpectrumPanel hideSourceControls={true} />
           </div>
         </div>
       {/if}

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -38,6 +38,14 @@
     type ScopeFrame,
   } from './spectrum-logic';
 
+  // --- Props ---
+  // `hideSourceControls` is forwarded to SpectrumToolbar so layouts that surface
+  // the DUAL + MAIN/SUB scope-source controls elsewhere (v2 desktop VfoHeader
+  // bridge, issue #832) can suppress the duplicate in the toolbar. Layouts that
+  // do not surface them (v1 desktop/mobile, v2 mobile chip view) omit the prop
+  // and keep the controls reachable (#832 mobile/v1 fallback).
+  let { hideSourceControls = false } = $props();
+
   // --- Component state ---
   let scopeConnected = $derived(isScopeConnected());
   let scopePixels = $state<Uint8Array | null>(null);
@@ -359,7 +367,7 @@
 />
 
 <div class="spectrum-panel" class:fullscreen onwheel={handleWheel}>
-  <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi />
+  <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {hideSourceControls} />
   <div class="spectrum-with-scales">
     <div class="db-scale">
       {#each DB_TICKS as tick}

--- a/frontend/src/components/spectrum/SpectrumToolbar.svelte
+++ b/frontend/src/components/spectrum/SpectrumToolbar.svelte
@@ -3,7 +3,7 @@
   import { type ColorSchemeName } from '../../lib/renderers/waterfall-renderer';
   import { radio } from '../../lib/stores/radio.svelte';
   import { sendCommand } from '../../lib/transport/ws-client';
-  import { hasCapability } from '../../lib/stores/capabilities.svelte';
+  import { hasCapability, hasDualReceiver } from '../../lib/stores/capabilities.svelte';
   import ScopeSettingsPopover from './ScopeSettingsPopover.svelte';
   import {
     SPAN_LABELS, SPEED_LABELS, SPEED_STATIC_LABEL, MODE_BUTTONS,
@@ -27,6 +27,13 @@
     showBandPlan = $bindable(true),
     hiddenLayers = $bindable([] as string[]),
     showEiBi = $bindable(false),
+    /**
+     * Hide the DUAL + MAIN/SUB scope-source controls. Set by layouts that
+     * surface these controls elsewhere (e.g. v2 desktop VfoHeader bridge,
+     * issue #832). Other layouts (v1 desktop/mobile, v2 mobile chip view)
+     * leave this `false` so the scope source remains reachable (#832 follow-up).
+     */
+    hideSourceControls = false,
   } = $props();
 
   let showSettings = $state(false);
@@ -117,6 +124,15 @@
   function toggleHold() {
     sendCommand('set_scope_hold', { on: !(scopeControls?.hold ?? false) });
   }
+
+  function toggleDual() {
+    sendCommand('set_scope_dual', { dual: !(scopeControls?.dual ?? false) });
+  }
+
+  function switchReceiver() {
+    const next = (scopeControls?.receiver ?? 0) === 1 ? 0 : 1;
+    sendCommand('switch_scope_receiver', { receiver: next });
+  }
 </script>
 
 <div class="spectrum-toolbar">
@@ -204,6 +220,15 @@
         <span class="toolbar-value ref-value">{(scopeControls?.refDb ?? 0) > 0 ? '+' : ''}{scopeControls?.refDb ?? 0}</span>
         <button class="toolbar-btn small" onclick={() => sendCommand('set_scope_ref', { ref: clampRef(scopeControls?.refDb ?? 0, 5) })}>+</button>
       </div>
+      {#if !hideSourceControls && hasDualReceiver()}
+        <div class="toolbar-sub-separator"></div>
+        <div class="toolbar-group">
+          <button class="toolbar-btn" class:active={scopeControls?.dual ?? false} onclick={toggleDual} title="Dual scope">DUAL</button>
+          <button class="toolbar-btn" onclick={switchReceiver} title="Switch scope receiver">
+            {scopeControls?.receiver === 1 ? 'SUB' : 'MAIN'}
+          </button>
+        </div>
+      {/if}
     </div>
   {/if}
   <div class="toolbar-separator"></div>

--- a/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
@@ -151,12 +151,43 @@ describe('SpectrumToolbar component', () => {
     expect(holdBtn).toBeDefined();
   });
 
-  it('does not render DUAL/MAIN scope-source buttons (moved to VfoHeader bridge in #832)', () => {
+  it('renders DUAL + MAIN/SUB scope-source buttons by default (mobile/v1 fallback for #832)', () => {
     const target = mountToolbar();
+    const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.toolbar-btn'));
+    const labels = buttons.map((b) => b.textContent?.trim());
+    expect(labels).toContain('DUAL');
+    // receiver starts at 0 → button label is 'MAIN'
+    expect(labels).toContain('MAIN');
+  });
+
+  it('hides DUAL + MAIN/SUB when hideSourceControls is true (v2 desktop; VfoHeader bridge owns them, #832)', () => {
+    const target = mountToolbar({ hideSourceControls: true });
     const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.toolbar-btn'));
     const labels = buttons.map((b) => b.textContent?.trim());
     expect(labels).not.toContain('DUAL');
     expect(labels).not.toContain('MAIN');
+    expect(labels).not.toContain('SUB');
+  });
+
+  it('DUAL button click dispatches set_scope_dual', () => {
+    const target = mountToolbar();
+    const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.toolbar-btn'));
+    const dualBtn = buttons.find((b) => b.textContent?.trim() === 'DUAL');
+    expect(dualBtn).toBeDefined();
+    dualBtn!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledWith('set_scope_dual', { dual: true });
+  });
+
+  it('receiver-switch button click dispatches switch_scope_receiver', () => {
+    const target = mountToolbar();
+    const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.toolbar-btn'));
+    // With receiver=0, the label is 'MAIN'; clicking flips to receiver=1.
+    const rxBtn = buttons.find((b) => b.textContent?.trim() === 'MAIN');
+    expect(rxBtn).toBeDefined();
+    rxBtn!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledWith('switch_scope_receiver', { receiver: 1 });
   });
 
   it('renders color scheme selector', () => {


### PR DESCRIPTION
## Summary

Post-merge regression from #870: moving DUAL + MAIN/SUB scope-source controls from `SpectrumToolbar` into `VfoHeader` broke the feature on every layout that does not render `VfoHeader`:

- **v2 `MobileRadioLayout`** (no VfoHeader mount)
- **v1 `AppShell` / `DesktopLayout` / `MobileLayout`** — still the **default** path per `App.svelte:105-109` (v2 is opt-in via `uiVersion === 'v2'`).

For dual-RX radios (IC-7610), toggling `set_scope_dual` and switching `switch_scope_receiver` is daily-use; losing it on the default desktop path plus all mobile paths is P1.

## Approach — Option B (prop-gated fallback in SpectrumToolbar)

The task brief recommended **Option C** (extract a shared `ScopeStatus` component, mount from both `VfoHeader` and `MobileRadioLayout`). That recommendation assumed v2 was the only live path. Once you count v1 (default) + v2 mobile, Option C needs mount sites in `RadioLayout`, `MobileRadioLayout`, `DesktopLayout`, and `MobileLayout` — four layouts plus the component, breaching the 3-file / 200-LOC guardrail and re-wiring v1 with v2-style plumbing.

**Option B — one opt-out prop on `SpectrumToolbar`** fits the actual scope:

- Re-introduce DUAL + MAIN/SUB buttons in `SpectrumToolbar`, gated by `!hideSourceControls && hasDualReceiver()`. Default `false`.
- `SpectrumPanel` accepts and forwards `hideSourceControls`.
- v2 `RadioLayout` (desktop) passes `hideSourceControls={true}` — VfoHeader bridge keeps ownership, no duplicate, **#870's desktop win is preserved**.
- Mobile (v1 + v2) and v1 desktop omit the prop, so the toolbar keeps the controls where users expect them.

3 source files + 1 test. No new component, no reverse-dependency between layout/ and spectrum/.

## Test plan
- [x] `npx vitest run` — 86 files, 1621 tests pass
- [x] `SpectrumToolbar.component.test.ts` updated: default renders DUAL + MAIN; `hideSourceControls={true}` hides DUAL + MAIN + SUB; click dispatches `set_scope_dual` and `switch_scope_receiver`
- [x] `eslint` clean on all touched files
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run pytest --ignore=tests/integration` — 4716 passed; 4 pre-existing failures on main (unrelated: CI-V timeout + HTTP 404 in test_web_server) verified against fresh `main`
- [ ] Manual verification on mobile (v1 + v2): DUAL toggle active state, MAIN↔SUB receiver switch
- [ ] Manual verification on v2 desktop: no duplicate controls, VfoHeader bridge still owns them

Closes the #870 mobile/v1 regression flagged by codex on closed PR #870.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>