### PR TITLE
fix(#827): keyboard active-receiver switch updates audio focus

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.test.ts
@@ -37,9 +37,20 @@ vi.mock('$lib/stores/tuning.svelte', () => ({
   adjustTuningStep: vi.fn(),
 }));
 
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    setAudioConfig: vi.fn(),
+    startRx: vi.fn(),
+    stopRx: vi.fn(),
+    setRxVolume: vi.fn(),
+    rxEnabled: false,
+  },
+}));
+
 import { sendCommand } from '$lib/transport/ws-client';
 import { getRadioState, getActiveReceiver, patchActiveReceiver, patchRadioState } from '$lib/stores/radio.svelte';
 import { adjustTuningStep } from '$lib/stores/tuning.svelte';
+import { audioManager } from '$lib/audio/audio-manager';
 import { makeKeyboardHandlers } from '../command-bus';
 
 const makeAction = (action: string, params?: Record<string, unknown>) => ({
@@ -114,5 +125,26 @@ describe('makeKeyboardHandlers', () => {
     makeKeyboardHandlers().dispatch({ action: 'adjust_tuning_step', params: { direction: 'down' }, id: 'step-down', section: 'Tuning', sequence: ['ArrowDown'] });
 
     expect(adjustTuningStep).toHaveBeenCalledWith('down');
+  });
+
+  // Regression for #827: the keyboard path for switching the active
+  // receiver must route through the same helper as the VFO click so
+  // audio focus follows the new receiver.  Otherwise the operator
+  // tunes MAIN but keeps hearing SUB (or vice-versa) in Dual-Watch /
+  // browser-audio flows.
+  it('set_active_vfo couples audio focus to the requested receiver', () => {
+    vi.mocked(audioManager.setAudioConfig).mockClear();
+
+    makeKeyboardHandlers().dispatch(makeAction('set_active_vfo', { vfo: 'SUB' }));
+
+    expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
+    expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
+    expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'sub' });
+
+    vi.mocked(audioManager.setAudioConfig).mockClear();
+
+    makeKeyboardHandlers().dispatch(makeAction('set_active_vfo', { vfo: 'MAIN' }));
+
+    expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'main' });
   });
 });

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -1028,8 +1028,12 @@ export function makeKeyboardHandlers() {
           if (target !== 'MAIN' && target !== 'SUB') {
             return;
           }
-          patchRadioState({ active: target });
-          cmd('set_vfo', { vfo: target });
+          // Route through the same helper the VFO-click path uses so the
+          // audio focus follows the active receiver (#827 follow-up): a
+          // `m`/Shift+M/Shift+S keypress must behave identically to
+          // clicking MAIN/SUB, otherwise the operator tunes one side but
+          // keeps hearing the other in Dual-Watch / browser-audio flows.
+          _activateReceiver(target);
           return;
         }
         case 'focus_target': {


### PR DESCRIPTION
## Summary
- Route the `set_active_vfo` keyboard action (`m` / `Shift+M` / `Shift+S`) through the shared `_activateReceiver()` helper so the audio-focus update that the VFO-click path applies also fires on keyboard dispatch.
- Without this, in Dual-Watch / browser-audio flows the operator switched the active receiver via keyboard but kept hearing the previous channel — tuning one side while hearing the other.
- Codex review finding on already-merged PR #868.

## Test plan
- [x] `npx vitest run src/components-v2/wiring/` — 53 passed, including new regression covering both `MAIN` and `SUB` keyboard dispatch triggering `audioManager.setAudioConfig`.
- [x] Helper is reused, not duplicated — no new abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)