### PR TITLE
feat(#861): LCD contrast control moved to control-strip

### DIFF
--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -17,6 +17,7 @@
   import { getKeyboardConfig } from '$lib/stores/capabilities.svelte';
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
   import AmberLcdDisplay from '../panels/lcd/AmberLcdDisplay.svelte';
+  import LcdContrastControl from '../panels/lcd/LcdContrastControl.svelte';
   import VfoControlPanel from '../panels/lcd/VfoControlPanel.svelte';
   import LeftSidebar from './LeftSidebar.svelte';
   import RightSidebar from './RightSidebar.svelte';
@@ -60,6 +61,9 @@
         <div class="lcd-frame">
           <AmberLcdDisplay />
         </div>
+      </div>
+      <div class="lcd-control-strip">
+        <LcdContrastControl />
       </div>
     </main>
 
@@ -149,7 +153,25 @@
     min-height: 0;
     min-width: 0;
     display: flex;
-    align-items: start;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+  }
+
+  /* Control strip beneath the amber LCD surface (issue #861). Houses the
+     contrast preset picker and any future non-touch controls that don't
+     belong on the amber display itself. */
+  .lcd-control-strip {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 6px;
+    border: 1px solid var(--v2-border-panel);
+    border-radius: 4px;
+    background:
+      linear-gradient(180deg, var(--v2-panel-bg-gradient-top) 0%, var(--v2-panel-bg-gradient-bottom) 100%);
+    box-shadow: var(--v2-shadow-sm);
   }
 
   .lcd-slot {

--- a/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberLcdDisplay.svelte
@@ -9,15 +9,6 @@
   import AmberSmeter from './AmberSmeter.svelte';
   import AmberAfScope from './AmberAfScope.svelte';
   import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
-  import { onMount } from 'svelte';
-  import {
-    LCD_CONTRAST_PRESETS,
-    applyLcdContrast,
-    getLcdContrastPreset,
-    setLcdContrastPreset,
-    stepLcdContrast,
-    type LcdContrastPreset,
-  } from '$lib/stores/lcd-contrast.svelte';
 
   // Band lookup by frequency (LCD-specific)
   const BANDS: [string, number, number][] = [
@@ -120,38 +111,6 @@
   function agcLabel(m: number): string {
     return AGC_LABELS[m] ?? `${m}`;
   }
-
-  // ── LCD contrast (issue #833 / plan §2) ──
-  let contrastPreset = $state<LcdContrastPreset>(getLcdContrastPreset());
-
-  function selectContrast(p: LcdContrastPreset): void {
-    setLcdContrastPreset(p);
-    contrastPreset = p;
-  }
-
-  function handleContrastKey(event: KeyboardEvent): void {
-    if (!event.shiftKey) return;
-    // Ignore when focus is in a text field.
-    const tag = (document.activeElement?.tagName ?? '').toUpperCase();
-    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-    // Shift+[ and Shift+] produce '{' and '}' on most US/EU layouts.
-    // Also accept the bare bracket keys in case the layout maps them directly.
-    const key = event.key;
-    let direction: 'up' | 'down' | null = null;
-    if (key === '{' || key === '[') direction = 'down';
-    else if (key === '}' || key === ']') direction = 'up';
-    if (!direction) return;
-    event.preventDefault();
-    contrastPreset = stepLcdContrast(direction);
-  }
-
-  onMount(() => {
-    applyLcdContrast();
-    window.addEventListener('keydown', handleContrastKey);
-    return () => {
-      window.removeEventListener('keydown', handleContrastKey);
-    };
-  });
 
   // Scope WS connection — reactive to capabilities (may load after mount)
   $effect(() => {
@@ -287,22 +246,6 @@
       {/if}
     </div>
 
-    <!-- ═══ Contrast preset row (segmented control) — plan §2.1 path 3 ═══ -->
-    <div class="lcd-contrast-row" role="radiogroup" aria-label="LCD contrast preset" style:grid-area="contrast">
-      <span class="lcd-contrast-label">CONTRAST</span>
-      {#each LCD_CONTRAST_PRESETS as p}
-        <button
-          type="button"
-          class="lcd-contrast-btn"
-          class:active={contrastPreset === p}
-          role="radio"
-          aria-checked={contrastPreset === p}
-          aria-label="Contrast preset {p}"
-          onclick={() => selectContrast(p)}
-        >{p}</button>
-      {/each}
-    </div>
-
   </div>
 </div>
 
@@ -354,15 +297,13 @@
       28px              /* meter */
       72px              /* vfo */
       auto              /* pb (RIT/XIT offset; collapses when inactive) */
-      minmax(0, 120px)  /* filter */
-      auto;             /* contrast */
+      minmax(0, 120px); /* filter */
     grid-template-areas:
       "indicators"
       "meter-a"
       "vfo-a"
       "pb"
-      "filter"
-      "contrast";
+      "filter";
   }
 
   .lcd-screen.dual {
@@ -372,8 +313,7 @@
       "meter-a    meter-b"
       "vfo-a      vfo-b"
       "pb         pb"
-      "filter     filter"
-      "contrast   contrast";
+      "filter     filter";
   }
 
   .lcd-scanlines {
@@ -591,38 +531,6 @@
     font-weight: bold;
     font-size: 16px;
     color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.6));
-  }
-
-  /* ── Contrast preset row ── */
-  .lcd-contrast-row {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    position: relative;
-    z-index: 2;
-    padding-top: 2px;
-    flex-wrap: wrap;
-  }
-  .lcd-contrast-label {
-    font: 700 9px/1 'JetBrains Mono', monospace;
-    letter-spacing: 0.1em;
-    color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.5));
-  }
-  .lcd-contrast-btn {
-    font: 700 10px/1 'JetBrains Mono', monospace;
-    color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.45));
-    background: transparent;
-    border: 1px solid rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.2));
-    border-radius: 2px;
-    padding: 1px 5px;
-    cursor: pointer;
-  }
-  .lcd-contrast-btn:hover {
-    border-color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.35));
-  }
-  .lcd-contrast-btn.active {
-    color: rgba(26, 16, 0, var(--lcd-alpha-active));
-    border-color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.5));
   }
 
   /* ── Filter / AF Scope row (full-width grid cell) ── */

--- a/frontend/src/components-v2/panels/lcd/LcdContrastControl.svelte
+++ b/frontend/src/components-v2/panels/lcd/LcdContrastControl.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    LCD_CONTRAST_PRESETS,
+    applyLcdContrast,
+    getLcdContrastPreset,
+    setLcdContrastPreset,
+    stepLcdContrast,
+    type LcdContrastPreset,
+  } from '$lib/stores/lcd-contrast.svelte';
+
+  // LCD contrast control — extracted from AmberLcdDisplay per issue #861.
+  // Presets + Shift+[/] keyboard shortcut preserved verbatim from #833.
+  let contrastPreset = $state<LcdContrastPreset>(getLcdContrastPreset());
+
+  function selectContrast(p: LcdContrastPreset): void {
+    setLcdContrastPreset(p);
+    contrastPreset = p;
+  }
+
+  function handleContrastKey(event: KeyboardEvent): void {
+    if (!event.shiftKey) return;
+    // Ignore when focus is in a text field.
+    const tag = (document.activeElement?.tagName ?? '').toUpperCase();
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+    // Shift+[ and Shift+] produce '{' and '}' on most US/EU layouts.
+    // Also accept the bare bracket keys in case the layout maps them directly.
+    const key = event.key;
+    let direction: 'up' | 'down' | null = null;
+    if (key === '{' || key === '[') direction = 'down';
+    else if (key === '}' || key === ']') direction = 'up';
+    if (!direction) return;
+    event.preventDefault();
+    contrastPreset = stepLcdContrast(direction);
+  }
+
+  onMount(() => {
+    applyLcdContrast();
+    window.addEventListener('keydown', handleContrastKey);
+    return () => {
+      window.removeEventListener('keydown', handleContrastKey);
+    };
+  });
+</script>
+
+<div class="lcd-contrast-row" role="radiogroup" aria-label="LCD contrast preset">
+  <span class="lcd-contrast-label">CONTRAST</span>
+  {#each LCD_CONTRAST_PRESETS as p}
+    <button
+      type="button"
+      class="lcd-contrast-btn"
+      class:active={contrastPreset === p}
+      role="radio"
+      aria-checked={contrastPreset === p}
+      aria-label="Contrast preset {p}"
+      onclick={() => selectContrast(p)}
+    >{p}</button>
+  {/each}
+</div>
+
+<style>
+  .lcd-contrast-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    padding: 4px 8px;
+  }
+  .lcd-contrast-label {
+    font: 700 10px/1 'JetBrains Mono', monospace;
+    letter-spacing: 0.1em;
+    color: var(--v2-text-dim, rgba(200, 160, 48, 0.7));
+  }
+  .lcd-contrast-btn {
+    font: 700 11px/1 'JetBrains Mono', monospace;
+    color: var(--v2-text-dim, rgba(200, 160, 48, 0.7));
+    background: transparent;
+    border: 1px solid var(--v2-border-panel, rgba(200, 160, 48, 0.3));
+    border-radius: 3px;
+    padding: 3px 8px;
+    cursor: pointer;
+    transition: border-color 0.12s, color 0.12s;
+  }
+  .lcd-contrast-btn:hover {
+    border-color: var(--v2-border-darker, rgba(200, 160, 48, 0.55));
+    color: var(--v2-text, rgba(200, 160, 48, 0.9));
+  }
+  .lcd-contrast-btn.active {
+    color: var(--v2-text, rgba(200, 160, 48, 1));
+    border-color: var(--v2-border-darker, rgba(200, 160, 48, 0.7));
+  }
+</style>


### PR DESCRIPTION
## Summary
- Extract DIM/LOW/MID/HIGH/MAX preset picker + `Shift+[` / `Shift+]` handler out of `AmberLcdDisplay.svelte` into new `LcdContrastControl.svelte`.
- Mount the control in a new `.lcd-control-strip` inside `LcdLayout.svelte`, directly below the amber display — outside the amber surface where clicks are ergonomic.
- Drop the `contrast` grid-area row from `.lcd-screen` (template-rows, template-areas single + dual, related CSS).
- `useLcdContrast` store, localStorage persistence, and `Shift+[/]` behavior preserved verbatim from #833. Keyboard shortcut still fires via `window` listener; `keyboard-map.ts` untouched.

Closes #861.

## Test plan
- [x] `npx vitest run src/components-v2/` — 1152/1152 pass
- [x] `uv run ruff check src/ tests/` — clean
- [x] `npx eslint` on the three touched files — clean
- [ ] Manual: contrast picker renders under the LCD (not on amber), `Shift+[` / `Shift+]` still steps through presets, selection persists across reload.

Guardrails: 3 files, ~118 LOC added / 96 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)