### PR TITLE
fix: break scope re-enable deadlock on reconnect

### DIFF
--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -668,22 +668,29 @@ class WebServer:
             finally:
                 if self._radio_poller is not None:
                     self._radio_poller._initial_fetch_done.set()
-            # Re-enable scope after refetch completes
+            # Re-enable scope after refetch completes.
+            # Do NOT gate on self._radio_ready(): that property waits for
+            # CI-V broadcast data, but on IC-7610 in the "deaf" firmware
+            # state broadcast may only resume once a scope-enable command
+            # is sent — creating a deadlock where scope re-enable waits
+            # for the very signal it would itself trigger.  The session
+            # is already up at this point (soft_reconnect completed auth +
+            # discovery), so queue EnableScope unconditionally; if the
+            # radio is genuinely unreachable the command will fail on its
+            # own, which is strictly better than a silent 30-second wait
+            # every reconnect cycle.
             if (
                 self._scope_handlers
                 and self._radio is not None
                 and _supports_scope(self._radio)
             ):
-                if self._radio_ready():
-                    self._set_scope_data_callback(self._broadcast_scope)
-                    self._command_queue.put(EnableScope())
-                    self._scope_enabled = True
-                    logger.info(
-                        "scope: re-enable queued after reconnect (%d handlers)",
-                        len(self._scope_handlers),
-                    )
-                else:
-                    self._schedule_scope_enable_when_ready(reason="radio_reconnect")
+                self._set_scope_data_callback(self._broadcast_scope)
+                self._command_queue.put(EnableScope())
+                self._scope_enabled = True
+                logger.info(
+                    "scope: re-enable queued after reconnect (%d handlers)",
+                    len(self._scope_handlers),
+                )
 
         asyncio.create_task(_refetch_and_reenable())
 

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -386,19 +386,30 @@ async def test_scope_health_and_radio_state_event_paths() -> None:
 
 
 @pytest.mark.asyncio
-async def test_on_radio_reconnect_waits_until_radio_ready() -> None:
+async def test_on_radio_reconnect_enables_scope_without_waiting_for_broadcast() -> None:
+    """Reconnect must queue EnableScope even while ``radio_ready`` is False.
+
+    Deadlock background: ``radio_ready`` waits for CI-V broadcast to resume,
+    but in the "deaf" firmware state observed on IC-7610 the broadcast may
+    not resume until a scope-enable CI-V command is sent.  Gating scope
+    re-enable behind ``radio_ready`` turned the two into a mutual wait
+    that timed out with "scope: radio not ready after 30s" every minute.
+
+    The reconnect path now trusts that ``soft_reconnect`` already brought
+    the session up (UDP + auth + discovery), and queues EnableScope
+    immediately.  If the radio is genuinely dead the command will fail
+    on its own — strictly better than a silent 30-second wait every cycle.
+    """
     radio = _scope_radio(ready=False)
+    radio._fetch_initial_state = AsyncMock()
     srv = WebServer(radio)
     srv._scope_handlers.add(MagicMock())
-    srv._scope_reenable_poll_interval = 0.01  # noqa: SLF001
-    srv._scope_reenable_timeout = 0.2  # noqa: SLF001
 
     srv._on_radio_reconnect()  # noqa: SLF001
-    assert not any(isinstance(c, EnableScope) for c in srv.command_queue.drain())
+    await asyncio.sleep(0.05)  # let the refetch task complete
 
-    radio.radio_ready = True
-    await asyncio.sleep(0.03)
     assert any(isinstance(c, EnableScope) for c in srv.command_queue.drain())
+    assert radio.radio_ready is False  # gate was bypassed, not flipped
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `_on_radio_reconnect._refetch_and_reenable` gated scope re-enable on `self._radio_ready()`. That property waits for CI-V broadcast (`_civ_stream_ready`), but on IC-7610 in the "deaf" firmware state observed after hours of uptime, broadcast does not resume on its own after `soft_reconnect` — so the gate never opens. Log shows `scope: radio not ready after 30s (radio_reconnect), skipping re-enable` every minute.
- The scope-enable CI-V command is plausibly one of the things that can re-engage broadcast, so waiting for broadcast to send it is circular.
- **Fix**: drop the gate. `soft_reconnect` has already completed UDP + auth + discovery, so queue `EnableScope` unconditionally. If the radio is genuinely unreachable the CI-V send will fail on its own — strictly better than a silent 30-second timeout every reconnect cycle.
- Handler-connect path (`register_scope_handler` at `server.py:416`) keeps its `radio_ready` gate — steady state where waiting for broadcast is legitimate.

## Context

Follow-up to #851. That fix (patient OpenClose, self-cancel avoidance) made the watchdog recovery loop robust but uncovered this deeper deadlock, which appeared in the updated log as a 30-second scope re-enable timeout after every reconnect:

```
02:00:46 scope: radio not ready after 30s (radio_reconnect), skipping re-enable
02:01:12 civ-data-watchdog: OpenClose failed for 60.1s, triggering soft_reconnect
02:01:48 scope: radio not ready after 30s (radio_reconnect), skipping re-enable
```

## Test plan

- [x] New test `test_on_radio_reconnect_enables_scope_without_waiting_for_broadcast`: `radio.radio_ready = False` throughout, `EnableScope` still queued after `_on_radio_reconnect`.
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4720 passed, 0 failed.
- [x] `uv run ruff check` on changed files — clean.
- [ ] Live IC-7610 soak — verify the "radio not ready" warning no longer appears in logs after reconnect, and that `EnableScope` does trigger on reconnect cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)