### PR TITLE
chore(#828): VFO area tooltip audit + standardization

### DIFF
--- a/frontend/src/components-v2/layout/VfoHeader.svelte
+++ b/frontend/src/components-v2/layout/VfoHeader.svelte
@@ -177,14 +177,14 @@
                 class="scope-pill"
                 class:active={scopeStatus.receiver !== 1}
                 onclick={() => onScopeReceiverChange?.(0)}
-                title="Scope source: MAIN"
+                title={`Set scope source to MAIN (current: ${scopeStatus.receiver === 1 ? 'SUB' : 'MAIN'})`}
               >MAIN</button>
               <button
                 type="button"
                 class="scope-pill"
                 class:active={scopeStatus.receiver === 1}
                 onclick={() => onScopeReceiverChange?.(1)}
-                title="Scope source: SUB"
+                title={`Set scope source to SUB (current: ${scopeStatus.receiver === 1 ? 'SUB' : 'MAIN'})`}
               >SUB</button>
             </div>
             <button
@@ -192,7 +192,7 @@
               class="scope-dual"
               class:active={scopeStatus.dual}
               onclick={() => onScopeDualToggle?.()}
-              title="Dual scope"
+              title={`Toggle dual scope (currently ${scopeStatus.dual ? 'ON' : 'OFF'})`}
             >DUAL</button>
           {/if}
           <span class="scope-status-row scope-digest">
@@ -209,7 +209,7 @@
       {/if}
 
       {#if onSpeak}
-        <button type="button" class="speak-btn" title="Speak frequency" onclick={onSpeak}>
+        <button type="button" class="speak-btn" title="Speak current frequency aloud" onclick={onSpeak}>
           SPEAK
         </button>
       {/if}

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -89,7 +89,11 @@
     <div class="control-strip">
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <div class="mode-badge-wrapper" onclick={(e) => { e.stopPropagation(); onModeClick?.(); }}>
+      <div
+        class="mode-badge-wrapper"
+        onclick={(e) => { e.stopPropagation(); onModeClick?.(); }}
+        title={`Change mode (current: ${mode})`}
+      >
         <StatusIndicator
           label={mode}
           active={true}


### PR DESCRIPTION
## Summary
- Audit tooltips on `VfoPanel.svelte` and `VfoHeader.svelte`; add/refine `title=` attributes so every interactive element has a tooltip following the `"<verb> <object> (<state>)"` convention used by `VfoOps`.
- `VfoPanel`: mode badge wrapper now has `title="Change mode (current: <mode>)"`.
- `VfoHeader`: scope MAIN/SUB pill tooltips now show the active scope source; DUAL scope button tooltip reports current ON/OFF state; SPEAK button wording clarified to "Speak current frequency aloud".

Per the rescoped issue, `DualVfoDisplay` activate-chip was already removed by #858 and `VfoOps` already has decent tooltips, so both are out of scope.

Closes #828.

## Test plan
- [x] `npx vitest run src/components-v2/layout/__tests__/vfo-header.test.ts src/components-v2/vfo/__tests__/VfoPanel.test.ts` → 59 passed
- [x] `npx eslint` on both edited files → clean
- [ ] Hover interactive elements in desktop-v2 skin and confirm tooltips render

No behavior change; tooltip text only.