### PR TITLE
fix: VFO bridge column overflow — SCOPE pills cropped

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -424,7 +424,7 @@
   .radio-layout {
     position: relative;
     display: grid;
-    grid-template-rows: 28px 156px minmax(0, 1fr) auto;
+    grid-template-rows: 28px 200px minmax(0, 1fr) auto;
     height: 100vh;
     background:
       linear-gradient(180deg, var(--v2-bg-gradient-start) 0%, var(--v2-bg-darkest) 100%),


### PR DESCRIPTION
## Summary

User reported (2026-04-19 screenshot) that the VFO center bridge column between MAIN and SUB panels is cropped at the bottom and awkwardly spaced at the top. The SCOPE MAIN/SUB source pills are cut off.

Root cause: Wave 2b.1/2b.2a introduced two new content blocks into the bridge stack that together exceeded the fixed 156px `.receiver-deck` row height in `RadioLayout.svelte`:

- **#825** — `ActiveReceiverToggle` `[M|S]` row at the top of `VfoOps`
- **#832** — SCOPE status block (DUAL toggle + MAIN/SUB pills + SPAN/SPEED digest) in the bridge

Combined with the existing COPY/SPLIT/DW/SWAP, TX indicator, SPLIT status and SPEAK button, total content is ~200-210px while the grid row caps at 156px and `.receiver-deck` has `overflow: hidden`, so the bottom is clipped.

## Fix

Bump `grid-template-rows` row 2 from `156px` → `200px` in `.radio-layout`. The spectrum row uses `minmax(0, 1fr)` so it absorbs the extra 44px — no cascading layout breakage elsewhere.

Pure CSS change, 1 line, 1 file.

## Test plan
- [x] `vfo-header.test.ts`, `VfoOps.test.ts`, `RadioLayout.test.ts`, `top-row-visual-regression.test.ts` — all 85 tests pass
- [ ] Manual: verify SCOPE MAIN/SUB pills fully visible in dual-RX layout
- [ ] Manual: verify single-RX layout not regressed (no extra whitespace)
- [ ] Manual: verify spectrum panel still sized correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)