### PR TITLE
fix: restore AudioSpectrumPanel in RightSidebar

### DIFF
--- a/frontend/src/lib/__tests__/drag-reorder.test.ts
+++ b/frontend/src/lib/__tests__/drag-reorder.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadPanelOrder, reorderPanels } from '../drag-reorder.svelte';
+
+const KEY = 'test:panel-order';
+const DEFAULTS = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'];
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
+beforeEach(() => {
+  localStorageMock.clear();
+});
+
+describe('loadPanelOrder', () => {
+  it('returns defaults when nothing stored', () => {
+    expect(loadPanelOrder(KEY, DEFAULTS)).toEqual(DEFAULTS);
+  });
+
+  it('returns stored order when it fully matches defaults', () => {
+    const custom = ['dsp', 'rx-audio', 'audio-scope', 'tx', 'cw', 'memory'];
+    localStorage.setItem(KEY, JSON.stringify(custom));
+    expect(loadPanelOrder(KEY, DEFAULTS)).toEqual(custom);
+  });
+
+  it('appends missing defaults so newly-introduced panels become visible (regression #821)', () => {
+    // Simulates a user whose localStorage was written before `audio-scope`
+    // was added to defaults. Without the merge, `audio-scope` never rendered.
+    const pre821 = ['rx-audio', 'dsp', 'tx', 'cw', 'memory'];
+    localStorage.setItem(KEY, JSON.stringify(pre821));
+    const result = loadPanelOrder(KEY, DEFAULTS);
+    expect(result).toContain('audio-scope');
+    // Existing order is preserved; new id is appended.
+    expect(result.slice(0, pre821.length)).toEqual(pre821);
+    expect(result[result.length - 1]).toBe('audio-scope');
+  });
+
+  it('preserves unknown (peer-owned) ids in stored order', () => {
+    const withForeign = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory', 'foreign-panel'];
+    localStorage.setItem(KEY, JSON.stringify(withForeign));
+    const result = loadPanelOrder(KEY, DEFAULTS);
+    expect(result).toContain('foreign-panel');
+  });
+
+  it('deduplicates ids in stored order', () => {
+    localStorage.setItem(KEY, JSON.stringify(['rx-audio', 'rx-audio', 'dsp']));
+    const result = loadPanelOrder(KEY, DEFAULTS);
+    expect(result.filter((id) => id === 'rx-audio')).toHaveLength(1);
+  });
+
+  it('falls back to defaults on invalid JSON', () => {
+    localStorage.setItem(KEY, '{not-json');
+    expect(loadPanelOrder(KEY, DEFAULTS)).toEqual(DEFAULTS);
+  });
+
+  it('falls back to defaults when stored value is not an array', () => {
+    localStorage.setItem(KEY, JSON.stringify({ foo: 1 }));
+    expect(loadPanelOrder(KEY, DEFAULTS)).toEqual(DEFAULTS);
+  });
+});
+
+describe('reorderPanels', () => {
+  it('moves a panel forward', () => {
+    const r = reorderPanels(DEFAULTS, 'rx-audio', 3);
+    expect(r[3]).toBe('rx-audio');
+    expect(r).toHaveLength(DEFAULTS.length);
+  });
+
+  it('is a no-op when source equals target index', () => {
+    const r = reorderPanels(DEFAULTS, 'dsp', 2);
+    expect(r).toBe(DEFAULTS);
+  });
+
+  it('returns input unchanged when id is not in the order', () => {
+    const r = reorderPanels(DEFAULTS, 'missing', 0);
+    expect(r).toBe(DEFAULTS);
+  });
+});

--- a/frontend/src/lib/drag-reorder.svelte.ts
+++ b/frontend/src/lib/drag-reorder.svelte.ts
@@ -32,7 +32,20 @@ export function loadPanelOrder(storageKey: string, defaults: string[]): string[]
             unique.push(id);
           }
         }
-        if (unique.length > 0) return unique;
+        if (unique.length > 0) {
+          // Merge in any default panel ids that are missing from the stored
+          // order — otherwise newly added panels (e.g. 'audio-scope' in PR
+          // #821) never render for existing users whose localStorage was
+          // written before the default was introduced. Unknown (peer-owned
+          // or removed) ids stay untouched so cross-sidebar moves survive.
+          for (const id of defaults) {
+            if (!seen.has(id)) {
+              seen.add(id);
+              unique.push(id);
+            }
+          }
+          return unique;
+        }
       }
     }
   } catch {


### PR DESCRIPTION
## Summary

User reported (2026-04-19) that after PR #821 the AudioSpectrumPanel (AF FFT + passband + PBT + notch/contour) had disappeared entirely from the desktop UI.

Root cause: PR #821 relocated the panel into `RightSidebar.svelte` as a drag-reorderable collapsible with the mount guard

```svelte
{#if showRx && drag.order.includes('audio-scope') && hasAudioFft()}
```

The new `'audio-scope'` id was added to `defaults` in `createDragReorder`, but `loadPanelOrder` returns any non-empty localStorage array verbatim. Existing users had a panel order persisted from before #821 that did not contain `'audio-scope'`, so `includes(...)` was permanently `false` and the panel never rendered — regardless of capability.

## Fix

Merge missing default ids into the loaded order (appended at the end, preserving the user's custom ordering). Unknown ids (e.g. peer-owned from cross-sidebar moves) stay in place. One-file, 14-line logic change.

- `frontend/src/lib/drag-reorder.svelte.ts` — merge defaults in `loadPanelOrder`
- `frontend/src/lib/__tests__/drag-reorder.test.ts` — 10 regression tests for the previously untested helpers

## Test plan

- [x] `npx vitest run src/lib/__tests__/drag-reorder.test.ts` — 10/10 pass
- [x] `npx vitest run` — 1653/1653 pass (no regressions)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest -q --ignore=tests/integration` — same 4 pre-existing failures as clean main (unrelated: `test_per_receiver_vfo_roundtrip`, `test_web_server` 404s)
- [ ] Manual verify on desktop UI with IC-7610: AudioSpectrumPanel appears in RightSidebar after reload; panel order is preserved

Refs: #821, PR #880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)