### PR TITLE
fix: preserve cross-sidebar drag in loadPanelOrder (known-defaults set)

### DIFF
--- a/frontend/src/lib/__tests__/drag-reorder.test.ts
+++ b/frontend/src/lib/__tests__/drag-reorder.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { loadPanelOrder, reorderPanels } from '../drag-reorder.svelte';
+import {
+  KNOWN_DEFAULTS_SUFFIX,
+  loadPanelOrder,
+  reorderPanels,
+} from '../drag-reorder.svelte';
 
 const KEY = 'test:panel-order';
+const KNOWN_KEY = KEY + KNOWN_DEFAULTS_SUFFIX;
 const DEFAULTS = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'];
 
 const localStorageMock = (() => {
@@ -73,6 +78,63 @@ describe('loadPanelOrder', () => {
   it('falls back to defaults when stored value is not an array', () => {
     localStorage.setItem(KEY, JSON.stringify({ foo: 1 }));
     expect(loadPanelOrder(KEY, DEFAULTS)).toEqual(DEFAULTS);
+  });
+
+  it('does NOT re-add a default that was deliberately removed (cross-sidebar drag)', () => {
+    // Simulates the aftermath of a cross-sidebar drag: the user moved
+    // `audio-scope` from this sidebar to its peer, so this sidebar's stored
+    // order no longer contains it, but `audio-scope` is in the known-defaults
+    // set because the app has previously presented it here. Re-adding would
+    // duplicate the panel across both sidebars.
+    const afterDrag = ['rx-audio', 'dsp', 'tx', 'cw', 'memory'];
+    localStorage.setItem(KEY, JSON.stringify(afterDrag));
+    localStorage.setItem(KNOWN_KEY, JSON.stringify(DEFAULTS));
+    const result = loadPanelOrder(KEY, DEFAULTS);
+    expect(result).toEqual(afterDrag);
+    expect(result).not.toContain('audio-scope');
+  });
+
+  it('appends a brand-new default not yet in known-defaults set', () => {
+    // User's known-defaults set predates a newly-added panel id.
+    const oldKnown = ['rx-audio', 'dsp', 'tx', 'cw', 'memory'];
+    const stored = ['rx-audio', 'dsp', 'tx', 'cw', 'memory'];
+    localStorage.setItem(KEY, JSON.stringify(stored));
+    localStorage.setItem(KNOWN_KEY, JSON.stringify(oldKnown));
+    const result = loadPanelOrder(KEY, DEFAULTS);
+    expect(result).toContain('audio-scope');
+    expect(result[result.length - 1]).toBe('audio-scope');
+  });
+
+  it('persists known-defaults set after load', () => {
+    loadPanelOrder(KEY, DEFAULTS);
+    const stored = localStorage.getItem(KNOWN_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(new Set(parsed)).toEqual(new Set(DEFAULTS));
+  });
+
+  it('round-trips: save then load the same order is stable', () => {
+    const custom = ['dsp', 'rx-audio', 'audio-scope', 'tx', 'cw', 'memory'];
+    localStorage.setItem(KEY, JSON.stringify(custom));
+    const first = loadPanelOrder(KEY, DEFAULTS);
+    // Simulate a subsequent save + load cycle.
+    localStorage.setItem(KEY, JSON.stringify(first));
+    const second = loadPanelOrder(KEY, DEFAULTS);
+    expect(second).toEqual(first);
+  });
+
+  it('round-trips after cross-sidebar removal: panel stays gone', () => {
+    // First load establishes known-defaults.
+    loadPanelOrder(KEY, DEFAULTS);
+    // User drags `audio-scope` away — stored order shrinks.
+    const afterDrag = ['rx-audio', 'dsp', 'tx', 'cw', 'memory'];
+    localStorage.setItem(KEY, JSON.stringify(afterDrag));
+    // Reload twice.
+    const r1 = loadPanelOrder(KEY, DEFAULTS);
+    localStorage.setItem(KEY, JSON.stringify(r1));
+    const r2 = loadPanelOrder(KEY, DEFAULTS);
+    expect(r1).toEqual(afterDrag);
+    expect(r2).toEqual(afterDrag);
   });
 });
 

--- a/frontend/src/lib/drag-reorder.svelte.ts
+++ b/frontend/src/lib/drag-reorder.svelte.ts
@@ -16,7 +16,38 @@
 
 // --- Pure helpers (exported for testing) ---
 
+export const KNOWN_DEFAULTS_SUFFIX = ':known-defaults';
+
+export function loadKnownDefaults(storageKey: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(storageKey + KNOWN_DEFAULTS_SUFFIX);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return new Set(parsed.filter((id): id is string => typeof id === 'string'));
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return new Set<string>();
+}
+
+export function saveKnownDefaults(storageKey: string, ids: Iterable<string>): void {
+  try {
+    localStorage.setItem(storageKey + KNOWN_DEFAULTS_SUFFIX, JSON.stringify([...ids]));
+  } catch {
+    /* ignore */
+  }
+}
+
 export function loadPanelOrder(storageKey: string, defaults: string[]): string[] {
+  const known = loadKnownDefaults(storageKey);
+  // Union known-defaults with the current defaults list so that future loads
+  // recognise today's defaults as "already presented".
+  const nextKnown = new Set<string>(known);
+  for (const id of defaults) nextKnown.add(id);
+
   try {
     const stored = localStorage.getItem(storageKey);
     if (stored) {
@@ -33,17 +64,19 @@ export function loadPanelOrder(storageKey: string, defaults: string[]): string[]
           }
         }
         if (unique.length > 0) {
-          // Merge in any default panel ids that are missing from the stored
-          // order — otherwise newly added panels (e.g. 'audio-scope' in PR
-          // #821) never render for existing users whose localStorage was
-          // written before the default was introduced. Unknown (peer-owned
-          // or removed) ids stay untouched so cross-sidebar moves survive.
+          // Append ONLY defaults that the app has never presented to this
+          // sidebar before (i.e. newly introduced panels). Defaults that are
+          // already in `known` but absent from the stored order were
+          // deliberately removed by the user (e.g. dragged to the peer
+          // sidebar) — re-adding them would duplicate the panel across both
+          // sidebars. Unknown (peer-owned) ids stay untouched.
           for (const id of defaults) {
-            if (!seen.has(id)) {
+            if (!seen.has(id) && !known.has(id)) {
               seen.add(id);
               unique.push(id);
             }
           }
+          saveKnownDefaults(storageKey, nextKnown);
           return unique;
         }
       }
@@ -51,6 +84,7 @@ export function loadPanelOrder(storageKey: string, defaults: string[]): string[]
   } catch {
     /* ignore */
   }
+  saveKnownDefaults(storageKey, nextKnown);
   return [...defaults];
 }
 
@@ -244,6 +278,7 @@ export function createDragReorder(options: DragReorderOptions): DragInstance {
     order = [...defaults];
     try {
       localStorage.removeItem(storageKey);
+      localStorage.removeItem(storageKey + KNOWN_DEFAULTS_SUFFIX);
     } catch {
       /* ignore */
     }


### PR DESCRIPTION
## Summary

Forward-fix for codex P1 review comment on merged PR #884.

PR #884's `loadPanelOrder` appends any missing default id on every load. That breaks cross-sidebar drag:

1. User drags panel P from sidebar A to sidebar B. A's stored order no longer contains P.
2. Next load: A sees P is "missing from defaults", re-adds it.
3. P now lives in both sidebars — duplicated.

## Fix

Track a per-sidebar known-defaults set at `{storageKey}:known-defaults`.

On load:
- Defaults NOT in known-set → truly new panels → append (fixes #884's original bug, PR #821).
- Defaults that ARE in known-set but absent from stored order → deliberately removed (cross-sidebar drag) → leave gone.
- Union known-set with current defaults and persist.

`reset()` also clears the known-defaults key so factory reset starts clean.

## Test plan

- [x] `npx vitest run src/lib/__tests__/drag-reorder.test.ts` — 15 tests pass
- [x] New test: default in known-set + absent from order → NOT re-added
- [x] New test: brand-new default not in known-set → appended
- [x] New test: known-defaults set persisted after load
- [x] New test: round-trip stability (save → load → save → load)
- [x] New test: round-trip after cross-sidebar removal — panel stays gone
- [x] Existing regression #821 test still passes (new users get defaults appended since known-set is empty)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)