### PR TITLE
feat(#888): register lcd-cockpit + lcd-scope skin IDs (Phase 0)

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -211,7 +211,7 @@
 
 {#if skinId === 'mobile'}
   <MobileRadioLayout />
-{:else if skinId === 'amber-lcd'}
+{:else if skinId === 'lcd-cockpit' || skinId === 'lcd-scope'}
   <LcdLayout />
 {:else}
 <div class="radio-layout">

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -11,7 +11,14 @@ import type { Component } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { LayoutMode } from '$lib/stores/layout.svelte';
 
-export type SkinId = 'desktop-v2' | 'amber-lcd' | 'mobile';
+export type SkinId = 'desktop-v2' | 'lcd-cockpit' | 'lcd-scope' | 'mobile';
+
+/**
+ * Persisted skin IDs include the legacy `amber-lcd` alias, which routes to
+ * `lcd-cockpit`. Kept indefinitely for backwards compatibility with stored
+ * user preferences (see docs/plans/2026-04-19-lcd-twin-skins.md §2).
+ */
+export type PersistedSkinId = SkinId | 'amber-lcd';
 
 export interface SkinResolutionContext {
   capabilities: Capabilities | null;
@@ -25,16 +32,16 @@ export interface SkinResolutionContext {
  *
  * Rules:
  * - Mobile viewport → mobile skin
- * - User forced 'lcd' → amber-lcd
+ * - User forced 'lcd' → lcd-cockpit (default LCD variant)
  * - User forced 'standard' → desktop-v2
- * - Auto: use desktop-v2 if any scope is available, amber-lcd otherwise
+ * - Auto: use desktop-v2 if any scope is available, lcd-cockpit otherwise
  */
 export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   if (ctx.isMobile) return 'mobile';
-  if (ctx.layoutPreference === 'lcd') return 'amber-lcd';
+  if (ctx.layoutPreference === 'lcd') return 'lcd-cockpit';
   if (ctx.layoutPreference === 'standard') return 'desktop-v2';
   // auto: scope available → desktop, otherwise LCD
-  return ctx.hasAnyScope ? 'desktop-v2' : 'amber-lcd';
+  return ctx.hasAnyScope ? 'desktop-v2' : 'lcd-cockpit';
 }
 
 /**
@@ -42,12 +49,27 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
  *
  * Returns the default export of the skin's entry Svelte component.
  * Skins are code-split — only the active skin is loaded.
+ *
+ * Phase 0 of the twin-skin epic (#887): both `lcd-cockpit` and `lcd-scope`
+ * point at the existing `LcdSkin.svelte` until dedicated wrappers land.
+ * The legacy `amber-lcd` alias is accepted via `resolvePersistedSkinId()`.
  */
 const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
   'desktop-v2': () => import('./desktop-v2/DesktopSkin.svelte'),
-  'amber-lcd': () => import('./amber-lcd/LcdSkin.svelte'),
+  'lcd-cockpit': () => import('./amber-lcd/LcdSkin.svelte'),
+  'lcd-scope': () => import('./amber-lcd/LcdSkin.svelte'),
   'mobile': () => import('./mobile/MobileSkin.svelte'),
 };
+
+/**
+ * Normalize a persisted skin ID, mapping the legacy `amber-lcd` alias to
+ * `lcd-cockpit`. Use this when reading from localStorage or other stored
+ * preferences.
+ */
+export function resolvePersistedSkinId(id: PersistedSkinId): SkinId {
+  if (id === 'amber-lcd') return 'lcd-cockpit';
+  return id;
+}
 
 export async function loadSkin(id: SkinId): Promise<Component> {
   return (await SKIN_LOADERS[id]).default;


### PR DESCRIPTION
## Summary

Phase 0 (S-PR1) of the LCD twin-skin epic #887. Registry-only groundwork — no visual changes.

- Extend `SkinId` union with `'lcd-cockpit'` and `'lcd-scope'`; add `PersistedSkinId` + `resolvePersistedSkinId()` helper so legacy `'amber-lcd'` stored preferences map to `'lcd-cockpit'` (kept indefinitely per plan §2).
- `resolveSkinId()` now returns `'lcd-cockpit'` where it previously returned `'amber-lcd'`.
- Both new loader entries point at the existing `amber-lcd/LcdSkin.svelte` until dedicated wrappers land (B-PR* / C-PR*).
- `RadioLayout.svelte`: branch on the new IDs (`lcd-cockpit` or `lcd-scope`) instead of `'amber-lcd'`.

Plan: `docs/plans/2026-04-19-lcd-twin-skins.md` §2, §4, §8.

## Test plan

- [x] `npx vitest run src/skins/ src/components-v2/layout/ src/lib/stores/` — 288 passed / 0 failed
- [x] No behavior change — same component renders for LCD preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)