### PR TITLE
feat(#895): AmberScope skin wrapper + variant routing

### DIFF
--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -17,6 +17,7 @@
   import { getKeyboardConfig } from '$lib/stores/capabilities.svelte';
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
   import AmberCockpit from '../panels/lcd/AmberCockpit.svelte';
+  import AmberScope from '../panels/lcd/AmberScope.svelte';
   import LcdContrastControl from '../panels/lcd/LcdContrastControl.svelte';
   import VfoControlPanel from '../panels/lcd/VfoControlPanel.svelte';
   import LeftSidebar from './LeftSidebar.svelte';
@@ -64,7 +65,11 @@
     <main class="content-center">
       <div class="lcd-slot">
         <div class="lcd-frame" data-lcd-variant={variant}>
-          <AmberCockpit />
+          {#if variant === 'scope'}
+            <AmberScope />
+          {:else}
+            <AmberCockpit />
+          {/if}
         </div>
       </div>
       <div class="lcd-control-strip">

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  // AmberScope — skeleton for the lcd-scope skin variant.
+  // Full scope-dominant layout (60/40 grid, AF scope, waterfall) arrives in C-PR2…C-PR6.
+  // No state derivations, no store imports, no FFT connection here.
+</script>
+
+<div class="amber-lcd amber-lcd-scope">
+  <div class="lcd-screen">
+    <div class="lcd-scanlines"></div>
+    <div class="lcd-placeholder">LCD SCOPE (coming soon)</div>
+  </div>
+</div>
+
+<style>
+  .amber-lcd {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: stretch;
+    padding: 4px;
+    box-sizing: border-box;
+    min-height: 0;
+  }
+
+  .lcd-screen {
+    /* Contrast tokens — identical defaults to AmberCockpit. */
+    --lcd-alpha-active: 1;
+    --lcd-alpha-inactive: 0.08;
+    --lcd-alpha-ghost: 0.06;
+
+    position: relative;
+    width: 100%;
+    background: #C8A030;
+    border: 2px solid #8A7020;
+    border-radius: 8px;
+    padding: 12px 18px;
+    overflow: hidden;
+    box-shadow:
+      inset 0 0 50px rgba(0, 0, 0, 0.06),
+      0 0 8px rgba(0, 0, 0, 0.5);
+    min-height: 0;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .lcd-scanlines {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 1;
+    background: repeating-linear-gradient(
+      to bottom,
+      transparent 0px,
+      transparent 3px,
+      rgba(0, 0, 0, 0.03) 3px,
+      rgba(0, 0, 0, 0.03) 6px
+    );
+  }
+
+  .lcd-placeholder {
+    position: relative;
+    z-index: 2;
+    font-family: 'JetBrains Mono', 'Courier New', monospace;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: rgba(26, 16, 0, var(--lcd-alpha-ghost));
+    user-select: none;
+  }
+</style>


### PR DESCRIPTION
## Summary

- New `frontend/src/components-v2/panels/lcd/AmberScope.svelte` — minimal skeleton with amber frame, scanlines, and a ghost-alpha placeholder label. Identical outer CSS to `AmberCockpit` (background, border, scanlines). No state, no imports.
- Updated `LcdLayout.svelte` — `variant === 'scope'` now mounts `<AmberScope />` instead of falling through to `<AmberCockpit />`. The `{#if variant === 'scope'}` branch is the exact shape specified in the issue.
- Registry and `LcdSkin.svelte` untouched — `lcd-scope` routing was already wired in Phase 0 (#888).

## Test plan

- [x] `pnpm test --run` — 87 files, 1663 tests, all pass
- [x] `pnpm lint` — zero ESLint violations
- [x] `pnpm check` — 186 TS errors (identical to main baseline; no new errors)
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] AmberScope has no imports from `$lib/transport/*` or `$lib/audio/audio-manager` (ESLint no-restricted-imports compliant)
- [x] Net LOC delta: 78 lines (within ~80 target)

Closes #895
Part of #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>