### PR TITLE
feat(#893): scope track fills remaining height

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberAfScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberAfScope.svelte
@@ -22,8 +22,8 @@
     notchFreq?: number;
     /** Auto notch active */
     autoNotch?: boolean;
-    /** Current mode string (e.g. 'USB', 'CW') */
-    mode?: string;
+    /** Layout sizing mode: 'compact' = fixed strip height; 'fill' = stretch to container */
+    mode?: 'compact' | 'fill';
     /** Audio sample rate */
     sampleRate?: number;
     /** Actual Hz width of the received FFT data (defaults to sampleRate) */
@@ -44,6 +44,7 @@
     notchFreq = 128,
     sampleRate = 48000,
     bandwidth,
+    mode = 'compact',
   }: Props = $props();
 
   // Effective bandwidth: use provided bandwidth, fall back to sampleRate

--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -53,7 +53,6 @@
 
   // ── LCD-specific derivations (no adapter equivalent) ──
   let rx = $derived(radioState?.active === 'SUB' ? radioState?.sub : radioState?.main);
-  let mode = $derived(rx?.mode ?? '---');
   let subSValue = $derived(radioState?.sub?.sMeter ?? 0);
 
   type MeterSource = 'S' | 'PO' | 'SWR' | 'ALC' | 'COMP';
@@ -370,8 +369,8 @@
             notchFreq={dsp.notchFreq}
             autoNotch={notchActive}
             bandwidth={fftBandwidth}
-            {mode}
             compact
+            mode="fill"
           />
         </div>
       {/if}
@@ -425,7 +424,7 @@
     grid-template-rows:
       auto               /* global indicator strip */
       auto               /* vfo-a cockpit */
-      minmax(0, 120px)   /* scope */
+      minmax(0, 1fr)     /* scope — fills remaining height */
       auto;              /* aux (reserved) */
     grid-template-areas:
       "global"
@@ -439,7 +438,7 @@
     grid-template-rows:
       auto               /* global indicator strip full-width */
       auto               /* vfo-a + vfo-b cockpits */
-      minmax(0, 120px)   /* scope full-width */
+      minmax(0, 1fr)     /* scope full-width — fills remaining height */
       auto;              /* aux (reserved) full-width */
     grid-template-areas:
       "global global"


### PR DESCRIPTION
## Summary

- `AmberCockpit.svelte`: change `grid-template-rows` scope row from `minmax(0, 120px)` to `minmax(0, 1fr)` in both single-RX and dual-RX grid definitions, so the scope track fills remaining vertical space
- `AmberAfScope.svelte`: add `mode: 'compact' | 'fill'` prop (default `'compact'`, preserving today's behavior); replaces the dead `mode?: string` radio-mode prop that was declared but never used
- `AmberCockpit.svelte`: pass `mode="fill"` to `<AmberAfScope />` in the cockpit scope row

Fixes D4 (empty amber vertical void below scope) from user feedback 2026-04-19.

Closes #893
Part of #887

## Test plan

- [x] `pnpm test --run` — 1663 tests pass (87 test files)
- [x] `pnpm lint` — zero ESLint violations
- [x] `pnpm check` — 186 pre-existing TS errors, no new errors introduced
- [x] `uv run ruff check src/ tests/` — zero violations
- [ ] Visual: amber skin scope row should expand to fill the grid cell height rather than capping at 120px

## Notes

- `compact` boolean prop kept in AmberAfScope for backward compat with #896 (running in parallel)
- `'dominant'` mode NOT added here — reserved for #898 (C-PR4)
- No AmberFilterGhost — reserved for #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>