### PR TITLE
fix(#895): thread variant prop through dedicated skin wrappers

### DIFF
--- a/frontend/src/skins/lcd-cockpit/LcdCockpitSkin.svelte
+++ b/frontend/src/skins/lcd-cockpit/LcdCockpitSkin.svelte
@@ -1,0 +1,10 @@
+<!--
+  LCD Cockpit Skin — TS-990S-style dual-cockpit layout.
+  Thin wrapper that mounts LcdLayout with variant="cockpit".
+  Part of #887 (LCD twin-skin redesign) / fixes #895 variant routing.
+-->
+<script lang="ts">
+  import LcdLayout from '../../components-v2/layout/LcdLayout.svelte';
+</script>
+
+<LcdLayout variant="cockpit" />

--- a/frontend/src/skins/lcd-scope/LcdScopeSkin.svelte
+++ b/frontend/src/skins/lcd-scope/LcdScopeSkin.svelte
@@ -1,0 +1,10 @@
+<!--
+  LCD Scope Skin — IC-7300-style scope-dominant layout.
+  Thin wrapper that mounts LcdLayout with variant="scope".
+  Part of #887 (LCD twin-skin redesign) / fixes #895 variant routing.
+-->
+<script lang="ts">
+  import LcdLayout from '../../components-v2/layout/LcdLayout.svelte';
+</script>
+
+<LcdLayout variant="scope" />

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -50,14 +50,15 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
  * Returns the default export of the skin's entry Svelte component.
  * Skins are code-split — only the active skin is loaded.
  *
- * Phase 0 of the twin-skin epic (#887): both `lcd-cockpit` and `lcd-scope`
- * point at the existing `LcdSkin.svelte` until dedicated wrappers land.
- * The legacy `amber-lcd` alias is accepted via `resolvePersistedSkinId()`.
+ * Each LCD variant has its own wrapper that mounts `LcdLayout` with the
+ * appropriate `variant` prop — this is how the cockpit/scope selection
+ * reaches LcdLayout (registry → skin wrapper → LcdLayout). The legacy
+ * `amber-lcd` alias is accepted via `resolvePersistedSkinId()`.
  */
 const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
   'desktop-v2': () => import('./desktop-v2/DesktopSkin.svelte'),
-  'lcd-cockpit': () => import('./amber-lcd/LcdSkin.svelte'),
-  'lcd-scope': () => import('./amber-lcd/LcdSkin.svelte'),
+  'lcd-cockpit': () => import('./lcd-cockpit/LcdCockpitSkin.svelte'),
+  'lcd-scope': () => import('./lcd-scope/LcdScopeSkin.svelte'),
   'mobile': () => import('./mobile/MobileSkin.svelte'),
 };
 


### PR DESCRIPTION
## Summary
Addresses **P1 Codex feedback** on PR #904 (#895 AmberScope skin wrapper):
> The `scope` branch is effectively unreachable — both `<LcdLayout />` callers pass no variant, so `lcd-scope` skin still shows `AmberCockpit`. The new `AmberScope` route is dead code.

Per [twin-skins §4](docs/plans/2026-04-19-lcd-twin-skins.md) architecture, introduce dedicated skin wrappers and route them from the registry:

- **NEW** \`skins/lcd-cockpit/LcdCockpitSkin.svelte\` — mounts \`<LcdLayout variant="cockpit" />\`
- **NEW** \`skins/lcd-scope/LcdScopeSkin.svelte\` — mounts \`<LcdLayout variant="scope" />\`
- **EDIT** \`skins/registry.ts\` — \`SKIN_LOADERS\` points \`lcd-cockpit\` and \`lcd-scope\` at the new wrappers

Legacy \`amber-lcd/LcdSkin.svelte\` kept untouched (still alias-routed via \`resolvePersistedSkinId\` → \`lcd-cockpit\`).

## Effect
After this fix the StatusBar skin-switcher dropdown (#889) actually toggles between \`AmberCockpit\` and \`AmberScope\` at runtime.

## Files (3)
- \`frontend/src/skins/lcd-cockpit/LcdCockpitSkin.svelte\` (new, 10 LOC)
- \`frontend/src/skins/lcd-scope/LcdScopeSkin.svelte\` (new, 10 LOC)
- \`frontend/src/skins/registry.ts\` (+6/-5)

Net: +21 LOC.

## Test plan
- [x] \`pnpm test --run\` — 1663/1663 pass
- [x] \`pnpm lint\` — clean
- [x] No architectural change — the only move is where the \`variant\` prop originates (skin wrapper instead of hardcoded default)

Part of #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)