### PR TITLE
fix(#891): preserve TX meter telemetry when SUB is active

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -248,13 +248,18 @@
   let vfoAActive = $derived(radioState?.active !== 'SUB');
   let vfoBActive = $derived(radioState?.active === 'SUB');
 
-  // Meter for main VFO cockpit (always main, but source follows active-meter logic)
+  // Meter for main VFO cockpit (always main, but source follows active-meter logic).
+  // During TX, the meter shows radio-global TX telemetry (PO/SWR/ALC/COMP) — this
+  // must win over the receiver-active check so the cockpit never loses TX feedback
+  // when SUB is the active RX (VFO B's meter is suppressed during TX by design).
   let mainMeterValue = $derived.by(() => {
-    if (vfoAActive) return meterValue;  // A is active — use the adapter-derived meter
-    // A is inactive — show main S-meter only
-    return mainSMeter;
+    if (tx.txActive) return meterValue;          // TX: radio-global telemetry
+    if (vfoAActive) return meterValue;           // RX + A active: use adapter-derived meter
+    return mainSMeter;                           // RX + B active: show A's own S-meter
   });
-  let mainMeterSource = $derived<MeterSource>(vfoAActive ? activeMeterSource : 'S');
+  let mainMeterSource = $derived<MeterSource>(
+    tx.txActive || vfoAActive ? activeMeterSource : 'S',
+  );
 </script>
 
 <!--


### PR DESCRIPTION
## Summary
Addresses **P1 Codex feedback** on PR #905 (#891 dual-cockpit grid):
> When `radioState.active === 'SUB'`, `vfoAActive` becomes false and this branch forces VFO A to show `mainSMeter` instead of the computed `meterValue` (which carries PO/SWR/ALC/COMP during TX). In the same state, VFO B's meter is already suppressed on TX, so transmitting with SUB active leaves the cockpit without any TX telemetry.

## Fix
TX telemetry (PO/SWR/ALC/COMP) is **radio-global**, not per-receiver. When TX is active, VFO A's meter must show the adapter-derived `meterValue` regardless of which receiver is the active RX. Since VFO B's meter is intentionally suppressed during TX (single-meter invariant), VFO A becomes the sole TX readout.

Priority order in \`mainMeterValue\`:
1. \`tx.txActive\` → \`meterValue\` (radio-global TX telemetry)
2. \`vfoAActive\` → \`meterValue\` (RX: adapter picks active RX sMeter)
3. else → \`mainSMeter\` (RX + B active: VFO A shows its own S-meter)

Same priority applied to \`mainMeterSource\` so the source label matches.

## Files (1)
- \`frontend/src/components-v2/panels/lcd/AmberCockpit.svelte\` (+10/-5)

## Test plan
- [x] \`pnpm test --run\` — 1663/1663 pass
- [x] \`pnpm lint\` — clean
- [ ] Manual verify with IC-7610 in dual-RX + SUB active: PTT → VFO A shows PO/SWR/ALC/COMP, source label updates

Part of #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)