### PR TITLE
feat(#894): mobile container-query collapse + aux row reserve

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -396,6 +396,9 @@
     padding: 4px;
     box-sizing: border-box;
     min-height: 0;
+    /* Container for narrow-viewport collapse query (issue #894).
+       inline-size tracks width only — avoids height-dependency loops. */
+    container-type: inline-size;
   }
 
   .lcd-screen {
@@ -650,5 +653,28 @@
     box-shadow:
       inset 0 0 40px rgba(180, 30, 0, 0.08),
       0 0 10px rgba(180, 30, 0, 0.15);
+  }
+
+  /* ── Narrow-viewport collapse (issue #894) ──
+     When the .amber-lcd container is ≤ 640px wide, collapse the dual-cockpit
+     grid to a single column with VFO B stacked below VFO A.
+     Desktop (> 640px) is completely unaffected — the rule never fires. */
+  @container (max-width: 640px) {
+    .lcd-screen.dual {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-areas:
+        "global"
+        "vfo-a"
+        "vfo-b"
+        "scope"
+        "aux";
+    }
+
+    /* Remove the side-by-side column separator — it reads as an artifact
+       when VFO B is stacked below VFO A instead of beside it. */
+    .lcd-screen.dual .lcd-vfo-b {
+      border-left: none;
+      padding-left: 0;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary

- Add `container-type: inline-size` to `.amber-lcd` (the outer wrapper) so a `@container` rule can target `.lcd-screen.dual` as a descendant — CSS container queries style descendants, not the container element itself.
- At `≤ 640px` the dual-cockpit grid collapses to single-column with VFO B stacked below VFO A (`grid-template-areas` reordered to `global / vfo-a / vfo-b / scope / aux`).
- Remove `border-left` / `padding-left` from `.lcd-screen.dual .lcd-vfo-b` inside the narrow layout — the side-by-side column separator looks like an artifact when B is below A rather than beside it.
- `aux` row: already `auto` in both grid definitions — correct behavior (collapses when empty, expands when #836/#837 fill it). No change needed.
- `LcdLayout.svelte`: unchanged.
- Desktop layout (> 640px): completely unaffected — `@container` rule never fires.

**Files:** 1 (`AmberCockpit.svelte`) | **LOC:** +26

## Test plan

- [x] `pnpm test --run` — 87 files, 1663 tests, all passed
- [x] `pnpm lint` — zero ESLint violations
- [x] `pnpm check` — 187 pre-existing TS errors, zero new errors in `AmberCockpit.svelte`
- [x] `uv run ruff check src/ tests/` — all checks passed
- [ ] Manual: resize browser window to < 640px wide on amber-lcd skin with dual-RX enabled → VFO B appears below VFO A
- [ ] Manual: desktop width (> 640px) → dual-cockpit side-by-side layout unchanged

Closes #894
Part of #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)