### PR TITLE
fix(#895): make lcd-scope variant actually reachable end-to-end

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -211,8 +211,10 @@
 
 {#if skinId === 'mobile'}
   <MobileRadioLayout />
-{:else if skinId === 'lcd-cockpit' || skinId === 'lcd-scope'}
-  <LcdLayout />
+{:else if skinId === 'lcd-cockpit'}
+  <LcdLayout variant="cockpit" />
+{:else if skinId === 'lcd-scope'}
+  <LcdLayout variant="scope" />
 {:else}
 <div class="radio-layout">
   <StatusBar onSettings={() => (settingsOpen = true)} />

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -21,12 +21,14 @@
   let { onSettings }: Props = $props();
 
   let layoutMode = $derived(getLayoutMode());
-  // Skin-switcher dropdown options. When #888 lands, this list can be sourced
-  // from the skin registry; for now it mirrors the LayoutMode preferences.
+  // Skin-switcher dropdown options. `lcd` is a legacy alias that maps to
+  // `lcd-cockpit` in resolveSkinId — not exposed separately here. Twin-skin
+  // variants (`lcd-cockpit`, `lcd-scope`) are selectable per #887 / #889.
   const skinOptions: Array<{ value: LayoutMode; label: string }> = [
     { value: 'auto', label: 'AUTO' },
     { value: 'standard', label: 'Standard' },
-    { value: 'lcd', label: 'LCD' },
+    { value: 'lcd-cockpit', label: 'LCD Cockpit' },
+    { value: 'lcd-scope', label: 'LCD Scope' },
   ];
 
   function handleSkinChange(ev: Event) {

--- a/frontend/src/lib/stores/layout.svelte.ts
+++ b/frontend/src/lib/stores/layout.svelte.ts
@@ -1,20 +1,26 @@
 /**
  * Layout preference store.
- * 'auto'     = standard layout when any scope available (HW or audio FFT), LCD otherwise
- * 'lcd'      = force LCD layout
- * 'standard' = force standard layout
+ * 'auto'        = standard layout when any scope available (HW or audio FFT), LCD otherwise
+ * 'lcd'         = force LCD layout — cockpit variant (legacy alias for 'lcd-cockpit')
+ * 'lcd-cockpit' = force LCD cockpit (TS-990S-style dual-cockpit)
+ * 'lcd-scope'   = force LCD scope (IC-7300-style scope-dominant)
+ * 'standard'    = force standard layout
+ *
+ * Legacy 'lcd' persisted values are mapped to 'lcd-cockpit' by resolveSkinId().
  */
 
 const STORAGE_KEY = 'icom-lan-layout';
 
-export type LayoutMode = 'auto' | 'lcd' | 'standard';
+export type LayoutMode = 'auto' | 'lcd' | 'lcd-cockpit' | 'lcd-scope' | 'standard';
 
 let mode = $state<LayoutMode>(loadMode());
 
 function loadMode(): LayoutMode {
   if (typeof window === 'undefined') return 'auto';
   const saved = localStorage.getItem(STORAGE_KEY);
-  if (saved === 'lcd' || saved === 'standard') return saved;
+  if (saved === 'lcd' || saved === 'lcd-cockpit' || saved === 'lcd-scope' || saved === 'standard') {
+    return saved;
+  }
   // Migrate old 'spectrum' value to 'standard'
   if (saved === 'spectrum') return 'standard';
   return 'auto';

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -32,13 +32,15 @@ export interface SkinResolutionContext {
  *
  * Rules:
  * - Mobile viewport → mobile skin
- * - User forced 'lcd' → lcd-cockpit (default LCD variant)
+ * - User forced 'lcd' or 'lcd-cockpit' → lcd-cockpit
+ * - User forced 'lcd-scope' → lcd-scope
  * - User forced 'standard' → desktop-v2
  * - Auto: use desktop-v2 if any scope is available, lcd-cockpit otherwise
  */
 export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   if (ctx.isMobile) return 'mobile';
-  if (ctx.layoutPreference === 'lcd') return 'lcd-cockpit';
+  if (ctx.layoutPreference === 'lcd' || ctx.layoutPreference === 'lcd-cockpit') return 'lcd-cockpit';
+  if (ctx.layoutPreference === 'lcd-scope') return 'lcd-scope';
   if (ctx.layoutPreference === 'standard') return 'desktop-v2';
   // auto: scope available → desktop, otherwise LCD
   return ctx.hasAnyScope ? 'desktop-v2' : 'lcd-cockpit';


### PR DESCRIPTION
## Summary
Addresses **P1 Codex re-review** on PR #909:
> `resolveSkinId` never returns \`lcd-scope\` (only resolves to \`mobile\`, \`desktop-v2\`, or \`lcd-cockpit\`), and \`RadioLayout.svelte\` still bypasses registry loaders and renders \`<LcdLayout />\` directly for both LCD skin IDs. In this state, the new wrappers remain dead code and the cockpit/scope toggle still cannot work at runtime.

The prior PR (#909) added wrappers but didn't wire the selection path. This PR closes the loop end-to-end.

## Changes
1. **\`LayoutMode\`** (\`lib/stores/layout.svelte.ts\`) — union extended to \`'auto' | 'lcd' | 'lcd-cockpit' | 'lcd-scope' | 'standard'\`. Legacy \`'lcd'\` kept as alias. \`loadMode()\` accepts the new values from localStorage.
2. **\`resolveSkinId\`** (\`skins/registry.ts\`) — returns \`'lcd-scope'\` when \`layoutPreference === 'lcd-scope'\`; legacy \`'lcd'\` and new \`'lcd-cockpit'\` both map to \`'lcd-cockpit'\`.
3. **\`RadioLayout.svelte\`** — branches on \`skinId\` to pass the right variant: \`lcd-cockpit\` → \`<LcdLayout variant="cockpit" />\`, \`lcd-scope\` → \`<LcdLayout variant="scope" />\`.
4. **\`StatusBar.svelte\`** dropdown — exposes "LCD Cockpit" and "LCD Scope" as distinct entries (replaces single "LCD").

## End-to-end flow now works
\`dropdown → setLayoutMode('lcd-scope') → resolveSkinId → 'lcd-scope' → RadioLayout → <LcdLayout variant="scope" /> → <AmberScope />\`

The scope skin is now actually reachable at runtime.

## Files (4)
- \`frontend/src/lib/stores/layout.svelte.ts\` (+11/-5)
- \`frontend/src/skins/registry.ts\` (+4/-2)
- \`frontend/src/components-v2/layout/RadioLayout.svelte\` (+4/-2)
- \`frontend/src/components-v2/layout/StatusBar.svelte\` (+5/-3)

Net: +12 LOC.

## Test plan
- [x] \`pnpm test --run\` — 1663/1663 pass
- [x] \`pnpm lint\` — clean
- [ ] Manual verify: StatusBar dropdown shows "LCD Cockpit" / "LCD Scope"; selecting each swaps the rendered LCD surface without reload.

## Notes
\`LcdCockpitSkin.svelte\` / \`LcdScopeSkin.svelte\` wrappers from #909 are kept — they're ready for the future refactor that replaces RadioLayout's hardcoded branches with dynamic \`<svelte:component>\` + \`loadSkin(id)\`. Today they're unused but harmless; removing them would re-churn when that refactor lands.

Part of #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)