### PR TITLE
feat(#900): AF-FFT unavailable fallback — ghost graticule + filter shape

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberFilterGhost.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberFilterGhost.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  interface Props {
+    /** Filter width in Hz (raw from radio) */
+    filterWidth?: number;
+    /** Max filter width value in Hz for normalization */
+    filterWidthMax?: number;
+  }
+
+  let { filterWidth = 2400, filterWidthMax = 9999 }: Props = $props();
+
+  // viewBox dimensions
+  const VW = 100;
+  const VH = 40;
+
+  // Trapezoid geometry mirrors AmberAfScope proportions, adapted to viewBox units.
+  // totalHalfW is 42% of VW; slopeExtra is 35% of trap height.
+  const trapTop = 0;
+  const trapH = VH;
+  const cx = VW / 2;
+  const totalHalfW = VW * 0.42;
+  const slopeExtra = trapH * 0.35;
+
+  // Filter ratio: clamp to [0.05, 1]
+  let filterRatio = $derived(
+    Math.max(0.05, Math.min(1, filterWidth / Math.max(1, filterWidthMax))),
+  );
+
+  // Top edge half-width scales with filter ratio
+  let maxTopHalfW = $derived(totalHalfW - slopeExtra);
+  let topHalfW = $derived(Math.max(trapH * 0.1 * (VH / 100), maxTopHalfW * filterRatio));
+
+  // Trapezoid corners
+  let tl = $derived(cx - topHalfW);
+  let tr = $derived(cx + topHalfW);
+  let bl = $derived(cx - topHalfW - slopeExtra);
+  let br = $derived(cx + topHalfW + slopeExtra);
+  let whiskerLeft = $derived(cx - totalHalfW);
+  let whiskerRight = $derived(cx + totalHalfW);
+
+  // Passband polygon points (trapezoid + whiskers as open path via polygon)
+  // We use a polyline for the open shape: whiskerLeft,VH → bl,VH → tl,trapTop → tr,trapTop → br,VH → whiskerRight,VH
+  let passbandPoints = $derived(
+    `${whiskerLeft},${VH} ${bl},${VH} ${tl},${trapTop} ${tr},${trapTop} ${br},${VH} ${whiskerRight},${VH}`,
+  );
+</script>
+
+<!--
+  AmberFilterGhost — static ghost graticule + passband outline shown when
+  hasAudioFft() returns false. Uses --lcd-alpha-ghost token for "turned-off
+  glass etching" aesthetic. Issue #900.
+-->
+<svg
+  class="ghost"
+  viewBox="0 0 {VW} {VH}"
+  preserveAspectRatio="none"
+  aria-hidden="true"
+>
+  <!-- Graticule: 9 vertical lines -->
+  {#each Array.from({ length: 9 }, (_, i) => 10 * (i + 1)) as x (x)}
+    <line x1={x} y1="0" x2={x} y2={VH} class="graticule-line" />
+  {/each}
+
+  <!-- Graticule: 3 horizontal lines -->
+  {#each [10, 20, 30] as y (y)}
+    <line x1="0" y1={y} x2={VW} y2={y} class="graticule-line" />
+  {/each}
+
+  <!-- Passband trapezoid outline (open polyline matching AmberAfScope shape) -->
+  <polyline points={passbandPoints} class="passband" />
+</svg>
+
+<style>
+  .ghost {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  .graticule-line,
+  .passband {
+    stroke: rgba(26, 16, 0, var(--lcd-alpha-ghost, 0.06));
+    fill: none;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .graticule-line {
+    stroke-width: 1;
+  }
+
+  .passband {
+    stroke-width: 2;
+  }
+</style>

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -6,6 +6,7 @@
   } from '../../wiring/state-adapter';
   import AmberFrequency from './AmberFrequency.svelte';
   import AmberAfScope from './AmberAfScope.svelte';
+  import AmberFilterGhost from './AmberFilterGhost.svelte';
   import AmberIndStrip from './AmberIndStrip.svelte';
   import type { IndToken } from './AmberIndStrip.svelte';
   import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
@@ -200,6 +201,11 @@
           ifShift={filterProps.ifShift}
           bandwidth={fftBandwidth}
           mode="dominant"
+        />
+      {:else}
+        <AmberFilterGhost
+          filterWidth={filterProps.filterWidth}
+          filterWidthMax={filterProps.filterWidthMax}
         />
       {/if}
     </div>


### PR DESCRIPTION
## Summary

- Adds `AmberFilterGhost.svelte` — a new static SVG component that renders a dim graticule grid (9 vertical + 3 horizontal lines) and a passband trapezoid outline using the `--lcd-alpha-ghost` CSS token, producing a "turned-off glass etching" aesthetic consistent with the retro LCD metaphor
- Wires it into `AmberScope.svelte` so the dominant scope row shows the ghost placeholder instead of an empty amber strip when `hasAudioFft()` returns false
- Trapezoid geometry mirrors `AmberAfScope` proportions (`totalHalfW=42%`, `slopeExtra=35%*h`, `filterRatio` clamped to `[0.05, 1]`) so the shape matches the live scope's passband outline
- Uses `vector-effect="non-scaling-stroke"` on all SVG elements to prevent stroke distortion in non-square containers

## Fixes

Closes #900
Part of #887

Closes the empty-amber D4 regression and P2 noted on PR #908: when the scope row became `1fr` (issue #893), radios without AF-FFT showed an unsightly empty amber cell; `AmberFilterGhost` fills it with a clearly-not-live visual that maintains layout integrity.

## Test plan

- [x] `pnpm test --run` — 87 files, 1663 tests, all passing
- [x] `pnpm lint` — zero ESLint violations
- [x] `pnpm check` — 186 TS errors (baseline, no regressions introduced)
- [x] `uv run ruff check src/ tests/` — zero violations
- [ ] Visual: on a radio without AF-FFT (`hasAudioFft()` returns false), the scope row shows a dim grid + filter outline rather than blank amber
- [ ] Visual: on a radio with AF-FFT, behavior is unchanged (ghost is not rendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)