### PR TITLE
fix(#887): codex P1/P2 batch (mobile grid, IP+ per-RX, legacy lcd)

### DIFF
--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -20,9 +20,16 @@
   }
   let { onSettings }: Props = $props();
 
-  let layoutMode = $derived(getLayoutMode());
-  // Skin-switcher dropdown options. `lcd` is a legacy alias that maps to
-  // `lcd-cockpit` in resolveSkinId — not exposed separately here. Twin-skin
+  // Canonicalize legacy 'lcd' to 'lcd-cockpit' for UI binding — the persisted
+  // value may still be 'lcd' (from pre-#889 installs), but the dropdown only
+  // exposes 'lcd-cockpit' / 'lcd-scope'. Without normalization the <select>
+  // would show no highlighted option for legacy users (codex P2 on PR #913).
+  let layoutMode = $derived.by<LayoutMode>(() => {
+    const raw = getLayoutMode();
+    return raw === 'lcd' ? 'lcd-cockpit' : raw;
+  });
+  // Skin-switcher dropdown options. `lcd` is a legacy persisted value that
+  // normalizes to `lcd-cockpit` above (kept for backward compat). Twin-skin
   // variants (`lcd-cockpit`, `lcd-scope`) are selectable per #887 / #889.
   const skinOptions: Array<{ value: LayoutMode; label: string }> = [
     { value: 'auto', label: 'AUTO' },
@@ -227,7 +234,7 @@
       </button>
     {/if}
     <label class="skin-switcher" title="Select UI skin">
-      {#if layoutMode === 'lcd'}
+      {#if layoutMode === 'lcd-cockpit' || layoutMode === 'lcd-scope'}
         <Tv size={14} strokeWidth={2} aria-hidden="true" />
       {:else}
         <Monitor size={14} strokeWidth={2} aria-hidden="true" />

--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -119,7 +119,9 @@
     ...(hasCapability('dial_lock') ? [{ id: 'lock' as const, label: 'LOCK', active: lockActive }] : []),
     ...(dataActive ? [{ id: 'data' as const, label: 'DATA', active: true }] : []),
     ...(hasCapability('ip_plus') ? [{
-      id: 'ipPlus' as const, label: 'IP+', active: radioState?.main?.ipplus ?? false,
+      // IP+ is a per-receiver setting on IC-7610 (codex P2 on PR #906).
+      // Bind to the active RX so SUB's IP+ state is reflected when SUB is active.
+      id: 'ipPlus' as const, label: 'IP+', active: rx?.ipplus ?? false,
     }] : []),
   ]);
 
@@ -662,6 +664,15 @@
   @container (max-width: 640px) {
     .lcd-screen.dual {
       grid-template-columns: minmax(0, 1fr);
+      /* Explicit 5-track rows — adding vfo-b to the area list without updating
+         rows would leave scope on the default auto track and hand the flexible
+         minmax(0, 1fr) to vfo-b instead (codex P1 on PR #912). */
+      grid-template-rows:
+        auto               /* global indicator strip */
+        auto               /* vfo-a cockpit */
+        auto               /* vfo-b cockpit (stacked) */
+        minmax(0, 1fr)     /* scope — keeps the flexible track */
+        auto;              /* aux (reserved) */
       grid-template-areas:
         "global"
         "vfo-a"


### PR DESCRIPTION
## Summary
Batch addressing 3 codex feedback items from recent epic #887 PRs. Kept to a single PR because each is 3-15 LOC and fixes land in two files that are simpler to review together.

### 🔴 P1 on [PR #912](https://github.com/morozsm/icom-lan/pull/912) — mobile grid tracks
\`AmberCockpit.svelte\`: the \`@container (max-width: 640px)\` override extended \`grid-template-areas\` to 5 rows (\`global / vfo-a / vfo-b / scope / aux\`) but kept the parent 4-track \`grid-template-rows\`. Scope row lost its flexible \`minmax(0, 1fr)\` track to \`vfo-b\` (area/track count mismatch). Added explicit 5-row definition so scope stays flexible when VFO B stacks.

### 🟡 P2 on [PR #906](https://github.com/morozsm/icom-lan/pull/906) — IP+ per-receiver
\`AmberCockpit.svelte\`: \`IP+\` indicator bound to \`radioState?.main?.ipplus\`. On IC-7610 IP+ is a **per-receiver** setting — rebound to \`rx?.ipplus\` (active receiver) to match other per-RX indicators (NB, NR, NOTCH, AGC, etc.).

### 🟡 P2 on [PR #913](https://github.com/morozsm/icom-lan/pull/913) — legacy \`lcd\` dropdown canonicalization
\`StatusBar.svelte\`: skin dropdown replaced single \`LCD\` option with \`LCD Cockpit\` / \`LCD Scope\`, but legacy persisted \`icom-lan-layout=lcd\` values still returned \`'lcd'\` from \`loadMode()\`. \`<select>\` showed no highlighted option for those users. Normalize legacy \`'lcd'\` → \`'lcd-cockpit'\` in the \`layoutMode\` derived; updated the Tv/Monitor icon guard accordingly.

## Files (2)
- \`frontend/src/components-v2/panels/lcd/AmberCockpit.svelte\` (+12/-1)
- \`frontend/src/components-v2/layout/StatusBar.svelte\` (+11/-4)

Net +23 LOC.

## Test plan
- [x] \`pnpm test --run\` — 1663/1663 pass
- [x] \`pnpm lint\` — clean
- [x] \`pnpm check\` — baseline 186 TS errors, 0 new
- [ ] Manual verify: IC-7610 dual-RX + IP+ toggled on SUB shows IP+ lit when SUB is active; StatusBar dropdown selects "LCD Cockpit" correctly after a fresh localStorage with old \`lcd\` value.

Part of #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)