### PR TITLE
fix(#919): AmberCockpit ghost fallback when AF-FFT unavailable

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -8,6 +8,7 @@
   import AmberFrequency from './AmberFrequency.svelte';
   import AmberSmeter from './AmberSmeter.svelte';
   import AmberAfScope from './AmberAfScope.svelte';
+  import AmberFilterGhost from './AmberFilterGhost.svelte';
   import AmberIndStrip from './AmberIndStrip.svelte';
   import type { IndToken } from './AmberIndStrip.svelte';
   import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
@@ -380,6 +381,14 @@
             mode="fill"
           />
         </div>
+      {:else}
+        <!-- Ghost fallback (#919 — mirrors AmberScope #900 integration).
+             Prevents the 1fr scope row from rendering as empty amber
+             when the radio has no AF-FFT capability. -->
+        <AmberFilterGhost
+          filterWidth={filterProps.filterWidth}
+          filterWidthMax={filterProps.filterWidthMax}
+        />
       {/if}
     </div>
 


### PR DESCRIPTION
Closes #919 (followup from codex P2 on PR #908).

## Summary
AmberScope got \`AmberFilterGhost\` fallback via #900 / PR #915 when \`hasAudioFft()\` is false. AmberCockpit was missed — its scope row (1fr from #893) still rendered as empty amber on radios without AF-FFT.

Mirrors the AmberScope integration: \`{:else}\` branch rendering \`<AmberFilterGhost />\` with \`filterWidth\` + \`filterWidthMax\` from \`filterProps\`.

## Files (1)
- \`frontend/src/components-v2/panels/lcd/AmberCockpit.svelte\` (+10/-1)

## Test plan
- [x] LCD tests pass (\`pnpm test src/components-v2/panels/lcd/\`)
- [ ] Full suite has a known flaky \`ws-client.test.ts\` test unrelated to this change — passes on re-run.
- [x] \`pnpm lint\` — clean
- [ ] Manual verify: radio without AF-FFT → cockpit scope row shows ghost graticule instead of blank amber

🤖 Generated with [Claude Code](https://claude.com/claude-code)