### PR TITLE
fix(#918): restore VFO A filter-width fallback in AmberScope

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -65,10 +65,13 @@
   let mainFreqHz = $derived(radioState?.main?.freqHz ?? 0);
   let mainMode = $derived(radioState?.main?.mode ?? '---');
   let mainBand = $derived(freqToBand(mainFreqHz));
-  let mainFilterWidth = $derived(radioState?.main?.filterWidth ?? 0);
+  // Fallback 2400 Hz matches `toFilterProps()` adapter default (codex P2 on
+  // PR #916): keeps the VFO A filter badge visible with a stable width when
+  // `main.filterWidth` is null (initial state or rig without filter reporting).
+  let mainFilterWidth = $derived(radioState?.main?.filterWidth ?? 2400);
   let mainFilterWidthLabel = $derived.by(() => {
     const w = mainFilterWidth;
-    if (!w || w <= 0) return '';
+    if (w <= 0) return '';
     return w >= 1000 ? `${(w / 1000).toFixed(1)} kHz` : `${w} Hz`;
   });
 


### PR DESCRIPTION
Closes #918 (codex P2 followup from PR #916).

## Problem
After #897 refactored AmberScope to read main receiver directly (\`radioState?.main?.filterWidth ?? 0\`), the VFO A filter badge stops rendering whenever \`main.filterWidth\` is null — a valid runtime state on initial load and on rigs without filter-width reporting. Before #897 the badge used \`toFilterProps()\` which defaults to 2400 Hz.

## Fix
Match the adapter default: fall back to \`2400\` instead of \`0\`. Label still hides on explicit \`<= 0\` (defensive) but the normal null-path now produces "2.4 kHz".

## Files (1)
- \`frontend/src/components-v2/panels/lcd/AmberScope.svelte\` (+4/-3)

## Test plan
- [x] LCD tests pass
- [x] ESLint clean
- [ ] Full suite — flaky ws-client test unrelated; passes on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)