### PR TITLE
fix(#441): read hamlib rig model from TOML in Yaesu dump_state

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -6,6 +6,8 @@
 [radio]
 id = "yaesu_ftx1"
 model = "FTX-1"
+# Hamlib rig_model integer (RIG_MODEL_FTX1). Used by rigctld dump_state.
+hamlib_model_id = 2028
 receiver_count = 2
 transceiver_count = 2
 has_lan = false

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -164,6 +164,16 @@ class YaesuCatRadio:
         return str(self._config.model)
 
     @property
+    def hamlib_model_id(self) -> int:
+        """Hamlib rig_model integer (e.g. ``2028`` for RIG_MODEL_FTX1).
+
+        Read from the rig's TOML ``[radio].hamlib_model_id`` field; used by
+        the rigctld Yaesu ``dump_state`` response so external clients see the
+        correct model (closes #441).
+        """
+        return int(self._config.hamlib_model_id)
+
+    @property
     def capabilities(self) -> set[str]:
         """Set of capability tags from the rig profile."""
         return set(self._config.capabilities)

--- a/src/icom_lan/rig_loader.py
+++ b/src/icom_lan/rig_loader.py
@@ -98,6 +98,10 @@ class RigConfig:
     antenna_tx_count: int = 1
     antenna_has_rx_ant: bool = False
     transceiver_count: int = 1
+    # Hamlib rig_model integer (from rigs_list.h). Used by rigctld Yaesu
+    # dump_state responses. Default 2028 = RIG_MODEL_FTX1. Icom radios
+    # are served by the built-in Icom routing path and don't use this.
+    hamlib_model_id: int = 2028
     scope_ref_min_db: float | None = None
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None
@@ -770,6 +774,7 @@ def load_rig(path: Path) -> RigConfig:
         civ_addr=civ_addr,
         receiver_count=radio["receiver_count"],
         transceiver_count=int(radio.get("transceiver_count", 1)),
+        hamlib_model_id=int(radio.get("hamlib_model_id", 2028)),
         has_lan=radio["has_lan"],
         has_wifi=radio["has_wifi"],
         default_baud=radio.get("default_baud", 19200),

--- a/src/icom_lan/rigctld/routing.py
+++ b/src/icom_lan/rigctld/routing.py
@@ -62,7 +62,7 @@ class RigctldRouting(Protocol):
 
 _YAESU_DUMP_STATE: list[str] = [
     "0",  # protocol version
-    "2028",  # TODO(#441): read rig model from TOML config
+    "2028",  # rig model — overridden per-radio from TOML by YaesuRouting.dump_state
     "1",  # ITU region
     "30000.000000 56000000.000000 0x1ff -1 -1 0x3 0xf",
     "0 0 0 0 0 0 0",
@@ -265,7 +265,12 @@ class YaesuRouting:
     # -- dump / info ---------------------------------------------------------
 
     def dump_state(self) -> list[str]:
-        return list(_YAESU_DUMP_STATE)
+        state = list(_YAESU_DUMP_STATE)
+        # Substitute the rig model from the radio's TOML config (closes #441).
+        # Default 2028 (FTX-1) if the radio doesn't expose hamlib_model_id.
+        model_id = getattr(self._radio, "hamlib_model_id", 2028)
+        state[1] = str(int(model_id))
+        return state
 
     def get_info(self) -> str:
         raw_model = getattr(self._radio, "model", "Yaesu")

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -2050,11 +2050,24 @@ async def test_yaesu_set_func_unknown_returns_einval(
 
 @pytest.mark.asyncio
 async def test_yaesu_dump_state(
-    yaesu_handler: RigctldHandler,
+    yaesu_handler: RigctldHandler, yaesu_radio: AsyncMock
 ) -> None:
+    # Rig model now comes from the radio's TOML config via
+    # `hamlib_model_id` (closes #441) — mock it explicitly.
+    yaesu_radio.hamlib_model_id = 2028
     resp = await yaesu_handler.execute(get_cmd("dump_state"))
     assert resp.ok
-    assert resp.values[1] == "2028"  # Yaesu rig model
+    assert resp.values[1] == "2028"  # Yaesu rig model (from TOML config)
+
+
+async def test_yaesu_dump_state_honors_toml_model_id(
+    yaesu_handler: RigctldHandler, yaesu_radio: AsyncMock
+) -> None:
+    """Non-default rig model from TOML appears in dump_state (closes #441)."""
+    yaesu_radio.hamlib_model_id = 1042  # RIG_MODEL_FTDX101D (example)
+    resp = await yaesu_handler.execute(get_cmd("dump_state"))
+    assert resp.ok
+    assert resp.values[1] == "1042"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ wheels = [
 
 [[package]]
 name = "icom-lan"
-version = "0.16.4"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyserial" },


### PR DESCRIPTION
Closes #441.

## Problem
\`_YAESU_DUMP_STATE[1]\` was hardcoded \`"2028"\` (RIG_MODEL_FTX1). External \`rigctl\` clients connecting to icom-lan's built-in rigctld saw that value regardless of the attached rig — wrong for any Yaesu model other than FTX-1.

## Fix
Thread a \`hamlib_model_id: int\` field from the rig's TOML \`[radio]\` section through \`RigConfig\` → \`YaesuCatRadio.hamlib_model_id\` property → \`YaesuRouting.dump_state()\` → value substituted at index \`[1]\` of the response list.

## Files (5)
- \`src/icom_lan/rig_loader.py\` (+5/-0) — new optional \`hamlib_model_id\` field on \`RigConfig\`
- \`src/icom_lan/backends/yaesu_cat/radio.py\` (+9/-0) — \`hamlib_model_id\` property
- \`src/icom_lan/rigctld/routing.py\` (+6/-2) — dynamic substitution in \`dump_state\`
- \`rigs/ftx1.toml\` (+2/-0) — explicit value (2028) for documentation
- \`tests/test_rigctld_handler.py\` (+14/-3) — mock updates + new test for non-default id

## Test plan
- [x] \`pytest tests/ -k "rig_loader or rigctld or yaesu_cat"\` — 513 pass
- [x] \`ruff check src/ tests/\` — zero violations
- [x] Backward compat: fallback to 2028 via \`getattr(radio, "hamlib_model_id", 2028)\` so older Icom code paths and test mocks without the spec still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)