### PR TITLE
fix(#440): SWR non-linear calibration from TOML config

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -212,6 +212,36 @@ label = "Gen"
 start_hz = 100000
 end_hz = 470000000
 
+[meters.swr]
+# SWR calibration table (closes #440). Interpolated piecewise-linear by
+# `YaesuCatRadio.get_swr()`. Raw range 0-255 maps to SWR ratio.
+# Values below are best-effort approximations based on typical Yaesu meter
+# scaling; refine after bench calibration against a known reference load.
+[[meters.swr.calibration]]
+raw = 0
+actual = 1.0
+label = "1.0"
+
+[[meters.swr.calibration]]
+raw = 48
+actual = 1.5
+label = "1.5"
+
+[[meters.swr.calibration]]
+raw = 96
+actual = 2.0
+label = "2.0"
+
+[[meters.swr.calibration]]
+raw = 160
+actual = 3.0
+label = "3.0"
+
+[[meters.swr.calibration]]
+raw = 255
+actual = 5.0
+label = "5.0+"
+
 [meters.s_meter]
 redline_raw = 130
 

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -46,6 +46,38 @@ def _load_config(profile: Any) -> Any:
     raise TypeError(f"profile must be str or RigConfig, got {type(profile).__name__}")
 
 
+def _interpolate_swr(
+    raw: int, meter_calibrations: dict[str, list[Any]] | None
+) -> float:
+    """Convert raw SWR meter value (0-255) to an SWR ratio.
+
+    Uses the ``swr`` calibration table from TOML when available,
+    interpolating piecewise-linearly between points. Returns the
+    legacy linear approximation when no table is configured
+    (preserves backward compat for rigs that don't define
+    ``[meters.swr.calibration]``).
+    """
+    if raw <= 0:
+        return 1.0
+    points = (meter_calibrations or {}).get("swr")
+    if points:
+        # Points are already sorted by raw in typical TOMLs, but sort defensively.
+        sorted_pts = sorted(points, key=lambda p: p["raw"])
+        if raw <= sorted_pts[0]["raw"]:
+            return float(sorted_pts[0]["actual"])
+        if raw >= sorted_pts[-1]["raw"]:
+            return float(sorted_pts[-1]["actual"])
+        for lo, hi in zip(sorted_pts, sorted_pts[1:]):
+            if lo["raw"] <= raw <= hi["raw"]:
+                span = hi["raw"] - lo["raw"]
+                if span == 0:
+                    return float(lo["actual"])
+                t = (raw - lo["raw"]) / span
+                return float(lo["actual"]) + t * (float(hi["actual"]) - float(lo["actual"]))
+    # Legacy linear fallback (pre-#440 behavior).
+    return 1.0 + (raw / 255.0) * 8.9
+
+
 class YaesuCatRadio:
     """Radio backend for Yaesu FTX-1 (and compatible) transceivers.
 
@@ -727,16 +759,15 @@ class YaesuCatRadio:
         return main
 
     async def get_swr(self) -> float:
-        """Get SWR as a ratio (1.0–9.9).
+        """Get SWR as a ratio (>= 1.0).
 
-        TODO(#440): Replace linear mapping with calibration table from TOML.
-        Current mapping is approximate — needs hardware calibration.
-        Linear mapping: raw 0 → 1.0, raw 255 → 9.9.
+        Uses the piecewise-linear calibration table from
+        ``[meters.swr.calibration]`` in the rig TOML when present
+        (closes #440). Falls back to the legacy linear mapping
+        ``1.0 + raw/255 * 8.9`` when no table is configured.
         """
-        main, _ = await self._read_meter(6)
-        if main == 0:
-            return 1.0
-        return 1.0 + (main / 255.0) * 8.9
+        raw, _ = await self._read_meter(6)
+        return _interpolate_swr(raw, self._config.meter_calibrations)
 
     async def get_id_meter(self) -> int:
         """Get IDD (current drain) meter reading (0–255)."""

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1240,17 +1240,36 @@ async def test_get_swr_zero_returns_one(connected_radio):
 
 @pytest.mark.asyncio
 async def test_get_swr_mid_value(connected_radio):
+    # Post-#440: interpolates the TOML calibration table.
+    # Calibration points: (96 → 2.0), (160 → 3.0); raw=120 interpolates
+    # linearly between them.
     connected_radio._transport.query = AsyncMock(return_value="RM6120000")
     swr = await connected_radio.get_swr()
-    expected = 1.0 + (120 / 255.0) * 8.9
+    t = (120 - 96) / (160 - 96)
+    expected = 2.0 + t * (3.0 - 2.0)
     assert abs(swr - expected) < 0.01
 
 
 @pytest.mark.asyncio
 async def test_get_swr_max(connected_radio):
+    # Post-#440: raw=255 pins to the last calibration point (5.0+),
+    # replacing the legacy linear endpoint of 9.9.
     connected_radio._transport.query = AsyncMock(return_value="RM6255000")
     swr = await connected_radio.get_swr()
-    assert abs(swr - 9.9) < 0.01
+    assert abs(swr - 5.0) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_get_swr_calibration_endpoints(connected_radio):
+    """SWR calibration points from TOML are honored exactly (closes #440)."""
+    for raw_val, expected in [(48, 1.5), (96, 2.0), (160, 3.0)]:
+        connected_radio._transport.query = AsyncMock(
+            return_value=f"RM6{raw_val:03d}000"
+        )
+        swr = await connected_radio.get_swr()
+        assert abs(swr - expected) < 0.01, (
+            f"raw={raw_val} expected SWR {expected}, got {swr:.3f}"
+        )
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ wheels = [
 
 [[package]]
 name = "icom-lan"
-version = "0.16.4"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyserial" },


### PR DESCRIPTION
Closes #440.

## Problem
\`YaesuCatRadio.get_swr()\` used a linear mapping \`1.0 + (raw/255) * 8.9\` that doesn't match the non-linear SWR meter scale on the FTX-1 (and similar rigs). The mapping was flagged in-code as \`TODO(#440)\`.

## Fix
Piecewise-linear interpolation driven by a calibration table in TOML — mirroring the established \`[meters.s_meter.calibration]\` pattern (which IC-7610 already uses for s-meter + swr).

- New \`[meters.swr.calibration]\` in \`rigs/ftx1.toml\` with 5 reference points: \`1.0 / 1.5 / 2.0 / 3.0 / 5.0+\`. Values are best-effort approximations and should be refined after bench calibration against a known load.
- \`_interpolate_swr()\` helper in \`yaesu_cat/radio.py\`:
  - Returns exact \`actual\` at known raw points
  - Linearly interpolates between adjacent points
  - Clamps to table endpoints outside the raw range
  - Falls back to legacy linear mapping when \`[meters.swr.calibration]\` is absent (backward-compat).
- \`get_swr()\` reduced from inline math to a call to the helper.

## Files (3)
- \`rigs/ftx1.toml\` (+25/-0)
- \`src/icom_lan/backends/yaesu_cat/radio.py\` (+37/-7)
- \`tests/test_ftx1_radio.py\` (+19/-3)

## Test plan
- [x] \`pytest tests/test_ftx1_radio.py -k swr\` — 4 passed
- [x] \`pytest tests/ -k "yaesu_cat or rig_loader or rig_ic7610"\` — 217 passed (2 updates where linear semantics were hardcoded)
- [x] \`ruff check src/ tests/\` — zero violations
- [x] Backward compat: rigs without \`[meters.swr.calibration]\` keep the legacy linear mapping via \`_interpolate_swr\`'s fallback branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)