### PR TITLE
fix(#440): honor SWR calibration table at raw=0

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -56,9 +56,12 @@ def _interpolate_swr(
     legacy linear approximation when no table is configured
     (preserves backward compat for rigs that don't define
     ``[meters.swr.calibration]``).
+
+    When a calibration table exists, the table is the source of truth
+    for the full raw range — including ``raw <= 0`` (codex P2 on
+    PR #924). Profiles can define a non-1.0 first point if their
+    meter produces such values.
     """
-    if raw <= 0:
-        return 1.0
     points = (meter_calibrations or {}).get("swr")
     if points:
         # Points are already sorted by raw in typical TOMLs, but sort defensively.
@@ -74,7 +77,9 @@ def _interpolate_swr(
                     return float(lo["actual"])
                 t = (raw - lo["raw"]) / span
                 return float(lo["actual"]) + t * (float(hi["actual"]) - float(lo["actual"]))
-    # Legacy linear fallback (pre-#440 behavior).
+    # No table: legacy linear fallback (pre-#440 behavior).
+    if raw <= 0:
+        return 1.0
     return 1.0 + (raw / 255.0) * 8.9
 
 


### PR DESCRIPTION
Addresses codex P2 feedback on [PR #924](https://github.com/morozsm/icom-lan/pull/924):

> \`_interpolate_swr()\` returns \`1.0\` for any \`raw <= 0\` before it consults the TOML calibration table, so rigs that define \`[[meters.swr.calibration]]\` with a non-\`1.0\` first point (or rely on endpoint clamping semantics) will never get that configured value at \`raw=0\`.

## Fix
Remove the \`if raw <= 0: return 1.0\` guard from before the table lookup. The table's first-point-clamp already handles \`raw <= first.raw\` correctly. The legacy \`raw<=0 → 1.0\` guard is preserved but only in the no-table fallback branch, so rigs without \`[meters.swr.calibration]\` keep the pre-#440 behavior.

FTX-1 no-op in practice (its first point is \`raw=0 → 1.0\`), but the contract is now consistent with the docstring claim of "first-point clamp".

## Files (1)
- \`src/icom_lan/backends/yaesu_cat/radio.py\` (+6/-3)

## Test plan
- [x] \`pytest tests/test_ftx1_radio.py -k swr\` — 4 passed
- [x] \`ruff check src/ tests/\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)