### PR TITLE
feat(#837): LCD telemetry strip (VD/TEMP/ID + sparklines)

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -10,6 +10,7 @@
   import AmberAfScope from './AmberAfScope.svelte';
   import AmberFilterGhost from './AmberFilterGhost.svelte';
   import AmberIndStrip from './AmberIndStrip.svelte';
+  import AmberTelemetryStrip from './AmberTelemetryStrip.svelte';
   import type { IndToken } from './AmberIndStrip.svelte';
   import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
 
@@ -392,8 +393,12 @@
       {/if}
     </div>
 
-    <!-- ═══ Aux row — reserved for future use (telemetry, memory) ═══ -->
-    <div style:grid-area="aux"></div>
+    <!-- ═══ Aux row — telemetry strip (#837) ═══
+         Memory / recent-QSY (#836) will share this grid-area via a
+         parent wrapper once that lands. -->
+    <div class="lcd-aux-row" style:grid-area="aux">
+      <AmberTelemetryStrip />
+    </div>
 
   </div>
 </div>

--- a/frontend/src/components-v2/panels/lcd/AmberSparkline.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberSparkline.svelte
@@ -1,0 +1,72 @@
+<!--
+  AmberSparkline — minimal inline SVG sparkline primitive for LCD tiles.
+
+  Renders a single polyline scaled to the available container size.
+  Uses `vector-effect: non-scaling-stroke` so the line stays visually
+  consistent when the SVG is stretched via `preserveAspectRatio="none"`.
+  No labels, no axes — it's a glanceable decoration only.
+
+  Empty / insufficient data yields an empty SVG (no error state) —
+  callers render the tile label beside it regardless.
+
+  Part of #837 / epic #818 LCD telemetry strip.
+-->
+<script lang="ts">
+  interface Props {
+    /** Recent samples, oldest-first. Typical 20-60 points. */
+    data: number[];
+    /** Optional fixed range; when omitted, auto-scales to min/max. */
+    min?: number;
+    max?: number;
+    /** Inline CSS color override (default picks up currentColor). */
+    color?: string;
+    /** SVG viewBox width — used purely for aspect; fits container via CSS. */
+    viewW?: number;
+    /** SVG viewBox height. */
+    viewH?: number;
+  }
+
+  let { data, min, max, color, viewW = 60, viewH = 14 }: Props = $props();
+
+  // Polyline points only when we have ≥ 2 samples to draw a line from.
+  let pointsAttr = $derived.by(() => {
+    if (!data || data.length < 2) return '';
+    const lo = min ?? Math.min(...data);
+    const hi = max ?? Math.max(...data);
+    const span = hi - lo || 1;
+    const stepX = viewW / (data.length - 1);
+    return data
+      .map((v, i) => {
+        const x = i * stepX;
+        const y = viewH - ((v - lo) / span) * viewH;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(' ');
+  });
+</script>
+
+<svg
+  class="amber-sparkline"
+  viewBox="0 0 {viewW} {viewH}"
+  preserveAspectRatio="none"
+  role="img"
+  aria-hidden="true"
+>
+  {#if pointsAttr}
+    <polyline
+      points={pointsAttr}
+      fill="none"
+      stroke={color ?? 'currentColor'}
+      stroke-width="1"
+      vector-effect="non-scaling-stroke"
+    />
+  {/if}
+</svg>
+
+<style>
+  .amber-sparkline {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>

--- a/frontend/src/components-v2/panels/lcd/AmberTelemetryStrip.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberTelemetryStrip.svelte
@@ -1,0 +1,161 @@
+<!--
+  AmberTelemetryStrip — 3 compact tiles (VD · TEMP · ID) with inline
+  sparklines showing the last ~30 samples. Mounted in the LCD aux
+  grid-area (#894 reserved the slot; #887 twin-skin lays the cockpit).
+
+  Data source: `ServerState.vdMeter` / `idMeter` and `tempMeter`
+  (when the backend surfaces it — not all rigs do). Missing fields
+  produce a "—" placeholder tile but keep the strip visible so the
+  grid row doesn't collapse under the user.
+
+  Sample history is kept per-tile in a local ring buffer (no store).
+  `$effect` watches the live values and pushes new samples when they
+  change materially (avoids building buffers of identical readings).
+
+  Part of #837 / epic #818 LCD telemetry strip.
+-->
+<script lang="ts">
+  import { radio } from '$lib/stores/radio.svelte';
+  import AmberSparkline from './AmberSparkline.svelte';
+
+  const BUFFER_SIZE = 30;
+  const PUSH_EPSILON = 1;    // ignore changes < 1 raw unit (stabilises sparklines)
+
+  let radioState = $derived(radio.current);
+
+  // Raw readings (nullable — backend may not provide all three).
+  let vdRaw = $derived<number | null>(radioState?.vdMeter ?? null);
+  let idRaw = $derived<number | null>(radioState?.idMeter ?? null);
+  // TEMP isn't yet on ServerState; read defensively for forward compat.
+  let tempRaw = $derived<number | null>(
+    (radioState as { tempMeter?: number } | null)?.tempMeter ?? null,
+  );
+
+  // Local ring buffers — $state so Svelte tracks them as arrays.
+  let vdHistory = $state<number[]>([]);
+  let idHistory = $state<number[]>([]);
+  let tempHistory = $state<number[]>([]);
+
+  function pushBuffer(buf: number[], value: number): number[] {
+    const last = buf.length ? buf[buf.length - 1] : null;
+    if (last !== null && Math.abs(value - last) < PUSH_EPSILON) return buf;
+    const next = buf.length >= BUFFER_SIZE ? buf.slice(1) : [...buf];
+    next.push(value);
+    return next;
+  }
+
+  $effect(() => {
+    if (vdRaw === null) return;
+    vdHistory = pushBuffer(vdHistory, vdRaw);
+  });
+  $effect(() => {
+    if (idRaw === null) return;
+    idHistory = pushBuffer(idHistory, idRaw);
+  });
+  $effect(() => {
+    if (tempRaw === null) return;
+    tempHistory = pushBuffer(tempHistory, tempRaw);
+  });
+
+  // Display conversions — rigs report raw 0..255; label text is best-effort.
+  function vdLabel(raw: number | null): string {
+    if (raw === null) return '—';
+    // Rough linear mapping 0..255 → 0..16 V. Adjust per rig in a followup.
+    return `${((raw / 255) * 16).toFixed(1)}V`;
+  }
+  function idLabel(raw: number | null): string {
+    if (raw === null) return '—';
+    return `${((raw / 255) * 25).toFixed(1)}A`;
+  }
+  function tempLabel(raw: number | null): string {
+    if (raw === null) return '—';
+    return `${Math.round((raw / 255) * 100)}°`;
+  }
+</script>
+
+<div class="amber-telemetry-strip">
+  <div class="tile" class:tile-empty={vdRaw === null}>
+    <div class="tile-head">
+      <span class="tile-tag">VD</span>
+      <span class="tile-value">{vdLabel(vdRaw)}</span>
+    </div>
+    <div class="tile-spark">
+      <AmberSparkline data={vdHistory} min={0} max={255} />
+    </div>
+  </div>
+
+  <div class="tile" class:tile-empty={tempRaw === null}>
+    <div class="tile-head">
+      <span class="tile-tag">TEMP</span>
+      <span class="tile-value">{tempLabel(tempRaw)}</span>
+    </div>
+    <div class="tile-spark">
+      <AmberSparkline data={tempHistory} min={0} max={255} />
+    </div>
+  </div>
+
+  <div class="tile" class:tile-empty={idRaw === null}>
+    <div class="tile-head">
+      <span class="tile-tag">ID</span>
+      <span class="tile-value">{idLabel(idRaw)}</span>
+    </div>
+    <div class="tile-spark">
+      <AmberSparkline data={idHistory} min={0} max={255} />
+    </div>
+  </div>
+</div>
+
+<style>
+  .amber-telemetry-strip {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+    width: 100%;
+    height: 100%;
+    min-height: 22px;
+    /* Uses the ambient warm-amber ink via --lcd-alpha-active from .lcd-screen. */
+    color: rgba(26, 16, 0, var(--lcd-alpha-active));
+  }
+
+  .tile {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0 4px;
+    min-width: 0;
+    border: 1px solid rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.2));
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .tile-empty {
+    opacity: 0.45;
+  }
+
+  .tile-head {
+    display: flex;
+    align-items: baseline;
+    gap: 3px;
+    flex-shrink: 0;
+    font-family: 'JetBrains Mono', 'Courier New', monospace;
+  }
+
+  .tile-tag {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.6));
+  }
+
+  .tile-value {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+
+  .tile-spark {
+    flex: 1;
+    min-width: 0;
+    height: 14px;
+  }
+</style>


### PR DESCRIPTION
Closes #837.

## Summary
Fills the LCD cockpit's \`aux\` grid-row (reserved empty by #894) with three compact tiles — voltage (VD), temperature (TEMP), drain current (ID) — each with a 30-sample inline sparkline.

## Components
1. **\`AmberSparkline.svelte\`** — pure SVG polyline primitive. Auto-scales to min/max or to a provided range. Uses \`vector-effect: non-scaling-stroke\` so stretching via \`preserveAspectRatio="none"\` keeps line weight consistent. Empty input → empty SVG (no error state).
2. **\`AmberTelemetryStrip.svelte\`** — 3-tile grid reading from \`ServerState.vdMeter\` / \`idMeter\`. \`tempMeter\` is read defensively (forward-compat with rigs that report it; others render "—"). Per-tile ring buffers (local \`$state\`) keep the last 30 samples; an epsilon-gate skips identical consecutive readings so lines don't pile flat.

## Integration
\`AmberCockpit.svelte\`: mount \`<AmberTelemetryStrip />\` in the \`aux\` grid-area. The row expands to the strip's min-height (22px) without competing with the scope row's \`1fr\`.

## Files (3)
- \`frontend/src/components-v2/panels/lcd/AmberSparkline.svelte\` (new, 62 LOC)
- \`frontend/src/components-v2/panels/lcd/AmberTelemetryStrip.svelte\` (new, 151 LOC)
- \`frontend/src/components-v2/panels/lcd/AmberCockpit.svelte\` (+6/-2)

## Caveats
- Raw → label mappings are linear best-effort (0..255 → 0..16 V etc). Per-rig TOML-driven calibration can refine later (mirrors #440 SWR approach).
- Ring buffers are per-mount. A parent remount loses history; acceptable for glanceable decoration.

## Test plan
- [x] \`pnpm test src/components-v2/panels/lcd/ src/components-v2/layout/__tests__/\` — 200/200 pass
- [x] \`pnpm lint\` — clean
- [ ] Manual: check strip appears in cockpit aux row on IC-7610 (has vd/id); "—" fallback for TEMP.

Part of epic #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)