### PR TITLE
chore(#843): landscape PTT guard parity

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -377,6 +377,59 @@
     // If latched, don't turn off on release
   }
 
+  // ── Landscape PTT guards (#843 parity with FAB) ──
+  // Adds pointermove-8px cancel + haptic + TX-permit dim-state so the
+  // landscape strip mirrors the guarded FAB (#840). Skips the 50ms hold
+  // delay — in landscape the thumb is already poised on PTT, so an
+  // intentional press should engage immediately once TX permit allows.
+  let lsPttStartX = 0;
+  let lsPttStartY = 0;
+  let lsPttEngaged = false;
+  const LS_PTT_MOVE_CANCEL_PX = 8;
+
+  function lsPttPointerDown(event: PointerEvent) {
+    if (pttMode === 'latched') {
+      // Tap-to-unlatch — delegate to shared state machine.
+      pttDown();
+      return;
+    }
+    if (txPermit === 'denied' && pttMode === 'idle') {
+      // Refuse the first press on out-of-band frequency. Second press
+      // within ~2s bypasses (user insists). Reuse the FAB convention.
+      const now = Date.now();
+      if (!lsLastDeniedPressAt || now - lsLastDeniedPressAt > 2000) {
+        lsLastDeniedPressAt = now;
+        return;
+      }
+    }
+    (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+    lsPttStartX = event.clientX;
+    lsPttStartY = event.clientY;
+    lsPttEngaged = true;
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      try { navigator.vibrate(10); } catch { /* noop */ }
+    }
+    pttDown();
+  }
+
+  function lsPttPointerMove(event: PointerEvent) {
+    if (!lsPttEngaged) return;
+    const dx = event.clientX - lsPttStartX;
+    const dy = event.clientY - lsPttStartY;
+    if (dx * dx + dy * dy > LS_PTT_MOVE_CANCEL_PX * LS_PTT_MOVE_CANCEL_PX) {
+      lsPttEngaged = false;
+      pttUp();
+    }
+  }
+
+  function lsPttPointerUp() {
+    if (!lsPttEngaged) return;
+    lsPttEngaged = false;
+    pttUp();
+  }
+
+  let lsLastDeniedPressAt = 0;
+
   // ── ATU (long-press = tune) ──
   let atuTimer: ReturnType<typeof setTimeout> | null = null;
   let atuDidLongPress = false;
@@ -450,9 +503,13 @@
           class="m-ls-ptt"
           class:m-ptt-held={pttMode === 'held'}
           class:m-ptt-latched={pttMode === 'latched'}
-          ontouchstart={(e) => { e.preventDefault(); pttDown(); }}
-          ontouchend={(e) => { e.preventDefault(); pttUp(); }}
-          ontouchcancel={() => pttUp()}
+          class:m-ls-ptt-dim={txPermit === 'denied' && pttMode === 'idle'}
+          onpointerdown={lsPttPointerDown}
+          onpointermove={lsPttPointerMove}
+          onpointerup={lsPttPointerUp}
+          onpointercancel={lsPttPointerUp}
+          oncontextmenu={(e) => e.preventDefault()}
+          title={txPermit === 'denied' ? 'TX not allowed on this frequency' : 'Push to talk'}
         >
           {pttMode === 'latched' ? 'TX🔒' : pttMode === 'held' ? 'TX' : 'PTT'}
         </button>
@@ -1094,6 +1151,14 @@
     background: var(--v2-accent-red, #ef4444);
     color: #fff;
     box-shadow: 0 0 16px rgba(239, 68, 68, 0.5);
+  }
+
+  /* TX-permit denied (#843): dim border + text so the operator sees at a
+     glance that the current frequency is out-of-band before pressing. */
+  .m-ls-ptt.m-ls-ptt-dim {
+    border-color: rgba(239, 68, 68, 0.35);
+    background: rgba(239, 68, 68, 0.04);
+    color: rgba(239, 68, 68, 0.5);
   }
 
   .m-ls-ptt.m-ptt-latched {


### PR DESCRIPTION
Closes #843.

## Summary
Brings landscape PTT (\`.m-ls-ptt\`) to parity with the guarded FAB from #840 / #928.

## Guards applied
| Guard | Behavior |
|-------|----------|
| Pointer Events API | Single handler path replaces split \`ontouchstart/end\`; cross-input parity (touch/mouse/pen) |
| \`pointermove > 8px\` cancel | Disengages TX if the user starts scrolling instead of pressing |
| Haptic | \`navigator.vibrate(10)\` on engage |
| TX-permit dim state | Border + text dim when frequency is out-of-band; first press silently ignored; second press within 2s bypasses |

## Guard NOT applied
**50ms press-and-hold minimum** — in landscape the thumb is already poised on PTT; an intentional press should engage immediately. The other guards are sufficient.

## Also NOT in this PR
Overlay auto-hide after 4s (§5.5 bullet) — explicitly deferred per the issue body.

## Files (1)
- \`frontend/src/components-v2/layout/MobileRadioLayout.svelte\` (+58/-5)

## Test plan
- [x] \`pnpm test src/components-v2/layout/\` — 167/167 pass
- [x] \`pnpm lint\` — clean
- [ ] Manual on iPhone landscape: pointermove-cancel, haptic, dim border on OOB frequency.

Part of epic #818 mobile IA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)