### PR TITLE
fix(ui): codex P1/P2 batch from PR #925/#928/#929/#930

### DIFF
--- a/frontend/src/components-v2/controls/PttFab.svelte
+++ b/frontend/src/components-v2/controls/PttFab.svelte
@@ -53,8 +53,11 @@
   let startY = 0;
 
   // TX-permit two-step arm state. First press arms; second press within
-  // the window engages. Expires automatically.
+  // the window engages. A timer resets armedAt back to 0 when the window
+  // lapses so the visual "armed" styling doesn't stick after timeout
+  // (codex P2 on PR #928).
   let armedAt = $state(0);
+  let armedResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   function vibrate(ms: number) {
     if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
@@ -90,10 +93,20 @@
       const now = Date.now();
       if (now - armedAt > PERMIT_ARM_WINDOW_MS) {
         armedAt = now;
+        if (armedResetTimer !== null) clearTimeout(armedResetTimer);
+        armedResetTimer = setTimeout(() => {
+          armedAt = 0;
+          armedResetTimer = null;
+        }, PERMIT_ARM_WINDOW_MS);
         onPermitWarning?.();
         return;
       }
-      // Within the arm window — fall through to engage logic below.
+      // Within the arm window — consume arm state and fall through to engage.
+      armedAt = 0;
+      if (armedResetTimer !== null) {
+        clearTimeout(armedResetTimer);
+        armedResetTimer = null;
+      }
     }
 
     // Capture so pointermove/pointerup still fire if the finger slides off.

--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -140,6 +140,10 @@
     { id: 'band', label: 'BAND' },
     { id: 'scan', label: 'SCAN' },
     { id: 'rf', label: 'RF' },
+    // DSP chip carries the level/threshold controls that ESSENTIALS exposes
+    // only as on/off toggles (codex P2 on PR #925 — removing the SETUP
+    // DSP panel left no mobile path to tune NR level, NB level, notch freq).
+    { id: 'dsp', label: 'DSP' },
     ...(ritXit.hasRit || ritXit.hasXit ? [{ id: 'rit', label: 'RIT/XIT' }] : []),
     ...(txCapable ? [{ id: 'tx', label: 'TX' }] : []),
   ]);
@@ -508,6 +512,7 @@
           onpointermove={lsPttPointerMove}
           onpointerup={lsPttPointerUp}
           onpointercancel={lsPttPointerUp}
+          onlostpointercapture={lsPttPointerUp}
           oncontextmenu={(e) => e.preventDefault()}
           title={txPermit === 'denied' ? 'TX not allowed on this frequency' : 'Push to talk'}
         >
@@ -677,6 +682,25 @@
             onPreChange={rfHandlers.onPreChange}
             onDigiSelToggle={rfHandlers.onDigiSelToggle}
             onIpPlusToggle={rfHandlers.onIpPlusToggle}
+          />
+        </CollapsiblePanel>
+      </section>
+    {:else if activeChipId === 'dsp'}
+      <section class="m-section" id="m-chip-panel-dsp" role="tabpanel">
+        <CollapsiblePanel title="DSP" panelId="m-dsp-chip" collapsible={false}>
+          <DspPanel
+            nrMode={dsp.nrMode}
+            nrLevel={dsp.nrLevel}
+            nbActive={dsp.nbActive}
+            nbLevel={dsp.nbLevel}
+            notchMode={dsp.notchMode}
+            notchFreq={dsp.notchFreq}
+            onNrModeChange={dspHandlers.onNrModeChange}
+            onNrLevelChange={dspHandlers.onNrLevelChange}
+            onNbToggle={dspHandlers.onNbToggle}
+            onNbLevelChange={dspHandlers.onNbLevelChange}
+            onNotchModeChange={dspHandlers.onNotchModeChange}
+            onNotchFreqChange={dspHandlers.onNotchFreqChange}
           />
         </CollapsiblePanel>
       </section>
@@ -969,11 +993,12 @@
 <!-- Toast notifications — rendered in fixed position overlay -->
 <Toast />
 
-{#if txCapable}
-  <!-- Guarded sticky PTT FAB (#840) — persistent 1-tap TX from any screen.
-       Layered guards (50ms hold, 8px cancel, haptic, TX-permit two-step)
-       live in the FAB component. State machine stays in the parent
-       (pttMode + 3-min safety timer + double-tap latch). -->
+{#if txCapable && !isLandscape}
+  <!-- Guarded sticky PTT FAB (#840) — persistent 1-tap TX in portrait only.
+       Landscape has its own guarded `.m-ls-ptt` button (#843); mounting
+       FAB there would give two simultaneous TX controls (codex P1 on
+       PR #928). Layered guards live in the FAB component. State machine
+       stays in the parent (pttMode + 3-min safety timer + double-tap). -->
   <PttFab
     mode={pttMode}
     txPermit={txPermit}

--- a/frontend/src/components-v2/panels/lcd/AmberTelemetryStrip.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberTelemetryStrip.svelte
@@ -19,7 +19,12 @@
   import AmberSparkline from './AmberSparkline.svelte';
 
   const BUFFER_SIZE = 30;
-  const PUSH_EPSILON = 1;    // ignore changes < 1 raw unit (stabilises sparklines)
+  // Minimum time between samples written to the ring buffer (codex P2 on
+  // PR #929). The previous epsilon-delta gate silently dropped stable
+  // values — rigs whose vdMeter rarely moves got blank sparklines. A time
+  // gate keeps lines drawing even for flat inputs while still decimating
+  // the incoming stream so every frame doesn't push through.
+  const PUSH_MIN_INTERVAL_MS = 1000;
 
   let radioState = $derived(radio.current);
 
@@ -37,24 +42,23 @@
   let tempHistory = $state<number[]>([]);
 
   function pushBuffer(buf: number[], value: number): number[] {
-    const last = buf.length ? buf[buf.length - 1] : null;
-    if (last !== null && Math.abs(value - last) < PUSH_EPSILON) return buf;
     const next = buf.length >= BUFFER_SIZE ? buf.slice(1) : [...buf];
     next.push(value);
     return next;
   }
 
+  // Interval-driven sampling instead of reactive-on-change (codex P2 on
+  // PR #929): if a meter value is stable (common for vdMeter), an effect
+  // keyed on `$derived` only fires once, leaving the sparkline blank.
+  // Reading the current raw values every PUSH_MIN_INTERVAL_MS guarantees
+  // a line is drawn even when input is flat.
   $effect(() => {
-    if (vdRaw === null) return;
-    vdHistory = pushBuffer(vdHistory, vdRaw);
-  });
-  $effect(() => {
-    if (idRaw === null) return;
-    idHistory = pushBuffer(idHistory, idRaw);
-  });
-  $effect(() => {
-    if (tempRaw === null) return;
-    tempHistory = pushBuffer(tempHistory, tempRaw);
+    const interval = setInterval(() => {
+      if (vdRaw !== null) vdHistory = pushBuffer(vdHistory, vdRaw);
+      if (idRaw !== null) idHistory = pushBuffer(idHistory, idRaw);
+      if (tempRaw !== null) tempHistory = pushBuffer(tempHistory, tempRaw);
+    }, PUSH_MIN_INTERVAL_MS);
+    return () => clearInterval(interval);
   });
 
   // Display conversions — rigs report raw 0..255; label text is best-effort.


### PR DESCRIPTION
Addresses five codex review findings from the recent UI sprint. All five changes live in two files; rolling them into one PR keeps review tight because each fix is 3-20 LOC.

## 🔴 P1

### PR #928 — PttFab rendered in landscape
\`<PttFab>\` was mounted under \`txCapable\` only, **outside** the \`{#if isLandscape}\` orientation split. Landscape had both the FAB (portrait design) and the existing \`.m-ls-ptt\` button — two simultaneous TX controls, against the "landscape behavior unchanged" contract of #928.

**Fix**: add \`&& !isLandscape\` to the FAB mount guard.

### PR #930 — Landscape PTT stuck on lost pointer capture
\`.m-ls-ptt\` calls \`setPointerCapture\` but only handled \`onpointerup\` / \`onpointercancel\`. Orientation-change or fullscreen interruption can fire \`lostpointercapture\` **without** triggering up/cancel, leaving \`lsPttEngaged\` and \`pttMode\` stuck — TX remains keyed until the 3-minute safety timer. The FAB already handles this via \`onlostpointercapture={() => cancelPress()}\`.

**Fix**: wire \`onlostpointercapture={lsPttPointerUp}\` on the landscape button.

## 🟡 P2

### PR #925 — DSP depth controls regression
Removing the DSP panel from SETUP removed the only mobile UI for **NR level**, **NB level**, and **notch frequency**. ESSENTIALS only exposes on/off toggles.

**Fix**: new \`dsp\` chip in the chip-scroll, mounting the full \`DspPanel\` exactly as it lived in SETUP.

### PR #928 — Armed state never cleared
PttFab's UI binds the "armed" yellow border to \`armedAt !== 0\`, but that flag was never reset after the 2-second arm window lapsed. Press logic correctly expired via \`now - armedAt > window\`, but the button stayed visually armed forever.

**Fix**: schedule \`setTimeout(() => armedAt = 0, PERMIT_ARM_WINDOW_MS)\` on arm, with proper cancel/reset when the second press engages or a new arm starts.

### PR #929 — Sparkline blank on stable telemetry
The epsilon-delta gate (\`Math.abs(value - last) < 1\`) silently dropped all but first sample for flat inputs. Since \`AmberSparkline\` only draws with ≥2 points, a rig whose \`vdMeter\` is stable got a permanently blank sparkline.

**Fix**: replace reactive \`$effect\`-per-raw with a single \`setInterval(1000)\` that reads current raw values and pushes to each buffer regardless of whether the underlying reactive values changed. Flat inputs now produce a flat visible line.

## Files (2)
- \`frontend/src/components-v2/controls/PttFab.svelte\` (+12/-2)
- \`frontend/src/components-v2/layout/MobileRadioLayout.svelte\` (+25/-3)
- \`frontend/src/components-v2/panels/lcd/AmberTelemetryStrip.svelte\` (+17/-21)

## Test plan
- [x] \`pnpm test src/components-v2/\` — 1176/1176 pass
- [x] \`pnpm lint\` — clean
- [ ] Manual: iPhone landscape — only \`.m-ls-ptt\` present, no FAB. Interrupt mid-press (rotate) — TX releases. Mobile DSP chip shows level sliders. FAB armed-border clears after 2s of inactivity. Telemetry sparkline draws a flat line even when vdMeter is static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)