### PR TITLE
feat(#836): LCD memory / recent-QSY strip

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -11,7 +11,10 @@
   import AmberFilterGhost from './AmberFilterGhost.svelte';
   import AmberIndStrip from './AmberIndStrip.svelte';
   import AmberTelemetryStrip from './AmberTelemetryStrip.svelte';
+  import AmberMemoryStrip from './AmberMemoryStrip.svelte';
   import type { IndToken } from './AmberIndStrip.svelte';
+  import { qsyHistory } from '$lib/stores/qsy-history.svelte';
+  import { runtime } from '$lib/runtime';
   import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
 
   // Band lookup by frequency (LCD-specific)
@@ -234,6 +237,21 @@
     return () => scope.disconnect();
   });
 
+  // Record active-receiver frequency changes into the local QSY history
+  // ring buffer (#836). `qsyHistory.record()` internally debounces +
+  // filters by Δ ≥ 500 Hz so dial-hunting doesn't pollute the buffer.
+  $effect(() => {
+    const freq = rx?.freqHz ?? 0;
+    const mode = rx?.mode ?? '';
+    if (freq > 0) qsyHistory.record(freq, mode);
+  });
+
+  function handleQsyRecall(freqHz: number, mode: string): void {
+    // Route through runtime — same CI-V path as other frequency changes.
+    runtime.send('set_freq', { freq: freqHz });
+    if (mode) runtime.send('set_mode', { mode });
+  }
+
   // ── Peer cockpit derivations ──
   // In the dual-cockpit peer layout, column A always = main VFO, column B always = sub VFO.
   // We derive main/sub data directly so each column has stable data regardless of active state.
@@ -393,10 +411,13 @@
       {/if}
     </div>
 
-    <!-- ═══ Aux row — telemetry strip (#837) ═══
-         Memory / recent-QSY (#836) will share this grid-area via a
-         parent wrapper once that lands. -->
+    <!-- ═══ Aux row — memory/QSY (#836) + telemetry (#837) ═══
+         Two compact rows stacked in the reserved aux grid-area. Memory
+         strip on top (user-initiated recalls), telemetry below (passive
+         sparklines). Each row is ~18px tall; the combined aux block
+         stays inside `auto` track without encroaching on scope. -->
     <div class="lcd-aux-row" style:grid-area="aux">
+      <AmberMemoryStrip onQsy={handleQsyRecall} />
       <AmberTelemetryStrip />
     </div>
 
@@ -661,6 +682,16 @@
     width: 100%;
     height: 100%;
     min-height: 0;
+  }
+
+  /* ── Aux row (#836 memory / #837 telemetry, stacked) ── */
+  .lcd-aux-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+    z-index: 2;
+    position: relative;
   }
 
   /* ── TX glow ── */

--- a/frontend/src/components-v2/panels/lcd/AmberMemoryStrip.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberMemoryStrip.svelte
@@ -1,0 +1,178 @@
+<!--
+  AmberMemoryStrip — compact aux-row widget showing 5 memory slots
+  (M1-M5) and the last 3 auto-QSY entries.
+
+  Memory slots (M1-M5) are placeholder-only in this first pass — the
+  repo has no frontend memory store yet, so slots render "—". The
+  backend-memory plumbing is tracked as a followup; once it exists,
+  `memoryStore.get(n)` plugs in here without touching the component
+  contract.
+
+  QSY entries come from `$lib/stores/qsy-history` — a local ring
+  buffer that debounces frequency changes into intentional QSYs
+  (≥ 500 Hz delta, 1.5s stability). Each entry is a clickable chip
+  that fires `onQsy(freqHz, mode)` so the parent can call into
+  `runtime.send('set_freq', ...)`.
+
+  Part of #836 / epic #818 LCD aux-row content.
+-->
+<script lang="ts">
+  import { qsyHistory } from '$lib/stores/qsy-history.svelte';
+
+  interface Props {
+    /** Invoked when a recent-QSY chip is tapped. Parent routes to runtime. */
+    onQsy?: (freqHz: number, mode: string) => void;
+  }
+
+  let { onQsy }: Props = $props();
+
+  // Show last 3 entries, newest-first.
+  let recentQsy = $derived<{ freqHz: number; mode: string; at: number }[]>(
+    qsyHistory.recent.slice(-3).reverse() as { freqHz: number; mode: string; at: number }[],
+  );
+
+  // Memory slots — placeholder until a store lands.
+  const memorySlots = [1, 2, 3, 4, 5];
+
+  function formatFreqShort(hz: number): string {
+    if (!hz || hz <= 0) return '—';
+    // Compact: "14.074" for HF, "144.52" for VHF.
+    const mhz = hz / 1_000_000;
+    return mhz >= 1000
+      ? `${(mhz / 1000).toFixed(3)}G`
+      : mhz >= 100
+        ? `${mhz.toFixed(3)}`
+        : `${mhz.toFixed(3)}`;
+  }
+
+  function handleQsyClick(freqHz: number, mode: string) {
+    onQsy?.(freqHz, mode);
+  }
+</script>
+
+<div class="amber-memory-strip">
+  <div class="section mem-section">
+    <span class="section-tag">MEM</span>
+    {#each memorySlots as slot}
+      <button class="slot slot-empty" disabled title={`Memory slot M${slot} — not wired yet`}>
+        <span class="slot-index">M{slot}</span>
+        <span class="slot-value">—</span>
+      </button>
+    {/each}
+  </div>
+
+  <div class="section qsy-section" class:qsy-empty={recentQsy.length === 0}>
+    <span class="section-tag">QSY</span>
+    {#if recentQsy.length === 0}
+      <span class="qsy-placeholder">—</span>
+    {:else}
+      {#each recentQsy as entry (entry.at)}
+        <button
+          type="button"
+          class="slot slot-qsy"
+          onclick={() => handleQsyClick(entry.freqHz, entry.mode)}
+          title={`Return to ${formatFreqShort(entry.freqHz)} MHz ${entry.mode}`}
+        >
+          <span class="slot-value">{formatFreqShort(entry.freqHz)}</span>
+          <span class="slot-mode">{entry.mode}</span>
+        </button>
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .amber-memory-strip {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    width: 100%;
+    min-height: 18px;
+    color: rgba(26, 16, 0, var(--lcd-alpha-active));
+    font-family: 'JetBrains Mono', 'Courier New', monospace;
+  }
+
+  .section {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .mem-section {
+    flex-shrink: 0;
+  }
+
+  .qsy-section {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .qsy-empty {
+    opacity: 0.45;
+  }
+
+  .section-tag {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.55));
+    flex-shrink: 0;
+  }
+
+  .qsy-placeholder {
+    font-size: 10px;
+    color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.4));
+  }
+
+  .slot {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 3px;
+    padding: 0 4px;
+    height: 16px;
+    border: 1px solid rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.2));
+    border-radius: 2px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .slot:disabled,
+  .slot-empty {
+    cursor: default;
+    opacity: 0.45;
+  }
+
+  .slot-qsy {
+    border-color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.4));
+  }
+
+  .slot-qsy:hover {
+    border-color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.65));
+    background: rgba(26, 16, 0, var(--lcd-alpha-ghost));
+  }
+
+  .slot-index {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.6));
+  }
+
+  .slot-value {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+
+  .slot-mode {
+    font-size: 8px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: rgba(26, 16, 0, calc(var(--lcd-alpha-active) * 0.55));
+  }
+</style>

--- a/frontend/src/lib/stores/qsy-history.svelte.ts
+++ b/frontend/src/lib/stores/qsy-history.svelte.ts
@@ -1,0 +1,89 @@
+/**
+ * QSY history — local ring buffer of recent frequency changes.
+ *
+ * Not persisted, not sent to the backend. Lives for the browser
+ * session only (cleared on reload). Used by LCD aux-row widgets
+ * (#836 AmberMemoryStrip) to show "where was I?" chips.
+ *
+ * We record frequency transitions only when they look intentional:
+ * - Require a minimum delta (> 500 Hz) to skip dial-hunting within
+ *   the same slice of the band.
+ * - Debounce ~1.5s — commit only after the frequency has been stable
+ *   that long, so hold-to-spin tuning doesn't fill the buffer.
+ *
+ * Drop-in API:
+ *   - `qsyHistory.recent` — reactive array, oldest-first.
+ *   - `qsyHistory.record(freqHz, mode)` — caller-driven (an effect in
+ *     the layout polls radio state and calls this).
+ *   - `qsyHistory.clear()`.
+ */
+
+export interface QsyEntry {
+  freqHz: number;
+  mode: string;
+  at: number; // Date.now() when recorded
+}
+
+const MAX_ENTRIES = 10;
+const MIN_DELTA_HZ = 500;
+const DEBOUNCE_MS = 1500;
+
+let recent = $state<QsyEntry[]>([]);
+
+// Pending commit state — the "candidate" next entry. When the frequency
+// stays here for DEBOUNCE_MS we commit it; otherwise the latest value
+// replaces the candidate.
+let pendingFreqHz = 0;
+let pendingMode = '';
+let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+function commitPending() {
+  if (pendingFreqHz <= 0) return;
+  const last = recent.length > 0 ? recent[recent.length - 1] : null;
+  if (last && Math.abs(last.freqHz - pendingFreqHz) < MIN_DELTA_HZ) return;
+  const entry: QsyEntry = {
+    freqHz: pendingFreqHz,
+    mode: pendingMode,
+    at: Date.now(),
+  };
+  const next = recent.length >= MAX_ENTRIES ? recent.slice(1) : [...recent];
+  next.push(entry);
+  recent = next;
+}
+
+export const qsyHistory = {
+  get recent(): readonly QsyEntry[] {
+    return recent;
+  },
+
+  /**
+   * Record a potential QSY. Caller passes live frequency + mode;
+   * the store debounces internally and only commits stable values.
+   */
+  record(freqHz: number, mode: string): void {
+    if (!Number.isFinite(freqHz) || freqHz <= 0) return;
+    // If the same freq is already the last committed entry, skip.
+    const last = recent.length > 0 ? recent[recent.length - 1] : null;
+    if (last && Math.abs(last.freqHz - freqHz) < MIN_DELTA_HZ) {
+      return;
+    }
+    // Update the candidate; reset the debounce timer.
+    pendingFreqHz = freqHz;
+    pendingMode = mode;
+    if (pendingTimer !== null) clearTimeout(pendingTimer);
+    pendingTimer = setTimeout(() => {
+      pendingTimer = null;
+      commitPending();
+    }, DEBOUNCE_MS);
+  },
+
+  clear(): void {
+    recent = [];
+    pendingFreqHz = 0;
+    pendingMode = '';
+    if (pendingTimer !== null) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+  },
+};


### PR DESCRIPTION
Closes #836.

## Summary
Fills the second half of the LCD cockpit's aux grid-row with a memory + recent-QSY strip. Pairs with the telemetry strip from #837 to form a two-tier aux block.

## Components
1. **\`qsy-history.svelte.ts\`** — local ring-buffer store. Records a frequency change only when:
   - Δ ≥ 500 Hz vs the last committed entry (skip dial-hunting)
   - The same freq has been stable for ≥ 1.5 s (skip crank-and-release)
   
   Max 10 entries, session-only. Exposes \`recent\` (readonly), \`record(freqHz, mode)\`, \`clear()\`.
2. **\`AmberMemoryStrip.svelte\`** — single row, two sections:
   - **MEM** — M1..M5 slots (disabled placeholders until backend memory plumbing lands; contract is ready)
   - **QSY** — up to 3 latest entries as clickable chips; tap fires \`onQsy(freqHz, mode)\`

## Integration in AmberCockpit
- New imports: strip, store, \`runtime\`.
- \`$effect\` watches active-receiver \`freqHz + mode\` and calls \`qsyHistory.record()\`.
- \`handleQsyRecall\` routes the click through \`runtime.send('set_freq')\` + \`set_mode\`, so the recall restores both freq and mode.
- Aux grid-area now wraps both strips in a flex-column (\`.lcd-aux-row\`). Memory strip on top (user-initiated), telemetry below (passive).

## Files (4)
- \`frontend/src/lib/stores/qsy-history.svelte.ts\` (new, 79 LOC)
- \`frontend/src/components-v2/panels/lcd/AmberMemoryStrip.svelte\` (new, 168 LOC)
- \`frontend/src/components-v2/panels/lcd/AmberCockpit.svelte\` (+24/-3)
- Implicit: memory-store contract documented in AmberMemoryStrip comment.

## Test plan
- [x] \`pnpm test src/components-v2/ src/lib/stores/\` — 1297/1297 pass
- [x] \`pnpm lint\` — clean
- [ ] Manual: tune across 14.074 → 14.230 → 7.074 → 7.100 with ≥ 1.5 s stability; see 3 QSY chips appear; tap oldest to return.

Part of epic #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)