### PR TITLE
feat(#838): LCD Display Mode effects (vintage / CRT / flicker)

### DIFF
--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -19,6 +19,9 @@
   import AmberCockpit from '../panels/lcd/AmberCockpit.svelte';
   import AmberScope from '../panels/lcd/AmberScope.svelte';
   import LcdContrastControl from '../panels/lcd/LcdContrastControl.svelte';
+  import LcdDisplayModeControl from '../panels/lcd/LcdDisplayModeControl.svelte';
+  import { getLcdDisplayMode } from '$lib/stores/lcd-display-mode.svelte';
+  import '../panels/lcd/lcd-vintage.css';
   import VfoControlPanel from '../panels/lcd/VfoControlPanel.svelte';
   import LeftSidebar from './LeftSidebar.svelte';
   import RightSidebar from './RightSidebar.svelte';
@@ -34,6 +37,9 @@
 
   let radioState = $derived(runtime.state);
   let keyboardConfig = $derived(getKeyboardConfig());
+  // Reactive Display Mode (#838) — the class is applied to .lcd-frame
+  // so CSS effects in lcd-vintage.css can layer on top of the base render.
+  let displayMode = $derived(getLcdDisplayMode());
   let activeMode = $derived(radioState?.active === 'SUB' ? radioState?.sub?.mode : radioState?.main?.mode);
 
   const keyboardHandlers = makeKeyboardHandlers();
@@ -64,7 +70,11 @@
 
     <main class="content-center">
       <div class="lcd-slot">
-        <div class="lcd-frame" data-lcd-variant={variant}>
+        <div
+          class="lcd-frame lcd-mode-{displayMode}"
+          data-lcd-variant={variant}
+          data-lcd-mode={displayMode}
+        >
           {#if variant === 'scope'}
             <AmberScope />
           {:else}
@@ -74,6 +84,7 @@
       </div>
       <div class="lcd-control-strip">
         <LcdContrastControl />
+        <LcdDisplayModeControl />
       </div>
     </main>
 
@@ -176,6 +187,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 16px;
+    flex-wrap: wrap;
     padding: 4px 6px;
     border: 1px solid var(--v2-border-panel);
     border-radius: 4px;

--- a/frontend/src/components-v2/panels/lcd/LcdDisplayModeControl.svelte
+++ b/frontend/src/components-v2/panels/lcd/LcdDisplayModeControl.svelte
@@ -1,0 +1,90 @@
+<!--
+  LcdDisplayModeControl — radio-group chooser for LCD display effects
+  (#838). Mirrors the LcdContrastControl affordance for consistency;
+  lives next to it in the LCD control strip.
+
+  "clean" is the default — no extra effects on top of the base render.
+  Vintage / CRT / Flicker are opt-in vanity modes; all layered via
+  `panels/lcd/lcd-vintage.css` applied as `.lcd-mode-{mode}` class on
+  `.lcd-frame` in LcdLayout.
+-->
+<script lang="ts">
+  import {
+    LCD_DISPLAY_MODES,
+    getLcdDisplayMode,
+    setLcdDisplayMode,
+    type LcdDisplayMode,
+  } from '$lib/stores/lcd-display-mode.svelte';
+
+  let mode = $state<LcdDisplayMode>(getLcdDisplayMode());
+
+  function selectMode(m: LcdDisplayMode): void {
+    setLcdDisplayMode(m);
+    mode = m;
+  }
+
+  function labelFor(m: LcdDisplayMode): string {
+    switch (m) {
+      case 'clean':   return 'CLEAN';
+      case 'vintage': return 'VINTAGE';
+      case 'crt':     return 'CRT';
+      case 'flicker': return 'FLICKER';
+    }
+  }
+</script>
+
+<div class="lcd-mode-row" role="radiogroup" aria-label="LCD display mode">
+  <span class="lcd-mode-label">DISPLAY</span>
+  {#each LCD_DISPLAY_MODES as m}
+    <button
+      type="button"
+      class="lcd-mode-btn"
+      class:active={mode === m}
+      role="radio"
+      aria-checked={mode === m}
+      aria-label="Display mode {labelFor(m)}"
+      onclick={() => selectMode(m)}
+    >{labelFor(m)}</button>
+  {/each}
+</div>
+
+<style>
+  .lcd-mode-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-family: 'JetBrains Mono', 'Courier New', monospace;
+  }
+
+  .lcd-mode-label {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--v2-text-dim, #777);
+    margin-right: 4px;
+  }
+
+  .lcd-mode-btn {
+    font-family: inherit;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 2px 6px;
+    border: 1px solid var(--v2-border-panel, #333);
+    border-radius: 3px;
+    background: transparent;
+    color: var(--v2-text-dim, #888);
+    cursor: pointer;
+  }
+
+  .lcd-mode-btn:hover {
+    border-color: var(--v2-border-lighter, #555);
+    color: var(--v2-text, #ddd);
+  }
+
+  .lcd-mode-btn.active {
+    background: rgba(250, 204, 21, 0.12);
+    border-color: var(--v2-accent-yellow, #facc15);
+    color: var(--v2-accent-yellow, #facc15);
+  }
+</style>

--- a/frontend/src/components-v2/panels/lcd/lcd-vintage.css
+++ b/frontend/src/components-v2/panels/lcd/lcd-vintage.css
@@ -1,0 +1,111 @@
+/**
+ * LCD Display Mode effects (#838).
+ *
+ * Applied by LcdLayout as a class on `.lcd-frame`. The base render
+ * (scanlines, warm amber background) lives in AmberCockpit/AmberScope
+ * and stays unchanged when `lcd-mode-clean` is active.
+ *
+ * CSS filters keep the effect layered and cheap — no extra DOM nodes,
+ * no JS animation loops. The `flicker` keyframe is intentionally short
+ * and low-amplitude so it reads as a CRT warm-up artifact, not a bug.
+ */
+
+/* Clean: no-op. Listed for documentation / CSS specificity symmetry. */
+.lcd-mode-clean {
+  /* default — no filter layer */
+}
+
+/* Vintage: slight sepia tint + gentle vignette. Warmth already baked
+   into the amber theme — this just compresses dynamic range a hair. */
+.lcd-mode-vintage {
+  filter: sepia(0.15) contrast(0.92) saturate(0.88);
+  position: relative;
+}
+.lcd-mode-vintage::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse at center,
+    transparent 55%,
+    rgba(0, 0, 0, 0.22) 100%
+  );
+  z-index: 3;
+  border-radius: inherit;
+}
+
+/* CRT: stronger vignette + slightly blurred + saturation boost,
+   mimicking a rounded phosphor tube. Scanlines come from the base
+   component, so we only thicken them via a compositional overlay. */
+.lcd-mode-crt {
+  filter: contrast(1.04) saturate(1.08);
+  position: relative;
+}
+.lcd-mode-crt::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(
+      ellipse at center,
+      transparent 45%,
+      rgba(0, 0, 0, 0.32) 100%
+    ),
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0px,
+      transparent 2px,
+      rgba(0, 0, 0, 0.035) 2px,
+      rgba(0, 0, 0, 0.035) 4px
+    );
+  z-index: 3;
+  border-radius: inherit;
+}
+
+/* Flicker: extends CRT with a subtle brightness oscillation. */
+.lcd-mode-flicker {
+  filter: contrast(1.04) saturate(1.08);
+  position: relative;
+  animation: lcd-flicker 5.5s infinite;
+}
+.lcd-mode-flicker::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(
+      ellipse at center,
+      transparent 45%,
+      rgba(0, 0, 0, 0.32) 100%
+    ),
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0px,
+      transparent 2px,
+      rgba(0, 0, 0, 0.035) 2px,
+      rgba(0, 0, 0, 0.035) 4px
+    );
+  z-index: 3;
+  border-radius: inherit;
+}
+
+@keyframes lcd-flicker {
+  0%, 100% { opacity: 1; }
+  16% { opacity: 0.985; }
+  17% { opacity: 1; }
+  48% { opacity: 0.99; }
+  49% { opacity: 1; }
+  82% { opacity: 0.975; }
+  83% { opacity: 1; }
+}
+
+/* Respect reduced-motion — flicker off when the user asks for no
+   animations. Base vignettes stay (they're static). */
+@media (prefers-reduced-motion: reduce) {
+  .lcd-mode-flicker {
+    animation: none;
+  }
+}

--- a/frontend/src/lib/stores/lcd-display-mode.svelte.ts
+++ b/frontend/src/lib/stores/lcd-display-mode.svelte.ts
@@ -1,0 +1,58 @@
+/**
+ * LCD Display Mode store (#838).
+ *
+ * Chooses a visual treatment layered on top of the base LCD render:
+ *  - `clean`    — default, no extra effects (current behavior).
+ *  - `vintage`  — slight sepia + vignette for a "worn readout" feel.
+ *  - `crt`      — scanlines amplified + curvature vignette.
+ *  - `flicker`  — subtle brightness flicker on top of `crt`.
+ *
+ * Persisted to localStorage. Applied by `LcdLayout` as a class on
+ * `.lcd-frame` — the CSS module `panels/lcd/lcd-vintage.css` handles
+ * the visual treatment per class.
+ */
+
+export type LcdDisplayMode = 'clean' | 'vintage' | 'crt' | 'flicker';
+
+export const LCD_DISPLAY_MODES: readonly LcdDisplayMode[] = [
+  'clean',
+  'vintage',
+  'crt',
+  'flicker',
+] as const;
+
+const STORAGE_KEY = 'icom-lan-lcd-display-mode';
+
+let mode = $state<LcdDisplayMode>(loadMode());
+
+function loadMode(): LcdDisplayMode {
+  if (typeof window === 'undefined') return 'clean';
+  try {
+    const saved = localStorage.getItem?.(STORAGE_KEY);
+    if (
+      saved === 'clean' ||
+      saved === 'vintage' ||
+      saved === 'crt' ||
+      saved === 'flicker'
+    ) {
+      return saved;
+    }
+  } catch {
+    // Test envs may stub localStorage with a partial shape — fall through.
+  }
+  return 'clean';
+}
+
+export function getLcdDisplayMode(): LcdDisplayMode {
+  return mode;
+}
+
+export function setLcdDisplayMode(next: LcdDisplayMode): void {
+  mode = next;
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem?.(STORAGE_KEY, next);
+  } catch {
+    /* test envs may stub localStorage; persistence best-effort */
+  }
+}


### PR DESCRIPTION
Closes #838.

## Summary
Adds an opt-in Display Mode selector alongside the contrast control. Four modes — default \`clean\` is the current render untouched; \`vintage\` / \`crt\` / \`flicker\` layer on top via pure CSS (no DOM changes, no JS animation loops).

## Visual treatment
| Mode | Effect |
|------|--------|
| \`clean\` | no-op |
| \`vintage\` | \`sepia(.15) contrast(.92) saturate(.88)\` + soft radial vignette |
| \`crt\` | \`contrast(1.04) saturate(1.08)\` + vignette + thicker scanlines overlay |
| \`flicker\` | \`crt\` + \`@keyframes lcd-flicker\` 5.5 s loop with low-amplitude opacity dips |

\`@media (prefers-reduced-motion: reduce)\` silences the flicker animation — a11y courtesy.

## Architecture
- Persisted store (\`lcd-display-mode.svelte.ts\`) with try/catch around \`localStorage\` so test envs with stubbed storage don't throw.
- Class applied on \`.lcd-frame\` in \`LcdLayout\` via \`class="lcd-frame lcd-mode-{displayMode}"\`.
- \`LcdDisplayModeControl\` mirrors \`LcdContrastControl\`'s radio-group pattern; both live in \`.lcd-control-strip\` with \`gap: 16px\` + \`flex-wrap\`.

## Files (4)
- \`frontend/src/lib/stores/lcd-display-mode.svelte.ts\` (new, ~65 LOC)
- \`frontend/src/components-v2/panels/lcd/lcd-vintage.css\` (new, ~100 LOC)
- \`frontend/src/components-v2/panels/lcd/LcdDisplayModeControl.svelte\` (new, ~85 LOC)
- \`frontend/src/components-v2/layout/LcdLayout.svelte\` (+14/-4)

## Test plan
- [x] \`pnpm test src/components-v2/\` — 1176/1176 pass
- [x] \`pnpm lint\` — clean
- [ ] Manual: cycle through modes; verify \`clean\` is pixel-identical to pre-PR; reduced-motion turns off flicker animation.

Part of epic #818 (LCD-8.6, marked P3 in original plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)