### PR TITLE
fix(ui): codex P1 — QSY debounce + orientation PTT release

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -381,6 +381,19 @@
     // If latched, don't turn off on release
   }
 
+  // Orientation-change safety net (codex P1 on PR #931).
+  // PttFab is conditionally mounted on `!isLandscape`; rotation removes
+  // the component so its `pointerup` never fires. Without this guard,
+  // an in-progress press would leave `pttMode === 'held'` and TX keyed
+  // until the 3-minute safety timer — a genuine TX hazard.
+  $effect(() => {
+    if (isLandscape && pttMode === 'held') {
+      pttMode = 'idle';
+      disengageTx();
+      clearPttSafety();
+    }
+  });
+
   // ── Landscape PTT guards (#843 parity with FAB) ──
   // Adds pointermove-8px cancel + haptic + TX-permit dim-state so the
   // landscape strip mirrors the guarded FAB (#840). Skips the 50ms hold

--- a/frontend/src/lib/stores/qsy-history.svelte.ts
+++ b/frontend/src/lib/stores/qsy-history.svelte.ts
@@ -67,6 +67,10 @@ export const qsyHistory = {
     if (last && Math.abs(last.freqHz - freqHz) < MIN_DELTA_HZ) {
       return;
     }
+    // Skip if the pending candidate already matches — otherwise a reactive
+    // effect that re-fires on every frame keeps restarting the debounce
+    // window and `commitPending()` never runs (codex P1 on PR #932).
+    if (freqHz === pendingFreqHz && mode === pendingMode) return;
     // Update the candidate; reset the debounce timer.
     pendingFreqHz = freqHz;
     pendingMode = mode;


### PR DESCRIPTION
Addresses two P1 codex findings with real user-facing impact.

## 🔴 PR #932 — QSY debounce never fires
`qsyHistory.record()` reset \`pendingTimer\` unconditionally. AmberCockpit calls it from a reactive \`$effect\` on live radio state, so normal-rate state updates keep restarting the debounce window — \`commitPending()\` never runs. Recent-QSY chips stay empty in practice.

**Fix** (+3 LOC): early-return when \`(freqHz, mode)\` already equals the pending candidate.

```ts
if (freqHz === pendingFreqHz && mode === pendingMode) return;
```

## 🔴 PR #931 — TX keyed after rotation to landscape
The `!isLandscape` guard on \`<PttFab>\` (my fix for PR #928 P1) unmounts the FAB on rotation. If the user rotates mid-press, \`pointerup\` never reaches the removed component → \`pttMode\` stays \`'held'\` → TX keyed until the 3-minute safety timer. Genuine TX hazard.

**Fix** (+8 LOC): new \`$effect\` in MobileRadioLayout watches \`isLandscape\`. When orientation flips to landscape while \`pttMode === 'held'\`, run the same release sequence as \`pttUp()\`:
```ts
$effect(() => {
  if (isLandscape && pttMode === 'held') {
    pttMode = 'idle';
    disengageTx();
    clearPttSafety();
  }
});
```

## Files (2)
- \`frontend/src/lib/stores/qsy-history.svelte.ts\` (+4/-1)
- \`frontend/src/components-v2/layout/MobileRadioLayout.svelte\` (+13/-0)

## Test plan
- [x] \`pnpm test src/components-v2/ src/lib/stores/\` — 1297/1297 pass
- [x] \`pnpm lint\` — clean
- [ ] Manual: tune across bands, wait 1.5 s stable, see QSY chip appear.
- [ ] Manual: press FAB PTT → rotate to landscape mid-press → verify TX releases immediately, not after 3 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)