### PR TITLE
fix(ui): gate orientation PTT release to transition, not state

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -50,7 +50,7 @@
   import { getKeyboardConfig } from '$lib/stores/capabilities.svelte';
   import { getTxAudioControl } from '$lib/runtime/adapters/tx-adapter';
   const txAudio = getTxAudioControl();
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, untrack } from 'svelte';
   import Toast from '../../components/shared/Toast.svelte';
 
   // ── State — via runtime ──
@@ -381,13 +381,25 @@
     // If latched, don't turn off on release
   }
 
-  // Orientation-change safety net (codex P1 on PR #931).
+  // Orientation-change safety net (codex P1 on PR #931 / #934 regression).
   // PttFab is conditionally mounted on `!isLandscape`; rotation removes
   // the component so its `pointerup` never fires. Without this guard,
   // an in-progress press would leave `pttMode === 'held'` and TX keyed
-  // until the 3-minute safety timer — a genuine TX hazard.
+  // until the 3-minute safety timer.
+  //
+  // Must fire ONLY on the transition `portrait → landscape`, not on
+  // every `pttMode` change — otherwise landscape hold-to-talk engages
+  // and is instantly released by this same effect (codex P1 on PR #934).
+  //
+  // Plain `let` for prevIsLandscape so it doesn't become a reactive
+  // dep; `untrack` on `pttMode` so only orientation changes re-run the
+  // effect body.
+  let prevIsLandscape = false;
   $effect(() => {
-    if (isLandscape && pttMode === 'held') {
+    const nowLandscape = isLandscape;
+    const enteredLandscape = !prevIsLandscape && nowLandscape;
+    prevIsLandscape = nowLandscape;
+    if (enteredLandscape && untrack(() => pttMode) === 'held') {
       pttMode = 'idle';
       disengageTx();
       clearPttSafety();


### PR DESCRIPTION
Addresses **P1 codex regression** on PR #934:
> This \`$effect\` runs whenever either \`isLandscape\` or \`pttMode\` changes, so in landscape mode any normal \`pttDown()\` (which sets \`pttMode\` to \`'held'\`) immediately satisfies \`isLandscape && pttMode === 'held'\` and forces \`pttMode\` back to \`'idle'\` with \`disengageTx()\`. Landscape hold-to-talk is cancelled as soon as it engages.

## Fix
Reshape the effect to fire **only on the portrait → landscape transition**, not on any state satisfying the predicate:

\`\`\`ts
let prevIsLandscape = false;  // plain let — not reactive
$effect(() => {
  const nowLandscape = isLandscape;
  const enteredLandscape = !prevIsLandscape && nowLandscape;
  prevIsLandscape = nowLandscape;
  if (enteredLandscape && untrack(() => pttMode) === 'held') {
    pttMode = 'idle';
    disengageTx();
    clearPttSafety();
  }
});
\`\`\`

Key changes:
1. \`prevIsLandscape\` is a plain \`let\` so writing to it inside the effect doesn't trigger a re-run (breaking the loop that \`$state\` would create).
2. \`pttMode\` is read via \`untrack(...)\` so its changes never re-trigger the effect. Orientation is the only trigger.
3. Release fires once on each portrait → landscape transition.

## Behavior matrix

| Orientation | pttMode action | Previous behavior | Fixed behavior |
|-|-|-|-|
| stays landscape | press → 'held' | TX cancelled instantly 🔴 | TX engages normally ✅ |
| portrait → landscape | was 'held' mid-press | TX released ✅ | TX released ✅ (preserved) |
| stays portrait | any pttMode change | no-op ✅ | no-op ✅ |
| landscape → portrait | any pttMode | no-op ✅ | no-op ✅ |

## Files (1)
- \`frontend/src/components-v2/layout/MobileRadioLayout.svelte\` (+18/-5)

## Test plan
- [x] \`pnpm test src/components-v2/\` — 1176/1176 pass
- [x] \`pnpm lint\` — clean
- [ ] Manual (landscape): press+hold \`.m-ls-ptt\` — TX stays keyed until release, not cancelled on engage.
- [ ] Manual (portrait): press+hold FAB → rotate to landscape mid-press → TX releases immediately (safety preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)