### PR TITLE
feat(#937): priority tier for meter polling — S-meter @ 16Hz RX, ~6.7Hz TX-tier

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -76,7 +76,10 @@ def _interpolate_swr(
                 if span == 0:
                     return float(lo["actual"])
                 t = (raw - lo["raw"]) / span
-                return float(lo["actual"]) + t * (float(hi["actual"]) - float(lo["actual"]))
+                return float(
+                    float(lo["actual"])
+                    + t * (float(hi["actual"]) - float(lo["actual"]))
+                )
     # No table: legacy linear fallback (pre-#440 behavior).
     if raw <= 0:
         return 1.0

--- a/src/icom_lan/usb_audio_resolve.py
+++ b/src/icom_lan/usb_audio_resolve.py
@@ -141,7 +141,7 @@ def _resolve_macos(
     sd: Any = sounddevice_module
     if sd is None:
         try:
-            import sounddevice as sd_mod  # type: ignore[import-untyped]
+            import sounddevice as sd_mod
 
             sd = sd_mod
         except ImportError:

--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -1756,16 +1756,60 @@ class RadioPoller:
     ]
     _FAST_CMDS: list[tuple[int, int | None]] = _FAST_CMDS_LAN  # class default
 
+    # Issue #937 — two-tier meter scheme (LAN only).
+    # HIGH tier — emitted on most meter cycles, gated by PTT.
+    _HIGH_TIER_RX: list[tuple[int, int | None]] = [
+        (0x15, 0x02),  # S-meter
+    ]
+    _HIGH_TIER_TX: list[tuple[int, int | None]] = [
+        (0x15, 0x11),  # RF power
+        (0x15, 0x12),  # SWR
+        (0x15, 0x13),  # ALC
+    ]
+    # LOW tier — emitted every _LOW_STRIDE-th HIGH meter cycle, rotating.
+    _LOW_TIER: list[tuple[int, int | None]] = [
+        (0x15, 0x14),  # Compressor meter
+        (0x15, 0x15),  # Vd
+        (0x15, 0x16),  # Id
+    ]
+    _LOW_STRIDE: int = 5
+
     # State queries interleaved on odd cycles.
     # Tuple: (cmd, sub, receiver) where receiver=None means global query.
     # Populated per instance from runtime profile/capabilities.
     _STATE_QUERIES: list[tuple[int, int | None, int | None]] = []
 
+    def _pick_high_meter(self, high_idx: int) -> tuple[int, int | None]:
+        """Choose HIGH-tier meter based on PTT state."""
+        on_tx = (
+            getattr(self._radio_state, "ptt", False)
+            if self._radio_state is not None
+            else False
+        )
+        if not on_tx:
+            return self._HIGH_TIER_RX[0]
+        return self._HIGH_TIER_TX[high_idx % len(self._HIGH_TIER_TX)]
+
     async def _send_query(self) -> None:
         # Even cycles → meter query; odd cycles → state query.
         if self._poll_index % 2 == 0:
-            fast_idx = (self._poll_index // 2) % len(self._FAST_CMDS)
-            cmd_byte, sub_byte = self._FAST_CMDS[fast_idx]
+            if self._is_serial:
+                # Serial path UNCHANGED — keep flat round-robin over _FAST_CMDS.
+                fast_idx = (self._poll_index // 2) % len(self._FAST_CMDS)
+                cmd_byte, sub_byte = self._FAST_CMDS[fast_idx]
+            else:
+                # LAN: two-tier scheme (issue #937).
+                high_idx = self._poll_index // 2
+                on_tx = (
+                    getattr(self._radio_state, "ptt", False)
+                    if self._radio_state is not None
+                    else False
+                )
+                if not on_tx and high_idx % self._LOW_STRIDE == 0:
+                    low_idx = (high_idx // self._LOW_STRIDE) % len(self._LOW_TIER)
+                    cmd_byte, sub_byte = self._LOW_TIER[low_idx]
+                else:
+                    cmd_byte, sub_byte = self._pick_high_meter(high_idx)
             await self._civ(cmd_byte, sub=sub_byte, data=b"")
         else:
             if not self._STATE_QUERIES:

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -812,3 +812,110 @@ class TestAdaptiveGap:
         poller = self._make_poller(1.0)
         base = poller._gap  # noqa: SLF001
         assert poller._adaptive_gap() == base * 2.0  # noqa: SLF001
+
+
+# Issue #937 — two-tier meter polling tests.
+
+
+@pytest.mark.asyncio
+async def test_high_tier_emits_s_meter_on_rx_for_consecutive_cycles() -> None:
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+    poller._radio_state = SimpleNamespace(ptt=False)  # noqa: SLF001
+    # _poll_index ∈ {2,4,6,8} → high_idx ∈ {1,2,3,4} (none multiple of 5).
+    for poll_idx in (2, 4, 6, 8):
+        radio.send_civ.reset_mock()
+        poller._poll_index = poll_idx  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+        args = radio.send_civ.await_args.args
+        kwargs = radio.send_civ.await_args.kwargs
+        assert (args[0], kwargs.get("sub")) == (0x15, 0x02)
+
+
+@pytest.mark.asyncio
+async def test_high_tier_rotates_pwr_swr_alc_on_tx() -> None:
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+    poller._radio_state = SimpleNamespace(ptt=True)  # noqa: SLF001
+    emissions: set[tuple[int, int | None]] = set()
+    for poll_idx in (2, 4, 6, 8, 10, 12):
+        radio.send_civ.reset_mock()
+        poller._poll_index = poll_idx  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+        args = radio.send_civ.await_args.args
+        kwargs = radio.send_civ.await_args.kwargs
+        emissions.add((args[0], kwargs.get("sub")))
+    assert emissions == {(0x15, 0x11), (0x15, 0x12), (0x15, 0x13)}
+    assert (0x15, 0x02) not in emissions
+
+
+@pytest.mark.asyncio
+async def test_low_tier_emits_at_expected_stride_for_lan() -> None:
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+    poller._radio_state = SimpleNamespace(ptt=False)  # noqa: SLF001
+    expected = [(0x15, 0x14), (0x15, 0x15), (0x15, 0x16)]
+    for poll_idx, exp in zip((0, 10, 20), expected, strict=True):
+        radio.send_civ.reset_mock()
+        poller._poll_index = poll_idx  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+        args = radio.send_civ.await_args.args
+        kwargs = radio.send_civ.await_args.kwargs
+        assert (args[0], kwargs.get("sub")) == exp
+
+
+def test_low_tier_contains_comp_vd_id_for_ic7610() -> None:
+    assert set(RadioPoller._LOW_TIER) == {  # noqa: SLF001
+        (0x15, 0x14),
+        (0x15, 0x15),
+        (0x15, 0x16),
+    }
+    assert RadioPoller._LOW_STRIDE == 5  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_poll_index_monotonic_across_ptt_toggle() -> None:
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+    state = SimpleNamespace(ptt=False)
+    poller._radio_state = state  # noqa: SLF001
+    for _ in range(4):
+        await poller._send_query()  # noqa: SLF001
+    state.ptt = True
+    for _ in range(4):
+        await poller._send_query()  # noqa: SLF001
+    assert poller._poll_index == 8  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_serial_backend_unchanged_on_ptt_toggle() -> None:
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+    poller._is_serial = True  # noqa: SLF001
+    poller._FAST_CMDS = list(RadioPoller._FAST_CMDS_SERIAL)  # noqa: SLF001
+    state = SimpleNamespace(ptt=False)
+    poller._radio_state = state  # noqa: SLF001
+
+    serial_set = set(RadioPoller._FAST_CMDS_SERIAL)  # noqa: SLF001
+    rx_emissions: dict[int, tuple[int, int | None]] = {}
+    for poll_idx in (0, 2, 4, 6):
+        radio.send_civ.reset_mock()
+        poller._poll_index = poll_idx  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+        args = radio.send_civ.await_args.args
+        kwargs = radio.send_civ.await_args.kwargs
+        emission = (args[0], kwargs.get("sub"))
+        assert emission in serial_set
+        rx_emissions[poll_idx] = emission
+
+    state.ptt = True
+    for poll_idx in (0, 2, 4, 6):
+        radio.send_civ.reset_mock()
+        poller._poll_index = poll_idx  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+        args = radio.send_civ.await_args.args
+        kwargs = radio.send_civ.await_args.kwargs
+        emission = (args[0], kwargs.get("sub"))
+        assert emission in serial_set
+        # PTT state must not change which command is emitted at given index.
+        assert emission == rx_emissions[poll_idx]


### PR DESCRIPTION
Closes #937. Part of epic #936.

## Summary

- LAN-only two-tier meter scheme inside `radio_poller._send_query` even-branch:
  - **HIGH** (every meter cycle, PTT-aware): S-meter on RX; rotates Pwr/SWR/ALC on TX
  - **LOW** (every 5th HIGH cycle, RX only): Vd / Id / Comp
- PTT-on skips the LOW slot so TX-tier rate meets the ≥6 Hz acceptance target
- Serial backend deliberately untouched — its `_FAST_CMDS_SERIAL` round-robin keeps the existing trimmed shape (rate targets are LAN-specific)
- `_FAST_INTERVAL`, meter↔state alternation, `_poll_index` semantics, and `_FAST_CMDS_LAN/_FAST_CMDS_SERIAL/_FAST_CMDS` all preserved

## Effective rates (LAN, `_FAST_INTERVAL = 25 ms`)

| Meter | Before | After |
|---|---|---|
| S-meter (RX) | 2.86 Hz | **16 Hz** |
| Pwr/SWR/ALC (TX) | 2.86 Hz | **6.67 Hz** each |
| Vd/Id/Comp (RX) | 350 ms | 750 ms each (close to ~800 ms target) |

## Tests

- 6 new tests in `tests/test_radio_poller_coverage.py`:
  - HIGH tier emits S-meter on consecutive RX cycles
  - HIGH tier rotates Pwr/SWR/ALC on TX
  - LOW tier emitted at expected stride
  - LOW tier contents/stride introspection guard
  - `_poll_index` monotonic across PTT toggle
  - Serial backend unchanged on PTT toggle (regression guard)
- Both pre-existing tests (`test_send_query_even_and_odd_branch_variants`, `test_fast_cmds_include_comp_meter_for_ic7610`) preserved byte-identical

## Drive-by cleanup

Three pre-existing lint/mypy issues on `main` (verified via stash) — fixed so the branch lands fully green:

- `src/icom_lan/usb_audio_resolve.py:144` — removed unused `# type: ignore[import-untyped]` (sounddevice now has stubs)
- `src/icom_lan/backends/yaesu_cat/radio.py:79` — wrapped interpolation expression in `float(...)` to fix `Returning Any from function declared to return "float"`
- `src/icom_lan/backends/yaesu_cat/radio.py` — applied `ruff format` (1 reformat)

Per the project's "fix all errors regardless of origin" convention, these are bundled here rather than spun off into a separate cleanup PR.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → 4729 passed, 0 failed
- [x] `uv run ruff check src/ tests/` → All checks passed
- [x] `uv run ruff format --check src/ tests/` → 315 files already formatted
- [x] `uv run mypy src/` → Success: no issues found in 143 source files
- [ ] Live verification with IC-7610 — S-meter feels responsive on RX; SWR/ALC/Pwr smooth on TX (left to manual smoke test)

## Out of scope (covered by #938)

Frontend smoothing (rAF lerp on `AmberSmeter.svelte` + `MetersDockPanel.svelte`) — paired sub-issue under epic #936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)