### PR TITLE
feat(#938): needle smoothing for S-meter and TX-tier meters

### DIFF
--- a/frontend/src/components-v2/panels/MetersDockPanel.svelte
+++ b/frontend/src/components-v2/panels/MetersDockPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onMount, untrack } from 'svelte';
+  import { createSmoother } from '$lib/utils/smoothing.svelte';
   import {
     formatAlc,
     formatAmps,
@@ -191,6 +192,38 @@
     }
     return out;
   });
+
+  // Issue #938 — per-tile rAF-driven bar smoothing. Smoothers are keyed by
+  // tile.key and reused across renders so the bar carries fractional state
+  // between updates. Peak-hold (`peakPct`) and digit text (`tile.display`)
+  // continue to read raw props; only the bar-fill width is smoothed. Each
+  // smoother is seeded with the tile's current fillPct on first creation so
+  // the initial synchronous render matches the raw target (no flash from 0).
+  type Smoother = ReturnType<typeof createSmoother>;
+  const smoothers = new Map<Tile['key'], Smoother>();
+
+  function getSmoother(key: Tile['key'], initial: number): Smoother {
+    let s = smoothers.get(key);
+    if (!s) {
+      s = createSmoother(0.05, 0.15, initial);
+      s.start();
+      smoothers.set(key, s);
+    }
+    return s;
+  }
+
+  $effect(() => {
+    for (const tile of tiles) {
+      getSmoother(tile.key, tile.fillPct).update(tile.fillPct);
+    }
+  });
+
+  onMount(() => {
+    return () => {
+      for (const s of smoothers.values()) s.stop();
+      smoothers.clear();
+    };
+  });
 </script>
 
 <article class="meters-dock-panel" data-testid="meters-dock-panel">
@@ -207,6 +240,7 @@
             ? peakHoldDisplay(peaks[tile.key], tile.fillPct, now)
             : undefined
           : undefined}
+      {@const displayPct = smoothers.get(tile.key)?.value ?? tile.fillPct}
       <div
         class="dock-tile"
         role="group"
@@ -227,7 +261,7 @@
         <div class="tile-bar" style:background={tile.track}>
           <div
             class="tile-bar-fill"
-            style:width={`${Math.max(0, Math.min(100, tile.fillPct))}%`}
+            style:width={`${Math.max(0, Math.min(100, displayPct))}%`}
             style:background={tile.fill}
           ></div>
           {#if peakPct !== undefined && tile.relevant}

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import type { ComponentProps } from 'svelte';
 import MetersDockPanel from '../MetersDockPanel.svelte';
+import { createSmoother } from '$lib/utils/smoothing.svelte';
 import {
   formatAmps,
   formatVolts,
@@ -423,5 +424,32 @@ describe('MetersDockPanel formatted values', () => {
   it('displays S-meter as S-units', () => {
     const t = mountPanel(fullProps);
     expect(t.querySelector('[data-meter="s"] .tile-value')?.textContent).toBe('S9');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #938 — bar-fill smoothing
+// ---------------------------------------------------------------------------
+
+describe('createSmoother initial value (issue #938)', () => {
+  it('seeds the internal state with the supplied initialValue', () => {
+    const s = createSmoother(0.05, 0.15, 42);
+    expect(s.value).toBe(42);
+  });
+});
+
+describe('MetersDockPanel bar-fill smoothing', () => {
+  it('starts the Po bar-fill at the raw target on the first synchronous render', () => {
+    // powerMeter=128 -> raw fillPct ~50%. With the v2 seed the smoother is
+    // initialized at the current target, so the bar-fill width must equal
+    // the raw fillPct on first paint (no flash to 0). This asserts the seed
+    // wires correctly through getSmoother(key, initial).
+    const t = mountPanel({ ...fullProps, powerMeter: 128, txActive: true });
+    const fill = t.querySelector('[data-meter="po"] .tile-bar-fill') as HTMLElement;
+    expect(fill).not.toBeNull();
+    const fillPct = parseFloat(fill.style.width);
+    // 128/255 * 100 ≈ 50.2%. Allow a small tolerance for floating-point.
+    expect(fillPct).toBeGreaterThan(40);
+    expect(fillPct).toBeLessThan(60);
   });
 });

--- a/frontend/src/components-v2/panels/lcd/AmberSmeter.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberSmeter.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+  import { createSmoother } from '$lib/utils/smoothing.svelte';
   import { getCalibrationPoints, getS9Raw, rawToSUnit, rawToDbm } from '../../meters/smeter-scale';
 
   type MeterSource = 'S' | 'PO' | 'SWR' | 'ALC' | 'COMP';
@@ -44,7 +46,26 @@
     return ticks;
   })());
 
-  let filledSegs = $derived(Math.round(Math.min(SEGMENTS, Math.max(0, (value / MAX_RAW) * SEGMENTS))));
+  // Issue #938 — rAF-driven needle smoothing: asymmetric attack (50 ms) /
+  // release (150 ms) so the bar punches in fast and glides down. Drives the
+  // bar fill only; sReadout/ticks stay on the raw value. Seed the smoother
+  // with the current computed segment count so the first synchronous render
+  // matches the raw target (no flash to 0 on mount).
+  function computeSegs(raw: number): number {
+    return Math.min(SEGMENTS, Math.max(0, (raw / MAX_RAW) * SEGMENTS));
+  }
+
+  // svelte-ignore state_referenced_locally — intentional one-shot seed read
+  const smoother = createSmoother(0.05, 0.15, computeSegs(value));
+  $effect(() => {
+    smoother.update(computeSegs(value));
+  });
+  onMount(() => {
+    smoother.start();
+    return () => smoother.stop();
+  });
+
+  let filledSegs = $derived(Math.round(smoother.value));
 
   let sReadout = $derived.by(() => {
     if (source === 'S') return { label: rawToSUnit(value), sub: rawToDbm(value) + ' dBm' };

--- a/frontend/src/lib/utils/smoothing.svelte.ts
+++ b/frontend/src/lib/utils/smoothing.svelte.ts
@@ -2,8 +2,8 @@
  * Exponential smoothing for meter values.
  * React useSmoothedValue → Svelte $state + rAF loop.
  */
-export function createSmoother(attack = 0.12, release = 0.32) {
-  let current = $state(0);
+export function createSmoother(attack = 0.12, release = 0.32, initialValue = 0) {
+  let current = $state(initialValue);
   let target = 0;
   let frameId = 0;
   let lastTime = 0;


### PR DESCRIPTION
Closes #938. Part of epic #936. Pairs with #937 / PR #939 (backend priority tier).

## Summary

- Wire the existing `createSmoother` util into:
  - `AmberSmeter.svelte` — smooths bar fill (`filledSegs`); S-unit/dBm readout stays on raw value
  - `MetersDockPanel.svelte` — per-tile `Map<key, Smoother>` smooths `tile-bar-fill` width; peak markers and digit readouts stay on raw values
- Asymmetric smoothing: attack τ = 50 ms (rising), release τ = 150 ms (falling) — needle punches in immediately on signal rise, glides on release
- Util gets one optional seed parameter `initialValue = 0` — backward-compatible default preserves all 3 existing call sites (BarGauge, NeedleGauge, LinearSMeter) exactly

## Why the util needed a seed parameter

Without `initialValue`, meter components flash to 0 on first frame before the rAF lerp catches up. This was a real UX bug on mount/skin-switch AND broke 4 existing `lcd-components.test.ts` tests that assert synchronous post-mount segment counts. The `initialValue` param lets AmberSmeter and MetersDockPanel seed their smoothers with the current target so the first paint is already correct.

## Raw-value contracts preserved (peak-hold #823 integrity)

| Path | Source |
|---|---|
| AmberSmeter bar fill | smoothed |
| AmberSmeter S-unit / dBm readout | **raw** |
| MetersDockPanel bar fill | smoothed |
| MetersDockPanel peak marker | **raw** |
| MetersDockPanel digit text | **raw** |

## Tests

- `MetersDockPanel.test.ts` — new smoke test: with `powerMeter=128`, bar fill reaches ≈ 50% without first-frame flash
- `MetersDockPanel.test.ts` — lock-in: `createSmoother(0.05, 0.15, 42).value === 42`
- `lcd-components.test.ts` — unchanged; 4 previously-failing AmberSmeter segment-count assertions now pass without modification (seeded smoother == no first-frame flash)

## Test plan

- [x] `cd frontend && npx vitest run` → 87 files, 1665 tests passed, 0 failed
- [x] `cd frontend && npm run build` → ✓ built, **0 warnings, 0 errors**
- [x] Backend `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → 4723/0 (unaffected)
- [ ] Live verification with IC-7610 on amber-lcd skin — S-meter glides smoothly on RX, TX-tier meters (Pwr/SWR/ALC) glide smoothly during TX, no fps regression (manual smoke test)

## Out of scope

- Backend polling rate (#937 / PR #939)
- Restyling meter components
- Meter calibration changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)