### PR TITLE
fix(ui): codex P2 — prune tile smoothers on disappear (#940 follow-up)

### DIFF
--- a/frontend/src/components-v2/panels/MetersDockPanel.svelte
+++ b/frontend/src/components-v2/panels/MetersDockPanel.svelte
@@ -213,8 +213,19 @@
   }
 
   $effect(() => {
+    const activeKeys = new Set<Tile['key']>();
     for (const tile of tiles) {
+      activeKeys.add(tile.key);
       getSmoother(tile.key, tile.fillPct).update(tile.fillPct);
+    }
+    // Prune smoothers for tiles that disappeared (e.g. COMP when
+    // compressorOn toggles off). Without this, a re-entered tile would
+    // briefly render its stale last value before the rAF loop converged.
+    for (const [key, s] of smoothers) {
+      if (!activeKeys.has(key)) {
+        s.stop();
+        smoothers.delete(key);
+      }
     }
   });
 


### PR DESCRIPTION
Addresses [codex P2 comment](https://github.com/morozsm/icom-lan/pull/940#discussion_r-codex) on PR #940.

## Problem

`MetersDockPanel`'s per-tile smoother `Map<key, Smoother>` was never pruned when a tile dropped out of the `tiles` array (e.g. COMP when `compressorOn` toggles off). On re-entry, `getSmoother` reused the stale smoother, so the bar briefly rendered the old value before the rAF loop converged to the new target. Plan v2 for #938 called this "harmless" — codex correctly pointed out it's a real regression on capability/gating toggles.

## Fix

Prune inside the same `$effect`: after updating active smoothers, walk the Map and `stop()`+`delete()` any entry whose key is no longer in the current `tiles` set. On re-entry, `getSmoother` creates a fresh smoother seeded with the current `tile.fillPct` (via the `initialValue` parameter from #938), so the first paint is correct.

```ts
$effect(() => {
  const activeKeys = new Set<Tile['key']>();
  for (const tile of tiles) {
    activeKeys.add(tile.key);
    getSmoother(tile.key, tile.fillPct).update(tile.fillPct);
  }
  for (const [key, s] of smoothers) {
    if (!activeKeys.has(key)) {
      s.stop();
      smoothers.delete(key);
    }
  }
});
```

## Test plan

- [x] `cd frontend && npx vitest run` → 87 files / **1665 passed** / 0 failed
- [x] `cd frontend && npm run build` → ✓ built, **0 warnings**
- [ ] Live: toggle compressor on→off→on during TX on IC-7610, verify COMP bar starts at the new value on re-entry (not the old one)

## Why no new test

The bug only manifests within a single component instance when `tiles` changes mid-lifetime (compressorOn toggle). The existing test harness mounts a fresh component per test case and does not use reactive prop updates — adding that infrastructure for a 5-line fix would overshoot. Fix is trivial by inspection; the existing coverage catches any semantic regression on active tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)