### PR TITLE
docs: clarify UDP port mapping as defaults (codex P2)

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -267,11 +267,18 @@ packets each iteration.
 **What changed:** transport logs now include the remote endpoint in each UDP error
 line. This helps distinguish which logical channel is failing.
 
-**Port mapping:**
+**Port mapping (defaults):**
 
 - `:50001` -> control/keepalive channel
 - `:50002` -> CI-V command/state channel
 - `:50003` -> audio channel
+
+These are Icom's factory defaults and match the vast majority of deployments.
+If the radio's menu has been changed, or the client was started with a custom
+`--control-port` / `ICOM_PORT` (see `src/icom_lan/cli.py`), the actual ports may
+differ — CI-V and audio ports can also be reassigned by the radio's status
+report (see `src/icom_lan/_control_phase.py`). In that case, substitute your
+session's ports in the filters below.
 
 **How to interpret quickly:**
 
@@ -291,7 +298,7 @@ line. This helps distinguish which logical channel is failing.
 # Keep only UDP diagnostics from the daemon log
 rg "UDP error|UDP connection lost" logs/icom-lan.log
 
-# Focus on CI-V channel failures only
+# Focus on CI-V channel failures only (replace 50002 if your session uses a custom CI-V port)
 rg "peer=.*:50002" logs/icom-lan.log
 ```
 


### PR DESCRIPTION
## Summary
- Addresses codex P2 review on [#943](https://github.com/morozsm/icom-lan/pull/943): UDP runbook hard-coded `50001/50002/50003` as fixed values.
- Re-labels the table as **defaults** and notes that `--control-port` / `ICOM_PORT` (see `src/icom_lan/cli.py`) plus status-report override (`src/icom_lan/_control_phase.py`) can shift CI-V/audio ports at runtime.
- Adds a hint next to the `rg "peer=.*:50002"` filter to substitute the session's CI-V port if customized.

## Test plan
- [x] Docs-only change — no code paths touched
- [x] Read surrounding section (`## UDP Errors in Logs`) to confirm wording is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)