### PR TITLE
docs(#964): remove dead lazy-load references in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — Control Plane
 
 **icom-lan** v0.17.0 — Python 3.11+ asyncio library + Web UI for Icom transceivers over LAN/USB.
-IC-7610 at `192.168.55.40`, CI-V `0x98`. Context: `AGENTS.md`, `docs/PROJECT.md`.
+IC-7610 at `192.168.55.40`, CI-V `0x98`. Context: `docs/PROJECT.md`.
 
 ---
 
@@ -49,21 +49,6 @@ Never bare `python` or `pytest`. Worktrees: `uv sync --all-extras` first.
 - TDD — test first, implement second
 - Batch all fixes, run tests once (not per fix)
 - Audio tests: `FakeAudioBackend` only — no one-off mocks
-
----
-
-## External rules (lazy-load — read ONLY when relevant)
-
-| File | Load when |
-|------|-----------|
-| @.claude/docs/rag.md | transport/CI-V/audio/protocol changes |
-| @.claude/docs/rules.md | API or behavior changes needing doc updates |
-| @.claude/architecture/modules.md | navigating unfamiliar module |
-| @.claude/architecture/protocol.md | protocol-level work |
-| @.claude/workflow/testing.md | test strategy questions |
-| @.claude/context/loading.md | per-phase context budgets |
-
-Never load full documentation, large files, or unrelated sections into context.
 
 ---
 
@@ -183,4 +168,3 @@ Worktrees are ephemeral. Cleanup is mandatory and automatic.
 
 - Repeated mistakes or inconsistent decisions → `/clear`
 - 2+ corrections on same step → session reset
-- Context budget per phase: @.claude/context/loading.md


### PR DESCRIPTION
## Summary
- Remove 6 lazy-load table entries in `CLAUDE.md` that pointed to files never present in the repo (`.claude/docs/rag.md`, `.claude/docs/rules.md`, `.claude/architecture/modules.md`, `.claude/architecture/protocol.md`, `.claude/workflow/testing.md`, `.claude/context/loading.md`).
- Remove the `AGENTS.md` pointer from the header; `docs/PROJECT.md` remains as the canonical project-context source.
- Agents no longer silently fail to lazy-load missing files, which was causing subtly wrong behavior with no error signal.

Chose REMOVE over CREATE per issue guidance: no accurate content exists for these paths, and padding with speculative content would be worse than absence.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] Verified all listed paths are absent on `main`
- [x] Docs-only diff: `CLAUDE.md` (1 file, -17/+1)

Closes #964