### PR TITLE
test(#963): remove orphaned IcomRadio._handle_raw_civ_packet monkey-patch

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,15 +15,6 @@ from mock_server import MockIcomRadio
 
 from _caps import FULL_ICOM_CAPS as FULL_ICOM_CAPS  # noqa: F401 — re-export
 
-# ---------------------------------------------------------------------------
-# Patch for missing IcomRadio._handle_raw_civ_packet
-# radio.py:268 sets civ_transport.on_raw_packet to this method, but the
-# method body has not been implemented yet.  Add a no-op so the transport
-# callback doesn't AttributeError.
-# ---------------------------------------------------------------------------
-if not hasattr(IcomRadio, "_handle_raw_civ_packet"):
-    IcomRadio._handle_raw_civ_packet = lambda self, data: None  # type: ignore[attr-defined]
-
 _HEADER_FMT = "<IHHII"
 
 


### PR DESCRIPTION
## Summary
- Remove dead monkey-patch in `tests/conftest.py` that set a no-op `IcomRadio._handle_raw_civ_packet`.
- Confirmed via grep that the method does not exist anywhere in `src/` and no test depends on the patched attribute.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4 pre-existing failures on main, unrelated to this change (verified by running the same tests on the stashed baseline)

Closes #963