### PR TITLE
security(#945): cap WebSocket frame payload at 64 KiB

### DIFF
--- a/src/icom_lan/web/websocket.py
+++ b/src/icom_lan/web/websocket.py
@@ -46,12 +46,21 @@ WS_OP_PONG = 0xA
 
 _RSV1 = 0x40  # per-message deflate flag
 
+# Maximum accepted incoming frame payload (bytes). Frames larger than this
+# are rejected with close code 1009 (Message Too Big) before any allocation
+# to prevent memory exhaustion from a malicious/malformed length field.
+_MAX_WS_FRAME = 64 * 1024
+
 # zlib flush marker appended by deflate, stripped per RFC 7692 §7.2.1
 _DEFLATE_TAIL = b"\x00\x00\xff\xff"
 
 
 class WebSocketError(Exception):
     """Raised when a WebSocket protocol violation is detected."""
+
+
+class _FrameTooLargeError(WebSocketError):
+    """Raised when an incoming frame exceeds ``_MAX_WS_FRAME``."""
 
 
 def make_accept_key(client_key: str) -> str:
@@ -147,6 +156,11 @@ async def _read_one_frame(
         ext = await reader.readexactly(8)
         payload_len = struct.unpack("!Q", ext)[0]
 
+    if payload_len > _MAX_WS_FRAME:
+        raise _FrameTooLargeError(
+            f"frame payload {payload_len} exceeds max {_MAX_WS_FRAME}"
+        )
+
     mask_key = b""
     if masked:
         mask_key = await reader.readexactly(4)
@@ -230,6 +244,10 @@ class WebSocketConnection:
                 )
             except asyncio.IncompleteReadError as exc:
                 raise EOFError("connection closed") from exc
+            except _FrameTooLargeError as exc:
+                # Oversize frame: respond with close 1009 and abort.
+                await self.close(1009, "frame too large")
+                raise EOFError("frame too large") from exc
 
             if opcode == WS_OP_PING:
                 await self._send_raw(make_frame(WS_OP_PONG, payload))

--- a/tests/test_websocket_coverage.py
+++ b/tests/test_websocket_coverage.py
@@ -115,14 +115,43 @@ async def test_read_one_frame_16bit_extended_length() -> None:
     assert fin is True
 
 
-async def test_read_one_frame_64bit_extended_length() -> None:
-    """Payload larger than 65535 bytes uses 8-byte extended length encoding."""
-    payload = b"y" * 70000  # > 65535 → uses 64-bit length
-    frame = _client_frame(WS_OP_BINARY, payload)
-    reader = _make_reader(frame)
-    opcode, data, fin, _ = await _read_one_frame(reader)
-    assert opcode == WS_OP_BINARY
-    assert data == payload
+async def test_read_one_frame_64bit_extended_length_rejected() -> None:
+    """Payload >64 KiB (which requires 64-bit length) is rejected (S03).
+
+    Before reading any payload bytes, the frame parser must bail out to
+    prevent multi-GB allocations from a malicious length field.
+    """
+    # Craft a header that advertises a huge payload but don't supply any data.
+    # byte0 = 0x82 (FIN | BINARY), byte1 = 0x80|127 (mask, 64-bit length),
+    # followed by 8 bytes of length = 1 GiB, then 4-byte mask key.
+    header = (
+        bytes([0x82, 0x80 | 127]) + struct.pack("!Q", 1 << 30) + b"\x00\x00\x00\x00"
+    )
+    reader = _make_reader(header)
+    with pytest.raises(WebSocketError, match="exceeds max"):
+        await _read_one_frame(reader)
+
+
+async def test_recv_oversize_frame_sends_close_1009() -> None:
+    """recv() must send a 1009 (Message Too Big) close frame and raise EOFError."""
+    header = (
+        bytes([0x82, 0x80 | 127]) + struct.pack("!Q", 1 << 30) + b"\x00\x00\x00\x00"
+    )
+    reader = _make_reader(header)
+    writer = _make_writer()
+    ws = WebSocketConnection(reader, writer)
+    with pytest.raises(EOFError, match="frame too large"):
+        await ws.recv()
+    # Verify a close frame with code 1009 was written.
+    assert writer.write.called
+    sent = b"".join(call.args[0] for call in writer.write.call_args_list)
+    # Close frame: opcode 0x8, payload starts with 2-byte close code.
+    # Find a close frame (byte0 == 0x88) and check its code.
+    assert b"\x88" in sent
+    idx = sent.index(b"\x88")
+    # byte after 0x88 is payload length (no mask on server→client)
+    code = struct.unpack("!H", sent[idx + 2 : idx + 4])[0]
+    assert code == 1009
 
 
 async def test_read_one_frame_unmasked_payload() -> None:


### PR DESCRIPTION
## Summary
- Reject incoming WebSocket frames whose advertised payload exceeds `_MAX_WS_FRAME = 64 * 1024` before any `readexactly()` allocation.
- `recv()` sends a close frame with code 1009 (Message Too Big) and raises `EOFError` when an oversize frame is received.
- Prevents a trivial OOM DoS where a 10-byte header can allocate multi-GB (S03 in 2026-04-23 full review).

Closes #945

## Test plan
- [x] `uv run pytest tests/test_websocket_coverage.py -q` — 22 passed
- [x] New test: 64-bit length header is rejected with `WebSocketError("exceeds max")` before payload bytes are read
- [x] New test: `recv()` writes a close frame with code 1009 and raises `EOFError("frame too large")`
- [x] `uv run ruff check src/ tests/` — clean
- [x] Full non-hw suite — no new regressions (pre-existing failures on main: `test_per_receiver_vfo_roundtrip`, `test_web_server::test_root_returns_html`)