### PR TITLE
fix(#954): decay transient UDP error counter for .connected

### DIFF
--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -295,6 +295,13 @@ _DEFAULT_AUDIO_SAMPLE_RATE = _AUDIO_CAPABILITIES.default_sample_rate_hz
 # Default TTLs (seconds) for the GET-command cache fallback paths.
 _DEFAULT_CACHE_TTL: dict[str, float] = {"freq": 10.0, "mode": 10.0, "rf_power": 30.0}
 
+# Threshold for ``Radio.connected`` to treat a UDP transport as unhealthy.
+# A single transient ``error_received`` (e.g. EAGAIN/EWOULDBLOCK/Broken pipe)
+# should not latch the socket into a disconnected state — the counter is
+# cumulative and only the 30s watchdog resets it via ``soft_reconnect``.
+# Require >=3 accumulated errors before reporting ``connected = False``.
+_UDP_ERROR_THRESHOLD: int = 3
+
 
 def _resolve_profile_codec(
     profile: RadioProfile, explicit: "AudioCodec | int"
@@ -796,9 +803,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         civ = self._civ_transport
         if civ is None:
             return False
-        # Check for UDP errors (only on real IcomTransport, not mocks)
+        # Check for UDP errors (only on real IcomTransport, not mocks).
+        # A single transient EAGAIN/EWOULDBLOCK should not latch the socket
+        # into a "disconnected" state — only treat the transport as unhealthy
+        # after repeated errors.  The counter is reset on soft_reconnect and
+        # on reset_udp_error_count() after sustained healthy packet receipt.
         error_count = getattr(civ, "_udp_error_count", None)
-        if isinstance(error_count, int) and error_count > 0:
+        if isinstance(error_count, int) and error_count >= _UDP_ERROR_THRESHOLD:
             return False
         return True
 

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -1178,10 +1178,22 @@ async def test_capture_scope_frames_multiple(
 # ---------------------------------------------------------------------------
 
 
-def test_connected_returns_false_when_error_count_positive(radio: IcomRadio) -> None:
-    """connected returns False when transport has _udp_error_count > 0 (lines 261, 265)."""
-    radio._civ_transport._udp_error_count = 1  # type: ignore[attr-defined]
+def test_connected_returns_false_when_error_count_above_threshold(
+    radio: IcomRadio,
+) -> None:
+    """connected returns False only when _udp_error_count >= threshold (issue #954)."""
+    radio._civ_transport._udp_error_count = 3  # type: ignore[attr-defined]
     assert radio.connected is False
+
+
+def test_connected_stays_true_on_single_transient_udp_error(
+    radio: IcomRadio,
+) -> None:
+    """A single transient UDP error must not latch .connected to False (issue #954)."""
+    radio._civ_transport._udp_error_count = 1  # type: ignore[attr-defined]
+    assert radio.connected is True
+    radio._civ_transport._udp_error_count = 2  # type: ignore[attr-defined]
+    assert radio.connected is True
 
 
 def test_connected_returns_true_when_error_count_zero(radio: IcomRadio) -> None:


### PR DESCRIPTION
## Summary
- `Radio.connected` previously reported `False` on a single transient UDP `error_received` (EAGAIN / EWOULDBLOCK / Broken pipe), latching the state until the 30s watchdog ran `soft_reconnect`.
- Apply a `>=3` error threshold via new module constant `_UDP_ERROR_THRESHOLD` so isolated transient errors no longer flip `connected` to False while sustained error bursts still mark the CI-V transport unhealthy.

## Test plan
- [x] `tests/test_radio_coverage.py` updated: single-error case stays connected; `>=3` errors report disconnected.
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — only 4 pre-existing, unrelated failures (verified against main).
- [x] `uv run ruff check src/ tests/` — clean.

Closes #954