### PR TITLE
fix(#956): use asyncio.get_running_loop() in async transport methods

### DIFF
--- a/src/icom_lan/transport.py
+++ b/src/icom_lan/transport.py
@@ -178,7 +178,7 @@ class IcomTransport:
             TimeoutError: If the radio does not respond to discovery.
         """
         self.state = ConnectionState.CONNECTING
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         if sock is not None:
             # Caller reserved this socket earlier; connect + hand off.
             sock.connect((host, port))
@@ -232,7 +232,7 @@ class IcomTransport:
 
         saved_remote_id = self.remote_id
         self.state = ConnectionState.CONNECTING
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         local_addr = (local_host, 0) if local_host else None
         await loop.create_datagram_endpoint(
             lambda: _UdpProtocol(self),

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -136,7 +136,7 @@ class TestConnectionState:
         loop = _FakeLoop(("192.168.2.194", 50002))
 
         with (
-            patch("icom_lan.transport.asyncio.get_event_loop", return_value=loop),
+            patch("icom_lan.transport.asyncio.get_running_loop", return_value=loop),
             patch.object(t, "_discover", new=AsyncMock()),
             patch.object(t, "_ready_handshake", new=AsyncMock()),
         ):
@@ -166,7 +166,7 @@ class TestConnectionState:
         sock.bind(("0.0.0.0", 0))
 
         with (
-            patch("icom_lan.transport.asyncio.get_event_loop", return_value=loop),
+            patch("icom_lan.transport.asyncio.get_running_loop", return_value=loop),
             patch.object(t, "_discover", new=AsyncMock()),
             patch.object(t, "_ready_handshake", new=AsyncMock()),
         ):
@@ -191,7 +191,7 @@ class TestConnectionState:
         loop = _FakeLoop(("192.168.2.194", 50001))
 
         with (
-            patch("icom_lan.transport.asyncio.get_event_loop", return_value=loop),
+            patch("icom_lan.transport.asyncio.get_running_loop", return_value=loop),
             patch.object(t, "_ready_handshake", new=AsyncMock()),
         ):
             await t.reconnect(


### PR DESCRIPTION
## Summary
- Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` at `transport.py:181,235` (both inside `async def` — `connect` and `reconnect`).
- Avoids Python 3.13+ `DeprecationWarning` for `get_event_loop()` without a running loop.
- Update three corresponding `patch(...)` targets in `tests/test_transport.py`.

Scope is limited to `transport.py` per issue; `discovery.py` / `proxy.py` keep their current usage (out of scope).

Closes #956

## Test plan
- [x] `uv run pytest tests/test_transport.py -q` — 49 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] Full suite (excluding integration): only pre-existing failures unrelated to this change remain (verified by running the same failing tests on the pre-change tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)