### PR TITLE
test(#962): use AsyncMock for asyncio.Event in cw auto-tune wiring tests

### DIFF
--- a/tests/test_cw_auto_tune_wiring.py
+++ b/tests/test_cw_auto_tune_wiring.py
@@ -62,10 +62,16 @@ class TestCwAutoTuneWiring:
     async def test_timeout_returns_not_detected(self) -> None:
         """If no audio arrives within 3s, return detected=None."""
         handler = _make_handler()
+
+        async def _raise_timeout(coro: Any, timeout: float) -> None:
+            # Close the Event.wait() coroutine so it isn't left un-awaited.
+            coro.close()
+            raise asyncio.TimeoutError
+
         # No audio fed → tuner never fires → timeout
         with patch(
             "icom_lan.web.handlers.control.asyncio.wait_for",
-            side_effect=asyncio.TimeoutError,
+            side_effect=_raise_timeout,
         ):
             result = await handler._cw_auto_tune()
 
@@ -187,9 +193,14 @@ class TestCwAutoTuneWiring:
         handler = _make_handler()
         registry = handler._server._audio_broadcaster._tap_registry
 
+        async def _raise_timeout(coro: Any, timeout: float) -> None:
+            # Close the Event.wait() coroutine so it isn't left un-awaited.
+            coro.close()
+            raise asyncio.TimeoutError
+
         with patch(
             "icom_lan.web.handlers.control.asyncio.wait_for",
-            side_effect=asyncio.TimeoutError,
+            side_effect=_raise_timeout,
         ):
             await handler._cw_auto_tune()
 


### PR DESCRIPTION
## Summary
- Fixes `RuntimeWarning: coroutine 'Event.wait' was never awaited` in `tests/test_cw_auto_tune_wiring.py`.
- The two timeout tests patched `asyncio.wait_for` with `side_effect=asyncio.TimeoutError`, which dropped the `done.wait()` coroutine unawaited. Replaced with an async shim that calls `coro.close()` before raising `TimeoutError`.

## Test plan
- [x] `uv run pytest tests/test_cw_auto_tune_wiring.py -q -W error::RuntimeWarning` — passes
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — no new failures vs baseline
- [x] `uv run ruff check src/ tests/` — clean

Closes #962