### PR TITLE
security(#949): prefer ICOM_PASS env over --pass; warn on CLI use

### DIFF
--- a/src/icom_lan/cli.py
+++ b/src/icom_lan/cli.py
@@ -226,6 +226,52 @@ class _DeprecatedPortAction(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
+class _DeprecatedPassAction(argparse.Action):
+    """Deprecated --pass flag — warns about leakage via `ps aux` / shell history.
+
+    Prefer $ICOM_PASS environment variable or --pass-file PATH instead.
+    """
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ) -> None:
+        print(
+            "DeprecationWarning: --pass exposes the password on the process "
+            "command line (visible in `ps aux` and shell history). "
+            "Use $ICOM_PASS or --pass-file PATH instead.",
+            file=sys.stderr,
+        )
+        setattr(namespace, self.dest, values)
+
+
+def _resolve_password(args: argparse.Namespace) -> str:
+    """Resolve password with precedence: --pass (CLI) > --pass-file > $ICOM_PASS.
+
+    --pass takes precedence when explicitly supplied (it emits a deprecation
+    warning at parse time via _DeprecatedPassAction). Otherwise, read from the
+    file at --pass-file if given (stripping trailing newline), else fall back
+    to the $ICOM_PASS environment variable.
+    """
+    cli_pass = getattr(args, "password_cli", None)
+    if cli_pass:
+        return str(cli_pass)
+    pass_file = getattr(args, "pass_file", None)
+    if pass_file:
+        try:
+            return Path(pass_file).read_text(encoding="utf-8").rstrip("\n\r")
+        except OSError as e:
+            print(
+                f"Error: cannot read --pass-file {pass_file!r}: {e}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2) from e
+    return _get_env("ICOM_PASS", "")
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="icom-lan",
@@ -274,9 +320,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--pass",
-        dest="password",
-        default=_get_env("ICOM_PASS", ""),
-        help="Password (default: $ICOM_PASS)",
+        dest="password_cli",
+        default=None,
+        action=_DeprecatedPassAction,
+        help=(
+            "Deprecated: exposes password in `ps aux`/shell history. "
+            "Prefer $ICOM_PASS or --pass-file PATH."
+        ),
+    )
+    p.add_argument(
+        "--pass-file",
+        dest="pass_file",
+        default=None,
+        metavar="PATH",
+        help="Read password from file (first line, trailing newline stripped)",
     )
     p.add_argument(
         "--timeout",
@@ -1137,7 +1194,7 @@ async def _build_backend_config(
         host=host,
         port=args.control_port,
         username=args.user,
-        password=args.password,
+        password=_resolve_password(args),
         timeout=args.timeout,
         radio_addr=radio_addr,
         model=model_name,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from icom_lan.cli import (
     _build_backend_config,
     _build_parser,
     _parse_frequency,
+    _resolve_password,
     check_ports_available,
     main,
 )
@@ -206,6 +207,65 @@ class TestBuildParser:
             args = p.parse_args(["--port", "9999", "status"])
         assert args.control_port == 9999
         assert "deprecated" in mock_stderr.getvalue().lower()
+
+
+class TestPasswordResolution:
+    """Verify password resolution: --pass (deprecated) > --pass-file > $ICOM_PASS."""
+
+    def test_env_var_used_when_no_cli_flags(self, monkeypatch):
+        monkeypatch.setenv("ICOM_PASS", "env-secret")
+        p = _build_parser()
+        args = p.parse_args(["status"])
+        assert _resolve_password(args) == "env-secret"
+
+    def test_empty_when_nothing_set(self, monkeypatch):
+        monkeypatch.delenv("ICOM_PASS", raising=False)
+        p = _build_parser()
+        args = p.parse_args(["status"])
+        assert _resolve_password(args) == ""
+
+    def test_pass_file_overrides_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("ICOM_PASS", "env-secret")
+        pw_file = tmp_path / "pw.txt"
+        pw_file.write_text("file-secret\n", encoding="utf-8")
+        p = _build_parser()
+        args = p.parse_args(["--pass-file", str(pw_file), "status"])
+        assert _resolve_password(args) == "file-secret"
+
+    def test_cli_pass_overrides_pass_file_and_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("ICOM_PASS", "env-secret")
+        pw_file = tmp_path / "pw.txt"
+        pw_file.write_text("file-secret", encoding="utf-8")
+        p = _build_parser()
+        with patch("sys.stderr", new_callable=io.StringIO):
+            args = p.parse_args(
+                ["--pass", "cli-secret", "--pass-file", str(pw_file), "status"]
+            )
+        assert _resolve_password(args) == "cli-secret"
+
+    def test_deprecation_warning_on_cli_pass(self, monkeypatch):
+        monkeypatch.delenv("ICOM_PASS", raising=False)
+        p = _build_parser()
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            p.parse_args(["--pass", "secret", "status"])
+        err = mock_stderr.getvalue()
+        assert "DeprecationWarning" in err
+        assert "--pass" in err
+        assert "ICOM_PASS" in err
+
+    def test_no_warning_without_cli_pass(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("ICOM_PASS", "env-secret")
+        p = _build_parser()
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            p.parse_args(["status"])
+        assert "DeprecationWarning" not in mock_stderr.getvalue()
+
+    def test_pass_file_missing_exits(self, tmp_path):
+        p = _build_parser()
+        args = p.parse_args(["--pass-file", str(tmp_path / "nope.txt"), "status"])
+        with patch("sys.stderr", new_callable=io.StringIO):
+            with pytest.raises(SystemExit):
+                _resolve_password(args)
 
     def test_deprecated_port_prints_warning(self):
         p = _build_parser()


### PR DESCRIPTION
## Summary
- `--pass PASS` exposes the password in `ps aux` and shell history. Keep the flag (backwards compat) but emit a `DeprecationWarning` on stderr whenever it is used.
- Add `--pass-file PATH` to read the password from a file (first line, trailing newline stripped).
- Resolve with precedence: `--pass` (deprecated, explicit) > `--pass-file` > `$ICOM_PASS`.

## Test plan
- [x] `uv run pytest tests/test_cli.py -q` — 103 passed (new `TestPasswordResolution` covers env precedence, file override, CLI override, deprecation warning, missing-file SystemExit).
- [x] `uv run ruff check src/ tests/ && uv run ruff format --check` clean.
- [x] Full suite unchanged vs. main baseline (the 4 pre-existing failures in `test_per_receiver_vfo_roundtrip.py` and `test_web_server.py` reproduce on `main` without this change).

Closes #949

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>