### PR TITLE
fix(#952): propagate TimeoutError when restoring MAIN VFO

### DIFF
--- a/src/icom_lan/_dual_rx_runtime.py
+++ b/src/icom_lan/_dual_rx_runtime.py
@@ -126,13 +126,18 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
                 try:
                     await self.set_vfo(current)
                     self._radio_state.active = current
-                except Exception:
+                except TimeoutError:
+                    # Do not swallow — radio would silently remain on the
+                    # temporary receiver. Retry once (the first attempt may
+                    # fail because a prior fire-and-forget ACK sink consumed
+                    # the timeout budget), then propagate on a second failure.
                     logger.warning(
-                        "%s: failed to restore VFO receiver to %s",
+                        "%s: timeout restoring VFO receiver to %s, retrying once",
                         operation,
                         current,
-                        exc_info=True,
                     )
+                    await self.set_vfo(current)
+                    self._radio_state.active = current
 
     async def _get_frequency_main(
         self, *, bypass_cache: bool = False, update_cache: bool = True


### PR DESCRIPTION
## Summary
- `_run_with_receiver_vfo_fallback` swallowed every exception (including `TimeoutError`) while restoring the original VFO, leaving the radio silently on SUB after any SUB-routed op that timed out on restore.
- Replace the blanket swallow with log + retry-once + raise on `TimeoutError`. The first restore attempt can exhaust the per-call timeout budget because a prior fire-and-forget ACK sink drains it (`_drain_ack_sinks_before_blocking`); a second attempt completes cleanly. A second failure now propagates so callers see the stuck-on-SUB state.
- Other exceptions propagate unchanged (previously swallowed too).

Closes #952

## Test plan
- [x] `uv run pytest tests/test_per_receiver_vfo_roundtrip.py -q` -> 11 passed (previously 2 failed)
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` -> 4726 passed; 2 pre-existing web-server failures unrelated to this change (reproduce on main)
- [x] `uv run ruff check src/ tests/` -> clean

Guardrails: 1 file, +8 / -3 LOC.

Generated with [Claude Code](https://claude.com/claude-code)