### PR TITLE
security(#951): add baseline security response headers

### DIFF
--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -2482,6 +2482,16 @@ async def _send_json(
     await _send_response(writer, 200, "OK", body, extra)
 
 
+_SECURITY_HEADERS: dict[str, str] = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "no-referrer",
+    "Content-Security-Policy": (
+        "default-src 'self' ws: wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
+    ),
+}
+
+
 async def _send_response(
     writer: asyncio.StreamWriter,
     status: int,
@@ -2491,6 +2501,7 @@ async def _send_response(
 ) -> None:
     headers = {
         "Content-Length": str(len(body)),
+        **_SECURITY_HEADERS,
         **extra_headers,
     }
     header_lines = "".join(f"{k}: {v}\r\n" for k, v in headers.items())

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,127 @@
+"""Tests for baseline security response headers (issue #951).
+
+Verifies that every HTTP response from WebServer carries the four required
+security headers: X-Content-Type-Options, X-Frame-Options, Referrer-Policy,
+and Content-Security-Policy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from icom_lan.rigctld.state_cache import StateCache
+from icom_lan.web.server import WebConfig, WebServer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_radio() -> MagicMock:
+    radio = MagicMock(name="radio")
+    radio.connected = True
+    radio.radio_ready = True
+    radio.control_connected = True
+    radio.model = "IC-7610"
+    radio.capabilities = set()
+    radio.state_cache = StateCache()
+    radio.soft_disconnect = AsyncMock()
+    radio.disconnect = AsyncMock()
+    return radio
+
+
+def _addr(server: WebServer) -> tuple[str, int]:
+    assert server._server is not None
+    return server._server.sockets[0].getsockname()
+
+
+async def _http_get(
+    host: str, port: int, path: str
+) -> tuple[int, dict[str, str], bytes]:
+    """Minimal HTTP/1.1 GET over asyncio.  Returns (status, headers, body)."""
+    reader, writer = await asyncio.open_connection(host, port)
+    try:
+        request = (
+            f"GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
+        )
+        writer.write(request.encode())
+        await writer.drain()
+        raw = await asyncio.wait_for(reader.read(65536), timeout=5.0)
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+    header_end = raw.find(b"\r\n\r\n")
+    header_bytes = raw[:header_end]
+    body = raw[header_end + 4 :]
+
+    lines = header_bytes.decode("ascii", errors="replace").split("\r\n")
+    status_code = int(lines[0].split(" ", 2)[1])
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ":" in line:
+            k, _, v = line.partition(":")
+            headers[k.strip().lower()] = v.strip()
+
+    return status_code, headers, body
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def sec_server() -> WebServer:  # type: ignore[misc]
+    config = WebConfig(host="127.0.0.1", port=0, keepalive_interval=9999.0)
+    srv = WebServer(_make_radio(), config)
+    await srv.start()
+    yield srv  # type: ignore[misc]
+    await srv.stop()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityHeaders:
+    """Each security header must be present on a plain HTTP GET response."""
+
+    async def test_x_content_type_options(self, sec_server: WebServer) -> None:
+        host, port = _addr(sec_server)
+        _, headers, _ = await _http_get(host, port, "/api/v1/state")
+        assert headers.get("x-content-type-options") == "nosniff"
+
+    async def test_x_frame_options(self, sec_server: WebServer) -> None:
+        host, port = _addr(sec_server)
+        _, headers, _ = await _http_get(host, port, "/api/v1/state")
+        assert headers.get("x-frame-options") == "DENY"
+
+    async def test_referrer_policy(self, sec_server: WebServer) -> None:
+        host, port = _addr(sec_server)
+        _, headers, _ = await _http_get(host, port, "/api/v1/state")
+        assert headers.get("referrer-policy") == "no-referrer"
+
+    async def test_content_security_policy(self, sec_server: WebServer) -> None:
+        host, port = _addr(sec_server)
+        _, headers, _ = await _http_get(host, port, "/api/v1/state")
+        csp = headers.get("content-security-policy", "")
+        assert "default-src" in csp
+
+    async def test_all_headers_on_404(self, sec_server: WebServer) -> None:
+        """Security headers must also appear on error responses (e.g. 404)."""
+        host, port = _addr(sec_server)
+        status, headers, _ = await _http_get(host, port, "/nonexistent")
+        assert status == 404
+        assert headers.get("x-content-type-options") == "nosniff"
+        assert headers.get("x-frame-options") == "DENY"
+        assert headers.get("referrer-policy") == "no-referrer"
+        assert "default-src" in headers.get("content-security-policy", "")


### PR DESCRIPTION
## Summary

- Injects four security headers into every HTTP response via the single `_send_response` helper in `src/icom_lan/web/server.py`
- Headers: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `Content-Security-Policy: ...`
- WebSocket upgrade responses are unaffected (they go through a separate path)

## CSP note

The conservative `default-src 'self'` value was relaxed to `default-src 'self' ws: wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline'` because the frontend uses WebSocket connections and inline styles. Existing tests pass with this variant.

## Test plan

- [x] 5 new unit tests in `tests/test_security_headers.py` verify each header on a JSON endpoint (`/api/v1/state`) and on a 404 error response
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4740 passed, 0 failed
- [x] `uv run ruff check src/ tests/ && uv run ruff format src/ tests/` — all checks passed

Closes #951