### PR TITLE
security(#946): cap HTTP POST body size at 256 KiB

### DIFF
--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -65,6 +65,25 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_STATIC_DIR = pathlib.Path(__file__).parent / "static"
 _RADIO_MODEL = "IC-7610"
+_MAX_POST_BODY = 256 * 1024  # 256 KiB — hard ceiling for all POST body reads
+
+
+async def _read_capped_body(
+    reader: asyncio.StreamReader,
+    content_length: int,
+) -> bytes | None:
+    """Read up to *content_length* bytes, rejecting oversize requests.
+
+    Returns the raw bytes on success, or ``None`` when *content_length*
+    exceeds :data:`_MAX_POST_BODY` (caller must send HTTP 413).
+    """
+    if content_length > _MAX_POST_BODY:
+        return None
+    return await asyncio.wait_for(
+        reader.readexactly(content_length),
+        timeout=5.0,
+    )
+
 
 # Mode/filter lists moved to RadioProfile (profiles.py)
 
@@ -1796,10 +1815,22 @@ class WebServer:
             if reader is not None:
                 cl = int((headers or {}).get("content-length", "0"))
                 if cl > 0:
-                    body_bytes = await asyncio.wait_for(
-                        reader.readexactly(cl),
-                        timeout=5.0,
-                    )
+                    read_result = await _read_capped_body(reader, cl)
+                    if read_result is None:
+                        err = json.dumps(
+                            {"error": "request_too_large"},
+                            separators=(",", ":"),
+                        ).encode()
+                        await _send_response(
+                            writer,
+                            413,
+                            "Content Too Large",
+                            err,
+                            {"Content-Type": "application/json"},
+                        )
+                        writer.close()
+                        return
+                    body_bytes = read_result
             if not body_bytes:
                 err = json.dumps(
                     {"error": "missing_body"},
@@ -1897,11 +1928,22 @@ class WebServer:
             if reader is not None:
                 cl = int((headers or {}).get("content-length", "0"))
                 if cl > 0:
-                    body_bytes = await asyncio.wait_for(
-                        reader.readexactly(cl),
-                        timeout=5.0,
-                    )
-                    payload = json.loads(body_bytes)
+                    read_result = await _read_capped_body(reader, cl)
+                    if read_result is None:
+                        err = json.dumps(
+                            {"error": "request_too_large"},
+                            separators=(",", ":"),
+                        ).encode()
+                        await _send_response(
+                            writer,
+                            413,
+                            "Content Too Large",
+                            err,
+                            {"Content-Type": "application/json"},
+                        )
+                        writer.close()
+                        return
+                    payload = json.loads(read_result)
                     force = payload.get("force", False)
 
             result = await self._eibi.fetch(force=force)
@@ -2052,10 +2094,22 @@ class WebServer:
                 if reader is not None:
                     cl = int((headers or {}).get("content-length", "0"))
                     if cl > 0:
-                        body_bytes = await asyncio.wait_for(
-                            reader.readexactly(cl),
-                            timeout=5.0,
-                        )
+                        read_result = await _read_capped_body(reader, cl)
+                        if read_result is None:
+                            err = json.dumps(
+                                {"error": "request_too_large"},
+                                separators=(",", ":"),
+                            ).encode()
+                            await _send_response(
+                                writer,
+                                413,
+                                "Content Too Large",
+                                err,
+                                {"Content-Type": "application/json"},
+                            )
+                            writer.close()
+                            return
+                        body_bytes = read_result
                 if not body_bytes:
                     err = json.dumps(
                         {
@@ -2165,10 +2219,22 @@ class WebServer:
         if reader is not None:
             cl = int((headers or {}).get("content-length", "0"))
             if cl > 0:
-                body_bytes = await asyncio.wait_for(
-                    reader.readexactly(cl),
-                    timeout=5.0,
-                )
+                read_result = await _read_capped_body(reader, cl)
+                if read_result is None:
+                    err = json.dumps(
+                        {"error": "request_too_large"},
+                        separators=(",", ":"),
+                    ).encode()
+                    await _send_response(
+                        writer,
+                        413,
+                        "Content Too Large",
+                        err,
+                        {"Content-Type": "application/json"},
+                    )
+                    writer.close()
+                    return
+                body_bytes = read_result
         if not body_bytes:
             err = json.dumps(
                 {

--- a/tests/test_web_post_body_cap.py
+++ b/tests/test_web_post_body_cap.py
@@ -1,0 +1,188 @@
+"""Tests for POST body size cap (issue #946).
+
+Verifies _read_capped_body helper and that all four POST handlers
+return 413 when Content-Length exceeds _MAX_POST_BODY.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from icom_lan.web.server import _MAX_POST_BODY, _read_capped_body
+
+
+# ---------------------------------------------------------------------------
+# _read_capped_body unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_reader(data: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    reader.feed_eof()
+    return reader
+
+
+@pytest.mark.asyncio
+async def test_read_capped_body_within_limit() -> None:
+    """Body at or below the cap is returned intact."""
+    payload = b'{"key": "value"}'
+    reader = _make_reader(payload)
+    result = await _read_capped_body(reader, len(payload))
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_read_capped_body_exactly_at_limit() -> None:
+    """Body exactly at _MAX_POST_BODY is accepted."""
+    payload = b"x" * _MAX_POST_BODY
+    reader = _make_reader(payload)
+    result = await _read_capped_body(reader, _MAX_POST_BODY)
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_read_capped_body_exceeds_limit_returns_none() -> None:
+    """Content-Length one byte over the cap returns None without reading."""
+    oversized_cl = _MAX_POST_BODY + 1
+    # Reader has no data — if _read_capped_body tried to read it would hang/fail.
+    reader = asyncio.StreamReader()
+    result = await _read_capped_body(reader, oversized_cl)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_read_capped_body_huge_cl_does_not_allocate() -> None:
+    """Malicious huge Content-Length (1 GiB) is rejected immediately."""
+    one_gib = 1024 * 1024 * 1024
+    reader = asyncio.StreamReader()  # empty — no data fed
+    result = await _read_capped_body(reader, one_gib)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Helper: fake writer that captures output
+# ---------------------------------------------------------------------------
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+    def get_extra_info(self, name: str, default=None):
+        if name == "peername":
+            return ("127.0.0.1", 55555)
+        return default
+
+    @property
+    def response_status(self) -> int:
+        """Parse HTTP status code from the buffered response."""
+        line = self.buffer.split(b"\r\n", 1)[0]
+        return int(line.split(b" ")[1])
+
+    @property
+    def response_body(self) -> dict:
+        """Parse JSON body from the buffered response."""
+        body = self.buffer.split(b"\r\n\r\n", 1)[1]
+        return json.loads(body)
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests: handlers send 413 on oversized Content-Length
+# ---------------------------------------------------------------------------
+
+
+def _oversized_headers() -> dict[str, str]:
+    return {"content-length": str(_MAX_POST_BODY + 1)}
+
+
+def _small_headers(payload: bytes) -> dict[str, str]:
+    return {"content-length": str(len(payload))}
+
+
+@pytest.mark.asyncio
+async def test_band_plan_config_rejects_oversized_body() -> None:
+    """_handle_band_plan_config returns 413 for oversized Content-Length."""
+    from unittest.mock import MagicMock
+
+    from icom_lan.web.server import WebConfig, WebServer
+
+    srv = WebServer(MagicMock(), WebConfig(host="127.0.0.1", port=0))
+    writer = _FakeWriter()
+    reader = asyncio.StreamReader()  # empty — should not be read
+
+    await srv._handle_band_plan_config(
+        writer,  # type: ignore[arg-type]
+        headers=_oversized_headers(),
+        reader=reader,  # type: ignore[arg-type]
+    )
+
+    assert writer.response_status == 413
+    assert writer.response_body.get("error") == "request_too_large"
+    assert writer.closed
+
+
+@pytest.mark.asyncio
+async def test_eibi_fetch_rejects_oversized_body() -> None:
+    """_handle_eibi_fetch returns 413 for oversized Content-Length."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from icom_lan.web.server import WebConfig, WebServer
+
+    srv = WebServer(MagicMock(), WebConfig(host="127.0.0.1", port=0))
+    srv._eibi = MagicMock()
+    srv._eibi.fetch = AsyncMock(return_value={"status": "ok"})
+    writer = _FakeWriter()
+    reader = asyncio.StreamReader()
+
+    await srv._handle_eibi_fetch(
+        writer,  # type: ignore[arg-type]
+        headers=_oversized_headers(),
+        reader=reader,  # type: ignore[arg-type]
+    )
+
+    assert writer.response_status == 413
+    assert writer.response_body.get("error") == "request_too_large"
+    assert writer.closed
+
+
+@pytest.mark.asyncio
+async def test_band_plan_config_accepts_valid_body() -> None:
+    """_handle_band_plan_config succeeds with a small valid body."""
+    from unittest.mock import MagicMock
+
+    from icom_lan.web.server import WebConfig, WebServer
+
+    srv = WebServer(MagicMock(), WebConfig(host="127.0.0.1", port=0))
+    srv._band_plan_manager = MagicMock()
+    srv._band_plan_manager.set_region = MagicMock(return_value=None)
+    srv._band_plan_manager.get_all_bands = MagicMock(return_value=[])
+
+    payload = json.dumps({"region": "US"}).encode()
+    reader = _make_reader(payload)
+    writer = _FakeWriter()
+
+    await srv._handle_band_plan_config(
+        writer,  # type: ignore[arg-type]
+        headers=_small_headers(payload),
+        reader=reader,  # type: ignore[arg-type]
+    )
+
+    assert writer.response_status == 200
+    assert not writer.closed


### PR DESCRIPTION
## Summary

- Add module-level `_MAX_POST_BODY = 256 * 1024` constant as the hard ceiling for all POST body reads
- Add `_read_capped_body(reader, content_length)` helper that immediately returns `None` (without reading) when `content_length > _MAX_POST_BODY`, preventing unbounded allocation from attacker-controlled `Content-Length`
- Apply the helper to all four POST handler sites (`_handle_band_plan_config`, `_handle_eibi_fetch`, radio power, WebRTC offer); oversized requests get HTTP 413 and the connection is closed

## Security fix

**Finding (S04):** Four POST handlers called `reader.readexactly(content_length)` with an uncapped `content_length` from the request header. An attacker sending `Content-Length: 1073741824` could force the server to allocate 1 GiB of memory per connection.

**Fix:** `_read_capped_body` checks `content_length > _MAX_POST_BODY` before any `readexactly` call, returning `None` instantly. The caller sends 413 and closes the connection.

## Test plan

- [x] `test_read_capped_body_within_limit` — normal body returned intact
- [x] `test_read_capped_body_exactly_at_limit` — exactly 256 KiB accepted
- [x] `test_read_capped_body_exceeds_limit_returns_none` — one byte over cap returns None
- [x] `test_read_capped_body_huge_cl_does_not_allocate` — 1 GiB `Content-Length` rejected without touching the reader
- [x] `test_band_plan_config_rejects_oversized_body` — handler returns 413
- [x] `test_eibi_fetch_rejects_oversized_body` — handler returns 413
- [x] `test_band_plan_config_accepts_valid_body` — small valid body still returns 200
- [x] Full test suite: 4742 passed, 0 failures
- [x] `ruff check` + `ruff format` — zero violations

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)