### PR TITLE
security(#950): enforce read-only guard on web PTT dispatch

### DIFF
--- a/src/icom_lan/web/handlers/control.py
+++ b/src/icom_lan/web/handlers/control.py
@@ -353,12 +353,14 @@ class ControlHandler:
         server_version: str,
         radio_model: str,
         server: Any = None,
+        read_only: bool = False,
     ) -> None:
         self._ws = ws
         self._radio = radio
         self._version = server_version
         self._radio_model = radio_model
         self._server = server
+        self._read_only = read_only
         self._subscribed_streams: set[str] = set()
         self._event_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
             maxsize=100,
@@ -1211,14 +1213,20 @@ class ControlHandler:
     ) -> dict[str, Any] | None:
         match name:
             case "ptt":
+                if self._read_only:
+                    raise PermissionError("read-only mode: PTT rejected")
                 on = bool(params["state"])
                 logger.info("handler: PTT %s received", "ON" if on else "OFF")
                 q.put(PttOn() if on else PttOff())
                 return {"state": on}
             case "ptt_on":
+                if self._read_only:
+                    raise PermissionError("read-only mode: PTT rejected")
                 q.put(PttOn())
                 return {}
             case "ptt_off":
+                if self._read_only:
+                    raise PermissionError("read-only mode: PTT rejected")
                 q.put(PttOff())
                 return {}
             case "set_rf_power" | "set_power":

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -167,6 +167,7 @@ class WebConfig:
     tls: bool = False  # enable TLS (HTTPS with auto self-signed cert)
     discovery: bool = True  # enable UDP discovery responder
     discovery_port: int = 8470  # UDP port for discovery
+    read_only: bool = False  # reject PTT and other transmit commands
 
 
 class ConnectionManager:
@@ -2397,6 +2398,7 @@ class WebServer:
                 __version__,
                 model,
                 server=self,
+                read_only=self._config.read_only,
             )
         elif path == "/api/v1/scope":
             handler = ScopeHandler(ws, self._radio, server=self)

--- a/tests/test_web_ptt_readonly.py
+++ b/tests/test_web_ptt_readonly.py
@@ -1,0 +1,102 @@
+"""Tests for read-only guard on web PTT dispatch (issue #950)."""
+
+from __future__ import annotations
+
+from queue import Queue
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from icom_lan.web.handlers.control import ControlHandler
+
+
+def _make_handler(
+    *, read_only: bool = False, radio: Any = None
+) -> tuple[ControlHandler, Queue[Any]]:
+    """Build a ControlHandler with a fake server and return (handler, command_queue)."""
+    ws = MagicMock()
+
+    command_queue: Queue[Any] = Queue()
+
+    server = SimpleNamespace(
+        command_queue=command_queue,
+    )
+
+    if radio is None:
+        radio = MagicMock()
+
+    handler = ControlHandler(
+        ws=ws,
+        radio=radio,
+        server_version="test",
+        radio_model="IC-7610",
+        server=server,
+        read_only=read_only,
+    )
+    return handler, command_queue
+
+
+class TestWebPttReadOnly:
+    """read_only=True must reject PTT commands without enqueuing anything."""
+
+    @pytest.mark.asyncio
+    async def test_ptt_rejected_in_read_only_mode(self) -> None:
+        """ptt command raises PermissionError when read_only=True."""
+        handler, q = _make_handler(read_only=True)
+
+        with pytest.raises(PermissionError, match="read-only"):
+            await handler._enqueue_command("ptt", {"state": True})
+
+        assert q.empty(), "command queue must not be touched in read-only mode"
+
+    @pytest.mark.asyncio
+    async def test_ptt_on_rejected_in_read_only_mode(self) -> None:
+        """ptt_on command raises PermissionError when read_only=True."""
+        handler, q = _make_handler(read_only=True)
+
+        with pytest.raises(PermissionError, match="read-only"):
+            await handler._enqueue_command("ptt_on", {})
+
+        assert q.empty(), "command queue must not be touched in read-only mode"
+
+    @pytest.mark.asyncio
+    async def test_ptt_off_rejected_in_read_only_mode(self) -> None:
+        """ptt_off command raises PermissionError when read_only=True."""
+        handler, q = _make_handler(read_only=True)
+
+        with pytest.raises(PermissionError, match="read-only"):
+            await handler._enqueue_command("ptt_off", {})
+
+        assert q.empty(), "command queue must not be touched in read-only mode"
+
+    @pytest.mark.asyncio
+    async def test_ptt_allowed_when_not_read_only(self) -> None:
+        """ptt command dispatches normally when read_only=False."""
+        handler, q = _make_handler(read_only=False)
+
+        result = await handler._enqueue_command("ptt", {"state": True})
+
+        assert result == {"state": True}
+        assert not q.empty(), "PttOn must be enqueued"
+
+    @pytest.mark.asyncio
+    async def test_ptt_on_allowed_when_not_read_only(self) -> None:
+        """ptt_on command dispatches normally when read_only=False."""
+        handler, q = _make_handler(read_only=False)
+
+        result = await handler._enqueue_command("ptt_on", {})
+
+        assert result == {}
+        assert not q.empty(), "PttOn must be enqueued"
+
+    @pytest.mark.asyncio
+    async def test_ptt_off_allowed_when_not_read_only(self) -> None:
+        """ptt_off command dispatches normally when read_only=False."""
+        handler, q = _make_handler(read_only=False)
+
+        result = await handler._enqueue_command("ptt_off", {})
+
+        assert result == {}
+        assert not q.empty(), "PttOff must be enqueued"


### PR DESCRIPTION
## Summary

- `rigctld` already had a read-only gate on set commands; the web PTT path (`ControlHandler._enqueue_rc_power`) was missing an equivalent guard
- Add `read_only: bool = False` to `WebConfig` and pass it through to `ControlHandler` at construction
- Gate `ptt`, `ptt_on`, and `ptt_off` cases in `_enqueue_rc_power` — raises `PermissionError("read-only mode: PTT rejected")` before touching the command queue

## Test plan

- [x] 6 new unit tests in `tests/test_web_ptt_readonly.py` cover all three PTT commands in both read-only and normal mode
- [x] Tests verify `queue.empty()` to confirm the command queue is never touched when rejected
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4741 passed, 0 failures
- [x] `uv run ruff check src/ tests/ && uv run ruff format src/ tests/` — zero violations

Closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)