### PR TITLE
security(#948): redact auth token from query-string log

### DIFF
--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -66,6 +66,28 @@ logger = logging.getLogger(__name__)
 _DEFAULT_STATIC_DIR = pathlib.Path(__file__).parent / "static"
 _RADIO_MODEL = "IC-7610"
 
+
+def _redact_token_in_path(path: str) -> str:
+    """Return `path` with any `token=` query value replaced by `***`.
+
+    Prevents auth tokens from leaking into log captures when clients
+    authenticate via the `?token=` query parameter (see issue #948).
+    """
+    if "token=" not in path:
+        return path
+    base, _, query = path.partition("?")
+    if not query:
+        return path
+    parts = []
+    for pair in query.split("&"):
+        key, eq, _value = pair.partition("=")
+        if key == "token" and eq:
+            parts.append("token=***")
+        else:
+            parts.append(pair)
+    return f"{base}?{'&'.join(parts)}"
+
+
 # Mode/filter lists moved to RadioProfile (profiles.py)
 
 
@@ -1286,7 +1308,13 @@ class WebServer:
                 return
             method, path, headers, query = result
 
-            logger.debug("request: %s %s from %s:%s", method, path, peer[0], peer[1])
+            logger.debug(
+                "request: %s %s from %s:%s",
+                method,
+                _redact_token_in_path(path),
+                peer[0],
+                peer[1],
+            )
 
             # WebSocket upgrade?
             if (
@@ -2438,7 +2466,7 @@ class WebServer:
         try:
             await handler.run()
         except Exception as exc:
-            logger.debug("ws handler error on %s: %s", path, exc)
+            logger.debug("ws handler error on %s: %s", _redact_token_in_path(path), exc)
         finally:
             keepalive.cancel()
             try:

--- a/tests/test_web_server_token_redaction.py
+++ b/tests/test_web_server_token_redaction.py
@@ -1,0 +1,48 @@
+"""Tests for auth-token redaction in request logging (issue #948)."""
+
+from __future__ import annotations
+
+from icom_lan.web.server import _redact_token_in_path
+
+
+def test_redact_token_simple() -> None:
+    assert _redact_token_in_path("/api/v1/ws?token=secret123") == "/api/v1/ws?token=***"
+
+
+def test_redact_token_with_other_params_before() -> None:
+    assert (
+        _redact_token_in_path("/api/v1/ws?foo=1&token=secret&bar=2")
+        == "/api/v1/ws?foo=1&token=***&bar=2"
+    )
+
+
+def test_redact_token_with_other_params_after() -> None:
+    assert (
+        _redact_token_in_path("/api/v1/ws?token=secret&foo=1")
+        == "/api/v1/ws?token=***&foo=1"
+    )
+
+
+def test_redact_empty_token_value() -> None:
+    assert _redact_token_in_path("/api/v1/ws?token=") == "/api/v1/ws?token=***"
+
+
+def test_no_token_param_unchanged() -> None:
+    assert _redact_token_in_path("/api/v1/ws?foo=bar") == "/api/v1/ws?foo=bar"
+
+
+def test_no_query_unchanged() -> None:
+    assert _redact_token_in_path("/api/v1/ws") == "/api/v1/ws"
+
+
+def test_token_substring_in_other_param_is_not_redacted() -> None:
+    # A param named `mytoken=...` must NOT be redacted — only exact `token`.
+    assert _redact_token_in_path("/api/v1/ws?mytoken=abc") == "/api/v1/ws?mytoken=abc"
+
+
+def test_path_with_token_in_body_but_no_query_unchanged() -> None:
+    # The substring `token=` appears in the literal path, not as a query arg.
+    # Our guard (`"token=" not in path`) is a fast-path; since there IS
+    # `token=` in the literal, we go into the split logic, but without a `?`
+    # we return the path as-is.
+    assert _redact_token_in_path("/tokens/token=foo") == "/tokens/token=foo"


### PR DESCRIPTION
## Summary

Resolves issue #948 — auth tokens leak into log files when clients authenticate via `?token=...` query param.

- Added `_redact_token_in_path()` helper in `web/server.py` that replaces `token=<value>` with `token=***`.
- Applied at two log sites:
  - `_handle_connection`: request-line log at line 1289
  - `_handle_websocket`: ws handler-error log at line 2441
- Conservative matching: only the exact query key `token` is redacted (not `mytoken=`), and paths without a `?` pass through unchanged.

## Test plan
- [x] `uv run pytest tests/test_web_server_token_redaction.py -q` — 8/8 pass
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4743 passed, 0 failures
- [x] `uv run ruff check src/ tests/` — clean

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)