### PR TITLE
fix(#986): widen CSP to permit web font sources

### DIFF
--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -2589,7 +2589,9 @@ _SECURITY_HEADERS: dict[str, str] = {
     "X-Frame-Options": "DENY",
     "Referrer-Policy": "no-referrer",
     "Content-Security-Policy": (
-        "default-src 'self' ws: wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
+        "default-src 'self' ws: wss:; img-src 'self' data:; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net"
     ),
 }
 

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -116,6 +116,20 @@ class TestSecurityHeaders:
         csp = headers.get("content-security-policy", "")
         assert "default-src" in csp
 
+    async def test_csp_font_origins(self, sec_server: WebServer) -> None:
+        """CSP must permit the external font origins used by frontend/src/components-v2/theme/*.css.
+
+        fonts.googleapis.com serves Google Fonts CSS stylesheets.
+        fonts.gstatic.com serves the actual woff2 font binaries from Google.
+        cdn.jsdelivr.net serves DSEG woff2 binaries used by digital VFO skins.
+        """
+        host, port = _addr(sec_server)
+        _, headers, _ = await _http_get(host, port, "/api/v1/state")
+        csp = headers.get("content-security-policy", "")
+        assert "fonts.googleapis.com" in csp, "style-src must allow Google Fonts CSS"
+        assert "fonts.gstatic.com" in csp, "font-src must allow Google Fonts binaries"
+        assert "cdn.jsdelivr.net" in csp, "font-src must allow jsDelivr (DSEG fonts)"
+
     async def test_all_headers_on_404(self, sec_server: WebServer) -> None:
         """Security headers must also appear on error responses (e.g. 404)."""
         host, port = _addr(sec_server)


### PR DESCRIPTION
## Summary

- Extends `Content-Security-Policy` in `_SECURITY_HEADERS` to allow the external origins used by `frontend/src/components-v2/theme/fonts.css` and `fonts-digital.css`
- `style-src` now includes `https://fonts.googleapis.com` (serves Google Fonts CSS `@import` responses)
- `font-src` now includes `https://fonts.gstatic.com` (Google Fonts woff2 binaries) and `https://cdn.jsdelivr.net` (DSEG7 woff2 binaries used by digital VFO skins)
- No wildcards or `unsafe-*` directives added beyond what was already present

## Test plan

- [x] New test `test_csp_font_origins` asserts all three origins are present in the CSP header
- [x] Existing `test_content_security_policy` and `test_all_headers_on_404` still pass
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4771 passed, 0 failures
- [x] `uv run ruff check src/ tests/` — clean

Closes #986

🤖 Generated with [Claude Code](https://claude.com/claude-code)