### PR TITLE
fix(#984,#985): correct --pass empty-string and --pass-file first-line semantics

### DIFF
--- a/src/icom_lan/cli.py
+++ b/src/icom_lan/cli.py
@@ -257,12 +257,13 @@ def _resolve_password(args: argparse.Namespace) -> str:
     to the $ICOM_PASS environment variable.
     """
     cli_pass = getattr(args, "password_cli", None)
-    if cli_pass:
+    if cli_pass is not None:
         return str(cli_pass)
     pass_file = getattr(args, "pass_file", None)
     if pass_file:
         try:
-            return Path(pass_file).read_text(encoding="utf-8").rstrip("\n\r")
+            lines = Path(pass_file).read_text(encoding="utf-8").splitlines()
+            return lines[0] if lines else ""
         except OSError as e:
             print(
                 f"Error: cannot read --pass-file {pass_file!r}: {e}",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -267,6 +267,22 @@ class TestPasswordResolution:
             with pytest.raises(SystemExit):
                 _resolve_password(args)
 
+    def test_cli_pass_empty_string_overrides_env(self, monkeypatch):
+        """--pass '' (explicit empty string) must win over $ICOM_PASS (#984)."""
+        monkeypatch.setenv("ICOM_PASS", "env-secret")
+        p = _build_parser()
+        with patch("sys.stderr", new_callable=io.StringIO):
+            args = p.parse_args(["--pass", "", "status"])
+        assert _resolve_password(args) == ""
+
+    def test_pass_file_first_line_only(self, tmp_path):
+        """--pass-file returns only the first line, ignoring trailing content (#985)."""
+        pw_file = tmp_path / "pw.txt"
+        pw_file.write_text("real-secret\n# comment\nextra-line\n", encoding="utf-8")
+        p = _build_parser()
+        args = p.parse_args(["--pass-file", str(pw_file), "status"])
+        assert _resolve_password(args) == "real-secret"
+
     def test_deprecated_port_prints_warning(self):
         p = _build_parser()
         with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:


### PR DESCRIPTION
## Summary

- **#984**: `_resolve_password()` used `if cli_pass:` (truthy check), so `--pass ''` fell through to `$ICOM_PASS`. Changed to `if cli_pass is not None:` so any explicit `--pass` invocation — including empty string — wins, as documented.
- **#985**: `--pass-file` returned the whole file content (only stripping a trailing newline). Changed to `.splitlines()[0]` (with empty-file guard returning `""`) so multi-line files (password + comments/metadata) are handled correctly.

## Test plan

- [x] `test_cli_pass_empty_string_overrides_env` — `--pass ''` overrides `$ICOM_PASS`
- [x] `test_pass_file_first_line_only` — multi-line pass-file returns only first line
- [x] All 4772 existing tests pass (`uv run pytest tests/ -q --tb=short --ignore=tests/integration`)
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/icom_lan/cli.py` — pre-existing unused-ignore unrelated to this change

Closes #984
Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)