### PR TITLE
security(#987): gate all TX-capable web commands under read_only

### DIFF
--- a/src/icom_lan/web/handlers/control.py
+++ b/src/icom_lan/web/handlers/control.py
@@ -346,6 +346,17 @@ class ControlHandler:
         ]
     )
 
+    # Commands that key the transmitter — rejected when read_only=True.
+    # set_tuner_status value=2 (TUNING) is handled inline in _enqueue_read_only.
+    _TX_COMMANDS: frozenset[str] = frozenset(
+        {
+            "ptt",
+            "ptt_on",
+            "ptt_off",
+            "send_cw_text",
+        }
+    )
+
     def __init__(
         self,
         ws: WebSocketConnection,
@@ -841,6 +852,10 @@ class ControlHandler:
         logger.info("enqueue_command: %s params=%s", name, params)
         radio = self._radio
 
+        # Transmit safety gate — must come before any dispatch.
+        if self._read_only and name in self._TX_COMMANDS:
+            raise PermissionError(f"read-only mode: {name} rejected")
+
         # Read-only commands — bypass command queue
         result = await self._enqueue_read_only(name, params, radio)
         if result is not None:
@@ -969,6 +984,10 @@ class ControlHandler:
             value = int(params["value"])
             if value not in (0, 1, 2):
                 raise ValueError(f"tuner value must be 0, 1, or 2, got {value}")
+            if self._read_only and value == 2:
+                raise PermissionError(
+                    "read-only mode: set_tuner_status TUNING rejected"
+                )
             # Try direct call if the radio has the method
             if radio is not None and CAP_TUNER in radio.capabilities:
                 await radio.set_tuner_status(value)

--- a/tests/test_web_ptt_readonly.py
+++ b/tests/test_web_ptt_readonly.py
@@ -1,14 +1,15 @@
-"""Tests for read-only guard on web PTT dispatch (issue #950)."""
+"""Tests for read-only guard on web PTT dispatch (issue #950, #987)."""
 
 from __future__ import annotations
 
 from queue import Queue
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from icom_lan.capabilities import CAP_CW, CAP_TUNER
 from icom_lan.web.handlers.control import ControlHandler
 
 
@@ -100,3 +101,98 @@ class TestWebPttReadOnly:
 
         assert result == {}
         assert not q.empty(), "PttOff must be enqueued"
+
+
+class TestWebCwReadOnly:
+    """read_only=True must reject send_cw_text without keying the radio."""
+
+    def _make_cw_radio(self) -> MagicMock:
+        radio = MagicMock()
+        radio.capabilities = frozenset({CAP_CW})
+        radio.send_cw_text = AsyncMock(return_value=None)
+        return radio
+
+    @pytest.mark.asyncio
+    async def test_send_cw_text_rejected_in_read_only_mode(self) -> None:
+        """send_cw_text raises PermissionError when read_only=True."""
+        handler, q = _make_handler(read_only=True, radio=self._make_cw_radio())
+
+        with pytest.raises(PermissionError, match="read-only"):
+            await handler._enqueue_command("send_cw_text", {"text": "CQ CQ"})
+
+        assert q.empty(), "command queue must not be touched in read-only mode"
+
+    @pytest.mark.asyncio
+    async def test_send_cw_text_not_called_on_radio_in_read_only_mode(self) -> None:
+        """Radio send_cw_text must never be invoked when read_only=True."""
+        radio = self._make_cw_radio()
+        handler, _ = _make_handler(read_only=True, radio=radio)
+
+        with pytest.raises(PermissionError):
+            await handler._enqueue_command("send_cw_text", {"text": "TEST"})
+
+        radio.send_cw_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_cw_text_allowed_when_not_read_only(self) -> None:
+        """send_cw_text dispatches normally when read_only=False."""
+        radio = self._make_cw_radio()
+        handler, q = _make_handler(read_only=False, radio=radio)
+
+        result = await handler._enqueue_command("send_cw_text", {"text": "CQ"})
+
+        assert result == {"text": "CQ"}
+        radio.send_cw_text.assert_awaited_once_with("CQ")
+
+
+class TestWebTunerReadOnly:
+    """read_only=True must reject set_tuner_status TUNING (value=2) only."""
+
+    def _make_tuner_radio(self) -> MagicMock:
+        radio = MagicMock()
+        radio.capabilities = frozenset({CAP_TUNER})
+        radio.set_tuner_status = AsyncMock(return_value=None)
+        return radio
+
+    @pytest.mark.asyncio
+    async def test_tuner_tune_rejected_in_read_only_mode(self) -> None:
+        """set_tuner_status value=2 (TUNING) raises PermissionError when read_only=True."""
+        handler, q = _make_handler(read_only=True, radio=self._make_tuner_radio())
+
+        with pytest.raises(PermissionError, match="read-only"):
+            await handler._enqueue_command("set_tuner_status", {"value": 2})
+
+        assert q.empty(), "command queue must not be touched in read-only mode"
+
+    @pytest.mark.asyncio
+    async def test_tuner_on_allowed_in_read_only_mode(self) -> None:
+        """set_tuner_status value=1 (ON) is allowed even when read_only=True."""
+        radio = self._make_tuner_radio()
+        handler, q = _make_handler(read_only=True, radio=radio)
+
+        result = await handler._enqueue_command("set_tuner_status", {"value": 1})
+
+        assert result == {"value": 1, "label": "ON"}
+        radio.set_tuner_status.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_tuner_off_allowed_in_read_only_mode(self) -> None:
+        """set_tuner_status value=0 (OFF) is allowed even when read_only=True."""
+        radio = self._make_tuner_radio()
+        handler, q = _make_handler(read_only=True, radio=radio)
+
+        result = await handler._enqueue_command("set_tuner_status", {"value": 0})
+
+        assert result == {"value": 0, "label": "OFF"}
+        radio.set_tuner_status.assert_awaited_once_with(0)
+
+    @pytest.mark.asyncio
+    async def test_tuner_tune_allowed_when_not_read_only(self) -> None:
+        """set_tuner_status value=2 (TUNING) dispatches normally when read_only=False."""
+        radio = self._make_tuner_radio()
+        handler, q = _make_handler(read_only=False, radio=radio)
+
+        result = await handler._enqueue_command("set_tuner_status", {"value": 2})
+
+        assert result == {"value": 2, "label": "TUNING"}
+        radio.set_tuner_status.assert_awaited_once_with(2)


### PR DESCRIPTION
## Summary

Closes #987

PR #979 added `read_only` guards to the three `ptt*` branches in `_enqueue_rc_power`, but two other transmit-capable paths in `control.py` remained ungated:

- **`send_cw_text`** — keys the transmitter via CW message (path: `_enqueue_read_only`)
- **`set_tuner_status` value=2 (TUNING)** — briefly transmits for antenna tuner calibration (path: `_enqueue_read_only`)

## What changed

### `src/icom_lan/web/handlers/control.py`
- Added class-level `_TX_COMMANDS = frozenset({"ptt", "ptt_on", "ptt_off", "send_cw_text"})` — single authoritative list of commands that key the transmitter
- Added a central `read_only` guard at the top of `_enqueue_command` (before any dispatch) that raises `PermissionError(f"read-only mode: {name} rejected")` for any command in `_TX_COMMANDS`
- Added inline guard in `_enqueue_read_only` for `set_tuner_status` when `value == 2` (TUNING only; OFF/ON are non-transmitting and remain allowed)
- Existing per-branch guards in `_enqueue_rc_power` are retained for defense-in-depth

### `tests/test_web_ptt_readonly.py`
Added 7 new tests in two new classes:
- `TestWebCwReadOnly`: `send_cw_text` rejected with `read_only=True`; `radio.send_cw_text` never called; dispatches normally with `read_only=False`
- `TestWebTunerReadOnly`: value=2 rejected with `read_only=True`; value=0 and value=1 allowed even with `read_only=True`; value=2 dispatches normally with `read_only=False`

## Test plan
- [x] `uv run pytest tests/test_web_ptt_readonly.py -v` — 13/13 passed (was 6)
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4777 passed, 0 failures
- [x] `uv run ruff check src/icom_lan/web/handlers/control.py tests/test_web_ptt_readonly.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)