### PR TITLE
refactor(#993): add backend_id property to Radio protocol

### DIFF
--- a/src/icom_lan/backends/factory.py
+++ b/src/icom_lan/backends/factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
 from ..radio import IcomRadio  # noqa: TID251
 from ..radio_protocol import Radio
@@ -45,12 +46,16 @@ def create_radio(config: BackendConfig) -> Radio:
             model=config.model,
         )
     if isinstance(config, YaesuCatBackendConfig):
-        return YaesuCatRadio(
-            device=config.device,
-            baudrate=config.baudrate,
-            rx_device=config.rx_device,
-            tx_device=config.tx_device,
-            audio_sample_rate=config.audio_sample_rate,
+        # cast: YaesuCatRadio will implement backend_id in #994
+        return cast(
+            Radio,
+            YaesuCatRadio(
+                device=config.device,
+                baudrate=config.baudrate,
+                rx_device=config.rx_device,
+                tx_device=config.tx_device,
+                audio_sample_rate=config.audio_sample_rate,
+            ),
         )
     if isinstance(config, SerialBackendConfig):
         # Route to model-specific serial backend
@@ -59,12 +64,16 @@ def create_radio(config: BackendConfig) -> Radio:
         # Yaesu CAT radios (FTX-1, FT-710, FT-991A, etc.)
         _YAESU_MODELS = {"FTX-1", "FT-710", "FT-991A", "FT-991", "FTDX101", "FTDX10"}
         if model in _YAESU_MODELS or model.startswith("FT"):
-            return YaesuCatRadio(
-                device=config.device,
-                baudrate=config.baudrate or 38400,
-                rx_device=config.rx_device,
-                tx_device=config.tx_device,
-                audio_sample_rate=config.audio_sample_rate or 48000,
+            # cast: YaesuCatRadio will implement backend_id in #994
+            return cast(
+                Radio,
+                YaesuCatRadio(
+                    device=config.device,
+                    baudrate=config.baudrate or 38400,
+                    rx_device=config.rx_device,
+                    tx_device=config.tx_device,
+                    audio_sample_rate=config.audio_sample_rate or 48000,
+                ),
             )
 
         serial_class: (

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -197,6 +197,20 @@ class Radio(Protocol):
         ...
 
     @property
+    def backend_id(self) -> str:
+        """Stable string identifier for the backend family.
+
+        Consumers (web server, rigctld) use this to route backend-specific
+        logic without importing concrete backend classes.
+
+        Known values (family-level, not per-model):
+          - ``"icom_lan"``    — Icom LAN/CI-V-over-Ethernet (IC-7610, IC-9700, …)
+          - ``"icom_serial"`` — Icom serial CI-V (IC-7300, IC-705, …)
+          - ``"yaesu_cat"``   — Yaesu CAT (FTX-1, …)
+        """
+        ...
+
+    @property
     def capabilities(self) -> set[str]:
         """Set of capability tags this radio supports.
 

--- a/tests/test_radio_protocol.py
+++ b/tests/test_radio_protocol.py
@@ -1,0 +1,65 @@
+"""Tests for the Radio protocol surface in radio_protocol.py."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from icom_lan.radio_protocol import Radio
+from icom_lan.radio_state import RadioState
+
+
+class _StubRadio:
+    """Minimal conforming stub that implements the Radio protocol."""
+
+    @property
+    def backend_id(self) -> str:
+        return "icom_lan"
+
+    @property
+    def connected(self) -> bool:
+        return False
+
+    @property
+    def radio_ready(self) -> bool:
+        return False
+
+    @property
+    def radio_state(self) -> RadioState:
+        return RadioState()
+
+    @property
+    def model(self) -> str:
+        return "IC-TEST"
+
+    @property
+    def capabilities(self) -> set[str]:
+        return set()
+
+    def supports_command(self, command: str) -> bool:
+        return False
+
+    async def connect(self) -> None: ...
+    async def disconnect(self) -> None: ...
+    async def __aenter__(self) -> "_StubRadio": return self
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None: ...
+    async def get_freq(self, receiver: int = 0) -> int: return 0
+    async def set_freq(self, freq: int, receiver: int = 0) -> None: ...
+    async def get_mode(self, receiver: int = 0) -> tuple[str, int | None]: return ("USB", None)
+    async def set_mode(self, mode: str, filter_width: int | None = None, receiver: int = 0) -> None: ...
+    async def get_data_mode(self) -> bool: return False
+    async def set_data_mode(self, on: int | bool, receiver: int = 0) -> None: ...
+    async def set_ptt(self, on: bool) -> None: ...
+
+
+def test_backend_id_property_on_stub() -> None:
+    """Radio protocol surface includes backend_id returning a str."""
+    stub = _StubRadio()
+    assert isinstance(stub, Radio)
+    assert stub.backend_id == "icom_lan"
+    assert isinstance(stub.backend_id, str)
+
+
+def test_backend_id_known_values() -> None:
+    """backend_id can hold any of the documented family values."""
+    known_ids = {"icom_lan", "icom_serial", "yaesu_cat"}
+    assert _StubRadio().backend_id in known_ids


### PR DESCRIPTION
## Summary

- Adds `backend_id: str` read-only property to the `Radio` Protocol in `radio_protocol.py` with docstring listing the three known family values: `"icom_lan"`, `"icom_serial"`, `"yaesu_cat"`
- Adds `cast(Radio, ...)` in `backends/factory.py` for `YaesuCatRadio` return sites so `mypy` stays clean until #994 implements the property in each backend
- Adds `tests/test_radio_protocol.py` with a conforming stub class that exercises the new protocol member via `isinstance(stub, Radio)` and property value assertions

Closes #993. Part of #957.

## Test plan

- [x] `uv run pytest tests/test_radio_protocol.py -q` — 2 new tests pass
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4782 passed, 0 failures
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — zero errors

**Note:** The `cast()` in `factory.py` is temporary scaffolding; it will be removed in #994 when `YaesuCatRadio` (and all other backends) implement `backend_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)