### PR TITLE
refactor(#1004): move PRESSURE_THRESHOLD to neutral module

### DIFF
--- a/src/icom_lan/_queue_pressure.py
+++ b/src/icom_lan/_queue_pressure.py
@@ -1,0 +1,8 @@
+"""Queue pressure threshold for transport and poller coordination.
+
+Neutral module shared by both transport and radio_poller to avoid circular dependencies.
+"""
+
+__all__ = ["PRESSURE_THRESHOLD"]
+
+PRESSURE_THRESHOLD = 0.7

--- a/src/icom_lan/transport.py
+++ b/src/icom_lan/transport.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 from enum import StrEnum
 
+from ._queue_pressure import PRESSURE_THRESHOLD
 from .exceptions import TimeoutError as _TimeoutError
 from .types import HEADER_SIZE, PacketType
 
@@ -35,7 +36,6 @@ DISCOVERY_TIMEOUT = 1.0  # seconds per attempt
 BUFSIZE = 500
 MAX_MISSING = 50
 PACKET_QUEUE_MAXSIZE = 4096
-PRESSURE_THRESHOLD = 0.7
 
 
 class ConnectionState(StrEnum):

--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -67,9 +67,9 @@ from ..capabilities import (
     CAP_TUNER,
     CAP_VOX,
 )
+from .._queue_pressure import PRESSURE_THRESHOLD
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
-from ..transport import PRESSURE_THRESHOLD
 
 if TYPE_CHECKING:
     from ..radio_protocol import Radio


### PR DESCRIPTION
## Summary
Move the queue pressure threshold constant from transport.py to a neutral module (_queue_pressure.py) to eliminate circular dependency concerns while maintaining backward compatibility.

## Changes
- Create `src/icom_lan/_queue_pressure.py` with `PRESSURE_THRESHOLD` constant
- Import from `_queue_pressure` in `transport.py` (re-exported for backward compatibility)
- Import from `_queue_pressure` in `web/radio_poller.py` (instead of transport)
- Remove duplicate constant definition from `transport.py`

## Testing
- All tests pass: `uv run pytest tests/ -q --tb=short --ignore=tests/integration`
- Linting clean: `uv run ruff check src/ tests/`
- Critical affected tests (test_transport.py, test_radio_poller_coverage.py) verified passing

## Acceptance Criteria Met
✓ PRESSURE_THRESHOLD defined in exactly one neutral module (_queue_pressure.py)
✓ transport.py has access to the constant via import (re-exported for compatibility)
✓ radio_poller.py imports from _queue_pressure (not transport)
✓ Public compatibility through icom_lan.transport.PRESSURE_THRESHOLD preserved
✓ All tests pass with zero failures
✓ Ruff linting clean

Closes #1004