### PR TITLE
refactor(#991): add ScopeController singleton to FrontendRuntime

### DIFF
--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for ScopeController.
+ *
+ * Uses constructor injection (channelFactory) so no vi.mock is needed —
+ * safe to run in the fast (non-isolated) vitest pool.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ScopeController } from '../scope-controller.svelte';
+import type { ScopeFrame } from '../scope-controller.svelte';
+
+// ── Helpers ──
+
+function makeMockChannel() {
+  const binaryHandlers = new Set<(buf: ArrayBuffer) => void>();
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    onBinary: vi.fn((handler: (buf: ArrayBuffer) => void) => {
+      binaryHandlers.add(handler);
+      return () => { binaryHandlers.delete(handler); };
+    }),
+    /** Fire a binary message to all registered handlers. */
+    _fire(buf: ArrayBuffer) {
+      for (const h of binaryHandlers) h(buf);
+    },
+  };
+}
+
+/** Build a minimal valid scope frame ArrayBuffer (16-byte header + 4 pixels). */
+function makeScopeFrameBuffer(pixelCount = 4): ArrayBuffer {
+  const buf = new ArrayBuffer(16 + pixelCount);
+  const view = new DataView(buf);
+  view.setUint8(0, 0x01);          // magic
+  view.setUint8(1, 0);             // receiver 0
+  view.setUint32(3, 14_100_000, true); // startFreq
+  view.setUint32(7, 14_200_000, true); // endFreq
+  view.setUint16(14, pixelCount, true);
+  return buf;
+}
+
+// ── Tests ──
+
+describe('ScopeController', () => {
+  let channel: ReturnType<typeof makeMockChannel>;
+  let ctrl: ScopeController;
+
+  beforeEach(() => {
+    channel = makeMockChannel();
+    ctrl = new ScopeController(() => channel as any);
+  });
+
+  it('subscribe() opens the WS channel on first subscriber', () => {
+    expect(channel.connect).not.toHaveBeenCalled();
+
+    ctrl.subscribe(vi.fn());
+
+    expect(channel.connect).toHaveBeenCalledTimes(1);
+    expect(channel.connect).toHaveBeenCalledWith('/api/v1/audio-scope');
+  });
+
+  it('second subscribe() reuses the existing channel without reconnecting', () => {
+    ctrl.subscribe(vi.fn());
+    ctrl.subscribe(vi.fn());
+
+    expect(channel.connect).toHaveBeenCalledTimes(1);
+    expect(channel.onBinary).toHaveBeenCalledTimes(1);
+  });
+
+  it('last unsubscribe() closes the channel', () => {
+    const unsub1 = ctrl.subscribe(vi.fn());
+    const unsub2 = ctrl.subscribe(vi.fn());
+
+    unsub1();
+    expect(channel.disconnect).not.toHaveBeenCalled();
+
+    unsub2();
+    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('both subscribers receive parsed frames', () => {
+    const h1 = vi.fn<[ScopeFrame], void>();
+    const h2 = vi.fn<[ScopeFrame], void>();
+
+    ctrl.subscribe(h1);
+    ctrl.subscribe(h2);
+
+    channel._fire(makeScopeFrameBuffer());
+
+    expect(h1).toHaveBeenCalledTimes(1);
+    expect(h2).toHaveBeenCalledTimes(1);
+
+    const frame = h1.mock.calls[0][0];
+    expect(frame.startFreq).toBe(14_100_000);
+    expect(frame.endFreq).toBe(14_200_000);
+  });
+
+  it('unsubscribed handler no longer receives frames', () => {
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+
+    const unsub1 = ctrl.subscribe(h1);
+    ctrl.subscribe(h2);
+
+    unsub1();
+    channel._fire(makeScopeFrameBuffer());
+
+    expect(h1).not.toHaveBeenCalled();
+    expect(h2).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores malformed frames (wrong magic byte)', () => {
+    const handler = vi.fn();
+    ctrl.subscribe(handler);
+
+    // Bad magic — parseScopeFrame returns null
+    const bad = new ArrayBuffer(20);
+    channel._fire(bad);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('reopens the channel after all subscribers leave and a new one joins', () => {
+    const unsub = ctrl.subscribe(vi.fn());
+    unsub();
+
+    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+
+    ctrl.subscribe(vi.fn());
+    expect(channel.connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -29,6 +29,8 @@ import { sendCommand, connect, sendRaw } from '$lib/transport/ws-client';
 import { fetchCapabilities, startPolling } from '$lib/transport/http-client';
 import { audioManager } from '$lib/audio/audio-manager';
 import { systemController } from './system-controller';
+import { scopeController } from './scope-controller.svelte';
+import type { ScopeController } from './scope-controller.svelte';
 
 import type { ServerState, ReceiverState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
@@ -110,6 +112,13 @@ class FrontendRuntime {
   /** System actions (power, connect/disconnect, frequency identification). */
   get system() {
     return systemController;
+  }
+
+  // ── Scope controller ──
+
+  /** Single owner of the audio-scope WS channel. Subscribe to receive parsed frames. */
+  get scope(): ScopeController {
+    return scopeController;
   }
 
   // ── Bootstrap ──

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -1,0 +1,91 @@
+/**
+ * ScopeController — singleton owner of the audio-scope WebSocket channel.
+ *
+ * Opens `/api/v1/audio-scope` lazily when the first subscriber attaches and
+ * closes it when the last subscriber detaches. Parses binary frames with
+ * `parseScopeFrame()` from `scope-adapter.ts` and stores the latest frame as
+ * a reactive `$state` property that Svelte components can read via `$derived`.
+ *
+ * Satisfies ADR INV-2 (single scope ownership) and INV-5 (mount/unmount of
+ * presentation panels must not change transport state).
+ *
+ * @see docs/plans/2026-04-12-target-frontend-architecture.md §ScopeController
+ */
+
+import { getChannel } from '$lib/transport/ws-client';
+import { markScopeFrame } from '$lib/stores/connection.svelte';
+import { parseScopeFrame } from '$lib/runtime/adapters/scope-adapter';
+import type { ScopeFrame } from '$lib/runtime/adapters/scope-adapter';
+import type { WsChannel } from '$lib/transport/ws-client';
+
+export type { ScopeFrame };
+
+type FrameHandler = (frame: ScopeFrame) => void;
+type ChannelFactory = (name: string) => WsChannel;
+
+export class ScopeController {
+  /** Latest parsed audio-scope frame (Svelte 5 reactive). */
+  audioScopeFrame: ScopeFrame | null = $state(null);
+
+  /** Hardware scope — not yet implemented; always false for now. */
+  readonly hardwareScopeAvailable = false;
+  readonly audioScopeAvailable = true;
+  readonly activeScope: 'hardware' | 'audio-fft' | null = 'audio-fft';
+  readonly scopeFrame: ScopeFrame | null = null;
+
+  private _subscribers = new Set<FrameHandler>();
+  private _unsubBinary: (() => void) | null = null;
+  private _channel: WsChannel | null = null;
+  private _getChannel: ChannelFactory;
+
+  constructor(channelFactory: ChannelFactory = getChannel) {
+    this._getChannel = channelFactory;
+  }
+
+  /**
+   * Subscribe to parsed scope frames.
+   * Opens the WS channel on the first subscriber.
+   * Returns an `unsubscribe` function — call it to stop receiving frames.
+   */
+  subscribe(handler: FrameHandler): () => void {
+    this._subscribers.add(handler);
+
+    if (this._subscribers.size === 1) {
+      this._connect();
+    }
+
+    return () => {
+      this._subscribers.delete(handler);
+      if (this._subscribers.size === 0) {
+        this._disconnect();
+      }
+    };
+  }
+
+  private _connect(): void {
+    const ch = this._getChannel('audio-scope');
+    this._channel = ch;
+    ch.connect('/api/v1/audio-scope');
+    this._unsubBinary = ch.onBinary((buf: ArrayBuffer) => {
+      markScopeFrame();
+      const frame = parseScopeFrame(buf);
+      if (frame) {
+        this.audioScopeFrame = frame;
+        for (const h of this._subscribers) {
+          h(frame);
+        }
+      }
+    });
+  }
+
+  private _disconnect(): void {
+    this._unsubBinary?.();
+    this._unsubBinary = null;
+    this._channel?.disconnect();
+    this._channel = null;
+    this.audioScopeFrame = null;
+  }
+}
+
+/** Singleton instance used by FrontendRuntime. */
+export const scopeController = new ScopeController();


### PR DESCRIPTION
## Summary

- Adds `ScopeController` (`frontend/src/lib/runtime/scope-controller.svelte.ts`) as the single owner of the `/api/v1/audio-scope` WS channel, satisfying ADR INV-2 (single scope ownership) and INV-5 (mount/unmount must not change transport state)
- Lazy-connects on first `subscribe()` call; disconnects when the last subscriber unsubscribes; reuses `parseScopeFrame()` from `scope-adapter.ts`
- Exposes `runtime.scope` getter on `FrontendRuntime` (5-line delta in `frontend-runtime.ts`)

## Test plan

- [x] 7 vitest unit tests in `scope-controller.test.ts` — subscribe opens channel, second subscribe shares it, last unsubscribe closes, both handlers receive frames, unsubscribed handler no longer fires, malformed frames ignored, channel reopens after full unsubscribe cycle
- [x] Full vitest suite: 1678 tests, 89 files, all pass
- [x] `pnpm exec tsc --noEmit` — no errors
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `createAudioScopeConnection()` in `scope-adapter.ts` preserved (panels migrated in #992)

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)