### PR TITLE
refactor(#1002): switch runtime/adapters to import from lib/runtime/ modules

### DIFF
--- a/frontend/src/lib/runtime/adapters/audio-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/audio-adapter.ts
@@ -6,8 +6,8 @@
  */
 
 import { runtime } from '../frontend-runtime';
-import { toRxAudioProps, type RxAudioProps } from '../../../components-v2/wiring/state-adapter';
-import { makeRxAudioHandlers } from '../../../components-v2/wiring/command-bus';
+import { toRxAudioProps, type RxAudioProps } from '../props/panel-props';
+import { makeRxAudioHandlers } from '../commands/panel-commands';
 
 export function deriveRxAudioProps(): RxAudioProps {
   const state = runtime.state;

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -13,14 +13,14 @@ import {
   toRfFrontEndProps, toRitXitProps, toScanProps,
   toMeterProps, toCwProps, toDspProps, toTxProps,
   toFilterProps, toBandSelectorProps,
-} from '../../../components-v2/wiring/state-adapter';
+} from '../props/panel-props';
 import {
   makeAgcHandlers, makeModeHandlers, makeAntennaHandlers,
   makeRfFrontEndHandlers, makeRitXitHandlers, makeScanHandlers,
   makeMeterHandlers, makeCwPanelHandlers, makeDspHandlers,
   makeTxHandlers, makeFilterHandlers, makeBandHandlers,
   makePresetHandlers,
-} from '../../../components-v2/wiring/command-bus';
+} from '../commands/panel-commands';
 
 // Re-export types for panel imports
 export type {
@@ -28,7 +28,7 @@ export type {
   RfFrontEndProps, RitXitProps, ScanProps,
   MeterProps, CwProps, DspProps, TxProps,
   FilterProps, BandSelectorProps,
-} from '../../../components-v2/wiring/state-adapter';
+} from '../props/panel-props';
 
 // ── AGC ──
 export function deriveAgcProps() {

--- a/frontend/src/lib/runtime/adapters/vfo-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/vfo-adapter.ts
@@ -5,8 +5,8 @@
  */
 
 import { runtime } from '../frontend-runtime';
-import { toVfoProps, toVfoOpsProps } from '../../../components-v2/wiring/state-adapter';
-import type { VfoStateProps, VfoOpsProps } from '../../../components-v2/wiring/state-adapter';
+import { toVfoProps, toVfoOpsProps } from '../props/panel-props';
+import type { VfoStateProps, VfoOpsProps } from '../props/panel-props';
 
 export function deriveMainVfo(): VfoStateProps {
   return toVfoProps(runtime.state, 'main');


### PR DESCRIPTION
## Summary

- Replace inverted `lib/runtime/adapters/` → `components-v2/wiring/` imports with canonical `lib/runtime/` modules
- `audio-adapter.ts`: now imports from `../props/panel-props` and `../commands/panel-commands`
- `panel-adapters.ts`: same substitution; type re-exports at lines 25–31 also updated to `../props/panel-props`
- `vfo-adapter.ts`: imports updated to `../props/panel-props`

No logic changes — import paths only.

Closes #1002

## Acceptance gate

```
grep -rE "from ['\"][^'\"]*components-v2" frontend/src/lib/runtime/
```
Returns **0 matches** ✓

## Test plan

- [x] Acceptance gate: zero `components-v2` imports in `lib/runtime/` (`grep` returns empty)
- [x] `pnpm exec tsc --noEmit` — clean (zero errors)
- [x] `pnpm exec vitest run` — 88 test files, 1671 tests passed
- [x] Python baseline unchanged (failures are pre-existing, unrelated to frontend changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)