### PR TITLE
refactor(#994): implement backend_id in all concrete backends

### DIFF
--- a/src/icom_lan/backends/_icom_serial_base.py
+++ b/src/icom_lan/backends/_icom_serial_base.py
@@ -158,6 +158,15 @@ class _IcomSerialRadioBase(CoreRadio):
         self._serial_audio_seq = 0
 
     # ------------------------------------------------------------------
+    # Backend identity
+    # ------------------------------------------------------------------
+
+    @property
+    def backend_id(self) -> str:
+        """Stable backend family identifier — ``"icom_serial"`` for serial CI-V."""
+        return "icom_serial"
+
+    # ------------------------------------------------------------------
     # Connection properties
     # ------------------------------------------------------------------
 

--- a/src/icom_lan/backends/factory.py
+++ b/src/icom_lan/backends/factory.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
 
 from ..radio import IcomRadio  # noqa: TID251
 from ..radio_protocol import Radio
@@ -46,16 +45,12 @@ def create_radio(config: BackendConfig) -> Radio:
             model=config.model,
         )
     if isinstance(config, YaesuCatBackendConfig):
-        # cast: YaesuCatRadio will implement backend_id in #994
-        return cast(
-            Radio,
-            YaesuCatRadio(
-                device=config.device,
-                baudrate=config.baudrate,
-                rx_device=config.rx_device,
-                tx_device=config.tx_device,
-                audio_sample_rate=config.audio_sample_rate,
-            ),
+        return YaesuCatRadio(
+            device=config.device,
+            baudrate=config.baudrate,
+            rx_device=config.rx_device,
+            tx_device=config.tx_device,
+            audio_sample_rate=config.audio_sample_rate,
         )
     if isinstance(config, SerialBackendConfig):
         # Route to model-specific serial backend
@@ -64,16 +59,12 @@ def create_radio(config: BackendConfig) -> Radio:
         # Yaesu CAT radios (FTX-1, FT-710, FT-991A, etc.)
         _YAESU_MODELS = {"FTX-1", "FT-710", "FT-991A", "FT-991", "FTDX101", "FTDX10"}
         if model in _YAESU_MODELS or model.startswith("FT"):
-            # cast: YaesuCatRadio will implement backend_id in #994
-            return cast(
-                Radio,
-                YaesuCatRadio(
-                    device=config.device,
-                    baudrate=config.baudrate or 38400,
-                    rx_device=config.rx_device,
-                    tx_device=config.tx_device,
-                    audio_sample_rate=config.audio_sample_rate or 48000,
-                ),
+            return YaesuCatRadio(
+                device=config.device,
+                baudrate=config.baudrate or 38400,
+                rx_device=config.rx_device,
+                tx_device=config.tx_device,
+                audio_sample_rate=config.audio_sample_rate or 48000,
             )
 
         serial_class: (

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -197,6 +197,11 @@ class YaesuCatRadio:
         return self._transport.connected
 
     @property
+    def backend_id(self) -> str:
+        """Stable backend family identifier — ``"yaesu_cat"`` for Yaesu CAT."""
+        return "yaesu_cat"
+
+    @property
     def model(self) -> str:
         """Human-readable radio model name (e.g. ``'FTX-1'``)."""
         return str(self._config.model)

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -900,6 +900,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         return self._profile.model
 
     @property
+    def backend_id(self) -> str:
+        """Stable backend family identifier — ``"icom_lan"`` for LAN/CI-V-over-Ethernet."""
+        return "icom_lan"
+
+    @property
     def capabilities(self) -> set[str]:
         """Set of capability tags supported by this radio.
 

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -7,8 +7,9 @@ from dataclasses import dataclass
 import pytest
 
 from icom_lan import IcomRadio, create_radio
-from icom_lan.backends.config import LanBackendConfig, SerialBackendConfig
+from icom_lan.backends.config import LanBackendConfig, SerialBackendConfig, YaesuCatBackendConfig
 from icom_lan.backends.icom7610 import Icom7610SerialRadio
+from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
 from icom_lan.backends.icom7610.drivers.contracts import (
     AudioDriver,
     CivLink,
@@ -109,6 +110,19 @@ class TestCreateRadioFactory:
         )
         assert isinstance(radio, Icom7610SerialRadio)
         assert radio._serial_ptt_mode == "civ"
+
+    def test_lan_backend_has_icom_lan_backend_id(self) -> None:
+        radio = create_radio(LanBackendConfig(host="192.168.55.40"))
+        assert radio.backend_id == "icom_lan"
+
+    def test_serial_icom_backend_has_icom_serial_backend_id(self) -> None:
+        radio = create_radio(SerialBackendConfig(device="/dev/ttyUSB0"))
+        assert radio.backend_id == "icom_serial"
+
+    def test_yaesu_cat_backend_config_has_yaesu_cat_backend_id(self) -> None:
+        radio = create_radio(YaesuCatBackendConfig(device="/dev/ttyUSB0"))
+        assert isinstance(radio, YaesuCatRadio)
+        assert radio.backend_id == "yaesu_cat"
 
     def test_create_radio_rejects_unknown_backend(self) -> None:
         @dataclass(slots=True)


### PR DESCRIPTION
## Summary

- Add `backend_id` property to `CoreRadio` returning `"icom_lan"` (covers `IcomRadio` and all LAN-based subclasses)
- Override `backend_id` in `_IcomSerialRadioBase` returning `"icom_serial"` (covers all Icom serial backends)
- Add `backend_id` property to `YaesuCatRadio` returning `"yaesu_cat"`
- Remove the two `cast(Radio, YaesuCatRadio(...))` workarounds and associated comments from `factory.py`; drop the now-unused `from typing import cast` import

## Test plan

- [ ] `uv run pytest tests/test_backend_factory.py` — all 20 tests pass including 3 new `backend_id` assertions for each backend path
- [ ] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4784 passed, 0 failures from our changes (one pre-existing flaky timing test irrelevant to this PR)
- [ ] `uv run ruff check src/ tests/` — zero violations
- [ ] `uv run mypy src/` — zero issues across 144 source files

Closes #994
Closes #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)