### PR TITLE
docs(#1031): correct web dispatch description — CommandQueue/RadioPoller

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -371,7 +371,7 @@ enable/disable. Avoids request-response patterns to survive the IC-7610's 225-pa
 scope flood.
 
 **`web/handlers/`** — WebSocket handler subpackage: scope, meters, audio, and control
-handlers. Routes incoming WebSocket messages to the radio via `IcomCommander`.
+handlers. Enqueues commands via `CommandQueue`; `RadioPoller` drains the queue and dispatches to the radio. (`IcomCommander` is a lower-level CI-V helper used by the backend, not part of the web dispatch path.)
 
 **`web/band_plan.py`** — Amateur radio band definitions and frequency validation helpers.
 Used by the web UI to show band segments and validate frequency input.


### PR DESCRIPTION
Closes #1031

## Summary
Corrects inaccurate documentation in `docs/internals/architecture.md:374`. Previously claimed web handlers route WebSocket messages via `IcomCommander`, but the actual dispatch path is:

`ControlHandler` → `CommandQueue` → `RadioPoller`

`WebServer` exposes the queue to the poller; `IcomCommander` is a lower-level CI-V helper used by the backend, not the web dispatch layer.

## Changes
- Single line update to clarify the actual dispatch chain
- Mentions `IcomCommander` context to prevent future layering confusion