### PR TITLE
refactor(#989): migrate App.svelte to FrontendRuntime.bootstrap()

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { fetchCapabilities, startPolling, setPollingMultiplier } from './lib/transport/http-client';
-  import { connect, sendRaw } from './lib/transport/ws-client';
   import { initBatteryMonitor } from './lib/utils/battery';
-  import { setCapabilities } from './lib/stores/capabilities.svelte';
-  import { setRadioState } from './lib/stores/radio.svelte';
   import { initUiVersion, getUiVersion } from './lib/stores/ui-version.svelte';
   import AppShell from './components/layout/AppShell.svelte';
   import RadioLayoutV2 from './components-v2/layout/RadioLayout.svelte';
   import ControlButtonDemo from './components-v2/controls/ControlButtonDemo.svelte';
   import { initMediaSession, destroyMediaSession } from './lib/media/media-session';
-  import { systemController } from './lib/runtime/system-controller';
+  import { runtime } from './lib/runtime/frontend-runtime';
   import './app.css';
 
   let backendError = $state<string | null>(null);
@@ -34,30 +30,18 @@
 
     initMediaSession();
 
-    // Register polling lifecycle with SystemController for connect/disconnect
-    systemController.registerPolling(() =>
-      startPolling((state) => { setRadioState(state); }, 1000),
-    );
-    const stopPolling = startPolling((state) => {
-      setRadioState(state);
-    }, 1000);
-    systemController.setStopPolling(stopPolling);
-
+    let cleanupBootstrap: (() => void) | null = null;
     let cleanupBattery: (() => void) | null = null;
-    initBatteryMonitor((multiplier) => {
-      setPollingMultiplier(multiplier);
-    }).then(cleanup => { cleanupBattery = cleanup; });
-
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    initBatteryMonitor((multiplier) => {
+      runtime.setPollingMultiplier(multiplier);
+    }).then(cleanup => { cleanupBattery = cleanup; });
 
     (async () => {
       try {
-        const caps = await fetchCapabilities();
-        setCapabilities(caps);
+        cleanupBootstrap = await runtime.bootstrap();
         backendError = null;
-
-        connect('/api/v1/ws');
-        sendRaw({ type: 'subscribe', streams: ['events'] });
       } catch (err) {
         console.error('init error:', err);
         backendError = `Backend error: ${err}`;
@@ -78,7 +62,7 @@
     return () => {
       destroyMediaSession();
       cleanupBattery?.();
-      stopPolling();
+      cleanupBootstrap?.();
       if (retryTimer) clearTimeout(retryTimer);
     };
   });

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -26,7 +26,7 @@ import {
 } from '$lib/stores/connection.svelte';
 import { getAudioState, setVolume, setMuted, toggleMute } from '$lib/stores/audio.svelte';
 import { sendCommand, connect, sendRaw } from '$lib/transport/ws-client';
-import { fetchCapabilities, startPolling } from '$lib/transport/http-client';
+import { fetchCapabilities, startPolling, setPollingMultiplier } from '$lib/transport/http-client';
 import { audioManager } from '$lib/audio/audio-manager';
 import { systemController } from './system-controller';
 
@@ -203,6 +203,11 @@ class FrontendRuntime {
 
   toggleMute(): void {
     toggleMute();
+  }
+
+  /** Adjust HTTP polling cadence (e.g. from battery monitor). */
+  setPollingMultiplier(m: number): void {
+    setPollingMultiplier(m);
   }
 }
 


### PR DESCRIPTION
## Summary

- Remove direct `$lib/transport/http-client` and `$lib/transport/ws-client` imports from `App.svelte`
- Replace inline bootstrap sequence (`fetchCapabilities` → `startPolling` → `connect` → `sendRaw`) with a single `await runtime.bootstrap()` call
- Add `setPollingMultiplier()` delegation method to `FrontendRuntime` so the battery monitor callback no longer reaches into `$lib/transport/*` directly
- Preserve retry logic, error state, and cleanup orchestration in `App.svelte`

Closes #989

## Test plan

- [x] `pnpm exec tsc --noEmit` — zero errors
- [x] `pnpm exec vitest run` — 88 test files, 1671 tests, all passed
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] Python test failures (23) are pre-existing and unrelated to this change (confirmed via baseline comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)