### PR TITLE
refactor(#995): use backend_id discriminator in web/server.py

### DIFF
--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -964,13 +964,7 @@ class WebServer:
             from ..radio_protocol import StateNotifyCapable
 
             # --- Yaesu CAT backend: use YaesuCatPoller (request-response) ---
-            _is_yaesu = False
-            try:
-                from ..backends.yaesu_cat.radio import YaesuCatRadio
-
-                _is_yaesu = isinstance(self._radio, YaesuCatRadio)
-            except ImportError:
-                pass
+            _is_yaesu = getattr(self._radio, "backend_id", None) == "yaesu_cat"
 
             if _is_yaesu:
                 from ..backends.yaesu_cat.poller import YaesuCatPoller


### PR DESCRIPTION
Closes #995.

Replace isinstance(self._radio, YaesuCatRadio) check with backend_id discriminator (getattr(self._radio, 'backend_id', None) == 'yaesu_cat'), removing concrete backend import from consumer layer.

This follows the decoupling pattern from #994 and satisfies the architecture requirement to route via protocol properties instead of concrete types.