### PR TITLE
refactor(#992): migrate scope panels to runtime.scope.subscribe

### DIFF
--- a/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
+++ b/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
@@ -2,7 +2,7 @@
   import { radio } from '$lib/stores/radio.svelte';
   import { resolveFilterModeConfig } from '../../wiring/state-adapter';
   import { getCapabilities } from '$lib/stores/capabilities.svelte';
-  import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
+  import { runtime } from '$lib/runtime';
   import AudioSpectrumCanvas from './AudioSpectrumCanvas.svelte';
 
   // ── Radio state extraction ──
@@ -31,15 +31,15 @@
   let fftBandwidth = $state(48000);
   let fftPush: ((data: Uint8Array) => void) | null = null;
 
+  // Scope subscription — delegates lifecycle to ScopeController (ADR INV-2, INV-5)
   $effect(() => {
-    const scope = createAudioScopeConnection((frame) => {
+    return runtime.scope.subscribe((frame) => {
       fftPixels = frame.pixels;
       if (frame.endFreq > frame.startFreq) {
         fftBandwidth = frame.endFreq - frame.startFreq;
       }
       fftPush?.(frame.pixels);
     });
-    return () => scope.disconnect();
   });
 </script>
 

--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -15,7 +15,6 @@
   import type { IndToken } from './AmberIndStrip.svelte';
   import { qsyHistory } from '$lib/stores/qsy-history.svelte';
   import { runtime } from '$lib/runtime';
-  import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
 
   // Band lookup by frequency (LCD-specific)
   const BANDS: [string, number, number][] = [
@@ -224,17 +223,15 @@
     }] : []),
   ]);
 
-  // Scope WS connection — reactive to capabilities (may load after mount)
+  // Scope subscription — delegates lifecycle to ScopeController (ADR INV-2, INV-5)
   $effect(() => {
     if (!hasAudioFft()) return;
 
-    const scope = createAudioScopeConnection((frame) => {
+    return runtime.scope.subscribe((frame) => {
       fftPixels = frame.pixels;
       fftBandwidth = frame.endFreq > frame.startFreq ? frame.endFreq - frame.startFreq : undefined;
       fftPush?.(frame.pixels);
     });
-
-    return () => scope.disconnect();
   });
 
   // Record active-receiver frequency changes into the local QSY history

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -9,7 +9,7 @@
   import AmberFilterGhost from './AmberFilterGhost.svelte';
   import AmberIndStrip from './AmberIndStrip.svelte';
   import type { IndToken } from './AmberIndStrip.svelte';
-  import { createAudioScopeConnection } from '$lib/runtime/adapters/scope-adapter';
+  import { runtime } from '$lib/runtime';
 
   // Band lookup by frequency (LCD-specific, mirrors AmberCockpit)
   const BANDS: [string, number, number][] = [
@@ -155,16 +155,15 @@
   let fftPush: ((data: Uint8Array) => void) | null = null;
   let showFft = $derived(hasAudioFft());
 
+  // Scope subscription — delegates lifecycle to ScopeController (ADR INV-2, INV-5)
   $effect(() => {
     if (!hasAudioFft()) return;
 
-    const scope = createAudioScopeConnection((frame) => {
+    return runtime.scope.subscribe((frame) => {
       fftPixels = frame.pixels;
       fftBandwidth = frame.endFreq > frame.startFreq ? frame.endFreq - frame.startFreq : undefined;
       fftPush?.(frame.pixels);
     });
-
-    return () => scope.disconnect();
   });
 </script>
 


### PR DESCRIPTION
## Summary

- Removes `createAudioScopeConnection()` calls from `AmberCockpit.svelte`, `AmberScope.svelte`, and `AudioSpectrumPanel.svelte`
- Each panel now calls `runtime.scope.subscribe(handler)` and returns the unsubscribe function from the `$effect` cleanup
- The `ScopeController` (landed in #1036) owns the single WS channel, opening it on the first subscriber and closing it when all unsubscribe

Closes #992.

## ADR Invariants satisfied

- **INV-2**: Single scope ownership — `ScopeController` is the sole WS channel opener; all three panels are now read-only consumers
- **INV-5**: Mount/unmount of a presentation panel no longer changes transport state; the channel lifecycle is controlled exclusively by subscribe/unsubscribe reference counting in `ScopeController`

## Test plan

- [x] `pnpm exec vitest run` — 1679 tests passed, 89 test files
- [x] `pnpm exec tsc --noEmit` — clean, zero errors
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] No calls to `createAudioScopeConnection` remain in `components-v2/panels/`
- [x] LOC delta: 3 files changed, 8 insertions, 12 deletions (well within ≤100 LOC guardrail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)