### PR TITLE
docs(#1045): align Phase 11 heading with actual body status

### DIFF
--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -247,10 +247,10 @@ Each UDP packet has a fixed-format header (see `packettypes.h` in wfview):
 - **Multi-model factory architecture (2026-03-23):** Factory.create_radio() now routes by model parameter: IC-7610 → Icom7610SerialRadio (default), IC-705 → Ic705SerialRadio, IC-7300 → Ic7300SerialRadio, IC-9700 → Ic9700SerialRadio. All backends inherit from CoreRadio (shared command logic). Profile-driven CI-V address resolution (0x80, 0xA4, 0x94, 0xA2). Extensible pattern for future models (IC-705 and IC-9700 are LAN-capable).
 - **State contract unification (issue #301, 2026-03-17):** web HTTP/WS public state and the web runtime path now derive from canonical `RadioState` without a web-side `StateCache` runtime dependency; default `rigctld` reads are `RadioState`-first with only handler-local fallback/optimistic state, and default server startup no longer binds consumer layers to backend-shared `StateCache`/poller state.
 
-### Phase 11 — M6 Productization (M6) ✅ COMPLETE (2026-03-24)
+### Phase 11 — M6 Productization (M6) 🚧 IN PROGRESS (3/4 CORE + ALL OPTIMIZATIONS COMPLETE)
 
 **Goal:** Production-ready library with audio codec support, documentation, and performance optimization.
-**Status**: All core tasks and optimizations complete (M6.1, M6.3, M6.P2). M6.2 extended response protocol research documented.
+**Status**: Core tasks 3/4 complete (M6.1, M6.3, M6.P2); M6.2 research phase complete, implementation blocked on hardware testing.
 
 #### M6.1 ulaw→pcm Audio Codec Decoder ✅ COMPLETE (2026-03-23)
 - [x] Pure-Python ulaw→PCM16 decoder (`_audio_codecs.py`) with standard 256-entry lookup table


### PR DESCRIPTION
Resolves #1045

**Summary**
Phase 11 heading falsely claimed completion while the body text documented that M6.2 (Extended Response Protocol Support) is still in the research phase, blocked on hardware testing.

**Fix**
- Reverted Phase 11 heading from '✅ COMPLETE' to '🚧 IN PROGRESS (3/4 CORE + ALL OPTIMIZATIONS COMPLETE)'
- Updated status line to accurately reflect: Core tasks 3/4 complete (M6.1, M6.3, M6.P2); M6.2 research phase complete, implementation blocked on hardware testing
- Verified against git log: Commit 28f2800 shows M6.2 was only intended for research phase, not full implementation
- M6.2 status remains 'research documented' in the detailed section (line 264: '🔍 IN PROGRESS')

**Testing**
- ruff check: passes
- no file changes beyond the 2-line documentation fix
- change scope: 1 file, <30 LOC