### PR TITLE
fix(#1046): count subscriptions in ScopeController instead of deduping by ref

### DIFF
--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -129,4 +129,26 @@ describe('ScopeController', () => {
     ctrl.subscribe(vi.fn());
     expect(channel.connect).toHaveBeenCalledTimes(2);
   });
+
+  it('counts subscriptions: same handler reference subscribed twice requires two unsubscribes', () => {
+    const handler = vi.fn<[ScopeFrame], void>();
+
+    const unsub1 = ctrl.subscribe(handler);
+    const unsub2 = ctrl.subscribe(handler);
+
+    expect(channel.connect).toHaveBeenCalledTimes(1);
+    expect(channel.disconnect).not.toHaveBeenCalled();
+
+    // Fire a frame — both subscriptions should receive it
+    channel._fire(makeScopeFrameBuffer());
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    // First unsubscribe — channel stays open
+    unsub1();
+    expect(channel.disconnect).not.toHaveBeenCalled();
+
+    // Second unsubscribe — now channel closes
+    unsub2();
+    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -33,7 +33,8 @@ export class ScopeController {
   readonly activeScope: 'hardware' | 'audio-fft' | null = 'audio-fft';
   readonly scopeFrame: ScopeFrame | null = null;
 
-  private _subscribers = new Set<FrameHandler>();
+  private _subscribers = new Map<number, FrameHandler>();
+  private _nextId = 0;
   private _unsubBinary: (() => void) | null = null;
   private _channel: WsChannel | null = null;
   private _getChannel: ChannelFactory;
@@ -46,16 +47,18 @@ export class ScopeController {
    * Subscribe to parsed scope frames.
    * Opens the WS channel on the first subscriber.
    * Returns an `unsubscribe` function — call it to stop receiving frames.
+   * Each subscribe() call creates an independent subscription, even for the same handler reference.
    */
   subscribe(handler: FrameHandler): () => void {
-    this._subscribers.add(handler);
+    const id = this._nextId++;
+    this._subscribers.set(id, handler);
 
     if (this._subscribers.size === 1) {
       this._connect();
     }
 
     return () => {
-      this._subscribers.delete(handler);
+      this._subscribers.delete(id);
       if (this._subscribers.size === 0) {
         this._disconnect();
       }
@@ -71,7 +74,7 @@ export class ScopeController {
       const frame = parseScopeFrame(buf);
       if (frame) {
         this.audioScopeFrame = frame;
-        for (const h of this._subscribers) {
+        for (const h of this._subscribers.values()) {
           h(frame);
         }
       }


### PR DESCRIPTION
Closes #1046

## Summary
- Changed ScopeController._subscribers from Set<Handler> to Map<number, Handler> with incrementing IDs
- Each subscribe() call now creates an independent subscription, even for the same handler reference
- Unsubscribe removes the specific subscription ID, only disconnects when map becomes empty

## Test
- New test verifies same handler ref subscribed twice requires two unsubscribes before channel closes
- All existing tests pass; both callbacks receive frames
- Frontend tests: 1680 passed
- TypeScript: no errors