### PR TITLE
test(#1008): migrate test_audio_transcoder from MagicMock to stream fakes

### DIFF
--- a/tests/_audio_stream_fake.py
+++ b/tests/_audio_stream_fake.py
@@ -1,0 +1,63 @@
+"""FakeAudioStream — deterministic double for AudioStream in tests.
+
+Implements the public surface of :class:`icom_lan.audio.lan_stream.AudioStream`
+that production code and tests interact with:
+
+    start_rx(callback, *, jitter_depth=None)
+    stop_rx()
+    start_tx()
+    stop_tx()
+    push_tx(opus_data)
+
+Call-tracking attributes allow assertions without MagicMock:
+
+    fake.start_rx_count              # times start_rx was awaited
+    fake.stop_rx_count               # times stop_rx was awaited
+    fake.start_tx_count              # times start_tx was awaited
+    fake.stop_tx_count               # times stop_tx was awaited
+    fake.last_start_rx_callback      # callback passed to last start_rx call
+    fake.last_start_rx_jitter_depth  # jitter_depth kwarg from last start_rx
+    fake.tx_frames                   # list of bytes pushed via push_tx
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+class FakeAudioStream:
+    """Deterministic double for ``AudioStream`` — no real transport needed."""
+
+    def __init__(self) -> None:
+        self.start_rx_count: int = 0
+        self.stop_rx_count: int = 0
+        self.start_tx_count: int = 0
+        self.stop_tx_count: int = 0
+
+        self.last_start_rx_callback: Callable[..., Any] | None = None
+        self.last_start_rx_jitter_depth: int | None = None
+
+        self.tx_frames: list[bytes] = []
+
+    async def start_rx(
+        self,
+        callback: Callable[..., Any],
+        *,
+        jitter_depth: int | None = None,
+    ) -> None:
+        self.last_start_rx_callback = callback
+        self.last_start_rx_jitter_depth = jitter_depth
+        self.start_rx_count += 1
+
+    async def stop_rx(self) -> None:
+        self.stop_rx_count += 1
+
+    async def start_tx(self) -> None:
+        self.start_tx_count += 1
+
+    async def stop_tx(self) -> None:
+        self.stop_tx_count += 1
+
+    async def push_tx(self, opus_data: bytes) -> None:
+        self.tx_frames.append(opus_data)

--- a/tests/test_audio_transcoder.py
+++ b/tests/test_audio_transcoder.py
@@ -15,6 +15,7 @@ from icom_lan.exceptions import (
     AudioTranscodeError,
 )
 from icom_lan.radio import IcomRadio
+from _audio_stream_fake import FakeAudioStream
 
 
 class _FakeBackend:
@@ -165,8 +166,8 @@ class TestRadioPcmRxApi:
         radio = IcomRadio("192.168.1.100")
         radio._connected = True
         radio._civ_transport = MagicMock()
-        radio._audio_stream = MagicMock()
-        radio._audio_stream.start_rx = AsyncMock()
+        fake_stream = FakeAudioStream()
+        radio._audio_stream = fake_stream  # type: ignore[assignment]
 
         class _DummyTranscoder:
             def opus_to_pcm(self, opus: bytes) -> bytes:
@@ -181,9 +182,9 @@ class TestRadioPcmRxApi:
             jitter_depth=7,
         )
 
-        radio._audio_stream.start_rx.assert_awaited_once()
-        rx_callback = radio._audio_stream.start_rx.await_args.args[0]
-        assert radio._audio_stream.start_rx.await_args.kwargs["jitter_depth"] == 7
+        assert fake_stream.start_rx_count == 1
+        rx_callback = fake_stream.last_start_rx_callback
+        assert fake_stream.last_start_rx_jitter_depth == 7
 
         rx_callback(AudioPacket(ident=0x0080, send_seq=10, data=b"\x01\x02"))
         rx_callback(None)
@@ -193,11 +194,11 @@ class TestRadioPcmRxApi:
     @pytest.mark.asyncio
     async def test_stop_audio_rx_pcm_delegates(self) -> None:
         radio = IcomRadio("192.168.1.100")
-        radio._audio_stream = MagicMock()
-        radio._audio_stream.stop_rx = AsyncMock()
+        fake_stream = FakeAudioStream()
+        radio._audio_stream = fake_stream  # type: ignore[assignment]
 
         await radio.stop_audio_rx_pcm()
-        radio._audio_stream.stop_rx.assert_awaited_once()
+        assert fake_stream.stop_rx_count == 1
 
     @pytest.mark.asyncio
     async def test_start_audio_rx_pcm_invalid_callback(self) -> None:
@@ -238,14 +239,14 @@ class TestRadioPcmTxApi:
         radio = IcomRadio("192.168.1.100")
         radio._connected = True
         radio._civ_transport = MagicMock()
-        radio._audio_stream = MagicMock()
-        radio._audio_stream.start_tx = AsyncMock()
+        fake_stream = FakeAudioStream()
+        radio._audio_stream = fake_stream  # type: ignore[assignment]
         radio._pcm_transcoder = object()  # type: ignore[assignment]
         radio._pcm_transcoder_fmt = (48000, 1, 20)
 
         await radio.start_audio_tx_pcm(sample_rate=48000, channels=1, frame_ms=20)
 
-        radio._audio_stream.start_tx.assert_awaited_once()
+        assert fake_stream.start_tx_count == 1
         assert radio._pcm_tx_fmt == (48000, 1, 20)
 
     @pytest.mark.asyncio
@@ -299,8 +300,8 @@ class TestRadioPcmTxApi:
         radio = IcomRadio("192.168.1.100")
         radio._connected = True
         radio._civ_transport = MagicMock()
-        radio._audio_stream = MagicMock()
-        radio._audio_stream.start_tx = AsyncMock()
+        fake_stream = FakeAudioStream()
+        radio._audio_stream = fake_stream  # type: ignore[assignment]
         radio._get_pcm_transcoder = MagicMock(  # type: ignore[method-assign]
             side_effect=AudioCodecBackendError(
                 "Audio codec backend unavailable; install icom-lan[audio]."
@@ -309,7 +310,7 @@ class TestRadioPcmTxApi:
 
         with pytest.raises(AudioCodecBackendError, match="install icom-lan\\[audio\\]"):
             await radio.start_audio_tx_pcm()
-        radio._audio_stream.start_tx.assert_not_awaited()
+        assert fake_stream.start_tx_count == 0
 
     @pytest.mark.asyncio
     async def test_push_audio_tx_pcm_frame_size_error(self) -> None:
@@ -334,12 +335,12 @@ class TestRadioPcmTxApi:
     @pytest.mark.asyncio
     async def test_stop_audio_tx_pcm_delegates_and_clears_state(self) -> None:
         radio = IcomRadio("192.168.1.100")
-        radio._audio_stream = MagicMock()
-        radio._audio_stream.stop_tx = AsyncMock()
+        fake_stream = FakeAudioStream()
+        radio._audio_stream = fake_stream  # type: ignore[assignment]
         radio._pcm_tx_fmt = (48000, 1, 20)
 
         await radio.stop_audio_tx_pcm()
-        radio._audio_stream.stop_tx.assert_awaited_once()
+        assert fake_stream.stop_tx_count == 1
         assert radio._pcm_tx_fmt is None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Introduces `tests/_audio_stream_fake.py` with `FakeAudioStream`, a deterministic double implementing the `AudioStream` public surface (`start_rx`, `stop_rx`, `start_tx`, `stop_tx`, `push_tx`) with call-tracking counters (no MagicMock plumbing)
- Replaces all 5 `radio._audio_stream = MagicMock()` occurrences in `tests/test_audio_transcoder.py` with `FakeAudioStream` instances; assertions updated from `assert_awaited_once()` / `await_args` to counter checks and stored attributes
- Remaining `MagicMock` usage is for `_civ_transport` (transport, not audio-backend-shaped) and `_get_pcm_transcoder` / `push_audio_tx_opus` method overrides — these are appropriate and untouched

Closes #1008

## Test plan

- [x] `uv run pytest tests/test_audio_transcoder.py -q -W error::RuntimeWarning` — 26 passed, 0 failures, 0 RuntimeWarnings
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — full suite green (1 pre-existing flaky perf test excluded)
- [x] `uv run ruff check tests/test_audio_transcoder.py tests/_audio_stream_fake.py` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)