### PR TITLE
refactor(#990): extend no-restricted-imports to cover src/App.svelte

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -88,9 +88,10 @@ export default [
   },
 
   // ── Import boundary: presentation components ──
-  // Panels, layouts, LCD, skins — must NOT import runtime/transport directly.
+  // Panels, layouts, LCD, skins, and app entry — must NOT import runtime/transport directly.
   {
     files: [
+      'src/App.svelte',
       'src/components-v2/panels/**/*.svelte',
       'src/components-v2/panels/**/*.ts',
       'src/components-v2/layout/**/*.svelte',


### PR DESCRIPTION
## Summary
Extends the ESLint `no-restricted-imports` rule to cover `src/App.svelte`, locking in the architecture boundary established by #989.

- Adds `src/App.svelte` to the `files` array in the existing "Import boundary: presentation components" block
- Severity remains `error` to fail CI if regression occurs
- No changes to existing presentation-component restrictions (panels, layouts, skins, etc.)

## Testing
- [x] `pnpm exec eslint .` passes
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec vitest run` passes (89 files, 1679 tests)
- [x] Verified rule catches violations: test import of `$lib/transport/*` triggers error
- [x] Current codebase clean after #989 migration

Closes #990