### PR TITLE
refactor(#1001): use backend_id discriminator in rigctld/routing.py

### DIFF
--- a/src/icom_lan/rigctld/routing.py
+++ b/src/icom_lan/rigctld/routing.py
@@ -310,10 +310,6 @@ def create_routing(
     Returns None for Icom radios — the handler's built-in Icom routing
     is used as the default path.
     """
-    try:
-        from ..backends.yaesu_cat.radio import YaesuCatRadio
-    except ImportError:
-        return None
-    if isinstance(radio, YaesuCatRadio):
+    if getattr(radio, "backend_id", None) == "yaesu_cat":
         return YaesuRouting(radio, cache, max_power_w)
     return None

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1615,8 +1615,9 @@ class _FakeYaesuRadio(YaesuCatRadio):
 
 @pytest.fixture
 def yaesu_radio() -> AsyncMock:
-    """AsyncMock that isinstance-checks as YaesuCatRadio."""
+    """AsyncMock of a Yaesu CAT radio with backend_id discriminator."""
     mock = AsyncMock(spec=_FakeYaesuRadio)
+    mock.backend_id = "yaesu_cat"
     return mock
 
 


### PR DESCRIPTION
Closes #1001

Replace the `isinstance(radio, YaesuCatRadio)` check with `backend_id == "yaesu_cat"` to remove concrete backend import from the consumer (rigctld) layer.

## Changes
- Removed try/except import of YaesuCatRadio from create_routing()
- Replaced isinstance check with getattr(radio, "backend_id") == "yaesu_cat"
- Updated test fixture to set backend_id property on mock radio

## Testing
- All 5007 tests pass
- Ruff and mypy pass