### PR TITLE
refactor(#1002): switch runtime/adapters to lib/runtime/ modules

### DIFF
--- a/frontend/src/lib/runtime/adapters/audio-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/audio-adapter.ts
@@ -6,8 +6,8 @@
  */
 
 import { runtime } from '../frontend-runtime';
-import { toRxAudioProps, type RxAudioProps } from '../../../components-v2/wiring/state-adapter';
-import { makeRxAudioHandlers } from '../../../components-v2/wiring/command-bus';
+import { toRxAudioProps, type RxAudioProps } from '../props/panel-props';
+import { makeRxAudioHandlers } from '../commands/panel-commands';
 
 export function deriveRxAudioProps(): RxAudioProps {
   const state = runtime.state;

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -13,14 +13,14 @@ import {
   toRfFrontEndProps, toRitXitProps, toScanProps,
   toMeterProps, toCwProps, toDspProps, toTxProps,
   toFilterProps, toBandSelectorProps,
-} from '../../../components-v2/wiring/state-adapter';
+} from '../props/panel-props';
 import {
   makeAgcHandlers, makeModeHandlers, makeAntennaHandlers,
   makeRfFrontEndHandlers, makeRitXitHandlers, makeScanHandlers,
   makeMeterHandlers, makeCwPanelHandlers, makeDspHandlers,
   makeTxHandlers, makeFilterHandlers, makeBandHandlers,
   makePresetHandlers,
-} from '../../../components-v2/wiring/command-bus';
+} from '../commands/panel-commands';
 
 // Re-export types for panel imports
 export type {
@@ -28,7 +28,7 @@ export type {
   RfFrontEndProps, RitXitProps, ScanProps,
   MeterProps, CwProps, DspProps, TxProps,
   FilterProps, BandSelectorProps,
-} from '../../../components-v2/wiring/state-adapter';
+} from '../props/panel-props';
 
 // ── AGC ──
 export function deriveAgcProps() {

--- a/frontend/src/lib/runtime/adapters/vfo-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/vfo-adapter.ts
@@ -5,8 +5,8 @@
  */
 
 import { runtime } from '../frontend-runtime';
-import { toVfoProps, toVfoOpsProps } from '../../../components-v2/wiring/state-adapter';
-import type { VfoStateProps, VfoOpsProps } from '../../../components-v2/wiring/state-adapter';
+import { toVfoProps, toVfoOpsProps } from '../props/panel-props';
+import type { VfoStateProps, VfoOpsProps } from '../props/panel-props';
 
 export function deriveMainVfo(): VfoStateProps {
   return toVfoProps(runtime.state, 'main');


### PR DESCRIPTION
## Summary

- Replace all inverted `lib/runtime/adapters/` → `components-v2/wiring/` imports with canonical `lib/runtime/` modules
- `audio-adapter.ts`: imports from `../props/panel-props` and `../commands/panel-commands`
- `panel-adapters.ts`: same substitution; type re-exports at lines 25–31 also updated to `../props/panel-props`
- `vfo-adapter.ts`: both import lines updated to `../props/panel-props`

No logic changes — import paths only (7 lines changed).

Closes #1002

## Prerequisite

**#1044** (extract `pendingFocusVfo`/`setPendingFocus`/`consumePendingFocus` to shared `$lib/radio/pending-focus.ts`) was merged in commit `4253957`. Both `components-v2/wiring/command-bus.ts` and `lib/runtime/commands/panel-commands.ts` now import from the shared module — there are no inline duplicates, so the VFO → Mode focus handoff works correctly across the new import paths.

## Why #1037 was closed

PR #1037 (first attempt at this migration) was caught by codex review: `panel-commands.ts` had **inline duplicate** `pendingFocusVfo` state, meaning VFO badge clicks (writing to `wiring/command-bus`'s copy) and Mode selection (reading from `panel-commands`'s own copy) operated on disjoint state — the pending focus was always empty in the mode handler. #1044 fixed this before this PR was opened.

## Acceptance gate

```
grep -rE "from '[^']*components-v2" frontend/src/lib/runtime/
```
Returns **0 matches** ✓

## Test plan

- [x] Acceptance gate: zero `components-v2` imports in `lib/runtime/` — verified
- [x] `pnpm exec vitest run src/lib/radio/pending-focus.test.ts` — 4/4 tests pass (cross-module VFO→Mode regression test from #1044)
- [x] `pnpm exec vitest run` — 90 test files, 1684 tests passed
- [x] `pnpm exec tsc --noEmit` — zero errors
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] Python test failures are pre-existing on main (confirmed by baseline check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)