### PR TITLE
test(#1007): use create_autospec(UsbAudioDriver) in test_ftx1_audio

### DIFF
--- a/tests/test_ftx1_audio.py
+++ b/tests/test_ftx1_audio.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 
 from icom_lan.audio import AudioPacket
+from icom_lan.audio.usb_driver import UsbAudioDriver
 from icom_lan.audio_bus import AudioBus
 from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
 from icom_lan.exceptions import AudioFormatError
@@ -19,14 +20,7 @@ from icom_lan.exceptions import AudioFormatError
 
 @pytest.fixture
 def mock_audio_driver():
-    driver = MagicMock()
-    driver.start_rx = AsyncMock()
-    driver.stop_rx = AsyncMock()
-    driver.start_tx = AsyncMock()
-    driver.stop_tx = AsyncMock()
-    driver.push_tx_pcm = AsyncMock()
-    driver.tx_running = False
-    return driver
+    return create_autospec(UsbAudioDriver, instance=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Replaces bare `MagicMock()` in the `mock_audio_driver` fixture with `create_autospec(UsbAudioDriver, instance=True)`, enforcing the real class signature at test time.
- Removes the now-redundant explicit `AsyncMock()` method assignments and `tx_running = False` attribute override — `create_autospec` generates coroutine-aware mocks from the real class automatically.
- Non-USB mocks (transport, generic callbacks) are left as `MagicMock()` per scope.

## Test plan

- [x] `uv run pytest tests/test_ftx1_audio.py -q -W error::RuntimeWarning` — 26 passed, zero RuntimeWarnings
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4785 passed, zero failures
- [x] `uv run ruff check tests/test_ftx1_audio.py` — zero violations

Closes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)