### PR TITLE
test(#1009): migrate test_audio_recovery to FakeAudioStream

### DIFF
--- a/tests/_audio_stream_fake.py
+++ b/tests/_audio_stream_fake.py
@@ -25,11 +25,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from icom_lan.audio import AudioState
+
 
 class FakeAudioStream:
     """Deterministic double for ``AudioStream`` — no real transport needed."""
 
     def __init__(self) -> None:
+        self.state: AudioState = AudioState.IDLE
+
         self.start_rx_count: int = 0
         self.stop_rx_count: int = 0
         self.start_tx_count: int = 0

--- a/tests/test_audio_recovery.py
+++ b/tests/test_audio_recovery.py
@@ -13,7 +13,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from icom_lan.audio import AudioState, AudioStream
+from _audio_stream_fake import FakeAudioStream
+
+from icom_lan.audio import AudioState
 from icom_lan.radio import AudioRecoveryState, IcomRadio
 
 
@@ -48,15 +50,9 @@ def _make_radio(**kwargs) -> IcomRadio:
     return radio
 
 
-def _install_audio_stream(radio: IcomRadio) -> MagicMock:
-    """Install a mock AudioStream on the radio."""
-    stream = MagicMock(spec=AudioStream)
-    stream.start_rx = AsyncMock()
-    stream.stop_rx = AsyncMock()
-    stream.start_tx = AsyncMock()
-    stream.stop_tx = AsyncMock()
-    stream.push_tx = AsyncMock()
-    stream.state = AudioState.IDLE
+def _install_audio_stream(radio: IcomRadio) -> FakeAudioStream:
+    """Install a FakeAudioStream on the radio."""
+    stream = FakeAudioStream()
     radio._audio_stream = stream
     radio._audio_transport = MagicMock()
     radio._audio_transport.disconnect = AsyncMock()


### PR DESCRIPTION
## Summary

- Replaces `MagicMock(spec=AudioStream)` in `_install_audio_stream()` with `FakeAudioStream` from `tests/_audio_stream_fake.py`
- Extends `FakeAudioStream` with a writable `state: AudioState` attribute (default `AudioState.IDLE`) so recovery tests can set `RECEIVING`/`TRANSMITTING` without MagicMock
- Callback doubles (`cb = MagicMock()`) and transport mocks remain as `MagicMock` per the issue #1009 acceptance criteria carve-out

## Test plan

- [x] `uv run pytest tests/test_audio_recovery.py -q -W error::RuntimeWarning` — 24 passed, no RuntimeWarnings
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4785 passed, 0 failures
- [x] `uv run ruff check tests/test_audio_recovery.py tests/_audio_stream_fake.py` — zero violations

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)