### PR TITLE
refactor(#1005): block components-v2 imports from lib/runtime via ESLint

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -110,6 +110,33 @@ export default [
     },
   },
 
+  // ── Import boundary: lib/runtime isolation ──
+  // lib/runtime must NOT import from components-v2 to prevent circular dependencies.
+  // See ADR 2026-04-12 and issue #1005.
+  {
+    files: [
+      'src/lib/runtime/**/*.ts',
+      'src/lib/runtime/**/*.svelte',
+      'src/lib/runtime/**/*.svelte.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/components-v2/**'],
+              message:
+                'lib/runtime must not import from components-v2. ' +
+                'Use lib/runtime/props/ or lib/runtime/commands/ instead. ' +
+                'See ADR 2026-04-12.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // ── Legacy V1 components — same restrictions ──
   {
     files: [


### PR DESCRIPTION
Closes #1005

## Summary
Adds an ESLint `no-restricted-imports` rule to prevent imports from `components-v2` within `lib/runtime` modules, enforcing the architectural boundary established by #1002.

This guards against future regressions where adapters in `lib/runtime` could accidentally re-import from `components-v2/wiring` and recreate the M-4 circular dependency.

## Changes
- Added new override block in `frontend/eslint.config.js` targeting `src/lib/runtime/**/*.ts` (and related patterns)
- Rule blocks all `**/components-v2/**` imports with descriptive error message

## Verification
- Existing codebase clean (no inverted imports exist post-#1002)
- ESLint rule verified to catch violations (tested with temporary import, then removed)
- Full suite passing: ESLint ✓, TypeScript ✓, Vitest ✓, Ruff ✓