### PR TITLE
fix(web): align send_cw_text payload limit

### DIFF
--- a/src/icom_lan/web/handlers/control.py
+++ b/src/icom_lan/web/handlers/control.py
@@ -164,6 +164,7 @@ from ...radio_protocol import MemoryCapable
 __all__ = ["ControlHandler"]
 
 logger = logging.getLogger(__name__)
+_MAX_CW_TEXT_CHARS = 512
 
 
 class ControlHandler:
@@ -932,9 +933,10 @@ class ControlHandler:
             if CAP_CW not in radio.capabilities:
                 raise RuntimeError("radio does not support this command")
             text = str(params.get("text", ""))
-            if len(text) > 30:
+            if len(text) > _MAX_CW_TEXT_CHARS:
                 raise ValueError(
-                    f"CW text too long: max 30 characters, got {len(text)}"
+                    "CW text too long: "
+                    f"max {_MAX_CW_TEXT_CHARS} characters, got {len(text)}"
                 )
             await radio.send_cw_text(text)
             return {"text": text}

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1501,13 +1501,30 @@ async def test_send_cw_text_calls_radio_method() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_cw_text_too_long_raises() -> None:
-    """send_cw_text raises ValueError when text exceeds 30 characters."""
+async def test_send_cw_text_multi_frame_text_reaches_radio_unchanged() -> None:
+    """send_cw_text allows text longer than one CI-V keyer frame."""
     radio = _capable_radio()
+    radio.send_cw_text = AsyncMock()
     handler = _control_handler(radio=radio)
-    long_text = "A" * 31
-    with pytest.raises(ValueError, match="CW text too long"):
+    text = "CQ " * 20
+
+    result = await handler._enqueue_command("send_cw_text", {"text": text})
+
+    assert result == {"text": text}
+    radio.send_cw_text.assert_awaited_once_with(text)
+
+
+@pytest.mark.asyncio
+async def test_send_cw_text_over_payload_limit_raises() -> None:
+    """send_cw_text raises ValueError when text exceeds the web payload cap."""
+    radio = _capable_radio()
+    radio.send_cw_text = AsyncMock()
+    handler = _control_handler(radio=radio)
+    long_text = "A" * 513
+
+    with pytest.raises(ValueError, match="CW text too long: max 512 characters"):
         await handler._enqueue_command("send_cw_text", {"text": long_text})
+    radio.send_cw_text.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1066

## Summary
- Allows web `send_cw_text` commands longer than one 30-character CI-V keyer frame, relying on the radio API's internal chunking.
- Adds a conservative 512-character web payload cap with a clear error message.
- Keeps existing no-radio, read-only, unsupported-radio, and short-message dispatch behavior intact.

## Changed
- `src/icom_lan/web/handlers/control.py`: replaces the 30-character guard with a named 512-character cap.
- `tests/test_handlers_coverage.py`: adds focused coverage for multi-frame text passed unchanged and over-limit rejection without keying the radio.

## Tests
- `pytest tests/test_handlers_coverage.py -k 'send_cw_text'`
- `pytest tests/test_web_ptt_readonly.py tests/test_handlers_coverage.py -k 'send_cw_text or cw_text'`
- `ruff check src/icom_lan/web/handlers/control.py tests/test_handlers_coverage.py`
- `act pull_request -W .github/workflows/test.yml -j test --matrix python-version:3.13`

## Manual Verification
- Verified via handler tests that a 60-character CW payload reaches `radio.send_cw_text` unchanged.
- Verified via handler tests that a 513-character CW payload raises `CW text too long: max 512 characters` and does not call the radio.

## Limitations
- Local `act` verification was run for Python 3.13 only, not the full 3.11/3.12/3.13 matrix, to keep runtime bounded.
- GH CI was not used because it is disabled for budget.
