### PR TITLE
feat(web-ui): add same-origin local extension host

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,7 @@
   import AppShell from './components/layout/AppShell.svelte';
   import RadioLayoutV2 from './components-v2/layout/RadioLayout.svelte';
   import ControlButtonDemo from './components-v2/controls/ControlButtonDemo.svelte';
+  import LocalExtensionsHost from './lib/local-extensions/LocalExtensionsHost.svelte';
   import { initMediaSession, destroyMediaSession } from './lib/media/media-session';
   import { runtime } from './lib/runtime/frontend-runtime';
   import './app.css';
@@ -90,6 +91,10 @@
   <RadioLayoutV2 />
 {:else}
   <AppShell />
+{/if}
+
+{#if demoMode !== 'control-buttons' && !backendError}
+  <LocalExtensionsHost />
 {/if}
 
 <style>

--- a/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { DEFAULT_KEYBOARD_CONFIG, resolveAction, shouldIgnoreEvent } from '../keyboard-map';
+import {
+  resetLocalExtensionKeyboardScope,
+  setLocalExtensionKeyboardScope,
+} from '$lib/local-extensions/keyboard-scope';
 
 describe('resolveAction', () => {
   it('ArrowLeft tunes down by the current frontend step', () => {
@@ -101,8 +105,18 @@ describe('shouldIgnoreEvent', () => {
   });
 
   it('keeps shortcuts active on non-editable elements', () => {
+    resetLocalExtensionKeyboardScope();
     expect(shouldIgnoreEvent(makeEl('DIV'))).toBe(false);
     expect(shouldIgnoreEvent(makeEl('BUTTON'))).toBe(false);
     expect(shouldIgnoreEvent(null)).toBe(false);
+  });
+
+  it('suppresses shortcuts while a local extension owns keyboard scope', () => {
+    setLocalExtensionKeyboardScope('extension-input');
+
+    expect(shouldIgnoreEvent(makeEl('DIV'))).toBe(true);
+    expect(shouldIgnoreEvent(null)).toBe(true);
+
+    resetLocalExtensionKeyboardScope();
   });
 });

--- a/frontend/src/components-v2/layout/keyboard-map.ts
+++ b/frontend/src/components-v2/layout/keyboard-map.ts
@@ -2,6 +2,7 @@ import type {
   KeyboardBindingConfig as CapKeyboardBindingConfig,
   KeyboardConfig as CapKeyboardConfig,
 } from '$lib/types/capabilities';
+import { isLocalExtensionKeyboardScopeActive } from '$lib/local-extensions/keyboard-scope';
 
 export type KeyboardBindingConfig = CapKeyboardBindingConfig;
 export type KeyboardConfig = CapKeyboardConfig;
@@ -298,6 +299,7 @@ export function findBindingByAction(
  * keyboard shortcuts should be suppressed.
  */
 export function shouldIgnoreEvent(activeElement: Element | null): boolean {
+  if (isLocalExtensionKeyboardScopeActive()) return true;
   if (!activeElement) return false;
   return IGNORED_TAGS.has(activeElement.tagName);
 }

--- a/frontend/src/lib/local-extensions/LocalExtensionsHost.svelte
+++ b/frontend/src/lib/local-extensions/LocalExtensionsHost.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import {
+    loadLocalExtensionManifest,
+    type LocalExtensionDescriptor,
+  } from './manifest';
+  import {
+    createDefaultLocalExtensionHostApi,
+    installLocalExtensionHostApi,
+    type LocalExtensionRegistration,
+  } from './host-api';
+
+  let extensions = $state<LocalExtensionDescriptor[]>([]);
+  const disposers = new Map<string, () => void>();
+
+  function disposeExtension(id: string): void {
+    const dispose = disposers.get(id);
+    if (dispose) {
+      dispose();
+      disposers.delete(id);
+    }
+  }
+
+  function registerExtension(extension: LocalExtensionRegistration): void {
+    if (typeof extension.id !== 'string' || extension.id.trim() === '') {
+      return;
+    }
+
+    const container = document.querySelector<HTMLElement>(
+      `[data-local-extension-container="${CSS.escape(extension.id)}"]`,
+    );
+    if (!container) {
+      return;
+    }
+
+    disposeExtension(extension.id);
+    container.replaceChildren();
+    const dispose = extension.render(container, api);
+    if (typeof dispose === 'function') {
+      disposers.set(extension.id, dispose);
+    }
+  }
+
+  const api = createDefaultLocalExtensionHostApi(registerExtension);
+
+  async function loadExtensionAssets(list: LocalExtensionDescriptor[]): Promise<void> {
+    await tick();
+    for (const extension of list) {
+      if (extension.style) {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = extension.style;
+        link.dataset.localExtensionId = extension.id;
+        document.head.appendChild(link);
+      }
+
+      const script = document.createElement('script');
+      script.src = extension.entry;
+      script.async = true;
+      script.dataset.localExtensionId = extension.id;
+      document.body.appendChild(script);
+    }
+  }
+
+  function unloadExtensionAssets(): void {
+    for (const extension of extensions) {
+      disposeExtension(extension.id);
+    }
+    document
+      .querySelectorAll('[data-local-extension-id]')
+      .forEach((node) => node.parentNode?.removeChild(node));
+  }
+
+  onMount(() => {
+    let disposed = false;
+    const uninstallApi = installLocalExtensionHostApi(window, api);
+
+    // Public host boundary: this component only mounts generic same-origin
+    // extension URLs from the local manifest. Extension implementations stay
+    // behind the local endpoint and are never imported into the open frontend.
+    void loadLocalExtensionManifest().then((manifest) => {
+      if (!disposed) {
+        extensions = manifest?.extensions ?? [];
+        void loadExtensionAssets(extensions);
+      }
+    });
+
+    return () => {
+      disposed = true;
+      unloadExtensionAssets();
+      extensions = [];
+      uninstallApi();
+    };
+  });
+</script>
+
+{#if extensions.length > 0}
+  <aside class="local-extension-host" aria-label="Local extensions">
+    {#each extensions as extension (extension.id)}
+      <section class="local-extension-panel" data-local-extension-mount={extension.mount}>
+        {#if extension.title}
+          <div class="local-extension-title">{extension.title}</div>
+        {/if}
+        <div
+          class="local-extension-content"
+          data-local-extension-container={extension.id}
+        ></div>
+      </section>
+    {/each}
+  </aside>
+{/if}
+
+<style>
+  .local-extension-host {
+    position: fixed;
+    right: 12px;
+    bottom: 12px;
+    z-index: 1250;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: min(420px, calc(100vw - 24px));
+    pointer-events: none;
+  }
+
+  .local-extension-panel {
+    min-height: 240px;
+    overflow: hidden;
+    border: 1px solid var(--v2-border-panel, var(--panel-border));
+    border-radius: 4px;
+    background: var(--v2-bg-card, var(--panel));
+    box-shadow: var(--v2-shadow-md, 0 12px 30px rgba(0, 0, 0, 0.35));
+    pointer-events: auto;
+  }
+
+  .local-extension-title {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--v2-border-panel, var(--panel-border));
+    color: var(--v2-text-secondary, var(--text-muted));
+    font: 600 11px/1.2 var(--v2-font-mono, var(--font-mono));
+    text-transform: uppercase;
+  }
+
+  .local-extension-content {
+    display: block;
+    width: 100%;
+    min-height: 240px;
+    background: transparent;
+  }
+</style>

--- a/frontend/src/lib/local-extensions/__tests__/host-api.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/host-api.test.ts
@@ -80,6 +80,10 @@ describe('createLocalExtensionHostApi', () => {
     expect(dispatchCommand.mock.calls[0][1]).toEqual({ freq: 14_074_000 });
     expect(api.dispatchCommand('set_mode', { mode: 'CW' })).toBe(true);
     expect(dispatchCommand).toHaveBeenLastCalledWith('set_mode', { mode: 'CW' });
+
+    const { dispatchCommand: unboundDispatchCommand } = api;
+    expect(unboundDispatchCommand('set_filter', { filter: 2 })).toBe(true);
+    expect(dispatchCommand).toHaveBeenLastCalledWith('set_filter', { filter: 2 });
   });
 
   it('rejects empty command names', () => {

--- a/frontend/src/lib/local-extensions/__tests__/host-api.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/host-api.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import {
+  createLocalExtensionHostApi,
+  LOCAL_EXTENSION_HOST_API_VERSION,
+  type RadioStateSubscriber,
+} from '../host-api';
+import {
+  getLocalExtensionKeyboardScope,
+  resetLocalExtensionKeyboardScope,
+  setLocalExtensionKeyboardScope,
+} from '../keyboard-scope';
+
+describe('createLocalExtensionHostApi', () => {
+  afterEach(() => {
+    resetLocalExtensionKeyboardScope();
+  });
+
+  it('exposes a versioned state and capabilities API', () => {
+    const state = { revision: 7 } as ServerState;
+    const capabilities = { model: 'TEST', capabilities: [] } as unknown as Capabilities;
+    const api = createLocalExtensionHostApi({
+      getState: () => state,
+      getCapabilities: () => capabilities,
+      subscribeState: vi.fn(),
+      dispatchCommand: vi.fn(),
+      setKeyboardScope: vi.fn(),
+      register: vi.fn(),
+    });
+
+    expect(api.version).toBe(LOCAL_EXTENSION_HOST_API_VERSION);
+    expect(api.getState()).toBe(state);
+    expect(api.getCapabilities()).toBe(capabilities);
+  });
+
+  it('subscribes to radio state updates', () => {
+    let subscriber: RadioStateSubscriber | null = null;
+    const unsubscribe = vi.fn();
+    const api = createLocalExtensionHostApi({
+      getState: () => null,
+      getCapabilities: () => null,
+      subscribeState: (handler) => {
+        subscriber = handler;
+        return unsubscribe;
+      },
+      dispatchCommand: vi.fn(),
+      setKeyboardScope: vi.fn(),
+      register: vi.fn(),
+    });
+    const received: Array<ServerState | null> = [];
+
+    const stop = api.subscribeState((state) => received.push(state));
+    expect(subscriber).not.toBeNull();
+    const emit = subscriber as unknown as RadioStateSubscriber;
+    emit({ revision: 8 } as ServerState);
+    stop();
+
+    expect(received).toEqual([{ revision: 8 }]);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches existing radio commands through the provided command path', () => {
+    const dispatchCommand = vi.fn().mockReturnValue(true);
+    const params = { freq: 14_074_000 };
+    const api = createLocalExtensionHostApi({
+      getState: () => null,
+      getCapabilities: () => null,
+      subscribeState: vi.fn(),
+      dispatchCommand,
+      setKeyboardScope: vi.fn(),
+      register: vi.fn(),
+    });
+
+    expect(api.sendCommand('set_freq', params)).toBe(true);
+    expect(dispatchCommand).toHaveBeenCalledWith('set_freq', { freq: 14_074_000 });
+
+    params.freq = 7_074_000;
+    expect(dispatchCommand.mock.calls[0][1]).toEqual({ freq: 14_074_000 });
+    expect(api.dispatchCommand('set_mode', { mode: 'CW' })).toBe(true);
+    expect(dispatchCommand).toHaveBeenLastCalledWith('set_mode', { mode: 'CW' });
+  });
+
+  it('rejects empty command names', () => {
+    const dispatchCommand = vi.fn();
+    const api = createLocalExtensionHostApi({
+      getState: () => null,
+      getCapabilities: () => null,
+      subscribeState: vi.fn(),
+      dispatchCommand,
+      setKeyboardScope: vi.fn(),
+      register: vi.fn(),
+    });
+
+    expect(api.sendCommand('')).toBe(false);
+    expect(dispatchCommand).not.toHaveBeenCalled();
+  });
+
+  it('sets and clears the extension keyboard scope', () => {
+    const api = createLocalExtensionHostApi({
+      getState: () => null,
+      getCapabilities: () => null,
+      subscribeState: vi.fn(),
+      dispatchCommand: vi.fn(),
+      setKeyboardScope: setLocalExtensionKeyboardScope,
+      register: vi.fn(),
+    });
+
+    api.setKeyboardScope('meter-input');
+    expect(getLocalExtensionKeyboardScope()).toBe('meter-input');
+
+    api.setKeyboardScope(null);
+    expect(getLocalExtensionKeyboardScope()).toBeNull();
+  });
+
+  it('registers extension renderers through the provided callback', () => {
+    const register = vi.fn();
+    const extension = {
+      id: 'meter',
+      render: vi.fn(),
+    };
+    const api = createLocalExtensionHostApi({
+      getState: () => null,
+      getCapabilities: () => null,
+      subscribeState: vi.fn(),
+      dispatchCommand: vi.fn(),
+      setKeyboardScope: vi.fn(),
+      register,
+    });
+
+    api.register(extension);
+
+    expect(register).toHaveBeenCalledWith(extension);
+  });
+});

--- a/frontend/src/lib/local-extensions/__tests__/manifest.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/manifest.test.ts
@@ -67,6 +67,16 @@ describe('loadLocalExtensionManifest', () => {
     await expect(loadLocalExtensionManifest({ fetch })).resolves.toBeNull();
   });
 
+  it('treats malformed host API versions as no local extensions', async () => {
+    const fetch = vi.fn().mockResolvedValue(mockResponse(200, {
+      version: 1,
+      host_api: 1,
+      extensions: [{ id: 'one', mount: 'floating-overlay', entry: '/local/one.js' }],
+    }));
+
+    await expect(loadLocalExtensionManifest({ fetch })).resolves.toBeNull();
+  });
+
   it('loads valid same-origin floating overlay extensions', async () => {
     const fetch = vi.fn().mockResolvedValue(mockResponse(200, {
       version: 1,

--- a/frontend/src/lib/local-extensions/__tests__/manifest.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/manifest.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  LOCAL_EXTENSION_MANIFEST_URL,
+  loadLocalExtensionManifest,
+  parseLocalExtensionManifest,
+} from '../manifest';
+
+function mockResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('loadLocalExtensionManifest', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('treats 404 as no local extensions', async () => {
+    const fetch = vi.fn().mockResolvedValue(mockResponse(404, null));
+
+    await expect(loadLocalExtensionManifest({ fetch })).resolves.toBeNull();
+    expect(fetch).toHaveBeenCalledWith(
+      LOCAL_EXTENSION_MANIFEST_URL,
+      expect.objectContaining({
+        credentials: 'same-origin',
+        cache: 'no-store',
+      }),
+    );
+  });
+
+  it('treats network failures as no local extensions', async () => {
+    const fetch = vi.fn().mockRejectedValue(new TypeError('failed'));
+
+    await expect(loadLocalExtensionManifest({ fetch })).resolves.toBeNull();
+  });
+
+  it('treats invalid JSON as no local extensions', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockRejectedValue(new SyntaxError('bad json')),
+    } as unknown as Response);
+
+    await expect(loadLocalExtensionManifest({ fetch })).resolves.toBeNull();
+  });
+
+  it('treats unsupported manifest versions as no local extensions', async () => {
+    const fetch = vi.fn().mockResolvedValue(mockResponse(200, {
+      version: 2,
+      extensions: [{ id: 'one', mount: 'floating-overlay', entry: '/local/one.js' }],
+    }));
+
+    await expect(loadLocalExtensionManifest({ fetch })).resolves.toBeNull();
+  });
+
+  it('treats unsupported host API versions as no local extensions', async () => {
+    const fetch = vi.fn().mockResolvedValue(mockResponse(200, {
+      version: 1,
+      host_api: '2.0',
+      extensions: [{ id: 'one', mount: 'floating-overlay', entry: '/local/one.js' }],
+    }));
+
+    await expect(loadLocalExtensionManifest({ fetch })).resolves.toBeNull();
+  });
+
+  it('loads valid same-origin floating overlay extensions', async () => {
+    const fetch = vi.fn().mockResolvedValue(mockResponse(200, {
+      version: 1,
+      host_api: '1.0',
+      extensions: [
+        {
+          id: 'meter',
+          title: 'Meter',
+          mount: 'floating-overlay',
+          entry: '/local/meter.js?x=1#top',
+          style: '/local/meter.css',
+          requires: ['meter'],
+        },
+      ],
+    }));
+
+    const manifest = await loadLocalExtensionManifest({
+      fetch,
+      baseUrl: 'http://radio.local/ui/',
+    });
+
+    expect(manifest).toEqual({
+      version: 1,
+      host_api: '1.0',
+      extensions: [
+        {
+          id: 'meter',
+          title: 'Meter',
+          mount: 'floating-overlay',
+          entry: '/local/meter.js?x=1#top',
+          style: '/local/meter.css',
+          requires: ['meter'],
+        },
+      ],
+    });
+  });
+});
+
+describe('parseLocalExtensionManifest', () => {
+  it('drops invalid extension descriptors', () => {
+    const manifest = parseLocalExtensionManifest({
+      version: 1,
+      extensions: [
+        { id: 'ok', mount: 'floating-overlay', entry: '/local/ok.js' },
+        { id: '', mount: 'floating-overlay', entry: '/local/no-id.js' },
+        { id: 'bad-mount', mount: 'sidecar', entry: '/local/bad-mount.js' },
+        { id: 'remote', mount: 'floating-overlay', entry: 'https://example.com/remote.js' },
+      ],
+    }, 'http://radio.local/');
+
+    expect(manifest?.extensions).toEqual([
+      {
+        id: 'ok',
+        mount: 'floating-overlay',
+        entry: '/local/ok.js',
+        title: undefined,
+        requires: undefined,
+        style: undefined,
+      },
+    ]);
+  });
+
+  it('returns null when no valid extensions remain', () => {
+    expect(parseLocalExtensionManifest({
+      version: 1,
+      extensions: [
+        { id: 'remote', mount: 'floating-overlay', entry: 'https://example.com/remote.js' },
+      ],
+    }, 'http://radio.local/')).toBeNull();
+  });
+});

--- a/frontend/src/lib/local-extensions/host-api.ts
+++ b/frontend/src/lib/local-extensions/host-api.ts
@@ -1,0 +1,100 @@
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import { getCapabilities } from '$lib/stores/capabilities.svelte';
+import { getRadioState, subscribeRadioState } from '$lib/stores/radio.svelte';
+import { sendCommand } from '$lib/transport/ws-client';
+import {
+  resetLocalExtensionKeyboardScope,
+  setLocalExtensionKeyboardScope,
+} from './keyboard-scope';
+
+export const LOCAL_EXTENSION_HOST_API_VERSION = 1;
+
+export type RadioStateSubscriber = (state: ServerState | null) => void;
+
+export interface LocalExtensionHostApiV1 {
+  version: typeof LOCAL_EXTENSION_HOST_API_VERSION;
+  getState(): ServerState | null;
+  getCapabilities(): Capabilities | null;
+  subscribeState(handler: RadioStateSubscriber): () => void;
+  sendCommand(name: string, params?: Record<string, unknown>): boolean;
+  dispatchCommand(name: string, params?: Record<string, unknown>): boolean;
+  setKeyboardScope(scope: string | null): void;
+  register(extension: LocalExtensionRegistration): void;
+}
+
+export interface LocalExtensionHostDependencies {
+  getState: () => ServerState | null;
+  getCapabilities: () => Capabilities | null;
+  subscribeState: (handler: RadioStateSubscriber) => () => void;
+  dispatchCommand: (name: string, params?: Record<string, unknown>) => boolean;
+  setKeyboardScope: (scope: string | null) => void;
+  register: (extension: LocalExtensionRegistration) => void;
+}
+
+export interface LocalExtensionRegistration {
+  id: string;
+  title?: string;
+  mount?: string;
+  render(container: HTMLElement, api: LocalExtensionHostApiV1): void | (() => void);
+}
+
+export interface LocalExtensionHostWindow extends Window {
+  icomLanExtensionHost?: LocalExtensionHostApiV1;
+}
+
+function cloneParams(params: Record<string, unknown> | undefined): Record<string, unknown> {
+  return params ? { ...params } : {};
+}
+
+export function createLocalExtensionHostApi(
+  deps: LocalExtensionHostDependencies,
+): LocalExtensionHostApiV1 {
+  return {
+    version: LOCAL_EXTENSION_HOST_API_VERSION,
+    getState: deps.getState,
+    getCapabilities: deps.getCapabilities,
+    subscribeState: deps.subscribeState,
+    sendCommand(name, params) {
+      if (typeof name !== 'string' || name.trim() === '') {
+        return false;
+      }
+      return deps.dispatchCommand(name, cloneParams(params));
+    },
+    dispatchCommand(name, params) {
+      return this.sendCommand(name, params);
+    },
+    setKeyboardScope(scope) {
+      deps.setKeyboardScope(scope);
+    },
+    register(extension) {
+      deps.register(extension);
+    },
+  };
+}
+
+export function createDefaultLocalExtensionHostApi(
+  register: (extension: LocalExtensionRegistration) => void = () => {},
+): LocalExtensionHostApiV1 {
+  return createLocalExtensionHostApi({
+    getState: getRadioState,
+    getCapabilities,
+    subscribeState: (handler) => subscribeRadioState(handler),
+    dispatchCommand: sendCommand,
+    setKeyboardScope: setLocalExtensionKeyboardScope,
+    register,
+  });
+}
+
+export function installLocalExtensionHostApi(
+  targetWindow: LocalExtensionHostWindow = window as LocalExtensionHostWindow,
+  api: LocalExtensionHostApiV1 = createDefaultLocalExtensionHostApi(),
+): () => void {
+  targetWindow.icomLanExtensionHost = api;
+  return () => {
+    if (targetWindow.icomLanExtensionHost === api) {
+      delete targetWindow.icomLanExtensionHost;
+    }
+    resetLocalExtensionKeyboardScope();
+  };
+}

--- a/frontend/src/lib/local-extensions/host-api.ts
+++ b/frontend/src/lib/local-extensions/host-api.ts
@@ -47,6 +47,17 @@ function cloneParams(params: Record<string, unknown> | undefined): Record<string
   return params ? { ...params } : {};
 }
 
+function dispatchVia(
+  deps: LocalExtensionHostDependencies,
+  name: string,
+  params: Record<string, unknown> | undefined,
+): boolean {
+  if (typeof name !== 'string' || name.trim() === '') {
+    return false;
+  }
+  return deps.dispatchCommand(name, cloneParams(params));
+}
+
 export function createLocalExtensionHostApi(
   deps: LocalExtensionHostDependencies,
 ): LocalExtensionHostApiV1 {
@@ -56,13 +67,10 @@ export function createLocalExtensionHostApi(
     getCapabilities: deps.getCapabilities,
     subscribeState: deps.subscribeState,
     sendCommand(name, params) {
-      if (typeof name !== 'string' || name.trim() === '') {
-        return false;
-      }
-      return deps.dispatchCommand(name, cloneParams(params));
+      return dispatchVia(deps, name, params);
     },
     dispatchCommand(name, params) {
-      return this.sendCommand(name, params);
+      return dispatchVia(deps, name, params);
     },
     setKeyboardScope(scope) {
       deps.setKeyboardScope(scope);

--- a/frontend/src/lib/local-extensions/keyboard-scope.ts
+++ b/frontend/src/lib/local-extensions/keyboard-scope.ts
@@ -1,0 +1,18 @@
+let keyboardScope: string | null = null;
+
+export function setLocalExtensionKeyboardScope(scope: string | null): void {
+  const next = typeof scope === 'string' && scope.trim() !== '' ? scope : null;
+  keyboardScope = next;
+}
+
+export function getLocalExtensionKeyboardScope(): string | null {
+  return keyboardScope;
+}
+
+export function isLocalExtensionKeyboardScopeActive(): boolean {
+  return keyboardScope !== null;
+}
+
+export function resetLocalExtensionKeyboardScope(): void {
+  keyboardScope = null;
+}

--- a/frontend/src/lib/local-extensions/manifest.ts
+++ b/frontend/src/lib/local-extensions/manifest.ts
@@ -1,0 +1,153 @@
+export const LOCAL_EXTENSION_MANIFEST_URL = '/api/local/v1/ui/manifest';
+export const LOCAL_EXTENSION_MANIFEST_VERSION = 1;
+export const LOCAL_EXTENSION_HOST_API_VERSION = '1.0';
+
+export type LocalExtensionMount = 'floating-overlay';
+
+export interface LocalExtensionDescriptor {
+  id: string;
+  entry: string;
+  style?: string;
+  mount: LocalExtensionMount;
+  title?: string;
+  requires?: string[];
+}
+
+export interface LocalExtensionManifest {
+  version: typeof LOCAL_EXTENSION_MANIFEST_VERSION;
+  host_api?: typeof LOCAL_EXTENSION_HOST_API_VERSION;
+  extensions: LocalExtensionDescriptor[];
+}
+
+export interface LoadManifestOptions {
+  fetch?: typeof globalThis.fetch;
+  url?: string;
+  baseUrl?: string;
+}
+
+const SUPPORTED_MOUNTS = new Set<LocalExtensionMount>(['floating-overlay']);
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function currentBaseUrl(): string {
+  return globalThis.location?.href ?? 'http://localhost/';
+}
+
+function normalizeSameOriginPath(value: unknown, baseUrl: string): string | null {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return null;
+  }
+
+  try {
+    const base = new URL(baseUrl);
+    const url = new URL(value, base);
+    if (url.origin !== base.origin) {
+      return null;
+    }
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+export function parseLocalExtensionManifest(
+  value: unknown,
+  baseUrl: string = currentBaseUrl(),
+): LocalExtensionManifest | null {
+  const manifest = asObject(value);
+  if (!manifest || manifest.version !== LOCAL_EXTENSION_MANIFEST_VERSION) {
+    return null;
+  }
+
+  if (
+    typeof manifest.host_api === 'string'
+    && manifest.host_api !== LOCAL_EXTENSION_HOST_API_VERSION
+  ) {
+    return null;
+  }
+
+  if (!Array.isArray(manifest.extensions)) {
+    return null;
+  }
+
+  const extensions: LocalExtensionDescriptor[] = [];
+
+  for (const candidate of manifest.extensions) {
+    const item = asObject(candidate);
+    if (!item || typeof item.id !== 'string' || item.id.trim() === '') {
+      continue;
+    }
+
+    const mount = item.mount;
+    if (typeof mount !== 'string' || !SUPPORTED_MOUNTS.has(mount as LocalExtensionMount)) {
+      continue;
+    }
+
+    const entry = normalizeSameOriginPath(item.entry, baseUrl);
+    if (!entry) {
+      continue;
+    }
+
+    const style = item.style === undefined
+      ? undefined
+      : normalizeSameOriginPath(item.style, baseUrl) ?? undefined;
+    const requires = Array.isArray(item.requires)
+      ? item.requires.filter((requirement): requirement is string => typeof requirement === 'string')
+      : undefined;
+
+    extensions.push({
+      id: item.id,
+      entry,
+      style,
+      mount: mount as LocalExtensionMount,
+      title: typeof item.title === 'string' && item.title.trim() !== '' ? item.title : undefined,
+      requires,
+    });
+  }
+
+  if (extensions.length === 0) {
+    return null;
+  }
+
+  return typeof manifest.host_api === 'string'
+    ? {
+        version: LOCAL_EXTENSION_MANIFEST_VERSION,
+        host_api: LOCAL_EXTENSION_HOST_API_VERSION,
+        extensions,
+      }
+    : { version: LOCAL_EXTENSION_MANIFEST_VERSION, extensions };
+}
+
+export async function loadLocalExtensionManifest(
+  options: LoadManifestOptions = {},
+): Promise<LocalExtensionManifest | null> {
+  const fetcher = options.fetch ?? globalThis.fetch;
+  if (typeof fetcher !== 'function') {
+    return null;
+  }
+
+  let response: Response;
+  try {
+    response = await fetcher(options.url ?? LOCAL_EXTENSION_MANIFEST_URL, {
+      headers: { Accept: 'application/json' },
+      credentials: 'same-origin',
+      cache: 'no-store',
+    });
+  } catch {
+    return null;
+  }
+
+  if (!response.ok) {
+    return null;
+  }
+
+  try {
+    return parseLocalExtensionManifest(await response.json(), options.baseUrl);
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/lib/local-extensions/manifest.ts
+++ b/frontend/src/lib/local-extensions/manifest.ts
@@ -64,7 +64,7 @@ export function parseLocalExtensionManifest(
   }
 
   if (
-    typeof manifest.host_api === 'string'
+    manifest.host_api !== undefined
     && manifest.host_api !== LOCAL_EXTENSION_HOST_API_VERSION
   ) {
     return null;

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -17,7 +17,11 @@ const stateSubscribers = new Set<(state: ServerState | null) => void>();
 
 function notifyRadioStateSubscribers(): void {
   for (const handler of stateSubscribers) {
-    handler(radio.current);
+    try {
+      handler(radio.current);
+    } catch (error) {
+      console.warn('Local extension radio state subscriber failed', error);
+    }
   }
 }
 

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -13,6 +13,21 @@ class RadioStore {
 export const radio = new RadioStore();
 
 let lastRevision = -1;
+const stateSubscribers = new Set<(state: ServerState | null) => void>();
+
+function notifyRadioStateSubscribers(): void {
+  for (const handler of stateSubscribers) {
+    handler(radio.current);
+  }
+}
+
+export function subscribeRadioState(handler: (state: ServerState | null) => void): () => void {
+  stateSubscribers.add(handler);
+  handler(radio.current);
+  return () => {
+    stateSubscribers.delete(handler);
+  };
+}
 
 // Optimistic patches: field → { value, expires, serverValueAtPatch }
 // Kept until server confirms (value matches) OR hard timeout (5s)
@@ -110,6 +125,7 @@ export function resetRadioState(): void {
   optimisticSub.clear();
   optimisticTopLevel.clear();
   lockedFields.clear();
+  notifyRadioStateSubscribers();
 }
 
 export function setRadioState(state: ServerState): void {
@@ -123,6 +139,7 @@ export function setRadioState(state: ServerState): void {
   if (isInitial || state.revision > lastRevision || isReset) {
     lastRevision = state.revision;
     radio.current = applyOptimistic(state);
+    notifyRadioStateSubscribers();
     // Sync power status to connection store
     if (state.powerOn !== undefined) {
       setRadioPowerOn(state.powerOn);
@@ -174,6 +191,7 @@ export function patchActiveReceiver(patch: Partial<ReceiverState>, lock = false)
     ...s,
     [key]: { ...s[key], ...patch },
   };
+  notifyRadioStateSubscribers();
 }
 
 /**
@@ -204,6 +222,7 @@ export function patchReceiver(receiver: 0 | 1, patch: Partial<ReceiverState>, lo
     ...s,
     [key]: { ...s[key], ...patch },
   };
+  notifyRadioStateSubscribers();
 }
 
 /**
@@ -221,6 +240,7 @@ export function patchRadioState(patch: Partial<ServerState>): void {
     }
   }
   radio.current = { ...s, ...patch };
+  notifyRadioStateSubscribers();
 }
 
 // Convenience getters (still work in non-reactive contexts like callbacks)


### PR DESCRIPTION
Closes #1064

## Summary
Adds a generic same-origin local extension host to the public web UI. Normal open-core deployments remain unchanged when `/api/local/v1/ui/manifest` is absent or invalid.

## What changed
- Probes `GET /api/local/v1/ui/manifest` and treats 404/network/invalid/unsupported responses as no-op.
- Parses a versioned manifest with same-origin `entry`/`style` assets and `floating-overlay` mount targets.
- Installs `window.icomLanExtensionHost` with versioned state, capability, command, keyboard-scope, and extension registration APIs.
- Adds a fixed overlay host for registered local extensions.
- Suppresses global keyboard shortcuts while a local extension owns keyboard scope.

## Test coverage
- `npm run test -- --run src/lib/local-extensions src/components-v2/layout/__tests__/keyboard-map.test.ts`
- `npm run lint -- src/lib/local-extensions src/components-v2/layout/keyboard-map.ts src/components-v2/layout/__tests__/keyboard-map.test.ts`

## Manual verification
- Verified valid/invalid manifest behavior through unit tests.
- Verified the host contract matches the pro manifest shape planned for same-origin CW Console assets.

## Known limitations / follow-up
- This is the generic host shell, not the final dock/resize host. Dockable layout is tracked by #1065.
- `npm run check` currently reports existing unrelated Svelte/TS errors across the frontend; the targeted local-extension tests and lint pass.
- Full local `act` was not run before opening; it should be run before merge because GitHub CI is disabled for budget.
