### PR TITLE
feat(web-ui): add local extension dock host

### DIFF
--- a/frontend/src/lib/local-extensions/LocalExtensionsHost.svelte
+++ b/frontend/src/lib/local-extensions/LocalExtensionsHost.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import {
+    Minimize2,
+    Move,
+    PanelBottom,
+    PanelLeft,
+    PanelRight,
+  } from 'lucide-svelte';
+  import {
     loadLocalExtensionManifest,
     type LocalExtensionDescriptor,
   } from './manifest';
@@ -9,9 +16,38 @@
     installLocalExtensionHostApi,
     type LocalExtensionRegistration,
   } from './host-api';
+  import {
+    DEFAULT_LOCAL_EXTENSION_DOCK_MODE,
+    getLocalExtensionDockMode,
+    loadLocalExtensionDockLayout,
+    saveLocalExtensionDockLayout,
+    setLocalExtensionDockMode,
+    type LocalExtensionDockMode,
+    type LocalExtensionDockLayoutState,
+  } from './dock-layout';
 
   let extensions = $state<LocalExtensionDescriptor[]>([]);
+  let renderedExtensions = $state<LocalExtensionDescriptor[]>([]);
+  let dockLayout = $state<LocalExtensionDockLayoutState>({
+    version: 1,
+    extensions: {},
+  });
   const disposers = new Map<string, () => void>();
+  const registrations = new Map<string, LocalExtensionRegistration>();
+  const dockModes: LocalExtensionDockMode[] = [
+    'floating',
+    'dock-right',
+    'dock-left',
+    'dock-bottom',
+    'collapsed',
+  ];
+
+  function escapeCssIdentifier(value: string): string {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+      return CSS.escape(value);
+    }
+    return value.replace(/["\\]/g, '\\$&');
+  }
 
   function disposeExtension(id: string): void {
     const dispose = disposers.get(id);
@@ -21,13 +57,27 @@
     }
   }
 
-  function registerExtension(extension: LocalExtensionRegistration): void {
-    if (typeof extension.id !== 'string' || extension.id.trim() === '') {
+  function describeRegisteredExtensions(): LocalExtensionDescriptor[] {
+    return extensions
+      .filter((extension) => registrations.has(extension.id))
+      .map((extension) => {
+        const registration = registrations.get(extension.id);
+        return {
+          ...extension,
+          title: registration?.title ?? extension.title,
+        };
+      });
+  }
+
+  async function renderExtension(extension: LocalExtensionRegistration): Promise<void> {
+    await tick();
+    if (modeFor(extension.id) === 'collapsed') {
+      disposeExtension(extension.id);
       return;
     }
 
     const container = document.querySelector<HTMLElement>(
-      `[data-local-extension-container="${CSS.escape(extension.id)}"]`,
+      `[data-local-extension-container="${escapeCssIdentifier(extension.id)}"]`,
     );
     if (!container) {
       return;
@@ -38,6 +88,44 @@
     const dispose = extension.render(container, api);
     if (typeof dispose === 'function') {
       disposers.set(extension.id, dispose);
+    }
+  }
+
+  function registerExtension(extension: LocalExtensionRegistration): void {
+    if (typeof extension.id !== 'string' || extension.id.trim() === '') {
+      return;
+    }
+
+    if (typeof extension.render !== 'function') {
+      return;
+    }
+
+    if (!extensions.some((candidate) => candidate.id === extension.id)) {
+      return;
+    }
+
+    registrations.set(extension.id, extension);
+    renderedExtensions = describeRegisteredExtensions();
+    void renderExtension(extension);
+  }
+
+  function modeFor(id: string): LocalExtensionDockMode {
+    return getLocalExtensionDockMode(dockLayout, id);
+  }
+
+  function extensionsForMode(mode: LocalExtensionDockMode): LocalExtensionDescriptor[] {
+    return renderedExtensions.filter((extension) => modeFor(extension.id) === mode);
+  }
+
+  function setDockMode(id: string, mode: LocalExtensionDockMode): void {
+    dockLayout = setLocalExtensionDockMode(dockLayout, id, mode);
+    saveLocalExtensionDockLayout(dockLayout);
+    if (mode === 'collapsed') {
+      api.setKeyboardScope(null);
+    }
+    const registration = registrations.get(id);
+    if (registration) {
+      void renderExtension(registration);
     }
   }
 
@@ -74,6 +162,7 @@
   onMount(() => {
     let disposed = false;
     const uninstallApi = installLocalExtensionHostApi(window, api);
+    dockLayout = loadLocalExtensionDockLayout();
 
     // Public host boundary: this component only mounts generic same-origin
     // extension URLs from the local manifest. Extension implementations stay
@@ -89,23 +178,99 @@
       disposed = true;
       unloadExtensionAssets();
       extensions = [];
+      renderedExtensions = [];
+      registrations.clear();
       uninstallApi();
     };
   });
 </script>
 
-{#if extensions.length > 0}
+{#if renderedExtensions.length > 0}
   <aside class="local-extension-host" aria-label="Local extensions">
-    {#each extensions as extension (extension.id)}
-      <section class="local-extension-panel" data-local-extension-mount={extension.mount}>
-        {#if extension.title}
-          <div class="local-extension-title">{extension.title}</div>
-        {/if}
-        <div
-          class="local-extension-content"
-          data-local-extension-container={extension.id}
-        ></div>
-      </section>
+    {#each dockModes as dockMode}
+      {@const dockedExtensions = extensionsForMode(dockMode)}
+      {#if dockedExtensions.length > 0}
+        <div class={`local-extension-stack local-extension-stack--${dockMode}`}>
+          {#each dockedExtensions as extension (extension.id)}
+            {@const currentMode = modeFor(extension.id)}
+            {@const title = extension.title ?? 'Local extension'}
+            <section
+              class="local-extension-panel"
+              class:local-extension-panel--collapsed={currentMode === 'collapsed'}
+              data-local-extension-mount={extension.mount}
+              data-local-extension-dock-mode={currentMode}
+            >
+              {#if currentMode === 'collapsed'}
+                <button
+                  class="local-extension-pill"
+                  type="button"
+                  aria-label={`Restore ${title}`}
+                  title={`Restore ${title}`}
+                  onclick={() => setDockMode(extension.id, DEFAULT_LOCAL_EXTENSION_DOCK_MODE)}
+                >
+                  <Move size={14} aria-hidden="true" />
+                  <span>{title}</span>
+                </button>
+              {:else}
+                <header class="local-extension-header">
+                  <div class="local-extension-title">{title}</div>
+                  <div class="local-extension-tools" aria-label={`${title} dock placement`}>
+                    <button
+                      type="button"
+                      aria-label={`Float ${title}`}
+                      aria-pressed={currentMode === 'floating'}
+                      title="Float"
+                      onclick={() => setDockMode(extension.id, 'floating')}
+                    >
+                      <Move size={14} aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Dock ${title} left`}
+                      aria-pressed={currentMode === 'dock-left'}
+                      title="Dock left"
+                      onclick={() => setDockMode(extension.id, 'dock-left')}
+                    >
+                      <PanelLeft size={14} aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Dock ${title} right`}
+                      aria-pressed={currentMode === 'dock-right'}
+                      title="Dock right"
+                      onclick={() => setDockMode(extension.id, 'dock-right')}
+                    >
+                      <PanelRight size={14} aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Dock ${title} bottom`}
+                      aria-pressed={currentMode === 'dock-bottom'}
+                      title="Dock bottom"
+                      onclick={() => setDockMode(extension.id, 'dock-bottom')}
+                    >
+                      <PanelBottom size={14} aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Collapse ${title}`}
+                      title="Collapse"
+                      onclick={() => setDockMode(extension.id, 'collapsed')}
+                    >
+                      <Minimize2 size={14} aria-hidden="true" />
+                    </button>
+                  </div>
+                </header>
+              {/if}
+              <div
+                class="local-extension-content"
+                class:local-extension-content--collapsed={currentMode === 'collapsed'}
+                data-local-extension-container={extension.id}
+              ></div>
+            </section>
+          {/each}
+        </div>
+      {/if}
     {/each}
   </aside>
 {/if}
@@ -113,18 +278,64 @@
 <style>
   .local-extension-host {
     position: fixed;
-    right: 12px;
-    bottom: 12px;
+    inset: 0;
     z-index: 1250;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    width: min(420px, calc(100vw - 24px));
     pointer-events: none;
   }
 
+  .local-extension-stack {
+    position: fixed;
+    display: flex;
+    gap: 8px;
+    pointer-events: none;
+  }
+
+  .local-extension-stack--floating {
+    right: 12px;
+    bottom: 12px;
+    flex-direction: column;
+    width: min(420px, calc(100vw - 24px));
+    max-height: calc(100dvh - 24px);
+  }
+
+  .local-extension-stack--dock-right,
+  .local-extension-stack--dock-left {
+    top: 12px;
+    bottom: 12px;
+    flex-direction: column;
+    width: min(440px, 34vw, calc(100vw - 24px));
+  }
+
+  .local-extension-stack--dock-right {
+    right: 12px;
+  }
+
+  .local-extension-stack--dock-left {
+    left: 12px;
+  }
+
+  .local-extension-stack--dock-bottom {
+    right: 12px;
+    bottom: 12px;
+    left: 12px;
+    flex-direction: row;
+    align-items: flex-end;
+    max-height: min(360px, 45dvh);
+  }
+
+  .local-extension-stack--collapsed {
+    right: 12px;
+    bottom: 12px;
+    flex-flow: row-reverse wrap;
+    max-width: calc(100vw - 24px);
+  }
+
   .local-extension-panel {
-    min-height: 240px;
+    display: flex;
+    min-height: 220px;
+    max-height: min(560px, calc(100dvh - 24px));
+    flex: 1 1 auto;
+    flex-direction: column;
     overflow: hidden;
     border: 1px solid var(--v2-border-panel, var(--panel-border));
     border-radius: 4px;
@@ -133,18 +344,132 @@
     pointer-events: auto;
   }
 
-  .local-extension-title {
-    padding: 6px 8px;
+  .local-extension-stack--dock-right .local-extension-panel,
+  .local-extension-stack--dock-left .local-extension-panel {
+    min-height: 0;
+    max-height: none;
+  }
+
+  .local-extension-stack--dock-bottom .local-extension-panel {
+    min-width: min(360px, calc(100vw - 24px));
+    min-height: 180px;
+    max-height: min(360px, 45dvh);
+  }
+
+  .local-extension-panel--collapsed {
+    min-height: 0;
+    border-radius: 999px;
+    background: var(--v2-bg-elevated, var(--panel));
+  }
+
+  .local-extension-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     border-bottom: 1px solid var(--v2-border-panel, var(--panel-border));
+  }
+
+  .local-extension-title {
+    min-width: 0;
+    padding: 6px 8px;
+    overflow: hidden;
     color: var(--v2-text-secondary, var(--text-muted));
     font: 600 11px/1.2 var(--v2-font-mono, var(--font-mono));
+    text-overflow: ellipsis;
     text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .local-extension-tools {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    gap: 2px;
+    padding: 4px;
+  }
+
+  .local-extension-tools button,
+  .local-extension-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid transparent;
+    color: var(--v2-text-secondary, var(--text-muted));
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .local-extension-tools button {
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+  }
+
+  .local-extension-tools button:hover,
+  .local-extension-tools button[aria-pressed='true'] {
+    border-color: var(--v2-border-control, var(--panel-border));
+    color: var(--v2-text-primary, var(--text));
+    background: var(--v2-bg-control, rgba(255, 255, 255, 0.08));
+  }
+
+  .local-extension-pill {
+    min-height: 32px;
+    gap: 6px;
+    padding: 0 10px;
+    border-radius: 999px;
+    border-color: var(--v2-border-panel, var(--panel-border));
+    box-shadow: var(--v2-shadow-sm, 0 8px 18px rgba(0, 0, 0, 0.28));
+    font: 600 11px/1.2 var(--v2-font-mono, var(--font-mono));
+    text-transform: uppercase;
+  }
+
+  .local-extension-pill span {
+    max-width: min(220px, calc(100vw - 96px));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .local-extension-content {
     display: block;
     width: 100%;
-    min-height: 240px;
+    min-height: 0;
+    flex: 1 1 auto;
+    overflow: auto;
     background: transparent;
+  }
+
+  .local-extension-content--collapsed {
+    display: none;
+  }
+
+  @media (max-width: 760px) {
+    .local-extension-stack--floating,
+    .local-extension-stack--dock-right,
+    .local-extension-stack--dock-left,
+    .local-extension-stack--dock-bottom {
+      right: 8px;
+      bottom: 8px;
+      left: 8px;
+      top: auto;
+      width: auto;
+      max-height: min(52dvh, 420px);
+      flex-direction: column;
+    }
+
+    .local-extension-stack--collapsed {
+      right: 8px;
+      bottom: 8px;
+      left: 8px;
+      justify-content: flex-end;
+    }
+
+    .local-extension-panel,
+    .local-extension-stack--dock-bottom .local-extension-panel {
+      min-width: 0;
+      min-height: 180px;
+      max-height: min(52dvh, 420px);
+    }
   }
 </style>

--- a/frontend/src/lib/local-extensions/__tests__/dock-layout.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/dock-layout.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  LOCAL_EXTENSION_DOCK_LAYOUT_STORAGE_KEY,
+  getLocalExtensionDockMode,
+  loadLocalExtensionDockLayout,
+  normalizeLocalExtensionDockLayout,
+  saveLocalExtensionDockLayout,
+  setLocalExtensionDockMode,
+  type LocalExtensionDockStorage,
+} from '../dock-layout';
+
+function memoryStorage(initial = new Map<string, string>()): LocalExtensionDockStorage {
+  return {
+    getItem: (key) => initial.get(key) ?? null,
+    setItem: (key, value) => {
+      initial.set(key, value);
+    },
+  };
+}
+
+describe('local extension dock layout', () => {
+  it('loads a default floating layout when storage is empty or invalid', () => {
+    expect(loadLocalExtensionDockLayout(null)).toEqual({
+      version: 1,
+      extensions: {},
+    });
+    expect(normalizeLocalExtensionDockLayout({ version: 2, extensions: {} })).toEqual({
+      version: 1,
+      extensions: {},
+    });
+    expect(getLocalExtensionDockMode(loadLocalExtensionDockLayout(null), 'meter')).toBe('floating');
+  });
+
+  it('validates persisted extension placement state', () => {
+    const state = normalizeLocalExtensionDockLayout({
+      version: 1,
+      extensions: {
+        meter: { mode: 'dock-right' },
+        '': { mode: 'dock-left' },
+        badMode: { mode: 'popup' },
+        badShape: 'dock-bottom',
+        keyer: { mode: 'collapsed' },
+      },
+    });
+
+    expect(state).toEqual({
+      version: 1,
+      extensions: {
+        meter: { mode: 'dock-right' },
+        keyer: { mode: 'collapsed' },
+      },
+    });
+  });
+
+  it('persists validated layout under the icom-lan key', () => {
+    const backing = new Map<string, string>();
+    const storage = memoryStorage(backing);
+    const state = setLocalExtensionDockMode(loadLocalExtensionDockLayout(storage), 'meter', 'dock-bottom');
+
+    saveLocalExtensionDockLayout(state, storage);
+
+    expect(JSON.parse(backing.get(LOCAL_EXTENSION_DOCK_LAYOUT_STORAGE_KEY) ?? '')).toEqual({
+      version: 1,
+      extensions: {
+        meter: { mode: 'dock-bottom' },
+      },
+    });
+    expect(loadLocalExtensionDockLayout(storage)).toEqual(state);
+  });
+
+  it('treats storage failures as best-effort persistence', () => {
+    const storage: LocalExtensionDockStorage = {
+      getItem: vi.fn(() => {
+        throw new Error('blocked');
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('quota');
+      }),
+    };
+
+    expect(loadLocalExtensionDockLayout(storage)).toEqual({
+      version: 1,
+      extensions: {},
+    });
+    expect(() => saveLocalExtensionDockLayout({
+      version: 1,
+      extensions: { meter: { mode: 'dock-left' } },
+    }, storage)).not.toThrow();
+  });
+});

--- a/frontend/src/lib/local-extensions/dock-layout.ts
+++ b/frontend/src/lib/local-extensions/dock-layout.ts
@@ -1,0 +1,141 @@
+export const LOCAL_EXTENSION_DOCK_LAYOUT_STORAGE_KEY = 'icom-lan:local-extension-dock-layout:v1';
+export const LOCAL_EXTENSION_DOCK_LAYOUT_VERSION = 1;
+
+export type LocalExtensionDockMode =
+  | 'floating'
+  | 'dock-bottom'
+  | 'dock-right'
+  | 'dock-left'
+  | 'collapsed';
+
+export interface LocalExtensionDockPlacement {
+  mode: LocalExtensionDockMode;
+}
+
+export interface LocalExtensionDockLayoutState {
+  version: typeof LOCAL_EXTENSION_DOCK_LAYOUT_VERSION;
+  extensions: Record<string, LocalExtensionDockPlacement>;
+}
+
+export type LocalExtensionDockStorage = Pick<Storage, 'getItem' | 'setItem'> | null | undefined;
+
+export const DEFAULT_LOCAL_EXTENSION_DOCK_MODE: LocalExtensionDockMode = 'floating';
+
+const SUPPORTED_DOCK_MODES = new Set<LocalExtensionDockMode>([
+  'floating',
+  'dock-bottom',
+  'dock-right',
+  'dock-left',
+  'collapsed',
+]);
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function createDefaultState(): LocalExtensionDockLayoutState {
+  return {
+    version: LOCAL_EXTENSION_DOCK_LAYOUT_VERSION,
+    extensions: {},
+  };
+}
+
+function defaultStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function isLocalExtensionDockMode(value: unknown): value is LocalExtensionDockMode {
+  return typeof value === 'string' && SUPPORTED_DOCK_MODES.has(value as LocalExtensionDockMode);
+}
+
+export function normalizeLocalExtensionDockLayout(
+  value: unknown,
+): LocalExtensionDockLayoutState {
+  const source = asObject(value);
+  if (!source || source.version !== LOCAL_EXTENSION_DOCK_LAYOUT_VERSION) {
+    return createDefaultState();
+  }
+
+  const rawExtensions = asObject(source.extensions);
+  if (!rawExtensions) {
+    return createDefaultState();
+  }
+
+  const extensions: Record<string, LocalExtensionDockPlacement> = {};
+  for (const [id, rawPlacement] of Object.entries(rawExtensions)) {
+    const placement = asObject(rawPlacement);
+    if (id.trim() === '' || !placement || !isLocalExtensionDockMode(placement.mode)) {
+      continue;
+    }
+    extensions[id] = { mode: placement.mode };
+  }
+
+  return {
+    version: LOCAL_EXTENSION_DOCK_LAYOUT_VERSION,
+    extensions,
+  };
+}
+
+export function loadLocalExtensionDockLayout(
+  storage: LocalExtensionDockStorage = defaultStorage(),
+): LocalExtensionDockLayoutState {
+  if (!storage) {
+    return createDefaultState();
+  }
+
+  try {
+    const item = storage.getItem(LOCAL_EXTENSION_DOCK_LAYOUT_STORAGE_KEY);
+    return item ? normalizeLocalExtensionDockLayout(JSON.parse(item)) : createDefaultState();
+  } catch {
+    return createDefaultState();
+  }
+}
+
+export function saveLocalExtensionDockLayout(
+  state: LocalExtensionDockLayoutState,
+  storage: LocalExtensionDockStorage = defaultStorage(),
+): void {
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(
+      LOCAL_EXTENSION_DOCK_LAYOUT_STORAGE_KEY,
+      JSON.stringify(normalizeLocalExtensionDockLayout(state)),
+    );
+  } catch {
+    // localStorage can be unavailable or quota-limited; layout persistence is best-effort.
+  }
+}
+
+export function getLocalExtensionDockMode(
+  state: LocalExtensionDockLayoutState,
+  id: string,
+): LocalExtensionDockMode {
+  return state.extensions[id]?.mode ?? DEFAULT_LOCAL_EXTENSION_DOCK_MODE;
+}
+
+export function setLocalExtensionDockMode(
+  state: LocalExtensionDockLayoutState,
+  id: string,
+  mode: LocalExtensionDockMode,
+): LocalExtensionDockLayoutState {
+  if (id.trim() === '' || !isLocalExtensionDockMode(mode)) {
+    return normalizeLocalExtensionDockLayout(state);
+  }
+
+  return {
+    version: LOCAL_EXTENSION_DOCK_LAYOUT_VERSION,
+    extensions: {
+      ...normalizeLocalExtensionDockLayout(state).extensions,
+      [id]: { mode },
+    },
+  };
+}


### PR DESCRIPTION
Closes #1065

## Summary
Adds generic dock/collapse layout behavior for same-origin local extensions.

## What changed
- Adds a local extension dock layout helper with validation and `localStorage` persistence under `icom-lan:local-extension-dock-layout:v1`.
- Extends `LocalExtensionsHost` with float, left/right/bottom dock, and collapsed status pill modes.
- Keeps the extension host generic and product-neutral; extension content still comes from same-origin local manifests/assets.
- Clears extension keyboard scope when an extension is collapsed.

## Test coverage
- `npm run test -- --run src/lib/local-extensions src/components-v2/layout/__tests__/keyboard-map.test.ts`
- `npm run lint -- src/lib/local-extensions src/components-v2/layout/keyboard-map.ts src/components-v2/layout/__tests__/keyboard-map.test.ts`

## Manual verification
- Verified persisted layout parsing rejects malformed modes/shapes and tolerates storage failures.
- Verified the host still renders only registered extensions from the manifest.

## Known limitations / follow-up
- This is a fixed-position dock host; freeform drag/resize can be added later if needed.
- Full local `act` was not run before opening; it should be run before merge because GitHub CI is disabled for budget.
