### PR TITLE
fix(rigctld): get_powerstat dispatches to radio instead of returning hardcoded 1

### DIFF
--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -964,7 +964,8 @@ class RigctldHandler:
         return RigctldResponse(values=["1" if dual else "0"])
 
     async def _cmd_get_powerstat(self, cmd: RigctldCommand) -> RigctldResponse:
-        return RigctldResponse(values=["1"])
+        on = await self._radio.get_powerstat()
+        return RigctldResponse(values=[str(int(bool(on)))])
 
     async def _cmd_quit(self, cmd: RigctldCommand) -> RigctldResponse:
         # Return OK; server.py detects cmd_echo == "quit" and closes the connection

--- a/tests/golden/protocol_golden.json
+++ b/tests/golden/protocol_golden.json
@@ -249,9 +249,9 @@
   },
   {
     "id": "get_powerstat",
-    "description": "get_powerstat — always returns 1 (rig on)",
+    "description": "get_powerstat — dispatches to radio (ON)",
     "input": "\\get_powerstat",
-    "mock": {},
+    "mock": {"get_powerstat": true},
     "expected_output": "1\n",
     "extended_output": "get_powerstat:\n1\nRPRT 0\n"
   },

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -718,9 +718,31 @@ async def test_chk_vfo(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
 
 @pytest.mark.asyncio
 async def test_get_powerstat(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
+    mock_radio.get_powerstat = AsyncMock(return_value=True)
     resp = await handler.execute(get_cmd("get_powerstat"))
     assert resp.ok
     assert resp.values == ["1"]
+    mock_radio.get_powerstat.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rigctld_get_powerstat_returns_real_value(
+    handler: RigctldHandler, mock_radio: AsyncMock
+) -> None:
+    """get_powerstat dispatches to radio and reflects ON vs STANDBY."""
+    # Radio reports STANDBY (off).
+    mock_radio.get_powerstat = AsyncMock(return_value=False)
+    resp = await handler.execute(get_cmd("get_powerstat"))
+    assert resp.ok
+    assert resp.values == ["0"]
+    mock_radio.get_powerstat.assert_awaited_once()
+
+    # Radio reports ON.
+    mock_radio.get_powerstat = AsyncMock(return_value=True)
+    resp = await handler.execute(get_cmd("get_powerstat"))
+    assert resp.ok
+    assert resp.values == ["1"]
+    mock_radio.get_powerstat.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_wire.py
+++ b/tests/test_server_wire.py
@@ -95,6 +95,7 @@ def _make_mock_radio() -> _MockRadio:
     radio.set_mode = AsyncMock(return_value=None)
     radio.set_data_mode = AsyncMock(return_value=None)
     radio.set_ptt = AsyncMock(return_value=None)
+    radio.get_powerstat = AsyncMock(return_value=True)
     return radio
 
 


### PR DESCRIPTION
Closes #1095

## Summary
- `_cmd_get_powerstat` was a stub that always returned `"1"`, silently mis-reporting power state to all Hamlib clients regardless of the radio's actual STANDBY/ON status.
- Replace the stub with `await self._radio.get_powerstat()` and format as `str(int(bool(...)))`, matching surrounding patterns (`_cmd_get_ptt` etc.). Every backend already implements `get_powerstat` via `PowerControlCapable`.

## Tests
- Extend `test_get_powerstat` to assert dispatch via `assert_awaited_once`.
- Add `test_rigctld_get_powerstat_returns_real_value` — verifies STANDBY (False → "0") vs ON (True → "1") dispatch.
- Update `test_server_wire.py` `_make_mock_radio` and `tests/golden/protocol_golden.json` `get_powerstat` fixture to provide the new dispatched call.

## Test plan
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4789 passed
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run ruff format src/ tests/` — clean

## References
- Synthesis: `00-synthesis.md` Phase A, PR-4 + Side defect P3-05
- Audit: `api-audit/12-tx-power.md`
- Parent epic: #1091
- Release target: v0.18.1