### PR TITLE
fix(rigctld): add get_squelch to LevelsCapable + Icom impl

### DIFF
--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -399,6 +399,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             "set_rf_gain",
             "get_rf_gain",
             "set_squelch",
+            "get_squelch",
             "get_nr_level",
             "set_nr_level",
             "get_nb_level",
@@ -1719,6 +1720,27 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
         civ = _set_squelch(level, to_addr=self._radio_addr, receiver=receiver)
         await self._send_civ_raw(civ, wait_response=False)
+
+    async def get_squelch(self, receiver: int = 0) -> int:
+        """Read the current squelch level (0-255)."""
+        self._check_connected()
+        self._require_capability("squelch", operation="get_squelch")
+        self._require_receiver(receiver, operation="get_squelch")
+        self._require_cmd29_route(
+            0x14,
+            0x03,
+            receiver=receiver,
+            operation="get_squelch",
+        )
+        from .commands import get_squelch as _get_squelch
+
+        civ = _get_squelch(to_addr=self._radio_addr, receiver=receiver)
+        return await self._get_bcd_level(
+            civ,
+            key=f"get_squelch:{receiver}",
+            command=0x14,
+            sub=0x03,
+        )
 
     async def get_apf_type_level(self, receiver: int = RECEIVER_MAIN) -> int:
         """Read APF Type Level (0-255)."""

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -266,6 +266,17 @@ class LevelsCapable(Protocol):
         """
         ...
 
+    async def get_squelch(self, receiver: int = 0) -> int:
+        """Get squelch level (0-255).
+
+        Args:
+            receiver: 0 = main (default), 1 = sub.
+
+        Returns:
+            Current squelch level in 0-255 scale.
+        """
+        ...
+
     async def get_nr_level(self, receiver: int = 0) -> int:
         """Get noise reduction level (0-255)."""
         ...

--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -109,6 +109,7 @@ _IC7610_DUMP_STATE: list[str] = [
 _GET_LEVEL_FLOAT: dict[str, str] = {
     "AF": "get_af_level",
     "RF": "get_rf_gain",
+    "SQL": "get_squelch",
     "NR": "get_nr_level",
     "NB": "get_nb_level",
     "COMP": "get_compressor_level",

--- a/src/icom_lan/rigctld/routing.py
+++ b/src/icom_lan/rigctld/routing.py
@@ -129,8 +129,10 @@ class YaesuRouting:
             return RigctldResponse(values=[f"{swr:.6f}"])
 
         # 0–255 → 0.0–1.0
-        if level in ("AF", "RF", "SQL"):
-            m = {"AF": "get_af_level", "RF": "get_rf_gain", "SQL": "get_squelch"}[level]
+        if level == "SQL":
+            return RigctldResponse(values=[f"{await radio.get_squelch() / 255.0:.6f}"])
+        if level in ("AF", "RF"):
+            m = {"AF": "get_af_level", "RF": "get_rf_gain"}[level]
             return RigctldResponse(values=[f"{await getattr(radio, m)() / 255.0:.6f}"])
 
         # 0–100 → 0.0–1.0

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -492,6 +492,26 @@ class TestRfGainAfLevel:
             await radio.set_af_level(-1)
 
 
+class TestSquelch:
+    """Test get_squelch — verifies cmd29 path and frame parsing (issue #1093)."""
+
+    @pytest.mark.asyncio
+    async def test_levels_get_squelch_icom(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """get_squelch on MAIN parses a non-cmd29 0x14 0x03 BCD response."""
+        mock_transport.queue_response(_level_response(0x03, 200))
+        assert await radio.get_squelch() == 200
+
+    @pytest.mark.asyncio
+    async def test_levels_get_squelch_icom_sub(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """get_squelch on SUB parses a cmd29-wrapped 0x14 0x03 BCD response."""
+        mock_transport.queue_response(_level_response(0x03, 128, receiver=1))
+        assert await radio.get_squelch(receiver=1) == 128
+
+
 class TestPtt:
     """Test PTT toggle."""
 

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -956,6 +956,18 @@ async def test_get_level_rf_gain(
 
 
 @pytest.mark.asyncio
+async def test_rigctld_get_level_sql_icom(
+    handler: RigctldHandler, mock_radio: AsyncMock
+) -> None:
+    """get_level SQL on Icom uses LevelsCapable.get_squelch — no AttributeError (issue #1093)."""
+    mock_radio.get_squelch = AsyncMock(return_value=128)
+    resp = await handler.execute(get_cmd("get_level", "SQL"))
+    assert resp.ok
+    assert float(resp.values[0]) == pytest.approx(128 / 255.0, rel=1e-6)
+    mock_radio.get_squelch.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
 async def test_get_level_nr(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
     mock_radio.get_nr_level = AsyncMock(return_value=0)
     resp = await handler.execute(get_cmd("get_level", "NR"))


### PR DESCRIPTION
Closes #1093

## Summary

- Add `get_squelch(receiver: int = 0) -> int` to `LevelsCapable` and implement on `CoreRadio` (Icom), mirroring the existing `set_squelch` cmd29 routing. The CI-V codec for `0x14 0x03` already exists in `commands/levels.py`.
- Switch `rigctld/routing.py` (Yaesu) to call the typed protocol method instead of a string-keyed getattr.
- Register `SQL -> get_squelch` in `rigctld/handler.py::_GET_LEVEL_FLOAT` so the Icom default rigctld dispatch resolves `get_level SQL` instead of returning `EINVAL`.

Pre-Tier-1 protocol addition (Tier-1 commitment starts v0.19; this ships in v0.18.1).

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4791 passed
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — zero errors (Protocol shape stable)
- [x] New unit tests `test_levels_get_squelch_icom` (MAIN, no cmd29) and `test_levels_get_squelch_icom_sub` (SUB, cmd29-wrapped) verify frame parsing.
- [x] New integration test `test_rigctld_get_level_sql_icom` verifies the rigctld dispatch reaches `radio.get_squelch()` with the 0-255 → 0.0-1.0 normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)