### PR TITLE
fix(yaesu): delegate compressor-level aliases to processor-level

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -399,12 +399,12 @@ class YaesuCatRadio:
         logger.debug("set_drive_gain: not supported on this radio")
 
     async def get_compressor_level(self) -> int:
-        """Compressor level not available via CAT on FTX-1."""
-        return 0
+        """Alias for LevelsCapable compatibility — delegates to processor level."""
+        return await self.get_processor_level()
 
     async def set_compressor_level(self, level: int) -> None:
-        """Compressor level not available via CAT on FTX-1."""
-        logger.debug("set_compressor_level: not supported on this radio")
+        """Alias for LevelsCapable compatibility — delegates to processor level."""
+        await self.set_processor_level(level)
 
     # -- Optional commands (profile-dependent) ------------------------------
 

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1309,6 +1309,35 @@ async def test_get_processor_level_no_last_drive_gain_attribute(connected_radio)
     assert not hasattr(connected_radio, "_last_drive_gain")
 
 
+@pytest.mark.asyncio
+async def test_set_compressor_level_delegates_to_set_processor_level(connected_radio):
+    """set_compressor_level is a thin alias for set_processor_level (issue #1098)."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_compressor_level(75)
+    connected_radio._transport.write.assert_called_once_with("PL075;")
+
+
+@pytest.mark.asyncio
+async def test_get_compressor_level_delegates_to_get_processor_level(connected_radio):
+    """get_compressor_level is a thin alias for get_processor_level (issue #1098)."""
+    connected_radio._transport.query = AsyncMock(return_value="PL045")
+    level = await connected_radio.get_compressor_level()
+    assert level == 45
+    connected_radio._transport.query.assert_called_once_with("PL;")
+
+
+@pytest.mark.asyncio
+async def test_compressor_level_round_trip(connected_radio):
+    """Round-trip set→get reports the value just written (was 0 before #1098)."""
+    connected_radio._transport.write = AsyncMock()
+    connected_radio._transport.query = AsyncMock(return_value="PL060")
+    await connected_radio.set_compressor_level(60)
+    level = await connected_radio.get_compressor_level()
+    assert level == 60
+    connected_radio._transport.write.assert_called_once_with("PL060;")
+    connected_radio._transport.query.assert_called_once_with("PL;")
+
+
 # ---------------------------------------------------------------------------
 # Bug #550: capabilities must not advertise unimplemented features
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1098

## Summary

- Yaesu `get_compressor_level` returned hard-coded `0`; `set_compressor_level` was a logged no-op. The Yaesu-spelled twins (`get_processor_level` / `set_processor_level`) actually work via FTX-1's PL CAT command, so the web/poller reported 0 forever and writes were silently dropped.
- Convert the Icom-spelled aliases into thin delegations to the processor-level methods, mirroring the existing `set_compressor → set_processor` alias pattern at `yaesu_cat/radio.py:1387`.
- Fixes side-defect **P1-01** (silent data loss) from the Speech/Processor/Monitor audit (#1078). Synthesis ref: Phase B, PR-6.

## Changes

- `src/icom_lan/backends/yaesu_cat/radio.py` — `get_compressor_level()` → `get_processor_level()`, `set_compressor_level()` → `set_processor_level()`
- `tests/test_ftx1_radio.py` — round-trip set→get test plus delegation asserts on the PL command

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4791 passed, 0 failures
- [x] `uv run ruff check src/ tests/` — clean
- [ ] FTX-1 hardware smoke: web compressor slider actually moves the radio (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)