### PR TITLE
fix(yaesu): route APF through canonical set_audio_peak_filter

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/poller.py
+++ b/src/icom_lan/backends/yaesu_cat/poller.py
@@ -480,8 +480,12 @@ class YaesuCatPoller:
                 case SetDualWatch(on=on):
                     await radio.set_dual_watch(on)
 
+                # ── APF (Audio Peak Filter) ──
+                case SetApf(mode=mode, receiver=rx):
+                    await radio.set_audio_peak_filter(mode, receiver=rx)
+
                 # ── IC-7610-specific (not applicable) ──
-                case SetIpPlus() | SetApf() | SetTwinPeak() | SetDigiSel():
+                case SetIpPlus() | SetTwinPeak() | SetDigiSel():
                     pass  # Icom-only DSP features
 
                 case _:

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -1520,13 +1520,39 @@ class YaesuCatRadio:
     async def get_dual_watch(self) -> bool:
         raise NotImplementedError("Dual watch query not supported on Yaesu radios")
 
-    # -- APF / Twin Peak (not supported on Yaesu) -----------------------------
+    # -- Audio Peak Filter (canonical 3-mode adapter over Yaesu bool APF) -----
 
     async def set_audio_peak_filter(self, mode: int, receiver: int = 0) -> None:
-        raise NotImplementedError("APF not supported on Yaesu radios")
+        """Set Audio Peak Filter via the canonical 3-mode contract.
+
+        The cross-vendor contract is `mode = 0=off, 1=soft, 2=sharp`
+        (`DspControlCapable.set_audio_peak_filter`). Yaesu hardware exposes
+        APF as a plain on/off toggle (CO02) plus a tunable centre frequency
+        (CO03), so this adapter degrades the 3-mode form onto the bool form:
+
+        - mode 0 → APF off.
+        - mode 1 → APF on; centre frequency set to 0 (CW-pitch centred,
+          the natural "soft" default).
+        - mode 2 → not supported; the hardware has no separate "sharp" mode.
+
+        Delegates to the backend-internal `set_apf` / `set_apf_freq` CAT
+        primitives.
+        """
+        if mode == 0:
+            await self.set_apf(False, receiver=receiver)
+        elif mode == 1:
+            await self.set_apf(True, receiver=receiver)
+            await self.set_apf_freq(0, receiver=receiver)
+        else:
+            raise NotImplementedError(
+                f"APF mode {mode} (sharp) not supported on Yaesu — "
+                "only off (0) and on (1)"
+            )
 
     async def get_audio_peak_filter(self, receiver: int = 0) -> int:
         raise NotImplementedError("APF not supported on Yaesu radios")
+
+    # -- Twin Peak Filter (not supported on Yaesu) ----------------------------
 
     async def set_twin_peak_filter(self, on: bool, receiver: int = 0) -> None:
         raise NotImplementedError("Twin Peak not supported on Yaesu radios")

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -881,6 +881,41 @@ async def test_set_apf_freq(connected_radio):
 
 
 # ---------------------------------------------------------------------------
+# Canonical APF adapter (DspControlCapable.set_audio_peak_filter)
+# Mode 0/1/2 → Yaesu bool APF (with mode-2 raising clearly)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_audio_peak_filter_mode_0_disables_apf(connected_radio):
+    """Mode 0 (off) → CO020000;"""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_audio_peak_filter(0)
+    connected_radio._transport.write.assert_called_once_with("CO020000;")
+
+
+@pytest.mark.asyncio
+async def test_set_audio_peak_filter_mode_1_enables_apf_and_centres_freq(
+    connected_radio,
+):
+    """Mode 1 (soft) → APF on (CO020001;) plus centre-frequency reset (CO030000;)."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_audio_peak_filter(1)
+    assert connected_radio._transport.write.await_count == 2
+    sent = [c.args[0] for c in connected_radio._transport.write.await_args_list]
+    assert sent == ["CO020001;", "CO030000;"]
+
+
+@pytest.mark.asyncio
+async def test_set_audio_peak_filter_mode_2_raises(connected_radio):
+    """Mode 2 (sharp) → NotImplementedError; Yaesu has no sharp mode."""
+    connected_radio._transport.write = AsyncMock()
+    with pytest.raises(NotImplementedError, match="sharp"):
+        await connected_radio.set_audio_peak_filter(2)
+    connected_radio._transport.write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # D9: Tone/TSQL
 # ---------------------------------------------------------------------------
 

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -858,3 +858,36 @@ async def test_slow_poll_skips_fr_ft_without_dual_rx() -> None:
 
     radio.get_rx_func.assert_not_called()
     radio.get_tx_func.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Command dispatch — SetApf (formerly dropped as "Icom-only DSP feature")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_command_set_apf_dispatches_to_radio() -> None:
+    """SetApf must reach radio.set_audio_peak_filter — used to be silently dropped."""
+    from icom_lan._poller_types import SetApf
+
+    radio = make_radio()
+    radio.set_audio_peak_filter = AsyncMock()
+    poller = YaesuCatPoller(radio, callback=lambda s: None, fast_interval=10.0)
+
+    await poller._execute_command(SetApf(mode=1, receiver=0))
+
+    radio.set_audio_peak_filter.assert_awaited_once_with(1, receiver=0)
+
+
+@pytest.mark.asyncio
+async def test_execute_command_set_apf_off_dispatches_to_radio() -> None:
+    """SetApf(mode=0) reaches the canonical entry point too."""
+    from icom_lan._poller_types import SetApf
+
+    radio = make_radio()
+    radio.set_audio_peak_filter = AsyncMock()
+    poller = YaesuCatPoller(radio, callback=lambda s: None, fast_interval=10.0)
+
+    await poller._execute_command(SetApf(mode=0, receiver=0))
+
+    radio.set_audio_peak_filter.assert_awaited_once_with(0, receiver=0)


### PR DESCRIPTION
Closes #1110

## Summary

- The Yaesu poller was dropping `SetApf` actions as "Icom-only DSP feature" at `backends/yaesu_cat/poller.py:484`, so the FTX-1 web UI APF button did nothing — and the Yaesu native `get_apf`/`set_apf` (bool) primitives were unreachable from the web pipeline. **Side defect P2-01 (dead code → reachable).**
- Promote `YaesuCatRadio.set_audio_peak_filter(mode, receiver=0)` (already required by `DspControlCapable`) to be the canonical entry point. It adapts the cross-vendor 3-mode form (0=off, 1=soft, 2=sharp) onto Yaesu's bool CAT primitives:
  - mode 0 → `set_apf(False)`
  - mode 1 → `set_apf(True)` + `set_apf_freq(0)` (CW-pitch-centred default)
  - mode 2 → `NotImplementedError` (Yaesu has no separate sharp mode)
- Drop `SetApf` from the poller's "Icom-only" union; add a dedicated dispatch case that calls `radio.set_audio_peak_filter(mode, receiver=rx)` — same canonical entry point the Icom backend uses via `web/radio_poller.py:1079`.

**Synthesis ref:** Phase F, PR-18 + Side defect P2-01
**Audit:** `api-audit/08-dsp-lock-notch.md`
**Files:** 2 src + 2 tests; **LOC:** ~100

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4793 passed, 0 failures
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check` on changed files — already formatted
- [x] New unit tests:
  - `test_set_audio_peak_filter_mode_0_disables_apf`
  - `test_set_audio_peak_filter_mode_1_enables_apf_and_centres_freq`
  - `test_set_audio_peak_filter_mode_2_raises`
  - `test_execute_command_set_apf_dispatches_to_radio`
  - `test_execute_command_set_apf_off_dispatches_to_radio`
- [ ] Manual smoke (post-merge, on FTX-1 hardware): toggle APF from web UI, verify CO02/CO03 CAT frames hit the radio.