### PR TITLE
refactor(audio): privatise facade helpers + rename Yaesu has_command (P3-12, P3-13)

### DIFF
--- a/src/icom_lan/audio/usb_driver.py
+++ b/src/icom_lan/audio/usb_driver.py
@@ -478,7 +478,7 @@ class UsbAudioDriver:
             )
             await self._tx_stream.start()
 
-    async def push_tx_pcm(self, frame: bytes) -> None:
+    async def _push_tx_pcm(self, frame: bytes) -> None:
         """Queue one PCM frame for playback."""
         if not self.tx_running:
             raise AudioDriverLifecycleError("Audio TX stream is not started.")

--- a/src/icom_lan/backends/_icom_serial_base.py
+++ b/src/icom_lan/backends/_icom_serial_base.py
@@ -68,7 +68,7 @@ class _SerialAudioDriver(Protocol):
 
     async def stop_tx(self) -> None: ...
 
-    async def push_tx_pcm(self, frame: bytes) -> None: ...
+    async def _push_tx_pcm(self, frame: bytes) -> None: ...
 
     @property
     def tx_running(self) -> bool: ...
@@ -474,14 +474,14 @@ class _IcomSerialRadioBase(CoreRadio):
     async def stop_audio_tx_pcm(self) -> None:
         await self._serial_audio_driver.stop_tx()
 
-    async def push_pcm_tx(self, frame: bytes) -> None:
+    async def _push_pcm_tx(self, frame: bytes) -> None:
         if not isinstance(frame, bytes):
             raise TypeError(f"frame must be bytes, got {type(frame).__name__}.")
         if len(frame) == 0:
             raise ValueError("frame must not be empty.")
 
         self._check_connected()
-        await self._serial_audio_driver.push_tx_pcm(frame)
+        await self._serial_audio_driver._push_tx_pcm(frame)
 
     # ------------------------------------------------------------------
     # Serial stubs (no-ops for serial transport)

--- a/src/icom_lan/backends/icom7610/serial.py
+++ b/src/icom_lan/backends/icom7610/serial.py
@@ -49,7 +49,7 @@ class Icom7610SerialRadio(_IcomSerialRadioBase):
                 frame_ms=20,
             )
             payload = transcoder.opus_to_pcm(payload)
-        await self._serial_audio_driver.push_tx_pcm(payload)
+        await self._serial_audio_driver._push_tx_pcm(payload)
 
     async def stop_audio_tx_opus(self) -> None:
         await self._serial_audio_driver.stop_tx()
@@ -110,7 +110,7 @@ class Icom7610SerialRadio(_IcomSerialRadioBase):
                 f"PCM frame size mismatch: expected {expected} bytes "
                 f"({frame_ms}ms at {sample_rate}Hz, {channels}ch s16le), got {len(frame)}."
             )
-        await self._serial_audio_driver.push_tx_pcm(frame)
+        await self._serial_audio_driver._push_tx_pcm(frame)
 
     async def stop_audio_tx_pcm(self) -> None:
         await self.stop_audio_tx_opus()

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -351,14 +351,14 @@ class YaesuCatRadio:
     async def stop_audio_tx_pcm(self) -> None:
         await self._audio_driver.stop_tx()
 
-    async def push_pcm_tx(self, frame: bytes) -> None:
+    async def _push_pcm_tx(self, frame: bytes) -> None:
         if not isinstance(frame, bytes):
             raise TypeError(f"frame must be bytes, got {type(frame).__name__}.")
         if len(frame) == 0:
             raise ValueError("frame must not be empty.")
 
         self._require_connected()
-        await self._audio_driver.push_tx_pcm(frame)
+        await self._audio_driver._push_tx_pcm(frame)
 
     # -- AudioCapable TX methods --------------------------------------------
 
@@ -366,11 +366,11 @@ class YaesuCatRadio:
         """Forward Opus TX data as PCM (USB audio is always PCM)."""
         # Browser sends Opus; AudioBroadcaster transcodes to PCM before calling.
         # If raw Opus arrives here, just push as-is (driver handles it).
-        await self.push_pcm_tx(data)
+        await self._push_pcm_tx(data)
 
     async def push_audio_tx_pcm(self, data: bytes) -> None:
         """Push raw PCM TX data."""
-        await self.push_pcm_tx(data)
+        await self._push_pcm_tx(data)
 
     async def start_audio_tx_opus(self) -> None:
         """No-op: USB audio TX is started via start_audio_tx_pcm."""
@@ -415,9 +415,9 @@ class YaesuCatRadio:
         ``set_nb_level(0)`` for off and ``set_nb_level(default)`` for on.
         No-op if neither ``set_nb`` nor ``set_nb_level`` is defined.
         """
-        if self.has_write_command("set_nb"):
+        if self._has_write_command("set_nb"):
             await self._write("set_nb", state="1" if on else "0")
-        elif self.has_write_command("set_nb_level"):
+        elif self._has_write_command("set_nb_level"):
             if on:
                 current = self._state.main.nb_level
                 level = current if current > 0 else self._default_nb_level()
@@ -432,9 +432,9 @@ class YaesuCatRadio:
         ``set_nr_level(0)`` for off and ``set_nr_level(default)`` for on.
         No-op if neither ``set_nr`` nor ``set_nr_level`` is defined.
         """
-        if self.has_write_command("set_nr"):
+        if self._has_write_command("set_nr"):
             await self._write("set_nr", state="1" if on else "0")
-        elif self.has_write_command("set_nr_level"):
+        elif self._has_write_command("set_nr_level"):
             if on:
                 current = self._state.main.nr_level
                 level = current if current > 0 else self._default_nr_level()
@@ -448,19 +448,19 @@ class YaesuCatRadio:
         No-op with warning if the rig profile does not define a
         ``set_dual_watch`` command.
         """
-        if self.has_write_command("set_dual_watch"):
+        if self._has_write_command("set_dual_watch"):
             await self._write("set_dual_watch", state="1" if on else "0")
         else:
             logger.warning("set_dual_watch: no CAT command defined for %s", self.model)
 
     # -- Runtime profile introspection -------------------------------------
 
-    def has_command(self, name: str) -> bool:
+    def _has_command(self, name: str) -> bool:
         """Check if a command is defined in the rig profile."""
         spec = self._config.commands.get(name)
         return spec is not None and isinstance(spec, CatCommandSpec)
 
-    def has_write_command(self, name: str) -> bool:
+    def _has_write_command(self, name: str) -> bool:
         """Check if a write command is defined in the rig profile."""
         spec = self._config.commands.get(name)
         return (
@@ -471,7 +471,7 @@ class YaesuCatRadio:
 
     def supports_command(self, command: str) -> bool:
         """Check if a command is defined in the rig profile."""
-        return self.has_command(command)
+        return self._has_command(command)
 
     def _default_nb_level(self) -> int:
         """Default NB level for turning on when current level is 0."""
@@ -681,7 +681,7 @@ class YaesuCatRadio:
         profile to map mode pairs.  For now, log a warning if the
         profile lacks a ``set_data_mode`` CAT command.
         """
-        if self.has_write_command("set_data_mode"):
+        if self._has_write_command("set_data_mode"):
             await self._write("set_data_mode", state="1" if on else "0")
         else:
             logger.warning("set_data_mode: no CAT command defined for %s", self.model)

--- a/tests/test_ftx1_audio.py
+++ b/tests/test_ftx1_audio.py
@@ -217,7 +217,7 @@ async def test_stop_audio_rx_pcm(radio, mock_audio_driver):
 
 
 # ---------------------------------------------------------------------------
-# start_audio_tx_pcm / stop_audio_tx_pcm / push_pcm_tx
+# start_audio_tx_pcm / stop_audio_tx_pcm / _push_pcm_tx
 # ---------------------------------------------------------------------------
 
 
@@ -241,18 +241,18 @@ async def test_stop_audio_tx_pcm(radio, mock_audio_driver):
 
 async def test_push_pcm_tx(radio, mock_audio_driver):
     frame = b"\xab" * 960
-    await radio.push_pcm_tx(frame)
-    mock_audio_driver.push_tx_pcm.assert_called_once_with(frame)
+    await radio._push_pcm_tx(frame)
+    mock_audio_driver._push_tx_pcm.assert_called_once_with(frame)
 
 
 async def test_push_pcm_tx_not_bytes(radio):
     with pytest.raises(TypeError, match="frame must be bytes"):
-        await radio.push_pcm_tx("string")
+        await radio._push_pcm_tx("string")
 
 
 async def test_push_pcm_tx_empty(radio):
     with pytest.raises(ValueError, match="frame must not be empty"):
-        await radio.push_pcm_tx(b"")
+        await radio._push_pcm_tx(b"")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -161,7 +161,7 @@ class _FakeUsbAudioDriver:
     async def stop_tx(self) -> None:
         self.tx_running = False
 
-    async def push_tx_pcm(self, frame: bytes) -> None:
+    async def _push_tx_pcm(self, frame: bytes) -> None:
         self.tx_frames.append(bytes(frame))
 
     def emit_rx_pcm(self, frame: bytes) -> None:

--- a/tests/test_serial_backend_smoke.py
+++ b/tests/test_serial_backend_smoke.py
@@ -72,7 +72,7 @@ class _FakeUsbAudioDriver:
     async def stop_tx(self) -> None:
         self.tx_running = False
 
-    async def push_tx_pcm(self, frame: bytes) -> None:
+    async def _push_tx_pcm(self, frame: bytes) -> None:
         self.tx_frames.append(bytes(frame))
 
     def emit_rx_pcm(self, frame: bytes) -> None:

--- a/tests/test_supports_command.py
+++ b/tests/test_supports_command.py
@@ -89,7 +89,7 @@ def yaesu_radio(ftx1_config):
 
 
 class TestYaesuSupportsCommand:
-    """YaesuCatRadio.supports_command delegates to has_command."""
+    """YaesuCatRadio.supports_command delegates to _has_command."""
 
     def test_defined_commands_return_true(self, yaesu_radio):
         for cmd in (
@@ -113,9 +113,9 @@ class TestYaesuSupportsCommand:
             )
 
     def test_matches_has_command(self, yaesu_radio, ftx1_config):
-        """supports_command must agree with has_command for every TOML key."""
+        """supports_command must agree with _has_command for every TOML key."""
         for name in ftx1_config.commands:
-            assert yaesu_radio.supports_command(name) == yaesu_radio.has_command(name)
+            assert yaesu_radio.supports_command(name) == yaesu_radio._has_command(name)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_usb_audio_stub.py
+++ b/tests/test_usb_audio_stub.py
@@ -142,7 +142,7 @@ async def test_usb_audio_driver_lifecycle_start_stop_and_io() -> None:
     tx_stream = backend.tx_streams[0]
     assert tx_stream.running is True
 
-    await driver.push_tx_pcm(pcm_frame)
+    await driver._push_tx_pcm(pcm_frame)
     assert tx_stream.written_frames == [pcm_frame]
 
     await driver.stop_tx()
@@ -162,7 +162,7 @@ async def test_usb_audio_driver_double_start_and_missing_tx_guardrails() -> None
     with pytest.raises(
         AudioDriverLifecycleError, match="Audio TX stream is not started"
     ):
-        await driver.push_tx_pcm(b"\x00\x01" * 960)
+        await driver._push_tx_pcm(b"\x00\x01" * 960)
     await driver.stop_rx()
     await driver.stop_rx()  # idempotent
 

--- a/tests/test_yaesu_audio.py
+++ b/tests/test_yaesu_audio.py
@@ -80,7 +80,7 @@ class FakeAudioDriver:
             self._tx_task = None
         self._tx_queue = asyncio.Queue(maxsize=64)
 
-    async def push_tx_pcm(self, frame: bytes) -> None:
+    async def _push_tx_pcm(self, frame: bytes) -> None:
         if not self.tx_running:
             raise RuntimeError("Audio TX stream is not started.")
         await self._tx_queue.put(frame)
@@ -264,7 +264,7 @@ class TestTxAudio:
         await radio.connect()
         await radio.start_audio_tx_pcm()
         frame = b"\x42" * 1920
-        await radio.push_pcm_tx(frame)
+        await radio._push_pcm_tx(frame)
         queued = await asyncio.wait_for(fake_driver._tx_queue.get(), timeout=1)
         assert queued == frame
         await radio.stop_audio_tx_pcm()
@@ -286,19 +286,19 @@ class TestTxAudio:
         await radio.connect()
         assert not fake_driver.tx_running
         with pytest.raises(RuntimeError, match="not started"):
-            await fake_driver.push_tx_pcm(b"\x00" * 960)
+            await fake_driver._push_tx_pcm(b"\x00" * 960)
 
     @pytest.mark.asyncio
     async def test_push_pcm_tx_rejects_non_bytes(self, radio: YaesuCatRadio) -> None:
         await radio.connect()
         with pytest.raises(TypeError, match="bytes"):
-            await radio.push_pcm_tx("not bytes")  # type: ignore[arg-type]
+            await radio._push_pcm_tx("not bytes")  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_push_pcm_tx_rejects_empty(self, radio: YaesuCatRadio) -> None:
         await radio.connect()
         with pytest.raises(ValueError, match="empty"):
-            await radio.push_pcm_tx(b"")
+            await radio._push_pcm_tx(b"")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1112

## Summary

Privatise audio-facade and Yaesu-internal helpers that mirror canonical public Protocol methods (`supports_command`, `push_audio_tx_pcm`, `push_audio_tx_opus`). The leading-underscore form makes the privacy explicit and removes confusing public/private duplicates.

- `_IcomSerialRadioBase.push_pcm_tx` -> `_push_pcm_tx`
- `YaesuCatRadio.push_pcm_tx` -> `_push_pcm_tx`
- `UsbAudioDriver.push_tx_pcm` -> `_push_tx_pcm` (and the matching `_SerialAudioDriver` Protocol slot)
- `YaesuCatRadio.has_command` -> `_has_command`
- `YaesuCatRadio.has_write_command` -> `_has_write_command`

All internal callers updated (`icom7610/serial.py`, `yaesu_cat/radio.py`). No deprecation aliases: these are Yaesu-internal helpers with no external consumers in `web/`, `cli`, `rigctld/`, or third-party `_SerialAudioDriver` implementers.

Side defects fixed: P3-12, P3-13.
Synthesis ref: Phase G, PR-20.
Audit: `api-audit/14-hamlib-aliases.md`.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` -> 4788 passed
- [x] `uv run ruff check src/ tests/` -> clean
- [x] `uv run mypy src/` -> 0 errors in 144 files
- [x] grep verifies zero non-private call sites for the renamed methods