### PR TITLE
refactor: migrate vfo_exchange/vfo_equalize callers to canonical names

### DIFF
--- a/src/icom_lan/profiles_runtime.py
+++ b/src/icom_lan/profiles_runtime.py
@@ -61,7 +61,8 @@ class OperatingProfile:
         data1_mod_input: DATA-1 modulation input source index.
         squelch_level: Squelch level (0 = open).
         equalize_vfo: If ``True``, copy the active VFO to both VFOs after
-            tuning. Requires ``radio.vfo_equalize()``.
+            tuning. Dispatches to ``radio.equalize_main_sub()`` on dual-RX
+            profiles and ``radio.equalize_vfo_ab(0)`` on single-RX profiles.
         scope_enabled: ``True`` to enable spectrum scope, ``False`` to disable,
             ``None`` to leave unchanged.
         scope_mode: Scope centre/fixed mode index.
@@ -167,10 +168,31 @@ async def apply_profile(radio: Any, profile: OperatingProfile) -> dict[str, obje
             logger.debug("apply_profile: radio has no set_data1_mod_input, skipping")
 
     if profile.equalize_vfo:
-        if hasattr(radio, "vfo_equalize"):
-            await radio.vfo_equalize()
+        # Inline the dispatch previously hidden behind the deprecated
+        # ``vfo_equalize`` alias: dual-RX profiles use ``equalize_main_sub``
+        # (MAIN→SUB), single-RX profiles use ``equalize_vfo_ab(0)`` (A→B).
+        # The profile guard tolerates duck-typed radios that may not expose a
+        # ``profile`` attribute (e.g. lightweight test doubles) — when in
+        # doubt, prefer the canonical method that is actually present.
+        radio_profile = getattr(radio, "profile", None)
+        receiver_count = getattr(radio_profile, "receiver_count", None)
+        is_dual_rx = isinstance(receiver_count, int) and receiver_count > 1
+        if is_dual_rx and hasattr(radio, "equalize_main_sub"):
+            await radio.equalize_main_sub()
+        elif not is_dual_rx and hasattr(radio, "equalize_vfo_ab"):
+            await radio.equalize_vfo_ab(0)
+        elif hasattr(radio, "equalize_main_sub"):
+            # No profile info but the dual-RX method is available — assume
+            # the caller knows what they're doing (covers AsyncMock-based
+            # test doubles that pre-declare ``equalize_main_sub``).
+            await radio.equalize_main_sub()
+        elif hasattr(radio, "equalize_vfo_ab"):
+            await radio.equalize_vfo_ab(0)
         else:
-            logger.debug("apply_profile: radio has no vfo_equalize, skipping")
+            logger.debug(
+                "apply_profile: radio has no equalize_main_sub or "
+                "equalize_vfo_ab, skipping"
+            )
 
     if profile.squelch_level is not None:
         if hasattr(radio, "set_squelch"):

--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -231,12 +231,25 @@ class IcomRadio:
     select_vfo = set_vfo
 
     def vfo_equalize(self) -> None:
-        """Copy VFO A to VFO B."""
-        self._run(self._radio.vfo_equalize())
+        """Copy VFO A to VFO B (dispatches to canonical async method)."""
+        # Inline the dispatch previously hidden behind the deprecated
+        # ``vfo_equalize`` alias: dual-RX profiles route to
+        # ``equalize_main_sub`` (MAIN→SUB), single-RX profiles route to
+        # ``equalize_vfo_ab(0)`` (A→B).
+        if self._radio.profile.receiver_count > 1:
+            self._run(self._radio.equalize_main_sub())
+        else:
+            self._run(self._radio.equalize_vfo_ab(0))
 
     def vfo_exchange(self) -> None:
-        """Swap VFO A and B."""
-        self._run(self._radio.vfo_exchange())
+        """Swap VFO A and B (dispatches to canonical async method)."""
+        # Inline the dispatch previously hidden behind the deprecated
+        # ``vfo_exchange`` alias: dual-RX profiles route to ``swap_main_sub``
+        # (MAIN↔SUB), single-RX profiles route to ``swap_vfo_ab(0)`` (A↔B).
+        if self._radio.profile.receiver_count > 1:
+            self._run(self._radio.swap_main_sub())
+        else:
+            self._run(self._radio.swap_vfo_ab(0))
 
     def set_split_mode(self, on: bool) -> None:
         """Enable or disable split mode."""

--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -1352,14 +1352,14 @@ class RadioPoller:
             case VfoSwap():
                 self._last_user_write_ts = time.monotonic()
                 if CAP_DUAL_RX in self._caps:
-                    await radio.vfo_exchange()
+                    await radio.swap_main_sub()
                 # After swap, active VFO stays same but freqs are exchanged
                 if self._on_state_event:
                     self._on_state_event("vfo_swapped", {})
             case VfoEqualize():
                 self._last_user_write_ts = time.monotonic()
                 if CAP_DUAL_RX in self._caps:
-                    await radio.vfo_equalize()
+                    await radio.equalize_main_sub()
             case EnableScope(policy=policy):
                 if CAP_SCOPE in self._caps:
                     # Defer scope enable during initial fetch to avoid

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -649,8 +649,13 @@ async def test_enqueue_command_errors() -> None:
         set_scope_ref=AsyncMock(),
         get_scope_hold=AsyncMock(return_value=False),
         set_scope_hold=AsyncMock(),
+        # Keep deprecated aliases so the radio still satisfies
+        # ``DualReceiverCapable`` (Protocol untouched until #1114).
         vfo_exchange=AsyncMock(),
         vfo_equalize=AsyncMock(),
+        # Canonical dual-RX VFO methods (post-#1113).
+        swap_main_sub=AsyncMock(),
+        equalize_main_sub=AsyncMock(),
     )
     handler = _control_handler(
         radio=radio,

--- a/tests/test_ic705.py
+++ b/tests/test_ic705.py
@@ -33,7 +33,11 @@ async def test_prepare_ic705_data_profile_applies_expected_sequence() -> None:
     radio.set_data_mode.assert_awaited_once_with(True)
     radio.set_data_off_mod_input.assert_awaited_once_with(3)
     radio.set_data1_mod_input.assert_awaited_once_with(4)
-    radio.vfo_equalize.assert_awaited_once()
+    # #1113: apply_profile dispatches to canonical ``equalize_main_sub`` /
+    # ``equalize_vfo_ab`` instead of the deprecated ``vfo_equalize`` alias.
+    # The bare AsyncMock has no real ``profile`` attribute, so the dispatch
+    # takes the single-RX fallback path (matches IC-705's actual profile).
+    radio.equalize_vfo_ab.assert_awaited_once_with(0)
     radio.set_squelch.assert_awaited_once_with(0)
     radio.enable_scope.assert_awaited_once_with(
         output=False,

--- a/tests/test_profiles_runtime.py
+++ b/tests/test_profiles_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -168,8 +169,14 @@ class TestApplyProfileFull:
 
     @pytest.mark.asyncio()
     async def test_applies_equalize_vfo(self, radio: AsyncMock) -> None:
+        # #1113: apply_profile now dispatches to the canonical
+        # ``equalize_main_sub`` (dual-RX) or ``equalize_vfo_ab(0)``
+        # (single-RX) instead of the deprecated ``vfo_equalize`` alias.
+        # The bare AsyncMock fixture has no real ``profile`` attribute, so
+        # the dispatch falls through to the single-RX path.
         await apply_profile(radio, OperatingProfile(equalize_vfo=True))
-        radio.vfo_equalize.assert_awaited_once()
+        radio.equalize_vfo_ab.assert_awaited_once_with(0)
+        radio.vfo_equalize.assert_not_awaited()
 
     @pytest.mark.asyncio()
     async def test_scope_enabled(self, radio: AsyncMock) -> None:
@@ -235,7 +242,9 @@ class TestApplyProfileFull:
         radio.set_data_mode.assert_awaited()
         radio.set_data_off_mod_input.assert_awaited()
         radio.set_data1_mod_input.assert_awaited()
-        radio.vfo_equalize.assert_awaited()
+        # #1113: dispatches to canonical ``equalize_vfo_ab(0)`` (bare
+        # AsyncMock has no real profile attribute → single-RX fallback).
+        radio.equalize_vfo_ab.assert_awaited_with(0)
         radio.set_squelch.assert_awaited()
         radio.enable_scope.assert_awaited()
         radio.set_scope_mode.assert_awaited()
@@ -279,6 +288,54 @@ class TestApplyProfileMinimal:
         assert isinstance(snapshot, dict)
         # Only the supported setter was called
         radio.set_freq.assert_awaited_with(14_074_000)
+
+
+# ---------------------------------------------------------------------------
+# apply_profile — equalize_vfo dispatch (issue #1113)
+# ---------------------------------------------------------------------------
+
+
+class TestEqualizeVfoDispatch:
+    """Verify ``equalize_vfo=True`` dispatches to the right canonical method.
+
+    Regression coverage for #1113: ``apply_profile`` must NOT call the
+    deprecated ``vfo_equalize`` alias on the radio.  Dual-RX profiles route
+    to ``equalize_main_sub``; single-RX profiles route to ``equalize_vfo_ab(0)``.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_dual_rx_profile_uses_equalize_main_sub(self) -> None:
+        radio = AsyncMock()
+        radio.snapshot_state.return_value = {}
+        # Profile guard: receiver_count > 1 → dual-RX branch
+        radio.profile = SimpleNamespace(receiver_count=2)
+        await apply_profile(radio, OperatingProfile(equalize_vfo=True))
+        radio.equalize_main_sub.assert_awaited_once_with()
+        radio.equalize_vfo_ab.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_single_rx_profile_uses_equalize_vfo_ab(self) -> None:
+        radio = AsyncMock(
+            spec=[
+                "snapshot_state",
+                "equalize_vfo_ab",
+                "profile",
+            ]
+        )
+        radio.snapshot_state = AsyncMock(return_value={})
+        radio.equalize_vfo_ab = AsyncMock()
+        radio.profile = SimpleNamespace(receiver_count=1)
+        await apply_profile(radio, OperatingProfile(equalize_vfo=True))
+        radio.equalize_vfo_ab.assert_awaited_once_with(0)
+
+    @pytest.mark.asyncio()
+    async def test_radio_without_either_method_skips_silently(self) -> None:
+        radio = AsyncMock(spec=["snapshot_state", "profile"])
+        radio.snapshot_state = AsyncMock(return_value={})
+        radio.profile = SimpleNamespace(receiver_count=1)
+        # Should NOT raise even though radio has neither equalize method
+        snapshot = await apply_profile(radio, OperatingProfile(equalize_vfo=True))
+        assert snapshot == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -39,6 +39,7 @@ from icom_lan.web.radio_poller import (
     SetScopeRbw,
     SetScopeVbw,
     SwitchScopeReceiver,
+    VfoEqualize,
     VfoSwap,
 )
 
@@ -95,8 +96,9 @@ def _make_radio(active: str = "MAIN") -> MagicMock:
     radio.set_usb_mod_level = AsyncMock()
     radio.set_lan_mod_level = AsyncMock()
     radio.set_compressor = AsyncMock()
-    radio.vfo_exchange = AsyncMock()
-    radio.vfo_equalize = AsyncMock()
+    # Canonical dual-RX VFO methods (radio_poller calls these directly post-#1113)
+    # ``equalize_main_sub`` / ``swap_main_sub`` are already wired above for
+    # QuickDwTrigger / QuickSplitTrigger composites.
     radio.enable_scope = AsyncMock()
     radio.disable_scope = AsyncMock()
     radio.on_scope_data = MagicMock()
@@ -255,6 +257,15 @@ async def test_execute_event_emitting_commands_and_vfo_paths() -> None:
 
     await poller._execute(VfoSwap())  # noqa: SLF001
     assert any(name == "vfo_swapped" for name, _ in events)
+    # #1113: poller now calls canonical ``swap_main_sub`` directly; the
+    # deprecated ``vfo_exchange`` alias must no longer be touched here.
+    radio.swap_main_sub.assert_awaited_once_with()
+
+    # #1113: VfoEqualize routes to canonical ``equalize_main_sub``; the
+    # deprecated ``vfo_equalize`` alias must no longer be touched here.
+    eq_before = radio.equalize_main_sub.await_count
+    await poller._execute(VfoEqualize())  # noqa: SLF001
+    assert radio.equalize_main_sub.await_count == eq_before + 1
 
     await poller._execute(EnableScope(policy="fast"))  # noqa: SLF001
     await poller._execute(DisableScope())  # noqa: SLF001

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -65,8 +65,8 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
     r._radio.set_rf_power = AsyncMock()
     r._radio.set_ptt = AsyncMock()
     r._radio.set_vfo = AsyncMock()
-    r._radio.vfo_equalize = AsyncMock()
-    r._radio.vfo_exchange = AsyncMock()
+    r._radio.equalize_main_sub = AsyncMock()
+    r._radio.swap_main_sub = AsyncMock()
     r._radio.set_split_mode = AsyncMock()
     r._radio.set_attenuator_level = AsyncMock()
     r._radio.set_attenuator = AsyncMock()
@@ -135,8 +135,9 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
     r._radio.set_rf_power.assert_awaited_once_with(150)
     r._radio.set_ptt.assert_awaited_once_with(True)
     r._radio.set_vfo.assert_awaited_once_with("B")
-    r._radio.vfo_equalize.assert_awaited_once()
-    r._radio.vfo_exchange.assert_awaited_once()
+    # IC-7610 (default profile, receiver_count=2) → canonical dual-RX methods
+    r._radio.equalize_main_sub.assert_awaited_once()
+    r._radio.swap_main_sub.assert_awaited_once()
     r._radio.set_split_mode.assert_awaited_once_with(True)
     r._radio.set_attenuator_level.assert_awaited_once_with(18)
     r._radio.set_attenuator.assert_awaited_once_with(True)
@@ -155,6 +156,35 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
     )
     r._radio.set_scope_mode.assert_awaited_once_with(3)
     r._radio.set_scope_span.assert_awaited_once_with(6)
+    r._loop.close()
+
+
+def test_vfo_dispatch_single_rx_uses_ab_methods() -> None:
+    """On single-RX profiles (e.g. IC-7300, addr=0x94), ``vfo_equalize`` /
+    ``vfo_exchange`` route to ``equalize_vfo_ab(0)`` / ``swap_vfo_ab(0)``.
+    """
+    r = IcomRadio("127.0.0.1", radio_addr=0x94)  # IC-7300 → receiver_count=1
+    r._radio.connect = AsyncMock()
+    r._radio.disconnect = AsyncMock()
+    # Make radio appear connected so guards do not raise
+    r._radio._ctrl_transport = MagicMock()
+    r._radio._ctrl_transport._udp_transport = MagicMock()
+    r._radio._civ_transport = MagicMock()
+    r._radio._conn_state = RadioConnectionState.CONNECTED
+    r._radio.equalize_vfo_ab = AsyncMock()
+    r._radio.swap_vfo_ab = AsyncMock()
+    # Canonical dual-RX methods must NOT be touched on a single-RX rig
+    r._radio.equalize_main_sub = AsyncMock()
+    r._radio.swap_main_sub = AsyncMock()
+
+    assert r._radio.profile.receiver_count == 1
+    r.vfo_equalize()
+    r.vfo_exchange()
+
+    r._radio.equalize_vfo_ab.assert_awaited_once_with(0)
+    r._radio.swap_vfo_ab.assert_awaited_once_with(0)
+    r._radio.equalize_main_sub.assert_not_awaited()
+    r._radio.swap_main_sub.assert_not_awaited()
     r._loop.close()
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -348,8 +348,15 @@ def mock_radio() -> MagicMock:
     radio.set_preamp = AsyncMock()
     radio.set_vfo = AsyncMock()
     radio.vfo_swap = AsyncMock()
+    # ``vfo_exchange`` / ``vfo_equalize`` are kept here so the radio still
+    # satisfies the ``DualReceiverCapable`` Protocol (#1113 migrated callers
+    # but the Protocol declarations are untouched until PR-22 / #1114).
     radio.vfo_exchange = AsyncMock()
     radio.vfo_equalize = AsyncMock()
+    # Canonical dual-RX VFO methods (post-#1113 migration); the radio_poller
+    # invokes ``swap_main_sub`` / ``equalize_main_sub`` directly now.
+    radio.swap_main_sub = AsyncMock()
+    radio.equalize_main_sub = AsyncMock()
     radio.vfo_a_equals_b = AsyncMock()
     radio.set_main_sub_tracking = AsyncMock()
     radio.get_main_sub_tracking = AsyncMock(return_value=False)
@@ -870,7 +877,10 @@ class TestControlChannel:
             assert resp["ok"] is True
             # vfo_swap goes through command queue; wait for poller to drain it
             await asyncio.sleep(0.05)
-            mock_radio.vfo_exchange.assert_awaited_once()
+            # #1113: the poller dispatches to ``swap_main_sub`` directly on
+            # dual-RX rigs; the deprecated ``vfo_exchange`` alias is no longer
+            # called from the poller path.
+            mock_radio.swap_main_sub.assert_awaited_once()
         finally:
             await _close_ws(writer)
 
@@ -2439,8 +2449,14 @@ class TestRadioPoller:
         radio.set_freq = AsyncMock()
         radio.set_mode = AsyncMock()
         radio.set_ptt = AsyncMock()
+        # Keep the deprecated aliases so the radio still satisfies
+        # ``DualReceiverCapable`` (Protocol untouched until #1114).
         radio.vfo_exchange = AsyncMock()
         radio.vfo_equalize = AsyncMock()
+        # Canonical dual-RX VFO methods (post-#1113); poller calls these
+        # directly now instead of the deprecated aliases.
+        radio.swap_main_sub = AsyncMock()
+        radio.equalize_main_sub = AsyncMock()
         radio.send_civ = AsyncMock()  # RadioPoller now calls send_civ directly
         radio.state_cache = StateCache()
         return radio
@@ -2630,8 +2646,12 @@ class TestSwitchScopeReceiver:
         radio.set_nr = AsyncMock()
         radio.set_digisel = AsyncMock()
         radio.set_ip_plus = AsyncMock()
+        # Keep deprecated aliases for ``DualReceiverCapable`` compliance.
         radio.vfo_exchange = AsyncMock()
         radio.vfo_equalize = AsyncMock()
+        # Canonical dual-RX VFO methods (post-#1113).
+        radio.swap_main_sub = AsyncMock()
+        radio.equalize_main_sub = AsyncMock()
         return radio
 
     async def test_switch_scope_receiver_main_sends_civ(self) -> None:


### PR DESCRIPTION
Closes #1113

## Summary

Migrate the three remaining live callers off the deprecated `vfo_exchange` / `vfo_equalize` aliases (deprecated since v0.17, slated for removal in v0.19 per Q4 author decision). The `IcomRadio.vfo_exchange` / `vfo_equalize` aliases and the `DualReceiverCapable` Protocol declarations remain untouched — their removal is the next step (PR-22 / **#1114**, which depends on this PR landing first).

## Changes

- **`web/radio_poller.py`** — `VfoSwap` / `VfoEqualize` now call `swap_main_sub` / `equalize_main_sub` directly under the existing `CAP_DUAL_RX` guard.
- **`profiles_runtime.apply_profile`** — replaces the `hasattr(radio, "vfo_equalize")` probe with a profile-guarded dispatch (`equalize_main_sub` on dual-RX, `equalize_vfo_ab(0)` on single-RX). Tolerates duck-typed radios that don't expose `profile`.
- **`sync.IcomRadio.vfo_equalize` / `vfo_exchange`** — public sync API kept; internal dispatch routes to the canonical async methods via `self._radio.profile.receiver_count`.

## Verification

After this change, the only `DeprecationWarning` emissions left in the test suite come from `test_radio_extended.py` and `test_vfo_dual_watch.py`, which intentionally exercise the alias methods. With `-W error::DeprecationWarning`, all 4788 non-deselected tests pass.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4792 passed, 0 failed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/ -W error::DeprecationWarning` (with the four alias-deprecation tests deselected) — 4788 passed
- [x] New focused unit tests cover dual-RX, single-RX, and no-method fallback paths in `apply_profile`
- [x] New single-RX dispatch test added to `tests/test_sync_coverage.py` (IC-7300, addr=0x94)

## Blocks / unblocks

- **Prerequisite for #1114** (PR-22 — alias and Protocol declaration removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)