### PR TITLE
refactor(api): lift get_rf_power into PowerControlCapable

### DIFF
--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -324,7 +324,14 @@ class MetersCapable(Protocol):
         ...
 
     async def get_rf_power(self) -> int:
-        """Get TX power level (0-255 normalised scale)."""
+        """Get TX power level (0-255 normalised scale).
+
+        .. deprecated::
+            Redundant with :meth:`PowerControlCapable.get_rf_power`. Kept here
+            to preserve ``isinstance(radio, MetersCapable)`` checks. New code
+            should program against :class:`PowerControlCapable`, which exposes
+            both ``get_rf_power`` and ``set_rf_power`` together.
+        """
         ...
 
     async def get_comp_meter(self) -> int:
@@ -357,6 +364,15 @@ class PowerControlCapable(Protocol):
 
         Args:
             on: True to power on, False to power off.
+        """
+        ...
+
+    async def get_rf_power(self) -> int:
+        """Get TX power level (0-255 normalised scale).
+
+        Paired with :meth:`set_rf_power`. Also declared on
+        :class:`MetersCapable` for backwards compatibility with existing
+        ``isinstance`` checks.
         """
         ...
 

--- a/tests/test_radio_protocol.py
+++ b/tests/test_radio_protocol.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from icom_lan.radio_protocol import Radio
+from icom_lan.radio_protocol import MetersCapable, PowerControlCapable, Radio
 from icom_lan.radio_state import RadioState
 
 
@@ -63,3 +63,42 @@ def test_backend_id_known_values() -> None:
     """backend_id can hold any of the documented family values."""
     known_ids = {"icom_lan", "icom_serial", "yaesu_cat"}
     assert _StubRadio().backend_id in known_ids
+
+
+class _PowerStub:
+    """Stub implementing both PowerControlCapable and MetersCapable surfaces.
+
+    Verifies that ``get_rf_power`` declared on PowerControlCapable does not
+    break the duplicate declaration on MetersCapable — both ``isinstance``
+    checks must still pass for backends that implement the read+write pair.
+    """
+
+    async def get_powerstat(self) -> bool: return True
+    async def set_powerstat(self, on: bool) -> None: ...
+    async def get_rf_power(self) -> int: return 128
+    async def set_rf_power(self, level: int) -> None: ...
+    # MetersCapable surface
+    async def get_s_meter(self, receiver: int = 0) -> int: return 0
+    async def get_swr(self) -> float: return 1.0
+    async def get_comp_meter(self) -> int: return 0
+    async def get_id_meter(self) -> int: return 0
+    async def get_vd_meter(self) -> int: return 0
+
+
+def test_get_rf_power_visible_on_power_control_capable() -> None:
+    """get_rf_power is reachable through a PowerControlCapable typed reference.
+
+    The declaration was lifted into PowerControlCapable so the read+write pair
+    lives together, while remaining declared on MetersCapable for backwards
+    compatibility (refs #1109).
+    """
+    stub: PowerControlCapable = _PowerStub()
+    assert hasattr(stub, "get_rf_power")
+    assert hasattr(stub, "set_rf_power")
+
+
+def test_power_stub_satisfies_both_protocols() -> None:
+    """A radio implementing get_rf_power satisfies both protocols."""
+    stub = _PowerStub()
+    assert isinstance(stub, PowerControlCapable)
+    assert isinstance(stub, MetersCapable)


### PR DESCRIPTION
Closes #1109

## Summary

- Add `get_rf_power` declaration to `PowerControlCapable` so the read+write pair (`get_rf_power` / `set_rf_power`) lives together on the same capability protocol.
- Retain the redundant `MetersCapable.get_rf_power` declaration to preserve existing `isinstance(radio, MetersCapable)` checks; flag it in the docstring as redundant and point at `PowerControlCapable` as the preferred surface for new code.
- Purely additive declaration lift — backends already implement `get_rf_power`, so no runtime behavior changes.

## Refs

- Synthesis: Phase E, PR-17 + Cross-conflict §9
- Audit: `api-audit/12-tx-power.md`
- Parent epic: #1096

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4790 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] New test `test_power_stub_satisfies_both_protocols` asserts a stub implementing `get_rf_power` satisfies both `PowerControlCapable` and `MetersCapable` `isinstance` checks
- [x] New test `test_get_rf_power_visible_on_power_control_capable` asserts `get_rf_power` is reachable through a `PowerControlCapable`-typed reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)