### PR TITLE
feat(api): unify CwControlCapable break-in surface + FTX-1 capability

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -38,6 +38,7 @@ features = [
     "compressor",
     # "monitor",  # ML; rejected by FTX-1 (not supported via CAT)
     "cw",
+    "break_in",
     "rit",
     "tuner",
     "meters",

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from ...audio import AudioPacket
 from ...audio.usb_driver import UsbAudioDriver
 from ...command_spec import CatCommandSpec
-from ...types import AudioCodec
+from ...types import AudioCodec, BreakInMode
 from ...exceptions import AudioFormatError, CommandError
 from ...exceptions import ConnectionError as RadioConnectionError
 from ...radio_state import RadioState
@@ -1151,14 +1151,27 @@ class YaesuCatRadio:
         """Set CW pitch index (0–75)."""
         await self._write("set_key_pitch", idx=idx)
 
-    async def get_break_in(self) -> bool:
-        """Get CW break-in state."""
-        result = await self._query("get_break_in")
-        return bool(result["state"] == "1")
+    async def get_break_in(self) -> BreakInMode:
+        """Get CW break-in mode.
 
-    async def set_break_in(self, state: bool) -> None:
-        """Set CW break-in state."""
-        await self._write("set_break_in", state="1" if state else "0")
+        FTX-1 CAT exposes only binary on/off; map ``"1"`` to
+        :attr:`BreakInMode.SEMI` and ``"0"`` to :attr:`BreakInMode.OFF`.
+        :class:`BreakInMode` is an :class:`IntEnum` and remains
+        bool-compatible at runtime.
+        """
+        result = await self._query("get_break_in")
+        return BreakInMode.SEMI if result["state"] == "1" else BreakInMode.OFF
+
+    async def set_break_in(self, mode: BreakInMode | int | bool) -> None:
+        """Set CW break-in mode.
+
+        FTX-1 CAT supports binary on/off only — :attr:`BreakInMode.OFF`
+        maps to ``"0"`` and any non-OFF value (``SEMI``/``FULL``) maps
+        to ``"1"``. ``bool`` values remain accepted for backward
+        compatibility (``False``/``True`` → ``OFF``/``SEMI``).
+        """
+        on = BreakInMode(int(mode)) != BreakInMode.OFF
+        await self._write("set_break_in", state="1" if on else "0")
 
     async def get_cw_spot(self) -> bool:
         """Get CW spot tone state."""

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, runtime_checkable
 
 from .radio_state import RadioState, VfoSlotState
-from .types import Mode
+from .types import BreakInMode, Mode
 
 if TYPE_CHECKING:
     from ._state_cache import StateCache
@@ -773,13 +773,31 @@ class AntennaControlCapable(Protocol):
 
 @runtime_checkable
 class CwControlCapable(Protocol):
-    """CW text, key speed, pitch, dash ratio, break-in delay."""
+    """CW text, key speed, pitch, dash ratio, break-in mode/delay."""
 
     async def send_cw_text(self, text: str) -> None: ...
     async def stop_cw_text(self) -> None: ...
 
     async def get_cw_pitch(self) -> int: ...
     async def set_cw_pitch(self, freq: int) -> None: ...
+
+    async def get_break_in(self) -> BreakInMode:
+        """Get CW break-in mode (OFF/SEMI/FULL).
+
+        Backends that only expose binary on/off (e.g. Yaesu CAT) map
+        ``False`` to :attr:`BreakInMode.OFF` and ``True`` to
+        :attr:`BreakInMode.SEMI`. :class:`BreakInMode` is an :class:`IntEnum`
+        and remains bool-compatible at runtime.
+        """
+        ...
+
+    async def set_break_in(self, mode: BreakInMode | int) -> None:
+        """Set CW break-in mode (accepts :class:`BreakInMode` or int).
+
+        Backends that only expose binary on/off (e.g. Yaesu CAT) treat
+        :attr:`BreakInMode.OFF` as off and any other value as on.
+        """
+        ...
 
     async def set_break_in_delay(self, level: int) -> None:
         """Set CW break-in delay (0-255)."""

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -768,8 +768,60 @@ async def test_set_break_in_delay(connected_radio):
 
 @pytest.mark.asyncio
 async def test_get_break_in(connected_radio):
+    from icom_lan.types import BreakInMode
+
     connected_radio._transport.query = AsyncMock(return_value="BI1")
-    assert await connected_radio.get_break_in() is True
+    result = await connected_radio.get_break_in()
+    assert result == BreakInMode.SEMI
+    # IntEnum stays bool-compatible at runtime.
+    assert bool(result) is True
+
+
+@pytest.mark.asyncio
+async def test_get_break_in_off_maps_to_off(connected_radio):
+    from icom_lan.types import BreakInMode
+
+    connected_radio._transport.query = AsyncMock(return_value="BI0")
+    result = await connected_radio.get_break_in()
+    assert result == BreakInMode.OFF
+    assert bool(result) is False
+
+
+@pytest.mark.asyncio
+async def test_set_break_in_accepts_break_in_mode(connected_radio):
+    from icom_lan.types import BreakInMode
+
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_break_in(BreakInMode.SEMI)
+    connected_radio._transport.write.assert_called_once_with("BI1;")
+
+
+@pytest.mark.asyncio
+async def test_set_break_in_full_maps_to_on(connected_radio):
+    from icom_lan.types import BreakInMode
+
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_break_in(BreakInMode.FULL)
+    connected_radio._transport.write.assert_called_once_with("BI1;")
+
+
+@pytest.mark.asyncio
+async def test_set_break_in_off_maps_to_off(connected_radio):
+    from icom_lan.types import BreakInMode
+
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_break_in(BreakInMode.OFF)
+    connected_radio._transport.write.assert_called_once_with("BI0;")
+
+
+@pytest.mark.asyncio
+async def test_set_break_in_accepts_bool_for_backward_compat(connected_radio):
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_break_in(True)
+    connected_radio._transport.write.assert_called_once_with("BI1;")
+    connected_radio._transport.write.reset_mock()
+    await connected_radio.set_break_in(False)
+    connected_radio._transport.write.assert_called_once_with("BI0;")
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1841,6 +1841,61 @@ class TestTransceiverStatusParity:
         assert mock_transport.sent_packets[-1].endswith(expected_tail)
 
 
+class TestBreakInModeRoundTrip:
+    """Issue #1100 — CwControlCapable.get_break_in/set_break_in type contract.
+
+    Both Icom and Yaesu backends must agree on the :class:`BreakInMode`
+    enum return type. Icom exposes the full 3-state enum; Yaesu maps
+    ``False`` ↔ ``OFF`` and ``True`` ↔ ``SEMI`` while keeping
+    bool-compatibility at runtime (``IntEnum``).
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            (b"\x00", BreakInMode.OFF),
+            (b"\x01", BreakInMode.SEMI),
+            (b"\x02", BreakInMode.FULL),
+        ],
+    )
+    async def test_icom_get_break_in_returns_enum(
+        self,
+        radio: IcomRadio,
+        mock_transport: MockTransport,
+        payload: bytes,
+        expected: BreakInMode,
+    ) -> None:
+        mock_transport.queue_response(_function_response(0x47, payload))
+        result = await radio.get_break_in()
+        assert result == expected
+        assert isinstance(result, BreakInMode)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("value", "expected_byte"),
+        [
+            (BreakInMode.OFF, 0x00),
+            (BreakInMode.SEMI, 0x01),
+            (BreakInMode.FULL, 0x02),
+            (0, 0x00),
+            (1, 0x01),
+            (2, 0x02),
+        ],
+    )
+    async def test_icom_set_break_in_accepts_int_or_enum(
+        self,
+        radio: IcomRadio,
+        mock_transport: MockTransport,
+        value: BreakInMode | int,
+        expected_byte: int,
+    ) -> None:
+        await radio.set_break_in(value)
+        assert mock_transport.sent_packets[-1].endswith(
+            bytes([0x16, 0x47, expected_byte, 0xFD])
+        )
+
+
 class TestToneTsqlParity:
     """Test high-level tone/TSQL parity methods (#134)."""
 


### PR DESCRIPTION
## Summary

- Adds `get_break_in() -> BreakInMode` and `set_break_in(mode: BreakInMode | int)` to `CwControlCapable`. Both backends already implemented these but with type mismatch — Icom returned the 3-state `BreakInMode` IntEnum, Yaesu returned plain `bool`. Reconciled to `BreakInMode`; Yaesu maps `BI0/BI1` ↔ `OFF/SEMI` and accepts `bool`/`int`/`BreakInMode` for backward compat. `IntEnum` keeps existing bool-truthy callers working.
- Adds `"break_in"` to `rigs/ftx1.toml` capability list — fixes **P2-03**: web `_ensure_capability` was rejecting break-in commands on FTX-1 even though the Yaesu backend supports them.

## Spec deviation (please confirm)

The issue body listed `receiver: int = 0` kwargs on the new protocol methods. I dropped them because:

1. Every sibling method in `CwControlCapable` (`set_break_in_delay`, `set_dash_ratio`, `set_key_speed`, …) is rig-global with no `receiver` arg.
2. The existing `IcomRadio.get_break_in` / `set_break_in` (radio.py:2240) and `YaesuCat.get_break_in` / `set_break_in` (yaesu_cat/radio.py:1154) take no `receiver` kwarg either. Adding the kwarg only to the protocol would break structural compatibility; adding it to the backends too would expand scope to a 4th file.
3. CW break-in is per-transceiver state on every supported rig, not per-receiver.

Happy to revisit if the architecture audit really meant per-receiver routing.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4802 passed
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] New `TestBreakInModeRoundTrip` in `tests/test_radio.py` covers Icom 3-state enum round-trip (`OFF`/`SEMI`/`FULL` for both `get_*` and `set_*`, plus `int` accepted by setter).
- [x] New tests in `tests/test_ftx1_radio.py` cover Yaesu `BI0`↔`OFF`, `BI1`↔`SEMI`, `FULL`→`BI1` (graceful downgrade), and bool back-compat (`True`/`False`).
- [ ] Manual smoke: hit FTX-1 break-in toggle in the web UI (was previously rejected).

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)