### PR TITLE
refactor(api): extract RitXitCapable from TransceiverStatusCapable + RMW fix

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/poller.py
+++ b/src/icom_lan/backends/yaesu_cat/poller.py
@@ -418,13 +418,13 @@ class YaesuCatPoller:
 
                 # ── RIT / Clarifier ──
                 case SetRitStatus(on=on):
-                    # RX clarifier only; TX clarifier left unchanged
-                    await radio.set_clarifier(rx_clar=on, tx_clar=False)
+                    # Canonical name; read-modify-write preserves XIT bit.
+                    await radio.set_rit_status(on)
                 case SetRitTxStatus(on=on):
-                    # TX clarifier only; RX clarifier left unchanged
-                    await radio.set_clarifier(rx_clar=False, tx_clar=on)
+                    # Canonical name; read-modify-write preserves RIT bit.
+                    await radio.set_rit_tx_status(on)
                 case SetRitFrequency(freq=freq):
-                    await radio.set_clarifier_freq(freq)
+                    await radio.set_rit_frequency(freq)
 
                 # ── Data Mode ──
                 case SetDataMode(mode=mode):

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -1296,6 +1296,39 @@ class YaesuCatRadio:
         sign = "+" if offset >= 0 else "-"
         await self._write("set_clarifier_freq", sign=sign, offset=abs(offset))
 
+    # -- Canonical RIT/XIT surface (RitXitCapable) --------------------------
+    # Cross-vendor names that delegate to the *_clarifier* CAT helpers.
+    # set_rit_status / set_rit_tx_status do read-modify-write on CF000 so a
+    # single-bit setter does not clobber the other bit (P1-02 fix).
+
+    async def get_rit_frequency(self) -> int:
+        """Get RIT frequency offset in Hz (signed)."""
+        return await self.get_clarifier_freq()
+
+    async def set_rit_frequency(self, freq_hz: int) -> None:
+        """Set RIT frequency offset in Hz (signed). Fire-and-forget."""
+        await self.set_clarifier_freq(freq_hz)
+
+    async def get_rit_status(self) -> bool:
+        """Get RIT (RX clarifier) on/off status."""
+        rx_clar, _tx_clar = await self.get_clarifier()
+        return rx_clar
+
+    async def set_rit_status(self, on: bool) -> None:
+        """Set RIT (RX clarifier) on/off — preserves XIT bit (read-modify-write)."""
+        _rx_clar, tx_clar = await self.get_clarifier()
+        await self.set_clarifier(rx_clar=on, tx_clar=tx_clar)
+
+    async def get_rit_tx_status(self) -> bool:
+        """Get RIT TX / XIT (TX clarifier) on/off status."""
+        _rx_clar, tx_clar = await self.get_clarifier()
+        return tx_clar
+
+    async def set_rit_tx_status(self, on: bool) -> None:
+        """Set RIT TX / XIT on/off — preserves RIT bit (read-modify-write)."""
+        rx_clar, _tx_clar = await self.get_clarifier()
+        await self.set_clarifier(rx_clar=rx_clar, tx_clar=on)
+
     # -- D9: Tone/TSQL ------------------------------------------------------
 
     async def get_sql_type(self, receiver: int = 0) -> int:

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -77,6 +77,7 @@ __all__ = [
     "PowerControlCapable",
     "SplitCapable",
     "StateNotifyCapable",
+    "RitXitCapable",
     "TransceiverStatusCapable",
     "MemoryCapable",
 ]
@@ -1087,8 +1088,13 @@ class AdvancedControlCapable(
 
 
 @runtime_checkable
-class TransceiverStatusCapable(Protocol):
-    """Radio supports RIT/XIT and transceiver status queries (M4 transceiver_status family)."""
+class RitXitCapable(Protocol):
+    """Radio supports RIT/XIT (a.k.a. clarifier) frequency offset and on/off control.
+
+    Cross-vendor surface: Icom calls this RIT/XIT, Yaesu calls it the
+    "clarifier" — semantically identical six-method contract on every HF
+    rig in the project (IC-7610, IC-7300, IC-705, IC-9700, FTX-1).
+    """
 
     async def get_rit_frequency(self) -> int:
         """Get RIT frequency offset in Hz."""
@@ -1113,6 +1119,15 @@ class TransceiverStatusCapable(Protocol):
     async def set_rit_tx_status(self, on: bool) -> None:
         """Set RIT TX (XIT) on/off status."""
         ...
+
+
+@runtime_checkable
+class TransceiverStatusCapable(Protocol):
+    """Radio supports TX frequency monitor (M4 transceiver_status family).
+
+    RIT/XIT lives in :class:`RitXitCapable` — the two were previously bundled
+    here but have unrelated semantics.
+    """
 
     async def get_tx_freq_monitor(self) -> bool:
         """Get TX frequency monitor on/off status."""

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -916,6 +916,76 @@ async def test_reset_clarifier(connected_radio):
 
 
 # ---------------------------------------------------------------------------
+# Canonical RIT/XIT surface (RitXitCapable) — delegates to *_clarifier* helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_rit_frequency_delegates(connected_radio):
+    connected_radio._transport.query = AsyncMock(return_value="CF001-0250")
+    assert await connected_radio.get_rit_frequency() == -250
+
+
+@pytest.mark.asyncio
+async def test_set_rit_frequency_delegates(connected_radio):
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_rit_frequency(600)
+    connected_radio._transport.write.assert_called_once_with("CF001+0600;")
+
+
+@pytest.mark.asyncio
+async def test_get_rit_status_returns_rx_bit(connected_radio):
+    connected_radio._transport.query = AsyncMock(return_value="CF00010000")
+    assert await connected_radio.get_rit_status() is True
+
+
+@pytest.mark.asyncio
+async def test_get_rit_tx_status_returns_tx_bit(connected_radio):
+    # CF000 layout: CF000 + {rx:1d} + {tx:1d} + {pad:03d}
+    connected_radio._transport.query = AsyncMock(return_value="CF00001000")
+    assert await connected_radio.get_rit_tx_status() is True
+
+
+@pytest.mark.asyncio
+async def test_set_rit_status_preserves_xit(connected_radio):
+    """P1-02 fix: enabling RIT must not clobber an active XIT bit."""
+    # Rig currently reports RIT=off, XIT=on (CF000 = 0 1 000).
+    connected_radio._transport.query = AsyncMock(return_value="CF00001000")
+    connected_radio._transport.write = AsyncMock()
+
+    await connected_radio.set_rit_status(True)
+
+    # Wire frame must carry RX=1, TX=1 — XIT bit preserved by RMW.
+    connected_radio._transport.write.assert_called_once_with("CF00011000;")
+
+
+@pytest.mark.asyncio
+async def test_set_rit_tx_status_preserves_rit(connected_radio):
+    """P1-02 fix: enabling XIT must not clobber an active RIT bit."""
+    # Rig currently reports RIT=on, XIT=off (CF000 = 1 0 000).
+    connected_radio._transport.query = AsyncMock(return_value="CF00010000")
+    connected_radio._transport.write = AsyncMock()
+
+    await connected_radio.set_rit_tx_status(True)
+
+    # Wire frame must carry RX=1, TX=1 — RIT bit preserved by RMW.
+    connected_radio._transport.write.assert_called_once_with("CF00011000;")
+
+
+@pytest.mark.asyncio
+async def test_set_rit_status_off_preserves_xit(connected_radio):
+    """RMW symmetry: turning RIT off must not flip XIT off too."""
+    # Rig currently reports RIT=on, XIT=on (CF000 = 1 1 000).
+    connected_radio._transport.query = AsyncMock(return_value="CF00011000")
+    connected_radio._transport.write = AsyncMock()
+
+    await connected_radio.set_rit_status(False)
+
+    # XIT must remain set: RX=0, TX=1.
+    connected_radio._transport.write.assert_called_once_with("CF00001000;")
+
+
+# ---------------------------------------------------------------------------
 # APF (Audio Peak Filter, CO02/CO03)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_radio_protocol.py
+++ b/tests/test_radio_protocol.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
+from icom_lan import radio_protocol
 from icom_lan.radio_protocol import (
     MetersCapable,
     PowerControlCapable,
     Radio,
+    RitXitCapable,
+    TransceiverStatusCapable,
     VoiceControlCapable,
 )
 from icom_lan.radio_state import RadioState
@@ -211,3 +214,69 @@ def test_voice_compressor_round_trip_protocol_typed() -> None:
     initial, after = asyncio.run(_voice_compressor_round_trip(stub))
     assert initial is False
     assert after is True
+
+
+# ---------------------------------------------------------------------------
+# RitXitCapable / TransceiverStatusCapable split (issue #1099)
+# ---------------------------------------------------------------------------
+
+
+class _RitXitStub:
+    """Minimal stub that satisfies RitXitCapable (six methods)."""
+
+    async def get_rit_frequency(self) -> int: return 0
+    async def set_rit_frequency(self, freq_hz: int) -> None: ...
+    async def get_rit_status(self) -> bool: return False
+    async def set_rit_status(self, on: bool) -> None: ...
+    async def get_rit_tx_status(self) -> bool: return False
+    async def set_rit_tx_status(self, on: bool) -> None: ...
+
+
+class _TxMonitorStub:
+    """Minimal stub that satisfies the reduced TransceiverStatusCapable."""
+
+    async def get_tx_freq_monitor(self) -> bool: return False
+    async def set_tx_freq_monitor(self, on: bool) -> None: ...
+
+
+class _IcomLikeStub(_RitXitStub, _TxMonitorStub):
+    """Stub mimicking IcomRadio: satisfies BOTH protocols simultaneously."""
+
+
+def test_ritxit_capable_in_all() -> None:
+    """The new RitXitCapable protocol is publicly exported."""
+    assert "RitXitCapable" in radio_protocol.__all__
+
+
+def test_ritxit_capable_isinstance() -> None:
+    """A class implementing the six RIT/XIT methods satisfies RitXitCapable."""
+    assert isinstance(_RitXitStub(), RitXitCapable)
+
+
+def test_transceiver_status_capable_only_tx_monitor() -> None:
+    """TransceiverStatusCapable is now only the tx_freq_monitor pair."""
+    assert isinstance(_TxMonitorStub(), TransceiverStatusCapable)
+    # A stub with only RIT methods must NOT satisfy TransceiverStatusCapable.
+    assert not isinstance(_RitXitStub(), TransceiverStatusCapable)
+
+
+def test_icom_like_stub_satisfies_both_protocols() -> None:
+    """IcomRadio-shaped class satisfies both RitXitCapable and TransceiverStatusCapable."""
+    stub = _IcomLikeStub()
+    assert isinstance(stub, RitXitCapable)
+    assert isinstance(stub, TransceiverStatusCapable)
+
+
+def test_yaesu_cat_radio_satisfies_ritxit_capable() -> None:
+    """YaesuCatRadio class declares the canonical six methods (PR-7 migration)."""
+    from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
+
+    for name in (
+        "get_rit_frequency",
+        "set_rit_frequency",
+        "get_rit_status",
+        "set_rit_status",
+        "get_rit_tx_status",
+        "set_rit_tx_status",
+    ):
+        assert hasattr(YaesuCatRadio, name), f"YaesuCatRadio missing {name}"


### PR DESCRIPTION
## Summary

- Split the six `*_rit_*` declarations out of `TransceiverStatusCapable` into a new focused `RitXitCapable` Protocol; `TransceiverStatusCapable` now only covers `get/set_tx_freq_monitor`.
- `YaesuCatRadio` now exposes the canonical six methods (`get/set_rit_frequency`, `get/set_rit_status`, `get/set_rit_tx_status`) that delegate to the existing `*_clarifier*` CAT helpers, so the Yaesu backend satisfies `RitXitCapable` cross-vendor.
- **Fixes P1-02**: the new `YaesuCatRadio.set_rit_status` / `set_rit_tx_status` do read-modify-write on CF000 first, so a single-bit setter no longer clobbers the other RX/TX bit. Migrated the Yaesu poller's `SetRit*` dispatch (`backends/yaesu_cat/poller.py:462–469`) to call the canonical names — that removes the latent bug where `SetRitStatus` / `SetRitTxStatus` always wrote `False` for the unaffected channel.
- The CAT-level `*_clarifier*` helpers and the Yaesu poller's GET path (`radio.get_clarifier()` / `radio.get_clarifier_freq()`) are intentionally left in place; they are the delegate targets and are still exercised directly by `tests/test_ftx1_radio.py`.

Refs synthesis Phase B / PR-7 and audit `api-audit/03-clarifier.md`.

Closes #1099

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4800 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] New unit tests cover:
  - `isinstance` against both `RitXitCapable` and reduced `TransceiverStatusCapable`
  - `RitXitCapable` is exported from `radio_protocol.__all__`
  - `YaesuCatRadio` declares the canonical six methods
  - `set_rit_status(True)` while XIT is on → wire frame keeps XIT set (RMW)
  - `set_rit_tx_status(True)` while RIT is on → wire frame keeps RIT set (RMW)
  - `set_rit_status(False)` while both are armed → XIT preserved
  - `get_rit_status` / `get_rit_tx_status` / `get_rit_frequency` / `set_rit_frequency` delegate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)