### PR TITLE
feat(api): AudioCapable codec + sample_rate properties + Yaesu sample_rate fix

### DIFF
--- a/src/icom_lan/_audio_runtime_mixin.py
+++ b/src/icom_lan/_audio_runtime_mixin.py
@@ -22,7 +22,7 @@ from ._audio_transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
 from .audio import AudioStats, AudioStream
 from .exceptions import ConnectionError
 from .transport import IcomTransport
-from .types import AudioCapabilities, AudioCodec, get_audio_capabilities
+from .types import AudioCodec
 
 logger = logging.getLogger(__name__)
 
@@ -445,11 +445,6 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     def audio_sample_rate(self) -> int:
         """Configured audio sample rate in Hz."""
         return self._audio_sample_rate
-
-    @staticmethod
-    def audio_capabilities() -> AudioCapabilities:
-        """Return icom-lan audio capabilities and deterministic defaults."""
-        return get_audio_capabilities()
 
     async def _ensure_audio_transport(self) -> None:
         """Connect the audio transport if not already connected."""

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -239,6 +239,11 @@ class YaesuCatRadio:
         return AudioCodec.PCM_1CH_16BIT
 
     @property
+    def audio_sample_rate(self) -> int:
+        """Configured audio sample rate in Hz (default 48000)."""
+        return self._audio_sample_rate
+
+    @property
     def audio_bus(self) -> "AudioBus":
         """AudioBus instance for pub/sub audio distribution."""
         if self._audio_bus is None:

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, runtime_checkable
 
 from .radio_state import RadioState, VfoSlotState
-from .types import BreakInMode, Mode
+from .types import AudioCodec, BreakInMode, Mode
 
 if TYPE_CHECKING:
     from ._state_cache import StateCache
@@ -486,6 +486,26 @@ class AudioCapable(Protocol):
         Returns an :class:`~icom_lan.audio_bus.AudioBus` that manages
         subscriptions and automatically starts/stops the radio's audio
         stream based on subscriber count.
+        """
+        ...
+
+    @property
+    def audio_codec(self) -> AudioCodec:
+        """Configured audio codec for the radio's audio stream.
+
+        Backends fix this once at construction time (e.g. Yaesu USB-audio
+        always reports :attr:`~icom_lan.types.AudioCodec.PCM_1CH_16BIT`);
+        Icom LAN backends honour the value supplied to the constructor.
+        """
+        ...
+
+    @property
+    def audio_sample_rate(self) -> int:
+        """Configured audio sample rate in Hz.
+
+        Used by the web audio broadcaster to clock the relay correctly
+        (see ``web/handlers/audio.py``); a missing property would silently
+        fall back to a default rate and mis-clock playback.
         """
         ...
 

--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -23,7 +23,7 @@ from .ic705 import (
 )
 from .radio import IcomRadio as _AsyncIcomRadio, _DEFAULT_AUDIO_CODEC  # noqa: TID251
 from .capabilities import CAP_METERS, CAP_POWER_CONTROL
-from .types import AudioCapabilities, AudioCodec, Mode, ScopeCompletionPolicy
+from .types import AudioCodec, Mode, ScopeCompletionPolicy
 
 T = TypeVar("T")
 
@@ -485,8 +485,3 @@ class IcomRadio:
     def audio_sample_rate(self) -> int:
         """Configured audio sample rate."""
         return self._radio.audio_sample_rate
-
-    @staticmethod
-    def audio_capabilities() -> AudioCapabilities:
-        """Return icom-lan audio capabilities and deterministic defaults."""
-        return _AsyncIcomRadio.audio_capabilities()

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -74,7 +74,9 @@ class TestAudioCapabilities:
         assert caps.default_channels in caps.supported_channels
 
     def test_radio_exposes_audio_capabilities(self) -> None:
-        caps = IcomRadio.audio_capabilities()
+        # ``audio_capabilities()`` was removed from the class surface in #1106.
+        # The module-level helper remains the single source of truth.
+        caps = get_audio_capabilities()
         assert caps == get_audio_capabilities()
 
     def test_to_dict_json_shape(self) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -67,7 +67,9 @@ class TestSyncAudioNaming:
         r._loop.close()
 
     def test_audio_capabilities(self) -> None:
-        caps = IcomRadio.audio_capabilities()
+        from icom_lan.types import get_audio_capabilities
+
+        caps = get_audio_capabilities()
         assert caps.default_codec.name == "PCM_2CH_16BIT"
         assert caps.default_sample_rate_hz == 48000
         assert caps.default_channels == 2

--- a/tests/test_yaesu_audio.py
+++ b/tests/test_yaesu_audio.py
@@ -140,6 +140,52 @@ class TestAudioCodecProperty:
 
 
 # ---------------------------------------------------------------------------
+# audio_sample_rate property — regression guard for #1106 / P2-02
+# ---------------------------------------------------------------------------
+
+
+class TestAudioSampleRateProperty:
+    """Regression guard for issue #1106 (P2-02).
+
+    Before the fix the Yaesu backend stored ``_audio_sample_rate`` but did
+    not expose it as a property, so ``getattr(radio, "audio_sample_rate", None)``
+    returned ``None`` in :mod:`icom_lan.web.handlers.audio` and the relay
+    fell back to a default rate, mis-clocking FTX-1 audio.
+    """
+
+    def test_default_returns_48000(self, radio: YaesuCatRadio) -> None:
+        assert radio.audio_sample_rate == 48000
+
+    def test_custom_value_is_exposed(self) -> None:
+        r = YaesuCatRadio(
+            device="/dev/fake0",
+            audio_driver=FakeAudioDriver(),  # type: ignore[arg-type]
+            audio_sample_rate=44100,
+        )
+        assert r.audio_sample_rate == 44100
+
+    def test_getattr_does_not_fallback(self, radio: YaesuCatRadio) -> None:
+        # The web audio broadcaster relies on this exact pattern; ensure it
+        # never returns ``None`` again (the bug under P2-02).
+        sr = getattr(radio, "audio_sample_rate", None)
+        assert sr is not None
+        assert isinstance(sr, int)
+        assert sr > 0
+
+
+# ---------------------------------------------------------------------------
+# AudioCapable protocol satisfaction
+# ---------------------------------------------------------------------------
+
+
+class TestAudioCapableProtocol:
+    def test_yaesu_satisfies_audio_capable(self, radio: YaesuCatRadio) -> None:
+        from icom_lan.radio_protocol import AudioCapable
+
+        assert isinstance(radio, AudioCapable)
+
+
+# ---------------------------------------------------------------------------
 # get_audio_stats
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `audio_codec: AudioCodec` and `audio_sample_rate: int` properties to the `AudioCapable` Protocol so consumers can rely on the contract instead of `getattr` probing. The LAN/Icom-serial mixin already implemented both.
- **Fix P2-02 (Yaesu sample-rate property missing).** The Yaesu CAT backend stored `_audio_sample_rate` but did not expose it as a property, so `getattr(radio, "audio_sample_rate", None)` in `web/handlers/audio.py:288,716` returned `None` and the broadcaster fell back to a default rate, mis-clocking FTX-1 audio. One-line `@property` added.
- Drop `audio_capabilities()` static method from the class surface (`AudioRuntimeMixin` + `sync.IcomRadio`); `types.get_audio_capabilities()` remains the single source of truth. Two test consumers migrated accordingly.

Out of scope: `stop_audio_tx` reconciliation belongs to PR-19 (#1111) and is intentionally untouched here.

## Files

- `src/icom_lan/radio_protocol.py` — extend `AudioCapable` Protocol
- `src/icom_lan/backends/yaesu_cat/radio.py` — P2-02 fix (`audio_sample_rate` property)
- `src/icom_lan/_audio_runtime_mixin.py` — drop `audio_capabilities()` from class surface
- `src/icom_lan/sync.py` — drop `audio_capabilities()` from class surface
- `tests/test_yaesu_audio.py` — regression guard for P2-02 + protocol-satisfaction test
- `tests/test_sync.py`, `tests/test_audio_codec.py` — migrate consumers to module helper

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4792 passed
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — zero errors
- [x] New regression test: Yaesu `audio_sample_rate` returns 48000 by default and honours custom value (P2-02 guard)
- [x] New protocol-satisfaction test: `YaesuCatRadio` satisfies extended `AudioCapable`
- [x] LAN protocol-satisfaction continues to hold via existing `radio.py:3740` `__main__` assertion

Closes #1106
Refs #1096 (parent epic), Phase C / PR-14 in synthesis

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)