### PR TITLE
feat(api): LevelsCapable extension — af_level + rf_gain getters (P3-03)

### DIFF
--- a/src/icom_lan/commands/levels.py
+++ b/src/icom_lan/commands/levels.py
@@ -110,14 +110,23 @@ def set_rf_power(
 def get_rf_gain(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
+    receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    """Build a 'read RF gain' CI-V command (0x14 0x02)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_rf_gain", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=_SUB_RF_GAIN)
+    """Build a 'read RF gain' CI-V command (0x14 0x02).
+
+    For SUB receiver, the frame is wrapped in cmd29 (0x29 0x01) — same routing
+    as ``set_rf_gain``.
+    """
+    return _build_level_get(
+        _SUB_RF_GAIN,
+        to_addr=to_addr,
+        from_addr=from_addr,
+        receiver=receiver,
+        command29=(receiver != RECEIVER_MAIN),
+        cmd_map=cmd_map,
+        cmd_name="get_rf_gain",
+    )
 
 
 def set_rf_gain(
@@ -154,14 +163,23 @@ def set_rf_gain(
 def get_af_level(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
+    receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    """Build a 'read AF output level' CI-V command (0x14 0x01)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_af_level", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=_SUB_AF_LEVEL)
+    """Build a 'read AF output level' CI-V command (0x14 0x01).
+
+    For SUB receiver, the frame is wrapped in cmd29 (0x29 0x01) — same routing
+    as ``set_af_level``.
+    """
+    return _build_level_get(
+        _SUB_AF_LEVEL,
+        to_addr=to_addr,
+        from_addr=from_addr,
+        receiver=receiver,
+        command29=(receiver != RECEIVER_MAIN),
+        cmd_map=cmd_map,
+        cmd_name="get_af_level",
+    )
 
 
 def set_af_level(

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -1646,13 +1646,27 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         await self._send_civ_raw(civ, wait_response=False)
         self._last_power = level
 
-    async def get_rf_gain(self) -> int:
-        """Read the current RF gain level (0-255)."""
+    async def get_rf_gain(self, receiver: int = 0) -> int:
+        """Read the current RF gain level (0-255).
+
+        Routes through cmd29 (0x29 0x01) for the SUB receiver, mirroring
+        ``set_rf_gain``.
+        """
         self._check_connected()
-        civ = get_rf_gain(to_addr=self._radio_addr)
+        self._require_receiver(receiver, operation="get_rf_gain")
+        self._require_cmd29_route(
+            0x14,
+            0x02,
+            receiver=receiver,
+            operation="get_rf_gain",
+        )
+        civ = get_rf_gain(to_addr=self._radio_addr, receiver=receiver)
         try:
             resp = await self._send_civ_expect(
-                civ, key="get_rf_gain", dedupe=True, label="get_rf_gain"
+                civ,
+                key=f"get_rf_gain:{receiver}",
+                dedupe=True,
+                label="get_rf_gain",
             )
             return self._parse_level(resp)
         except TimeoutError:
@@ -1674,13 +1688,27 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         civ = set_rf_gain(level, to_addr=self._radio_addr, receiver=receiver)
         await self._send_civ_raw(civ, wait_response=False)
 
-    async def get_af_level(self) -> int:
-        """Read the current AF output level (0-255)."""
+    async def get_af_level(self, receiver: int = 0) -> int:
+        """Read the current AF output level (0-255).
+
+        Routes through cmd29 (0x29 0x01) for the SUB receiver, mirroring
+        ``set_af_level``.
+        """
         self._check_connected()
-        civ = get_af_level(to_addr=self._radio_addr)
+        self._require_receiver(receiver, operation="get_af_level")
+        self._require_cmd29_route(
+            0x14,
+            0x01,
+            receiver=receiver,
+            operation="get_af_level",
+        )
+        civ = get_af_level(to_addr=self._radio_addr, receiver=receiver)
         try:
             resp = await self._send_civ_expect(
-                civ, key="get_af_level", dedupe=True, label="get_af_level"
+                civ,
+                key=f"get_af_level:{receiver}",
+                dedupe=True,
+                label="get_af_level",
             )
             return self._parse_level(resp)
         except TimeoutError:

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -239,11 +239,27 @@ class Radio(Protocol):
 class LevelsCapable(Protocol):
     """Radio supports setting receiver levels: AF, RF gain, squelch."""
 
+    async def get_af_level(self, receiver: int = 0) -> int:
+        """Get AF (audio) output level (0-255).
+
+        Args:
+            receiver: 0 = main (default), 1 = sub.
+        """
+        ...
+
     async def set_af_level(self, level: int, receiver: int = 0) -> None:
         """Set AF (audio) output level (0-255).
 
         Args:
             level: Level in 0-255 scale.
+            receiver: 0 = main (default), 1 = sub.
+        """
+        ...
+
+    async def get_rf_gain(self, receiver: int = 0) -> int:
+        """Get RF gain level (0-255).
+
+        Args:
             receiver: 0 = main (default), 1 = sub.
         """
         ...

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -544,6 +544,48 @@ class TestCmd29ReceiverRouting:
         assert frame[6] == 0x14
         assert frame[7] == 0x01  # AF level sub
 
+    def test_get_rf_gain_main_no_cmd29(self) -> None:
+        from icom_lan.commands import RECEIVER_MAIN, get_rf_gain
+
+        frame = get_rf_gain(receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x14  # Direct level cmd, no cmd29 prefix
+        assert frame[5] == 0x02  # RF gain sub
+
+    def test_get_rf_gain_sub_uses_cmd29(self) -> None:
+        from icom_lan.commands import RECEIVER_SUB, get_rf_gain
+
+        frame = get_rf_gain(receiver=RECEIVER_SUB)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x01  # SUB receiver
+        assert frame[6] == 0x14  # Level command
+        assert frame[7] == 0x02  # RF gain sub
+
+    def test_get_rf_gain_default_is_main(self) -> None:
+        from icom_lan.commands import RECEIVER_MAIN, get_rf_gain
+
+        assert get_rf_gain() == get_rf_gain(receiver=RECEIVER_MAIN)
+
+    def test_get_af_level_main_no_cmd29(self) -> None:
+        from icom_lan.commands import RECEIVER_MAIN, get_af_level
+
+        frame = get_af_level(receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x14
+        assert frame[5] == 0x01  # AF level sub
+
+    def test_get_af_level_sub_uses_cmd29(self) -> None:
+        from icom_lan.commands import RECEIVER_SUB, get_af_level
+
+        frame = get_af_level(receiver=RECEIVER_SUB)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x01  # SUB receiver
+        assert frame[6] == 0x14
+        assert frame[7] == 0x01  # AF level sub
+
+    def test_get_af_level_default_is_main(self) -> None:
+        from icom_lan.commands import RECEIVER_MAIN, get_af_level
+
+        assert get_af_level() == get_af_level(receiver=RECEIVER_MAIN)
+
     def test_set_squelch_main_no_cmd29(self) -> None:
         from icom_lan.commands import RECEIVER_MAIN, set_squelch
 

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -491,6 +491,75 @@ class TestRfGainAfLevel:
         with pytest.raises(ValueError):
             await radio.set_af_level(-1)
 
+    @pytest.mark.asyncio
+    async def test_get_rf_gain_sub_uses_cmd29(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """get_rf_gain(receiver=1) should send a cmd29-wrapped frame."""
+        d = f"{200:04d}"
+        b0 = (int(d[0]) << 4) | int(d[1])
+        b1 = (int(d[2]) << 4) | int(d[3])
+        civ = build_cmd29_frame(
+            CONTROLLER_ADDR,
+            IC_7610_ADDR,
+            _CMD_LEVEL,
+            sub=0x02,
+            data=bytes([b0, b1]),
+            receiver=1,
+        )
+        mock_transport.queue_response(_wrap_civ_in_udp(civ))
+        result = await radio.get_rf_gain(receiver=1)
+        # Verify the request used cmd29 routing
+        sent = bytes(mock_transport.sent_packets[-1])
+        # Find CI-V payload — last sent frame must be cmd29 (0x29) wrapping 0x14 0x02
+        assert b"\x29\x01\x14\x02" in sent
+        assert result == 200
+
+    @pytest.mark.asyncio
+    async def test_get_af_level_sub_uses_cmd29(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """get_af_level(receiver=1) should send a cmd29-wrapped frame."""
+        d = f"{150:04d}"
+        b0 = (int(d[0]) << 4) | int(d[1])
+        b1 = (int(d[2]) << 4) | int(d[3])
+        civ = build_cmd29_frame(
+            CONTROLLER_ADDR,
+            IC_7610_ADDR,
+            _CMD_LEVEL,
+            sub=0x01,
+            data=bytes([b0, b1]),
+            receiver=1,
+        )
+        mock_transport.queue_response(_wrap_civ_in_udp(civ))
+        result = await radio.get_af_level(receiver=1)
+        sent = bytes(mock_transport.sent_packets[-1])
+        assert b"\x29\x01\x14\x01" in sent
+        assert result == 150
+
+
+class TestLevelsCapableProtocol:
+    """Protocol satisfaction: backends must implement LevelsCapable getters/setters."""
+
+    def test_icom_radio_satisfies_levels_capable(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        from icom_lan.radio_protocol import LevelsCapable
+
+        assert isinstance(radio, LevelsCapable)
+
+    def test_icom_radio_has_af_rf_getters_with_receiver_param(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        import inspect
+
+        # Both getters must accept a `receiver` keyword (P3-03 fix).
+        for fn_name in ("get_af_level", "get_rf_gain"):
+            sig = inspect.signature(getattr(radio, fn_name))
+            assert "receiver" in sig.parameters, (
+                f"{fn_name} is missing `receiver` parameter"
+            )
+
 
 class TestPtt:
     """Test PTT toggle."""


### PR DESCRIPTION
Closes #1103
Parent epic: #1096
Synthesis ref: Phase C, PR-11
Defects fixed: P3-03

## Summary

- Add `get_af_level(receiver=0) -> int` and `get_rf_gain(receiver=0) -> int` to `LevelsCapable`. Closes the headline asymmetry — every setter on the protocol now has a matching getter.
- Fix Icom impls at `radio.py:1649,1677` (P3-03) to accept `receiver: int = 0`, mirroring their setters at lines 1666-1675/1689-1701.
- Route SUB-receiver getters through cmd29 (`0x29 0x01 → 0x14 0x{01,02}`), same wire path the setters use.
- Refactor `commands/levels.py` `get_rf_gain` / `get_af_level` builders to use the shared `_build_level_get` template (the pattern already used by `get_squelch` / `get_nr_level` / `get_apf_type_level`).

## Files

- `src/icom_lan/radio_protocol.py` — protocol additions
- `src/icom_lan/radio.py` — Icom impl with `receiver` param + cmd29 routing
- `src/icom_lan/commands/levels.py` — builder signatures + cmd29 wrapping for SUB

Diff: 5 files, +193 / -20.

## Test plan

- [x] Golden-frame byte tests for both getters: MAIN (no cmd29) + SUB (cmd29 wrap), in `tests/test_commands.py`.
- [x] cmd29 SUB-path radio-level tests in `tests/test_radio.py` — verifies the request frame on the wire is `0x29 0x01 0x14 0x{01,02}`.
- [x] Protocol satisfaction: `isinstance(IcomRadio, LevelsCapable)` + signature check that both new getters expose `receiver` kwarg.
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4798 passed.
- [x] `uv run ruff check src/ tests/` — zero violations.
- [x] `uv run mypy src/` — zero errors.
- [ ] **Hardware verification (pending)**: per CLAUDE.md "MagicMock success ≠ hardware correctness", live IC-7610 SUB-receiver readback should be exercised before v0.19 ships. Golden-frame tests cover protocol correctness but the SDK has not yet observed real radio responses on this new wire path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)