### PR TITLE
refactor(audio): reconcile stop_audio_tx + remove overdue LAN aliases

### DIFF
--- a/src/icom_lan/_audio_runtime_mixin.py
+++ b/src/icom_lan/_audio_runtime_mixin.py
@@ -7,7 +7,6 @@ Part of the radio.py decomposition (#505). All methods are accessed via
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -43,17 +42,6 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     # ------------------------------------------------------------------
     # Audio streaming
     # ------------------------------------------------------------------
-
-    @staticmethod
-    def _warn_audio_alias(old_name: str, replacement: str) -> None:
-        warnings.warn(
-            (
-                f"IcomRadio.{old_name}() is deprecated and will be removed after two "
-                f"minor releases; use IcomRadio.{replacement}() instead."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     async def start_audio_rx_opus(
         self,
@@ -308,43 +296,6 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         await self.stop_audio_tx_opus()
         await self.stop_audio_rx_opus()
 
-    async def start_audio_rx(
-        self, callback: Callable[[AudioPacket | None], None]
-    ) -> None:
-        """Deprecated alias for :meth:`start_audio_rx_opus`."""
-        self._warn_audio_alias("start_audio_rx", "start_audio_rx_opus")
-        await self.start_audio_rx_opus(callback)
-
-    async def stop_audio_rx(self) -> None:
-        """Deprecated alias for :meth:`stop_audio_rx_opus`."""
-        self._warn_audio_alias("stop_audio_rx", "stop_audio_rx_opus")
-        await self.stop_audio_rx_opus()
-
-    async def start_audio_tx(self) -> None:
-        """Deprecated alias for :meth:`start_audio_tx_opus`."""
-        self._warn_audio_alias("start_audio_tx", "start_audio_tx_opus")
-        await self.start_audio_tx_opus()
-
-    async def push_audio_tx(self, opus_data: bytes) -> None:
-        """Deprecated alias for :meth:`push_audio_tx_opus`."""
-        self._warn_audio_alias("push_audio_tx", "push_audio_tx_opus")
-        await self.push_audio_tx_opus(opus_data)
-
-    async def stop_audio_tx(self) -> None:
-        """Deprecated alias for :meth:`stop_audio_tx_opus`."""
-        self._warn_audio_alias("stop_audio_tx", "stop_audio_tx_opus")
-        await self.stop_audio_tx_opus()
-
-    async def start_audio(
-        self,
-        rx_callback: Callable[[AudioPacket | None], None],
-        *,
-        tx_enabled: bool = True,
-    ) -> None:
-        """Deprecated alias for :meth:`start_audio_opus`."""
-        self._warn_audio_alias("start_audio", "start_audio_opus")
-        await self.start_audio_opus(rx_callback, tx_enabled=tx_enabled)
-
     def get_audio_stats(self) -> dict[str, bool | int | float | str]:
         """Return runtime audio stats for the active stream.
 
@@ -354,11 +305,6 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         if self._audio_stream is None:
             return AudioStats.inactive().to_dict()
         return self._audio_stream.get_audio_stats()
-
-    async def stop_audio(self) -> None:
-        """Deprecated alias for :meth:`stop_audio_opus`."""
-        self._warn_audio_alias("stop_audio", "stop_audio_opus")
-        await self.stop_audio_opus()
 
     def _get_pcm_transcoder(
         self,

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -382,7 +382,7 @@ class YaesuCatRadio:
         """No-op: USB audio TX is started via start_audio_tx_pcm."""
         pass
 
-    async def stop_audio_tx(self) -> None:
+    async def stop_audio_tx_opus(self) -> None:
         """Stop TX audio."""
         await self.stop_audio_tx_pcm()
 

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -16,7 +16,7 @@ Quick start::
 
     # Check optional capabilities at runtime:
     if isinstance(radio, AudioCapable):
-        await radio.start_audio_rx(callback)
+        await radio.start_audio_rx_opus(callback)
 
 Architecture::
 
@@ -572,7 +572,7 @@ class AudioCapable(Protocol):
     async def stop_audio_tx_pcm(self) -> None: ...
     async def get_audio_stats(self) -> dict[str, Any]: ...
     async def start_audio_tx_opus(self) -> None: ...
-    async def stop_audio_tx(self) -> None: ...
+    async def stop_audio_tx_opus(self) -> None: ...
 
 
 @runtime_checkable

--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -13,7 +13,6 @@ Example::
 """
 
 import asyncio
-import warnings
 from typing import Any, Callable, Coroutine, TypeVar
 
 from .audio import AudioPacket
@@ -75,17 +74,6 @@ class IcomRadio:
     def _run(self, coro: Coroutine[Any, Any, T]) -> T:
         """Run a coroutine on the internal event loop."""
         return self._loop.run_until_complete(coro)
-
-    @staticmethod
-    def _warn_audio_alias(old_name: str, replacement: str) -> None:
-        warnings.warn(
-            (
-                f"icom_lan.sync.IcomRadio.{old_name}() is deprecated and will be "
-                f"removed after two minor releases; use {replacement}() instead."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     # ------------------------------------------------------------------
     # Connection
@@ -466,31 +454,6 @@ class IcomRadio:
     def stop_audio_tx_opus(self) -> None:
         """Stop Opus TX audio."""
         self._run(self._radio.stop_audio_tx_opus())
-
-    def start_audio_rx(self, callback: Callable[[AudioPacket | None], None]) -> None:
-        """Deprecated alias for :meth:`start_audio_rx_opus`."""
-        self._warn_audio_alias("start_audio_rx", "start_audio_rx_opus")
-        self.start_audio_rx_opus(callback)
-
-    def stop_audio_rx(self) -> None:
-        """Deprecated alias for :meth:`stop_audio_rx_opus`."""
-        self._warn_audio_alias("stop_audio_rx", "stop_audio_rx_opus")
-        self.stop_audio_rx_opus()
-
-    def start_audio_tx(self) -> None:
-        """Deprecated alias for :meth:`start_audio_tx_opus`."""
-        self._warn_audio_alias("start_audio_tx", "start_audio_tx_opus")
-        self.start_audio_tx_opus()
-
-    def push_audio_tx(self, opus_data: bytes) -> None:
-        """Deprecated alias for :meth:`push_audio_tx_opus`."""
-        self._warn_audio_alias("push_audio_tx", "push_audio_tx_opus")
-        self.push_audio_tx_opus(opus_data)
-
-    def stop_audio_tx(self) -> None:
-        """Deprecated alias for :meth:`stop_audio_tx_opus`."""
-        self._warn_audio_alias("stop_audio_tx", "stop_audio_tx_opus")
-        self.stop_audio_tx_opus()
 
     def get_audio_stats(self) -> dict[str, bool | int | float | str]:
         """Return runtime audio stats for the active stream."""

--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -595,7 +595,7 @@ class AudioHandler:
                 await self._stop_rx()
             elif direction == "tx":
                 if self._radio and CAP_AUDIO in self._radio.capabilities:
-                    await self._radio.stop_audio_tx()  # type: ignore[attr-defined]
+                    await self._radio.stop_audio_tx_opus()  # type: ignore[attr-defined]
                 self._tx_active = False
                 logger.info("audio: TX stopped")
         elif msg_type == "audio_config":

--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -829,7 +829,7 @@ class RadioPoller:
                 # Stop TX audio stream after PTT, then restart RX
                 if CAP_AUDIO in self._caps:
                     try:
-                        await radio.stop_audio_tx()
+                        await radio.stop_audio_tx_opus()
                         logger.info("poller: TX audio stream stopped")
 
                         # Restart RX audio after TX (IC-7610 doesn't support full duplex)

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -1116,7 +1116,7 @@ class WebServer:
                 logger.warning("yaesu poller stop timed out")
             self._yaesu_poller = None
 
-        # 2. Stop audio relay (stops AudioBus subscription → stop_audio_rx)
+        # 2. Stop audio relay (stops AudioBus subscription → stop_audio_rx_opus)
         try:
             await asyncio.wait_for(self._audio_broadcaster._stop_relay(), timeout=2.0)
         except (TimeoutError, Exception) as exc:

--- a/tests/test_audio_rx_tx_transition.py
+++ b/tests/test_audio_rx_tx_transition.py
@@ -8,7 +8,7 @@ Expected flow:
   2. PTT ON → stop RX, start TX
   3. PTT OFF → stop TX, restart RX  ← THIS WAS BROKEN
 
-Fix: radio_poller.py PttOff case now calls start_audio_rx_opus() after stop_audio_tx()
+Fix: radio_poller.py PttOff case now calls start_audio_rx_opus() after stop_audio_tx_opus()
 """
 
 from __future__ import annotations
@@ -57,7 +57,7 @@ def _make_audio_capable_radio() -> SimpleNamespace:
         get_audio_stats=AsyncMock(return_value={}),
         # PTT transition methods (used by poller when AudioCapable)
         start_audio_tx_opus=AsyncMock(),
-        stop_audio_tx=AsyncMock(),
+        stop_audio_tx_opus=AsyncMock(),
     )
 
 
@@ -117,14 +117,14 @@ async def test_ptt_off_restarts_rx_audio(
     radio.set_ptt.assert_awaited_once_with(False)
 
     # Verify TX audio stopped
-    radio.stop_audio_tx.assert_awaited_once()
+    radio.stop_audio_tx_opus.assert_awaited_once()
 
     # CRITICAL: Verify RX audio restarted (this was the bug)
     radio.start_audio_rx_opus.assert_awaited_once()
 
     # Verify call order: PTT off → stop TX → start RX
     assert radio.set_ptt.await_count == 1
-    assert radio.stop_audio_tx.await_count == 1
+    assert radio.stop_audio_tx_opus.await_count == 1
     assert radio.start_audio_rx_opus.await_count == 1
 
 
@@ -142,7 +142,7 @@ async def test_ptt_cycle_full_sequence(
     # PTT OFF
     await poller._execute(PttOff())
 
-    assert radio.stop_audio_tx.await_count == 1
+    assert radio.stop_audio_tx_opus.await_count == 1
     assert radio.set_ptt.call_args_list[-1][0][0] is False  # Last call was False
 
     # CRITICAL: RX audio должен быть восстановлен
@@ -155,7 +155,7 @@ async def test_ptt_off_handles_audio_errors_gracefully(
 ) -> None:
     """PTT OFF должен обрабатывать ошибки audio transitions без crash."""
     # Simulate audio method failures
-    radio.stop_audio_tx.side_effect = RuntimeError("TX stop failed")
+    radio.stop_audio_tx_opus.side_effect = RuntimeError("TX stop failed")
     radio.start_audio_rx_opus.side_effect = RuntimeError("RX start failed")
 
     # Should not raise, errors are logged
@@ -179,6 +179,6 @@ async def test_multiple_ptt_cycles(
 
     # Each cycle should call all methods
     assert radio.start_audio_tx_opus.await_count == 3
-    assert radio.stop_audio_tx.await_count == 3
+    assert radio.stop_audio_tx_opus.await_count == 3
     assert radio.start_audio_rx_opus.await_count == 3
     assert radio.set_ptt.await_count == 6  # 3 ON + 3 OFF

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -52,7 +52,7 @@ def _add_capability_protocols(radio: MagicMock) -> MagicMock:
     radio.stop_audio_tx_pcm = AsyncMock()
     radio.get_audio_stats = AsyncMock(return_value={})
     radio.start_audio_tx_opus = AsyncMock()
-    radio.stop_audio_tx = AsyncMock()
+    radio.stop_audio_tx_opus = AsyncMock()
     # ScopeCapable
     radio.enable_scope = AsyncMock()
     if not hasattr(radio, "disable_scope"):

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -88,7 +88,7 @@ def _make_full_capable_mock() -> _CapableRadio:
     radio.stop_audio_tx_pcm = AsyncMock()
     radio.get_audio_stats = AsyncMock(return_value={})
     radio.start_audio_tx_opus = AsyncMock()
-    radio.stop_audio_tx = AsyncMock()
+    radio.stop_audio_tx_opus = AsyncMock()
     # ScopeCapable
     radio.enable_scope = AsyncMock()
     radio.disable_scope = AsyncMock()
@@ -354,7 +354,7 @@ def _make_audio_capable_mock(base: MagicMock | None = None) -> MagicMock:
     radio.stop_audio_tx_pcm = AsyncMock()
     radio.get_audio_stats = AsyncMock(return_value={})
     radio.start_audio_tx_opus = AsyncMock()
-    radio.stop_audio_tx = AsyncMock()
+    radio.stop_audio_tx_opus = AsyncMock()
     return radio
 
 

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -39,7 +39,7 @@ def _add_audio_capable(radio: MagicMock) -> MagicMock:
     radio.stop_audio_rx_opus = AsyncMock()
     radio.push_audio_tx_opus = AsyncMock()
     radio.start_audio_tx_opus = AsyncMock()
-    radio.stop_audio_tx = AsyncMock()
+    radio.stop_audio_tx_opus = AsyncMock()
     return radio
 
 

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1102,7 +1102,7 @@ async def test_audio_broadcaster_subscribe_unsubscribe_lifecycle() -> None:
         stop_audio_tx_pcm=AsyncMock(),
         get_audio_stats=AsyncMock(return_value={}),
         start_audio_tx_opus=AsyncMock(),
-        stop_audio_tx=AsyncMock(),
+        stop_audio_tx_opus=AsyncMock(),
         audio_bus=None,
     )
     bus = AudioBus(radio)
@@ -1138,7 +1138,7 @@ async def test_audio_broadcaster_codec_and_frame_metadata() -> None:
         stop_audio_tx_pcm=AsyncMock(),
         get_audio_stats=AsyncMock(return_value={}),
         start_audio_tx_opus=AsyncMock(),
-        stop_audio_tx=AsyncMock(),
+        stop_audio_tx_opus=AsyncMock(),
         audio_bus=None,
     )
     bus = AudioBus(radio)
@@ -1241,7 +1241,7 @@ async def test_audio_handler_reader_control_tx_and_sender_paths(
     radio.capabilities = {"audio"}
     radio.push_audio_tx_opus = AsyncMock()
     radio.start_audio_tx_opus = AsyncMock()
-    radio.stop_audio_tx = AsyncMock()
+    radio.stop_audio_tx_opus = AsyncMock()
     ws = SimpleNamespace(
         recv=AsyncMock(
             side_effect=[
@@ -1276,7 +1276,7 @@ async def test_audio_handler_reader_control_tx_and_sender_paths(
     assert handler._tx_active is False
     radio.start_audio_tx_opus.assert_awaited_once()
     radio.push_audio_tx_opus.assert_awaited_once_with(b"\x11\x22")
-    radio.stop_audio_tx.assert_awaited_once()
+    radio.stop_audio_tx_opus.assert_awaited_once()
 
     handler._done.clear()
     frame = b"frame"
@@ -1319,7 +1319,7 @@ async def test_audio_handler_control_and_tx_guard_paths() -> None:
         start_audio_rx_opus = AsyncMock()
         stop_audio_rx_opus = AsyncMock()
         start_audio_tx_opus = AsyncMock()
-        stop_audio_tx = AsyncMock()
+        stop_audio_tx_opus = AsyncMock()
         audio_bus = None
 
     radio = _FakeAudioRadio()
@@ -1347,7 +1347,7 @@ async def test_audio_handler_control_and_tx_guard_paths() -> None:
     await handler._handle_tx_audio(b"\x00" * AUDIO_HEADER_SIZE + b"\x99")
     radio.push_audio_tx_opus.assert_awaited_once_with(b"\x99")
     await handler._handle_control({"type": "audio_stop", "direction": "tx"})
-    radio.stop_audio_tx.assert_awaited_once()
+    radio.stop_audio_tx_opus.assert_awaited_once()
     assert handler._tx_active is False
 
 

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -270,93 +270,27 @@ async def test_soft_reconnect_does_full_connect_when_ctrl_dead(
 
 
 # ---------------------------------------------------------------------------
-# Deprecated audio aliases (lines 823-864)
+# Removed audio aliases (issue #1111) — verify they raise AttributeError
 # ---------------------------------------------------------------------------
 
 
-async def test_stop_audio_rx_alias_calls_stop_audio_rx_opus(radio: IcomRadio) -> None:
-    called = False
-
-    async def _stop() -> None:
-        nonlocal called
-        called = True
-
-    with patch.object(radio, "stop_audio_rx_opus", side_effect=_stop):
-        with pytest.warns(DeprecationWarning, match="stop_audio_rx"):
-            await radio.stop_audio_rx()
-
-    assert called
-
-
-async def test_start_audio_tx_alias_calls_start_audio_tx_opus(radio: IcomRadio) -> None:
-    called = False
-
-    async def _start() -> None:
-        nonlocal called
-        called = True
-
-    with patch.object(radio, "start_audio_tx_opus", side_effect=_start):
-        with pytest.warns(DeprecationWarning, match="start_audio_tx"):
-            await radio.start_audio_tx()
-
-    assert called
-
-
-async def test_stop_audio_tx_alias_calls_stop_audio_tx_opus(radio: IcomRadio) -> None:
-    called = False
-
-    async def _stop() -> None:
-        nonlocal called
-        called = True
-
-    with patch.object(radio, "stop_audio_tx_opus", side_effect=_stop):
-        with pytest.warns(DeprecationWarning, match="stop_audio_tx"):
-            await radio.stop_audio_tx()
-
-    assert called
-
-
-async def test_stop_audio_alias_calls_stop_audio_opus(radio: IcomRadio) -> None:
-    called = False
-
-    async def _stop() -> None:
-        nonlocal called
-        called = True
-
-    with patch.object(radio, "stop_audio_opus", side_effect=_stop):
-        with pytest.warns(DeprecationWarning, match="stop_audio"):
-            await radio.stop_audio()
-
-    assert called
-
-
-async def test_start_audio_alias_calls_start_audio_opus(radio: IcomRadio) -> None:
-    called = False
-
-    async def _start(rx_cb: object, *, tx_enabled: bool = True) -> None:
-        nonlocal called
-        called = True
-
-    with patch.object(radio, "start_audio_opus", side_effect=_start):
-        cb = MagicMock()
-        with pytest.warns(DeprecationWarning, match="start_audio"):
-            await radio.start_audio(cb)
-
-    assert called
-
-
-async def test_push_audio_tx_alias_calls_push_audio_tx_opus(radio: IcomRadio) -> None:
-    called = False
-
-    async def _push(data: bytes) -> None:
-        nonlocal called
-        called = True
-
-    with patch.object(radio, "push_audio_tx_opus", side_effect=_push):
-        with pytest.warns(DeprecationWarning, match="push_audio_tx"):
-            await radio.push_audio_tx(b"\x00\x01")
-
-    assert called
+@pytest.mark.parametrize(
+    "name",
+    [
+        "start_audio_rx",
+        "stop_audio_rx",
+        "start_audio_tx",
+        "push_audio_tx",
+        "stop_audio_tx",
+        "start_audio",
+        "stop_audio",
+    ],
+)
+def test_removed_audio_aliases_raise_attribute_error(
+    radio: IcomRadio, name: str
+) -> None:
+    """Aliases removed in #1111 (overdue from v0.15) must not exist on IcomRadio."""
+    assert not hasattr(radio, name)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -443,44 +443,6 @@ class TestPowerControl:
 
 class TestAudio:
     @pytest.mark.asyncio
-    async def test_start_audio_rx_alias_warns_and_calls_opus(
-        self, radio: IcomRadio
-    ) -> None:
-        radio._audio_stream = MagicMock()
-        radio._audio_stream.start_rx = AsyncMock()
-
-        with pytest.warns(DeprecationWarning, match="start_audio_rx_opus"):
-            await radio.start_audio_rx(lambda pkt: None)
-
-        radio._audio_stream.start_rx.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_push_audio_tx_alias_warns_and_calls_opus(
-        self, radio: IcomRadio
-    ) -> None:
-        radio._audio_stream = MagicMock()
-        radio._audio_stream.push_tx = AsyncMock()
-
-        with pytest.warns(DeprecationWarning, match="push_audio_tx_opus"):
-            await radio.push_audio_tx(b"\x00" * 10)
-
-        radio._audio_stream.push_tx.assert_awaited_once_with(b"\x00" * 10)
-
-    @pytest.mark.asyncio
-    async def test_start_audio_alias_warns_and_calls_opus(
-        self, radio: IcomRadio
-    ) -> None:
-        radio._audio_stream = MagicMock()
-        radio._audio_stream.start_rx = AsyncMock()
-        radio._audio_stream.start_tx = AsyncMock()
-
-        with pytest.warns(DeprecationWarning, match="start_audio_opus"):
-            await radio.start_audio(lambda pkt: None, tx_enabled=True)
-
-        radio._audio_stream.start_rx.assert_awaited_once()
-        radio._audio_stream.start_tx.assert_awaited_once()
-
-    @pytest.mark.asyncio
     async def test_start_rx_disconnected(self) -> None:
         r = IcomRadio("192.168.1.100")
         with pytest.raises(ConnectionError):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from icom_lan.sync import IcomRadio
 from icom_lan.types import AudioCodec
 
@@ -47,16 +45,6 @@ class TestSyncContextManager:
 
 
 class TestSyncAudioNaming:
-    def test_start_audio_rx_alias_warns_and_calls_opus(self) -> None:
-        r = IcomRadio("192.168.1.100")
-        r._radio.start_audio_rx_opus = AsyncMock()
-
-        with pytest.warns(DeprecationWarning, match="start_audio_rx_opus"):
-            r.start_audio_rx(lambda pkt: None)
-
-        r._radio.start_audio_rx_opus.assert_awaited_once()
-        r._loop.close()
-
     def test_new_opus_method_calls_async_impl(self) -> None:
         r = IcomRadio("192.168.1.100")
         r._radio.push_audio_tx_opus = AsyncMock()

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -188,7 +188,7 @@ def test_vfo_dispatch_single_rx_uses_ab_methods() -> None:
     r._loop.close()
 
 
-def test_audio_wrappers_and_deprecated_aliases() -> None:
+def test_audio_wrappers_canonical_only() -> None:
     r = _radio()
 
     def cb(_pkt: object) -> None:
@@ -211,17 +211,6 @@ def test_audio_wrappers_and_deprecated_aliases() -> None:
     r._radio.start_audio_tx_opus.assert_awaited_once()
     r._radio.push_audio_tx_opus.assert_awaited_once_with(b"\xaa\xbb")
     r._radio.stop_audio_tx_opus.assert_awaited_once()
-
-    with pytest.warns(DeprecationWarning):
-        r.start_audio_rx(cb)
-    with pytest.warns(DeprecationWarning):
-        r.stop_audio_rx()
-    with pytest.warns(DeprecationWarning):
-        r.start_audio_tx()
-    with pytest.warns(DeprecationWarning):
-        r.push_audio_tx(b"\x01")
-    with pytest.warns(DeprecationWarning):
-        r.stop_audio_tx()
     r._loop.close()
 
 
@@ -239,3 +228,22 @@ def test_sync_set_split_mode_emits_deprecation_warning() -> None:
 
     r._radio.set_split.assert_awaited_once_with(True)
     r._loop.close()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "start_audio_rx",
+        "stop_audio_rx",
+        "start_audio_tx",
+        "push_audio_tx",
+        "stop_audio_tx",
+    ],
+)
+def test_removed_audio_aliases_raise_attribute_error(name: str) -> None:
+    """Sync aliases removed in #1111 must not exist on icom_lan.sync.IcomRadio."""
+    r = _radio()
+    try:
+        assert not hasattr(r, name)
+    finally:
+        r._loop.close()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -381,7 +381,7 @@ def mock_radio() -> MagicMock:
     radio.stop_audio_tx_pcm = AsyncMock()
     radio.get_audio_stats = AsyncMock(return_value={})
     radio.start_audio_tx_opus = AsyncMock()
-    radio.stop_audio_tx = AsyncMock()
+    radio.stop_audio_tx_opus = AsyncMock()
     radio.audio_codec = None
     radio.audio_sample_rate = 48000
     # State cache shared between radio and server


### PR DESCRIPTION
Closes #1111
Parent epic: #1096
Synthesis ref: Phase G, PR-19 + Cross-conflict §1
Audit: `api-audit/04-audio.md`, `api-audit/14-hamlib-aliases.md`

## Summary

- **Cross-conflict §1 resolved.** `AudioCapable` declared `stop_audio_tx`
  as canonical at `radio_protocol.py:471`, but the LAN mixin emitted
  `DeprecationWarning` on calls to it. The Protocol now exposes
  `stop_audio_tx_opus` (mirrors `start_audio_tx_opus` / `push_audio_tx_opus`),
  and the only working Yaesu TX-stop is renamed to match.
- **Seven LAN audio aliases removed (overdue from v0.15).** Deprecated
  for ≥3 minor releases (current `pyproject.toml` is v0.18+). Removed
  from `_audio_runtime_mixin` (`start_audio_rx`, `stop_audio_rx`,
  `start_audio_tx`, `push_audio_tx`, `stop_audio_tx`, `start_audio`,
  `stop_audio`) and from `sync.IcomRadio` (the five sync-side aliases
  per the issue's `sync.py:437-457` reference). The
  now-dead `_warn_audio_alias` helpers + `warnings` imports go too.
- **Web call sites migrated.** `web/handlers/audio.py` and
  `web/radio_poller.py` now use `stop_audio_tx_opus`.

## Files

| File | Change |
|------|--------|
| `src/icom_lan/radio_protocol.py` | `stop_audio_tx` → `stop_audio_tx_opus` in `AudioCapable`; doctring example uses canonical name |
| `src/icom_lan/_audio_runtime_mixin.py` | delete 7 aliases + `_warn_audio_alias` helper + `warnings` import |
| `src/icom_lan/sync.py` | delete 5 sync aliases + helper + `warnings` import |
| `src/icom_lan/backends/yaesu_cat/radio.py` | rename `stop_audio_tx` → `stop_audio_tx_opus` |
| `src/icom_lan/web/handlers/audio.py` | migrate call site |
| `src/icom_lan/web/radio_poller.py` | migrate call site |
| `src/icom_lan/web/server.py` | comment string update |
| 10 test files | rename mock attrs + delete obsolete alias tests + add `AttributeError` guards |

Net delta: **+65 / -264 LOC** across 17 files (mostly mechanical alias removal).

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4790 passed, 2 skipped, 2 deselected, 10 xfailed
- [x] `uv run pytest tests/test_audio_rx_tx_transition.py tests/test_handlers_coverage.py tests/test_web_server.py -W error::DeprecationWarning` — 303 passed (no DeprecationWarning escapes from the migrated PTT/TX paths)
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run mypy src/` — Success: no issues found in 144 source files
- [x] New parametrized tests verify the seven aliases raise `AttributeError`
      (`tests/test_radio_coverage.py::test_removed_audio_aliases_raise_attribute_error`,
      `tests/test_sync_coverage.py::test_removed_audio_aliases_raise_attribute_error`)
- [ ] Hardware smoke (PTT cycle on IC-7610): not executed — pure rename + alias removal, no protocol changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)