### PR TITLE
refactor(api): remove deprecated vfo_exchange/vfo_equalize aliases (v0.19)

### DIFF
--- a/docs/parity/ic7610_command_matrix.json
+++ b/docs/parity/ic7610_command_matrix.json
@@ -275,7 +275,7 @@
       "status": "implemented",
       "runtime_symbols": [
         "icom_lan.commands:vfo_swap",
-        "icom_lan.radio:CoreRadio.vfo_exchange"
+        "icom_lan.radio:CoreRadio.swap_main_sub"
       ],
       "test_patterns": [
         "tests/test_commands_extended.py::test_vfo_swap"
@@ -293,7 +293,7 @@
       "status": "implemented",
       "runtime_symbols": [
         "icom_lan.commands:vfo_a_equals_b",
-        "icom_lan.radio:CoreRadio.vfo_equalize"
+        "icom_lan.radio:CoreRadio.equalize_main_sub"
       ],
       "test_patterns": [
         "tests/test_commands_extended.py::test_vfo_a_equals_b"

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -502,8 +502,6 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             "set_dual_watch",
             # VFO / split / scan
             "set_vfo",
-            "vfo_equalize",
-            "vfo_exchange",
             "get_split",
             "set_split",
             "get_tuning_step",
@@ -2862,46 +2860,6 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if ack is False:
             raise CommandError(f"Radio rejected VFO select {vfo}")
         self._last_vfo = vfo.upper()
-
-    async def vfo_equalize(self) -> None:
-        """Copy VFO state (deprecated — use ``equalize_main_sub`` or ``equalize_vfo_ab``).
-
-        On dual-RX profiles this delegates to :meth:`equalize_main_sub`; on
-        single-RX profiles it delegates to :meth:`equalize_vfo_ab` with
-        ``receiver=0``.
-        """
-        import warnings
-
-        warnings.warn(
-            "vfo_equalize() is deprecated; use equalize_main_sub() or "
-            "equalize_vfo_ab() explicitly",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if self._profile.receiver_count > 1:
-            await self.equalize_main_sub()
-        else:
-            await self.equalize_vfo_ab(0)
-
-    async def vfo_exchange(self) -> None:
-        """Swap VFO state (deprecated — use ``swap_main_sub`` or ``swap_vfo_ab``).
-
-        On dual-RX profiles this delegates to :meth:`swap_main_sub`; on
-        single-RX profiles it delegates to :meth:`swap_vfo_ab` with
-        ``receiver=0``.
-        """
-        import warnings
-
-        warnings.warn(
-            "vfo_exchange() is deprecated; use swap_main_sub() or "
-            "swap_vfo_ab() explicitly",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if self._profile.receiver_count > 1:
-            await self.swap_main_sub()
-        else:
-            await self.swap_vfo_ab(0)
 
     async def set_split(self, on: bool) -> None:
         """Enable or disable split mode (CI-V ``0x0F``)."""

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -651,11 +651,11 @@ class ScopeCapable(Protocol):
 class DualReceiverCapable(Protocol):
     """Radio has two independent receivers (e.g. IC-7610 Main/Sub)."""
 
-    async def vfo_exchange(self) -> None:
+    async def swap_main_sub(self) -> None:
         """Swap Main and Sub VFO frequencies."""
         ...
 
-    async def vfo_equalize(self) -> None:
+    async def equalize_main_sub(self) -> None:
         """Set Sub VFO frequency equal to Main."""
         ...
 

--- a/tests/integration/test_radio_integration.py
+++ b/tests/integration/test_radio_integration.py
@@ -290,7 +290,7 @@ class TestVFO:
                 await radio.set_frequency(main0 + 1000)
                 sub0 = await radio.get_frequency()
 
-            await radio.vfo_exchange()
+            await radio.swap_main_sub()
 
             await radio.select_vfo("MAIN")
             main1 = await radio.get_frequency()
@@ -302,7 +302,7 @@ class TestVFO:
             print("VFO exchange ✓")
 
             # Restore original placement
-            await radio.vfo_exchange()
+            await radio.swap_main_sub()
             await radio.select_vfo("MAIN")
         except Exception as e:
             pytest.skip(f"VFO exchange not supported in current rig state: {e}")
@@ -320,7 +320,7 @@ class TestVFO:
             sub0 = await radio.get_frequency()
 
             await radio.select_vfo("MAIN")
-            await radio.vfo_equalize()
+            await radio.equalize_main_sub()
 
             await radio.select_vfo("MAIN")
             main1 = await radio.get_frequency()

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -649,11 +649,7 @@ async def test_enqueue_command_errors() -> None:
         set_scope_ref=AsyncMock(),
         get_scope_hold=AsyncMock(return_value=False),
         set_scope_hold=AsyncMock(),
-        # Keep deprecated aliases so the radio still satisfies
-        # ``DualReceiverCapable`` (Protocol untouched until #1114).
-        vfo_exchange=AsyncMock(),
-        vfo_equalize=AsyncMock(),
-        # Canonical dual-RX VFO methods (post-#1113).
+        # Canonical dual-RX VFO methods (DualReceiverCapable post-#1114).
         swap_main_sub=AsyncMock(),
         equalize_main_sub=AsyncMock(),
     )

--- a/tests/test_profiles_runtime.py
+++ b/tests/test_profiles_runtime.py
@@ -169,14 +169,13 @@ class TestApplyProfileFull:
 
     @pytest.mark.asyncio()
     async def test_applies_equalize_vfo(self, radio: AsyncMock) -> None:
-        # #1113: apply_profile now dispatches to the canonical
+        # #1114: apply_profile dispatches to the canonical
         # ``equalize_main_sub`` (dual-RX) or ``equalize_vfo_ab(0)``
-        # (single-RX) instead of the deprecated ``vfo_equalize`` alias.
+        # (single-RX). The legacy ``vfo_equalize`` alias has been removed.
         # The bare AsyncMock fixture has no real ``profile`` attribute, so
         # the dispatch falls through to the single-RX path.
         await apply_profile(radio, OperatingProfile(equalize_vfo=True))
         radio.equalize_vfo_ab.assert_awaited_once_with(0)
-        radio.vfo_equalize.assert_not_awaited()
 
     @pytest.mark.asyncio()
     async def test_scope_enabled(self, radio: AsyncMock) -> None:
@@ -291,16 +290,16 @@ class TestApplyProfileMinimal:
 
 
 # ---------------------------------------------------------------------------
-# apply_profile — equalize_vfo dispatch (issue #1113)
+# apply_profile — equalize_vfo dispatch (issues #1113 / #1114)
 # ---------------------------------------------------------------------------
 
 
 class TestEqualizeVfoDispatch:
     """Verify ``equalize_vfo=True`` dispatches to the right canonical method.
 
-    Regression coverage for #1113: ``apply_profile`` must NOT call the
-    deprecated ``vfo_equalize`` alias on the radio.  Dual-RX profiles route
-    to ``equalize_main_sub``; single-RX profiles route to ``equalize_vfo_ab(0)``.
+    Regression coverage for #1113/#1114: ``apply_profile`` calls only the
+    canonical methods. Dual-RX profiles route to ``equalize_main_sub``;
+    single-RX profiles route to ``equalize_vfo_ab(0)``.
     """
 
     @pytest.mark.asyncio()

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -82,38 +82,20 @@ class TestVFO:
             await radio.set_vfo("A")
 
     @pytest.mark.asyncio
-    async def test_vfo_equalize(
-        self, radio: IcomRadio, mock_transport: MockTransport
-    ) -> None:
-        mock_transport.queue_response(_ack_response())
-        await radio.vfo_equalize()
-        assert len(mock_transport.sent_packets) > 0
-
-    @pytest.mark.asyncio
-    async def test_vfo_exchange(
-        self, radio: IcomRadio, mock_transport: MockTransport
-    ) -> None:
-        mock_transport.queue_response(_ack_response())
-        await radio.vfo_exchange()
-        assert len(mock_transport.sent_packets) > 0
-
-    @pytest.mark.asyncio
     async def test_select_vfo_disconnected(self) -> None:
         r = IcomRadio("192.168.1.100")
         with pytest.raises(ConnectionError):
             await r.set_vfo("A")
 
-    @pytest.mark.asyncio
-    async def test_vfo_equalize_disconnected(self) -> None:
+    def test_vfo_exchange_attribute_removed(self) -> None:
+        """Deprecated ``vfo_exchange`` alias is removed in v0.19."""
         r = IcomRadio("192.168.1.100")
-        with pytest.raises(ConnectionError):
-            await r.vfo_equalize()
+        assert not hasattr(r, "vfo_exchange")
 
-    @pytest.mark.asyncio
-    async def test_vfo_exchange_disconnected(self) -> None:
+    def test_vfo_equalize_attribute_removed(self) -> None:
+        """Deprecated ``vfo_equalize`` alias is removed in v0.19."""
         r = IcomRadio("192.168.1.100")
-        with pytest.raises(ConnectionError):
-            await r.vfo_exchange()
+        assert not hasattr(r, "vfo_equalize")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -257,12 +257,12 @@ async def test_execute_event_emitting_commands_and_vfo_paths() -> None:
 
     await poller._execute(VfoSwap())  # noqa: SLF001
     assert any(name == "vfo_swapped" for name, _ in events)
-    # #1113: poller now calls canonical ``swap_main_sub`` directly; the
-    # deprecated ``vfo_exchange`` alias must no longer be touched here.
+    # #1114: poller calls canonical ``swap_main_sub`` directly; the
+    # deprecated wrapper has been removed.
     radio.swap_main_sub.assert_awaited_once_with()
 
-    # #1113: VfoEqualize routes to canonical ``equalize_main_sub``; the
-    # deprecated ``vfo_equalize`` alias must no longer be touched here.
+    # #1114: VfoEqualize routes to canonical ``equalize_main_sub``; the
+    # deprecated wrapper has been removed.
     eq_before = radio.equalize_main_sub.await_count
     await poller._execute(VfoEqualize())  # noqa: SLF001
     assert radio.equalize_main_sub.await_count == eq_before + 1

--- a/tests/test_vfo_dual_watch.py
+++ b/tests/test_vfo_dual_watch.py
@@ -1,6 +1,5 @@
 """Unit tests for VFO/dual-watch/scanning commands (Issue #132)."""
 
-import warnings
 from unittest.mock import patch
 
 import pytest
@@ -579,34 +578,31 @@ class TestSwapMainSubVsSwapVfoAb:
         # IC-7300 declares equal = [0xA0] in scheme=ab → equal_ab_code.
         assert send.frames[0].endswith(b"\x07\xa0\xfd")
 
-    @pytest.mark.asyncio
-    async def test_vfo_exchange_alias_emits_deprecation_warning(self) -> None:
+    def test_vfo_exchange_alias_removed(self) -> None:
+        """v0.19: deprecated ``vfo_exchange`` alias is gone (raises AttributeError)."""
         r = _make_radio("IC-7610")
-        send = _RecordingSend()
-        with patch.object(r, "_send_civ_raw", send):
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                await r.vfo_exchange()
-        # DeprecationWarning raised once, pointing to caller (this test file).
-        dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert len(dep) == 1
-        assert "vfo_exchange" in str(dep[0].message)
-        assert dep[0].filename.endswith("test_vfo_dual_watch.py")
-        # Still dispatches to swap_main_sub under the hood.
-        assert len(send.frames) == 1
-        assert send.frames[0].endswith(b"\x07\xb0\xfd")
+        assert not hasattr(r, "vfo_exchange")
+        with pytest.raises(AttributeError):
+            r.vfo_exchange  # noqa: B018
 
-    @pytest.mark.asyncio
-    async def test_vfo_equalize_alias_emits_deprecation_warning(self) -> None:
+    def test_vfo_equalize_alias_removed(self) -> None:
+        """v0.19: deprecated ``vfo_equalize`` alias is gone (raises AttributeError)."""
         r = _make_radio("IC-7300")
-        send = _RecordingSend()
-        with patch.object(r, "_send_civ_raw", send):
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                await r.vfo_equalize()
-        dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert len(dep) == 1
-        assert "vfo_equalize" in str(dep[0].message)
-        assert dep[0].filename.endswith("test_vfo_dual_watch.py")
-        assert len(send.frames) == 1
-        assert send.frames[0].endswith(b"\x07\xa0\xfd")
+        assert not hasattr(r, "vfo_equalize")
+        with pytest.raises(AttributeError):
+            r.vfo_equalize  # noqa: B018
+
+    def test_dual_rx_satisfies_dual_receiver_capable_protocol(self) -> None:
+        """IC-7610 backend still satisfies ``DualReceiverCapable`` after the
+        legacy ``vfo_exchange`` / ``vfo_equalize`` declarations were replaced
+        with the canonical ``swap_main_sub`` / ``equalize_main_sub`` methods.
+        """
+        from icom_lan.radio_protocol import DualReceiverCapable
+
+        r = _make_radio("IC-7610")
+        assert isinstance(r, DualReceiverCapable)
+        # Canonical methods are present and callable.
+        assert callable(r.swap_main_sub)
+        assert callable(r.equalize_main_sub)
+        assert callable(r.set_main_sub_tracking)
+        assert callable(r.get_main_sub_tracking)

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -83,9 +83,14 @@ def test_runtime_capabilities_falls_back_to_protocols_when_caps_missing() -> Non
         async def push_audio_tx_opus(self, data: bytes) -> None:  # noqa: ARG002
             ...
 
-        async def vfo_exchange(self) -> None: ...
+        async def swap_main_sub(self) -> None: ...
 
-        async def vfo_equalize(self) -> None: ...
+        async def equalize_main_sub(self) -> None: ...
+
+        async def set_main_sub_tracking(self, on: bool) -> None: ...  # noqa: ARG002
+
+        async def get_main_sub_tracking(self) -> bool:
+            return False
 
     radio = _ProtoRadio()
     caps = runtime_capabilities(radio)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -348,13 +348,8 @@ def mock_radio() -> MagicMock:
     radio.set_preamp = AsyncMock()
     radio.set_vfo = AsyncMock()
     radio.vfo_swap = AsyncMock()
-    # ``vfo_exchange`` / ``vfo_equalize`` are kept here so the radio still
-    # satisfies the ``DualReceiverCapable`` Protocol (#1113 migrated callers
-    # but the Protocol declarations are untouched until PR-22 / #1114).
-    radio.vfo_exchange = AsyncMock()
-    radio.vfo_equalize = AsyncMock()
-    # Canonical dual-RX VFO methods (post-#1113 migration); the radio_poller
-    # invokes ``swap_main_sub`` / ``equalize_main_sub`` directly now.
+    # Canonical dual-RX VFO methods on ``DualReceiverCapable`` (post-#1114);
+    # the radio_poller invokes these directly.
     radio.swap_main_sub = AsyncMock()
     radio.equalize_main_sub = AsyncMock()
     radio.vfo_a_equals_b = AsyncMock()
@@ -877,9 +872,8 @@ class TestControlChannel:
             assert resp["ok"] is True
             # vfo_swap goes through command queue; wait for poller to drain it
             await asyncio.sleep(0.05)
-            # #1113: the poller dispatches to ``swap_main_sub`` directly on
-            # dual-RX rigs; the deprecated ``vfo_exchange`` alias is no longer
-            # called from the poller path.
+            # #1114: the poller dispatches to ``swap_main_sub`` directly on
+            # dual-RX rigs; the deprecated wrapper has been removed.
             mock_radio.swap_main_sub.assert_awaited_once()
         finally:
             await _close_ws(writer)
@@ -2449,12 +2443,8 @@ class TestRadioPoller:
         radio.set_freq = AsyncMock()
         radio.set_mode = AsyncMock()
         radio.set_ptt = AsyncMock()
-        # Keep the deprecated aliases so the radio still satisfies
-        # ``DualReceiverCapable`` (Protocol untouched until #1114).
-        radio.vfo_exchange = AsyncMock()
-        radio.vfo_equalize = AsyncMock()
-        # Canonical dual-RX VFO methods (post-#1113); poller calls these
-        # directly now instead of the deprecated aliases.
+        # Canonical dual-RX VFO methods (DualReceiverCapable post-#1114);
+        # poller calls these directly.
         radio.swap_main_sub = AsyncMock()
         radio.equalize_main_sub = AsyncMock()
         radio.send_civ = AsyncMock()  # RadioPoller now calls send_civ directly
@@ -2646,10 +2636,7 @@ class TestSwitchScopeReceiver:
         radio.set_nr = AsyncMock()
         radio.set_digisel = AsyncMock()
         radio.set_ip_plus = AsyncMock()
-        # Keep deprecated aliases for ``DualReceiverCapable`` compliance.
-        radio.vfo_exchange = AsyncMock()
-        radio.vfo_equalize = AsyncMock()
-        # Canonical dual-RX VFO methods (post-#1113).
+        # Canonical dual-RX VFO methods on ``DualReceiverCapable`` (post-#1114).
         radio.swap_main_sub = AsyncMock()
         radio.equalize_main_sub = AsyncMock()
         return radio


### PR DESCRIPTION
Closes #1114

## Summary

- Delete the deprecated ``vfo_exchange`` / ``vfo_equalize`` async wrappers from ``IcomRadio`` (``src/icom_lan/radio.py``).
- Remove the legacy ``vfo_exchange`` / ``vfo_equalize`` declarations from ``DualReceiverCapable`` and replace them with the canonical ``swap_main_sub`` / ``equalize_main_sub`` (``src/icom_lan/radio_protocol.py``).
- ``IcomRadio`` already inherits the canonical implementations from ``DualRxRuntimeMixin`` (``_dual_rx_runtime.py``), so the Protocol still admits the real backend.

## Q4 author decision: tighter "warn-1, remove-2" policy

Per the issue body: these aliases were warned in v0.17 (commit ``a070c23``); one full minor (v0.18) of warnings has elapsed; removal lands in **v0.19**. The synthesis default was v0.20; user explicitly accelerated.

## Dependencies

- Depends on #1122 (PR-21, **merged**) — migrated all live callers off ``vfo_exchange`` / ``vfo_equalize`` to ``swap_main_sub`` / ``equalize_main_sub``. Verified pre-removal that no source-tree caller (outside the deprecated wrappers themselves) still references the old names.

## Tests

- ``tests/test_radio_extended.py`` — replace ``await radio.vfo_*()`` calls with ``hasattr`` guards (``not hasattr(r, 'vfo_exchange')``).
- ``tests/test_vfo_dual_watch.py`` — replace deprecation-warning tests with AttributeError guards + a positive ``isinstance(radio, DualReceiverCapable)`` test verifying that the IC-7610 backend still satisfies the protocol after the canonical-method rewrite.
- ``tests/test_web_runtime_helpers.py`` — rename Protocol-stub methods to ``swap_main_sub`` / ``equalize_main_sub`` (and add the existing ``set_main_sub_tracking`` / ``get_main_sub_tracking`` declarations the Protocol already required).
- ``tests/test_handlers_coverage.py`` / ``tests/test_web_server.py`` / ``tests/test_profiles_runtime.py`` — drop the legacy ``AsyncMock`` attrs kept only to satisfy the (now removed) Protocol declarations.
- ``tests/integration/test_radio_integration.py`` — rename to canonical (won't run in CI, but no point leaving stale).
- ``docs/parity/ic7610_command_matrix.json`` — update ``runtime_symbols`` for "VFO Swap M/S" / "VFO Equal MS" to ``CoreRadio.swap_main_sub`` / ``CoreRadio.equalize_main_sub`` (was breaking the parity-matrix test that resolves each symbol via getattr).

## Test plan

- [x] ``uv run pytest tests/ -q --tb=short --ignore=tests/integration`` — 4893 passed, 0 failed
- [x] ``uv run ruff check src/ tests/`` — All checks passed
- [x] ``uv run mypy src/`` — Success
- [x] Verified no remaining source-tree callers of ``radio.vfo_exchange`` / ``radio.vfo_equalize`` (sync wrappers in ``sync.py`` and the public web-API command names ``vfo_swap`` / ``vfo_equalize`` are intentionally separate surfaces and were left untouched)
- [x] Rebased onto ``origin/main`` (post-#1130 / #1132 / #1128)

🤖 Generated with [Claude Code](https://claude.com/claude-code)