### PR TITLE
feat(web): default bridge=auto with graceful degrade on loopback miss

### DIFF
--- a/src/icom_lan/cli.py
+++ b/src/icom_lan/cli.py
@@ -837,11 +837,16 @@ def _build_parser() -> argparse.ArgumentParser:
     web_p.add_argument(
         "--bridge",
         dest="web_bridge",
-        default=None,
+        default="auto",
         nargs="?",
         const="auto",
         metavar="DEVICE",
-        help="Start audio bridge to virtual device (e.g. 'BlackHole 2ch', or omit for auto-detect)",
+        help=(
+            "Start audio bridge to virtual device (e.g. 'BlackHole 2ch'). "
+            "Default: auto-detect; if no loopback is found, the bridge is "
+            "skipped with a warning. Pass an explicit DEVICE to fail hard "
+            "when missing."
+        ),
     )
     web_p.add_argument(
         "--bridge-tx-device",
@@ -2635,11 +2640,18 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
     config = WebConfig(**config_kwargs)
     server = WebServer(radio, config)
 
-    # Start audio bridge if requested
+    # Start audio bridge.
+    #
+    # Default behaviour (issue #1088): `--bridge` is auto-enabled. When a
+    # virtual loopback device is auto-detected, the bridge starts; if not,
+    # we log a warning and continue serving the web UI without it. Only an
+    # explicit `--bridge=<DEVICE>` (a concrete device name) preserves the
+    # previous fail-hard behaviour.
     bridge_device = getattr(args, "web_bridge", None)
     bridge_info: str | None = None
     if bridge_device is not None:
-        device_name = None if bridge_device == "auto" else bridge_device
+        is_auto = bridge_device == "auto"
+        device_name = None if is_auto else bridge_device
         tx_device_name = getattr(args, "web_bridge_tx_device", None)
         rx_only = getattr(args, "web_bridge_rx_only", False)
         bridge_label = getattr(args, "web_bridge_label", None)
@@ -2653,17 +2665,25 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
                 retry_base_delay=getattr(args, "web_bridge_retry_delay", 1.0),
             )
             direction = "RX only" if rx_only else "RX+TX"
-            bridge_info = f"active ({direction})"
-        except Exception as exc:
-            print(f"Error: audio bridge failed: {exc}", file=sys.stderr)
-            print(
-                "The --bridge flag was explicitly requested. "
-                "Fix the device configuration or remove --bridge to start without it.",
-                file=sys.stderr,
+            bridge_info = (
+                f"auto-enabled ({direction})" if is_auto else f"active ({direction})"
             )
-            return 1
+        except Exception as exc:
+            if is_auto:
+                # Graceful degrade — keep serving web UI without the bridge.
+                logger.warning("Audio bridge auto-start failed: %s", exc)
+                bridge_info = "loopback not found, bridge disabled"
+            else:
+                print(f"Error: audio bridge failed: {exc}", file=sys.stderr)
+                print(
+                    "The --bridge flag was explicitly requested with a device. "
+                    "Fix the device configuration or remove --bridge to start without it.",
+                    file=sys.stderr,
+                )
+                return 1
 
-    # Detect loopback device availability for hint (only when bridge not requested)
+    # Detect loopback device availability for hint (only when bridge not requested
+    # — i.e. when web_bridge was explicitly set to None, e.g. by tests).
     loopback_hint: str | None = None
     if bridge_device is None:
         loopback_hint = _detect_loopback_hint()

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -767,6 +767,79 @@ async def test_cmd_serve_and_cmd_web_paths(
         assert await _cmd_web(radio, args2) == 0
 
 
+def _web_cmd_args(*, web_bridge: str | None) -> argparse.Namespace:
+    """Build a minimal Namespace for _cmd_web with bridge-related fields."""
+    return argparse.Namespace(
+        web_host="127.0.0.1",
+        web_port=9092,
+        web_static_dir=None,
+        web_bridge=web_bridge,
+        web_bridge_tx_device=None,
+        web_bridge_rx_only=False,
+        web_bridge_label=None,
+        web_bridge_max_retries=1,
+        web_bridge_retry_delay=0.1,
+        web_rigctld=False,
+        dx_cluster=None,
+        callsign=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cli_web_no_loopback_graceful(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Auto bridge with no loopback device: warn and continue (no exit 1)."""
+    radio = AsyncMock()
+
+    class FakeWebServer:
+        def __init__(self, _radio, cfg):
+            self.radio = _radio
+            self.cfg = cfg
+
+        async def start_audio_bridge(self, **_kwargs):
+            raise RuntimeError("no loopback device found")
+
+        async def serve_forever(self):
+            raise asyncio.CancelledError
+
+    args = _web_cmd_args(web_bridge="auto")
+    with patch("icom_lan.web.server.WebServer", FakeWebServer):
+        rc = await _cmd_web(radio, args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "loopback not found, bridge disabled" in out
+
+
+@pytest.mark.asyncio
+async def test_cli_web_explicit_bridge_still_fails(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Explicit --bridge=NonExistent must fail fast with clear error."""
+    radio = AsyncMock()
+
+    class FakeWebServer:
+        def __init__(self, _radio, cfg):
+            self.radio = _radio
+            self.cfg = cfg
+
+        async def start_audio_bridge(self, **_kwargs):
+            raise RuntimeError("device 'NonExistent' not found")
+
+        async def serve_forever(self):
+            raise asyncio.CancelledError
+
+    args = _web_cmd_args(web_bridge="NonExistent")
+    with patch("icom_lan.web.server.WebServer", FakeWebServer):
+        rc = await _cmd_web(radio, args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "audio bridge failed" in captured.err
+    assert "explicitly requested" in captured.err
+
+
 @pytest.mark.asyncio
 async def test_cmd_discover_found_and_not_found(
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
Closes #1088

Part of Form H UX-defaults epic #1087.

## Summary

- `icom-lan web` now auto-enables the audio bridge by default; missing loopback no longer aborts startup.
- `--bridge` argparse default changes from `None` to `"auto"`. Explicit `--bridge=<DEVICE>` (e.g. `--bridge=NonExistent`) keeps the prior fail-hard semantics so user-pinned devices still surface configuration errors.
- Startup banner reflects actual state: `auto-enabled (RX+TX)` on success, `loopback not found, bridge disabled` on graceful skip, `active (...)` on explicit success.

## Behaviour matrix

| Invocation | Loopback present | Result |
|---|---|---|
| `icom-lan web` (default) | yes | bridge auto-starts, banner: `auto-enabled (RX+TX)` |
| `icom-lan web` (default) | no | warning logged, bridge disabled, web UI keeps serving (rc=0) |
| `icom-lan web --bridge` | yes | same as default with loopback present |
| `icom-lan web --bridge` | no | graceful (treated as `auto`) |
| `icom-lan web --bridge=BlackHole 2ch` | yes | bridge starts, banner: `active (RX+TX)` |
| `icom-lan web --bridge=NonExistent` | n/a | exit 1 with explicit-device error (unchanged) |

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4897 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] New tests added:
  - `test_cli_web_no_loopback_graceful` — auto path with `start_audio_bridge` raising returns 0 and prints `loopback not found, bridge disabled`.
  - `test_cli_web_explicit_bridge_still_fails` — `web_bridge="NonExistent"` returns 1 with `audio bridge failed` + `explicitly requested` in stderr.
- [x] Existing preset test (`test_preset_digimode_enables_bridge_and_wsjtx`) and explicit-flag override test still pass under the new default.

## Scope notes

Strictly limited to `--bridge` defaults per #1088. Does not touch rigctld defaults (#1089) or `[bridge]` extras (#1090). Anticipated minor conflict with #1089 in `cli.py`; will rebase after that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)