### PR TITLE
feat(web): default rigctld=on with --no-rigctld opt-out

### DIFF
--- a/src/icom_lan/cli.py
+++ b/src/icom_lan/cli.py
@@ -1270,11 +1270,10 @@ async def _run(args: argparse.Namespace) -> int:
     radio = create_radio(config)
 
     if args.command == "web":
-        ports_to_check: list[int] = [args.web_port]
-        if getattr(args, "web_rigctld", False):
-            ports_to_check.append(getattr(args, "web_rigctld_port", 4532))
+        # Only the web port is required. rigctld is best-effort: if its port
+        # is busy we log a warning and continue (handled in _cmd_web).
         try:
-            check_ports_available(ports_to_check)
+            check_ports_available([args.web_port])
         except RuntimeError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
@@ -2668,7 +2667,8 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
     if bridge_device is None:
         loopback_hint = _detect_loopback_hint()
 
-    # Start rigctld if requested
+    # Start rigctld if requested. Failure (e.g. port already in use) is
+    # logged as a warning and skipped — the web server keeps serving.
     rigctld_server = None
     rigctld_addr: str | None = None
     if getattr(args, "web_rigctld", False):
@@ -2681,16 +2681,20 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
             port=rigctld_port,
             wsjtx_compat=getattr(args, "wsjtx_compat", False),
         )
-        rigctld_server = RigctldServer(radio, rigctld_config)
+        candidate = RigctldServer(radio, rigctld_config)
         try:
-            await rigctld_server.start()
-        except Exception as exc:
-            print(
-                f"Error: failed to start rigctld on port {rigctld_port}: {exc}",
-                file=sys.stderr,
+            await candidate.start()
+        except OSError as exc:
+            logger.warning(
+                "rigctld disabled: failed to bind port %d: %s "
+                "(another rigctld may already be running; pass --no-rigctld to silence)",
+                rigctld_port,
+                exc,
             )
-            return 1
-        rigctld_addr = f"0.0.0.0:{rigctld_port}"
+            rigctld_server = None
+        else:
+            rigctld_server = candidate
+            rigctld_addr = f"0.0.0.0:{rigctld_port}"
 
     scheme = "https" if config_kwargs.get("tls") else "http"
     web_url = f"{scheme}://{args.web_host}:{args.web_port}/"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -712,6 +712,149 @@ class TestPresets:
             _apply_preset(args, "nonexistent")
 
 
+class TestWebRigctldDefault:
+    """Issue #1089: rigctld is on by default with --no-rigctld opt-out."""
+
+    def test_parser_default_enables_rigctld(self):
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web"])
+        assert args.web_rigctld is True
+        assert args.web_rigctld_port == 4532
+
+    def test_parser_no_rigctld_flag_disables(self):
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web", "--no-rigctld"])
+        assert args.web_rigctld is False
+
+    async def test_cli_web_default_rigctld(self, capsys):
+        """rigctld starts by default (no flag passed) and banner shows it."""
+        import asyncio
+
+        from icom_lan.cli import _cmd_web
+
+        radio = AsyncMock()
+        radio.model = "IC-7610"
+
+        started = []
+
+        class FakeRigctldServer:
+            def __init__(self, _radio, cfg):
+                self.cfg = cfg
+
+            async def start(self):
+                started.append(self.cfg.port)
+
+            async def stop(self):
+                pass
+
+        class FakeWebServer:
+            def __init__(self, _radio, _cfg):
+                pass
+
+            async def serve_forever(self):
+                raise asyncio.CancelledError
+
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web"])
+
+        with (
+            patch("icom_lan.web.server.WebServer", FakeWebServer),
+            patch("icom_lan.rigctld.server.RigctldServer", FakeRigctldServer),
+        ):
+            rc = await _cmd_web(radio, args)
+
+        assert rc == 0
+        assert started == [4532], "rigctld should start on default port 4532"
+        out = capsys.readouterr().out
+        assert "rigctld:" in out
+        assert "4532" in out
+
+    async def test_cli_web_no_rigctld_opt_out(self, capsys):
+        """`--no-rigctld` disables rigctld; banner omits the rigctld line."""
+        import asyncio
+
+        from icom_lan.cli import _cmd_web
+
+        radio = AsyncMock()
+        radio.model = "IC-7610"
+
+        class ExplodingRigctldServer:
+            def __init__(self, *_args, **_kwargs):
+                raise AssertionError(
+                    "rigctld must not be constructed when --no-rigctld is set"
+                )
+
+        class FakeWebServer:
+            def __init__(self, _radio, _cfg):
+                pass
+
+            async def serve_forever(self):
+                raise asyncio.CancelledError
+
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web", "--no-rigctld"])
+
+        with (
+            patch("icom_lan.web.server.WebServer", FakeWebServer),
+            patch("icom_lan.rigctld.server.RigctldServer", ExplodingRigctldServer),
+        ):
+            rc = await _cmd_web(radio, args)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "rigctld:" not in out
+
+    async def test_cli_web_rigctld_port_busy_graceful(self, caplog, capsys):
+        """Port-busy on rigctld logs warning and continues serving the web."""
+        import asyncio
+        import logging
+
+        from icom_lan.cli import _cmd_web
+
+        radio = AsyncMock()
+        radio.model = "IC-7610"
+
+        class BusyRigctldServer:
+            def __init__(self, _radio, cfg):
+                self.cfg = cfg
+
+            async def start(self):
+                raise OSError(48, "Address already in use")
+
+            async def stop(self):  # pragma: no cover - never called
+                pass
+
+        class FakeWebServer:
+            def __init__(self, _radio, _cfg):
+                pass
+
+            async def serve_forever(self):
+                raise asyncio.CancelledError
+
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web"])
+
+        with (
+            patch("icom_lan.web.server.WebServer", FakeWebServer),
+            patch("icom_lan.rigctld.server.RigctldServer", BusyRigctldServer),
+            caplog.at_level(logging.WARNING, logger="icom_lan.cli"),
+        ):
+            rc = await _cmd_web(radio, args)
+
+        assert rc == 0, "web must keep running even if rigctld port is busy"
+        # Warning must mention the port and surface the problem.
+        assert any(
+            "rigctld" in rec.message.lower() and "4532" in rec.message
+            for rec in caplog.records
+        ), (
+            f"expected rigctld port-busy warning, got {[r.message for r in caplog.records]}"
+        )
+        out = capsys.readouterr().out
+        assert "rigctld:" not in out, (
+            "banner must not advertise rigctld when bind failed"
+        )
+
+
 class TestBackendAwareDiscover:
     def test_discover_serial_exits_with_error(self, capsys):
         with patch("sys.argv", ["icom-lan", "--backend", "serial", "discover"]):


### PR DESCRIPTION
Closes #1089
Refs #1087

## Summary

- `icom-lan web` now starts the embedded rigctld (Hamlib NET rigctl) on port 4532 by default — no need for `--preset digimode` to get WSJT-X / fldigi / JS8Call working.
- New `--no-rigctld` flag opts out (the flag and `default=True` were already wired in the parser; this PR makes the runtime match).
- If port 4532 is already in use (e.g. another rigctld is running), the web server logs a warning and keeps serving instead of aborting startup. The startup banner only shows the `rigctld:` line when the bind succeeded.

## Changes

- `_run`: drop the rigctld port from the pre-flight `check_ports_available` — the web port is still required, rigctld is best-effort.
- `_cmd_web`: catch `OSError` from `RigctldServer.start()`, log a warning, and continue. Other (non-OSError) failures still surface as before.

## Tests

- `TestWebRigctldDefault.test_parser_default_enables_rigctld`
- `TestWebRigctldDefault.test_parser_no_rigctld_flag_disables`
- `TestWebRigctldDefault.test_cli_web_default_rigctld` — rigctld starts by default, banner shows it
- `TestWebRigctldDefault.test_cli_web_no_rigctld_opt_out` — `--no-rigctld` skips rigctld and the banner
- `TestWebRigctldDefault.test_cli_web_rigctld_port_busy_graceful` — port-busy logs warning and `_cmd_web` returns 0

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4900 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [ ] Manual: `icom-lan web` shows `rigctld: 0.0.0.0:4532` in the banner
- [ ] Manual: `icom-lan web --no-rigctld` omits the rigctld line
- [ ] Manual: with another rigctld already on 4532, web starts with a warning

## Scope

- Strictly within the rigctld default. No bridge default changes (#1088) and no `[bridge]` extras changes (#1090).

🤖 Generated with [Claude Code](https://claude.com/claude-code)