### PR TITLE
build: fold [bridge] extras into core dependencies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Audio-bridge dependencies folded into core install (#1090).** `opuslib`,
+  `sounddevice`, and `numpy` moved from the `[bridge]` extra into the main
+  `dependencies` list — `pip install icom-lan` now ships the audio bridge,
+  Opus codec, and USB audio device listing out of the box. The legacy
+  `[audio]` and `[bridge]` extras remain as no-op aliases so existing
+  install commands keep working. The `[dsp]` extra now installs only
+  `scipy>=1.11` (numpy is core). Documentation updated accordingly.
+
 ## [0.18.0] — 2026-04-19
 
 ### Added

--- a/docs/guide/audio-recipes.md
+++ b/docs/guide/audio-recipes.md
@@ -12,7 +12,9 @@ export ICOM_PASS=YOUR_PASS
 ```
 
 ```bash
-pip install "icom-lan[audio]"
+# Audio dependencies (opuslib, sounddevice, numpy) ship with the core
+# install since v0.19 — `pip install icom-lan` is enough.
+pip install icom-lan
 ```
 
 ---
@@ -242,8 +244,8 @@ asyncio.run(main())
 Run Web UI + audio bridge + rigctld in a single command:
 
 ```bash
-# Install dependencies
-pip install icom-lan[bridge]
+# Install (audio-bridge deps ship with the core install since v0.19)
+pip install icom-lan
 brew install blackhole-2ch  # macOS
 
 # Start everything

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -639,10 +639,8 @@ icom-lan audio bridge --device "BlackHole 2ch" --rx-only
     After install, reboot to load the audio driver. Then `BlackHole 2ch` appears as an audio device.
 
 !!! note "Dependencies"
-    Audio bridge requires optional dependencies:
-    ```bash
-    pip install icom-lan[bridge]
-    ```
+    Audio-bridge dependencies (`opuslib`, `sounddevice`, `numpy`) ship with
+    the core install since v0.19 — `pip install icom-lan` is sufficient.
     On macOS with Homebrew, you may also need:
     ```bash
     export DYLD_LIBRARY_PATH=/opt/homebrew/lib

--- a/docs/guide/ic705-usb-setup.md
+++ b/docs/guide/ic705-usb-setup.md
@@ -49,17 +49,15 @@ This guide shows how to control the IC-705 via **USB serial CI-V + USB audio dev
 ### 1. Install icom-lan
 
 ```bash
+# Core install — includes serial CI-V (pyserial), USB audio RX/TX,
+# audio-device listing (sounddevice + numpy + opuslib).
 pip install icom-lan
-
-# For serial CI-V control:
-pip install icom-lan
-
-# For USB audio RX/TX and audio-device listing:
-pip install 'icom-lan[serial,bridge]'
-
-# serial: pyserial + pyserial-asyncio
-# bridge: sounddevice + numpy + opuslib
 ```
+
+!!! note
+    Since v0.19 the audio-bridge stack (`sounddevice`, `numpy`, `opuslib`)
+    is part of the core install. The legacy `[bridge]` and `[audio]` extras
+    still resolve but are now no-op aliases.
 
 ### 2. Connect the Radio
 
@@ -97,11 +95,8 @@ IC-705:
 icom-lan --list-audio-devices
 ```
 
-This command requires the optional bridge dependencies:
-
-```bash
-pip install 'icom-lan[bridge]'
-```
+Audio-device listing requires `sounddevice`, which ships with the core
+install since v0.19 (`pip install icom-lan`).
 
 **Example output:**
 
@@ -300,7 +295,7 @@ ls -l /dev/cu.*
 **Symptoms:** CI-V control works but no audio in browser/WSJT-X
 
 **Solutions:**
-- Install bridge dependencies: `pip install 'icom-lan[bridge]'`
+- Make sure you're on icom-lan v0.19+ (audio deps ship with the core install; for older versions run `pip install 'icom-lan[bridge]'`)
 - Verify `USB Audio RX/TX = Enabled` in radio settings
 - Check audio device names with `icom-lan --list-audio-devices`
 - macOS may require microphone/audio permissions for the terminal app

--- a/docs/guide/ic7610-usb-setup.md
+++ b/docs/guide/ic7610-usb-setup.md
@@ -45,17 +45,15 @@ This guide shows how to control the IC-7610 via **USB serial CI-V + USB audio de
 ### 1. Install icom-lan
 
 ```bash
+# Core install — includes serial CI-V (pyserial), USB audio RX/TX,
+# audio-device listing (sounddevice + numpy + opuslib).
 pip install icom-lan
-
-# For serial CI-V control:
-pip install icom-lan
-
-# For USB audio RX/TX and audio-device listing:
-pip install 'icom-lan[serial,bridge]'
-
-# serial: pyserial + pyserial-asyncio
-# bridge: sounddevice + numpy + opuslib
 ```
+
+!!! note
+    Since v0.19 the audio-bridge stack (`sounddevice`, `numpy`, `opuslib`)
+    is part of the core install. The legacy `[bridge]` and `[audio]` extras
+    still resolve but are now no-op aliases.
 
 ### 2. Connect the Radio
 
@@ -93,11 +91,8 @@ IC-7610:
 icom-lan --list-audio-devices
 ```
 
-This command requires the optional bridge dependencies:
-
-```bash
-pip install 'icom-lan[bridge]'
-```
+Audio-device listing requires `sounddevice`, which ships with the core
+install since v0.19 (`pip install icom-lan`).
 
 Example output:
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -33,13 +33,18 @@ pip install -e ".[dev]"
 ## Optional Dependencies
 
 ```bash
-pip install icom-lan[audio]    # Opus codec (opuslib)
-pip install icom-lan[bridge]   # Audio bridge (opuslib, sounddevice, numpy)
 pip install icom-lan[scope]    # Scope PNG rendering (pillow)
 pip install icom-lan[tls]      # HTTPS with auto-generated certs (cryptography)
+pip install icom-lan[webrtc]   # WebRTC audio transport (aiortc)
 ```
 
-Audio support (`[audio]`) installs `opuslib` for Opus codec. Not required for PCM/uLaw audio.
+!!! note "Audio bridge included by default (since v0.19)"
+    `opuslib`, `sounddevice`, and `numpy` are now part of the core install.
+    `pip install icom-lan` is enough for the Web UI, audio bridge, and Opus
+    codec support — no extras needed.
+
+    The legacy `[audio]` and `[bridge]` extras are preserved as no-op
+    aliases so existing install commands keep working.
 
 ## Verify Installation
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -428,8 +428,9 @@ icom-lan --list-audio-devices --json
 # Check radio settings:
 # Menu → Set → Connectors → USB Audio → USB Audio (RX/TX) → Enabled
 
-# Install serial + USB audio dependencies if missing
-pip install 'icom-lan[serial,bridge]'
+# Audio dependencies ship with the core install (since v0.19); the legacy
+# `[bridge]` extra still resolves but is now a no-op alias.
+pip install icom-lan
 ```
 
 ### "Scope over serial requires baudrate >= 115200"

--- a/docs/guide/wsjtx-setup.md
+++ b/docs/guide/wsjtx-setup.md
@@ -10,8 +10,8 @@ to work with `icom-lan serve` as a Hamlib NET rigctld replacement.
 **Recommended: all-in-one** (Web UI + audio bridge + rigctld):
 
 ```bash
-# Install bridge dependencies
-pip install icom-lan[bridge]
+# Install icom-lan (audio-bridge deps ship with the core install since v0.19)
+pip install icom-lan
 
 # Install BlackHole virtual audio devices (macOS)
 # Two devices required: one for RX, one for TX (single device creates feedback loop)

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -338,7 +338,7 @@ Bidirectional PCM bridge between radio and virtual audio devices:
 - RX: opus → decode → PCM → sounddevice OutputStream → BlackHole/Loopback
 - TX: sounddevice InputStream → noise gate → opus encode → radio
 - Uses AudioBus subscription (shares RX stream with other consumers)
-- Optional dependency: `pip install icom-lan[bridge]` (sounddevice + numpy + opuslib)
+- Dependencies: `sounddevice`, `numpy`, `opuslib` ship with the core install (since v0.19, #1090)
 
 ### `web/` — Built-in Web UI
 
@@ -749,20 +749,30 @@ while separating concerns. `IcomRadio` inherits from `ControlPhaseMixin`,
 ## Dependencies
 
 ```
-icom-lan (runtime)
-└── Python 3.11+ stdlib only
-    ├── asyncio, struct, socket, logging, dataclasses
+icom-lan (runtime, core install — since v0.19)
+├── pyserial, pyserial-asyncio (CI-V serial transport)
+├── sounddevice (PortAudio bindings — virtual-audio bridge, USB audio devices)
+├── numpy (PCM frame processing, DSP)
+└── opuslib (Opus codec for decode/encode)
 
 icom-lan[dev]
-├── pytest, pytest-asyncio
+├── pytest, pytest-asyncio, pytest-cov, pytest-timeout
+├── ruff, mypy
 
 icom-lan[scope]
 └── Pillow (for scope image rendering)
 
-icom-lan[bridge]
-├── sounddevice (PortAudio bindings)
-├── numpy (PCM frame processing)
-└── opuslib (Opus codec for decode/encode)
+icom-lan[dsp]
+└── scipy (advanced DSP — anti-aliasing FIR filter design, etc.)
+
+icom-lan[webrtc]
+└── aiortc (WebRTC audio transport)
+
+icom-lan[tls]
+└── cryptography (auto-generated HTTPS certs)
+
+icom-lan[audio]   # no-op alias preserved for backwards compat (#1090)
+icom-lan[bridge]  # no-op alias preserved for backwards compat (#1090)
 ```
 
 ## High-Level Flows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ requires-python = ">=3.11"
 dependencies = [
     "pyserial>=3.5",
     "pyserial-asyncio>=0.6",
+    "opuslib",
+    "sounddevice",
+    "numpy",
 ]
 authors = [
     { name = "Sergey Morozik", email = "morozsm@gmail.com" },
@@ -37,12 +40,15 @@ Issues = "https://github.com/morozsm/icom-lan/issues"
 icom-lan = "icom_lan.cli:main"
 
 [project.optional-dependencies]
-audio = ["opuslib"]
-bridge = ["opuslib", "sounddevice", "numpy"]
+# `audio` and `bridge` extras are kept as no-op aliases for backwards
+# compatibility — `opuslib`, `sounddevice`, and `numpy` are now part of
+# the core dependencies (#1090). New users should run `pip install icom-lan`.
+audio = []
+bridge = []
 scope = [
     "pillow>=10.0",
 ]
-dsp = ["numpy>=1.24", "scipy>=1.11"]
+dsp = ["scipy>=1.11"]
 webrtc = ["aiortc>=1.9"]
 tls = ["cryptography>=41.0"]
 dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout", "ruff", "mypy"]
@@ -108,9 +114,9 @@ ignore_missing_imports = true
 module = ["scipy", "scipy.*"]
 ignore_missing_imports = true
 
-# Optional audio / bridge / DSP deps (installed via ``[audio]`` /
-# ``[bridge]`` / ``[dsp]`` extras).  Ignore missing stubs so mypy runs
-# cleanly against the default (non-extras) install that CI uses.
+# Audio / DSP deps without published type stubs.  ``numpy``, ``sounddevice``
+# and ``opuslib`` ship with the core install since #1090; ``scipy`` is still
+# behind the ``[dsp]`` extra.  Ignore missing stubs so mypy runs cleanly.
 [[tool.mypy.overrides]]
 module = [
     "numpy",

--- a/uv.lock
+++ b/uv.lock
@@ -745,19 +745,14 @@ name = "icom-lan"
 version = "0.18.0"
 source = { editable = "." }
 dependencies = [
+    { name = "numpy" },
+    { name = "opuslib" },
     { name = "pyserial" },
     { name = "pyserial-asyncio" },
+    { name = "sounddevice" },
 ]
 
 [package.optional-dependencies]
-audio = [
-    { name = "opuslib" },
-]
-bridge = [
-    { name = "numpy" },
-    { name = "opuslib" },
-    { name = "sounddevice" },
-]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
@@ -767,7 +762,6 @@ dev = [
     { name = "ruff" },
 ]
 dsp = [
-    { name = "numpy" },
     { name = "scipy" },
 ]
 scope = [
@@ -799,10 +793,8 @@ requires-dist = [
     { name = "aiortc", marker = "extra == 'webrtc'", specifier = ">=1.9" },
     { name = "cryptography", marker = "extra == 'tls'", specifier = ">=41.0" },
     { name = "mypy", marker = "extra == 'dev'" },
-    { name = "numpy", marker = "extra == 'bridge'" },
-    { name = "numpy", marker = "extra == 'dsp'", specifier = ">=1.24" },
-    { name = "opuslib", marker = "extra == 'audio'" },
-    { name = "opuslib", marker = "extra == 'bridge'" },
+    { name = "numpy" },
+    { name = "opuslib" },
     { name = "pillow", marker = "extra == 'scope'", specifier = ">=10.0" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyserial-asyncio", specifier = ">=0.6" },
@@ -812,7 +804,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scipy", marker = "extra == 'dsp'", specifier = ">=1.11" },
-    { name = "sounddevice", marker = "extra == 'bridge'" },
+    { name = "sounddevice" },
 ]
 provides-extras = ["audio", "bridge", "scope", "dsp", "webrtc", "tls", "dev"]
 


### PR DESCRIPTION
Closes #1090
Refs #1087 (Form H — packaging modernization epic)

## Summary

- Move `opuslib`, `sounddevice`, and `numpy` from the `[bridge]` optional-dependencies group into the main `[project] dependencies` list. `pip install icom-lan` now ships the audio bridge, Opus codec, and USB audio device listing out of the box.
- Preserve the legacy `[audio]` and `[bridge]` extras as **no-op aliases** (`audio = []`, `bridge = []`) so existing `pip install icom-lan[audio,bridge]` commands continue to resolve without error. Documented as a deliberate choice in the CHANGELOG and `installation.md`.
- Reduce `[dsp]` extra to `scipy>=1.11` since `numpy` is now in core.
- Update install instructions across `docs/guide/{installation,cli,ic705-usb-setup,ic7610-usb-setup,audio-recipes,wsjtx-setup,troubleshooting}.md` and `docs/internals/architecture.md`.
- CHANGELOG entry under `### Changed` for v0.19.

## Migration impact

- Users who did `pip install icom-lan` — now pull `opuslib`, `sounddevice`, `numpy` automatically. **Additive, no breakage.**
- Users who did `pip install icom-lan[bridge]` or `[audio]` — still resolve (alias preserved). No `DeprecationWarning` emitted at install time; the no-op aliases are simply invisible to the resolver.
- Code-level error strings (e.g. `Audio codec backend unavailable; install icom-lan[audio]` in `_audio_transcoder.py`, install hints in `cli.py` / `audio_bridge.py` / `audio/backend.py` / `audio/usb_driver.py`) are intentionally **left unchanged** — the alias keeps those hints valid (the install command still resolves) and a single existing test asserts on the message string. Out of scope for this issue.

## Footprint

- `numpy` (~20 MB) + `sounddevice` (~few MB) + `opuslib` (small). Acceptable for an end-user app whose primary use case is the Web UI + audio bridge.

## Test plan

- [x] `uv sync --no-dev --no-extra=...` — all three (`numpy`, `sounddevice`, `opuslib`) appear in the resulting environment without any extra flag.
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4895 passed, 2 skipped, 9 xfailed, 1 xpassed.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run mypy src/` — clean (144 files).
- [x] `tests/test_audio_transcoder.py` — error-message assertion still passes (alias keeps the install hint valid).

## Notes

- PR-1088 / PR-1089 (parallel Form H tasks) touch `cli.py`; this PR only touches `pyproject.toml` + docs + CHANGELOG. Independent — no rebase conflicts expected.