### PR TITLE
fix(profiles): apply_profile falls back to set_split_mode during deprecation window

### DIFF
--- a/src/icom_lan/profiles_runtime.py
+++ b/src/icom_lan/profiles_runtime.py
@@ -131,6 +131,16 @@ async def apply_profile(radio: Any, profile: OperatingProfile) -> dict[str, obje
     if profile.split is not None:
         if hasattr(radio, "set_split"):
             await radio.set_split(profile.split)
+        elif hasattr(radio, "set_split_mode"):
+            # TODO(post-v0.20): drop this fallback once ``set_split_mode`` is
+            # removed (see PR #1130 deprecation schedule). During the v0.19
+            # window legacy adapters may still expose only the deprecated
+            # alias — call it so profiles continue to apply fully.
+            logger.debug(
+                "apply_profile: radio has no set_split, "
+                "falling back to deprecated set_split_mode"
+            )
+            await radio.set_split_mode(profile.split)
         else:
             logger.debug("apply_profile: radio has no set_split, skipping")
 

--- a/tests/test_profiles_runtime.py
+++ b/tests/test_profiles_runtime.py
@@ -338,6 +338,52 @@ class TestEqualizeVfoDispatch:
 
 
 # ---------------------------------------------------------------------------
+# apply_profile — set_split / set_split_mode fallback (issue #1144)
+# ---------------------------------------------------------------------------
+
+
+class TestApplySplitFallback:
+    """Verify ``apply_profile`` handles the v0.19 deprecation window.
+
+    PR #1130 introduced ``set_split`` and deprecated ``set_split_mode``
+    (warned in v0.19, removed in v0.20). During the deprecation window
+    ``apply_profile`` must:
+
+    * call ``set_split`` on adapters that expose the canonical name; and
+    * fall back to ``set_split_mode`` on legacy adapters that still only
+      expose the deprecated alias — without raising or silently skipping
+      the split step.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_canonical_set_split_is_preferred(self) -> None:
+        radio = AsyncMock(spec=["snapshot_state", "set_split", "set_split_mode"])
+        radio.snapshot_state = AsyncMock(return_value={})
+        radio.set_split = AsyncMock()
+        radio.set_split_mode = AsyncMock()
+        await apply_profile(radio, OperatingProfile(split=True))
+        radio.set_split.assert_awaited_once_with(True)
+        radio.set_split_mode.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_legacy_set_split_mode_fallback(self) -> None:
+        # Legacy adapter exposes only the deprecated alias.
+        radio = AsyncMock(spec=["snapshot_state", "set_split_mode"])
+        radio.snapshot_state = AsyncMock(return_value={})
+        radio.set_split_mode = AsyncMock()
+        await apply_profile(radio, OperatingProfile(split=True))
+        radio.set_split_mode.assert_awaited_once_with(True)
+
+    @pytest.mark.asyncio()
+    async def test_no_split_setter_is_skipped_silently(self) -> None:
+        radio = AsyncMock(spec=["snapshot_state"])
+        radio.snapshot_state = AsyncMock(return_value={})
+        # Should not raise even though radio has neither setter.
+        snapshot = await apply_profile(radio, OperatingProfile(split=True))
+        assert snapshot == {}
+
+
+# ---------------------------------------------------------------------------
 # Presets
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `apply_profile` now probes `set_split` first and falls back to the deprecated `set_split_mode` (with a debug log) so legacy adapters keep applying the split step during the v0.19 deprecation window.
- Added a `TODO(post-v0.20)` marking the fallback for removal alongside the alias drop scheduled in PR-22 follow-up.
- Tests cover both the canonical-primary preference (`set_split` wins when both exist) and the legacy fallback (only `set_split_mode` exposed).

## Test plan

- [x] `uv run pytest tests/test_profiles_runtime.py -q --tb=short`
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4905 passed, 2 skipped, 2 deselected, 9 xfailed, 1 xpassed
- [x] `uv run ruff check src/ tests/`

Closes #1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)