### PR TITLE
fix(yaesu): preserve APF frequency on mode-1 toggle

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -1648,18 +1648,18 @@ class YaesuCatRadio:
         (CO03), so this adapter degrades the 3-mode form onto the bool form:
 
         - mode 0 → APF off.
-        - mode 1 → APF on; centre frequency set to 0 (CW-pitch centred,
-          the natural "soft" default).
+        - mode 1 → APF on. The centre frequency is *not* touched here so
+          a previously-tuned APF frequency survives an off/on toggle. Set
+          it explicitly via `set_apf_freq()` if a particular pitch is
+          required.
         - mode 2 → not supported; the hardware has no separate "sharp" mode.
 
-        Delegates to the backend-internal `set_apf` / `set_apf_freq` CAT
-        primitives.
+        Delegates to the backend-internal `set_apf` CAT primitive.
         """
         if mode == 0:
             await self.set_apf(False, receiver=receiver)
         elif mode == 1:
             await self.set_apf(True, receiver=receiver)
-            await self.set_apf_freq(0, receiver=receiver)
         else:
             raise NotImplementedError(
                 f"APF mode {mode} (sharp) not supported on Yaesu — "

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1046,15 +1046,39 @@ async def test_set_audio_peak_filter_mode_0_disables_apf(connected_radio):
 
 
 @pytest.mark.asyncio
-async def test_set_audio_peak_filter_mode_1_enables_apf_and_centres_freq(
+async def test_set_audio_peak_filter_mode_1_enables_apf_only(
     connected_radio,
 ):
-    """Mode 1 (soft) → APF on (CO020001;) plus centre-frequency reset (CO030000;)."""
+    """Mode 1 (soft) → APF on (CO020001;) only — no implicit freq reset.
+
+    Regression for #1141: an unconditional `set_apf_freq(0)` would clobber
+    any user-tuned APF centre frequency every time APF was toggled on.
+    """
     connected_radio._transport.write = AsyncMock()
     await connected_radio.set_audio_peak_filter(1)
-    assert connected_radio._transport.write.await_count == 2
+    connected_radio._transport.write.assert_called_once_with("CO020001;")
+
+
+@pytest.mark.asyncio
+async def test_set_audio_peak_filter_mode_1_preserves_freq_across_toggle(
+    connected_radio,
+):
+    """APF centre frequency must survive an off/on toggle (#1141).
+
+    Sequence: enable APF (mode 1) → tune freq → disable (mode 0) →
+    re-enable (mode 1). Only the bool toggles and the explicit freq set
+    must hit the wire; nothing in `set_audio_peak_filter` may overwrite
+    the user-set frequency.
+    """
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_audio_peak_filter(1)
+    await connected_radio.set_apf_freq(200)
+    await connected_radio.set_audio_peak_filter(0)
+    await connected_radio.set_audio_peak_filter(1)
     sent = [c.args[0] for c in connected_radio._transport.write.await_args_list]
-    assert sent == ["CO020001;", "CO030000;"]
+    assert sent == ["CO020001;", "CO030200;", "CO020000;", "CO020001;"]
+    # Critical: only one CO03 frame — the explicit user one.
+    assert sum(1 for s in sent if s.startswith("CO03")) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Drops the unconditional `set_apf_freq(0)` from the mode-1 branch of `YaesuCatRadio.set_audio_peak_filter` so the user-tuned APF centre frequency survives an off/on toggle (e.g. `SetApf`, rigctld `APF ON`, repeated calls from polling).
- The dedicated `set_apf_freq()` remains the canonical entry point for changing the APF centre pitch — the toggle is now strictly an on/off bool that no longer mutates centre-frequency state.
- Updates the existing mode-1 unit test (which previously locked in the buggy behaviour) and adds a dedicated regression test that walks `enable → tune → off → on` and asserts only the explicit user CO03 frame hits the wire.

## Why

Codex P2 review on #1120 (`src/icom_lan/backends/yaesu_cat/radio.py:1545`): the mode-1 path was non-idempotent w.r.t. frequency state because every toggle-on rewrote CO03 to 0, clobbering the user-set pitch.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4903 passed, 0 failed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] New regression test `test_set_audio_peak_filter_mode_1_preserves_freq_across_toggle` exercises the full off/on cycle and verifies exactly one CO03 frame on the wire (the explicit user one).

Closes #1141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)