### PR TITLE
fix(api): get_split honors documented cache fallback on no-response

### DIFF
--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -2897,7 +2897,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """
         self._check_connected()
         civ = get_split(to_addr=self._radio_addr)
-        resp = await self._send_civ_expect(civ, label="get_split")
+        try:
+            resp = await self._send_civ_expect(civ, label="get_split")
+        except CommandError:
+            if self._last_split is not None:
+                logger.debug(
+                    "get_split: no response, returning cached %s", self._last_split
+                )
+                return self._last_split
+            return False
         if resp.data:
             on = bool(resp.data[0])
             self._last_split = on

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -163,6 +163,32 @@ class TestSplitMode:
         mock_transport.queue_response(_wrap_civ_in_udp(civ))
         assert await radio.get_split() is False
 
+    @pytest.mark.asyncio
+    async def test_get_split_falls_back_to_cache_on_no_response(
+        self, radio: IcomRadio
+    ) -> None:
+        """Issue #1143: ``get_split`` honors documented cache fallback when
+        ``_send_civ_expect`` raises ``CommandError`` (e.g. no response on
+        transient link issues / unsupported reads).
+        """
+        radio._last_split = True
+        radio._send_civ_expect = AsyncMock(  # type: ignore[method-assign]
+            side_effect=CommandError("No response for get_split")
+        )
+        assert await radio.get_split() is True
+
+    @pytest.mark.asyncio
+    async def test_get_split_no_response_no_cache_returns_false(
+        self, radio: IcomRadio
+    ) -> None:
+        """When there is no cached value and no response, return ``False``
+        instead of propagating ``CommandError``."""
+        radio._last_split = None
+        radio._send_civ_expect = AsyncMock(  # type: ignore[method-assign]
+            side_effect=CommandError("No response for get_split")
+        )
+        assert await radio.get_split() is False
+
 
 # ---------------------------------------------------------------------------
 # Attenuator


### PR DESCRIPTION
## Summary

- `IcomRadio.get_split()` documented a cached last-known fallback on no-response, but the impl used `_send_civ_expect()` which raises `CommandError` — bypassing cache and forcing callers (e.g. rigctld SPLIT) to handle exceptions on transient link issues / unsupported reads.
- Wrap `_send_civ_expect()` in `try/except CommandError` and fall back to `self._last_split` (default `False`), mirroring the timeout fallback pattern in `get_rf_power()`.
- Add two regression tests: cache hit path returns last value; no-cache path returns `False` instead of propagating.

Closes #1143

## Test plan

- [x] `uv run pytest tests/test_radio_extended.py -k split` — 9 passed (incl. 2 new)
- [x] `uv run pytest tests/ -q --ignore=tests/integration` — 4904 passed
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run mypy src/icom_lan/radio.py` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>