### PR TITLE
fix(cli): narrow rigctld OSError catch to EADDRINUSE

### DIFF
--- a/src/icom_lan/cli.py
+++ b/src/icom_lan/cli.py
@@ -24,6 +24,7 @@ __all__ = ["main", "check_ports_available"]
 
 import argparse
 import asyncio
+import errno
 import json
 import logging
 from logging.handlers import RotatingFileHandler
@@ -2705,13 +2706,27 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
         try:
             await candidate.start()
         except OSError as exc:
-            logger.warning(
-                "rigctld disabled: failed to bind port %d: %s "
-                "(another rigctld may already be running; pass --no-rigctld to silence)",
-                rigctld_port,
-                exc,
-            )
-            rigctld_server = None
+            # Only port-busy (EADDRINUSE) is treated as graceful degrade —
+            # another rigctld is likely already running. Other errno values
+            # (EACCES on privileged ports, EMFILE on fd exhaustion,
+            # ENETUNREACH, etc.) indicate a misconfigured environment and
+            # must surface so the operator can fix it.
+            if exc.errno == errno.EADDRINUSE:
+                logger.warning(
+                    "rigctld disabled: failed to bind port %d: %s "
+                    "(another rigctld may already be running; pass --no-rigctld to silence)",
+                    rigctld_port,
+                    exc,
+                )
+                rigctld_server = None
+            else:
+                logger.error(
+                    "rigctld failed to start on port %d: %s (errno=%s)",
+                    rigctld_port,
+                    exc,
+                    exc.errno,
+                )
+                raise
         else:
             rigctld_server = candidate
             rigctld_addr = f"0.0.0.0:{rigctld_port}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -805,8 +805,9 @@ class TestWebRigctldDefault:
         assert "rigctld:" not in out
 
     async def test_cli_web_rigctld_port_busy_graceful(self, caplog, capsys):
-        """Port-busy on rigctld logs warning and continues serving the web."""
+        """EADDRINUSE on rigctld logs warning and continues serving the web."""
         import asyncio
+        import errno
         import logging
 
         from icom_lan.cli import _cmd_web
@@ -819,7 +820,7 @@ class TestWebRigctldDefault:
                 self.cfg = cfg
 
             async def start(self):
-                raise OSError(48, "Address already in use")
+                raise OSError(errno.EADDRINUSE, "Address already in use")
 
             async def stop(self):  # pragma: no cover - never called
                 pass
@@ -852,6 +853,101 @@ class TestWebRigctldDefault:
         out = capsys.readouterr().out
         assert "rigctld:" not in out, (
             "banner must not advertise rigctld when bind failed"
+        )
+
+    async def test_cli_web_rigctld_eacces_surfaces(self, caplog):
+        """EACCES (privileged port) must NOT degrade silently — surfaces as error."""
+        import errno
+        import logging
+
+        from icom_lan.cli import _cmd_web
+
+        radio = AsyncMock()
+        radio.model = "IC-7610"
+
+        class PrivilegedRigctldServer:
+            def __init__(self, _radio, cfg):
+                self.cfg = cfg
+
+            async def start(self):
+                raise OSError(errno.EACCES, "Permission denied")
+
+            async def stop(self):  # pragma: no cover - never called
+                pass
+
+        class FakeWebServer:  # pragma: no cover - rigctld fails before web starts
+            def __init__(self, _radio, _cfg):
+                pass
+
+            async def serve_forever(self):
+                raise AssertionError("web must not start when rigctld fails hard")
+
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web"])
+
+        with (
+            patch("icom_lan.web.server.WebServer", FakeWebServer),
+            patch("icom_lan.rigctld.server.RigctldServer", PrivilegedRigctldServer),
+            caplog.at_level(logging.ERROR, logger="icom_lan.cli"),
+        ):
+            with pytest.raises(OSError) as exc_info:
+                await _cmd_web(radio, args)
+
+        assert exc_info.value.errno == errno.EACCES
+        # ERROR-level log must surface the failure — no silent degrade.
+        assert any(
+            "rigctld" in rec.message.lower() and rec.levelno >= logging.ERROR
+            for rec in caplog.records
+        ), (
+            "expected ERROR log for EACCES, got "
+            f"{[(r.levelname, r.message) for r in caplog.records]}"
+        )
+
+    async def test_cli_web_rigctld_emfile_surfaces(self, caplog):
+        """EMFILE (fd exhaustion) must NOT degrade silently — surfaces as error."""
+        import errno
+        import logging
+
+        from icom_lan.cli import _cmd_web
+
+        radio = AsyncMock()
+        radio.model = "IC-7610"
+
+        class ExhaustedRigctldServer:
+            def __init__(self, _radio, cfg):
+                self.cfg = cfg
+
+            async def start(self):
+                raise OSError(errno.EMFILE, "Too many open files")
+
+            async def stop(self):  # pragma: no cover - never called
+                pass
+
+        class FakeWebServer:  # pragma: no cover - rigctld fails before web starts
+            def __init__(self, _radio, _cfg):
+                pass
+
+            async def serve_forever(self):
+                raise AssertionError("web must not start when rigctld fails hard")
+
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web"])
+
+        with (
+            patch("icom_lan.web.server.WebServer", FakeWebServer),
+            patch("icom_lan.rigctld.server.RigctldServer", ExhaustedRigctldServer),
+            caplog.at_level(logging.ERROR, logger="icom_lan.cli"),
+        ):
+            with pytest.raises(OSError) as exc_info:
+                await _cmd_web(radio, args)
+
+        assert exc_info.value.errno == errno.EMFILE
+        assert any(
+            "rigctld" in rec.message.lower() and rec.levelno >= logging.ERROR
+            for rec in caplog.records
+        ), (
+            "expected ERROR log for EMFILE, got "
+            f"{[(r.levelname, r.message) for r in caplog.records]}"
         )
 
 


### PR DESCRIPTION
Closes #1147
Refs #1140 (parent epic), #1138 (introduced the broad catch)

## Summary
- PR #1138 added rigctld graceful degrade on `OSError`, but the catch was too broad: `EACCES` (privileged port), `EMFILE` (fd exhaustion), `ENETUNREACH`, etc. were all silently swallowed, leaving operators thinking CAT was available when rigctld never bound.
- Narrow the catch in `src/icom_lan/cli.py` to `errno.EADDRINUSE` only — that is the legitimate "another rigctld is already running" path. All other `OSError` codes are logged at `ERROR` level and re-raised.
- Add two negative tests (`EACCES`, `EMFILE`) and switch the existing `port-busy` test to `errno.EADDRINUSE` (portable across macOS/Linux).

## Test plan
- [x] `uv run pytest tests/test_cli.py -q` — 112 passed (including 7 in `TestWebRigctldDefault`).
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4904 passed, 2 skipped.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] Manual check: rigctld disabled gracefully on `EADDRINUSE`; surfaces hard on `EACCES` / `EMFILE`.

## Acceptance (per #1147)
- [x] EADDRINUSE → graceful degrade with WARNING.
- [x] EACCES → ERROR log + raise.
- [x] EMFILE → ERROR log + raise.