### PR TITLE
fix(cli): narrow auto-bridge fallback to missing-loopback only

### DIFF
--- a/src/icom_lan/audio_bridge.py
+++ b/src/icom_lan/audio_bridge.py
@@ -58,9 +58,22 @@ __all__ = [
     "BridgeMetrics",
     "BridgeState",
     "BridgeStateChange",
+    "LoopbackNotFoundError",
     "derive_bridge_label",
     "find_loopback_device",
 ]
+
+
+class LoopbackNotFoundError(RuntimeError):
+    """Raised when no virtual loopback audio device can be located.
+
+    Subclass of :class:`RuntimeError` for backward compatibility with
+    callers that catch the generic exception. Use this type to distinguish
+    "loopback driver not installed" (recoverable in auto-bridge mode) from
+    other bridge setup failures (unsupported radio, missing audio backend,
+    runtime errors).
+    """
+
 
 # Audio format constants — must match radio PCM settings
 SAMPLE_RATE = 48000
@@ -372,7 +385,7 @@ class AudioBridge:
         dev = _find_device_in_backend(self._backend, self._device_name)
         if dev is None:
             searched = self._device_name or "BlackHole/Loopback/VB-Cable/PipeWire"
-            raise RuntimeError(
+            raise LoopbackNotFoundError(
                 f"Virtual audio device not found (searched: {searched}). "
                 f"Install a loopback driver: "
                 f"macOS → brew install blackhole-2ch | "

--- a/src/icom_lan/cli.py
+++ b/src/icom_lan/cli.py
@@ -2654,6 +2654,8 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
         tx_device_name = getattr(args, "web_bridge_tx_device", None)
         rx_only = getattr(args, "web_bridge_rx_only", False)
         bridge_label = getattr(args, "web_bridge_label", None)
+        from .audio_bridge import LoopbackNotFoundError
+
         try:
             await server.start_audio_bridge(
                 device_name=device_name,
@@ -2667,11 +2669,26 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
             bridge_info = (
                 f"auto-enabled ({direction})" if is_auto else f"active ({direction})"
             )
-        except Exception as exc:
+        except LoopbackNotFoundError as exc:
             if is_auto:
                 # Graceful degrade — keep serving web UI without the bridge.
                 logger.warning("Audio bridge auto-start failed: %s", exc)
                 bridge_info = "loopback not found, bridge disabled"
+            else:
+                print(f"Error: audio bridge failed: {exc}", file=sys.stderr)
+                print(
+                    "The --bridge flag was explicitly requested with a device. "
+                    "Fix the device configuration or remove --bridge to start without it.",
+                    file=sys.stderr,
+                )
+                return 1
+        except Exception as exc:
+            # Non-loopback failure (unsupported radio audio, missing backend,
+            # runtime error). Surface the actual cause — do NOT mask as a
+            # missing loopback driver.
+            if is_auto:
+                logger.error("Audio bridge auto-start failed (non-loopback): %s", exc)
+                bridge_info = f"disabled: {exc}"
             else:
                 print(f"Error: audio bridge failed: {exc}", file=sys.stderr)
                 print(

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -790,6 +790,8 @@ async def test_cli_web_no_loopback_graceful(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Auto bridge with no loopback device: warn and continue (no exit 1)."""
+    from icom_lan.audio_bridge import LoopbackNotFoundError
+
     radio = AsyncMock()
 
     class FakeWebServer:
@@ -798,7 +800,7 @@ async def test_cli_web_no_loopback_graceful(
             self.cfg = cfg
 
         async def start_audio_bridge(self, **_kwargs):
-            raise RuntimeError("no loopback device found")
+            raise LoopbackNotFoundError("no loopback device found")
 
         async def serve_forever(self):
             raise asyncio.CancelledError
@@ -813,10 +815,18 @@ async def test_cli_web_no_loopback_graceful(
 
 
 @pytest.mark.asyncio
-async def test_cli_web_explicit_bridge_still_fails(
+async def test_cli_web_unrelated_bridge_failure_surfaces(
     capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Explicit --bridge=NonExistent must fail fast with clear error."""
+    """Auto bridge with a non-loopback failure: surface the real error.
+
+    Issue #1146 — generic ``Exception`` previously masked unrelated
+    failures (unsupported radio audio, missing audio backend, runtime
+    errors) as misleading "loopback not found" messages. The narrowed
+    handler must keep serving (graceful) but expose the actual cause
+    in logs and the bridge_info banner.
+    """
     radio = AsyncMock()
 
     class FakeWebServer:
@@ -825,7 +835,50 @@ async def test_cli_web_explicit_bridge_still_fails(
             self.cfg = cfg
 
         async def start_audio_bridge(self, **_kwargs):
-            raise RuntimeError("device 'NonExistent' not found")
+            raise RuntimeError(
+                "Audio bridge is unavailable: active radio does not support "
+                "audio streaming."
+            )
+
+        async def serve_forever(self):
+            raise asyncio.CancelledError
+
+    args = _web_cmd_args(web_bridge="auto")
+    with (
+        caplog.at_level("ERROR", logger="icom_lan.cli"),
+        patch("icom_lan.web.server.WebServer", FakeWebServer),
+    ):
+        rc = await _cmd_web(radio, args)
+
+    # Web server keeps running.
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Must NOT pretend the loopback driver is missing.
+    assert "loopback not found, bridge disabled" not in out
+    # Must mention the actual cause via logs and/or bridge banner.
+    assert any(
+        "non-loopback" in rec.message
+        and "does not support audio streaming" in rec.message
+        for rec in caplog.records
+    ), f"expected non-loopback error log, got: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_cli_web_explicit_bridge_still_fails(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Explicit --bridge=NonExistent must fail fast with clear error."""
+    from icom_lan.audio_bridge import LoopbackNotFoundError
+
+    radio = AsyncMock()
+
+    class FakeWebServer:
+        def __init__(self, _radio, cfg):
+            self.radio = _radio
+            self.cfg = cfg
+
+        async def start_audio_bridge(self, **_kwargs):
+            raise LoopbackNotFoundError("device 'NonExistent' not found")
 
         async def serve_forever(self):
             raise asyncio.CancelledError


### PR DESCRIPTION
Closes #1146

## Summary
- PR #1137 caught every `Exception` from `start_audio_bridge` and reported "loopback not found, bridge disabled". This silently downgraded unrelated failures (unsupported radio audio, missing audio backend, runtime errors) to a misleading loopback-miss message.
- Add `LoopbackNotFoundError(RuntimeError)` in `audio_bridge.py` and raise it from the loopback device-search miss path (subclass of `RuntimeError` for backward compat with existing catchers).
- `cli._cmd_web` now catches `LoopbackNotFoundError` separately for the graceful banner; non-loopback exceptions in auto mode log the real cause via `logger.error` and surface it in the `bridge_info` banner (`"disabled: <reason>"`) instead of masking it. Explicit `--bridge=DEVICE` still fails fast on either type.

## Files
- `src/icom_lan/audio_bridge.py` — new `LoopbackNotFoundError`, raised from `_setup_streams` device-miss path
- `src/icom_lan/cli.py` (~line 2675) — narrowed except clause + non-loopback branch
- `tests/test_cli_coverage.py` — existing graceful test updated to use specific exception; new `test_cli_web_unrelated_bridge_failure_surfaces`

## Test plan
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4903 passed, 2 skipped, 9 xfailed, 1 xpassed
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check` — modified files formatted
- [x] mypy — no new errors vs baseline (2 pre-existing on `main`)
- [x] Acceptance: missing-loopback (auto) → graceful, exit 0, "loopback not found, bridge disabled"
- [x] Acceptance: unsupported-radio-audio (auto) → logs real cause, banner reflects it, exit 0, NOT masked as loopback miss
- [x] Existing: explicit `--bridge=NonExistent` → exit 1 with clear error

Refs: parent epic #1140, sibling rigctld fix #1147 (no overlap, ~20 lines apart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)