### PR TITLE
fix(api): get_filter_width branches on profile encoding (Codex P1)

### DIFF
--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -1550,8 +1550,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_filter_width(self, receiver: int = 0) -> int:
         """Get DSP IF filter width in Hz (CI-V 0x1A 0x03).
 
-        The CI-V index is translated to Hz using the active profile's
-        filter rule for the current mode.
+        Branches on the active profile's ``filter_width_encoding``,
+        mirroring :meth:`set_filter_width`:
+
+        * ``segmented_bcd_index`` (IC-7610) — request is cmd29-wrapped, the
+          response payload is a 1-byte BCD index translated to Hz via the
+          active mode's segment table.
+        * ``direct_bcd_hz`` (IC-705, IC-9700) — request is sent directly
+          (no cmd29 wrap); the response payload is a 2-byte BCD value
+          encoding the width in Hz (e.g. ``0x24 0x00`` → 2400 Hz).
 
         Args:
             receiver: 0=MAIN, 1=SUB.
@@ -1562,26 +1569,41 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._check_connected()
         self._require_receiver(receiver, operation="get_filter_width")
 
-        index = await self._get_bcd_level(
-            get_filter_width(to_addr=self._radio_addr, receiver=receiver),
+        encoding = self._profile.filter_width_encoding
+        # CI-V 1A 03: cmd29-wrapped 1-byte BCD index for segmented profiles
+        # (IC-7610), direct 2-byte BCD Hz for direct_bcd_hz profiles
+        # (IC-705, IC-9700). Mirrors the routing/encoding split in
+        # set_filter_width above.
+        if encoding == "segmented_bcd_index" and self._profile.supports_cmd29(
+            0x1A, 0x03
+        ):
+            civ = get_filter_width(to_addr=self._radio_addr, receiver=receiver)
+            bcd_bytes = 1
+        else:
+            civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1A, sub=0x03)
+            bcd_bytes = 2
+
+        value = await self._get_bcd_level(
+            civ,
             key=f"get_filter_width:{receiver}",
             command=0x1A,
             sub=0x03,
-            bcd_bytes=1,
+            bcd_bytes=bcd_bytes,
         )
 
-        if self._profile.filter_width_encoding == "segmented_bcd_index":
+        if encoding == "segmented_bcd_index":
             target = self._radio_state.receiver("SUB" if receiver else "MAIN")
             mode_name = getattr(target, "mode", None)
             data_mode = int(getattr(target, "data_mode", 0) or 0)
             rule = self._profile.resolve_filter_rule(mode_name, data_mode=data_mode)
             if rule is not None and rule.segments:
                 try:
-                    return filter_index_to_hz(index, segments=rule.segments)
+                    return filter_index_to_hz(value, segments=rule.segments)
                 except ValueError:
                     # Out-of-band index — return raw value rather than fail.
-                    return index
-        return index
+                    return value
+        # direct_bcd_hz: the BCD-decoded payload is already Hz.
+        return value
 
     async def set_mode(
         self, mode: Mode | str, filter_width: int | None = None, receiver: int = 0

--- a/tests/test_dsp_filter_family.py
+++ b/tests/test_dsp_filter_family.py
@@ -27,6 +27,7 @@ from icom_lan.profiles import resolve_radio_profile
 from icom_lan.radio import IcomRadio
 from icom_lan.radio_protocol import DspControlCapable
 from icom_lan.rig_loader import load_rig
+from icom_lan.types import CivFrame
 
 _RIGS_DIR = Path(__file__).parents[1] / "rigs"
 
@@ -130,9 +131,12 @@ class TestDspControlCapableSatisfaction:
 # ---------------------------------------------------------------------------
 
 
-def _connected_icom() -> IcomRadio:
+def _connected_icom(*, model: str | None = None) -> IcomRadio:
     """Build a minimally-connected IcomRadio for unit tests."""
-    radio = IcomRadio(host="127.0.0.1", username="x", password="y")
+    kwargs: dict[str, str] = {}
+    if model is not None:
+        kwargs["model"] = model
+    radio = IcomRadio(host="127.0.0.1", username="x", password="y", **kwargs)
     # Bypass _check_connected without touching transport internals.
     radio._civ_runtime._check_connected = lambda: None  # type: ignore[method-assign]
     radio._civ_runtime._connected = True  # type: ignore[attr-defined]
@@ -180,6 +184,90 @@ async def test_icom_set_filter_width_rejects_out_of_range() -> None:
     with pytest.raises(CommandError):
         await radio.set_filter_width(20, receiver=0)
     radio.send_civ.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# get_filter_width — branches on profile.filter_width_encoding (issue #1145)
+# ---------------------------------------------------------------------------
+
+
+class TestIcomGetFilterWidthProfileBranching:
+    """get_filter_width must branch on encoding, mirroring set_filter_width.
+
+    Regression for #1145: prior code always used a cmd29-wrapped 1-byte BCD
+    GET, which broke ``direct_bcd_hz`` profiles (IC-705, IC-9700) — multi-byte
+    BCD widths like 2400 Hz were truncated to 24.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ic7610_segmented_index_request_is_cmd29_wrapped(self) -> None:
+        """IC-7610 (segmented_bcd_index): request frame is cmd29-wrapped."""
+        radio = _connected_icom(model="IC-7610")
+        captured: dict[str, bytes] = {}
+
+        async def fake_expect(civ: bytes, **_: object) -> CivFrame:
+            captured["civ"] = civ
+            # 1-byte BCD 0x20 = decimal 20 = USB segment index 20 → 1600 Hz.
+            return CivFrame(
+                to_addr=0xE0, from_addr=0x98, command=0x1A, sub=0x03, data=b"\x20"
+            )
+
+        radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+        radio._radio_state.main.mode = "USB"
+
+        hz = await radio.get_filter_width(receiver=0)
+        # Wire frame: cmd29-wrapped (0x29 + receiver=0x00 + 0x1A 0x03).
+        assert captured["civ"].hex() == "fefe98e029001a03fd"
+        # Decoded: BCD 0x20 → index 20 → USB segment 600 + (20 - 10) * 100 = 1600 Hz.
+        assert hz == 1600
+
+    @pytest.mark.asyncio
+    async def test_ic705_direct_bcd_hz_request_is_not_cmd29_wrapped(self) -> None:
+        """IC-705 (direct_bcd_hz): request frame is direct, NOT cmd29-wrapped."""
+        radio = _connected_icom(model="IC-705")
+        captured: dict[str, bytes] = {}
+
+        async def fake_expect(civ: bytes, **_: object) -> CivFrame:
+            captured["civ"] = civ
+            # 2-byte BCD: 0x24 0x00 = 2400 Hz (raw Hz, not index).
+            return CivFrame(
+                to_addr=0xE0,
+                from_addr=0xA4,
+                command=0x1A,
+                sub=0x03,
+                data=b"\x24\x00",
+            )
+
+        radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+
+        hz = await radio.get_filter_width(receiver=0)
+        # Wire frame: direct 0x1A 0x03 GET with no cmd29 wrap, no receiver byte.
+        assert captured["civ"].hex() == "fefea4e01a03fd"
+        # Decoded: 2-byte BCD 0x24 0x00 → 2400 Hz (regression: was 24 before fix).
+        assert hz == 2400
+
+    @pytest.mark.asyncio
+    async def test_ic9700_direct_bcd_hz_request_is_not_cmd29_wrapped(self) -> None:
+        """IC-9700 (direct_bcd_hz, no cmd29 support): direct GET frame."""
+        radio = _connected_icom(model="IC-9700")
+        captured: dict[str, bytes] = {}
+
+        async def fake_expect(civ: bytes, **_: object) -> CivFrame:
+            captured["civ"] = civ
+            return CivFrame(
+                to_addr=0xE0,
+                from_addr=0xA2,
+                command=0x1A,
+                sub=0x03,
+                data=b"\x24\x00",
+            )
+
+        radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+
+        hz = await radio.get_filter_width(receiver=0)
+        # Wire frame: direct GET (IC-9700 has no cmd29 at all per profile).
+        assert captured["civ"].hex() == "fefea2e01a03fd"
+        assert hz == 2400
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `IcomRadio.get_filter_width` (PR #1132) always built a cmd29-wrapped 1-byte BCD GET. That worked for the segmented-index IC-7610 but broke `direct_bcd_hz` profiles (IC-705, IC-9700) — multi-byte BCD widths were truncated, e.g. 2400 Hz read back as `24`.
- Now mirrors the routing/encoding split that `set_filter_width` already had:
  - `segmented_bcd_index` + cmd29-supported → cmd29-wrapped GET, decode 1-byte BCD index, translate via segments.
  - `direct_bcd_hz` (IC-705, IC-9700) → non-cmd29 `0x1A 0x03` GET, decode 2-byte BCD payload as raw Hz.
- Adds wire-frame golden tests for all three profiles in `tests/test_dsp_filter_family.py`. Existing tests unchanged.

## Affected radios

- IC-705 — filter-width readouts now return Hz instead of truncated index byte.
- IC-9700 — same fix; profile has no cmd29 at all, so the direct path is the only correct one.
- IC-7610 — unchanged behavior, segmented path preserved.

## Out of scope (follow-ups)

- `set_filter_width` for `direct_bcd_hz` is also broken (`bcd_encode_value(2400, byte_count=1)` raises). Setter sweep needed in a separate issue.
- wfview source treats every Icom rig as 1-byte BCD index (segmented). Whether IC-705/IC-9700 should migrate to `segmented_bcd_index` with proper segments is a profile-design question, also out of scope for this fix.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4905 passed, 0 failed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — no issues
- [x] New tests assert wire-frame bytes for IC-7610, IC-705, IC-9700 GET requests AND decoded Hz values

Closes #1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)