### PR TITLE
fix(api): drop direct_bcd_hz, unify filter_width on segmented BCD index per wfview

### DIFF
--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -241,7 +241,7 @@ Additional optional fields:
 | Field            | Type   | Required | Description                                      |
 |------------------|--------|----------|--------------------------------------------------|
 | `style`          | string | no       | `"named_slots"` (default) or `"per_mode"`        |
-| `encoding`       | string | no       | `"direct_bcd_hz"` (default) or `"segmented_bcd_index"` |
+| `encoding`       | string | no       | `"segmented_bcd_index"` (default, all Icom rigs) or `"table_index"` (Yaesu) |
 | `width_min_hz`   | int    | no       | Minimum IF filter width in Hz                    |
 | `width_max_hz`   | int    | no       | Maximum IF filter width in Hz                    |
 

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -178,9 +178,90 @@ inputs = [
 
 [filters]
 list = ["FIL1", "FIL2", "FIL3"]
-# wfview Filter Width: Min=50 Max=10000
+# CI-V 0x1A 0x03: width is a 1-byte BCD index, not raw Hz.
+# wfview's funcFilterWidth handler (icomcommander.cpp:1131) decodes a single
+# BCD byte using the same segmented formula for all Icom rigs:
+#   non-AM: pass 0..10 → 50..550 Hz step 50; pass 11..40 → 700..3600 Hz step 100
+#   AM:     pass 0..49 → 200..10000 Hz step 200
+# Matches IC-7610 / IC-7300 (issue #1156).
+encoding = "segmented_bcd_index"
 width_min_hz = 50
 width_max_hz = 10000
+
+[filters.width.USB]
+min_hz = 50
+max_hz = 3600
+defaults = [3000, 2400, 1800]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 3600, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.LSB]
+min_hz = 50
+max_hz = 3600
+defaults = [3000, 2400, 1800]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 3600, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.CW]
+min_hz = 50
+max_hz = 3600
+defaults = [1200, 500, 250]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 3600, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.CW-R]
+min_hz = 50
+max_hz = 3600
+defaults = [1200, 500, 250]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 3600, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.RTTY]
+min_hz = 50
+max_hz = 2700
+defaults = [2400, 500, 250]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 2700, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.RTTY-R]
+min_hz = 50
+max_hz = 2700
+defaults = [2400, 500, 250]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 2700, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.AM]
+min_hz = 200
+max_hz = 10000
+step_hz = 200
+defaults = [9000, 6000, 3000]
+segments = [
+    { hz_min = 200, hz_max = 10000, step_hz = 200, index_min = 0 },
+]
+
+[filters.width.FM]
+fixed = true
+defaults = [15000, 10000, 7000]
+
+[filters.width.WFM]
+fixed = true
+defaults = [200000, 200000, 200000]
+
+[filters.width.DV]
+fixed = true
+defaults = [7000, 7000, 7000]
 
 [vfo]
 scheme = "ab"

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -185,9 +185,82 @@ inputs = [
 
 [filters]
 list = ["FIL1", "FIL2", "FIL3"]
-# CI-V 0x1A 0x03: IF filter width 50-10000 Hz
+# CI-V 0x1A 0x03: width is a 1-byte BCD index, not raw Hz.
+# wfview's funcFilterWidth handler (icomcommander.cpp:1131) decodes a single
+# BCD byte using the same segmented formula for all Icom rigs:
+#   non-AM: pass 0..10 → 50..550 Hz step 50; pass 11..40 → 700..3600 Hz step 100
+#   AM:     pass 0..49 → 200..10000 Hz step 200
+# Matches IC-7610 / IC-7300 (issue #1156).
+encoding = "segmented_bcd_index"
 width_min_hz = 50
 width_max_hz = 9999
+
+[filters.width.USB]
+min_hz = 50
+max_hz = 3600
+defaults = [3000, 2400, 1800]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 3600, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.LSB]
+min_hz = 50
+max_hz = 3600
+defaults = [3000, 2400, 1800]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 3600, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.CW]
+min_hz = 50
+max_hz = 3600
+defaults = [1200, 500, 250]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 3600, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.CW-R]
+min_hz = 50
+max_hz = 3600
+defaults = [1200, 500, 250]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 3600, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.RTTY]
+min_hz = 50
+max_hz = 2700
+defaults = [2400, 500, 250]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 2700, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.RTTY-R]
+min_hz = 50
+max_hz = 2700
+defaults = [2400, 500, 250]
+segments = [
+    { hz_min = 50, hz_max = 500, step_hz = 50, index_min = 0 },
+    { hz_min = 600, hz_max = 2700, step_hz = 100, index_min = 10 },
+]
+
+[filters.width.AM]
+min_hz = 200
+max_hz = 10000
+step_hz = 200
+defaults = [9000, 6000, 3000]
+segments = [
+    { hz_min = 200, hz_max = 10000, step_hz = 200, index_min = 0 },
+]
+
+[filters.width.FM]
+fixed = true
+defaults = [15000, 10000, 7000]
 
 [vfo]
 # IC-9700 has two receivers (MAIN/SUB), not VFO A/B at the radio level.

--- a/src/icom_lan/profiles.py
+++ b/src/icom_lan/profiles.py
@@ -158,7 +158,7 @@ class RadioProfile:
     filters: tuple[str, ...] = ()
     filter_width_min: int = 50
     filter_width_max: int = 9999
-    filter_width_encoding: str = "direct_bcd_hz"
+    filter_width_encoding: str = "segmented_bcd_index"
     filter_config: dict[str, FilterWidthRule] | None = None
     att_values: tuple[int, ...] | None = None
     att_labels: dict[str, str] | None = None

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -1488,8 +1488,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def set_filter_width(self, width_hz: int, receiver: int = 0) -> None:
         """Set DSP IF filter width in Hz (CI-V 0x1A 0x03).
 
-        Hz is translated to a profile-defined CI-V index (1-byte BCD) and
-        wrapped via cmd29 when the profile supports it.
+        Hz is translated to a profile-defined 1-byte BCD index (wfview's
+        ``funcFilterWidth`` segmented formula — see ``icomcommander.cpp:1131``)
+        and wrapped via cmd29 only when the profile lists ``[0x1A, 0x03]`` in
+        its cmd29 routes (IC-7610). IC-705 and IC-9700 send the frame directly.
 
         Args:
             width_hz: Filter width in Hz. Bounds and step depend on the
@@ -1521,21 +1523,19 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 f"for {mode_name}, got {width_hz}"
             )
 
-        clamped = min(width_hz, 9999)
-        payload_value = clamped
-        if self._profile.filter_width_encoding == "segmented_bcd_index":
-            if rule is None or not rule.segments:
-                raise CommandError(
-                    f"set_filter_width has no filter-width mapping for mode {mode_name}"
-                )
-            try:
-                payload_value = filter_hz_to_index(clamped, segments=rule.segments)
-            except ValueError as exc:
-                raise CommandError(str(exc)) from exc
+        if rule is None or not rule.segments:
+            raise CommandError(
+                f"set_filter_width has no filter-width mapping for mode {mode_name}"
+            )
+        try:
+            payload_value = filter_hz_to_index(width_hz, segments=rule.segments)
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
 
         bcd_index_byte = bcd_encode_value(payload_value, byte_count=1)
         # CI-V 1A 03: 1-byte BCD index (wfview-confirmed). cmd29-wrapped
-        # for receiver routing on dual-RX rigs (IC-7610), direct on single-RX.
+        # for receiver routing on dual-RX rigs (IC-7610), direct on single-RX
+        # (IC-705) and on dual-RX rigs without cmd29 support (IC-9700).
         if self._profile.supports_cmd29(0x1A, 0x03):
             await self.send_civ(
                 0x29,
@@ -1550,15 +1550,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_filter_width(self, receiver: int = 0) -> int:
         """Get DSP IF filter width in Hz (CI-V 0x1A 0x03).
 
-        Branches on the active profile's ``filter_width_encoding``,
-        mirroring :meth:`set_filter_width`:
-
-        * ``segmented_bcd_index`` (IC-7610) — request is cmd29-wrapped, the
-          response payload is a 1-byte BCD index translated to Hz via the
-          active mode's segment table.
-        * ``direct_bcd_hz`` (IC-705, IC-9700) — request is sent directly
-          (no cmd29 wrap); the response payload is a 2-byte BCD value
-          encoding the width in Hz (e.g. ``0x24 0x00`` → 2400 Hz).
+        Per wfview's ``funcFilterWidth`` handler (``icomcommander.cpp:1131``),
+        all Icom rigs return a 1-byte BCD segmented index. The request is
+        cmd29-wrapped only when the profile lists ``[0x1A, 0x03]`` in its
+        cmd29 routes (IC-7610). IC-705 and IC-9700 send the request directly
+        and the response is decoded with the same segmented formula
+        (issue #1156).
 
         Args:
             receiver: 0=MAIN, 1=SUB.
@@ -1569,40 +1566,32 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._check_connected()
         self._require_receiver(receiver, operation="get_filter_width")
 
-        encoding = self._profile.filter_width_encoding
-        # CI-V 1A 03: cmd29-wrapped 1-byte BCD index for segmented profiles
-        # (IC-7610), direct 2-byte BCD Hz for direct_bcd_hz profiles
-        # (IC-705, IC-9700). Mirrors the routing/encoding split in
-        # set_filter_width above.
-        if encoding == "segmented_bcd_index" and self._profile.supports_cmd29(
-            0x1A, 0x03
-        ):
+        # CI-V 1A 03: 1-byte BCD index for every Icom rig (wfview-confirmed).
+        # cmd29-wrapped only for receiver routing on dual-RX rigs that list
+        # the route (IC-7610). IC-705/IC-9700 send the request directly.
+        if self._profile.supports_cmd29(0x1A, 0x03):
             civ = get_filter_width(to_addr=self._radio_addr, receiver=receiver)
-            bcd_bytes = 1
         else:
             civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1A, sub=0x03)
-            bcd_bytes = 2
 
         value = await self._get_bcd_level(
             civ,
             key=f"get_filter_width:{receiver}",
             command=0x1A,
             sub=0x03,
-            bcd_bytes=bcd_bytes,
+            bcd_bytes=1,
         )
 
-        if encoding == "segmented_bcd_index":
-            target = self._radio_state.receiver("SUB" if receiver else "MAIN")
-            mode_name = getattr(target, "mode", None)
-            data_mode = int(getattr(target, "data_mode", 0) or 0)
-            rule = self._profile.resolve_filter_rule(mode_name, data_mode=data_mode)
-            if rule is not None and rule.segments:
-                try:
-                    return filter_index_to_hz(value, segments=rule.segments)
-                except ValueError:
-                    # Out-of-band index — return raw value rather than fail.
-                    return value
-        # direct_bcd_hz: the BCD-decoded payload is already Hz.
+        target = self._radio_state.receiver("SUB" if receiver else "MAIN")
+        mode_name = getattr(target, "mode", None)
+        data_mode = int(getattr(target, "data_mode", 0) or 0)
+        rule = self._profile.resolve_filter_rule(mode_name, data_mode=data_mode)
+        if rule is not None and rule.segments:
+            try:
+                return filter_index_to_hz(value, segments=rule.segments)
+            except ValueError:
+                # Out-of-band index — return raw value rather than fail.
+                return value
         return value
 
     async def set_mode(

--- a/src/icom_lan/rig_loader.py
+++ b/src/icom_lan/rig_loader.py
@@ -83,7 +83,7 @@ class RigConfig:
     agc_labels: dict[str, str] | None
     filter_width_min: int = 50
     filter_width_max: int = 9999
-    filter_width_encoding: str = "direct_bcd_hz"
+    filter_width_encoding: str = "segmented_bcd_index"
     filter_config: dict[str, FilterWidthRule] | None = None
     data_mode_count: int = 0
     data_mode_labels: dict[str, str] | None = None
@@ -520,7 +520,7 @@ def load_rig(path: Path) -> RigConfig:
         raise RigLoadError(f"{filename}: [filters].list must not be empty")
     filter_width_min = int(filter_section.get("width_min_hz", 50))
     filter_width_max = int(filter_section.get("width_max_hz", 9999))
-    filter_width_encoding = str(filter_section.get("encoding", "direct_bcd_hz"))
+    filter_width_encoding = str(filter_section.get("encoding", "segmented_bcd_index"))
     filter_config_raw = filter_section.get("width", {})
     filter_config: dict[str, FilterWidthRule] | None = None
     if isinstance(filter_config_raw, dict) and filter_config_raw:

--- a/tests/test_dsp_filter_family.py
+++ b/tests/test_dsp_filter_family.py
@@ -187,21 +187,28 @@ async def test_icom_set_filter_width_rejects_out_of_range() -> None:
 
 
 # ---------------------------------------------------------------------------
-# get_filter_width — branches on profile.filter_width_encoding (issue #1145)
+# get_filter_width — unified 1-byte BCD segmented index per wfview (issue #1156)
 # ---------------------------------------------------------------------------
 
 
-class TestIcomGetFilterWidthProfileBranching:
-    """get_filter_width must branch on encoding, mirroring set_filter_width.
+class TestIcomGetFilterWidthRouting:
+    """get_filter_width: unified 1-byte BCD segmented index for all Icom rigs.
 
-    Regression for #1145: prior code always used a cmd29-wrapped 1-byte BCD
-    GET, which broke ``direct_bcd_hz`` profiles (IC-705, IC-9700) — multi-byte
-    BCD widths like 2400 Hz were truncated to 24.
+    Per wfview's funcFilterWidth handler (icomcommander.cpp:1131), every Icom
+    rig (IC-7610, IC-705, IC-9700, IC-7300) returns a 1-byte BCD index decoded
+    via the same segmented formula:
+        non-AM: pass 0..10 → 50..550 Hz step 50;
+                pass 11..40 → 700..3600 Hz step 100
+        AM:     pass → 200 + pass * 200 Hz
+
+    cmd29 wrapping is per-rig (only IC-7610 lists [0x1A, 0x03] in cmd29 routes).
+    Issue #1156 removed the prior ``direct_bcd_hz`` profile assumption that
+    treated IC-705/IC-9700 as raw 2-byte BCD Hz — wfview-verified incorrect.
     """
 
     @pytest.mark.asyncio
     async def test_ic7610_segmented_index_request_is_cmd29_wrapped(self) -> None:
-        """IC-7610 (segmented_bcd_index): request frame is cmd29-wrapped."""
+        """IC-7610: cmd29-wrapped 1-byte BCD index request and response."""
         radio = _connected_icom(model="IC-7610")
         captured: dict[str, bytes] = {}
 
@@ -222,33 +229,35 @@ class TestIcomGetFilterWidthProfileBranching:
         assert hz == 1600
 
     @pytest.mark.asyncio
-    async def test_ic705_direct_bcd_hz_request_is_not_cmd29_wrapped(self) -> None:
-        """IC-705 (direct_bcd_hz): request frame is direct, NOT cmd29-wrapped."""
+    async def test_ic705_request_is_not_cmd29_wrapped(self) -> None:
+        """IC-705: 1-byte BCD index, NOT cmd29-wrapped (no cmd29 support)."""
         radio = _connected_icom(model="IC-705")
         captured: dict[str, bytes] = {}
 
         async def fake_expect(civ: bytes, **_: object) -> CivFrame:
             captured["civ"] = civ
-            # 2-byte BCD: 0x24 0x00 = 2400 Hz (raw Hz, not index).
+            # 1-byte BCD 0x28 = decimal 28 = USB segment index 28
+            # → 600 + (28 - 10) * 100 = 2400 Hz (wfview formula).
             return CivFrame(
                 to_addr=0xE0,
                 from_addr=0xA4,
                 command=0x1A,
                 sub=0x03,
-                data=b"\x24\x00",
+                data=b"\x28",
             )
 
         radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+        radio._radio_state.main.mode = "USB"
 
         hz = await radio.get_filter_width(receiver=0)
-        # Wire frame: direct 0x1A 0x03 GET with no cmd29 wrap, no receiver byte.
+        # Wire frame: direct 0x1A 0x03 GET, no cmd29 wrap, no receiver byte.
         assert captured["civ"].hex() == "fefea4e01a03fd"
-        # Decoded: 2-byte BCD 0x24 0x00 → 2400 Hz (regression: was 24 before fix).
+        # Decoded: 1-byte BCD 0x28 → index 28 → 2400 Hz (wfview funcFilterWidth).
         assert hz == 2400
 
     @pytest.mark.asyncio
-    async def test_ic9700_direct_bcd_hz_request_is_not_cmd29_wrapped(self) -> None:
-        """IC-9700 (direct_bcd_hz, no cmd29 support): direct GET frame."""
+    async def test_ic9700_request_is_not_cmd29_wrapped(self) -> None:
+        """IC-9700: 1-byte BCD index, NOT cmd29-wrapped (HasCommand29=false)."""
         radio = _connected_icom(model="IC-9700")
         captured: dict[str, bytes] = {}
 
@@ -259,15 +268,88 @@ class TestIcomGetFilterWidthProfileBranching:
                 from_addr=0xA2,
                 command=0x1A,
                 sub=0x03,
-                data=b"\x24\x00",
+                data=b"\x28",
             )
 
         radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+        radio._radio_state.main.mode = "USB"
 
         hz = await radio.get_filter_width(receiver=0)
-        # Wire frame: direct GET (IC-9700 has no cmd29 at all per profile).
+        # Wire frame: direct GET (IC-9700 lists no cmd29 routes per profile).
         assert captured["civ"].hex() == "fefea2e01a03fd"
+        # Decoded: 1-byte BCD 0x28 → index 28 → 2400 Hz.
         assert hz == 2400
+
+    @pytest.mark.asyncio
+    async def test_ic705_am_mode_uses_am_segments(self) -> None:
+        """IC-705 AM: pass 0..49 → 200 + pass * 200 Hz (wfview AM branch)."""
+        radio = _connected_icom(model="IC-705")
+
+        async def fake_expect(_civ: bytes, **_: object) -> CivFrame:
+            # 1-byte BCD 0x29 = decimal 29 → AM: 200 + 29 * 200 = 6000 Hz.
+            return CivFrame(
+                to_addr=0xE0,
+                from_addr=0xA4,
+                command=0x1A,
+                sub=0x03,
+                data=b"\x29",
+            )
+
+        radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+        radio._radio_state.main.mode = "AM"
+
+        hz = await radio.get_filter_width(receiver=0)
+        assert hz == 6000
+
+
+class TestIcomSetFilterWidthRouting:
+    """set_filter_width: unified 1-byte BCD segmented index for all Icom rigs.
+
+    Companion to TestIcomGetFilterWidthRouting — covers issue #1155 (parallel
+    bug to #1145 on the setter side: ``bcd_encode_value(2400, byte_count=1)``
+    raised ValueError on direct_bcd_hz profiles). With direct_bcd_hz removed,
+    every rig now encodes a 1-byte BCD index and only IC-7610 wraps via cmd29.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ic705_set_filter_width_2400_is_direct_index_28(self) -> None:
+        """IC-705 USB 2400 Hz → index 28 (BCD 0x28), direct frame, no cmd29."""
+        radio = _connected_icom(model="IC-705")
+        radio.send_civ = AsyncMock()  # type: ignore[method-assign]
+        radio._radio_state.main.mode = "USB"
+
+        await radio.set_filter_width(2400, receiver=0)
+
+        # Direct CI-V 1A 03 with single BCD byte 0x28 (= decimal 28).
+        radio.send_civ.assert_awaited_once_with(
+            0x1A, sub=0x03, data=b"\x28", wait_response=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_ic9700_set_filter_width_2400_is_direct_index_28(self) -> None:
+        """IC-9700 USB 2400 Hz → index 28, direct frame (HasCommand29=false)."""
+        radio = _connected_icom(model="IC-9700")
+        radio.send_civ = AsyncMock()  # type: ignore[method-assign]
+        radio._radio_state.main.mode = "USB"
+
+        await radio.set_filter_width(2400, receiver=0)
+
+        radio.send_civ.assert_awaited_once_with(
+            0x1A, sub=0x03, data=b"\x28", wait_response=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_ic705_set_filter_width_am_uses_am_segments(self) -> None:
+        """IC-705 AM 6000 Hz → index 29 (200 + 29 * 200 = 6000)."""
+        radio = _connected_icom(model="IC-705")
+        radio.send_civ = AsyncMock()  # type: ignore[method-assign]
+        radio._radio_state.main.mode = "AM"
+
+        await radio.set_filter_width(6000, receiver=0)
+
+        radio.send_civ.assert_awaited_once_with(
+            0x1A, sub=0x03, data=b"\x29", wait_response=False
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1155

Closes #1156

## Summary

Verified against wfview's `funcFilterWidth` handler (`references/wfview/src/radio/icomcommander.cpp:1131`): **every Icom rig** (IC-7610, IC-705, IC-9700, IC-7300) decodes filter width from a single BCD byte using the same segmented formula:

```
non-AM: pass 0..10  -> 50..550 Hz step 50
        pass 11..40 -> 700..3600 Hz step 100
AM:     pass        -> 200 + pass * 200 Hz
```

The prior `direct_bcd_hz` profile (PR #1132 / PR #1154) was incorrect for IC-705 and IC-9700 — wfview proves these rigs use the same 1-byte BCD index as IC-7610, just without cmd29 wrapping.

cmd29 routing is per-rig:

| Rig     | cmd29 | Encoding                  |
|---------|-------|---------------------------|
| IC-7610 | wrap  | 1-byte BCD segmented index |
| IC-705  | no    | 1-byte BCD segmented index |
| IC-9700 | no    | 1-byte BCD segmented index |
| IC-7300 | no    | 1-byte BCD segmented index |

## Changes

- **`rigs/ic705.toml`, `rigs/ic9700.toml`**: add `encoding = "segmented_bcd_index"` plus full `[filters.width.<MODE>]` segment tables (USB / LSB / CW / CW-R / RTTY / RTTY-R / AM and fixed-width FM / WFM / DV).
- **`src/icom_lan/radio.py`**: simplify `set_filter_width` and `get_filter_width` to a single 1-byte BCD segmented index path. cmd29 wrapping driven only by the profile's cmd29 routes.
- **`src/icom_lan/profiles.py`, `rig_loader.py`**: change default `filter_width_encoding` to `"segmented_bcd_index"` (`direct_bcd_hz` is no longer a runtime mode).
- **`rigs/_schema.md`**: doc note reflecting new default.
- **`tests/test_dsp_filter_family.py`**: replace `direct_bcd_hz` golden tests with the wfview-correct 1-byte BCD index tests for IC-705/IC-9700, add AM-mode round-trip test, and add `set_filter_width` companion tests for #1155.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4919 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (no new errors)
- [x] `uv run ruff format src/ tests/` — formatted
- [ ] **Hardware verification on real IC-705 and IC-9700 still required.** wfview's shared handler is strong evidence but cannot fully substitute for on-rig testing. AM-mode behaviour in particular should be confirmed against the radio.

## Notes

- This is a real-bug fix that overrides part of the design from #1132 and #1154 — both PRs encoded/decoded incorrectly for IC-705 and IC-9700. PR #1132 used cmd29 + 1-byte BCD index for all rigs (cmd29 wrong on IC-705/IC-9700, encoding right); PR #1154 fixed cmd29 routing but switched to 2-byte BCD raw Hz (encoding wrong).
- IC-705 / IC-9700 previously had no `[filters.width.<MODE>]` sections at all — they relied on raw-Hz encoding without segments. This PR adds the segments tables from scratch (cribbing from IC-7610 / IC-7300, which wfview confirms share the same handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)