### PR TITLE
fix(api): get_split fallback also catches TimeoutError (refs #1158)

### DIFF
--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -2910,7 +2910,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         civ = get_split(to_addr=self._radio_addr)
         try:
             resp = await self._send_civ_expect(civ, label="get_split")
-        except CommandError:
+        except (CommandError, TimeoutError):
             if self._last_split is not None:
                 logger.debug(
                     "get_split: no response, returning cached %s", self._last_split

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -7,7 +7,7 @@ import pytest
 from icom_lan import IC_7610_ADDR
 from icom_lan.commands import CONTROLLER_ADDR, build_civ_frame
 from icom_lan.commander import Priority
-from icom_lan.exceptions import ConnectionError, CommandError
+from icom_lan.exceptions import CommandError, ConnectionError, TimeoutError
 from icom_lan.radio import IcomRadio
 from icom_lan.types import CivFrame, Mode, bcd_encode
 
@@ -186,6 +186,35 @@ class TestSplitMode:
         radio._last_split = None
         radio._send_civ_expect = AsyncMock(  # type: ignore[method-assign]
             side_effect=CommandError("No response for get_split")
+        )
+        assert await radio.get_split() is False
+
+    @pytest.mark.asyncio
+    async def test_get_split_falls_back_to_cache_on_timeout(
+        self, radio: IcomRadio
+    ) -> None:
+        """Issue #1158: ``get_split`` must also fall back to cache when
+        ``_send_civ_expect`` raises ``TimeoutError`` — that is the actual
+        exception the CI-V runtime raises on real radio silence (see
+        ``_civ_rx._execute_civ_raw``).
+        """
+        radio._last_split = True
+        radio._send_civ_expect = AsyncMock(  # type: ignore[method-assign]
+            side_effect=TimeoutError("CI-V response timed out")
+        )
+        assert await radio.get_split() is True
+
+    @pytest.mark.asyncio
+    async def test_get_split_timeout_no_cache_returns_false(
+        self, radio: IcomRadio
+    ) -> None:
+        """Issue #1158: when there is no cached value and the radio times out,
+        ``get_split`` should return ``False`` instead of propagating
+        ``TimeoutError``.
+        """
+        radio._last_split = None
+        radio._send_civ_expect = AsyncMock(  # type: ignore[method-assign]
+            side_effect=TimeoutError("CI-V response timed out")
         )
         assert await radio.get_split() is False
 


### PR DESCRIPTION
## Summary

- Codex P1 review on PR #1150 (post-merge) flagged that the new `try/except CommandError` around `_send_civ_expect` in `IcomRadio.get_split` does not cover the actual no-response path: the CI-V runtime (`_civ_rx._execute_civ_raw`) raises `TimeoutError("CI-V response timed out")`, not `CommandError`. Real radio silence therefore still bubbled out and the documented "fall back to cached value" stayed broken on hardware.
- Widened the catch to `(CommandError, TimeoutError)` so the cache fallback works on both transient errors and timeouts.
- Existing fallback tests mocked `CommandError` only — added parallel `TimeoutError` cases (cached and uncached) so this regression cannot recur.

Scope: only `get_split` matched the incomplete pattern. Other documented-cache getters in `radio.py` (`get_rf_power`, `get_attenuator_level`, `get_preamp`, ...) already handle `TimeoutError` correctly. The other surviving `except CommandError` in `radio.py` (line ~3140 in `set_preamp`) is not a cache-fallback — it filters a specific error to re-raise — so it stays as is.

Closes #1158

## Test plan

- [x] `uv run pytest tests/test_radio_extended.py -k get_split` — 6 passed (4 existing + 2 new).
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4921 passed, 0 failed.
- [x] `uv run ruff check src/ tests/` — All checks passed.
- [x] `uv run mypy src/` — Success: no issues found in 144 source files.