### PR TITLE
fix(api): close P1-03 cw_pitch Hz/idx + set_level SQL set-side

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/poller.py
+++ b/src/icom_lan/backends/yaesu_cat/poller.py
@@ -756,11 +756,12 @@ class YaesuCatPoller:
             except Exception:
                 logger.debug("YaesuCatPoller: get_keyer_speed failed", exc_info=True)
             try:
-                state.cw_pitch = await radio.get_key_pitch()
+                # state.cw_pitch is Hz; get_cw_pitch returns Hz (300-1050)
+                state.cw_pitch = await radio.get_cw_pitch()
             except NotImplementedError:
                 pass
             except Exception:
-                logger.debug("YaesuCatPoller: get_key_pitch failed", exc_info=True)
+                logger.debug("YaesuCatPoller: get_cw_pitch failed", exc_info=True)
             try:
                 # FTX-1 CAT only has binary on/off — no semi/full distinction
                 state.break_in = 1 if await radio.get_break_in() else 0

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -1478,12 +1478,26 @@ class YaesuCatRadio:
     # -- AdvancedControlCapable aliases ----------------------------------------
 
     async def get_cw_pitch(self) -> int:
-        """Alias for AdvancedControlCapable compatibility."""
-        return await self.get_key_pitch()
+        """CW pitch in Hz (300-1050).
+
+        ``get_key_pitch`` is the Yaesu-internal helper and returns the FTX-1
+        idx (0-75). The Icom-spelled ``CwControlCapable`` contract is Hz, so
+        we map ``idx → 300 + idx * 10`` (FTX-1 documented mapping: 0=300 Hz,
+        75=1050 Hz, 10 Hz step).
+        """
+        idx = await self.get_key_pitch()
+        return 300 + idx * 10
 
     async def set_cw_pitch(self, freq: int) -> None:
-        """Alias for AdvancedControlCapable compatibility."""
-        await self.set_key_pitch(freq)
+        """Set CW pitch in Hz (300-1050).
+
+        Maps Hz to FTX-1's 0-75 idx (10 Hz step). Raises ``ValueError`` on
+        out-of-range input.
+        """
+        if not 300 <= freq <= 1050:
+            raise ValueError(f"CW pitch must be 300-1050 Hz, got {freq}")
+        idx = (freq - 300) // 10
+        await self.set_key_pitch(idx)
 
     async def get_dial_lock(self) -> bool:
         """Alias for AdvancedControlCapable compatibility."""

--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -131,6 +131,7 @@ _GET_LEVEL_INT: dict[str, str] = {
 _SET_LEVEL_FLOAT: dict[str, str] = {
     "AF": "set_af_level",
     "RF": "set_rf_gain",
+    "SQL": "set_squelch",
     "NR": "set_nr_level",
     "NB": "set_nb_level",
     "COMP": "set_compressor_level",

--- a/src/icom_lan/rigctld/routing.py
+++ b/src/icom_lan/rigctld/routing.py
@@ -154,10 +154,9 @@ class YaesuRouting:
         if level == "IFSHIFT":
             return RigctldResponse(values=[str(await radio.get_if_shift())])
         if level == "CWPITCH":
-            idx = await radio.get_cw_pitch()
-            return RigctldResponse(
-                values=[str(self._CW_PITCH_BASE + idx * self._CW_PITCH_STEP)]
-            )
+            # radio.get_cw_pitch returns Hz directly (Yaesu backend converts
+            # idx → Hz internally per CwControlCapable contract).
+            return RigctldResponse(values=[str(await radio.get_cw_pitch())])
         if level == "KEYSPD":
             return RigctldResponse(values=[str(await radio.get_key_speed())])
 
@@ -211,10 +210,17 @@ class YaesuRouting:
             await radio.set_if_shift(round(value))
             return _ok()
         if level == "CWPITCH":
-            idx = max(
-                0, min(75, round((value - self._CW_PITCH_BASE) / self._CW_PITCH_STEP))
+            # radio.set_cw_pitch accepts Hz directly and clamps to FTX-1 range
+            # (300-1050) internally. Clamp here too for hamlib compatibility
+            # so an out-of-range hamlib value never bubbles a ValueError.
+            hz = max(
+                self._CW_PITCH_BASE,
+                min(
+                    self._CW_PITCH_BASE + 75 * self._CW_PITCH_STEP,
+                    round(value),
+                ),
             )
-            await radio.set_cw_pitch(idx)
+            await radio.set_cw_pitch(hz)
             return _ok()
         if level == "KEYSPD":
             await radio.set_key_speed(round(value))

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1297,17 +1297,62 @@ async def test_set_nr_off_sends_level_zero(connected_radio):
 
 
 @pytest.mark.asyncio
-async def test_get_cw_pitch_delegates_to_get_key_pitch(connected_radio):
+async def test_get_cw_pitch_returns_hz_from_idx(connected_radio):
+    """get_cw_pitch maps idx (0-75) → Hz via 300 + idx * 10. (#1162)"""
     connected_radio._transport.query = AsyncMock(return_value="KP25")
-    assert await connected_radio.get_cw_pitch() == 25
+    # idx 25 → 300 + 25*10 = 550 Hz
+    assert await connected_radio.get_cw_pitch() == 550
     connected_radio._transport.query.assert_called_once_with("KP;")
 
 
 @pytest.mark.asyncio
-async def test_set_cw_pitch_delegates_to_set_key_pitch(connected_radio):
+async def test_set_cw_pitch_accepts_hz(connected_radio):
+    """set_cw_pitch maps Hz → idx via (Hz - 300) // 10. (#1162)"""
     connected_radio._transport.write = AsyncMock()
-    await connected_radio.set_cw_pitch(30)
-    connected_radio._transport.write.assert_called_once_with("KP30;")
+    # 700 Hz → idx 40
+    await connected_radio.set_cw_pitch(700)
+    connected_radio._transport.write.assert_called_once_with("KP40;")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "hz, idx",
+    [(300, 0), (700, 40), (1050, 75)],
+)
+async def test_cw_pitch_round_trip_hz_idx(connected_radio, hz, idx):
+    """Boundary + middle round-trips: get returns Hz, set sends idx. (#1162)"""
+    connected_radio._transport.query = AsyncMock(return_value=f"KP{idx:02d}")
+    assert await connected_radio.get_cw_pitch() == hz
+
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_cw_pitch(hz)
+    connected_radio._transport.write.assert_called_once_with(f"KP{idx:02d};")
+
+
+@pytest.mark.asyncio
+async def test_set_cw_pitch_rejects_out_of_range(connected_radio):
+    """Hz outside 300-1050 raises ValueError. (#1162)"""
+    connected_radio._transport.write = AsyncMock()
+    with pytest.raises(ValueError, match="300-1050"):
+        await connected_radio.set_cw_pitch(299)
+    with pytest.raises(ValueError, match="300-1050"):
+        await connected_radio.set_cw_pitch(1051)
+    connected_radio._transport.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_key_pitch_still_returns_idx(connected_radio):
+    """Yaesu-named get_key_pitch keeps idx contract (no break). (#1162)"""
+    connected_radio._transport.query = AsyncMock(return_value="KP40")
+    assert await connected_radio.get_key_pitch() == 40
+
+
+@pytest.mark.asyncio
+async def test_set_key_pitch_still_takes_idx(connected_radio):
+    """Yaesu-named set_key_pitch keeps idx contract (no break). (#1162)"""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_key_pitch(40)
+    connected_radio._transport.write.assert_called_once_with("KP40;")
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1168,6 +1168,19 @@ async def test_set_level_nr(handler: RigctldHandler, mock_radio: AsyncMock) -> N
 
 
 @pytest.mark.asyncio
+async def test_rigctld_set_level_sql_icom(
+    handler: RigctldHandler, mock_radio: AsyncMock
+) -> None:
+    """set_level SQL on Icom dispatches to set_squelch — symmetric to #1093
+    get-side fix (#1118 get_squelch). (#1163)"""
+    mock_radio.set_squelch = AsyncMock()
+    resp = await handler.execute(set_cmd("set_level", "SQL", "0.500000"))
+    assert resp.ok
+    # 0.5 * 255 = 127.5, rounds to 128 (banker's rounding: round-half-to-even)
+    mock_radio.set_squelch.assert_awaited_once_with(128)
+
+
+@pytest.mark.asyncio
 async def test_set_level_nb(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
     resp = await handler.execute(set_cmd("set_level", "NB", "0.200000"))
     assert resp.ok
@@ -1800,7 +1813,8 @@ async def test_yaesu_get_level_nr(
 async def test_yaesu_get_level_cwpitch(
     yaesu_handler: RigctldHandler, yaesu_radio: AsyncMock
 ) -> None:
-    yaesu_radio.get_cw_pitch.return_value = 40  # index → 300 + 40*10 = 700 Hz
+    """Routing passes Hz through; backend converts idx → Hz internally. (#1162)"""
+    yaesu_radio.get_cw_pitch.return_value = 700  # backend returns Hz directly
     resp = await yaesu_handler.execute(get_cmd("get_level", "CWPITCH"))
     assert resp.ok
     assert resp.values == ["700"]
@@ -1906,9 +1920,10 @@ async def test_yaesu_set_level_nr(
 async def test_yaesu_set_level_cwpitch(
     yaesu_handler: RigctldHandler, yaesu_radio: AsyncMock
 ) -> None:
+    """Routing passes Hz through; backend converts Hz → idx internally. (#1162)"""
     resp = await yaesu_handler.execute(set_cmd("set_level", "CWPITCH", "700"))
     assert resp.ok
-    yaesu_radio.set_cw_pitch.assert_awaited_once_with(40)  # (700 - 300) / 10
+    yaesu_radio.set_cw_pitch.assert_awaited_once_with(700)  # Hz pass-through
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -92,7 +92,8 @@ def make_radio(
     radio.get_swr_meter = AsyncMock(return_value=0)
     radio._read_meter = AsyncMock(return_value=(0, 0))
     radio.get_keyer_speed = AsyncMock(return_value=20)
-    radio.get_key_pitch = AsyncMock(return_value=600)
+    radio.get_key_pitch = AsyncMock(return_value=30)  # idx — Yaesu-internal API
+    radio.get_cw_pitch = AsyncMock(return_value=600)  # Hz — Icom-spelled API (#1162)
     radio.get_break_in = AsyncMock(return_value=False)
     radio.get_break_in_delay = AsyncMock(return_value=0)
     radio.get_cw_spot = AsyncMock(return_value=False)
@@ -617,10 +618,10 @@ async def test_tx_meter_partial_failure_does_not_block_others() -> None:
 
 @pytest.mark.asyncio
 async def test_slow_poll_reads_cw_params() -> None:
-    """Slow poll should read keyer speed, key pitch, and break-in when CW capable."""
+    """Slow poll should read keyer speed, CW pitch (Hz), and break-in when CW capable."""
     radio = make_radio()
     radio.get_keyer_speed = AsyncMock(return_value=25)
-    radio.get_key_pitch = AsyncMock(return_value=700)
+    radio.get_cw_pitch = AsyncMock(return_value=700)  # Hz (#1162)
     radio.get_break_in = AsyncMock(return_value=True)
 
     poller = YaesuCatPoller(
@@ -635,7 +636,7 @@ async def test_slow_poll_reads_cw_params() -> None:
     await poller.stop()
 
     radio.get_keyer_speed.assert_called()
-    radio.get_key_pitch.assert_called()
+    radio.get_cw_pitch.assert_called()
     radio.get_break_in.assert_called()
     assert radio.radio_state.key_speed == 25
     assert radio.radio_state.cw_pitch == 700
@@ -660,7 +661,7 @@ async def test_slow_poll_skips_cw_without_capability() -> None:
     await poller.stop()
 
     radio.get_keyer_speed.assert_not_called()
-    radio.get_key_pitch.assert_not_called()
+    radio.get_cw_pitch.assert_not_called()
     radio.get_break_in.assert_not_called()
 
 
@@ -669,7 +670,7 @@ async def test_cw_partial_failure_does_not_block_others() -> None:
     """If get_keyer_speed fails, pitch and break-in must still be polled."""
     radio = make_radio()
     radio.get_keyer_speed = AsyncMock(side_effect=RuntimeError("CAT timeout"))
-    radio.get_key_pitch = AsyncMock(return_value=700)
+    radio.get_cw_pitch = AsyncMock(return_value=700)  # Hz (#1162)
     radio.get_break_in = AsyncMock(return_value=False)
 
     poller = YaesuCatPoller(
@@ -683,7 +684,7 @@ async def test_cw_partial_failure_does_not_block_others() -> None:
     await asyncio.sleep(0.05)
     await poller.stop()
 
-    radio.get_key_pitch.assert_called()
+    radio.get_cw_pitch.assert_called()
     radio.get_break_in.assert_called()
     assert radio.radio_state.cw_pitch == 700
     assert radio.radio_state.break_in == 0
@@ -785,7 +786,7 @@ async def test_slow_poll_reads_full_cw_block() -> None:
     """Slow poll populates key_speed, cw_pitch, break_in, break_in_delay, cw_spot."""
     radio = make_radio()
     radio.get_keyer_speed = AsyncMock(return_value=30)
-    radio.get_key_pitch = AsyncMock(return_value=750)
+    radio.get_cw_pitch = AsyncMock(return_value=750)  # Hz (#1162)
     radio.get_break_in = AsyncMock(return_value=True)
     radio.get_break_in_delay = AsyncMock(return_value=42)
     radio.get_cw_spot = AsyncMock(return_value=True)


### PR DESCRIPTION
## Summary

Audit-completion sweep — two related Icom-API contract gaps surfaced during the final pass over epic #1071 catalog:

- **#1162 (P1-03):** Yaesu `get/set_cw_pitch` were bare aliases for `get/set_key_pitch` (idx 0-75), but `CwControlCapable` promises Hz. Web UI and rigctld both reported wrong values on FTX-1. **Documented synthesis recommendation that hadn't been implemented** until this sweep.
- **#1163:** Symmetric set-side gap from PR #1118 (squelch fix on the get-side); the agent flagged it as a possible follow-up at the time. `set_level SQL <v>` was returning EINVAL on every backend.

Total: ~50 LOC, 7 files (4 src + 3 tests).

## Changes

**#1162 — Yaesu cw_pitch Hz/idx**
- `backends/yaesu_cat/radio.py` — `get_cw_pitch` returns Hz (`300 + idx * 10`), `set_cw_pitch(freq)` accepts Hz with 300-1050 bounds-check, maps to idx. Yaesu-internal `get/set_key_pitch` keeps idx contract.
- `backends/yaesu_cat/poller.py` — switch from `get_key_pitch` (idx) to `get_cw_pitch` (Hz) so `state.cw_pitch` (Hz field) is populated correctly. **This was the actual web-UI bug source** — issue's file pointers missed it; the new Hz API made it fixable in one line.
- `rigctld/routing.py` — simplify `YaesuRouting` CWPITCH paths to pass Hz through, since the radio API now handles idx ↔ Hz internally.

**#1163 — rigctld set_level SQL**
- `rigctld/handler.py` — add `"SQL": "set_squelch"` to `_SET_LEVEL_FLOAT` (one line).

**Tests**
- `test_ftx1_radio.py` — replace idx-mode tests with Hz-contract tests + boundary round-trips (300/700/1050) + range validation + backward-compat checks for `key_pitch`.
- `test_rigctld_handler.py` — new `test_rigctld_set_level_sql_icom`; update Yaesu CWPITCH routing tests for Hz pass-through.
- `test_yaesu_cat_poller.py` — switch CW poll mocks to `get_cw_pitch`.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4929 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] All 7 touched files `ruff format` clean (4 unrelated test files have pre-existing format drift, untouched)

Closes #1162

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)