### PR TITLE
chore(api): deprecate commands/levels.py backward-compat aliases (#1167)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **`icom_lan.commands.levels` backward-compat aliases (#1167).** The four
+  CI-V frame-builder aliases `get_power`, `set_power`, `get_sql`, and
+  `set_sql` are deprecated and will be removed in v0.20. Accessing them via
+  `icom_lan.commands.<name>` or `icom_lan.commands.levels.<name>` now emits
+  `DeprecationWarning`. Use the canonical builders directly: `get_rf_power` /
+  `set_rf_power` and `get_squelch` / `set_squelch`.
+
 ### Changed
 
 - **Audio-bridge dependencies folded into core install (#1090).** `opuslib`,

--- a/src/icom_lan/commands/__init__.py
+++ b/src/icom_lan/commands/__init__.py
@@ -16,6 +16,9 @@ Reference: wfview icomcommander.cpp, IC-7610.rig
 
 # Re-export everything from sub-modules -- no logic in this file.
 
+import warnings as _warnings
+from typing import Any as _Any
+
 from ..types import bcd_decode
 
 # --- _frame.py (kernel) ---
@@ -121,11 +124,9 @@ from .levels import (
     get_nr_level,
     get_pbt_inner,
     get_pbt_outer,
-    get_power,
     get_ref_adjust,
     get_rf_gain,
     get_rf_power,
-    get_sql,
     get_squelch,
     get_vox_delay,
     get_vox_gain,
@@ -148,11 +149,9 @@ from .levels import (
     set_nr_level,
     set_pbt_inner,
     set_pbt_outer,
-    set_power,
     set_ref_adjust,
     set_rf_gain,
     set_rf_power,
-    set_sql,
     set_squelch,
     set_vox_delay,
     set_vox_gain,
@@ -417,6 +416,31 @@ from .config import (
     set_lan_mod_level,
     set_usb_mod_level,
 )
+
+# Backward-compat aliases — DEPRECATED in v0.19, will be removed in v0.20.
+# Access via ``icom_lan.commands.<alias>`` emits ``DeprecationWarning``.
+# Use the canonical builders directly: ``get_rf_power``, ``set_rf_power``,
+# ``get_squelch``, ``set_squelch``.
+_DEPRECATED_ALIASES: dict[str, str] = {
+    "get_power": "get_rf_power",
+    "set_power": "set_rf_power",
+    "get_sql": "get_squelch",
+    "set_sql": "set_squelch",
+}
+
+
+def __getattr__(name: str) -> _Any:
+    """Forward deprecated alias access with a warning (PEP 562)."""
+    canonical = _DEPRECATED_ALIASES.get(name)
+    if canonical is not None:
+        _warnings.warn(
+            f"icom_lan.commands.{name} is deprecated since v0.19 and will be "
+            f"removed in v0.20; use {canonical} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[canonical]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [

--- a/src/icom_lan/commands/levels.py
+++ b/src/icom_lan/commands/levels.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
+import warnings
+from typing import TYPE_CHECKING, Any
 
 from ._builders import (
     _build_level_get,
@@ -979,8 +980,26 @@ def set_vox_delay(
     )
 
 
-# Backward-compat aliases
-get_power = get_rf_power
-set_power = set_rf_power
-get_sql = get_squelch
-set_sql = set_squelch
+# Backward-compat aliases — DEPRECATED in v0.19, will be removed in v0.20.
+# Use the canonical builders directly: get_rf_power, set_rf_power,
+# get_squelch, set_squelch.
+_DEPRECATED_ALIASES: dict[str, str] = {
+    "get_power": "get_rf_power",
+    "set_power": "set_rf_power",
+    "get_sql": "get_squelch",
+    "set_sql": "set_squelch",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Emit ``DeprecationWarning`` for legacy alias access (PEP 562)."""
+    canonical = _DEPRECATED_ALIASES.get(name)
+    if canonical is not None:
+        warnings.warn(
+            f"icom_lan.commands.levels.{name} is deprecated since v0.19 and "
+            f"will be removed in v0.20; use {canonical} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[canonical]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

- Mark four CI-V frame-builder aliases in `icom_lan.commands.levels` as deprecated: `get_power`, `set_power`, `get_sql`, `set_sql`. Use `get_rf_power` / `set_rf_power` and `get_squelch` / `set_squelch` instead.
- Implementation uses PEP 562 `__getattr__` at both the leaf module (`commands.levels`) and the package (`icom_lan.commands`); access emits `DeprecationWarning` and returns the canonical builder so existing call sites keep working.
- CHANGELOG entry added under `### Deprecated`. Targeted for removal in v0.20.

## Why option 2 (deprecate) over option 1 (delete)

Although `grep -rn 'levels\.get_power\|levels\.set_power\|levels\.get_sql\|levels\.set_sql' src/ tests/` returns no callers, the four names are listed in `__all__` of `icom_lan.commands` and documented under "Advanced / implementation detail" in `docs/api/public-api-surface.md`. External scripts may depend on them, so the safer path is a deprecation cycle.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4929 passed, 0 failed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/icom_lan/commands/levels.py src/icom_lan/commands/__init__.py` — clean
- [x] `uv run mypy src/` — clean
- [x] Verified `DeprecationWarning` is emitted on access via `icom_lan.commands.get_power` and `icom_lan.commands.levels.get_power` (visible in pytest warning summary).

Closes #1167

🤖 Generated with [Claude Code](https://claude.com/claude-code)