### PR TITLE
refactor(state): cw_spot tri-state + Yaesu-specific state extension

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/poller.py
+++ b/src/icom_lan/backends/yaesu_cat/poller.py
@@ -27,6 +27,7 @@ from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Callable
 
 from ...exceptions import ConnectionError as RadioConnectionError
+from ...radio_state import YaesuStateExtension
 
 if TYPE_CHECKING:
     from ..._poller_types import CommandQueue
@@ -782,16 +783,18 @@ class YaesuCatPoller:
             except Exception:
                 logger.debug("YaesuCatPoller: get_cw_spot failed", exc_info=True)
 
-        # -- RX/TX function mode (FR/FT) --
+        # -- RX/TX function mode (FR/FT) — Yaesu-specific extension --
         if "dual_rx" in caps:
+            if state.yaesu is None:
+                state.yaesu = YaesuStateExtension()
             try:
-                state.rx_func_mode = await radio.get_rx_func()
+                state.yaesu.rx_func_mode = await radio.get_rx_func()
             except NotImplementedError:
                 pass
             except Exception:
                 logger.debug("YaesuCatPoller: get_rx_func failed", exc_info=True)
             try:
-                state.tx_func_mode = await radio.get_tx_func()
+                state.yaesu.tx_func_mode = await radio.get_tx_func()
             except NotImplementedError:
                 pass
             except Exception:

--- a/src/icom_lan/radio_state.py
+++ b/src/icom_lan/radio_state.py
@@ -22,6 +22,7 @@ __all__ = [
     "TxBandEdge",
     "RadioState",
     "VfoSlotState",
+    "YaesuStateExtension",
 ]
 
 
@@ -218,6 +219,27 @@ class ScopeControlsState:
 
 
 @dataclass(slots=True)
+class YaesuStateExtension:
+    """Yaesu-CAT-specific state that has no clean Icom analog.
+
+    Populated by ``YaesuCatPoller``; left as ``None`` on
+    :class:`RadioState` for non-Yaesu backends. Keeping these fields in a
+    dedicated namespace keeps the generic :class:`RadioState` semantically
+    backend-neutral while still making Yaesu-only flags observable to UI
+    consumers (e.g. a Yaesu-specific panel).
+
+    Fields:
+        rx_func_mode: ``FR`` command — 0=dual RX off, 1=single RX.
+        tx_func_mode: ``FT`` command — 0=MAIN TX, 1=SUB TX.
+
+    ``None`` for any field means "not yet polled / unknown".
+    """
+
+    rx_func_mode: int | None = None
+    tx_func_mode: int | None = None
+
+
+@dataclass(slots=True)
 class RadioState:
     """Full radio state: two receivers + global parameters."""
 
@@ -256,14 +278,17 @@ class RadioState:
     compressor_level: int = 0  # 0-255
     monitor_on: bool = False
     break_in_delay: int = 0  # 0-255
-    cw_spot: bool = False
+    # cw_spot tri-state:
+    #   None = not populated by this backend (Icom backends leave it unset)
+    #   bool = explicit value reported by the radio (Yaesu backends populate it)
+    cw_spot: bool | None = None
     break_in: int = 0  # 0=off, 1=semi, 2=full
     dial_lock: bool = False
     drive_gain: int = 0  # 0-255
     monitor_gain: int = 0  # 0-255
     vfo_select: int = 0  # 0=VFO-A/MAIN, 1=VFO-B/SUB
-    rx_func_mode: int = 0  # FR: 0=dual RX off, 1=single RX (Yaesu CAT)
-    tx_func_mode: int = 0  # FT: 0=MAIN TX, 1=SUB TX (Yaesu CAT)
+    # Yaesu-specific extension; None on non-Yaesu backends, populated on Yaesu.
+    yaesu: YaesuStateExtension | None = None
     vox_on: bool = False
     vox_gain: int = 0  # 0-255
     anti_vox_gain: int = 0  # 0-255
@@ -319,8 +344,14 @@ class RadioState:
             "drive_gain": self.drive_gain,
             "monitor_gain": self.monitor_gain,
             "vfo_select": self.vfo_select,
-            "rx_func_mode": self.rx_func_mode,
-            "tx_func_mode": self.tx_func_mode,
+            "yaesu": (
+                {
+                    "rx_func_mode": self.yaesu.rx_func_mode,
+                    "tx_func_mode": self.yaesu.tx_func_mode,
+                }
+                if self.yaesu is not None
+                else None
+            ),
             "vox_on": self.vox_on,
             "vox_gain": self.vox_gain,
             "anti_vox_gain": self.anti_vox_gain,

--- a/tests/test_radio_state.py
+++ b/tests/test_radio_state.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from icom_lan.radio_state import RadioState, ReceiverState, VfoSlotState
+from icom_lan.radio_state import (
+    RadioState,
+    ReceiverState,
+    VfoSlotState,
+    YaesuStateExtension,
+)
 
 # ---------------------------------------------------------------------------
 # ReceiverState defaults
@@ -179,8 +184,7 @@ def test_to_dict_structure() -> None:
         "break_in_delay",
         "break_in",
         "cw_spot",
-        "rx_func_mode",
-        "tx_func_mode",
+        "yaesu",
         "dial_lock",
         "drive_gain",
         "monitor_gain",
@@ -450,3 +454,63 @@ class TestVfoSlotState:
         assert rx.vfo_a.mode == "CW"
         assert rx.vfo_a.filter_num == 3
         assert rx.active_slot == "A"
+
+
+# ---------------------------------------------------------------------------
+# State-contract sweep (#1169): cw_spot tri-state + Yaesu extension
+# ---------------------------------------------------------------------------
+
+
+class TestCwSpotTriState:
+    """``cw_spot`` is ``bool | None`` — None means "not populated"."""
+
+    def test_default_is_none(self) -> None:
+        """Icom backends never assign cw_spot — default must be None."""
+        rs = RadioState()
+        assert rs.cw_spot is None
+
+    def test_to_dict_serialises_none(self) -> None:
+        rs = RadioState()
+        d = rs.to_dict()
+        assert d["cw_spot"] is None
+
+    def test_to_dict_serialises_true(self) -> None:
+        rs = RadioState()
+        rs.cw_spot = True
+        assert rs.to_dict()["cw_spot"] is True
+
+    def test_to_dict_serialises_false(self) -> None:
+        rs = RadioState()
+        rs.cw_spot = False
+        assert rs.to_dict()["cw_spot"] is False
+
+
+class TestYaesuStateExtension:
+    """Yaesu-only flags live in ``state.yaesu`` namespace."""
+
+    def test_default_yaesu_is_none(self) -> None:
+        """Generic RadioState (Icom path) leaves yaesu unset."""
+        rs = RadioState()
+        assert rs.yaesu is None
+
+    def test_yaesu_extension_defaults(self) -> None:
+        ext = YaesuStateExtension()
+        assert ext.rx_func_mode is None
+        assert ext.tx_func_mode is None
+
+    def test_yaesu_assigned_namespace(self) -> None:
+        rs = RadioState()
+        rs.yaesu = YaesuStateExtension(rx_func_mode=1, tx_func_mode=0)
+        assert rs.yaesu is not None
+        assert rs.yaesu.rx_func_mode == 1
+        assert rs.yaesu.tx_func_mode == 0
+
+    def test_to_dict_yaesu_none(self) -> None:
+        rs = RadioState()
+        assert rs.to_dict()["yaesu"] is None
+
+    def test_to_dict_yaesu_populated(self) -> None:
+        rs = RadioState()
+        rs.yaesu = YaesuStateExtension(rx_func_mode=1, tx_func_mode=1)
+        d = rs.to_dict()
+        assert d["yaesu"] == {"rx_func_mode": 1, "tx_func_mode": 1}

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -763,8 +763,7 @@ def test_new_fields_in_to_dict() -> None:
     d = state.to_dict()
     for key in (
         "cw_spot",
-        "rx_func_mode",
-        "tx_func_mode",
+        "yaesu",
         "break_in_delay",
         "key_speed",
         "cw_pitch",
@@ -834,8 +833,9 @@ async def test_slow_poll_reads_rx_tx_func_mode() -> None:
 
     radio.get_rx_func.assert_called()
     radio.get_tx_func.assert_called()
-    assert radio.radio_state.rx_func_mode == 1
-    assert radio.radio_state.tx_func_mode == 1
+    assert radio.radio_state.yaesu is not None
+    assert radio.radio_state.yaesu.rx_func_mode == 1
+    assert radio.radio_state.yaesu.tx_func_mode == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #1169 — combined fix for P3-07 and P3-08 from the synthesis catalog.

- **P3-07**: `RadioState.cw_spot` is now `bool | None` (default `None`). Tri-state semantics: `None` = not populated by this backend (Icom path), `bool` = explicit value reported by the radio (Yaesu poller). Eliminates the misleading `False` default that conflated "off" with "unknown".
- **P3-08**: `rx_func_mode` / `tx_func_mode` (Yaesu FR/FT CAT semantics) moved out of generic `RadioState` into a new `YaesuStateExtension` dataclass exposed as `state.yaesu`. Generic state stays backend-neutral; Yaesu-only flags remain observable to UI consumers via the dedicated namespace.
- Yaesu poller constructs `state.yaesu = YaesuStateExtension()` lazily when the dual-RX FR/FT block runs. Non-Yaesu backends leave `state.yaesu = None`.
- `to_dict()` serialises `yaesu` as a nested dict on Yaesu and `null` elsewhere, keeping the "all keys always present" invariant for WebSocket consumers.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4938 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] New tests in `tests/test_radio_state.py`:
  - `cw_spot is None` default + `bool` round-trip via `to_dict()`
  - `state.yaesu is None` default + populated `YaesuStateExtension` round-trip via `to_dict()`
- [x] Existing Yaesu poller tests updated to read through `state.yaesu.rx_func_mode` / `state.yaesu.tx_func_mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)