### PR TITLE
refactor(poller): SetPower unit-tagged (Icom raw_255 vs Yaesu watts) — Closes #1168

### DIFF
--- a/src/icom_lan/_poller_types.py
+++ b/src/icom_lan/_poller_types.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 __all__ = [
     "Command",
@@ -175,7 +175,20 @@ class SetFilterShape:
 
 @dataclass(frozen=True, slots=True)
 class SetPower:
+    """Set TX RF power.
+
+    The ``unit`` tag disambiguates the level scale between backends:
+
+    - ``"raw_255"`` (default) — Icom CI-V scale, integer 0-255.
+    - ``"watts"`` — Yaesu CAT scale, integer watts (PC command, 0-999).
+
+    Each backend's poller verifies the unit matches its expected scale and
+    rejects mismatches with a clear ``ValueError``. The default keeps existing
+    Icom call sites unchanged (no migration churn).
+    """
+
     level: int
+    unit: Literal["raw_255", "watts"] = "raw_255"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/icom_lan/backends/yaesu_cat/poller.py
+++ b/src/icom_lan/backends/yaesu_cat/poller.py
@@ -349,7 +349,12 @@ class YaesuCatPoller:
                     await radio.set_squelch(level)
                 case SetMicGain(level=level):
                     await radio.set_mic_gain(level)
-                case SetPower(level=level):
+                case SetPower(level=level, unit=unit):
+                    if unit != "watts":
+                        raise ValueError(
+                            f"Yaesu backend expects SetPower unit='watts' "
+                            f"(PC command); got unit={unit!r}"
+                        )
                     await radio.set_power(level)
                 case SetDriveGain(level=level):
                     await radio.set_drive_gain(level)

--- a/src/icom_lan/web/handlers/control.py
+++ b/src/icom_lan/web/handlers/control.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ...profiles import RadioProfile
 from ...radio_state import RadioState
@@ -1259,7 +1259,14 @@ class ControlHandler:
                         "(missing power_control capability)"
                     )
                 level = int(params["level"])
-                q.put(SetPower(level))
+                # Tag the unit per backend: Yaesu CAT expects watts (PC
+                # command, 0-999), Icom expects raw 0-255 CI-V scale.
+                unit: Literal["raw_255", "watts"] = (
+                    "watts"
+                    if getattr(radio, "backend_id", "") == "yaesu_cat"
+                    else "raw_255"
+                )
+                q.put(SetPower(level, unit=unit))
                 return {"level": level}
             case "set_powerstat":
                 if radio is None:

--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -840,7 +840,12 @@ class RadioPoller:
                         logger.info("poller: RX audio stream restarted")
                     except Exception as e:
                         logger.debug("poller: audio stream transition failed: %s", e)
-            case SetPower(level=level):
+            case SetPower(level=level, unit=unit):
+                if unit != "raw_255":
+                    raise ValueError(
+                        f"Icom backend expects SetPower unit='raw_255' "
+                        f"(0-255 CI-V scale); got unit={unit!r}"
+                    )
                 if CAP_POWER_CONTROL in self._caps:
                     await radio.set_rf_power(level)
             case SetRfGain(level=level, receiver=rx):

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -328,7 +328,13 @@ def _scope_frame() -> ScopeFrame:
         ),
         ("ptt", {"state": True}, PttOn, {}, {"state": True}),
         ("ptt", {"state": False}, PttOff, {}, {"state": False}),
-        ("set_rf_power", {"level": 88}, SetPower, {"level": 88}, {"level": 88}),
+        (
+            "set_rf_power",
+            {"level": 88},
+            SetPower,
+            {"level": 88, "unit": "raw_255"},
+            {"level": 88},
+        ),
         (
             "set_rf_gain",
             {"level": 77, "receiver": 1},
@@ -616,6 +622,30 @@ async def test_enqueue_command_variants(
     assert isinstance(cmd, expected_type)
     for key, value in expected_attrs.items():
         assert getattr(cmd, key) == value
+
+
+async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
+    """Yaesu CAT backend → SetPower(unit='watts'); Icom default → 'raw_255'."""
+    queue = _QueueRecorder()
+    server = SimpleNamespace(command_queue=queue)
+
+    radio = _capable_radio()
+    radio.backend_id = "yaesu_cat"
+    handler = _control_handler(radio=radio, server=server)
+    await handler._enqueue_command("set_rf_power", {"level": 50})
+    assert isinstance(queue.items[-1], SetPower)
+    assert queue.items[-1].level == 50
+    assert queue.items[-1].unit == "watts"
+
+    queue2 = _QueueRecorder()
+    server2 = SimpleNamespace(command_queue=queue2)
+    radio2 = _capable_radio()
+    radio2.backend_id = "icom_lan"
+    handler2 = _control_handler(radio=radio2, server=server2)
+    await handler2._enqueue_command("set_rf_power", {"level": 200})
+    assert isinstance(queue2.items[-1], SetPower)
+    assert queue2.items[-1].level == 200
+    assert queue2.items[-1].unit == "raw_255"
 
 
 async def test_enqueue_command_errors() -> None:

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -927,3 +927,27 @@ async def test_serial_backend_unchanged_on_ptt_toggle() -> None:
         assert emission in serial_set
         # PTT state must not change which command is emitted at given index.
         assert emission == rx_emissions[poll_idx]
+
+
+# ----------------------------------------------------------------------
+# SetPower unit-tag (#1168)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setpower_icom_poller_accepts_raw_255() -> None:
+    """Default SetPower(unit='raw_255') flows to radio.set_rf_power on Icom."""
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+    await poller._execute(SetPower(level=128))  # noqa: SLF001
+    radio.set_rf_power.assert_awaited_once_with(128)
+
+
+@pytest.mark.asyncio
+async def test_setpower_icom_poller_rejects_watts_unit() -> None:
+    """Icom poller raises ValueError on unit='watts' and never calls set_rf_power."""
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+    with pytest.raises(ValueError, match="raw_255"):
+        await poller._execute(SetPower(level=50, unit="watts"))  # noqa: SLF001
+    radio.set_rf_power.assert_not_awaited()

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -892,3 +892,42 @@ async def test_execute_command_set_apf_off_dispatches_to_radio() -> None:
     await poller._execute_command(SetApf(mode=0, receiver=0))
 
     radio.set_audio_peak_filter.assert_awaited_once_with(0, receiver=0)
+
+
+# ---------------------------------------------------------------------------
+# Command dispatch — SetPower unit-tag (#1168)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_command_set_power_watts_unit_dispatches_to_radio() -> None:
+    """SetPower(unit='watts') flows directly to radio.set_power(watts)."""
+    from icom_lan._poller_types import SetPower
+
+    radio = make_radio()
+    radio.set_power = AsyncMock()
+    poller = YaesuCatPoller(radio, callback=lambda s: None, fast_interval=10.0)
+
+    await poller._execute_command(SetPower(level=50, unit="watts"))
+
+    radio.set_power.assert_awaited_once_with(50)
+
+
+@pytest.mark.asyncio
+async def test_execute_command_set_power_raw_255_unit_rejected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Default SetPower(unit='raw_255') is rejected by Yaesu poller and logs warning."""
+    import logging
+
+    from icom_lan._poller_types import SetPower
+
+    radio = make_radio()
+    radio.set_power = AsyncMock()
+    poller = YaesuCatPoller(radio, callback=lambda s: None, fast_interval=10.0)
+
+    with caplog.at_level(logging.WARNING, logger="icom_lan.backends.yaesu_cat.poller"):
+        await poller._execute_command(SetPower(level=200))  # default unit='raw_255'
+
+    radio.set_power.assert_not_awaited()
+    assert any("SetPower" in r.message or "failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- `SetPower(level)` was unit-ambiguous: the web handler enqueued raw 0-255 for Icom and the same shape was reinterpreted as watts by the Yaesu poller — silently broken when the web layer talked to a Yaesu radio.
- Add `unit: Literal[\"raw_255\", \"watts\"] = \"raw_255\"` to `SetPower`. Default keeps existing Icom call sites unchanged.
- Web handler tags `unit=\"watts\"` when `radio.backend_id == \"yaesu_cat\"`, `\"raw_255\"` otherwise.
- Both pollers verify the unit in their `match` arm and raise `ValueError` on mismatch (no implicit conversion — max-watts is rig-specific and out of scope).

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 4934 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] New tests:
  - Handler tags watts for Yaesu, raw_255 for Icom (`test_enqueue_set_rf_power_yaesu_tags_watts_unit`).
  - Icom poller rejects `unit=\"watts\"` (`test_setpower_icom_poller_rejects_watts_unit`).
  - Yaesu poller dispatches `unit=\"watts\"` to `radio.set_power` (`test_execute_command_set_power_watts_unit_dispatches_to_radio`).
  - Yaesu poller rejects default `unit=\"raw_255\"` and logs warning (`test_execute_command_set_power_raw_255_unit_rejected`).

Closes #1168