### PR TITLE
refactor(web): scope poller uses public ScopeCapable getters

### DIFF
--- a/src/icom_lan/_civ_rx.py
+++ b/src/icom_lan/_civ_rx.py
@@ -1321,6 +1321,22 @@ class CivRuntime:
         if frame.command == 0x17:
             return False
         if frame.command == 0x27:
+            # Scope-control GETs for subs 0x14, 0x15, 0x16, 0x17, 0x19, 0x1A,
+            # 0x1D, 0x1F may carry a single receiver-prefix byte (00=MAIN,
+            # 01=SUB) and still expect a data response. Subs without prefix
+            # (0x12, 0x13, 0x1B, 0x1C, 0x1E) keep the empty-data heuristic.
+            _SCOPE_GET_WITH_RX_PREFIX = (
+                0x14,
+                0x15,
+                0x16,
+                0x17,
+                0x19,
+                0x1A,
+                0x1D,
+                0x1F,
+            )
+            if frame.sub in _SCOPE_GET_WITH_RX_PREFIX:
+                return len(frame.data) <= 1
             return len(frame.data) == 0
         return len(frame.data) == 0
 

--- a/src/icom_lan/_scope_runtime.py
+++ b/src/icom_lan/_scope_runtime.py
@@ -231,11 +231,13 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def get_scope_mode(self) -> int:
         """Read the current scope mode (0=center, 1=fixed, 2=scroll-C, 3=scroll-F)."""
         self._check_connected()
+        receiver = self._scope_controls().receiver
         resp = await self._send_civ_expect(
-            _get_scope_mode_cmd(to_addr=self._radio_addr), label="get_scope_mode"
+            _get_scope_mode_cmd(to_addr=self._radio_addr, receiver=receiver),
+            label="get_scope_mode",
         )
-        receiver, mode = parse_scope_mode_response(resp)
-        self._apply_scope_receiver_hint(receiver)
+        rx_hint, mode = parse_scope_mode_response(resp)
+        self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().mode = mode
         return mode
 
@@ -252,11 +254,13 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def get_scope_span(self) -> int:
         """Read the scope span preset index (0..7)."""
         self._check_connected()
+        receiver = self._scope_controls().receiver
         resp = await self._send_civ_expect(
-            _get_scope_span_cmd(to_addr=self._radio_addr), label="get_scope_span"
+            _get_scope_span_cmd(to_addr=self._radio_addr, receiver=receiver),
+            label="get_scope_span",
         )
-        receiver, span = parse_scope_span_response(resp)
-        self._apply_scope_receiver_hint(receiver)
+        rx_hint, span = parse_scope_span_response(resp)
+        self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().span = span
         return span
 
@@ -273,11 +277,13 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def get_scope_edge(self) -> int:
         """Read the fixed-edge selection (1..4)."""
         self._check_connected()
+        receiver = self._scope_controls().receiver
         resp = await self._send_civ_expect(
-            _get_scope_edge_cmd(to_addr=self._radio_addr), label="get_scope_edge"
+            _get_scope_edge_cmd(to_addr=self._radio_addr, receiver=receiver),
+            label="get_scope_edge",
         )
-        receiver, edge = parse_scope_edge_response(resp)
-        self._apply_scope_receiver_hint(receiver)
+        rx_hint, edge = parse_scope_edge_response(resp)
+        self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().edge = edge
         return edge
 
@@ -294,11 +300,13 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def get_scope_hold(self) -> bool:
         """Read whether scope hold is enabled."""
         self._check_connected()
+        receiver = self._scope_controls().receiver
         resp = await self._send_civ_expect(
-            _get_scope_hold_cmd(to_addr=self._radio_addr), label="get_scope_hold"
+            _get_scope_hold_cmd(to_addr=self._radio_addr, receiver=receiver),
+            label="get_scope_hold",
         )
-        receiver, hold = parse_scope_hold_response(resp)
-        self._apply_scope_receiver_hint(receiver)
+        rx_hint, hold = parse_scope_hold_response(resp)
+        self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().hold = hold
         return hold
 
@@ -315,11 +323,13 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def get_scope_ref(self) -> float:
         """Read the scope reference level in dB."""
         self._check_connected()
+        receiver = self._scope_controls().receiver
         resp = await self._send_civ_expect(
-            _get_scope_ref_cmd(to_addr=self._radio_addr), label="get_scope_ref"
+            _get_scope_ref_cmd(to_addr=self._radio_addr, receiver=receiver),
+            label="get_scope_ref",
         )
-        receiver, ref_db = parse_scope_ref_response(resp)
-        self._apply_scope_receiver_hint(receiver)
+        rx_hint, ref_db = parse_scope_ref_response(resp)
+        self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().ref_db = ref_db
         return ref_db
 
@@ -336,11 +346,13 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def get_scope_speed(self) -> int:
         """Read the scope speed preset (0=fast, 1=mid, 2=slow)."""
         self._check_connected()
+        receiver = self._scope_controls().receiver
         resp = await self._send_civ_expect(
-            _get_scope_speed_cmd(to_addr=self._radio_addr), label="get_scope_speed"
+            _get_scope_speed_cmd(to_addr=self._radio_addr, receiver=receiver),
+            label="get_scope_speed",
         )
-        receiver, speed = parse_scope_speed_response(resp)
-        self._apply_scope_receiver_hint(receiver)
+        rx_hint, speed = parse_scope_speed_response(resp)
+        self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().speed = speed
         return speed
 
@@ -398,11 +410,13 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def get_scope_vbw(self) -> bool:
         """Read whether narrow scope VBW is enabled."""
         self._check_connected()
+        receiver = self._scope_controls().receiver
         resp = await self._send_civ_expect(
-            _get_scope_vbw_cmd(to_addr=self._radio_addr), label="get_scope_vbw"
+            _get_scope_vbw_cmd(to_addr=self._radio_addr, receiver=receiver),
+            label="get_scope_vbw",
         )
-        receiver, narrow = parse_scope_vbw_response(resp)
-        self._apply_scope_receiver_hint(receiver)
+        rx_hint, narrow = parse_scope_vbw_response(resp)
+        self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().vbw_narrow = narrow
         return narrow
 
@@ -457,11 +471,13 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def get_scope_rbw(self) -> int:
         """Read the scope RBW preset (0=wide, 1=mid, 2=narrow)."""
         self._check_connected()
+        receiver = self._scope_controls().receiver
         resp = await self._send_civ_expect(
-            _get_scope_rbw_cmd(to_addr=self._radio_addr), label="get_scope_rbw"
+            _get_scope_rbw_cmd(to_addr=self._radio_addr, receiver=receiver),
+            label="get_scope_rbw",
         )
-        receiver, rbw = parse_scope_rbw_response(resp)
-        self._apply_scope_receiver_hint(receiver)
+        rx_hint, rbw = parse_scope_rbw_response(resp)
+        self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().rbw = rbw
         return rbw
 

--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -542,30 +542,46 @@ class RadioPoller:
         Called after scope is enabled — IC-7610 ignores scope control
         queries when scope data output is off.
 
-        Note: commands 0x14, 0x15, 0x17, 0x19, 0x1A require a receiver
-        prefix byte (00=MAIN, 01=SUB) in the READ query — without it
-        the IC-7610 silently ignores the query.
+        Note: commands 0x14, 0x15, 0x16, 0x17, 0x19, 0x1A, 0x1D, 0x1F
+        require a receiver prefix byte (00=MAIN, 01=SUB) in the READ
+        query — without it the IC-7610 silently ignores the query.
+        The public ``get_scope_*`` methods on ``ScopeRuntimeMixin`` add
+        the prefix from ``radio_state.scope_controls.receiver`` for
+        each affected sub-command.
         """
-        # Determine active scope receiver (0=MAIN, 1=SUB)
+        from ..radio_protocol import ScopeCapable
+
+        radio = self._radio
+        if not isinstance(radio, ScopeCapable):
+            return
+
         scope_rx = 0
         if self._radio_state:
             scope_rx = self._radio_state.scope_controls.receiver
 
-        # Queries without receiver prefix
-        for sub in (0x12, 0x13, 0x1B, 0x1C):
+        # Iterate through all scope-control getters in the same order as
+        # the previous raw 0x27 sub-command sequence so cadence/queue
+        # behavior is preserved. Each call sleeps `_adaptive_gap()` to
+        # keep the existing throttle.
+        scope_getters: tuple[tuple[str, Any], ...] = (
+            ("get_scope_receiver", radio.get_scope_receiver),
+            ("get_scope_dual", radio.get_scope_dual),
+            ("get_scope_during_tx", radio.get_scope_during_tx),
+            ("get_scope_center_type", radio.get_scope_center_type),
+            ("get_scope_mode", radio.get_scope_mode),
+            ("get_scope_span", radio.get_scope_span),
+            ("get_scope_edge", radio.get_scope_edge),
+            ("get_scope_hold", radio.get_scope_hold),
+            ("get_scope_ref", radio.get_scope_ref),
+            ("get_scope_speed", radio.get_scope_speed),
+            ("get_scope_vbw", radio.get_scope_vbw),
+            ("get_scope_rbw", radio.get_scope_rbw),
+        )
+        for label, getter in scope_getters:
             try:
-                await self._civ(0x27, sub=sub, data=b"")
+                await getter()
             except Exception:
-                pass
-            await asyncio.sleep(self._adaptive_gap())
-
-        # Queries that require receiver prefix byte
-        rx_byte = bytes([scope_rx])
-        for sub in (0x14, 0x15, 0x16, 0x17, 0x19, 0x1A, 0x1D, 0x1F):
-            try:
-                await self._civ(0x27, sub=sub, data=rx_byte)
-            except Exception:
-                pass
+                logger.debug("radio-poller: %s failed", label, exc_info=True)
             await asyncio.sleep(self._adaptive_gap())
         logger.info("radio-poller: scope controls fetched (receiver=%d)", scope_rx)
 


### PR DESCRIPTION
Closes #1166

Replaces raw `self._civ(0x27, …)` calls in `web/radio_poller._fetch_scope_controls` with public `ScopeCapable.get_scope_*()` methods. Layering violation per CLAUDE.md ("Web/rigctld must never call transport directly").

## Bonus fixes uncovered

A literal raw→public swap would have regressed commit `178f729d` because the existing public getters in `_scope_runtime.py` did not include the receiver-prefix byte that IC-7610 requires for READ queries on subs `0x14/0x15/0x16/0x17/0x19/0x1A/0x1D/0x1F`. SET side threaded receiver, GET side didn't — asymmetry now corrected.

Also fixed `_civ_rx._civ_expects_response` for cmd `0x27`: the eight prefix-carrying GET subs now accept `len(data) <= 1` as response-expecting (was strictly `== 0`, which classified prefixed queries as fire-and-forget and timed out the response waiter).

Side benefit: web handlers' on-demand scope reads were affected by the same silent-ignore bug — now work correctly too.

## Files (3, within guardrail)

- `src/icom_lan/web/radio_poller.py` — refactor
- `src/icom_lan/_scope_runtime.py` — receiver-threading symmetry on GET side
- `src/icom_lan/_civ_rx.py` — `0x27` prefixed-query response classification

## Validation

- 4929 tests pass; ruff + mypy clean
- Per-call `_adaptive_gap()` throttle preserved

## Reference

- Audit: P2-05 from epic #1071 synthesis catalog
- Parent epic: #1165