### PR TITLE
feat(yaesu): implement ReceiverBankCapable + VfoSlotCapable on YaesuCatRadio

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -1131,6 +1131,166 @@ class YaesuCatRadio:
         """Copy VFO-B to VFO-A."""
         await self._write("vfo_b_to_a")
 
+    # -- ReceiverBankCapable -----------------------------------------------
+
+    @property
+    def receiver_count(self) -> int:
+        """Number of independent receivers exposed by this rig.
+
+        Profile-driven via ``[radio] receiver_count`` in the rig TOML.
+        FTX-1 reports ``2`` (MAIN + SUB); single-RX Yaesu CAT profiles
+        (e.g. FT-710, FT-991A — when added) report ``1``.
+        """
+        return int(self._config.receiver_count)
+
+    @staticmethod
+    def _normalize_receiver(which: int | str) -> int:
+        """Normalize a ``select_receiver`` argument to a 0-based index.
+
+        Accepts integer indices (``0`` / ``1``) or case-insensitive names
+        (``"main"`` / ``"sub"``).  Raises :class:`ValueError` for any other
+        value.
+        """
+        if isinstance(which, str):
+            key = which.strip().lower()
+            if key == "main":
+                return 0
+            if key == "sub":
+                return 1
+            raise ValueError(
+                f"select_receiver: unknown receiver name {which!r} "
+                "(expected 'main' or 'sub')"
+            )
+        if isinstance(which, bool) or not isinstance(which, int):
+            raise ValueError(
+                f"select_receiver: which must be int or str, got {type(which).__name__}"
+            )
+        return int(which)
+
+    async def select_receiver(self, which: int | str) -> None:
+        """Make ``which`` the active receiver for subsequent commands.
+
+        On dual-RX Yaesu CAT rigs (FTX-1) issues ``VS{0|1};`` via the
+        existing ``set_vfo_select`` template.  On single-RX profiles only
+        ``which == 0`` is accepted and the call is a no-op (matching the
+        :class:`~icom_lan.radio_protocol.ReceiverBankCapable` contract).
+        """
+        index = self._normalize_receiver(which)
+        count = self.receiver_count
+        if index < 0 or index >= count:
+            raise ValueError(
+                f"select_receiver: receiver index {index} out of range "
+                f"for receiver_count={count}"
+            )
+        if count <= 1:
+            # Single-RX: nothing to switch.
+            return
+        await self._write("set_vfo_select", vfo=str(index))
+
+    async def get_active_receiver(self) -> int:
+        """Return the index of the currently active receiver.
+
+        Reads ``VS;`` on dual-RX rigs; returns ``0`` on single-RX profiles.
+        """
+        if self.receiver_count <= 1:
+            return 0
+        result = await self._query("get_vfo_select")
+        return int(result["vfo"])
+
+    # -- VfoSlotCapable ----------------------------------------------------
+
+    def _vfo_slot_supported(self) -> bool:
+        """``True`` when the active profile exposes per-receiver A/B slots.
+
+        The FTX-1 family uses ``vfo_scheme = "ab_shared"`` — there is no
+        per-receiver A/B pair (each receiver has a single VFO addressed
+        via ``FA;``/``FB;``).  Single-RX Yaesu CAT rigs use
+        ``vfo_scheme = "ab"`` and route ``FR{vfo};`` through the shared
+        ``set_vfo_select`` / ``get_vfo_select`` plumbing.
+        """
+        return bool(self._config.vfo_scheme == "ab")
+
+    @staticmethod
+    def _slot_to_index(slot: str) -> int:
+        """Convert ``"A"`` / ``"B"`` (case-insensitive) to ``0`` / ``1``."""
+        if not isinstance(slot, str):
+            raise ValueError(f"slot must be str, got {type(slot).__name__}")
+        norm = slot.strip().upper()
+        if norm == "A":
+            return 0
+        if norm == "B":
+            return 1
+        raise ValueError(f"slot must be 'A' or 'B', got {slot!r}")
+
+    def _check_single_receiver(self, receiver: int, *, operation: str) -> None:
+        count = self.receiver_count
+        if receiver < 0 or receiver >= count:
+            raise ValueError(
+                f"{operation}: receiver index {receiver} out of range "
+                f"for receiver_count={count}"
+            )
+
+    async def get_vfo_slot(self, receiver: int = 0) -> str:
+        """Return the active VFO slot (``"A"`` or ``"B"``) for ``receiver``.
+
+        Raises :class:`NotImplementedError` on FTX-1 (``ab_shared`` scheme):
+        the FTX-1 has no per-receiver A/B pair.  Use
+        :meth:`select_receiver` for MAIN/SUB switching instead.
+        """
+        self._check_single_receiver(receiver, operation="get_vfo_slot")
+        if not self._vfo_slot_supported():
+            raise NotImplementedError(
+                f"get_vfo_slot not supported on {self.model} "
+                f"(vfo_scheme={self._config.vfo_scheme!r}); "
+                "use select_receiver() for MAIN/SUB on dual-RX Yaesu rigs"
+            )
+        result = await self._query("get_vfo_select")
+        return "B" if int(result["vfo"]) == 1 else "A"
+
+    async def set_vfo_slot(self, slot: str, receiver: int = 0) -> None:
+        """Make ``slot`` (``"A"`` or ``"B"``) the active VFO on ``receiver``.
+
+        Raises :class:`NotImplementedError` on FTX-1 (``ab_shared`` scheme).
+        """
+        self._check_single_receiver(receiver, operation="set_vfo_slot")
+        index = self._slot_to_index(slot)
+        if not self._vfo_slot_supported():
+            raise NotImplementedError(
+                f"set_vfo_slot not supported on {self.model} "
+                f"(vfo_scheme={self._config.vfo_scheme!r}); "
+                "use select_receiver() for MAIN/SUB on dual-RX Yaesu rigs"
+            )
+        await self._write("set_vfo_select", vfo=str(index))
+
+    async def swap_vfo_ab(self, receiver: int = 0) -> None:
+        """Swap VFO A and VFO B state on ``receiver``.
+
+        Yaesu CAT has no symmetric A↔B swap primitive: FTX-1 ``AB;``/
+        ``BA;`` are MAIN→SUB / SUB→MAIN copies (one-way), and Lab599-style
+        single-RX profiles do not expose a swap command at all.  This
+        method therefore raises :class:`NotImplementedError` on every
+        currently supported Yaesu CAT rig.
+        """
+        self._check_single_receiver(receiver, operation="swap_vfo_ab")
+        raise NotImplementedError(
+            f"swap_vfo_ab not supported on {self.model}: "
+            "Yaesu CAT has no symmetric A↔B swap primitive"
+        )
+
+    async def equalize_vfo_ab(self, receiver: int = 0) -> None:
+        """Copy the active VFO's state to the inactive VFO on ``receiver``.
+
+        Not supported by Yaesu CAT: FTX-1 ``AB;``/``BA;`` copy between
+        receivers (MAIN↔SUB), not between A/B within a receiver, and
+        single-RX Yaesu profiles do not expose an equalize command.
+        Raises :class:`NotImplementedError`.
+        """
+        self._check_single_receiver(receiver, operation="equalize_vfo_ab")
+        raise NotImplementedError(
+            f"equalize_vfo_ab not supported on {self.model}: "
+            "Yaesu CAT has no per-receiver A→B copy primitive"
+        )
+
     # -- D6: TX Stack -------------------------------------------------------
 
     async def get_power(self) -> tuple[int, int]:

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1787,3 +1787,273 @@ class TestIFBulkQuery:
         await radio.connect()  # should not raise
 
         assert radio.connected
+
+
+# ---------------------------------------------------------------------------
+# ReceiverBankCapable / VfoSlotCapable (#1171)
+# ---------------------------------------------------------------------------
+
+
+from icom_lan.backends.yaesu_cat.parser import CatCommandParser  # noqa: E402
+from icom_lan.command_spec import CatCommandSpec  # noqa: E402
+from icom_lan.radio_protocol import (  # noqa: E402
+    ReceiverBankCapable,
+    VfoSlotCapable,
+)
+
+
+@pytest.fixture()
+def single_rx_radio(config):
+    """YaesuCatRadio mutated to model a single-RX Yaesu CAT rig.
+
+    Lab599 TX-500 (Kenwood CAT) and FT-710 / FT-991A (Yaesu CAT, no
+    in-tree TOML yet) all expose a single receiver with VFO A/B routed
+    via ``FR;`` (``FR0;`` = VFO-A, ``FR1;`` = VFO-B).  We model that by
+    cloning the FTX-1 config and overriding ``receiver_count``,
+    ``vfo_scheme`` and the ``set_vfo_select`` / ``get_vfo_select``
+    command templates to point at ``FR;`` instead of ``VS;``.
+    """
+    cfg = config
+    new_commands = dict(cfg.commands)
+    new_commands["get_vfo_select"] = CatCommandSpec(read="FR;", parse="FR{vfo};")
+    new_commands["set_vfo_select"] = CatCommandSpec(write="FR{vfo};")
+    object.__setattr__(cfg, "commands", new_commands)
+    object.__setattr__(cfg, "receiver_count", 1)
+    object.__setattr__(cfg, "vfo_scheme", "ab")
+    r = YaesuCatRadio("/dev/null", profile=cfg)
+    # Rebuild parser cache so the swapped templates take effect.
+    r._parsers["get_vfo_select"] = CatCommandParser("FR{vfo};")
+    r._transport._connected = True
+    return r
+
+
+def test_receiver_count_ftx1(radio):
+    """FTX-1 profile reports receiver_count == 2 (MAIN + SUB)."""
+    assert radio.receiver_count == 2
+
+
+def test_receiver_count_single_rx(single_rx_radio):
+    """Single-RX synthetic profile reports receiver_count == 1."""
+    assert single_rx_radio.receiver_count == 1
+
+
+def test_protocol_satisfaction_receiver_bank(radio):
+    """YaesuCatRadio satisfies ReceiverBankCapable on FTX-1."""
+    assert isinstance(radio, ReceiverBankCapable)
+
+
+def test_protocol_satisfaction_vfo_slot(radio):
+    """YaesuCatRadio satisfies VfoSlotCapable on FTX-1."""
+    assert isinstance(radio, VfoSlotCapable)
+
+
+def test_protocol_satisfaction_single_rx(single_rx_radio):
+    """Single-RX YaesuCatRadio satisfies both protocols."""
+    assert isinstance(single_rx_radio, ReceiverBankCapable)
+    assert isinstance(single_rx_radio, VfoSlotCapable)
+
+
+# -- ReceiverBankCapable.select_receiver / get_active_receiver -------------
+
+
+@pytest.mark.asyncio
+async def test_select_receiver_main_writes_vs0(connected_radio):
+    """select_receiver(0) on dual-RX FTX-1 emits VS0;."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.select_receiver(0)
+    connected_radio._transport.write.assert_called_once_with("VS0;")
+
+
+@pytest.mark.asyncio
+async def test_select_receiver_sub_writes_vs1(connected_radio):
+    """select_receiver(1) on dual-RX FTX-1 emits VS1;."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.select_receiver(1)
+    connected_radio._transport.write.assert_called_once_with("VS1;")
+
+
+@pytest.mark.asyncio
+async def test_select_receiver_by_name_main(connected_radio):
+    """select_receiver('main') normalizes to index 0 → VS0;."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.select_receiver("main")
+    connected_radio._transport.write.assert_called_once_with("VS0;")
+
+
+@pytest.mark.asyncio
+async def test_select_receiver_by_name_sub_case_insensitive(connected_radio):
+    """select_receiver('SUB') is case-insensitive → VS1;."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.select_receiver("SUB")
+    connected_radio._transport.write.assert_called_once_with("VS1;")
+
+
+@pytest.mark.asyncio
+async def test_select_receiver_unknown_name_raises(connected_radio):
+    connected_radio._transport.write = AsyncMock()
+    with pytest.raises(ValueError, match="unknown receiver name"):
+        await connected_radio.select_receiver("tertiary")
+    connected_radio._transport.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_select_receiver_out_of_range_raises(connected_radio):
+    connected_radio._transport.write = AsyncMock()
+    with pytest.raises(ValueError, match="out of range"):
+        await connected_radio.select_receiver(2)
+    connected_radio._transport.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_select_receiver_single_rx_zero_is_noop(single_rx_radio):
+    """On single-RX rigs select_receiver(0) is a no-op (no wire traffic)."""
+    single_rx_radio._transport.write = AsyncMock()
+    await single_rx_radio.select_receiver(0)
+    single_rx_radio._transport.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_select_receiver_single_rx_nonzero_raises(single_rx_radio):
+    single_rx_radio._transport.write = AsyncMock()
+    with pytest.raises(ValueError, match="out of range"):
+        await single_rx_radio.select_receiver(1)
+    single_rx_radio._transport.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_active_receiver_dual_rx(connected_radio):
+    """get_active_receiver parses VS1; → 1 on dual-RX FTX-1."""
+    connected_radio._transport.query = AsyncMock(return_value="VS1")
+    assert await connected_radio.get_active_receiver() == 1
+    connected_radio._transport.query.assert_called_once_with("VS;")
+
+
+@pytest.mark.asyncio
+async def test_get_active_receiver_single_rx_returns_zero(single_rx_radio):
+    """Single-RX returns 0 without wire traffic."""
+    single_rx_radio._transport.query = AsyncMock()
+    assert await single_rx_radio.get_active_receiver() == 0
+    single_rx_radio._transport.query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_select_receiver_roundtrip_dual_rx(connected_radio):
+    """select_receiver(1) → get_active_receiver returns 1 (mocked)."""
+    connected_radio._transport.write = AsyncMock()
+    connected_radio._transport.query = AsyncMock(return_value="VS1")
+    await connected_radio.select_receiver(1)
+    assert await connected_radio.get_active_receiver() == 1
+
+
+# -- VfoSlotCapable on FTX-1 (ab_shared scheme — raises) -------------------
+
+
+@pytest.mark.asyncio
+async def test_get_vfo_slot_raises_on_ftx1(connected_radio):
+    """FTX-1 has no per-receiver A/B; get_vfo_slot raises NotImplementedError."""
+    with pytest.raises(NotImplementedError, match="ab_shared"):
+        await connected_radio.get_vfo_slot()
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_slot_raises_on_ftx1(connected_radio):
+    with pytest.raises(NotImplementedError, match="ab_shared"):
+        await connected_radio.set_vfo_slot("A")
+
+
+@pytest.mark.asyncio
+async def test_swap_vfo_ab_raises_on_ftx1(connected_radio):
+    """FTX-1 AB;/BA; copy MAIN↔SUB, not A↔B; swap_vfo_ab raises."""
+    with pytest.raises(NotImplementedError, match="no symmetric"):
+        await connected_radio.swap_vfo_ab()
+
+
+@pytest.mark.asyncio
+async def test_equalize_vfo_ab_raises_on_ftx1(connected_radio):
+    with pytest.raises(NotImplementedError, match="no per-receiver"):
+        await connected_radio.equalize_vfo_ab()
+
+
+# -- VfoSlotCapable on single-RX (FR; scheme — works) ----------------------
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_slot_a_writes_fr0(single_rx_radio):
+    """set_vfo_slot('A') emits FR0; on a single-RX rig."""
+    single_rx_radio._transport.write = AsyncMock()
+    await single_rx_radio.set_vfo_slot("A")
+    single_rx_radio._transport.write.assert_called_once_with("FR0;")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_slot_b_writes_fr1(single_rx_radio):
+    """set_vfo_slot('B') emits FR1;."""
+    single_rx_radio._transport.write = AsyncMock()
+    await single_rx_radio.set_vfo_slot("B")
+    single_rx_radio._transport.write.assert_called_once_with("FR1;")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_slot_case_insensitive(single_rx_radio):
+    """Lower-case slot names are accepted."""
+    single_rx_radio._transport.write = AsyncMock()
+    await single_rx_radio.set_vfo_slot("b")
+    single_rx_radio._transport.write.assert_called_once_with("FR1;")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_slot_invalid_raises(single_rx_radio):
+    single_rx_radio._transport.write = AsyncMock()
+    with pytest.raises(ValueError, match="slot must be 'A' or 'B'"):
+        await single_rx_radio.set_vfo_slot("C")
+    single_rx_radio._transport.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_vfo_slot_a(single_rx_radio):
+    """get_vfo_slot reads FR; → 'A' when radio reports FR0;."""
+    single_rx_radio._transport.query = AsyncMock(return_value="FR0")
+    assert await single_rx_radio.get_vfo_slot() == "A"
+    single_rx_radio._transport.query.assert_called_once_with("FR;")
+
+
+@pytest.mark.asyncio
+async def test_get_vfo_slot_b(single_rx_radio):
+    single_rx_radio._transport.query = AsyncMock(return_value="FR1")
+    assert await single_rx_radio.get_vfo_slot() == "B"
+
+
+@pytest.mark.asyncio
+async def test_set_get_vfo_slot_roundtrip(single_rx_radio):
+    """set_vfo_slot('B') then get_vfo_slot returns 'B' (mocked)."""
+    single_rx_radio._transport.write = AsyncMock()
+    single_rx_radio._transport.query = AsyncMock(return_value="FR1")
+    await single_rx_radio.set_vfo_slot("B")
+    assert await single_rx_radio.get_vfo_slot() == "B"
+
+
+@pytest.mark.asyncio
+async def test_swap_vfo_ab_raises_on_single_rx(single_rx_radio):
+    """Yaesu CAT has no A↔B swap primitive even on single-RX rigs."""
+    with pytest.raises(NotImplementedError, match="no symmetric"):
+        await single_rx_radio.swap_vfo_ab()
+
+
+@pytest.mark.asyncio
+async def test_equalize_vfo_ab_raises_on_single_rx(single_rx_radio):
+    with pytest.raises(NotImplementedError, match="no per-receiver"):
+        await single_rx_radio.equalize_vfo_ab()
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_slot_rejects_bad_receiver_index(single_rx_radio):
+    single_rx_radio._transport.write = AsyncMock()
+    with pytest.raises(ValueError, match="out of range"):
+        await single_rx_radio.set_vfo_slot("A", receiver=1)
+    single_rx_radio._transport.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_vfo_slot_rejects_bad_receiver_index(single_rx_radio):
+    with pytest.raises(ValueError, match="out of range"):
+        await single_rx_radio.get_vfo_slot(receiver=1)


### PR DESCRIPTION
Closes #1171

Implements receiver-tier protocols on `YaesuCatRadio` per audit P2-06 (Wave 4-B from epic #1165).

## Implementation

**Profile-driven dispatch** — branches on `_config.receiver_count` and `_config.vfo_scheme`, not hardcoded rig IDs. Single-RX Yaesu CAT TOMLs (FT-710 / FT-991A) will drop in without code changes.

**ReceiverBankCapable:**
- `receiver_count` property
- `select_receiver(MAIN/SUB)` via `VS{vfo};` (FTX-1) or `FR{vfo};` (single-RX)
- `get_active_receiver()`

**VfoSlotCapable:**
- `get_vfo_slot` / `set_vfo_slot` for single-RX profiles via `FR;`
- FTX-1 (`vfo_scheme = "ab_shared"`) raises `NotImplementedError` — per FTX-1 CAT manual, `AB;` / `BA;` are MAIN→SUB copies (not per-receiver A↔B); each receiver has a single VFO via `FA;` / `FB;`.
- `swap_vfo_ab` / `equalize_vfo_ab` raise on every supported Yaesu CAT rig today (Lab599-style profiles have `has_swap = false`, `has_equal = false`).

## Issue spec correction

Lab599 TX-500 is `kenwood_cat` backend; X6100 is CI-V (`IcomRadio`). Only FTX-1 is currently in the Yaesu CAT backend. Single-RX path tested via synthetic fixture cloning FTX-1's `RigConfig`.

## Validation

- 4960 tests pass; ruff + mypy clean
- Verified against `references/Yaesu-official/ftx1-cat-commands-extracted.md`

## Next

Wave 4-A (#1170, IcomRadio impl) is parallel sibling — runs after this lands.
Wave 4-C (#1172, web/rigctld migration) depends on both 4-A and 4-B.