### PR TITLE
feat(api): IcomRadio implements ReceiverBankCapable + VfoSlotCapable (Wave 4-A)

### DIFF
--- a/src/icom_lan/_dual_rx_runtime.py
+++ b/src/icom_lan/_dual_rx_runtime.py
@@ -355,3 +355,168 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._radio_addr, CONTROLLER_ADDR, _CMD_VFO, data=bytes([code])
         )
         await self._send_civ_raw(civ, wait_response=False)
+
+    # ------------------------------------------------------------------
+    # ReceiverBankCapable — Transceiver → Receiver tier (issue #1170)
+    # ------------------------------------------------------------------
+
+    @property
+    def receiver_count(self) -> int:
+        """Number of independent receivers exposed by this transceiver.
+
+        Profile-driven via ``[radio] receiver_count`` in the rig TOML.
+        IC-7610 / IC-9700 report ``2`` (MAIN + SUB); IC-7300 / IC-705
+        report ``1``.
+        """
+        return int(self._profile.receiver_count)
+
+    @staticmethod
+    def _normalize_receiver_index(which: int | str) -> int:
+        """Normalize a ``select_receiver`` argument to a 0-based index.
+
+        Accepts integer indices (``0`` / ``1``) or case-insensitive names
+        (``"main"`` / ``"sub"``).  Raises :class:`ValueError` on any other
+        value.
+        """
+        if isinstance(which, bool):
+            # ``bool`` is a subclass of ``int`` but is never a valid receiver
+            # index — reject explicitly to avoid silent ``True``→1 conversion.
+            raise ValueError(
+                f"select_receiver: which must be int or str, got {type(which).__name__}"
+            )
+        if isinstance(which, str):
+            key = which.strip().lower()
+            if key == "main":
+                return 0
+            if key == "sub":
+                return 1
+            raise ValueError(
+                f"select_receiver: unknown receiver name {which!r} "
+                "(expected 'main' or 'sub')"
+            )
+        if isinstance(which, int):
+            return int(which)
+        raise ValueError(
+            f"select_receiver: which must be int or str, got {type(which).__name__}"
+        )
+
+    async def select_receiver(self, which: int | str) -> None:
+        """Make ``which`` the active receiver for subsequent commands.
+
+        On dual-RX Icom rigs (IC-7610 / IC-9700) issues the profile's
+        ``main_select`` / ``sub_select`` opcode (``0x07 0xD0`` /
+        ``0x07 0xD1``) and updates :attr:`RadioState.active`.  On single-RX
+        profiles only ``which == 0`` is accepted and the call is a no-op
+        (matching the :class:`~icom_lan.radio_protocol.ReceiverBankCapable`
+        contract).  Out-of-range indices and unknown names raise
+        :class:`ValueError`.
+        """
+        self._check_connected()
+        index = self._normalize_receiver_index(which)
+        count = self.receiver_count
+        if index < 0 or index >= count:
+            raise ValueError(
+                f"select_receiver: receiver index {index} out of range "
+                f"for receiver_count={count}"
+            )
+        if count <= 1:
+            # Single-RX: nothing to switch.
+            return
+        target = "MAIN" if index == 0 else "SUB"
+        await self.set_vfo(target)
+        self._radio_state.active = target
+
+    async def get_active_receiver(self) -> int:
+        """Return the index of the currently active receiver.
+
+        Returns ``0`` for MAIN, ``1`` for SUB.  Reads the cached
+        :attr:`RadioState.active` value (poller-populated on dual-RX rigs).
+        Single-RX profiles always return ``0``.
+        """
+        if self.receiver_count <= 1:
+            return 0
+        active = getattr(self._radio_state, "active", "MAIN")
+        return 1 if active == "SUB" else 0
+
+    # ------------------------------------------------------------------
+    # VfoSlotCapable — per-receiver A/B slot ops (issue #1170)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_vfo_slot(slot: str) -> str:
+        """Validate and upper-case a VFO slot argument (``"A"`` or ``"B"``)."""
+        if not isinstance(slot, str):
+            raise ValueError(f"slot must be str, got {type(slot).__name__}")
+        norm = slot.strip().upper()
+        if norm not in {"A", "B"}:
+            raise ValueError(f"slot must be 'A' or 'B', got {slot!r}")
+        return norm
+
+    def _check_vfo_slot_receiver(self, receiver: int, *, operation: str) -> None:
+        """Raise ``ValueError`` when ``receiver`` is out of range for the profile."""
+        count = self.receiver_count
+        if receiver < 0 or receiver >= count:
+            raise ValueError(
+                f"{operation}: receiver index {receiver} out of range "
+                f"for receiver_count={count}"
+            )
+
+    async def get_vfo_slot(self, receiver: int = 0) -> str:
+        """Return the active VFO slot (``"A"`` or ``"B"``) for ``receiver``.
+
+        Reads cached :attr:`ReceiverState.active_slot` (poller-populated).
+        Single-RX rigs only accept ``receiver == 0``; out-of-range indices
+        raise :class:`ValueError`.
+        """
+        self._check_vfo_slot_receiver(receiver, operation="get_vfo_slot")
+        if self.receiver_count > 1:
+            rx_state = (
+                self._radio_state.sub if receiver == 1 else self._radio_state.main
+            )
+        else:
+            rx_state = self._radio_state.main
+        slot = getattr(rx_state, "active_slot", "A")
+        return "B" if str(slot).upper() == "B" else "A"
+
+    async def set_vfo_slot(self, slot: str, receiver: int = 0) -> None:
+        """Make ``slot`` (``"A"`` or ``"B"``) the active VFO on ``receiver``.
+
+        Wire bytes: CI-V ``0x07 0x00`` (A) or ``0x07 0x01`` (B).  On
+        dual-RX rigs (IC-7610 / IC-9700) the target receiver is selected
+        first via the VFO-switch pattern (``0x07 0xD0`` / ``0xD1``) so the
+        slot-select opcode affects the intended receiver, then the
+        previous receiver is restored.  Single-RX rigs send the opcode
+        directly.
+
+        Raises :class:`ValueError` for an invalid slot or out-of-range
+        receiver index.
+        """
+        self._check_connected()
+        self._check_vfo_slot_receiver(receiver, operation="set_vfo_slot")
+        norm_slot = self._normalize_vfo_slot(slot)
+        slot_code = 0x00 if norm_slot == "A" else 0x01
+
+        async def _emit_slot() -> None:
+            civ = build_civ_frame(
+                self._radio_addr,
+                CONTROLLER_ADDR,
+                _CMD_VFO,
+                data=bytes([slot_code]),
+            )
+            await self._send_civ_raw(civ, wait_response=False)
+            # Update cached per-receiver active_slot for subsequent get_vfo_slot.
+            rx_state = (
+                self._radio_state.sub
+                if (receiver == 1 and self.receiver_count > 1)
+                else self._radio_state.main
+            )
+            rx_state.active_slot = norm_slot
+
+        if self.receiver_count > 1:
+            await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="set_vfo_slot",
+                action=_emit_slot,
+            )
+        else:
+            await _emit_slot()

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -3958,7 +3958,14 @@ def _check_protocol_compliance() -> None:
     Note: ``@runtime_checkable`` checks only method/attribute *existence*.
     It does not validate full runtime semantics.
     """
-    from .radio_protocol import AudioCapable, DualReceiverCapable, Radio, ScopeCapable
+    from .radio_protocol import (
+        AudioCapable,
+        DualReceiverCapable,
+        Radio,
+        ReceiverBankCapable,
+        ScopeCapable,
+        VfoSlotCapable,
+    )
 
     assert isinstance(IcomRadio(host=""), Radio), (
         "IcomRadio does not satisfy Radio protocol"
@@ -3971,4 +3978,10 @@ def _check_protocol_compliance() -> None:
     )
     assert isinstance(IcomRadio(host=""), DualReceiverCapable), (
         "IcomRadio does not satisfy DualReceiverCapable protocol"
+    )
+    assert isinstance(IcomRadio(host=""), ReceiverBankCapable), (
+        "IcomRadio does not satisfy ReceiverBankCapable protocol"
+    )
+    assert isinstance(IcomRadio(host=""), VfoSlotCapable), (
+        "IcomRadio does not satisfy VfoSlotCapable protocol"
     )

--- a/tests/test_icom_receiver_tier.py
+++ b/tests/test_icom_receiver_tier.py
@@ -1,0 +1,445 @@
+"""Receiver-tier protocol implementations on IcomRadio (issue #1170).
+
+Wave 4-A: ``ReceiverBankCapable`` and ``VfoSlotCapable`` on the Icom backend.
+
+Coverage matrix:
+- Protocol satisfaction (``isinstance``) on all four supported Icom rigs.
+- Wire-frame golden bytes for ``select_receiver`` (dual-RX) and
+  ``set_vfo_slot`` (every rig).
+- ValueError on out-of-range ``receiver`` for single-RX rigs (IC-7300, IC-705).
+- ValueError on unknown receiver names / invalid slot strings.
+- Single-RX ``select_receiver(0)`` is a no-op (no wire frame emitted).
+- IC-7610 SUB ``set_vfo_slot`` uses VFO-switch fallback (SEL_SUB → slot →
+  restore SEL_MAIN).
+- ``get_vfo_slot`` / ``get_active_receiver`` read cached state.
+
+Hardware-smoke pending — these tests verify wire-bytes only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from icom_lan.radio import IcomRadio
+from icom_lan.radio_protocol import ReceiverBankCapable, VfoSlotCapable
+
+from test_radio import MockTransport, _wrap_civ_in_udp
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_transport() -> MockTransport:
+    return MockTransport()
+
+
+def _make_radio(model: str, mock_transport: MockTransport) -> IcomRadio:
+    """Build a connected IcomRadio for ``model`` wired to ``mock_transport``."""
+    r = IcomRadio("192.168.1.100", model=model, timeout=0.05)
+    r._civ_transport = mock_transport
+    r._ctrl_transport = mock_transport
+    r._connected = True
+    return r
+
+
+@pytest.fixture
+def ic7610(mock_transport: MockTransport):
+    r = _make_radio("IC-7610", mock_transport)
+    yield r
+    r._connected = False
+
+
+@pytest.fixture
+def ic9700(mock_transport: MockTransport):
+    r = _make_radio("IC-9700", mock_transport)
+    yield r
+    r._connected = False
+
+
+@pytest.fixture
+def ic7300(mock_transport: MockTransport):
+    r = _make_radio("IC-7300", mock_transport)
+    yield r
+    r._connected = False
+
+
+@pytest.fixture
+def ic705(mock_transport: MockTransport):
+    r = _make_radio("IC-705", mock_transport)
+    yield r
+    r._connected = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _civ_bytes(packets: list[bytes]) -> list[bytes]:
+    """Extract CI-V frames (FE FE ... FD) from UDP-wrapped or raw packets."""
+    out: list[bytes] = []
+    for pkt in packets:
+        i = pkt.find(b"\xfe\xfe")
+        if i < 0:
+            continue
+        j = pkt.find(b"\xfd", i)
+        if j < 0:
+            continue
+        out.append(pkt[i : j + 1])
+    return out
+
+
+# IC-7610 / IC-9700 receiver-select wire bytes.
+SEL_MAIN_7610 = b"\xfe\xfe\x98\xe0\x07\xd0\xfd"
+SEL_SUB_7610 = b"\xfe\xfe\x98\xe0\x07\xd1\xfd"
+SEL_MAIN_9700 = b"\xfe\xfe\xa2\xe0\x07\xd0\xfd"
+SEL_SUB_9700 = b"\xfe\xfe\xa2\xe0\x07\xd1\xfd"
+
+# Per-rig VFO-A and VFO-B slot-select wire bytes (CI-V 0x07 0x00 / 0x07 0x01).
+SLOT_A_7610 = b"\xfe\xfe\x98\xe0\x07\x00\xfd"
+SLOT_B_7610 = b"\xfe\xfe\x98\xe0\x07\x01\xfd"
+SLOT_A_9700 = b"\xfe\xfe\xa2\xe0\x07\x00\xfd"
+SLOT_B_9700 = b"\xfe\xfe\xa2\xe0\x07\x01\xfd"
+SLOT_A_7300 = b"\xfe\xfe\x94\xe0\x07\x00\xfd"
+SLOT_B_7300 = b"\xfe\xfe\x94\xe0\x07\x01\xfd"
+SLOT_A_705 = b"\xfe\xfe\xa4\xe0\x07\x00\xfd"
+SLOT_B_705 = b"\xfe\xfe\xa4\xe0\x07\x01\xfd"
+
+# CI-V ACK frames per rig (FB) wrapped in UDP for MockTransport.receive_packet.
+ACK_IC7610 = _wrap_civ_in_udp(b"\xfe\xfe\xe0\x98\xfb\xfd")
+ACK_IC9700 = _wrap_civ_in_udp(b"\xfe\xfe\xe0\xa2\xfb\xfd")
+
+
+# ---------------------------------------------------------------------------
+# Protocol satisfaction (runtime_checkable isinstance)
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolSatisfaction:
+    """``IcomRadio`` exposes the receiver-tier protocols on every Icom rig."""
+
+    def test_ic7610_satisfies_receiver_bank_capable(self, ic7610: IcomRadio) -> None:
+        assert isinstance(ic7610, ReceiverBankCapable)
+
+    def test_ic7610_satisfies_vfo_slot_capable(self, ic7610: IcomRadio) -> None:
+        assert isinstance(ic7610, VfoSlotCapable)
+
+    def test_ic9700_satisfies_both_protocols(self, ic9700: IcomRadio) -> None:
+        assert isinstance(ic9700, ReceiverBankCapable)
+        assert isinstance(ic9700, VfoSlotCapable)
+
+    def test_ic7300_satisfies_both_protocols(self, ic7300: IcomRadio) -> None:
+        assert isinstance(ic7300, ReceiverBankCapable)
+        assert isinstance(ic7300, VfoSlotCapable)
+
+    def test_ic705_satisfies_both_protocols(self, ic705: IcomRadio) -> None:
+        assert isinstance(ic705, ReceiverBankCapable)
+        assert isinstance(ic705, VfoSlotCapable)
+
+
+# ---------------------------------------------------------------------------
+# receiver_count property
+# ---------------------------------------------------------------------------
+
+
+class TestReceiverCount:
+    def test_ic7610_receiver_count_2(self, ic7610: IcomRadio) -> None:
+        assert ic7610.receiver_count == 2
+
+    def test_ic9700_receiver_count_2(self, ic9700: IcomRadio) -> None:
+        assert ic9700.receiver_count == 2
+
+    def test_ic7300_receiver_count_1(self, ic7300: IcomRadio) -> None:
+        assert ic7300.receiver_count == 1
+
+    def test_ic705_receiver_count_1(self, ic705: IcomRadio) -> None:
+        assert ic705.receiver_count == 1
+
+
+# ---------------------------------------------------------------------------
+# select_receiver
+# ---------------------------------------------------------------------------
+
+
+class TestSelectReceiver:
+    @pytest.mark.asyncio
+    async def test_ic7610_main_emits_0xD0(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        mock_transport.queue_response(ACK_IC7610)
+        await ic7610.select_receiver(0)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SEL_MAIN_7610 in frames
+        assert ic7610._radio_state.active == "MAIN"
+
+    @pytest.mark.asyncio
+    async def test_ic7610_sub_emits_0xD1(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        mock_transport.queue_response(ACK_IC7610)
+        await ic7610.select_receiver(1)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SEL_SUB_7610 in frames
+        assert ic7610._radio_state.active == "SUB"
+
+    @pytest.mark.asyncio
+    async def test_ic7610_by_name_main(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        mock_transport.queue_response(ACK_IC7610)
+        await ic7610.select_receiver("main")
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SEL_MAIN_7610 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic7610_by_name_sub_case_insensitive(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        mock_transport.queue_response(ACK_IC7610)
+        await ic7610.select_receiver("SUB")
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SEL_SUB_7610 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic9700_sub_emits_0xD1(
+        self, ic9700: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """IC-9700 uses the same 0x07 0xD0/0xD1 MAIN/SUB scheme as IC-7610."""
+        mock_transport.queue_response(ACK_IC9700)
+        await ic9700.select_receiver(1)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SEL_SUB_9700 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic7610_unknown_name_raises_value_error(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        with pytest.raises(ValueError, match="unknown receiver name"):
+            await ic7610.select_receiver("tertiary")
+        # No wire frame sent on validation failure.
+        assert _civ_bytes(mock_transport.sent_packets) == []
+
+    @pytest.mark.asyncio
+    async def test_ic7610_out_of_range_raises_value_error(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        with pytest.raises(ValueError, match="out of range"):
+            await ic7610.select_receiver(2)
+
+    @pytest.mark.asyncio
+    async def test_ic7300_zero_is_noop(
+        self, ic7300: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        await ic7300.select_receiver(0)
+        # Single-RX: no wire frame emitted.
+        assert _civ_bytes(mock_transport.sent_packets) == []
+
+    @pytest.mark.asyncio
+    async def test_ic7300_receiver_1_raises_value_error(
+        self, ic7300: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        with pytest.raises(ValueError, match="out of range"):
+            await ic7300.select_receiver(1)
+        assert _civ_bytes(mock_transport.sent_packets) == []
+
+    @pytest.mark.asyncio
+    async def test_ic705_receiver_1_raises_value_error(self, ic705: IcomRadio) -> None:
+        with pytest.raises(ValueError, match="out of range"):
+            await ic705.select_receiver(1)
+
+
+# ---------------------------------------------------------------------------
+# get_active_receiver
+# ---------------------------------------------------------------------------
+
+
+class TestGetActiveReceiver:
+    @pytest.mark.asyncio
+    async def test_ic7610_default_main_is_zero(self, ic7610: IcomRadio) -> None:
+        assert await ic7610.get_active_receiver() == 0
+
+    @pytest.mark.asyncio
+    async def test_ic7610_after_select_sub_returns_one(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        mock_transport.queue_response(ACK_IC7610)
+        await ic7610.select_receiver(1)
+        assert await ic7610.get_active_receiver() == 1
+
+    @pytest.mark.asyncio
+    async def test_ic7300_always_zero(self, ic7300: IcomRadio) -> None:
+        assert await ic7300.get_active_receiver() == 0
+
+    @pytest.mark.asyncio
+    async def test_ic705_always_zero(self, ic705: IcomRadio) -> None:
+        assert await ic705.get_active_receiver() == 0
+
+
+# ---------------------------------------------------------------------------
+# set_vfo_slot — wire-frame golden bytes
+# ---------------------------------------------------------------------------
+
+
+class TestSetVfoSlot:
+    @pytest.mark.asyncio
+    async def test_ic7610_main_slot_a_emits_0x07_0x00(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        # Dual-RX path: VFO-switch fallback. _radio_state.active defaults to
+        # MAIN, so when receiver=0 the fallback detects current==target and
+        # does NOT switch, but the surrounding pattern still emits the slot
+        # frame directly. No ACK queueing needed.
+        await ic7610.set_vfo_slot("A", receiver=0)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SLOT_A_7610 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic7610_main_slot_b_emits_0x07_0x01(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        await ic7610.set_vfo_slot("B", receiver=0)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SLOT_B_7610 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic7610_sub_uses_select_restore_pattern(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        # Dual-RX SUB path: select SUB → emit slot → restore MAIN. Two
+        # set_vfo() calls need ACKs.
+        mock_transport.queue_response(ACK_IC7610)
+        mock_transport.queue_response(ACK_IC7610)
+        await ic7610.set_vfo_slot("B", receiver=1)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        sel_idx = next((i for i, f in enumerate(frames) if f == SEL_SUB_7610), None)
+        slot_idx = next((i for i, f in enumerate(frames) if f == SLOT_B_7610), None)
+        assert sel_idx is not None, "expected 0x07 0xD1 (select SUB)"
+        assert slot_idx is not None and slot_idx > sel_idx
+        restore_idx = next(
+            (i for i, f in enumerate(frames) if f == SEL_MAIN_7610 and i > slot_idx),
+            None,
+        )
+        assert restore_idx is not None, (
+            "expected 0x07 0xD0 (restore MAIN) after slot frame"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ic9700_main_slot_a_emits_0x07_0x00(
+        self, ic9700: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        # IC-9700 also dual-RX with same wire scheme; receiver=0 (MAIN) is
+        # current, so no select/restore round-trip.
+        await ic9700.set_vfo_slot("A", receiver=0)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SLOT_A_9700 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic9700_sub_uses_select_restore_pattern(
+        self, ic9700: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        mock_transport.queue_response(ACK_IC9700)
+        mock_transport.queue_response(ACK_IC9700)
+        await ic9700.set_vfo_slot("A", receiver=1)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SEL_SUB_9700 in frames
+        assert SLOT_A_9700 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic7300_slot_a_direct(
+        self, ic7300: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        await ic7300.set_vfo_slot("A", receiver=0)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SLOT_A_7300 in frames
+        # Single-RX must not emit any receiver-select wrapping.
+        assert all(b"\xd0" not in f and b"\xd1" not in f for f in frames)
+
+    @pytest.mark.asyncio
+    async def test_ic7300_slot_b_direct(
+        self, ic7300: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        await ic7300.set_vfo_slot("B", receiver=0)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SLOT_B_7300 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic705_slot_b_direct(
+        self, ic705: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        await ic705.set_vfo_slot("B", receiver=0)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        assert SLOT_B_705 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic705_slot_a_direct(
+        self, ic705: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        await ic705.set_vfo_slot("a", receiver=0)
+        frames = _civ_bytes(mock_transport.sent_packets)
+        # Case-insensitive — lowercase "a" still routes to 0x00.
+        assert SLOT_A_705 in frames
+
+    @pytest.mark.asyncio
+    async def test_ic7300_receiver_1_raises_value_error(
+        self, ic7300: IcomRadio
+    ) -> None:
+        with pytest.raises(ValueError, match="out of range"):
+            await ic7300.set_vfo_slot("A", receiver=1)
+
+    @pytest.mark.asyncio
+    async def test_ic705_receiver_1_raises_value_error(self, ic705: IcomRadio) -> None:
+        with pytest.raises(ValueError, match="out of range"):
+            await ic705.set_vfo_slot("B", receiver=1)
+
+    @pytest.mark.asyncio
+    async def test_invalid_slot_raises_value_error(self, ic7300: IcomRadio) -> None:
+        with pytest.raises(ValueError, match="slot must be"):
+            await ic7300.set_vfo_slot("C", receiver=0)
+
+
+# ---------------------------------------------------------------------------
+# get_vfo_slot — reads cached state
+# ---------------------------------------------------------------------------
+
+
+class TestGetVfoSlot:
+    @pytest.mark.asyncio
+    async def test_ic7610_main_default_a(self, ic7610: IcomRadio) -> None:
+        assert await ic7610.get_vfo_slot(receiver=0) == "A"
+
+    @pytest.mark.asyncio
+    async def test_ic7610_sub_default_a(self, ic7610: IcomRadio) -> None:
+        assert await ic7610.get_vfo_slot(receiver=1) == "A"
+
+    @pytest.mark.asyncio
+    async def test_ic7610_after_set_b_returns_b(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        await ic7610.set_vfo_slot("B", receiver=0)
+        assert await ic7610.get_vfo_slot(receiver=0) == "B"
+
+    @pytest.mark.asyncio
+    async def test_ic7610_per_receiver_independent(
+        self, ic7610: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        # Set MAIN.B; SUB stays on A.
+        await ic7610.set_vfo_slot("B", receiver=0)
+        assert await ic7610.get_vfo_slot(receiver=0) == "B"
+        assert await ic7610.get_vfo_slot(receiver=1) == "A"
+
+    @pytest.mark.asyncio
+    async def test_ic7300_after_set_b_returns_b(
+        self, ic7300: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        await ic7300.set_vfo_slot("B", receiver=0)
+        assert await ic7300.get_vfo_slot(receiver=0) == "B"
+
+    @pytest.mark.asyncio
+    async def test_ic7300_receiver_1_raises_value_error(
+        self, ic7300: IcomRadio
+    ) -> None:
+        with pytest.raises(ValueError, match="out of range"):
+            await ic7300.get_vfo_slot(receiver=1)


### PR DESCRIPTION
Closes #1170

## Summary

**Wave 4-A** from the receiver-tier audit epic #1165 — implements the
missing concrete `ReceiverBankCapable` and `VfoSlotCapable` methods on
the Icom backend (CoreRadio mixin). These protocols were declared in
#711 but never implemented on any Icom backend; the Q1 deferral to #708
became moot when that epic closed without doing the work.

Sibling PR #1179 covers the Yaesu CAT backend (Wave 4-B). This PR is
strictly Icom-scoped — no Yaesu, web, or rigctld changes. Web/rigctld
callsites land in Wave 4-C (#1172).

## What changed

`src/icom_lan/_dual_rx_runtime.py` (mixin used by `CoreRadio`):

- `receiver_count` property — driven by profile (`[radio] receiver_count`).
- `select_receiver(int | str)` — issues `0x07 0xD0/0xD1` on dual-RX rigs
  (IC-7610, IC-9700); no-op for `which == 0` on single-RX (IC-7300, IC-705).
  Out-of-range indices and unknown names raise `ValueError`. The case-
  insensitive `"main"` / `"sub"` name normalizer matches Yaesu's reference
  implementation (Wave 4-B).
- `get_active_receiver()` — reads cached `RadioState.active`.
- `set_vfo_slot(slot, receiver)` — emits `0x07 0x00/0x01`. On dual-RX
  rigs the target receiver is selected first via the existing
  `_run_with_receiver_vfo_fallback` pattern so the slot opcode lands on
  the intended receiver, then MAIN is restored. No `cmd29` wrap — `0x07`
  is not in the `cmd29` routes table for IC-7610 / IC-9700, matching the
  protocol-architecture matrix in `.claude/architecture/protocol.md`.
- `get_vfo_slot(receiver)` — reads cached per-receiver `active_slot`.

`src/icom_lan/radio.py` — protocol compliance assertions added to
`_check_protocol_compliance` for both new protocols.

## Wire bytes (golden tests cover all four rigs)

| Method                         | Wire bytes            | IC-7610 | IC-9700 | IC-7300 | IC-705 |
|--------------------------------|-----------------------|:-------:|:-------:|:-------:|:------:|
| `select_receiver(0/MAIN)`      | `0x07 0xD0`           | ✓       | ✓       | no-op   | no-op  |
| `select_receiver(1/SUB)`       | `0x07 0xD1`           | ✓       | ✓       | raises  | raises |
| `set_vfo_slot("A", recv=0)`    | `0x07 0x00`           | ✓       | ✓       | ✓       | ✓      |
| `set_vfo_slot("B", recv=0)`    | `0x07 0x01`           | ✓       | ✓       | ✓       | ✓      |
| `set_vfo_slot(slot, recv=1)`   | SEL_SUB → slot → SEL_MAIN | ✓   | ✓       | raises  | raises |

## Tests

`tests/test_icom_receiver_tier.py` — 41 cases:

- Protocol satisfaction (`isinstance(r, ReceiverBankCapable / VfoSlotCapable)`)
  on every supported Icom rig.
- Wire-frame golden bytes for `select_receiver` and `set_vfo_slot` on each rig.
- IC-7610 SUB `set_vfo_slot` verifies the SEL_SUB → slot → restore SEL_MAIN sequence.
- `ValueError` on `receiver=1` for single-RX rigs and on unknown receiver names.
- Per-receiver slot-state independence on dual-RX (MAIN.B vs SUB.A).

## Hardware test plan

- [ ] Manual smoke on IC-7610 — `select_receiver` MAIN/SUB round-trip,
      `set_vfo_slot` per receiver via the SUB fallback.

Per CLAUDE.md "MagicMock success != hardware correctness" — this PR
ships **mock-only** validation. New wire paths are involved (the SUB
slot-select via VFO fallback in particular), so a hardware smoke is
recommended before downstream consumers (Wave 4-C, #1172) land.

## Validation

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **5054 passed**
- `uv run ruff check src/ tests/` — clean
- `uv run mypy src/` — clean

## Test plan

- [x] 41 new mock-level tests pass
- [x] Full suite green (5054 passed)
- [x] ruff + mypy clean
- [ ] Hardware smoke on IC-7610 (manual, per acceptance criteria)