### PR TITLE
fix(sync): expose get_swr_meter on sync.IcomRadio for raw 0-255 access

### DIFF
--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -189,13 +189,26 @@ class IcomRadio:
 
         Returns the calibrated float per
         :meth:`MetersCapable.get_swr`. For the raw 0–255 BCD reading
-        program against ``MetersCapable.get_swr_meter`` instead.
+        program against :meth:`get_swr_meter` instead.
         """
         if CAP_METERS not in self._radio.capabilities:
             raise AttributeError(
                 "get_swr requires a radio that implements MetersCapable"
             )
         return float(self._run(self._radio.get_swr()))
+
+    def get_swr_meter(self) -> int:
+        """Read the SWR meter (raw 0-255).
+
+        Returns the unscaled meter value mirroring
+        :meth:`MetersCapable.get_swr_meter`. For a calibrated SWR ratio
+        (>= 1.0) use :meth:`get_swr` instead.
+        """
+        if CAP_METERS not in self._radio.capabilities:
+            raise AttributeError(
+                "get_swr_meter requires a radio that implements MetersCapable"
+            )
+        return self._run(self._radio.get_swr_meter())
 
     def get_alc(self) -> int:
         """Read the ALC meter (0-255)."""

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -247,3 +247,41 @@ def test_removed_audio_aliases_raise_attribute_error(name: str) -> None:
         assert not hasattr(r, name)
     finally:
         r._loop.close()
+
+
+def test_sync_get_swr_meter_returns_int() -> None:
+    """``sync.IcomRadio.get_swr_meter`` returns the raw 0-255 BCD value
+    from the async ``MetersCapable.get_swr_meter`` (refs #1183)."""
+    r = _radio()
+    r._radio._ctrl_transport = MagicMock()
+    r._radio._ctrl_transport._udp_transport = MagicMock()
+    r._radio._civ_transport = MagicMock()
+    r._radio._conn_state = RadioConnectionState.CONNECTED
+    r._radio.get_swr_meter = AsyncMock(return_value=120)
+
+    try:
+        result = r.get_swr_meter()
+        assert result == 120
+        assert isinstance(result, int)
+        r._radio.get_swr_meter.assert_awaited_once()
+    finally:
+        r._loop.close()
+
+
+def test_sync_get_swr_returns_float() -> None:
+    """Regression guard for #1177: ``sync.IcomRadio.get_swr`` returns a
+    calibrated float (>= 1.0), not the raw 0-255 BCD reading."""
+    r = _radio()
+    r._radio._ctrl_transport = MagicMock()
+    r._radio._ctrl_transport._udp_transport = MagicMock()
+    r._radio._civ_transport = MagicMock()
+    r._radio._conn_state = RadioConnectionState.CONNECTED
+    r._radio.get_swr = AsyncMock(return_value=1.7)
+
+    try:
+        result = r.get_swr()
+        assert result == 1.7
+        assert isinstance(result, float)
+        r._radio.get_swr.assert_awaited_once()
+    finally:
+        r._loop.close()


### PR DESCRIPTION
## Summary

- Adds `get_swr_meter() -> int` to `sync.IcomRadio`, mirroring the async-side `MetersCapable.get_swr_meter` so sync callers have a path to the raw 0-255 BCD reading.
- Updates the `sync.IcomRadio.get_swr` docstring to reference the sync companion (`get_swr_meter`) instead of the async-only protocol method.
- After PR #1177 sync `get_swr()` returns a calibrated float; without this fix sync callers that previously consumed raw 0-255 had no replacement path.

Closes #1183

## Test plan

- [x] `test_sync_get_swr_meter_returns_int` — sync wrapper delegates to async `get_swr_meter` and returns `int`.
- [x] `test_sync_get_swr_returns_float` — regression guard for #1177 (calibrated float, not raw int).
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5056 passed.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run mypy src/` — clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

[Generated with Claude Code](https://claude.com/claude-code)