### PR TITLE
fix(api): commands.levels __all__ exposes deprecated aliases for wildcard import

### DIFF
--- a/src/icom_lan/commands/levels.py
+++ b/src/icom_lan/commands/levels.py
@@ -991,6 +991,74 @@ _DEPRECATED_ALIASES: dict[str, str] = {
 }
 
 
+# ``__all__`` lists every public name exported by this module. It must include
+# the deprecated aliases above so that ``from icom_lan.commands.levels import *``
+# triggers ``__getattr__`` (PEP 562) for them — wildcard import iterates
+# ``__all__`` rather than module globals, so without this list the deprecation
+# path would be invisible to star-imports and consumers would see ``NameError``
+# instead of the intended ``DeprecationWarning`` + working forward.
+__all__ = [
+    # Canonical level builders (alphabetised).
+    "get_af_level",
+    "get_anti_vox_gain",
+    "get_apf_type_level",
+    "get_break_in_delay",
+    "get_compressor_level",
+    "get_cw_pitch",
+    "get_dash_ratio",
+    "get_digisel_shift",
+    "get_drive_gain",
+    "get_key_speed",
+    "get_mic_gain",
+    "get_monitor_gain",
+    "get_nb_depth",
+    "get_nb_level",
+    "get_nb_width",
+    "get_notch_filter",
+    "get_nr_level",
+    "get_pbt_inner",
+    "get_pbt_outer",
+    "get_ref_adjust",
+    "get_rf_gain",
+    "get_rf_power",
+    "get_squelch",
+    "get_vox_delay",
+    "get_vox_gain",
+    "set_af_level",
+    "set_anti_vox_gain",
+    "set_apf_type_level",
+    "set_break_in_delay",
+    "set_compressor_level",
+    "set_cw_pitch",
+    "set_dash_ratio",
+    "set_digisel_shift",
+    "set_drive_gain",
+    "set_key_speed",
+    "set_mic_gain",
+    "set_monitor_gain",
+    "set_nb_depth",
+    "set_nb_level",
+    "set_nb_width",
+    "set_notch_filter",
+    "set_nr_level",
+    "set_pbt_inner",
+    "set_pbt_outer",
+    "set_ref_adjust",
+    "set_rf_gain",
+    "set_rf_power",
+    "set_squelch",
+    "set_vox_delay",
+    "set_vox_gain",
+    # Deprecated aliases — resolved lazily by ``__getattr__`` below.
+    # ruff F822: these names are intentionally not module globals; PEP 562
+    # ``__getattr__`` rewrites them to the canonical builders on first access.
+    "get_power",  # noqa: F822
+    "set_power",  # noqa: F822
+    "get_sql",  # noqa: F822
+    "set_sql",  # noqa: F822
+]
+
+
 def __getattr__(name: str) -> Any:
     """Emit ``DeprecationWarning`` for legacy alias access (PEP 562)."""
     canonical = _DEPRECATED_ALIASES.get(name)

--- a/tests/test_levels_deprecated_aliases.py
+++ b/tests/test_levels_deprecated_aliases.py
@@ -1,0 +1,96 @@
+"""Regression tests for the deprecated aliases in ``icom_lan.commands.levels``.
+
+PR #1174 introduced PEP 562 ``__getattr__`` to emit ``DeprecationWarning`` for
+the legacy alias names ``get_power``/``set_power``/``get_sql``/``set_sql``.
+Issue #1182 (Codex P2) noted that wildcard import (``from ... import *``) only
+iterates module globals (or ``__all__``) and therefore would silently drop the
+aliases, leaving ``NameError`` at the call site instead of the intended
+deprecation path.
+
+These tests pin the contract:
+
+1. Direct attribute access still resolves the alias and warns (regression guard
+   from #1174).
+2. Wildcard import via ``__all__`` exposes the aliases as callables and the
+   first call still emits ``DeprecationWarning`` (fix for #1182).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+
+
+def _fresh_levels_module():
+    """Reload ``icom_lan.commands.levels`` so ``__getattr__`` re-fires."""
+    sys.modules.pop("icom_lan.commands.levels", None)
+    return importlib.import_module("icom_lan.commands.levels")
+
+
+def test_direct_attribute_access_warns_and_resolves() -> None:
+    """Regression guard for PR #1174 — direct access still works + warns."""
+    levels = _fresh_levels_module()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn_get_power = levels.get_power  # type: ignore[attr-defined]
+        fn_set_power = levels.set_power  # type: ignore[attr-defined]
+        fn_get_sql = levels.get_sql  # type: ignore[attr-defined]
+        fn_set_sql = levels.set_sql  # type: ignore[attr-defined]
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    messages = " | ".join(str(w.message) for w in deprecations)
+    assert "get_power" in messages
+    assert "set_power" in messages
+    assert "get_sql" in messages
+    assert "set_sql" in messages
+    # Aliases resolve to the canonical builders.
+    assert fn_get_power is levels.get_rf_power
+    assert fn_set_power is levels.set_rf_power
+    assert fn_get_sql is levels.get_squelch
+    assert fn_set_sql is levels.set_squelch
+
+
+def test_wildcard_import_exposes_deprecated_aliases() -> None:
+    """Fix for #1182 — ``from icom_lan.commands.levels import *`` works."""
+    _fresh_levels_module()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        namespace: dict[str, object] = {}
+        exec("from icom_lan.commands.levels import *", namespace)
+
+    # All four deprecated aliases must be reachable as callables.
+    for name in ("get_power", "set_power", "get_sql", "set_sql"):
+        assert name in namespace, f"wildcard import dropped {name!r}"
+        assert callable(namespace[name]), f"{name} is not callable after import *"
+
+    # The wildcard import itself must emit a DeprecationWarning per alias.
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    messages = " | ".join(str(w.message) for w in deprecations)
+    for name in ("get_power", "set_power", "get_sql", "set_sql"):
+        assert name in messages, (
+            f"expected DeprecationWarning for {name} during wildcard import; "
+            f"got: {messages!r}"
+        )
+
+
+def test_all_lists_canonical_and_deprecated_names() -> None:
+    """``__all__`` must explicitly contain the deprecated alias names — that
+    is what makes wildcard import iterate them and trigger ``__getattr__``."""
+    levels = _fresh_levels_module()
+    exported = set(levels.__all__)
+    # Deprecated aliases.
+    assert {"get_power", "set_power", "get_sql", "set_sql"} <= exported
+    # A few canonical builders as a sanity spot-check.
+    assert {"get_rf_power", "set_rf_power", "get_squelch", "set_squelch"} <= exported
+
+
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    """``__getattr__`` only handles known aliases — anything else must raise."""
+    levels = _fresh_levels_module()
+    try:
+        _ = levels.no_such_thing  # type: ignore[attr-defined]
+    except AttributeError as exc:
+        assert "no_such_thing" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected AttributeError for unknown attribute")


### PR DESCRIPTION
## Summary

- Add `__all__` to `src/icom_lan/commands/levels.py` listing every canonical level builder plus the four deprecated aliases (`get_power`, `set_power`, `get_sql`, `set_sql`).
- Without `__all__`, `from icom_lan.commands.levels import *` silently dropped the aliases — wildcard import iterates `__all__` (or module globals when absent), not the PEP 562 `__getattr__` introduced by PR #1174. Consumers got `NameError` at the call site instead of the intended `DeprecationWarning` + working forward.
- The four alias entries carry inline `# noqa: F822` because they are intentionally not module globals; `__getattr__` rewrites them to the canonical builders on first access. Mirrors the pattern already used in `commands/__init__.py`.

## Tests

New regression file `tests/test_levels_deprecated_aliases.py` pins:

- direct attribute access still warns and resolves (guard from #1174);
- wildcard import exposes all four aliases as callables and emits a `DeprecationWarning` per alias (fix for #1182);
- `__all__` contains both canonical builders and the four aliases;
- `__getattr__` still raises `AttributeError` on unknown names.

## Validation

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5058 passed, 9 xfailed, 1 xpassed.
- `uv run ruff check src/ tests/` — clean.
- `uv run mypy src/` — clean.

## Test plan

- [x] Wildcard import path tested: `from icom_lan.commands.levels import *` exposes the four aliases.
- [x] Direct attribute access regression preserved.
- [x] `DeprecationWarning` fires on first call via either path.
- [x] `AttributeError` still raised for unknown names.

Closes #1182