### PR TITLE
refactor(web,rigctld): migrate off legacy set_vfo overloads (Wave 4-C) — closes #1172

### DIFF
--- a/src/icom_lan/_dual_rx_runtime.py
+++ b/src/icom_lan/_dual_rx_runtime.py
@@ -115,7 +115,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
                     f"{operation} receiver={receiver} is unsupported for profile "
                     f"{self._profile.model}: no MAIN VFO select code"
                 )
-            await self.set_vfo(target)
+            await self._set_vfo_wire(target)
             self._radio_state.active = target
             switched = True
 
@@ -124,7 +124,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         finally:
             if switched:
                 try:
-                    await self.set_vfo(current)
+                    await self._set_vfo_wire(current)
                     self._radio_state.active = current
                 except TimeoutError:
                     # Do not swallow — radio would silently remain on the
@@ -136,7 +136,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
                         operation,
                         current,
                     )
-                    await self.set_vfo(current)
+                    await self._set_vfo_wire(current)
                     self._radio_state.active = current
 
     async def _get_frequency_main(
@@ -325,7 +325,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
             )
         if self._profile.receiver_count > 1:
             target = "MAIN" if receiver == RECEIVER_MAIN else "SUB"
-            await self.set_vfo(target)
+            await self._set_vfo_wire(target)
         civ = build_civ_frame(
             self._radio_addr, CONTROLLER_ADDR, _CMD_VFO, data=bytes([code])
         )
@@ -350,7 +350,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
             )
         if self._profile.receiver_count > 1:
             target = "MAIN" if receiver == RECEIVER_MAIN else "SUB"
-            await self.set_vfo(target)
+            await self._set_vfo_wire(target)
         civ = build_civ_frame(
             self._radio_addr, CONTROLLER_ADDR, _CMD_VFO, data=bytes([code])
         )
@@ -423,7 +423,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
             # Single-RX: nothing to switch.
             return
         target = "MAIN" if index == 0 else "SUB"
-        await self.set_vfo(target)
+        await self._set_vfo_wire(target)
         self._radio_state.active = target
 
     async def get_active_receiver(self) -> int:

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -2866,12 +2866,17 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     # VFO / Split
     # ------------------------------------------------------------------
 
-    async def set_vfo(self, vfo: str = "A") -> None:
-        """Select VFO.
+    async def _set_vfo_wire(self, vfo: str) -> None:
+        """Wire-level CI-V VFO select (no deprecation warning).
+
+        Internal helper used by capability-protocol implementations
+        (:meth:`select_receiver`, :meth:`_run_with_receiver_vfo_fallback`,
+        :meth:`swap_vfo_ab`, :meth:`equalize_vfo_ab`) so the migrated
+        protocol surface does not self-trigger the legacy
+        :meth:`set_vfo` deprecation warning.
 
         Args:
-            vfo: "A", "B", "MAIN", or "SUB".
-                 IC-7610 uses MAIN/SUB.
+            vfo: "A", "B", "MAIN", or "SUB" (case-insensitive on input).
         """
         self._check_connected()
         civ = _select_vfo_cmd(vfo, to_addr=self._radio_addr)
@@ -2880,6 +2885,29 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if ack is False:
             raise CommandError(f"Radio rejected VFO select {vfo}")
         self._last_vfo = vfo.upper()
+
+    async def set_vfo(self, vfo: str = "A") -> None:
+        """Select VFO (legacy overload).
+
+        .. deprecated:: 0.19
+            Use :meth:`select_receiver` for MAIN/SUB receiver switching
+            (``"MAIN"`` / ``"SUB"`` on dual-RX rigs) and
+            :meth:`set_vfo_slot` for A/B slot switching within a receiver
+            (``"A"`` / ``"B"``).  ``set_vfo`` will be removed in v0.20.
+
+        Args:
+            vfo: "A", "B", "MAIN", or "SUB".  IC-7610 uses MAIN/SUB for
+                 receiver select.
+        """
+        import warnings
+
+        warnings.warn(
+            "IcomRadio.set_vfo() is deprecated; use select_receiver() for "
+            "MAIN/SUB or set_vfo_slot() for A/B. Removal scheduled for v0.20.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        await self._set_vfo_wire(vfo)
 
     async def set_split(self, on: bool) -> None:
         """Enable or disable split mode (CI-V ``0x0F``)."""
@@ -3663,7 +3691,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 logger.debug("restore_state: set_split failed", exc_info=True)
         if "vfo" in state:
             try:
-                await self.set_vfo(str(state["vfo"]))
+                # Internal: bypass the public ``set_vfo`` so restore_state
+                # does not emit a DeprecationWarning when reapplying a
+                # snapshot taken before the migration.
+                await self._set_vfo_wire(str(state["vfo"]))
             except Exception:
                 logger.debug("restore_state: set_vfo failed", exc_info=True)
 

--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -660,14 +660,25 @@ class RigctldHandler:
         if vfo not in ("VFOA", "VFOB") or info is None:
             return _ok()
         rc, _ = info
-        set_vfo = getattr(self._radio, "set_vfo", None)
-        if set_vfo is None:
-            return _ok()
+        # Issue #1172: route by capability, not by string-overloaded
+        # ``set_vfo``.  Dual-RX rigs use ``select_receiver`` (the
+        # Transceiver→Receiver tier from #1170); single-RX rigs use
+        # ``set_vfo_slot`` for the per-receiver A/B switch.  Both are
+        # part of the public protocol surface (``ReceiverBankCapable`` /
+        # ``VfoSlotCapable``) so the legacy MAIN/SUB↔A/B mapping that
+        # used to live here is gone.
         if rc >= 2:
+            select_receiver = getattr(self._radio, "select_receiver", None)
+            if select_receiver is None:
+                return _ok()
             target = "MAIN" if vfo == "VFOA" else "SUB"
+            await select_receiver(target)
         else:
-            target = "A" if vfo == "VFOA" else "B"
-        await set_vfo(target)
+            set_vfo_slot = getattr(self._radio, "set_vfo_slot", None)
+            if set_vfo_slot is None:
+                return _ok()
+            slot = "A" if vfo == "VFOA" else "B"
+            await set_vfo_slot(slot)
         return _ok()
 
     # ------------------------------------------------------------------

--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -1251,15 +1251,18 @@ class RadioPoller:
                         logger.warning("set_band: unknown bsr_code=%d", band)
             case SelectVfo(vfo=vfo):
                 self._last_user_write_ts = time.monotonic()
-                # Select the target receiver via 0x07 0xD0 (MAIN) or 0xD1
-                # (SUB).  Pre-#771 this used a MAIN↔SUB swap (0x07 0xB0)
-                # as a hack so that LAN audio (MAIN-only at the time)
-                # would "follow" the selected receiver.  After #721/#755
-                # introduced Phones L/R Mix + audio_config, audio routing
-                # is independent of which receiver is selected, and the
-                # swap hack actively corrupted user state on every click
-                # (frequencies/modes traded places).  Now uses the proper
-                # CI-V receiver-select primitive.  Idempotent: re-clicking
+                # Select the target receiver via the public
+                # ``ReceiverBankCapable.select_receiver`` (issue #1172).
+                # Pre-#771 this used a MAIN↔SUB swap (0x07 0xB0) as a hack
+                # so that LAN audio (MAIN-only at the time) would "follow"
+                # the selected receiver.  After #721/#755 introduced
+                # Phones L/R Mix + audio_config, audio routing is
+                # independent of which receiver is selected, and the swap
+                # hack actively corrupted user state on every click
+                # (frequencies/modes traded places).  Wave 4-A landed
+                # ``select_receiver`` (CI-V 0x07 0xD0/0xD1) on every
+                # backend, so the poller now goes through the typed API
+                # rather than a raw ``_civ`` write.  Idempotent: re-clicking
                 # the active receiver emits no CI-V (the state event still
                 # fires so UI listeners can refresh).
                 vfo_upper = vfo.upper()
@@ -1274,22 +1277,18 @@ class RadioPoller:
                 # mypy's type narrowing across branches.
                 target_name = "SUB" if is_sub else "MAIN"
                 if target_name != current:
-                    code = (
-                        self._profile.vfo_sub_code
-                        if is_sub
-                        else self._profile.vfo_main_code
-                    )
-                    if code is None:
+                    if (is_sub and self._profile.vfo_sub_code is None) or (
+                        not is_sub and self._profile.vfo_main_code is None
+                    ):
                         raise CommandError(
                             f"select_vfo({vfo}) is unsupported by profile "
                             f"{self._profile.model}: no MAIN/SUB select code"
                         )
-                    await self._civ(0x07, data=bytes([code]))
-                    logger.info(
-                        "radio-poller: select VFO=%s (0x07 0x%02X)",
-                        target_name,
-                        code,
-                    )
+                    await radio.select_receiver(target_name)
+                    logger.info("radio-poller: select_receiver=%s", target_name)
+                    # ``select_receiver`` updates ``_radio_state.active`` on
+                    # the dual-RX runtime; mirror it on radios that don't
+                    # ship that wiring (test mocks, custom backends).
                     rs = getattr(self._radio, "_radio_state", None)
                     if rs is not None and hasattr(rs, "active"):
                         rs.active = target_name

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -56,7 +56,8 @@ class TestVFO:
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
         mock_transport.queue_response(_ack_response())
-        await radio.set_vfo("A")
+        with pytest.warns(DeprecationWarning, match="select_receiver"):
+            await radio.set_vfo("A")
         assert len(mock_transport.sent_packets) > 0
 
     @pytest.mark.asyncio
@@ -64,28 +65,61 @@ class TestVFO:
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
         mock_transport.queue_response(_ack_response())
-        await radio.set_vfo("B")
+        with pytest.warns(DeprecationWarning, match="select_receiver"):
+            await radio.set_vfo("B")
 
     @pytest.mark.asyncio
     async def test_select_vfo_main(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
         mock_transport.queue_response(_ack_response())
-        await radio.set_vfo("MAIN")
+        with pytest.warns(DeprecationWarning, match="select_receiver"):
+            await radio.set_vfo("MAIN")
 
     @pytest.mark.asyncio
     async def test_select_vfo_nak(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
         mock_transport.queue_response(_nak_response())
-        with pytest.raises(CommandError):
+        with pytest.raises(CommandError), pytest.warns(DeprecationWarning):
             await radio.set_vfo("A")
 
     @pytest.mark.asyncio
     async def test_select_vfo_disconnected(self) -> None:
         r = IcomRadio("192.168.1.100")
-        with pytest.raises(ConnectionError):
+        with pytest.raises(ConnectionError), pytest.warns(DeprecationWarning):
             await r.set_vfo("A")
+
+    @pytest.mark.asyncio
+    async def test_set_vfo_emits_deprecation_warning(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """Issue #1172: legacy ``set_vfo`` overload warns; removal v0.20.
+
+        The warning message must mention both ``select_receiver`` (the new
+        Receiver-tier replacement) and ``set_vfo_slot`` (the new VFO-slot
+        replacement) so users know which API to migrate to.
+        """
+        mock_transport.queue_response(_ack_response())
+        with pytest.warns(DeprecationWarning) as record:
+            await radio.set_vfo("MAIN")
+        assert len(record) == 1
+        msg = str(record[0].message)
+        assert "select_receiver" in msg
+        assert "set_vfo_slot" in msg
+        assert "v0.20" in msg
+
+    @pytest.mark.asyncio
+    async def test_set_vfo_wire_does_not_warn(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """Internal ``_set_vfo_wire`` is silent — used by capability impls."""
+        import warnings
+
+        mock_transport.queue_response(_ack_response())
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            await radio._set_vfo_wire("A")
 
     def test_vfo_exchange_attribute_removed(self) -> None:
         """Deprecated ``vfo_exchange`` alias is removed in v0.19."""
@@ -401,24 +435,27 @@ class TestReceiverAwareContract:
     async def test_set_frequency_receiver_sub_uses_vfo_fallback(
         self, radio: IcomRadio
     ) -> None:
-        radio.set_vfo = AsyncMock()  # type: ignore[method-assign]
+        # Issue #1172: receiver-VFO fallback now goes through the
+        # internal ``_set_vfo_wire`` so the legacy ``set_vfo`` overload
+        # does not self-trigger its DeprecationWarning.
+        radio._set_vfo_wire = AsyncMock()  # type: ignore[method-assign]
         radio._send_civ_raw = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
         await radio.set_freq(14_074_000, receiver=1)
 
-        radio.set_vfo.assert_has_awaits([call("SUB"), call("MAIN")])
+        radio._set_vfo_wire.assert_has_awaits([call("SUB"), call("MAIN")])
         radio._send_civ_raw.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_set_mode_receiver_sub_uses_vfo_fallback(
         self, radio: IcomRadio
     ) -> None:
-        radio.set_vfo = AsyncMock()  # type: ignore[method-assign]
+        radio._set_vfo_wire = AsyncMock()  # type: ignore[method-assign]
         radio._send_civ_raw = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
         await radio.set_mode("USB", receiver=1)
 
-        radio.set_vfo.assert_has_awaits([call("SUB"), call("MAIN")])
+        radio._set_vfo_wire.assert_has_awaits([call("SUB"), call("MAIN")])
         radio._send_civ_raw.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -89,6 +89,18 @@ def _make_radio(active: str = "MAIN") -> MagicMock:
     radio.set_split = AsyncMock()
     radio.equalize_main_sub = AsyncMock()
     radio.swap_main_sub = AsyncMock()
+
+    # Receiver-tier capabilities (issue #1170 / #1172).  ``select_receiver``
+    # mirrors the wire-level CI-V the runtime would emit so existing
+    # ``send_civ(0x07, [0xD0/0xD1])`` assertions still apply.
+    async def _select_receiver(which: object) -> None:
+        name = str(which).strip().upper()
+        code = 0xD1 if name in ("SUB", "1") else 0xD0
+        await radio.send_civ(0x07, sub=None, data=bytes([code]), wait_response=False)
+        radio._radio_state.active = "SUB" if code == 0xD1 else "MAIN"
+
+    radio.select_receiver = AsyncMock(side_effect=_select_receiver)
+    radio.set_vfo_slot = AsyncMock()
     radio.get_dual_watch = AsyncMock(return_value=False)
     radio.set_tuner_status = AsyncMock()
     radio.get_tuner_status = AsyncMock(return_value=0)

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -2394,8 +2394,10 @@ async def test_set_vfo_dual_rx_vfob_selects_sub(
 ) -> None:
     resp = await dual_rx_handler.execute(set_cmd("set_vfo", "VFOB"))
     assert resp.ok
-    # SUB maps to CI-V 0x07 0xD1 via radio.set_vfo("SUB").
-    dual_rx_radio.set_vfo.assert_awaited_once_with("SUB")
+    # Issue #1172: dual-RX VFOB → ``select_receiver("SUB")`` (CI-V
+    # 0x07 0xD1).  No fallback through legacy ``set_vfo`` overload.
+    dual_rx_radio.select_receiver.assert_awaited_once_with("SUB")
+    dual_rx_radio.set_vfo.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2404,7 +2406,8 @@ async def test_set_vfo_dual_rx_vfoa_selects_main(
 ) -> None:
     resp = await dual_rx_handler.execute(set_cmd("set_vfo", "VFOA"))
     assert resp.ok
-    dual_rx_radio.set_vfo.assert_awaited_once_with("MAIN")
+    dual_rx_radio.select_receiver.assert_awaited_once_with("MAIN")
+    dual_rx_radio.set_vfo.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2413,8 +2416,10 @@ async def test_set_vfo_single_rx_vfob_selects_slot_b(
 ) -> None:
     resp = await single_rx_handler.execute(set_cmd("set_vfo", "VFOB"))
     assert resp.ok
-    # "B" maps to CI-V 0x07 0x01 via radio.set_vfo("B").
-    single_rx_radio.set_vfo.assert_awaited_once_with("B")
+    # Issue #1172: single-RX VFOB → ``set_vfo_slot("B")`` (CI-V
+    # 0x07 0x01).  No fallback through legacy ``set_vfo`` overload.
+    single_rx_radio.set_vfo_slot.assert_awaited_once_with("B")
+    single_rx_radio.set_vfo.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2423,7 +2428,8 @@ async def test_set_vfo_single_rx_vfoa_selects_slot_a(
 ) -> None:
     resp = await single_rx_handler.execute(set_cmd("set_vfo", "VFOA"))
     assert resp.ok
-    single_rx_radio.set_vfo.assert_awaited_once_with("A")
+    single_rx_radio.set_vfo_slot.assert_awaited_once_with("A")
+    single_rx_radio.set_vfo.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2435,6 +2441,8 @@ async def test_set_vfo_unknown_name_is_backward_compat_ok(
     resp = await dual_rx_handler.execute(set_cmd("set_vfo", "VFO-C"))
     assert resp.ok
     dual_rx_radio.set_vfo.assert_not_awaited()
+    dual_rx_radio.select_receiver.assert_not_awaited()
+    dual_rx_radio.set_vfo_slot.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2659,6 +2659,17 @@ class TestSwitchScopeReceiver:
         # Canonical dual-RX VFO methods on ``DualReceiverCapable`` (post-#1114).
         radio.swap_main_sub = AsyncMock()
         radio.equalize_main_sub = AsyncMock()
+        # Receiver-tier methods (issue #1170 / #1172).  Make
+        # ``select_receiver`` mirror the wire-level CI-V the runtime would
+        # emit so existing assertions on ``send_civ(0x07, …)`` still apply.
+        async def _select_receiver(which: object) -> None:
+            name = str(which).strip().upper()
+            code = 0xD1 if name in ("SUB", "1") else 0xD0
+            await radio.send_civ(0x07, data=bytes([code]))
+            radio._radio_state.active = "SUB" if code == 0xD1 else "MAIN"
+
+        radio.select_receiver = AsyncMock(side_effect=_select_receiver)
+        radio.set_vfo_slot = AsyncMock()
         return radio
 
     async def test_switch_scope_receiver_main_sends_civ(self) -> None:
@@ -2730,7 +2741,14 @@ class TestSwitchScopeReceiver:
         )
 
     async def test_select_vfo_sub_sends_receiver_select(self) -> None:
-        """SelectVfo("SUB") sends receiver-select (0x07 0xD1) when active=MAIN."""
+        """SelectVfo("SUB") goes through ``select_receiver`` (issue #1172).
+
+        Wave 4-C migrated the poller off the raw ``_civ(0x07, [0xD1])``
+        write to the typed ``ReceiverBankCapable.select_receiver`` API.
+        We assert both the public-API call and the wire-level CI-V the
+        mock emits as a side-effect (back-compat with downstream
+        test scaffolding that watches ``send_civ``).
+        """
         from icom_lan.web.radio_poller import CommandQueue, RadioPoller, SelectVfo
 
         radio = self._make_radio()
@@ -2742,6 +2760,9 @@ class TestSwitchScopeReceiver:
         await asyncio.sleep(0.03)
         poller.stop()
 
+        # Public API: poller now routes through ``select_receiver``.
+        radio.select_receiver.assert_awaited_once_with("SUB")
+        # Wire level (mock side-effect): CI-V 0x07 0xD1 emitted.
         sub_select_calls = [
             c
             for c in radio.send_civ.call_args_list
@@ -2781,6 +2802,8 @@ class TestSwitchScopeReceiver:
         await asyncio.sleep(0.03)
         poller.stop()
 
+        # Idempotent: no call to the public API when already on the target.
+        radio.select_receiver.assert_not_awaited()
         select_calls = [
             c
             for c in radio.send_civ.call_args_list


### PR DESCRIPTION
## Summary

Wave 4-C of epic #1165 closes the P2-07 receiver-tier audit gap. Builds on Wave 4-A (#1170/#1180) and Wave 4-B (#1179) which landed `select_receiver` / `set_vfo_slot` on every backend.

- **web/radio_poller.py** — `SelectVfo` now routes through `ReceiverBankCapable.select_receiver` (CI-V 0x07 0xD0/0xD1) instead of a raw `_civ` write.
- **rigctld/handler.py** — `_cmd_set_vfo` branches by capability (`select_receiver` for dual-RX, `set_vfo_slot` for single-RX) instead of the legacy receiver-count → string-overload (`"MAIN"`/`"A"`) mapping.
- **IcomRadio.set_vfo** (radio.py) — split into private `_set_vfo_wire` (wire-level, no warning) and the public deprecated overload that emits `DeprecationWarning` per Q4 tighter policy. Removal scheduled for v0.20. Internal callers in `_dual_rx_runtime.py` and `restore_state` go through `_set_vfo_wire` so the migrated protocol surface does not self-trigger the deprecation warning.

The `set_freq` / `set_mode` swap-and-restore fallback paths in the poller (lines ~720-735, 760-776, 1843-1893) keep their raw `_civ(0x07, …)` writes — they are intricate critical-section sequences with their own state machines, not standalone receiver-selects, and rewriting them is a larger refactor outside the scope of #1172.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5056 passed, no regressions
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] New tests:
  - `test_set_vfo_emits_deprecation_warning` — pins warning message + v0.20 schedule
  - `test_set_vfo_wire_does_not_warn` — internal helper is silent
  - rigctld VFO routing tests now assert `select_receiver` / `set_vfo_slot`
  - poller `SelectVfo` tests assert the public-API call AND the wire-level CI-V (back-compat with downstream test scaffolding)
- [ ] Manual smoke test against IC-7610 hardware: VFOA/VFOB switch in web UI, rigctld VFOA/VFOB via WSJT-X (deferred to integration suite)

Closes #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)