### PR TITLE
fix(web,rigctld): legacy backend fallback for set_vfo when ReceiverBankCapable absent

### DIFF
--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -669,16 +669,29 @@ class RigctldHandler:
         # used to live here is gone.
         if rc >= 2:
             select_receiver = getattr(self._radio, "select_receiver", None)
-            if select_receiver is None:
+            if select_receiver is not None:
+                target = "MAIN" if vfo == "VFOA" else "SUB"
+                await select_receiver(target)
                 return _ok()
             target = "MAIN" if vfo == "VFOA" else "SUB"
-            await select_receiver(target)
         else:
             set_vfo_slot = getattr(self._radio, "set_vfo_slot", None)
-            if set_vfo_slot is None:
+            if set_vfo_slot is not None:
+                slot = "A" if vfo == "VFOA" else "B"
+                await set_vfo_slot(slot)
                 return _ok()
-            slot = "A" if vfo == "VFOA" else "B"
-            await set_vfo_slot(slot)
+            target = "A" if vfo == "VFOA" else "B"
+        # Issue #1189: legacy backends (e.g. SerialMockRadio,
+        # 3rd-party Radio implementers) predate ``ReceiverBankCapable`` /
+        # ``VfoSlotCapable`` and only expose the legacy ``set_vfo``
+        # overload.  Fall back to it so ``V VFOA`` / ``V VFOB`` actually
+        # reach the radio instead of returning a silent ``RPRT 0``.  The
+        # ``DeprecationWarning`` from ``IcomRadio.set_vfo`` (#1187) is
+        # intentional — it signals migration.
+        legacy_set_vfo = getattr(self._radio, "set_vfo", None)
+        if legacy_set_vfo is None:
+            return _err(HamlibError.ENAVAIL)
+        await legacy_set_vfo(target)
         return _ok()
 
     # ------------------------------------------------------------------

--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -1305,8 +1305,34 @@ class RadioPoller:
                             f"select_vfo({vfo}) is unsupported by profile "
                             f"{self._profile.model}: no MAIN/SUB select code"
                         )
-                    await radio.select_receiver(target_name)
-                    logger.info("radio-poller: select_receiver=%s", target_name)
+                    # Issue #1189: legacy backends (e.g. SerialMockRadio,
+                    # 3rd-party Radio implementers) predate
+                    # ``ReceiverBankCapable`` and only expose the legacy
+                    # ``set_vfo`` overload.  Fall back to it so the poller
+                    # does not AttributeError on those backends.  The
+                    # DeprecationWarning from ``IcomRadio.set_vfo``
+                    # (#1187) is intentional — it signals migration.
+                    select_receiver = getattr(radio, "select_receiver", None)
+                    if select_receiver is not None:
+                        await select_receiver(target_name)
+                        logger.info(
+                            "radio-poller: select_receiver=%s", target_name
+                        )
+                    else:
+                        legacy_set_vfo = getattr(radio, "set_vfo", None)
+                        if legacy_set_vfo is None:
+                            logger.warning(
+                                "radio-poller: select_vfo(%s) — backend "
+                                "lacks select_receiver and set_vfo; skipping",
+                                vfo,
+                            )
+                            return
+                        await legacy_set_vfo(target_name)
+                        logger.info(
+                            "radio-poller: legacy set_vfo=%s "
+                            "(backend lacks ReceiverBankCapable)",
+                            target_name,
+                        )
                     # ``select_receiver`` updates ``_radio_state.active`` on
                     # the dual-RX runtime; mirror it on radios that don't
                     # ship that wiring (test mocks, custom backends).

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -289,6 +289,54 @@ async def test_execute_event_emitting_commands_and_vfo_paths() -> None:
 
 
 @pytest.mark.asyncio
+async def test_select_vfo_legacy_backend_falls_back_to_set_vfo() -> None:
+    """SelectVfo on backends predating ReceiverBankCapable falls back to set_vfo.
+
+    Issue #1189: backends like ``SerialMockRadio`` only expose the legacy
+    ``set_vfo`` overload.  The poller must not AttributeError on
+    ``radio.select_receiver(...)`` — it must fall back to ``set_vfo`` so
+    SUB selection still reaches the radio.  The DeprecationWarning from
+    ``IcomRadio.set_vfo`` (#1187) is intentional — it signals migration.
+    """
+    events: list[tuple[str, dict]] = []
+    radio = _make_radio(active="MAIN")
+    # Strip the new methods so the legacy fallback is exercised.  Using
+    # ``del`` rather than rebuilding via ``spec=`` keeps the rest of the
+    # ``_make_radio`` wiring (caps, profile, _radio_state) intact.
+    del radio.select_receiver
+    del radio.set_vfo_slot
+    radio.set_vfo = AsyncMock()
+
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        CommandQueue(),
+        on_state_event=lambda name, data: events.append((name, data)),
+    )
+
+    await poller._execute(SelectVfo("SUB"))  # noqa: SLF001
+
+    radio.set_vfo.assert_awaited_once_with("SUB")
+    assert any(name == "vfo_changed" for name, _ in events)
+
+
+@pytest.mark.asyncio
+async def test_select_vfo_no_capability_logs_and_skips() -> None:
+    """SelectVfo on a backend with neither new methods nor set_vfo: skip cleanly."""
+    radio = _make_radio(active="MAIN")
+    del radio.select_receiver
+    del radio.set_vfo_slot
+    # ``MagicMock`` auto-creates ``set_vfo`` on access; ``del`` removes
+    # it so ``getattr(radio, "set_vfo", None)`` returns ``None``.
+    del radio.set_vfo
+
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    # Must not raise; just no-op + warning log.
+    await poller._execute(SelectVfo("SUB"))  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_execute_receiver_routed_set_commands_use_backend_receiver_and_target_state() -> (
     None
 ):

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -2453,6 +2453,87 @@ async def test_set_vfo_no_args_returns_einval(
     assert resp.error == HamlibError.EINVAL
 
 
+# -- legacy backend fallback (issue #1189) ------------------------------------
+
+
+@pytest.fixture
+def legacy_dual_rx_radio() -> AsyncMock:
+    """Legacy dual-RX backend lacking ReceiverBankCapable / VfoSlotCapable.
+
+    Issue #1189: backends predating #1170/#1172 (e.g. ``SerialMockRadio``,
+    3rd-party ``Radio`` implementers) only expose the legacy ``set_vfo``
+    overload.  ``_cmd_set_vfo`` must fall back to it instead of returning
+    a silent ``RPRT 0``.
+    """
+    radio = AsyncMock(spec_set=["capabilities", "profile", "set_vfo"])
+    radio.capabilities = set(FULL_ICOM_CAPS)
+    radio.profile = _FakeProfile(receiver_count=2, vfo_scheme="main_sub")
+    radio.set_vfo = AsyncMock()
+    return radio
+
+
+@pytest.fixture
+def legacy_single_rx_radio() -> AsyncMock:
+    """Legacy single-RX backend lacking VfoSlotCapable."""
+    radio = AsyncMock(spec_set=["capabilities", "profile", "set_vfo"])
+    radio.capabilities = set(FULL_ICOM_CAPS)
+    radio.profile = _FakeProfile(receiver_count=1, vfo_scheme="ab")
+    radio.set_vfo = AsyncMock()
+    return radio
+
+
+@pytest.fixture
+def legacy_no_vfo_radio() -> AsyncMock:
+    """Backend with no VFO support at all — neither new nor legacy methods."""
+    radio = AsyncMock(spec_set=["capabilities", "profile"])
+    radio.capabilities = set(FULL_ICOM_CAPS)
+    radio.profile = _FakeProfile(receiver_count=2, vfo_scheme="main_sub")
+    return radio
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_legacy_dual_rx_falls_back_to_set_vfo(
+    legacy_dual_rx_radio: AsyncMock, config: RigctldConfig
+) -> None:
+    handler = RigctldHandler(legacy_dual_rx_radio, config)
+    resp = await handler.execute(set_cmd("set_vfo", "VFOB"))
+    assert resp.ok
+    # Legacy overload receives MAIN/SUB on dual-RX (matches pre-#1187 mapping).
+    legacy_dual_rx_radio.set_vfo.assert_awaited_once_with("SUB")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_legacy_dual_rx_vfoa_falls_back_to_set_vfo(
+    legacy_dual_rx_radio: AsyncMock, config: RigctldConfig
+) -> None:
+    handler = RigctldHandler(legacy_dual_rx_radio, config)
+    resp = await handler.execute(set_cmd("set_vfo", "VFOA"))
+    assert resp.ok
+    legacy_dual_rx_radio.set_vfo.assert_awaited_once_with("MAIN")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_legacy_single_rx_falls_back_to_set_vfo(
+    legacy_single_rx_radio: AsyncMock, config: RigctldConfig
+) -> None:
+    handler = RigctldHandler(legacy_single_rx_radio, config)
+    resp = await handler.execute(set_cmd("set_vfo", "VFOB"))
+    assert resp.ok
+    # Legacy overload receives A/B on single-RX.
+    legacy_single_rx_radio.set_vfo.assert_awaited_once_with("B")
+
+
+@pytest.mark.asyncio
+async def test_set_vfo_no_capability_returns_enavail(
+    legacy_no_vfo_radio: AsyncMock, config: RigctldConfig
+) -> None:
+    # Backend without select_receiver / set_vfo_slot / set_vfo:
+    # rigctld must surface ENAVAIL rather than silent RPRT 0 success.
+    handler = RigctldHandler(legacy_no_vfo_radio, config)
+    resp = await handler.execute(set_cmd("set_vfo", "VFOA"))
+    assert resp.error == HamlibError.ENAVAIL
+
+
 # -- set_split_vfo ------------------------------------------------------------
 
 

--- a/tests/test_serial_backend_smoke.py
+++ b/tests/test_serial_backend_smoke.py
@@ -339,6 +339,30 @@ async def test_rigctld_smoke_with_serial_mock_backend() -> None:
             await writer.drain()
             ptt_resp = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=2.0)
             assert ptt_resp.strip() == b"1"
+
+            # Issue #1189: legacy backends (no ReceiverBankCapable) must
+            # still see ``set_vfo`` actually invoked on ``V VFOA`` rather
+            # than the silent ``RPRT 0`` regression introduced by #1187.
+            # Spy on the radio's legacy ``set_vfo`` to verify dispatch
+            # reached the radio (not the rigctld success code alone,
+            # which would be returned even by the broken silent no-op).
+            calls: list[str] = []
+            original_set_vfo = radio.set_vfo
+
+            async def _spy(vfo: str) -> None:
+                calls.append(vfo)
+                await original_set_vfo(vfo)
+
+            radio.set_vfo = _spy  # type: ignore[method-assign]
+            writer.write(b"V VFOA\n")
+            await writer.drain()
+            set_vfo_resp = await asyncio.wait_for(
+                reader.readuntil(b"\n"), timeout=2.0
+            )
+            assert set_vfo_resp.strip() == b"RPRT 0"
+            assert calls == ["MAIN"], (
+                f"V VFOA must reach legacy set_vfo (got calls={calls!r})"
+            )
         finally:
             await _close_writer(writer)
     finally:


### PR DESCRIPTION
## Summary

- Restores the legacy `set_vfo` fallback in `rigctld/handler.py:_cmd_set_vfo` and `web/radio_poller.py` SelectVfo, both broken by #1187.
- rigctld now returns `RPRT ENAVAIL` (instead of silent `RPRT 0`) when no VFO method is available; the web poller logs a warning and skips.
- Capability ladder: `select_receiver` → `set_vfo_slot` → legacy `set_vfo` (deprecation warning fires intentionally) → `ENAVAIL` / no-op.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5071 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] New `test_rigctld_handler.py` cases: legacy dual-RX VFOA/VFOB → `set_vfo("MAIN"/"SUB")`, legacy single-RX VFOB → `set_vfo("B")`, no-VFO backend → `ENAVAIL`
- [x] New `test_radio_poller_coverage.py` cases: SelectVfo legacy fallback to `set_vfo`, no-capability silent skip
- [x] New `test_serial_backend_smoke.py` end-to-end: `V VFOA` against a real `SerialMockRadio` + `RigctldServer` — spy on `set_vfo` confirms dispatch reaches the radio (a `RPRT 0` assertion alone would still pass against the broken silent regression)
- [x] Existing capable-backend tests unchanged (`set_vfo.assert_not_awaited()` still holds on the dual/single-RX fixtures)

Closes #1189

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>