### PR TITLE
fix(web): scope poller timeout cancels CI-V command at worker level

### DIFF
--- a/src/icom_lan/commander.py
+++ b/src/icom_lan/commander.py
@@ -147,8 +147,10 @@ class IcomCommander:
         try:
             while True:
                 _, _, item = await self._queue.get()
+                execute_task: asyncio.Future[CivFrame | None] | None = None
                 try:
-                    # Skip abandoned requests (caller cancelled/timed out).
+                    # Skip abandoned requests (caller cancelled/timed out
+                    # before worker even started this item).
                     if item.future.done():
                         continue
 
@@ -161,11 +163,48 @@ class IcomCommander:
                     if item.future.done():
                         continue
 
-                    resp = await self._execute(item.payload, item.wait_response)
+                    # Run execute as an inner task so that a caller-side
+                    # timeout (asyncio.wait_for in `send`) cancels JUST this
+                    # in-flight command and the worker can move on, instead
+                    # of blocking on a dropped reply while the rest of the
+                    # queue piles up with pre-cancelled futures (#1188).
+                    execute_task = asyncio.ensure_future(
+                        self._execute(item.payload, item.wait_response)
+                    )
+                    inflight = execute_task
+
+                    def _propagate_cancel(
+                        f: asyncio.Future[CivFrame | None],
+                        t: asyncio.Future[CivFrame | None] = inflight,
+                    ) -> None:
+                        # Caller's wait_for fired, or caller went away.
+                        # Cancel the in-flight execute so the worker
+                        # unblocks immediately.
+                        if f.cancelled() and not t.done():
+                            t.cancel()
+
+                    item.future.add_done_callback(_propagate_cancel)
+
+                    try:
+                        resp = await execute_task
+                    except asyncio.CancelledError:
+                        # Distinguish caller-driven cancel from worker
+                        # teardown (c.stop()): on caller-cancel, item.future
+                        # is already in cancelled state; on worker stop, the
+                        # outer except below handles it.
+                        if item.future.cancelled():
+                            # Packet was sent on the wire — honor pacing
+                            # for the next item.
+                            self._last_send = asyncio.get_running_loop().time()
+                            continue
+                        raise
+
                     self._last_send = asyncio.get_running_loop().time()
                     if not item.future.done():
                         item.future.set_result(resp)
                 except asyncio.CancelledError:
+                    if execute_task is not None and not execute_task.done():
+                        execute_task.cancel()
                     if not item.future.done():
                         item.future.set_exception(ConnectionError("Commander stopped"))
                     raise

--- a/tests/test_commander.py
+++ b/tests/test_commander.py
@@ -141,6 +141,64 @@ async def test_stop_fails_inflight_command() -> None:
 
 
 @pytest.mark.asyncio
+async def test_caller_timeout_cancels_inflight_and_unblocks_queue() -> None:
+    """A caller-side timeout must cancel the in-flight CI-V command at the
+    worker and let queued items proceed.
+
+    Regression test for #1188: PR #1186 wrapped scope-getter calls with
+    ``asyncio.wait_for(getter(), 0.2)``.  When ``wait_for`` fired, only the
+    caller future was cancelled — the worker was still ``await``-ing the
+    in-flight ``_execute`` for the (dropped) response.  Subsequent items
+    were enqueued while the worker was blocked, and their own ``wait_for``
+    timers expired before they reached the head of the queue, so the worker
+    saw their futures as already cancelled and skipped them.  Effect: a
+    single dropped reply caused the rest of ``_fetch_scope_controls()`` to
+    be silently dropped.
+
+    Fix: worker runs ``_execute`` as an inner task and cancels it when the
+    caller future is cancelled, so the queue keeps draining at full speed.
+    """
+    seen: list[bytes] = []
+    started = asyncio.Event()
+    block = asyncio.Event()
+
+    async def execute(cmd: bytes, wait_response: bool = True) -> CivFrame | None:
+        seen.append(cmd)
+        if cmd == b"slow":
+            started.set()
+            await block.wait()
+        return CivFrame(to_addr=0xE0, from_addr=0x98, command=0xFB, sub=None, data=b"")
+
+    c = IcomCommander(execute, min_interval=0.0)
+    c.start()
+    try:
+        # First command hangs; caller waits with a tight timeout.
+        slow = asyncio.create_task(c.send(b"slow", timeout=0.05))
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+
+        # Enqueue 11 fast followers (no per-call timeout).  Without the
+        # fix, these get pre-cancelled while the worker is stuck on
+        # ``slow`` — only ``b"slow"`` would land in ``seen``.
+        fast = [asyncio.create_task(c.send(f"fast-{i}".encode())) for i in range(11)]
+
+        # Slow command must surface as TimeoutError to the caller.
+        with pytest.raises(asyncio.TimeoutError):
+            await slow
+
+        # All 11 fast followers must complete normally and reach execute().
+        await asyncio.wait_for(asyncio.gather(*fast), timeout=2.0)
+    finally:
+        block.set()  # unblock any leftover slow execute (defensive)
+        await c.stop()
+
+    # Worker dispatched all 12 items: the slow one (cancelled in-flight)
+    # plus all 11 fast followers.
+    assert seen[0] == b"slow"
+    assert sorted(seen[1:]) == sorted(f"fast-{i}".encode() for i in range(11))
+    assert len(seen) == 12
+
+
+@pytest.mark.asyncio
 async def test_cancelled_queued_request_is_not_executed() -> None:
     started = asyncio.Event()
     release = asyncio.Event()


### PR DESCRIPTION
## Summary

Codex P1 follow-up to #1186. The previous fix wrapped scope getters with `asyncio.wait_for(getter(), 0.2)` to bound the EnableScope hot path, but `wait_for` cancels only the caller's future — the `IcomCommander._loop` worker was still `await`-ing the in-flight `_execute` for the dropped CI-V response. Subsequent getters got enqueued while the worker was blocked, their own `wait_for` timers fired before the worker reached them, and `if item.future.done(): continue` silently skipped them on arrival.

Effect on real hardware: one dropped scope-control response would cause most of `_fetch_scope_controls()` to be skipped — the fix was worse than the original blocking behaviour.

## Fix

Move the cancellation point inside the worker. `_loop` now runs `_execute` as an inner task and cancels it via a done-callback when the caller future enters the cancelled state. The outer worker stays alive and proceeds to the next queued item, so a single dropped reply no longer cascades into a queue-wide skip.

- `item.future.cancelled()` distinguishes caller-driven cancel from worker teardown (`c.stop()` sets a `ConnectionError`, not `cancel`), preserving the existing "Commander stopped" path.
- Pacing (`_last_send`) is honoured on the caller-cancel path — the packet was already sent on the wire.
- Two-file diff (`commander.py` + `test_commander.py`); poller and `_scope_runtime` untouched. No public API changes.

## Test plan

- [x] New `test_caller_timeout_cancels_inflight_and_unblocks_queue`: 1 slow command + 11 fast followers via a real `IcomCommander` queue. Fails on `main` (only the slow command reaches `_execute`); passes with this fix (all 12 dispatched, slow one surfaces `TimeoutError` to the caller).
- [x] Existing `test_cancelled_queued_request_is_not_executed` still passes — caller cancellation of a *queued* (not in-flight) item is still skipped by the top-of-loop `done()` check.
- [x] Existing `test_stop_fails_pending` / `test_stop_fails_inflight_command` still pass — worker teardown still raises `ConnectionError` on inflight futures.
- [x] `uv run pytest tests/ -q --ignore=tests/integration` — 5066 passed.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run mypy src/` — clean.

Closes #1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)