### PR TITLE
docs(api): stability tiers section in public-api-surface.md

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **API: tier-1 stability commitment from v0.19 (#1195).** The public API
+  surface is now organised into three explicit tiers (stable / best-effort /
+  internal) with a documented migration policy. See
+  `docs/api/public-api-surface.md` for the tier policy, full symbol lists,
+  and import examples.
 - **Audio-bridge dependencies folded into core install (#1090).** `opuslib`,
   `sounddevice`, and `numpy` moved from the `[bridge]` extra into the main
   `dependencies` list — `pip install icom-lan` now ships the audio bridge,

--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -70,6 +70,125 @@ When extending the library or writing integration code, prefer importing from th
 
 ---
 
+## Stability tiers
+
+Effective from **v0.19**. Every public symbol in the package belongs to exactly
+one tier. The tier governs the breakage policy, the recommended import path,
+and whether the symbol is allowed in production code outside its owning
+subsystem.
+
+### Tier 1 — Stable
+
+Public API. Breaking changes require a **major version bump**
+(semver-strict). Symbols are loaded eagerly by `icom_lan/__init__.py` and
+available directly via `from icom_lan import …`.
+
+**Backend factory and configs**
+
+- `__version__`
+- `create_radio`
+- `BackendConfig`, `LanBackendConfig`, `SerialBackendConfig`,
+  `YaesuCatBackendConfig`
+
+**Capability protocols (from `icom_lan.radio_protocol`)**
+
+- `Radio`
+- `LevelsCapable`, `MetersCapable`, `PowerControlCapable`,
+  `StateNotifyCapable`
+- `AudioCapable`, `CivCommandCapable`, `ModeInfoCapable`, `ScopeCapable`
+- `DualReceiverCapable`, `ReceiverBankCapable`, `TransceiverBankCapable`,
+  `VfoSlotCapable`
+- `StateCacheCapable`, `RecoverableConnection`
+- `DspControlCapable`, `AntennaControlCapable`, `CwControlCapable`,
+  `VoiceControlCapable`
+- `SystemControlCapable`, `RepeaterControlCapable`, `AdvancedControlCapable`
+- `TransceiverStatusCapable`, `RitXitCapable`, `MemoryCapable`
+- `SplitCapable` (new in v0.19)
+
+**Exceptions (from `icom_lan.exceptions`)**
+
+- `IcomLanError`, `AudioCodecBackendError`, `AudioError`, `AudioFormatError`
+- `AudioTranscodeError`, `AuthenticationError`, `CommandError`
+- `ConnectionError`, `TimeoutError`
+
+**Public types (from `icom_lan.types`)**
+
+- `Mode`, `AudioCodec`, `BreakInMode`, `Meter` (and the other symbols
+  currently re-exported from `icom_lan.types`)
+
+**Public state types**
+
+- `RadioState`, `RadioProfile`, `VfoSlotState`, `YaesuStateExtension`
+
+Example (valid):
+
+```python
+from icom_lan import create_radio, Radio, LanBackendConfig, MetersCapable
+```
+
+### Tier 2 — Best-effort
+
+Available via `from icom_lan import …`, but loaded lazily through PEP 562
+`__getattr__` so they do not pull their subsystem into memory until the name
+is actually accessed. Breaking changes require a **CHANGELOG note plus a
+minor version bump**. No semver guarantee — these may be reshaped or moved
+without a major version.
+
+- `IcomRadio`, `IcomCommander`, `Priority`
+- Audio primitives: `audio.backend.AudioBackend`,
+  `audio.backend.PortAudioBackend`, `audio.backend.FakeAudioBackend`
+- DSP utilities: `audio.dsp.NoiseGate`, `audio.dsp.RmsNormalizer`,
+  `audio.dsp.Limiter`, `audio.dsp.DspPipeline`
+- Audio configuration and devices: `audio.config.AudioConfig`,
+  `audio.usb_driver.UsbAudioDriver` (and similar audio-stream primitives)
+
+Example (valid, lazy-loaded):
+
+```python
+from icom_lan import IcomRadio, IcomCommander  # tier-2 — works, but no semver guarantee
+```
+
+### Tier 3 — Internal
+
+Subject to change without notice. **Not** re-exported from the top-level
+package. Importing these from production source outside the owning
+subsystem triggers ruff `TID251`. Tests are exempt (see existing
+`tests/* per-file-ignores` in `pyproject.toml`).
+
+- `icom_lan.web.*` — internal to the web subsystem
+- `icom_lan.rigctld.*` — internal to the rigctld subsystem
+- `icom_lan.cli` — internal to the CLI
+- `icom_lan.radio.IcomRadio` — legacy direct-import path (use tier-2
+  re-export from `icom_lan` instead)
+- Most underscore-prefixed modules (`_connection_state`,
+  `_shared_state_runtime`, …)
+
+Example (invalid — flagged by `TID251` outside the owning subsystem):
+
+```python
+from icom_lan.web.handlers import ControlHandler  # tier-3 — forbidden in production
+from icom_lan.rigctld.server import RigctldServer  # tier-3 — forbidden in production
+```
+
+### Migration policy
+
+- **Promote tier 2 → tier 1.** Cite real-world usage in a PR; the tier-1
+  list grows by addition and is reviewed in the open. CHANGELOG entry under
+  `### Added`.
+- **Demote tier 1 → tier 2.** Requires a major version bump. CHANGELOG
+  entry under `### Changed`.
+- **Remove a tier-1 symbol.** Requires a major version bump **and** a
+  two-minor-release deprecation cycle (`DeprecationWarning` for at least
+  two minor releases before removal).
+- **Add a new tier-1 symbol.** PR + CHANGELOG entry under `### Added`. The
+  symbol must be re-exported from `icom_lan/__init__.py` and listed in this
+  document.
+- **Tier 2 / tier 3 changes.** May happen in any minor release with a
+  CHANGELOG note. No deprecation cycle is required, but a one-release
+  warning is preferred when a tier-2 symbol is being removed entirely.
+
+---
+
 ## Summary
 
 - **Use for new code**: `create_radio`, `Radio`, backend configs, capability protocols, exceptions, `RadioState`, profiles, and `sync.IcomRadio` for blocking use.


### PR DESCRIPTION
## Summary

- Adds a **Stability tiers** section to `docs/api/public-api-surface.md`, formalising the tier-1 / tier-2 / tier-3 contract that takes effect from v0.19.
- Per-tier symbol lists are copied verbatim from epic #1193 (capability protocols, exceptions, public types, state types, lazy tier-2 audio/DSP primitives, tier-3 internals).
- Includes valid / invalid import examples per tier and a migration policy paragraph (promote / demote / add / remove rules with deprecation cycle).
- CHANGELOG `### Changed` entry under `[Unreleased]` references the new tier policy.

Pure docs change — no behavior change. Sibling PRs #1194 (lazy `__init__.py`) and #1196 (TID251 bans) touch different files and are parallel-safe.

Closes #1195
Refs #1193

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5072 passed, 2 skipped, 9 xfailed, 1 xpassed
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] Markdown rendering of new section verified (headings, code fences, tier examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)