### PR TITLE
chore(api): __init__.py lazy imports via PEP 562 — tier-1 sealed

### DIFF
--- a/src/icom_lan/__init__.py
+++ b/src/icom_lan/__init__.py
@@ -1,20 +1,32 @@
-"""icom-lan: Python library for controlling Icom transceivers over LAN."""
-# ruff: noqa: F401  — all imports are intentional re-exports for public API
+"""icom-lan: Python library for controlling Icom transceivers over LAN.
+
+Public API is split into two stability tiers (Form F sealing, v0.19+):
+
+* **Tier 1 — STABLE.** Eager-imported below. Semver-protected: breaking
+  changes require a major-version bump.
+* **Tier 2 — BEST-EFFORT.** Lazy-loaded via :pep:`562` ``__getattr__``. Still
+  importable as ``from icom_lan import X``; backwards-compatible by default
+  but may change between minor releases with a deprecation cycle.
+
+Submodules and private symbols (``icom_lan.web``, ``icom_lan.cli``,
+``icom_lan.rigctld``, anything starting with ``_``) are **internal** and
+may change without warning.
+"""
 
 from importlib.metadata import version as _pkg_version
 
 __version__ = _pkg_version("icom-lan")
 
-from .auth import (
-    AuthResponse,
-    StatusResponse,
-    build_conninfo_packet,
-    build_login_packet,
-    encode_credentials,
-    parse_auth_response,
-    parse_status_response,
+# === Tier 1 — eager (semver-stable from v0.19) ===
+
+from .backends import (  # noqa: F401
+    BackendConfig,
+    LanBackendConfig,
+    SerialBackendConfig,
+    YaesuCatBackendConfig,
+    create_radio,
 )
-from .exceptions import (
+from .exceptions import (  # noqa: F401
     AudioCodecBackendError,
     AudioError,
     AudioFormatError,
@@ -25,165 +37,251 @@ from .exceptions import (
     IcomLanError,
     TimeoutError,
 )
-from .protocol import identify_packet_type, parse_header, serialize_header
-from .audio import (
-    AUDIO_HEADER_SIZE,
-    AudioPacket,
-    AudioState,
-    AudioStats,
-    AudioStream,
-    JitterBuffer,
-)
-from .transport import ConnectionState, IcomTransport
-from ._connection_state import RadioConnectionState
-from .commander import IcomCommander, Priority
-from .radio import AudioRecoveryState, IcomRadio  # noqa: TID251
-from .radio_protocol import (
+from .profiles import RadioProfile  # noqa: F401
+from .radio_protocol import (  # noqa: F401
     AdvancedControlCapable,
+    AntennaControlCapable,
     AudioCapable,
     CivCommandCapable,
+    CwControlCapable,
+    DspControlCapable,
     DualReceiverCapable,
     LevelsCapable,
+    MemoryCapable,
     MetersCapable,
     ModeInfoCapable,
     PowerControlCapable,
     Radio,
+    ReceiverBankCapable,
     RecoverableConnection,
+    RepeaterControlCapable,
+    RitXitCapable,
     ScopeCapable,
+    SplitCapable,
     StateCacheCapable,
     StateNotifyCapable,
+    SystemControlCapable,
+    TransceiverBankCapable,
+    TransceiverStatusCapable,
+    VfoSlotCapable,
+    VoiceControlCapable,
 )
-from .radio_state import RadioState
-from .profiles import RadioProfile, get_radio_profile, resolve_radio_profile
-from .radios import RADIOS, RadioModel, get_civ_addr, IC_7610_ADDR
-from .ic705 import prepare_ic705_data_profile, restore_ic705_data_profile
-from .profiles_runtime import OperatingProfile, apply_profile, PRESETS
-from .backends import (
-    BackendConfig,
-    LanBackendConfig,
-    SerialBackendConfig,
-    YaesuCatBackendConfig,
-    create_radio,
-)
-from .commands import (
-    CONTROLLER_ADDR,
-    RECEIVER_MAIN,
-    RECEIVER_SUB,
-    build_civ_frame,
-    build_cmd29_frame,
-    get_alc,
-    get_attenuator,
-    get_freq,
-    get_mode,
-    get_rf_power,
-    get_preamp,
-    get_s_meter,
-    get_swr,
-    parse_ack_nak,
-    parse_civ_frame,
-    parse_frequency_response,
-    parse_meter_response,
-    parse_mode_response,
-    ptt_off,
-    ptt_on,
-    get_scope_center_type,
-    get_scope_during_tx,
-    get_scope_edge,
-    get_scope_fixed_edge,
-    get_scope_hold,
-    get_scope_main_sub,
-    get_scope_mode,
-    get_scope_rbw,
-    get_scope_ref,
-    get_scope_single_dual,
-    get_scope_span,
-    get_scope_speed,
-    get_scope_vbw,
-    scope_data_output_off,
-    scope_data_output_on,
-    scope_main_sub,
-    scope_off,
-    scope_on,
-    scope_set_center_type,
-    scope_set_during_tx,
-    scope_set_edge,
-    scope_set_fixed_edge,
-    scope_set_hold,
-    scope_set_mode,
-    scope_set_rbw,
-    scope_set_ref,
-    scope_set_span,
-    scope_set_speed,
-    scope_set_vbw,
-    scope_single_dual,
-    set_attenuator,
-    set_attenuator_level,
-    set_freq,
-    set_mode,
-    set_rf_power,
-    get_af_level,
-    get_rf_gain,
-    set_af_level,
-    set_rf_gain,
-    set_preamp,
-)
-from .scope import ScopeAssembler, ScopeFrame
+from .radio_state import RadioState, VfoSlotState, YaesuStateExtension  # noqa: F401
+from .types import AudioCodec, BreakInMode, Mode  # noqa: F401
 
-# scope_render is an optional dep (Pillow); import lazily to avoid hard crash
-try:
-    from .scope_render import (  # noqa: F401
-        THEMES as SCOPE_THEMES,
-        amplitude_to_color,
-        render_scope_image,
-        render_spectrum,
-        render_waterfall,
-    )
+# === Tier 2 — lazy via PEP 562 ===
+#
+# Names below are still importable as ``from icom_lan import X`` and
+# ``icom_lan.X``, but their backing modules are loaded only on first
+# access. This keeps ``from icom_lan import Radio`` from transitively
+# pulling in audio, transport, web, rigctld and CLI machinery.
+#
+# Format: name -> (module, attribute)
+_LAZY_MAP: dict[str, tuple[str, str]] = {
+    # --- Backward-compat radio facades ---
+    "IcomRadio": ("icom_lan.radio", "IcomRadio"),
+    "AudioRecoveryState": ("icom_lan.radio", "AudioRecoveryState"),
+    # --- CI-V commander internals ---
+    "IcomCommander": ("icom_lan.commander", "IcomCommander"),
+    "Priority": ("icom_lan.commander", "Priority"),
+    # --- Connection / transport ---
+    "ConnectionState": ("icom_lan.transport", "ConnectionState"),
+    "IcomTransport": ("icom_lan.transport", "IcomTransport"),
+    "RadioConnectionState": ("icom_lan._connection_state", "RadioConnectionState"),
+    # --- Auth helpers ---
+    "AuthResponse": ("icom_lan.auth", "AuthResponse"),
+    "StatusResponse": ("icom_lan.auth", "StatusResponse"),
+    "build_conninfo_packet": ("icom_lan.auth", "build_conninfo_packet"),
+    "build_login_packet": ("icom_lan.auth", "build_login_packet"),
+    "encode_credentials": ("icom_lan.auth", "encode_credentials"),
+    "parse_auth_response": ("icom_lan.auth", "parse_auth_response"),
+    "parse_status_response": ("icom_lan.auth", "parse_status_response"),
+    # --- Wire-protocol helpers ---
+    "identify_packet_type": ("icom_lan.protocol", "identify_packet_type"),
+    "parse_header": ("icom_lan.protocol", "parse_header"),
+    "serialize_header": ("icom_lan.protocol", "serialize_header"),
+    # --- Audio (LAN stream) ---
+    "AUDIO_HEADER_SIZE": ("icom_lan.audio", "AUDIO_HEADER_SIZE"),
+    "AudioPacket": ("icom_lan.audio", "AudioPacket"),
+    "AudioState": ("icom_lan.audio", "AudioState"),
+    "AudioStats": ("icom_lan.audio", "AudioStats"),
+    "AudioStream": ("icom_lan.audio", "AudioStream"),
+    "JitterBuffer": ("icom_lan.audio", "JitterBuffer"),
+    # --- Audio backend / DSP / config ---
+    "AudioBackend": ("icom_lan.audio.backend", "AudioBackend"),
+    "PortAudioBackend": ("icom_lan.audio.backend", "PortAudioBackend"),
+    "FakeAudioBackend": ("icom_lan.audio.backend", "FakeAudioBackend"),
+    "NoiseGate": ("icom_lan.audio.dsp", "NoiseGate"),
+    "RmsNormalizer": ("icom_lan.audio.dsp", "RmsNormalizer"),
+    "Limiter": ("icom_lan.audio.dsp", "Limiter"),
+    "DspPipeline": ("icom_lan.audio.dsp", "DspPipeline"),
+    "AudioConfig": ("icom_lan.audio.config", "AudioConfig"),
+    "UsbAudioDriver": ("icom_lan.audio.usb_driver", "UsbAudioDriver"),
+    # --- Profiles / runtime profiles ---
+    "get_radio_profile": ("icom_lan.profiles", "get_radio_profile"),
+    "resolve_radio_profile": ("icom_lan.profiles", "resolve_radio_profile"),
+    "OperatingProfile": ("icom_lan.profiles_runtime", "OperatingProfile"),
+    "apply_profile": ("icom_lan.profiles_runtime", "apply_profile"),
+    "PRESETS": ("icom_lan.profiles_runtime", "PRESETS"),
+    # --- Radio model registry ---
+    "RADIOS": ("icom_lan.radios", "RADIOS"),
+    "RadioModel": ("icom_lan.radios", "RadioModel"),
+    "get_civ_addr": ("icom_lan.radios", "get_civ_addr"),
+    "IC_7610_ADDR": ("icom_lan.radios", "IC_7610_ADDR"),
+    # --- IC-705 helpers ---
+    "prepare_ic705_data_profile": (
+        "icom_lan.ic705",
+        "prepare_ic705_data_profile",
+    ),
+    "restore_ic705_data_profile": (
+        "icom_lan.ic705",
+        "restore_ic705_data_profile",
+    ),
+    # --- CI-V command helpers (subset historically re-exported) ---
+    "CONTROLLER_ADDR": ("icom_lan.commands", "CONTROLLER_ADDR"),
+    "RECEIVER_MAIN": ("icom_lan.commands", "RECEIVER_MAIN"),
+    "RECEIVER_SUB": ("icom_lan.commands", "RECEIVER_SUB"),
+    "build_civ_frame": ("icom_lan.commands", "build_civ_frame"),
+    "build_cmd29_frame": ("icom_lan.commands", "build_cmd29_frame"),
+    "parse_ack_nak": ("icom_lan.commands", "parse_ack_nak"),
+    "parse_civ_frame": ("icom_lan.commands", "parse_civ_frame"),
+    "parse_frequency_response": ("icom_lan.commands", "parse_frequency_response"),
+    "parse_meter_response": ("icom_lan.commands", "parse_meter_response"),
+    "parse_mode_response": ("icom_lan.commands", "parse_mode_response"),
+    "get_alc": ("icom_lan.commands", "get_alc"),
+    "get_attenuator": ("icom_lan.commands", "get_attenuator"),
+    "get_freq": ("icom_lan.commands", "get_freq"),
+    "get_mode": ("icom_lan.commands", "get_mode"),
+    "get_rf_power": ("icom_lan.commands", "get_rf_power"),
+    "get_preamp": ("icom_lan.commands", "get_preamp"),
+    "get_s_meter": ("icom_lan.commands", "get_s_meter"),
+    "get_swr": ("icom_lan.commands", "get_swr"),
+    "ptt_off": ("icom_lan.commands", "ptt_off"),
+    "ptt_on": ("icom_lan.commands", "ptt_on"),
+    "get_af_level": ("icom_lan.commands", "get_af_level"),
+    "get_rf_gain": ("icom_lan.commands", "get_rf_gain"),
+    "set_af_level": ("icom_lan.commands", "set_af_level"),
+    "set_rf_gain": ("icom_lan.commands", "set_rf_gain"),
+    "set_attenuator": ("icom_lan.commands", "set_attenuator"),
+    "set_attenuator_level": ("icom_lan.commands", "set_attenuator_level"),
+    "set_freq": ("icom_lan.commands", "set_freq"),
+    "set_mode": ("icom_lan.commands", "set_mode"),
+    "set_rf_power": ("icom_lan.commands", "set_rf_power"),
+    "set_preamp": ("icom_lan.commands", "set_preamp"),
+    "get_scope_center_type": ("icom_lan.commands", "get_scope_center_type"),
+    "get_scope_during_tx": ("icom_lan.commands", "get_scope_during_tx"),
+    "get_scope_edge": ("icom_lan.commands", "get_scope_edge"),
+    "get_scope_fixed_edge": ("icom_lan.commands", "get_scope_fixed_edge"),
+    "get_scope_hold": ("icom_lan.commands", "get_scope_hold"),
+    "get_scope_main_sub": ("icom_lan.commands", "get_scope_main_sub"),
+    "get_scope_mode": ("icom_lan.commands", "get_scope_mode"),
+    "get_scope_rbw": ("icom_lan.commands", "get_scope_rbw"),
+    "get_scope_ref": ("icom_lan.commands", "get_scope_ref"),
+    "get_scope_single_dual": ("icom_lan.commands", "get_scope_single_dual"),
+    "get_scope_span": ("icom_lan.commands", "get_scope_span"),
+    "get_scope_speed": ("icom_lan.commands", "get_scope_speed"),
+    "get_scope_vbw": ("icom_lan.commands", "get_scope_vbw"),
+    "scope_data_output_off": ("icom_lan.commands", "scope_data_output_off"),
+    "scope_data_output_on": ("icom_lan.commands", "scope_data_output_on"),
+    "scope_main_sub": ("icom_lan.commands", "scope_main_sub"),
+    "scope_off": ("icom_lan.commands", "scope_off"),
+    "scope_on": ("icom_lan.commands", "scope_on"),
+    "scope_set_center_type": ("icom_lan.commands", "scope_set_center_type"),
+    "scope_set_during_tx": ("icom_lan.commands", "scope_set_during_tx"),
+    "scope_set_edge": ("icom_lan.commands", "scope_set_edge"),
+    "scope_set_fixed_edge": ("icom_lan.commands", "scope_set_fixed_edge"),
+    "scope_set_hold": ("icom_lan.commands", "scope_set_hold"),
+    "scope_set_mode": ("icom_lan.commands", "scope_set_mode"),
+    "scope_set_rbw": ("icom_lan.commands", "scope_set_rbw"),
+    "scope_set_ref": ("icom_lan.commands", "scope_set_ref"),
+    "scope_set_span": ("icom_lan.commands", "scope_set_span"),
+    "scope_set_speed": ("icom_lan.commands", "scope_set_speed"),
+    "scope_set_vbw": ("icom_lan.commands", "scope_set_vbw"),
+    "scope_single_dual": ("icom_lan.commands", "scope_single_dual"),
+    # --- Scope assembler / frames ---
+    "ScopeAssembler": ("icom_lan.scope", "ScopeAssembler"),
+    "ScopeFrame": ("icom_lan.scope", "ScopeFrame"),
+    # --- Scope rendering (optional Pillow dep — handled by ImportError below) ---
+    "SCOPE_THEMES": ("icom_lan.scope_render", "THEMES"),
+    "amplitude_to_color": ("icom_lan.scope_render", "amplitude_to_color"),
+    "render_scope_image": ("icom_lan.scope_render", "render_scope_image"),
+    "render_spectrum": ("icom_lan.scope_render", "render_spectrum"),
+    "render_waterfall": ("icom_lan.scope_render", "render_waterfall"),
+    # --- Public types not in tier-1 ---
+    "HEADER_SIZE": ("icom_lan.types", "HEADER_SIZE"),
+    "AudioCapabilities": ("icom_lan.types", "AudioCapabilities"),
+    "CivFrame": ("icom_lan.types", "CivFrame"),
+    "PacketHeader": ("icom_lan.types", "PacketHeader"),
+    "PacketType": ("icom_lan.types", "PacketType"),
+    "ScopeCompletionPolicy": ("icom_lan.types", "ScopeCompletionPolicy"),
+    "ScopeFixedEdge": ("icom_lan.types", "ScopeFixedEdge"),
+    "bcd_decode": ("icom_lan.types", "bcd_decode"),
+    "bcd_encode": ("icom_lan.types", "bcd_encode"),
+    "get_audio_capabilities": ("icom_lan.types", "get_audio_capabilities"),
+}
 
-    _SCOPE_RENDER_AVAILABLE = True
-except ImportError:
-    _SCOPE_RENDER_AVAILABLE = False
-from .types import (
-    HEADER_SIZE,
-    AudioCapabilities,
-    AudioCodec,
-    CivFrame,
-    Mode,
-    PacketHeader,
-    PacketType,
-    ScopeCompletionPolicy,
-    ScopeFixedEdge,
-    bcd_decode,
-    bcd_encode,
-    get_audio_capabilities,
-)
 
-# Public API surface — trimmed to essential symbols only.
-# All other symbols remain importable by name (e.g. `from icom_lan import build_civ_frame`)
-# but are not part of the supported API and will not appear in `from icom_lan import *`.
+def __getattr__(name: str) -> object:
+    """:pep:`562` lazy attribute hook for tier-2 names.
+
+    Resolves tier-2 names on first access, caches them in ``globals()``
+    so subsequent lookups skip this hook entirely.
+    """
+    target = _LAZY_MAP.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = target
+    import importlib
+
+    module = importlib.import_module(module_name)
+    attr = getattr(module, attr_name)
+    globals()[name] = attr  # cache for subsequent access (skip __getattr__)
+    return attr
+
+
+def __dir__() -> list[str]:
+    """Include lazy tier-2 names in ``dir(icom_lan)`` for IDE/REPL discovery."""
+    return sorted({*globals().keys(), *_LAZY_MAP.keys()})
+
+
+# Public API surface — tier-1 (semver-stable) + tier-2 (best-effort lazy).
 __all__ = [
     "__version__",
-    # --- Factory ---
+    # --- Tier 1: Factory ---
     "create_radio",
-    # --- Backend configs ---
+    # --- Tier 1: Backend configs ---
     "BackendConfig",
     "LanBackendConfig",
     "SerialBackendConfig",
     "YaesuCatBackendConfig",
-    # --- Radio protocol + capability protocols ---
+    # --- Tier 1: Radio + capability protocols ---
     "Radio",
+    "AdvancedControlCapable",
+    "AntennaControlCapable",
     "AudioCapable",
-    "ScopeCapable",
+    "CivCommandCapable",
+    "CwControlCapable",
+    "DspControlCapable",
     "DualReceiverCapable",
     "LevelsCapable",
+    "MemoryCapable",
     "MetersCapable",
-    "PowerControlCapable",
-    "StateNotifyCapable",
-    "CivCommandCapable",
     "ModeInfoCapable",
+    "PowerControlCapable",
+    "ReceiverBankCapable",
     "RecoverableConnection",
-    "AdvancedControlCapable",
+    "RepeaterControlCapable",
+    "RitXitCapable",
+    "ScopeCapable",
+    "SplitCapable",
     "StateCacheCapable",
-    # --- Exceptions ---
+    "StateNotifyCapable",
+    "SystemControlCapable",
+    "TransceiverBankCapable",
+    "TransceiverStatusCapable",
+    "VfoSlotCapable",
+    "VoiceControlCapable",
+    # --- Tier 1: Exceptions ---
     "IcomLanError",
     "ConnectionError",
     "AuthenticationError",
@@ -193,11 +291,29 @@ __all__ = [
     "AudioCodecBackendError",
     "AudioFormatError",
     "AudioTranscodeError",
-    # --- Public types/enums ---
+    # --- Tier 1: Public types/enums ---
     "Mode",
     "AudioCodec",
+    "BreakInMode",
+    # --- Tier 1: Public state types ---
     "RadioState",
     "RadioProfile",
-    # --- Backward compat ---
+    "VfoSlotState",
+    "YaesuStateExtension",
+    # --- Tier 2 (lazy): backward-compat facade ---
     "IcomRadio",
+    # --- Tier 2 (lazy): commander internals ---
+    "IcomCommander",
+    "Priority",
+    # --- Tier 2 (lazy): audio primitives ---
+    "AudioStream",
+    "AudioBackend",
+    "PortAudioBackend",
+    "FakeAudioBackend",
+    "AudioConfig",
+    "NoiseGate",
+    "RmsNormalizer",
+    "Limiter",
+    "DspPipeline",
+    "UsbAudioDriver",
 ]

--- a/src/icom_lan/__init__.py
+++ b/src/icom_lan/__init__.py
@@ -14,6 +14,7 @@ may change without warning.
 """
 
 from importlib.metadata import version as _pkg_version
+from typing import Any
 
 __version__ = _pkg_version("icom-lan")
 
@@ -221,11 +222,13 @@ _LAZY_MAP: dict[str, tuple[str, str]] = {
 }
 
 
-def __getattr__(name: str) -> object:
+def __getattr__(name: str) -> Any:
     """:pep:`562` lazy attribute hook for tier-2 names.
 
     Resolves tier-2 names on first access, caches them in ``globals()``
-    so subsequent lookups skip this hook entirely.
+    so subsequent lookups skip this hook entirely. Returns :class:`~typing.Any`
+    so downstream typecheckers (mypy, pyright) keep the original symbol
+    types when a consumer does ``from icom_lan import IcomRadio``.
     """
     target = _LAZY_MAP.get(name)
     if target is None:

--- a/src/icom_lan/audio/__init__.py
+++ b/src/icom_lan/audio/__init__.py
@@ -3,68 +3,108 @@
 Provides:
 - LAN audio streaming (IC-7610 UDP) — from :mod:`.lan_stream`
 - USB audio device driver (all serial radios) — from :mod:`.usb_driver`
+
+Eager block is intentionally limited to :mod:`.lan_stream` symbols. Heavier
+abstractions (audio backends, DSP, USB driver, resampler) are loaded lazily
+via :pep:`562` ``__getattr__`` so consumers that only touch
+``AudioPacket``/``AudioStream`` (the wire-protocol types used by
+:mod:`icom_lan.radio` and :mod:`icom_lan.transport`) don't drag in
+PortAudio, ``numpy``-backed DSP, or platform USB plumbing.
+
+Direct submodule imports (``from icom_lan.audio.backend import ...``)
+remain the canonical path for callers that want the heavier abstractions.
 """
 
-# LAN audio (backward compat — was icom_lan.audio module)
+from typing import Any
+
+# LAN audio (eager — used by transport / radio / sync at import time)
 from .lan_stream import (  # noqa: F401
     AUDIO_HEADER_SIZE,
+    MAX_AUDIO_PAYLOAD,
+    RX_IDENT_0xA0,
+    TX_IDENT,
     AudioPacket,
     AudioState,
     AudioStats,
     AudioStream,
     JitterBuffer,
-    MAX_AUDIO_PAYLOAD,
-    RX_IDENT_0xA0,
-    TX_IDENT,
     build_audio_packet,
     parse_audio_packet,
 )
 
-# Audio backend abstraction (protocol + implementations)
-from .backend import (  # noqa: F401
-    AudioBackend,
-    AudioDeviceId,
-    AudioDeviceInfo,
-    FakeAudioBackend,
-    FakeRxStream,
-    FakeTxStream,
-    PortAudioBackend,
-    RxStream,
-    TxStream,
-)
+# Lazy submodule attribute map: name -> (module, attribute).
+# Resolved on first access via PEP 562 ``__getattr__`` and cached in
+# ``globals()`` so subsequent lookups skip this hook.
+_LAZY_MAP: dict[str, tuple[str, str]] = {
+    # Audio backend abstraction (protocol + implementations)
+    "AudioBackend": ("icom_lan.audio.backend", "AudioBackend"),
+    "AudioDeviceId": ("icom_lan.audio.backend", "AudioDeviceId"),
+    "AudioDeviceInfo": ("icom_lan.audio.backend", "AudioDeviceInfo"),
+    "FakeAudioBackend": ("icom_lan.audio.backend", "FakeAudioBackend"),
+    "FakeRxStream": ("icom_lan.audio.backend", "FakeRxStream"),
+    "FakeTxStream": ("icom_lan.audio.backend", "FakeTxStream"),
+    "PortAudioBackend": ("icom_lan.audio.backend", "PortAudioBackend"),
+    "RxStream": ("icom_lan.audio.backend", "RxStream"),
+    "TxStream": ("icom_lan.audio.backend", "TxStream"),
+    # Configuration
+    "AudioConfig": ("icom_lan.audio.config", "AudioConfig"),
+    "load_audio_config": ("icom_lan.audio.config", "load_audio_config"),
+    "save_audio_config": ("icom_lan.audio.config", "save_audio_config"),
+    # DSP pipeline
+    "DspPipeline": ("icom_lan.audio.dsp", "DspPipeline"),
+    "DspStage": ("icom_lan.audio.dsp", "DspStage"),
+    "Limiter": ("icom_lan.audio.dsp", "Limiter"),
+    "NoiseGate": ("icom_lan.audio.dsp", "NoiseGate"),
+    "RmsNormalizer": ("icom_lan.audio.dsp", "RmsNormalizer"),
+    # Resampling
+    "PcmResampler": ("icom_lan.audio.resample", "PcmResampler"),
+    "SampleRateNegotiation": (
+        "icom_lan.audio.resample",
+        "SampleRateNegotiation",
+    ),
+    "negotiate_sample_rate": (
+        "icom_lan.audio.resample",
+        "negotiate_sample_rate",
+    ),
+    # USB audio driver
+    "AudioDeviceSelectionError": (
+        "icom_lan.audio.usb_driver",
+        "AudioDeviceSelectionError",
+    ),
+    "AudioDriverLifecycleError": (
+        "icom_lan.audio.usb_driver",
+        "AudioDriverLifecycleError",
+    ),
+    "UsbAudioDevice": ("icom_lan.audio.usb_driver", "UsbAudioDevice"),
+    "UsbAudioDriver": ("icom_lan.audio.usb_driver", "UsbAudioDriver"),
+    "list_usb_audio_devices": (
+        "icom_lan.audio.usb_driver",
+        "list_usb_audio_devices",
+    ),
+    "select_usb_audio_devices": (
+        "icom_lan.audio.usb_driver",
+        "select_usb_audio_devices",
+    ),
+}
 
-# Configuration
-from .config import (  # noqa: F401
-    AudioConfig,
-    load_audio_config,
-    save_audio_config,
-)
 
-# DSP pipeline
-from .dsp import (  # noqa: F401
-    DspPipeline,
-    DspStage,
-    Limiter,
-    NoiseGate,
-    RmsNormalizer,
-)
+def __getattr__(name: str) -> Any:
+    """:pep:`562` lazy hook for heavier audio abstractions."""
+    target = _LAZY_MAP.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = target
+    import importlib
 
-# Resampling
-from .resample import (  # noqa: F401
-    PcmResampler,
-    SampleRateNegotiation,
-    negotiate_sample_rate,
-)
+    module = importlib.import_module(module_name)
+    attr = getattr(module, attr_name)
+    globals()[name] = attr  # cache for subsequent access
+    return attr
 
-# USB audio driver (moved from icom7610/drivers/)
-from .usb_driver import (  # noqa: F401
-    AudioDeviceSelectionError,
-    AudioDriverLifecycleError,
-    UsbAudioDevice,
-    UsbAudioDriver,
-    list_usb_audio_devices,
-    select_usb_audio_devices,
-)
+
+def __dir__() -> list[str]:
+    return sorted({*globals().keys(), *_LAZY_MAP.keys()})
+
 
 __all__ = [
     # Audio backend abstraction

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from ...audio import AudioPacket
-from ...audio.usb_driver import UsbAudioDriver
 from ...command_spec import CatCommandSpec
 from ...commands import hz_to_table_index, table_index_to_hz
 from ...types import AudioCodec, BreakInMode
@@ -23,6 +22,7 @@ from .parser import CatCommandParser, format_command
 from .transport import YaesuCatTransport
 
 if TYPE_CHECKING:
+    from ...audio.usb_driver import UsbAudioDriver
     from ...audio_bus import AudioBus
     from ...profiles import RadioProfile
     from ...types import BandStackRegister, MemoryChannel
@@ -101,14 +101,21 @@ class YaesuCatRadio:
         self._opus_rx_user_callback: Callable[[AudioPacket | None], None] | None = None
         self._pcm_rx_user_callback: Callable[[bytes | None], None] | None = None
         self._audio_sample_rate = audio_sample_rate
-        self._audio_driver: UsbAudioDriver = audio_driver or UsbAudioDriver(
-            serial_port=device,
-            rx_device=rx_device,
-            tx_device=tx_device,
-            sample_rate=audio_sample_rate,
-            channels=1,
-            backend=None,  # default PortAudioBackend
-        )
+        if audio_driver is None:
+            # Lazy import: avoids pulling icom_lan.audio.backend (PortAudio,
+            # numpy DSP) into top-level package import. PR #1200 / #1194.
+            from ...audio.usb_driver import UsbAudioDriver as _UsbAudioDriver
+
+            self._audio_driver: UsbAudioDriver = _UsbAudioDriver(
+                serial_port=device,
+                rx_device=rx_device,
+                tx_device=tx_device,
+                sample_rate=audio_sample_rate,
+                channels=1,
+                backend=None,  # default PortAudioBackend
+            )
+        else:
+            self._audio_driver = audio_driver
 
         # Build bidirectional mode code ↔ name maps.
         # FTX-1 CAT codes are 1-based: index 0 in modes list → code "1".

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -14,31 +14,47 @@ def test_audio_errors_exported() -> None:
 
 
 def test_public_api_surface() -> None:
-    """__all__ contains only the trimmed public API (~30 symbols)."""
+    """__all__ contains tier-1 (eager) + tier-2 (lazy) public surface.
+
+    See :pep:`562` and Form F sealing (epic #1193) for the tier policy.
+    """
     expected_public = {
         "__version__",
-        # Factory
+        # --- Tier 1: Factory ---
         "create_radio",
-        # Backend configs
+        # --- Tier 1: Backend configs ---
         "BackendConfig",
         "LanBackendConfig",
         "SerialBackendConfig",
         "YaesuCatBackendConfig",
-        # Radio protocol + capabilities
+        # --- Tier 1: Radio + capability protocols ---
         "Radio",
+        "AdvancedControlCapable",
+        "AntennaControlCapable",
         "AudioCapable",
-        "ScopeCapable",
+        "CivCommandCapable",
+        "CwControlCapable",
+        "DspControlCapable",
         "DualReceiverCapable",
         "LevelsCapable",
+        "MemoryCapable",
         "MetersCapable",
-        "PowerControlCapable",
-        "StateNotifyCapable",
-        "CivCommandCapable",
         "ModeInfoCapable",
+        "PowerControlCapable",
+        "ReceiverBankCapable",
         "RecoverableConnection",
-        "AdvancedControlCapable",
+        "RepeaterControlCapable",
+        "RitXitCapable",
+        "ScopeCapable",
+        "SplitCapable",
         "StateCacheCapable",
-        # Exceptions
+        "StateNotifyCapable",
+        "SystemControlCapable",
+        "TransceiverBankCapable",
+        "TransceiverStatusCapable",
+        "VfoSlotCapable",
+        "VoiceControlCapable",
+        # --- Tier 1: Exceptions ---
         "IcomLanError",
         "ConnectionError",
         "AuthenticationError",
@@ -48,19 +64,43 @@ def test_public_api_surface() -> None:
         "AudioCodecBackendError",
         "AudioFormatError",
         "AudioTranscodeError",
-        # Public types
+        # --- Tier 1: Public types/enums ---
         "Mode",
         "AudioCodec",
+        "BreakInMode",
+        # --- Tier 1: Public state types ---
         "RadioState",
         "RadioProfile",
-        # Backward compat
+        "VfoSlotState",
+        "YaesuStateExtension",
+        # --- Tier 2 (lazy): backward-compat facade ---
         "IcomRadio",
+        # --- Tier 2 (lazy): commander internals ---
+        "IcomCommander",
+        "Priority",
+        # --- Tier 2 (lazy): audio primitives ---
+        "AudioStream",
+        "AudioBackend",
+        "PortAudioBackend",
+        "FakeAudioBackend",
+        "AudioConfig",
+        "NoiseGate",
+        "RmsNormalizer",
+        "Limiter",
+        "DspPipeline",
+        "UsbAudioDriver",
     }
     assert set(icom_lan.__all__) == expected_public
 
 
 def test_internal_symbols_still_importable() -> None:
-    """Internal symbols removed from __all__ are still importable by name."""
+    """Internal symbols absent from __all__ are still importable by name.
+
+    These are tier-2 lazy targets (resolved via PEP 562 ``__getattr__``)
+    that we don't promote to the documented public surface. They remain
+    accessible for backward compatibility — ``hasattr`` triggers the
+    lazy hook and resolves the underlying symbol.
+    """
     internal_symbols = [
         "build_civ_frame",
         "parse_civ_frame",
@@ -71,7 +111,6 @@ def test_internal_symbols_still_importable() -> None:
         "RECEIVER_MAIN",
         "RECEIVER_SUB",
         "IcomTransport",
-        "IcomCommander",
         "ScopeAssembler",
         "ScopeFrame",
         "PacketHeader",

--- a/tests/test_ftx1_audio.py
+++ b/tests/test_ftx1_audio.py
@@ -55,10 +55,15 @@ def test_audio_seq_starts_at_zero(radio):
 
 
 def test_audio_driver_default_construction():
-    """UsbAudioDriver is created with correct args when not injected."""
+    """UsbAudioDriver is created with correct args when not injected.
+
+    The driver is imported lazily inside ``__init__`` (so the top-level
+    ``icom_lan`` import doesn't pull ``audio.backend``), so we patch the
+    canonical module path rather than a re-export.
+    """
     with (
         patch("icom_lan.backends.yaesu_cat.radio.YaesuCatTransport"),
-        patch("icom_lan.backends.yaesu_cat.radio.UsbAudioDriver") as MockDriver,
+        patch("icom_lan.audio.usb_driver.UsbAudioDriver") as MockDriver,
     ):
         MockDriver.return_value = MagicMock()
         YaesuCatRadio(


### PR DESCRIPTION
## Summary

Form F first PR core (refs #1194, parent epic #1193): trim
`src/icom_lan/__init__.py` to **tier-1 eager imports only** and move
backward-compat re-exports behind a [PEP 562](https://peps.python.org/pep-0562/)
`__getattr__` lazy hook. Names resolve on first access and are cached
in `globals()` so repeated lookups skip the hook.

The same lazy pattern is also applied one level deeper in
`icom_lan/audio/__init__.py` so that `from icom_lan import Radio` no
longer transitively imports `icom_lan.audio.backend` (PortAudio +
fakes), `audio.dsp`, `audio.config`, `audio.resample`, or
`audio.usb_driver`.

- **Tier 1 (eager, 71 lines):** factory + backend configs, all 25
  capability protocols, exceptions, public types/enums
  (`Mode`, `AudioCodec`, `BreakInMode`), state types (`RadioState`,
  `RadioProfile`, `VfoSlotState`, `YaesuStateExtension`).
- **Tier 2 (lazy):** `IcomRadio`, `IcomCommander`/`Priority`, audio
  primitives + DSP, `AudioConfig`/`UsbAudioDriver`, runtime profile
  presets, `RadioConnectionState`, `IcomTransport`, `ConnectionState`,
  CI-V command helpers, scope assembler/render, packet types, BCD codec.

`__all__` exposes both tiers so `from icom_lan import *` and IDE
auto-complete continue to work; `__dir__` is added so REPL discovery
sees the lazy names too. `__getattr__` returns `Any` (not `object`) so
downstream typecheckers preserve the original symbol type for
consumers of tier-2 names.

`backends/yaesu_cat/radio.py` defers its module-level `UsbAudioDriver`
import to runtime (matching the existing pattern in
`backends/_icom_serial_base.py`); this is the last module that forced
`audio.backend` into the top-level import graph.

## Import-time benchmark

```text
                            BEFORE      AFTER
from icom_lan import Radio  0.0664s     0.0697s     ~same
icom_lan submodule count    77          67          -13%
audio submodules pulled     6           2 (lan_stream + audio package)
```

(Wall-clock varies by ±5 ms run-to-run; module count is the stable
metric.)

Modules no longer pulled by `from icom_lan import Radio`:

- `icom_lan.web`, `icom_lan.cli`, `icom_lan.rigctld` — confirmed not
  pulled (acceptance criterion).
- `icom_lan.audio.backend`, `audio.dsp`, `audio.config`,
  `audio.resample`, `audio.usb_driver` — closed by the audio
  package's PEP 562 hook + deferring `UsbAudioDriver` in
  `yaesu_cat/radio.py`.
- `auth`, `_connection_state`, `protocol`, `commander`, `commands`
  package (16 leaf modules), `scope`, `radios`, `ic705`,
  `profiles_runtime` — closed by tier-2 lazy.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **5072 passed**
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — `Success: no issues found in 144 source files`
- [x] Sanity: `from icom_lan import Radio, IcomRadio, AudioStream, OperatingProfile, IC_7610_ADDR, bcd_encode, HEADER_SIZE` all resolve.
- [x] Wildcard: `from icom_lan import *` exposes tier-1 + tier-2.
- [x] Leakage: `web`/`cli`/`rigctld`/`audio.backend` not in `sys.modules` after `from icom_lan import Radio`.
- [x] `tests/test_exports.py` updated to match the new `__all__` (tier-1 + tier-2 lazy surface).
- [x] `tests/test_ftx1_audio.test_audio_driver_default_construction` repointed to canonical patch path (`icom_lan.audio.usb_driver.UsbAudioDriver`).

Reproduce the leak check:

```bash
uv run python -c "
import sys
from icom_lan import Radio
bad = sorted(m for m in sys.modules if any(x in m for x in (
    'icom_lan.web', 'icom_lan.cli', 'icom_lan.rigctld', 'icom_lan.audio.backend')))
print('LEAKED:', bad); assert not bad
"
# LEAKED: []
```

## Notes

- The epic's tier-1 list mentions `Meter`; no such symbol exists in
  `types.py` (closest is `MetersCapable` in `radio_protocol`, already
  tier-1). Dropped from the eager list.
- Sibling PRs in the Form F sealing: #1195 (docs) and #1196 (TID251
  bans) — disjoint files, no conflict expected.

Closes #1194

🤖 Generated with [Claude Code](https://claude.com/claude-code)