### PR TITLE
fix(build): TID251 narrow ignores — preserve IcomRadio ban in web/rigctld

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,6 @@ select = ["E4", "E7", "E9", "F", "TID251"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["TID251"]
-# Tier-3 subtrees use their own modules via relative imports; the cross-tier
-# ban is meant to police imports from outside the subtree, not internal cohesion.
-"src/icom_lan/web/*" = ["TID251"]
-"src/icom_lan/rigctld/*" = ["TID251"]
 # CLI is the orchestrator that composes tier-3 web and rigctld servers (issue-blessed).
 "src/icom_lan/cli.py" = ["TID251"]
 # Package entry point dispatches to cli.main.

--- a/src/icom_lan/rigctld/__init__.py
+++ b/src/icom_lan/rigctld/__init__.py
@@ -11,7 +11,7 @@ Usage::
 """
 
 try:
-    from .server import RigctldServer
+    from .server import RigctldServer  # noqa: TID251
 
     __all__ = ["RigctldServer"]
 except ImportError:

--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -23,7 +23,7 @@ from ..commands import build_civ_frame
 from ..exceptions import ConnectionError, TimeoutError
 from ..radio_state import RadioState, ReceiverState
 from ..types import Mode
-from .contract import (
+from .contract import (  # noqa: TID251
     CIV_TO_HAMLIB_MODE,
     HAMLIB_MODE_MAP,
     HamlibError,
@@ -31,13 +31,13 @@ from .contract import (
     RigctldConfig,
     RigctldResponse,
 )
-from .utils import get_mode_reader
+from .utils import get_mode_reader  # noqa: TID251
 
 if TYPE_CHECKING:
     from ..radio_protocol import Radio
 
 from ..capabilities import CAP_METERS
-from .routing import create_routing
+from .routing import create_routing  # noqa: TID251
 
 __all__ = ["RigctldHandler"]
 

--- a/src/icom_lan/rigctld/poller.py
+++ b/src/icom_lan/rigctld/poller.py
@@ -24,9 +24,9 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, cast
 from ..exceptions import ConnectionError as IcomConnectionError
 from ..exceptions import TimeoutError as IcomTimeoutError
 from ..radio_protocol import ModeInfoCapable
-from .circuit_breaker import CircuitBreaker, CircuitState
-from .contract import CIV_TO_HAMLIB_MODE, RigctldConfig
-from .state_cache import StateCache
+from .circuit_breaker import CircuitBreaker, CircuitState  # noqa: TID251
+from .contract import CIV_TO_HAMLIB_MODE, RigctldConfig  # noqa: TID251
+from .state_cache import StateCache  # noqa: TID251
 
 if TYPE_CHECKING:
     from ..radio_protocol import Radio

--- a/src/icom_lan/rigctld/protocol.py
+++ b/src/icom_lan/rigctld/protocol.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import logging
 
-from .contract import (
+from .contract import (  # noqa: TID251
     COMMAND_TABLE,
     ClientSession,
     RigctldCommand,

--- a/src/icom_lan/rigctld/routing.py
+++ b/src/icom_lan/rigctld/routing.py
@@ -23,9 +23,9 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from ..radio_protocol import Radio
-    from .handler import _FallbackRigState
+    from .handler import _FallbackRigState  # noqa: TID251
 
-from .contract import HamlibError, RigctldResponse
+from .contract import HamlibError, RigctldResponse  # noqa: TID251
 
 logger = logging.getLogger(__name__)
 

--- a/src/icom_lan/rigctld/server.py
+++ b/src/icom_lan/rigctld/server.py
@@ -22,10 +22,10 @@ from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any
 
 from ..startup_checks import assert_radio_startup_ready
-from . import audit as _audit
-from .circuit_breaker import CircuitBreaker, CircuitState
-from .contract import ClientSession, HamlibError, RigctldConfig
-from .utils import get_mode_reader
+from . import audit as _audit  # noqa: TID251
+from .circuit_breaker import CircuitBreaker, CircuitState  # noqa: TID251
+from .contract import ClientSession, HamlibError, RigctldConfig  # noqa: TID251
+from .utils import get_mode_reader  # noqa: TID251
 
 if TYPE_CHECKING:
     from ..radio_protocol import Radio
@@ -140,12 +140,12 @@ class RigctldServer:
         assert_radio_startup_ready(self._radio, component="rigctld startup")
 
         if self._protocol is None:
-            from . import protocol as _proto_mod  # noqa: PLC0415
+            from . import protocol as _proto_mod  # noqa: PLC0415, TID251
 
             self._protocol = _proto_mod
 
         if self._rig_handler is None:
-            from . import handler as _handler_mod  # noqa: PLC0415
+            from . import handler as _handler_mod  # noqa: PLC0415, TID251
 
             self._rig_handler = _handler_mod.RigctldHandler(self._radio, self._config)
 

--- a/src/icom_lan/web/__init__.py
+++ b/src/icom_lan/web/__init__.py
@@ -10,6 +10,6 @@ Entrypoint::
     await server.serve_forever()
 """
 
-from .server import WebConfig, WebServer, run_web_server
+from .server import WebConfig, WebServer, run_web_server  # noqa: TID251
 
 __all__ = ["WebConfig", "WebServer", "run_web_server"]

--- a/src/icom_lan/web/handlers/__init__.py
+++ b/src/icom_lan/web/handlers/__init__.py
@@ -6,9 +6,9 @@ Each handler manages the lifecycle of one client connection on one channel:
 - audio (/api/v1/audio): placeholder for future audio streaming
 """
 
-from .audio import AudioBroadcaster, AudioHandler
-from .control import ControlHandler
-from .scope import HIGH_WATERMARK, ScopeHandler
+from .audio import AudioBroadcaster, AudioHandler  # noqa: TID251
+from .control import ControlHandler  # noqa: TID251
+from .scope import HIGH_WATERMARK, ScopeHandler  # noqa: TID251
 
 __all__ = [
     "HIGH_WATERMARK",

--- a/src/icom_lan/web/handlers/audio.py
+++ b/src/icom_lan/web/handlers/audio.py
@@ -15,7 +15,7 @@ from ...env_config import (
     get_audio_client_high_watermark,
 )
 from ...types import AudioCodec
-from ..protocol import (
+from ..protocol import (  # noqa: TID251
     AUDIO_CODEC_OPUS,
     AUDIO_CODEC_PCM16,
     AUDIO_HEADER_SIZE,
@@ -24,7 +24,7 @@ from ..protocol import (
     encode_audio_frame,
     encode_json,
 )
-from ..websocket import WS_OP_BINARY, WS_OP_TEXT, WebSocketConnection
+from ..websocket import WS_OP_BINARY, WS_OP_TEXT, WebSocketConnection  # noqa: TID251
 
 if TYPE_CHECKING:
     from ...capabilities import CAP_AUDIO as _CAP_AUDIO_TYPE  # noqa: F401

--- a/src/icom_lan/web/handlers/control.py
+++ b/src/icom_lan/web/handlers/control.py
@@ -9,11 +9,11 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ...profiles import RadioProfile
 from ...radio_state import RadioState
-from ..protocol import (
+from ..protocol import (  # noqa: TID251
     decode_json,
     encode_json,
 )
-from ..radio_poller import (
+from ..radio_poller import (  # noqa: TID251
     PttOff,
     PttOn,
     ScanSetDfSpan,
@@ -132,12 +132,12 @@ from ..radio_poller import (
     QuickSplitTrigger,
     Speak,
 )
-from ..runtime_helpers import (
+from ..runtime_helpers import (  # noqa: TID251
     build_public_state_payload,
     radio_ready,
     runtime_capabilities,
 )
-from ..websocket import WS_OP_TEXT, WebSocketConnection
+from ..websocket import WS_OP_TEXT, WebSocketConnection  # noqa: TID251
 
 if TYPE_CHECKING:
     from ...radio_protocol import Radio
@@ -995,7 +995,7 @@ class ControlHandler:
                 await radio.set_tuner_status(value)
             else:
                 # Route through command queue
-                from ..radio_poller import SetTunerStatus
+                from ..radio_poller import SetTunerStatus  # noqa: TID251
 
                 q = self._server.command_queue if self._server is not None else None
                 if q is None:

--- a/src/icom_lan/web/handlers/scope.py
+++ b/src/icom_lan/web/handlers/scope.py
@@ -6,8 +6,8 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
-from ..protocol import decode_json, encode_scope_frame
-from ..websocket import WS_OP_TEXT, WebSocketConnection
+from ..protocol import decode_json, encode_scope_frame  # noqa: TID251
+from ..websocket import WS_OP_TEXT, WebSocketConnection  # noqa: TID251
 
 if TYPE_CHECKING:
     from ...scope import ScopeFrame

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -37,18 +37,18 @@ from ..capabilities import CAP_AUDIO, CAP_SCOPE
 from ..audio_analyzer import AudioAnalyzer
 from ..audio_fft_scope import AudioFftScope
 from ..startup_checks import assert_radio_startup_ready
-from ._delta_encoder import DeltaEncoder
-from .discovery import DiscoveryResponder, RadioInfo
-from .dx_cluster import DXClusterClient, SpotBuffer
-from .handlers import AudioBroadcaster, AudioHandler, ControlHandler, ScopeHandler
-from .rtc import handle_rtc_offer, rtc_capability_info, webrtc_available
-from .radio_poller import CommandQueue, DisableScope, EnableScope, RadioPoller
-from .runtime_helpers import (
+from ._delta_encoder import DeltaEncoder  # noqa: TID251
+from .discovery import DiscoveryResponder, RadioInfo  # noqa: TID251
+from .dx_cluster import DXClusterClient, SpotBuffer  # noqa: TID251
+from .handlers import AudioBroadcaster, AudioHandler, ControlHandler, ScopeHandler  # noqa: TID251
+from .rtc import handle_rtc_offer, rtc_capability_info, webrtc_available  # noqa: TID251
+from .radio_poller import CommandQueue, DisableScope, EnableScope, RadioPoller  # noqa: TID251
+from .runtime_helpers import (  # noqa: TID251
     build_public_state_payload,
     radio_ready,
     runtime_capabilities,
 )
-from .websocket import (
+from .websocket import (  # noqa: TID251
     WS_KEEPALIVE_INTERVAL,
     WebSocketConnection,
     make_accept_key,
@@ -345,11 +345,11 @@ class WebServer:
         self._bg_tasks: set[asyncio.Task[Any]] = set()
         self._scope_health_max_retries: int = 3  # give up after N failed re-enables
         # Band plan registry
-        from .band_plan import BandPlanRegistry
+        from .band_plan import BandPlanRegistry  # noqa: TID251
 
         self._band_plan = BandPlanRegistry()
         # EiBi broadcast database
-        from .eibi import EiBiProvider
+        from .eibi import EiBiProvider  # noqa: TID251
 
         self._eibi = EiBiProvider()
         # DX cluster
@@ -940,7 +940,7 @@ class WebServer:
 
         ssl_ctx = None
         if self._config.tls:
-            from .tls import build_ssl_context
+            from .tls import build_ssl_context  # noqa: TID251
 
             ssl_ctx = build_ssl_context(
                 cert_path=self._config.tls_cert or None,
@@ -1443,7 +1443,7 @@ class WebServer:
             # Fallback to FCC for US AM stations if no EiBi match
             if not matches and 530_000 <= freq <= 1_700_000:
                 try:
-                    from .eibi import fcc_identify
+                    from .eibi import fcc_identify  # noqa: TID251
 
                     matches = await fcc_identify(freq, tol)
                 except Exception:


### PR DESCRIPTION
Closes #1201

## Problem (Codex P1 on #1199)

`pyproject.toml` had broad `per-file-ignores = ["TID251"]` for
`src/icom_lan/web/*` and `src/icom_lan/rigctld/*` to silence
intra-tree relative-import violations from the new tier-3 bans
(`icom_lan.web`, `icom_lan.rigctld`).

Ruff per-file-ignores at the rule-code level disable **all** TID251
rules — so the pre-existing `icom_lan.radio.IcomRadio` ban (which
enforced "Use radio_protocol.Radio in web/ modules") was silently
disabled across both subtrees. A regression that no test would catch.

## Fix — option 2 (line-level noqa), not option 1 (relative imports)

The issue suggested option 1 (convert intra-tree absolute imports to
relative form). Empirically, that does not work: ruff TID251 resolves
relative imports against their absolute module path, so
`from .band_plan import X` inside `icom_lan/web/server.py` matches
the `icom_lan.web` ban exactly the same as the absolute form. After
removing the per-file-ignores, ruff reported **41 violations** all
on relative-form imports.

Pivoted to option 2 — append `# noqa: TID251` to each intra-tree
import. This narrows the suppression to known-good intra-tree imports
while leaving every other banned-api rule (the IcomRadio ban, plus
any future additions) fully enforceable.

`cli.py` and `__main__.py` keep their per-file-ignores — those
orchestrators legitimately compose tier-3 modules and were already
issue-blessed.

## Verification

Manual regression test (local, reverted before commit):

```python
# Append to src/icom_lan/web/server.py
from icom_lan.radio import IcomRadio
```

```
$ uv run ruff check src/icom_lan/web/server.py
TID251 `icom_lan.radio.IcomRadio` is banned: Use radio_protocol.Radio in
web/ modules (and capability protocols) instead of IcomRadio.
```

Same fires when added to `src/icom_lan/rigctld/server.py`. Ban active.

## Acceptance

- [x] `web/*` and `rigctld/*` per-file-ignores removed from `pyproject.toml`
- [x] Intra-web + intra-rigctld imports use line-level `# noqa: TID251`
- [x] `IcomRadio` ban triggers on hypothetical `from icom_lan.radio import IcomRadio` in web/ or rigctld/
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run mypy src/` clean (144 files)
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5072 passed

## Test plan

- [x] ruff clean
- [x] mypy clean
- [x] full pytest suite passes
- [x] manual injection test: IcomRadio import in web/server.py triggers TID251
- [x] manual injection test: IcomRadio import in rigctld/server.py triggers TID251

🤖 Generated with [Claude Code](https://claude.com/claude-code)