### PR TITLE
chore: remove deprecated IcomRadio.set_split_mode (v0.20 cleanup)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RadioProfile.meter_calibrations` (loaded from TOML
   `[[meters.<name>.calibration]]`). No public-API impact —
   `MeterType` and `interpolate_swr` remain exported.
+- **`IcomRadio.set_split_mode` deprecation alias (#1205).** The async method
+  on `icom_lan.radio.IcomRadio`, the sync wrapper on `icom_lan.sync.IcomRadio`,
+  and the `profiles_runtime.apply_profile` fallback branch are gone. Use
+  `set_split(...)` (`SplitCapable` protocol) — the canonical name introduced
+  in #1108. Deprecation was announced in v0.19; this is the scheduled v0.20
+  cleanup.
 
 ## [0.19.0] — 2026-04-29
 

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -360,10 +360,10 @@ async def vfo_exchange(self) -> None
 
 Swap VFO A and VFO B.
 
-### `set_split_mode()`
+### `set_split()`
 
 ```python
-async def set_split_mode(self, on: bool) -> None
+async def set_split(self, on: bool) -> None
 ```
 
 Enable or disable split mode (TX on VFO B, RX on VFO A).

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -136,8 +136,8 @@ await radio.vfo_equalize()
 await radio.vfo_exchange()
 
 # Split mode
-await radio.set_split_mode(True)   # TX on VFO B, RX on VFO A
-await radio.set_split_mode(False)
+await radio.set_split(True)   # TX on VFO B, RX on VFO A
+await radio.set_split(False)
 ```
 
 ## Attenuator & Preamp

--- a/docs/parity/ic7610_command_matrix.json
+++ b/docs/parity/ic7610_command_matrix.json
@@ -510,7 +510,7 @@
       "status": "implemented",
       "runtime_symbols": [
         "icom_lan.commands:set_split",
-        "icom_lan.radio:CoreRadio.set_split_mode",
+        "icom_lan.radio:CoreRadio.set_split",
         "icom_lan._civ_rx:_CivRxMixin._update_radio_state_from_frame"
       ],
       "test_patterns": [

--- a/src/icom_lan/profiles_runtime.py
+++ b/src/icom_lan/profiles_runtime.py
@@ -131,16 +131,6 @@ async def apply_profile(radio: Any, profile: OperatingProfile) -> dict[str, obje
     if profile.split is not None:
         if hasattr(radio, "set_split"):
             await radio.set_split(profile.split)
-        elif hasattr(radio, "set_split_mode"):
-            # TODO(post-v0.20): drop this fallback once ``set_split_mode`` is
-            # removed (see PR #1130 deprecation schedule). During the v0.19
-            # window legacy adapters may still expose only the deprecated
-            # alias — call it so profiles continue to apply fully.
-            logger.debug(
-                "apply_profile: radio has no set_split, "
-                "falling back to deprecated set_split_mode"
-            )
-            await radio.set_split_mode(profile.split)
         else:
             logger.debug("apply_profile: radio has no set_split, skipping")
 

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -2919,23 +2919,6 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             raise CommandError(f"Radio rejected split {'on' if on else 'off'}")
         self._last_split = on
 
-    async def set_split_mode(self, on: bool) -> None:
-        """Deprecated alias for :meth:`set_split`.
-
-        .. deprecated:: 0.19
-            Use :meth:`set_split` instead.  ``set_split_mode`` will be removed
-            in v0.20.
-        """
-        import warnings
-
-        warnings.warn(
-            "IcomRadio.set_split_mode() is deprecated; use set_split() "
-            "instead. Removal scheduled for v0.20.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        await self.set_split(on)
-
     async def get_split(self) -> bool:
         """Read split mode state (CI-V ``0x0F``).
 

--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -260,22 +260,6 @@ class IcomRadio:
         """Enable or disable split mode."""
         self._run(self._radio.set_split(on))
 
-    def set_split_mode(self, on: bool) -> None:
-        """Deprecated alias for :meth:`set_split`.
-
-        .. deprecated:: 0.19
-            Use :meth:`set_split` instead.  Removal scheduled for v0.20.
-        """
-        import warnings
-
-        warnings.warn(
-            "sync.IcomRadio.set_split_mode() is deprecated; use set_split() "
-            "instead. Removal scheduled for v0.20.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.set_split(on)
-
     def get_split(self) -> bool:
         """Read split mode state."""
         return self._run(self._radio.get_split())

--- a/tests/test_profiles_runtime.py
+++ b/tests/test_profiles_runtime.py
@@ -338,47 +338,30 @@ class TestEqualizeVfoDispatch:
 
 
 # ---------------------------------------------------------------------------
-# apply_profile — set_split / set_split_mode fallback (issue #1144)
+# apply_profile — set_split dispatch
 # ---------------------------------------------------------------------------
 
 
-class TestApplySplitFallback:
-    """Verify ``apply_profile`` handles the v0.19 deprecation window.
+class TestApplySplit:
+    """Verify ``apply_profile`` calls ``set_split`` when supported.
 
-    PR #1130 introduced ``set_split`` and deprecated ``set_split_mode``
-    (warned in v0.19, removed in v0.20). During the deprecation window
-    ``apply_profile`` must:
-
-    * call ``set_split`` on adapters that expose the canonical name; and
-    * fall back to ``set_split_mode`` on legacy adapters that still only
-      expose the deprecated alias — without raising or silently skipping
-      the split step.
+    The legacy ``set_split_mode`` deprecation alias was removed in v0.20
+    (issue #1205). ``apply_profile`` only dispatches to ``set_split``.
     """
 
     @pytest.mark.asyncio()
-    async def test_canonical_set_split_is_preferred(self) -> None:
-        radio = AsyncMock(spec=["snapshot_state", "set_split", "set_split_mode"])
+    async def test_set_split_is_called(self) -> None:
+        radio = AsyncMock(spec=["snapshot_state", "set_split"])
         radio.snapshot_state = AsyncMock(return_value={})
         radio.set_split = AsyncMock()
-        radio.set_split_mode = AsyncMock()
         await apply_profile(radio, OperatingProfile(split=True))
         radio.set_split.assert_awaited_once_with(True)
-        radio.set_split_mode.assert_not_awaited()
-
-    @pytest.mark.asyncio()
-    async def test_legacy_set_split_mode_fallback(self) -> None:
-        # Legacy adapter exposes only the deprecated alias.
-        radio = AsyncMock(spec=["snapshot_state", "set_split_mode"])
-        radio.snapshot_state = AsyncMock(return_value={})
-        radio.set_split_mode = AsyncMock()
-        await apply_profile(radio, OperatingProfile(split=True))
-        radio.set_split_mode.assert_awaited_once_with(True)
 
     @pytest.mark.asyncio()
     async def test_no_split_setter_is_skipped_silently(self) -> None:
         radio = AsyncMock(spec=["snapshot_state"])
         radio.snapshot_state = AsyncMock(return_value={})
-        # Should not raise even though radio has neither setter.
+        # Should not raise even though radio has no setter.
         snapshot = await apply_profile(radio, OperatingProfile(split=True))
         assert snapshot == {}
 

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -167,16 +167,6 @@ class TestSplitMode:
             await r.set_split(True)
 
     @pytest.mark.asyncio
-    async def test_set_split_mode_deprecation(
-        self, radio: IcomRadio, mock_transport: MockTransport
-    ) -> None:
-        """``set_split_mode`` still works but emits a DeprecationWarning."""
-        mock_transport.queue_response(_ack_response())
-        with pytest.warns(DeprecationWarning, match="set_split_mode"):
-            await radio.set_split_mode(True)
-        assert radio._last_split is True
-
-    @pytest.mark.asyncio
     async def test_get_split_round_trip(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -214,22 +214,6 @@ def test_audio_wrappers_canonical_only() -> None:
     r._loop.close()
 
 
-def test_sync_set_split_mode_emits_deprecation_warning() -> None:
-    """``sync.IcomRadio.set_split_mode`` is a deprecated alias for ``set_split``."""
-    r = _radio()
-    r._radio._ctrl_transport = MagicMock()
-    r._radio._ctrl_transport._udp_transport = MagicMock()
-    r._radio._civ_transport = MagicMock()
-    r._radio._conn_state = RadioConnectionState.CONNECTED
-    r._radio.set_split = AsyncMock()
-
-    with pytest.warns(DeprecationWarning, match="set_split_mode"):
-        r.set_split_mode(True)
-
-    r._radio.set_split.assert_awaited_once_with(True)
-    r._loop.close()
-
-
 @pytest.mark.parametrize(
     "name",
     [


### PR DESCRIPTION
## Summary

- Removes the `set_split_mode` deprecation alias on async `IcomRadio` (`radio.py`), sync `IcomRadio` (`sync.py`), and the legacy fallback branch in `profiles_runtime.apply_profile`. Use `set_split(...)` (`SplitCapable` protocol) — the canonical name introduced in #1108.
- Drops the deprecation-warning tests (the symbol no longer exists) and rewrites the `TestApplySplitFallback` block as `TestApplySplit`, asserting the single canonical dispatch path.
- Doc cleanup: `docs/guide/commands.md`, `docs/api/radio.md`, IC-7610 parity matrix runtime symbol; `### Removed` entry under `[Unreleased]` in `docs/CHANGELOG.md`.
- Part of the v0.20 deprecation-cleanup batch (parent epic #1204). Deprecated since v0.19.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5069 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (144 files)
- [x] `grep -rn "set_split_mode" src/ tests/` — only docstring/changelog historical references remain (no callers, no defs)

Closes #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)