### PR TITLE
chore: remove deprecated IcomRadio.get_alc (#1207)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `set_split(...)` (`SplitCapable` protocol) — the canonical name introduced
   in #1108. Deprecation was announced in v0.19; this is the scheduled v0.20
   cleanup.
+- **`IcomRadio.get_alc` / `sync.IcomRadio.get_alc` (#1207)** — deprecated in
+  v0.19 (#1129), removed per schedule. Use `get_alc_meter`
+  (`MetersCapable`).
 
 ## [0.19.0] — 2026-04-29
 

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -299,10 +299,10 @@ Read the SWR meter value (TX only). **Returns:** `int` (0–255)
 
 **Raises:** `TimeoutError` if not transmitting.
 
-### `get_alc()`
+### `get_alc_meter()`
 
 ```python
-async def get_alc(self) -> int
+async def get_alc_meter(self) -> int
 ```
 
 Read the ALC meter value (TX only). **Returns:** `int` (0–255)

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -80,11 +80,11 @@ s = await radio.get_s_meter()
 swr = await radio.get_swr()
 
 # ALC meter (0–255, during TX only)
-alc = await radio.get_alc()
+alc = await radio.get_alc_meter()
 ```
 
 !!! warning "TX-Only Meters"
-    `get_swr()` and `get_alc()` will timeout if the radio is not transmitting. Wrap them in try/except:
+    `get_swr()` and `get_alc_meter()` will timeout if the radio is not transmitting. Wrap them in try/except:
 
     ```python
     from icom_lan.exceptions import TimeoutError

--- a/docs/parity/ic7610_command_matrix.json
+++ b/docs/parity/ic7610_command_matrix.json
@@ -1224,7 +1224,7 @@
       "status": "implemented",
       "runtime_symbols": [
         "icom_lan.commands:get_alc",
-        "icom_lan.radio:CoreRadio.get_alc"
+        "icom_lan.radio:CoreRadio.get_alc_meter"
       ],
       "test_patterns": [
         "tests/test_commands.py::test_get_alc"

--- a/src/icom_lan/backends/icom7610/drivers/serial_stub.py
+++ b/src/icom_lan/backends/icom7610/drivers/serial_stub.py
@@ -329,9 +329,6 @@ class SerialMockRadio:
     async def get_swr_meter(self) -> int:
         return 25
 
-    async def get_alc(self) -> int:
-        return 80
-
     async def get_alc_meter(self) -> int:
         return 80
 

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -17,7 +17,6 @@ import logging
 import os
 import socket as _socket
 import time
-import warnings
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -457,7 +456,6 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             "get_s_meter",
             "get_swr",
             "get_swr_meter",
-            "get_alc",
             "get_alc_meter",
             "get_rf_power",
             "set_rf_power",
@@ -2666,21 +2664,6 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         civ = get_alc(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_alc_meter")
         return parse_meter_response(resp)
-
-    async def get_alc(self) -> int:
-        """Read the ALC meter value (0-255).
-
-        .. deprecated::
-            Use :meth:`get_alc_meter` instead. This alias is kept for
-            backward compatibility and will be removed in a future
-            release.
-        """
-        warnings.warn(
-            "IcomRadio.get_alc is deprecated; use get_alc_meter instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return await self.get_alc_meter()
 
     async def set_ptt(self, on: bool) -> None:
         """Toggle PTT (Push-To-Talk).

--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -210,12 +210,6 @@ class IcomRadio:
             )
         return self._run(self._radio.get_swr_meter())
 
-    def get_alc(self) -> int:
-        """Read the ALC meter (0-255)."""
-        if CAP_METERS not in self._radio.capabilities:
-            raise AttributeError("get_alc is not supported by this radio")
-        return self._run(self._radio.get_alc_meter())
-
     # ------------------------------------------------------------------
     # PTT
     # ------------------------------------------------------------------

--- a/tests/integration/test_radio_integration.py
+++ b/tests/integration/test_radio_integration.py
@@ -186,7 +186,7 @@ class TestMeters:
         assert 0 <= swr <= 255
         print(f"SWR meter: {swr} ✓")
 
-    async def test_get_alc(self, radio: IcomRadio) -> None:
+    async def test_get_alc_meter(self, radio: IcomRadio) -> None:
         """Read ALC value.
 
         On some radios/firmware, ALC may not respond reliably in pure RX state.
@@ -194,7 +194,7 @@ class TestMeters:
         (guarded by ICOM_ALLOW_PTT=1).
         """
         try:
-            alc = await self._read_with_retry(radio, "ALC", radio.get_alc)
+            alc = await self._read_with_retry(radio, "ALC", radio.get_alc_meter)
         except IcomTimeoutError:
             if not _flag_enabled("ICOM_ALLOW_PTT"):
                 pytest.skip(
@@ -204,7 +204,7 @@ class TestMeters:
             await radio.set_ptt(True)
             try:
                 await asyncio.sleep(0.05)
-                alc = await self._read_with_retry(radio, "ALC/PTT", radio.get_alc)
+                alc = await self._read_with_retry(radio, "ALC/PTT", radio.get_alc_meter)
             finally:
                 await radio.set_ptt(False)
 
@@ -799,7 +799,7 @@ class TestSoak:
                 await op("get_power", r.get_power)
                 await op("get_s_meter", r.get_s_meter)
                 await op("get_swr", r.get_swr)
-                await op("get_alc", r.get_alc)
+                await op("get_alc_meter", r.get_alc_meter)
 
                 if cycle % 5 == 0:
                     await op(

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -111,7 +111,6 @@ def mock_radio():
     radio.get_powerstat = AsyncMock(return_value=True)
     radio.get_s_meter = AsyncMock(return_value=120)
     radio.get_swr = AsyncMock(return_value=50)
-    radio.get_alc = AsyncMock(return_value=30)
     radio.get_alc_meter = AsyncMock(return_value=30)
     radio.get_comp_meter = AsyncMock(return_value=0)
     radio.get_id_meter = AsyncMock(return_value=0)

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -434,23 +434,6 @@ class TestMeters:
         assert val == 80
 
     @pytest.mark.asyncio
-    async def test_get_alc_deprecated_round_trip(
-        self, radio: IcomRadio, mock_transport: MockTransport
-    ) -> None:
-        """Legacy get_alc still works but emits DeprecationWarning and
-        returns the same value as get_alc_meter (issue #1104)."""
-        import warnings as _warnings
-
-        mock_transport.queue_response(_meter_response(_SUB_ALC_METER, 80))
-        with _warnings.catch_warnings(record=True) as caught:
-            _warnings.simplefilter("always")
-            val = await radio.get_alc()
-        assert val == 80
-        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert deprecations, "expected DeprecationWarning from get_alc"
-        assert "get_alc_meter" in str(deprecations[0].message)
-
-    @pytest.mark.asyncio
     async def test_get_swr_meter(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -48,7 +48,6 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
     r._radio.get_rf_power = AsyncMock(return_value=200)
     r._radio.get_s_meter = AsyncMock(return_value=99)
     r._radio.get_swr = AsyncMock(return_value=10)
-    r._radio.get_alc_meter = AsyncMock(return_value=5)
     r._radio.get_attenuator_level = AsyncMock(return_value=18)
     r._radio.get_attenuator = AsyncMock(return_value=True)
     r._radio.get_preamp = AsyncMock(return_value=1)
@@ -92,7 +91,6 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
     assert r.get_rf_power() == 200
     assert r.get_s_meter() == 99
     assert r.get_swr() == 10
-    assert r.get_alc() == 5
     assert r.get_attenuator_level() == 18
     assert r.get_attenuator() is True
     assert r.get_preamp() == 1

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -341,7 +341,6 @@ def mock_radio() -> MagicMock:
     radio.get_filter = AsyncMock(return_value=1)
     radio.get_s_meter = AsyncMock(return_value=42)
     radio.get_swr = AsyncMock(return_value=10)
-    radio.get_alc = AsyncMock(return_value=5)
     radio.get_rf_gain = AsyncMock(return_value=200)
     radio.get_af_level = AsyncMock(return_value=180)
     radio.get_attenuator_level = AsyncMock(return_value=0)
@@ -2454,7 +2453,6 @@ class TestRadioPoller:
         radio.get_s_meter = AsyncMock(return_value=42)
         radio.get_rf_power = AsyncMock(return_value=100)
         radio.get_swr = AsyncMock(return_value=10)
-        radio.get_alc = AsyncMock(return_value=5)
         radio.get_rf_gain = AsyncMock(return_value=128)
         radio.get_af_level = AsyncMock(return_value=64)
         radio.get_attenuator_level = AsyncMock(return_value=0)
@@ -2659,6 +2657,7 @@ class TestSwitchScopeReceiver:
         # Canonical dual-RX VFO methods on ``DualReceiverCapable`` (post-#1114).
         radio.swap_main_sub = AsyncMock()
         radio.equalize_main_sub = AsyncMock()
+
         # Receiver-tier methods (issue #1170 / #1172).  Make
         # ``select_receiver`` mirror the wire-level CI-V the runtime would
         # emit so existing assertions on ``send_civ(0x07, …)`` still apply.


### PR DESCRIPTION
## Summary

- Drops the v0.19 deprecation shim `IcomRadio.get_alc` (async + sync) per the v0.20 removal schedule. The CI-V frame builder `commands.get_alc` is preserved and remains the underlying request used by `get_alc_meter` (`MetersCapable`).
- Removes the corresponding `serial_stub.get_alc` alias, the `test_get_alc_deprecated_round_trip` deprecation assertion, and dead `get_alc` AsyncMocks across the web/cli/sync coverage suites.
- Migrates the integration suite (`test_radio_integration.py`) to `get_alc_meter`; updates parity matrix runtime symbol, API/guide docs, and adds a `### Removed` entry under `[Unreleased]` in `docs/CHANGELOG.md`.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5071 passed, 0 failed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — no issues found in 144 source files
- [x] `grep -rn "get_alc[^_]" src/ tests/` — only CI-V builder references remain (preserved)

Closes #1207

Generated with [Claude Code](https://claude.com/claude-code)