### PR TITLE
refactor(frontend): remove v1 branches from KeyboardHandler + dual-path components

### DIFF
--- a/frontend/src/components-v2/layout/KeyboardHandler.svelte
+++ b/frontend/src/components-v2/layout/KeyboardHandler.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
-  import { getUiVersion } from '$lib/stores/ui-version.svelte';
   import {
     normalizeKeyboardConfig,
     resolveAction,
@@ -62,7 +61,7 @@
   }
 
   function handleKeydown(event: KeyboardEvent): void {
-    if (!enabled || getUiVersion() !== 'v2') return;
+    if (!enabled) return;
     if (shouldIgnoreEvent(document.activeElement)) return;
 
     if (event.key === 'Alt' && keyboardConfig.altHints) {

--- a/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
@@ -4,10 +4,6 @@ import { flushSync, mount, unmount } from 'svelte';
 import KeyboardHandler from '../KeyboardHandler.svelte';
 import type { KeyboardConfig, KeyboardActionConfig } from '../keyboard-map';
 
-vi.mock('$lib/stores/ui-version.svelte', () => ({
-  getUiVersion: vi.fn(() => 'v2'),
-}));
-
 describe('KeyboardHandler', () => {
   let components: ReturnType<typeof mount>[] = [];
 


### PR DESCRIPTION
Closes #1218.

## Summary
- Removed the `getUiVersion() !== 'v2'` short-circuit and the matching `getUiVersion` import from `frontend/src/components-v2/layout/KeyboardHandler.svelte`. The handler now only checks the `enabled` prop before processing keyboard events; v2 is the only supported path.
- Dropped the now-unused `vi.mock('$lib/stores/ui-version.svelte', ...)` from `frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts`. Tests already exercised v2 behaviour exclusively, so no behavioural assertions changed.

## Components touched
- `frontend/src/components-v2/layout/KeyboardHandler.svelte` (the only component-layer consumer of `getUiVersion()` — App.svelte left for #1217).
- `frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts`.

A repo-wide grep confirms no other `getUiVersion` / `uiVersion !== 'v2'` / `=== 'v1'` callsites remain in components. Remaining references are inside `App.svelte` (#1217) and the `ui-version` store/test pair (out of scope here).

## Test plan
- [x] `cd frontend && npx vitest run` — 1704 tests passed across 93 files.
- [x] `cd frontend && npm run build` — built `dist/` successfully (pre-existing CSS unused-selector warnings only).
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5065 passed, 2 skipped, 2 deselected, 9 xfailed, 1 xpassed.
- [x] `uv run ruff check src/ tests/` — All checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)