### PR TITLE
docs(frontend): remove v1 references — CLAUDE.md + migration notes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **Web UI v1 layout shell (#874, #1220).** The legacy `AppShell` /
+  `DesktopLayout` / `MobileLayout` tree under `frontend/src/components/layout/`
+  is deprecated; v2 (`RadioLayoutV2` + `frontend/src/components-v2/`) is the
+  only supported path going forward. v2 has been the default since v0.15.1.
+  The `?ui=v1` URL fallback is on track for removal alongside the v1 code
+  drop (tracked under epic #874 / sub-issues #1216, #1217). Documentation
+  has been updated to v2-only language in this release; user-facing docs no
+  longer describe the v1 shell.
+
 ### Removed
 
 - **`meter_cal._TABLES` and `meter_cal.calibrate()` (#1209).** The hardcoded

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -203,16 +203,16 @@ The browser app startup path is implemented in `frontend/src/App.svelte` and
 
 ### Boot sequence
 
-1. Initialize UI version selector (`?ui=v1|v2` takes priority over localStorage).
+1. Initialize the skin selector from URL/localStorage (see "Layout and skin resolution" below).
 2. Register MediaSession handlers (when API is available).
 3. Start HTTP polling loop for `/api/v1/state` (interval set to `1000ms` in app bootstrap).
 4. Start battery monitor (progressive enhancement) and adjust polling multiplier.
 5. Fetch capabilities once from `/api/v1/capabilities`.
 6. Connect control WebSocket (`/api/v1/ws`) and subscribe to events.
 
-### v2 runtime ownership (actual code paths)
+### Runtime ownership (actual code paths)
 
-v2 keeps one behavior path and splits responsibilities by module:
+The frontend keeps one behavior path and splits responsibilities by module:
 
 | Responsibility | Current implementation path | Notes |
 |---|---|---|
@@ -221,9 +221,8 @@ v2 keeps one behavior path and splits responsibilities by module:
 | WS command dispatch | `frontend/src/components-v2/wiring/command-bus.ts` | Maps UI callbacks to `sendCommand(...)` calls and optimistic state patches. |
 | HTTP system actions | `frontend/src/lib/runtime/system-controller.ts` via `runtime.system.*` | Owns radio connect/disconnect, power on/off, and EiBi identify calls. |
 
-Current skin files in `frontend/src/skins/*` are migration wrappers that delegate
-to `components-v2/layout/*`; behavior is still implemented in the v2 layout and
-wiring modules listed above.
+Current skin files in `frontend/src/skins/*` delegate to `components-v2/layout/*`;
+behavior is implemented in the layout and wiring modules listed above.
 
 ### Backend CI-V poll cadence (state freshness)
 
@@ -295,7 +294,7 @@ Implementation path: `frontend/src/lib/media/media-session.ts`.
 | `Space` | Toggle PTT |
 | `Escape` | Close frequency-entry modal |
 
-## Mobile v2 Interaction Model
+## Mobile Interaction Model
 
 Mobile-first interaction logic is implemented in:
 
@@ -304,12 +303,7 @@ Mobile-first interaction logic is implemented in:
 - `frontend/src/components-v2/controls/BottomSheet.svelte`
 - `frontend/src/components-v2/controls/CollapsiblePanel.svelte`
 
-### Enabling v2 UI
-
-`v2` can be selected with `?ui=v2` (or stored in localStorage by the app).
-Without selection, UI version defaults to `v1`.
-
-### Layout and skin resolution in v2
+### Layout and skin resolution
 
 Skin/layout is resolved in `frontend/src/components-v2/layout/RadioLayout.svelte`
 using `resolveSkinId(...)` and `getLayoutMode()`:


### PR DESCRIPTION
Closes #1220.

## Summary

Docs-only scrub of v1 UI references in user-facing surfaces, plus a
deprecation note in the [Unreleased] CHANGELOG. v1 code is **not** touched
here — that lives in sibling sub-issues #1216 and #1217 of epic #874.

## Files updated

- `docs/guide/web-ui.md` — drop "?ui=v1|v2" from the boot sequence,
  rename "v2 runtime ownership" / "Mobile v2 Interaction Model" /
  "Layout and skin resolution in v2" to neutral v2-only wording, and
  remove the stale "Enabling v2 UI" subsection (its claim that the
  default is v1 has been incorrect since v0.15.1).
- `docs/CHANGELOG.md` — add an `### Deprecated` entry under [Unreleased]
  covering the v1 layout shell + `?ui=v1` URL fallback, scoped to epic
  #874. Wording is intentionally conservative (Deprecated, not Removed)
  because the code drop has not landed yet.

## Notes

- `CLAUDE.md` "Frontend layering" already describes v2 only (`lib/runtime/`,
  `components-v2/`, `skins/desktop-v2|amber-lcd|mobile`). The issue body
  predates that cleanup; no edits were needed there.
- Historical ADRs under `docs/plans/` (`2026-03-07-ui-architecture.md`,
  `2026-04-11-v2-lcd-runtime-audit.md`) are left intact per the issue's
  acceptance criterion ("unless historical context in ADRs").
- `/api/v1/...` REST API paths are unrelated to UI version and untouched.

## Test plan

- [x] `uv run mkdocs build --strict` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5065 passed, 2 skipped, 9 xfailed
- [x] `grep -rn 'AppShell\|MobileLayout\|DesktopLayout\|uiVersion\|ui=v1' docs/guide/ docs/internals/ CLAUDE.md` — only the new CHANGELOG deprecation entry hits

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>