### PR TITLE
chore(frontend): tighten ESLint no-restricted-imports — v2 layering only

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,10 +1,11 @@
 /**
- * ESLint flat config — frontend architecture guardrails.
+ * ESLint flat config — frontend architecture guardrails (v2 layering only).
  *
  * Enforces import boundaries defined in ADR 2026-04-12:
  *   - Presentational components (panels, layout, skins, semantic, primitives)
- *     must NOT import runtime/transport modules directly.
+ *     must NOT import runtime/transport modules directly (alias or relative).
  *   - Only wiring/ (adapter layer) and lib/ internals may import these.
+ *   - lib/runtime/** must NOT import from components-v2/ (no circular deps).
  *
  * @see docs/plans/2026-04-12-target-frontend-architecture.md
  */
@@ -27,9 +28,16 @@ const FORBIDDEN_RUNTIME_IMPORTS = {
   ],
   patterns: [
     {
-      group: ['$lib/transport/*'],
+      group: ['$lib/transport/*', '**/lib/transport/*'],
       message:
         'Presentation components must not import transport modules (sendCommand, getChannel). ' +
+        'Use callback props from the adapter/wiring layer instead. ' +
+        'See ADR 2026-04-12.',
+    },
+    {
+      group: ['**/lib/audio/audio-manager'],
+      message:
+        'Presentation components must not import audioManager directly (relative paths included). ' +
         'Use callback props from the adapter/wiring layer instead. ' +
         'See ADR 2026-04-12.',
     },
@@ -134,17 +142,6 @@ export default [
           ],
         },
       ],
-    },
-  },
-
-  // ── Legacy V1 components — same restrictions ──
-  {
-    files: [
-      'src/components/**/*.svelte',
-      'src/components/**/*.ts',
-    ],
-    rules: {
-      'no-restricted-imports': ['warn', FORBIDDEN_RUNTIME_IMPORTS],
     },
   },
 


### PR DESCRIPTION
Closes #1219

## Summary

Removes the v1-specific `components/` rule block and tightens the v2 presentation boundary patterns so they also catch relative-path imports. The config now assumes v2-only layering (parent epic #874).

## Rules added / modified

- **Removed:** soft (`warn`) rule block targeting `src/components/**` (v1 tree). v1 is being deleted in #1216; until then v1 files have no rule, which matches the issue's "no exemption" acceptance criterion.
- **Tightened panel/layout `FORBIDDEN_RUNTIME_IMPORTS`:**
  - `transport` group now matches `$lib/transport/*` AND `**/lib/transport/*` (catches relative paths like `../../lib/transport/ws-client`).
  - New pattern `**/lib/audio/audio-manager` mirrors the existing `$lib/audio/audio-manager` named-path rule for relative imports.
- **Unchanged:** `lib/runtime/**` cannot import from `components-v2/**` (issue #1005 / ADR 2026-04-12).
- Header comment updated to reflect v2-only scope.

## Out of scope (per issue)

- Banning `**/components/**` outright was optional; deferred because real shared imports remain (`components/spectrum/*` consumed by v2 layouts and wiring) and fixing those is #1216's scope.
- File deletions (#1216), App.svelte mount switch (#1217), KeyboardHandler dual-path removal (#1218), CLAUDE.md doc updates (#1220).

## Test plan

- [x] `npm --prefix frontend run lint` — zero violations
- [x] `npm --prefix frontend run build` — succeeds
- [x] `npx --prefix frontend vitest run` — 1704 / 1704 passing
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5065 passed
- [x] `uv run ruff check src/ tests/` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)