### PR TITLE
fix(sync): expose get_alc_meter on sync.IcomRadio

### DIFF
--- a/src/icom_lan/sync.py
+++ b/src/icom_lan/sync.py
@@ -197,6 +197,18 @@ class IcomRadio:
             )
         return float(self._run(self._radio.get_swr()))
 
+    def get_alc_meter(self) -> int:
+        """Read the ALC meter (raw 0-255).
+
+        Returns the unscaled meter value mirroring
+        :meth:`MetersCapable.get_alc_meter`.
+        """
+        if CAP_METERS not in self._radio.capabilities:
+            raise AttributeError(
+                "get_alc_meter requires a radio that implements MetersCapable"
+            )
+        return self._run(self._radio.get_alc_meter())
+
     def get_swr_meter(self) -> int:
         """Read the SWR meter (raw 0-255).
 

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -228,6 +228,25 @@ def test_removed_audio_aliases_raise_attribute_error(name: str) -> None:
         r._loop.close()
 
 
+def test_sync_get_alc_meter_returns_int() -> None:
+    """``sync.IcomRadio.get_alc_meter`` returns the raw 0-255 BCD value
+    from the async ``MetersCapable.get_alc_meter`` (refs #1226)."""
+    r = _radio()
+    r._radio._ctrl_transport = MagicMock()
+    r._radio._ctrl_transport._udp_transport = MagicMock()
+    r._radio._civ_transport = MagicMock()
+    r._radio._conn_state = RadioConnectionState.CONNECTED
+    r._radio.get_alc_meter = AsyncMock(return_value=128)
+
+    try:
+        result = r.get_alc_meter()
+        assert result == 128
+        assert isinstance(result, int)
+        r._radio.get_alc_meter.assert_awaited_once()
+    finally:
+        r._loop.close()
+
+
 def test_sync_get_swr_meter_returns_int() -> None:
     """``sync.IcomRadio.get_swr_meter`` returns the raw 0-255 BCD value
     from the async ``MetersCapable.get_swr_meter`` (refs #1183)."""


### PR DESCRIPTION
Closes #1226

## Summary

- Adds `sync.IcomRadio.get_alc_meter() -> int` wrapper around the async `MetersCapable.get_alc_meter`.
- Mirrors the pattern PR #1184 used for `get_swr_meter` — guards on `CAP_METERS`, delegates via `self._run(...)`.
- Restores ALC meter access for sync users that PR #1213 removed when it dropped the deprecated `get_alc` alias.

## Why

PR #1213 (Codex P1 follow-up) removed `sync.IcomRadio.get_alc` but did not add the documented replacement `get_alc_meter`. Sync users migrating per the docs hit `AttributeError`. Symmetric to the gap PR #1184 fixed for SWR.

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5066 passed, 0 failed.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run mypy src/` — clean.
- [x] New test `test_sync_get_alc_meter_returns_int` mocks the async side and asserts the wrapper returns an `int` and awaits the underlying coroutine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)