### PR TITLE
refactor(#1232,frontend): lazy-load ControlButtonDemo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`ControlButtonDemo` is now lazy-loaded (#1232).** Moved out of the main
+  bundle into a code-split chunk; the demo component loads on demand when the
+  debug route is mounted.
+
 ### Deprecated
 
 - **Web UI v1 layout shell (#874, #1220).** The legacy `AppShell` /

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,7 +2,6 @@
   import { onMount } from 'svelte';
   import { initBatteryMonitor } from './lib/utils/battery';
   import RadioLayoutV2 from './components-v2/layout/RadioLayout.svelte';
-  import ControlButtonDemo from './components-v2/controls/ControlButtonDemo.svelte';
   import LocalExtensionsHost from './lib/local-extensions/LocalExtensionsHost.svelte';
   import { initMediaSession, destroyMediaSession } from './lib/media/media-session';
   import { runtime } from './lib/runtime/frontend-runtime';
@@ -73,7 +72,9 @@
 </script>
 
 {#if demoMode === 'control-buttons'}
-  <ControlButtonDemo />
+  {#await import('./components-v2/controls/ControlButtonDemo.svelte') then mod}
+    <mod.default />
+  {/await}
 {:else if backendError}
   <div class="error-overlay" role="alert" aria-live="assertive">
     <div class="error-box">


### PR DESCRIPTION
## Summary
- `ControlButtonDemo` converted from static to dynamic import inside the existing `?demo=control-buttons` route guard (uses Svelte's `{#await import(...)}` pattern).
- Demo route guard logic unchanged — still mounted when `demoMode === 'control-buttons'`.
- Bundle splits cleanly: `ControlButtonDemo` is now its own chunk (58.78 kB JS + 3.88 kB CSS), trimmed from the main bundle.

## Bundle deltas (Vite production build)
| Asset | Before | After |
|---|---|---|
| main JS (`index-*.js`) | 541.80 kB (gzip 161.17 kB) | 483.68 kB (gzip 149.90 kB) |
| main CSS (`index-*.css`) | 333.73 kB (gzip 49.79 kB) | 329.85 kB (gzip 49.10 kB) |
| `ControlButtonDemo-*.js` | — | 58.78 kB (gzip 11.94 kB) |
| `ControlButtonDemo-*.css` | — | 3.88 kB (gzip 1.11 kB) |

Net: -58.12 kB raw / -11.27 kB gzip off the main JS bundle for normal users; the demo only loads when `?demo=control-buttons` is mounted.

## Test plan
- [x] `npm run build` succeeds; `ControlButtonDemo-*.js` and `ControlButtonDemo-*.css` emitted as separate chunks
- [x] `npx vitest run` — 1687 tests pass, zero failures
- [x] `npx eslint src/` — clean
- [x] `npx tsc --noEmit` — clean

Closes #1232
Refs #1063 (Tier 1)