### PR TITLE
refactor(#1230): extract BoundedQueue helper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`AudioStats.jitter_ms` renamed to `reorder_depth_ema_ms` (#1231).** The
   field measures reorder-depth EMA, not RFC 3550 jitter. Internal field; no
   back-compat alias.
+- **`BoundedQueue` helper extracted to `_bounded_queue.py` (#1230).** Four
+  asyncio call sites (transport RX, radio scope/civ event queues, web fanout)
+  now share a single bounded-queue implementation. No behavior change; drop
+  policies preserved per callsite.
 
 ### Deprecated
 

--- a/src/icom_lan/_bounded_queue.py
+++ b/src/icom_lan/_bounded_queue.py
@@ -1,0 +1,87 @@
+"""Minimal bounded async queue helper used by inter-task buffers.
+
+Asyncio-only. Single-event-loop semantics; no threading, no thread-safety
+locks — relies on the GIL for ordering of single-step operations the way
+``asyncio.Queue`` does. The wrapper is a thin facade over ``asyncio.Queue``
+with one shared idiom extracted: :meth:`put_drop_oldest`, which sites 2 & 3
+in radio.py used as a 5-line ``if full: get_nowait(); put_nowait(item)``.
+
+Drop policy is *caller-managed*: ``put_nowait`` raises ``asyncio.QueueFull``
+on overflow exactly like the underlying queue, so each callsite keeps its
+own logging / metrics / fast-path branching. This module deliberately does
+not introduce a ``drop_policy`` parameter — log messages and severities
+differ across callsites and forcing a single policy would erase that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class BoundedQueue(Generic[T]):
+    """Thin asyncio bounded queue with a drop-oldest helper.
+
+    Exposes the subset of ``asyncio.Queue`` operations actually used by the
+    four migrated callsites (transport RX, radio scope/civ-event, web
+    fanout). All operations are single-event-loop only.
+    """
+
+    __slots__ = ("_queue",)
+
+    def __init__(self, maxsize: int) -> None:
+        self._queue: asyncio.Queue[T] = asyncio.Queue(maxsize=maxsize)
+
+    async def get(self) -> T:
+        """Await and return the next item."""
+        return await self._queue.get()
+
+    def get_nowait(self) -> T:
+        """Return next item or raise :class:`asyncio.QueueEmpty`."""
+        return self._queue.get_nowait()
+
+    async def put(self, item: T) -> None:
+        """Await space and put ``item``."""
+        await self._queue.put(item)
+
+    def put_nowait(self, item: T) -> None:
+        """Put ``item`` or raise :class:`asyncio.QueueFull` when full."""
+        self._queue.put_nowait(item)
+
+    def put_drop_oldest(self, item: T) -> None:
+        """Put ``item``, evicting the oldest entry if the queue is full.
+
+        Encapsulates the ``if full: get_nowait(); put_nowait(item)`` recipe
+        used by the radio scope-frame and CI-V event publishers. Eviction
+        is silent — callers that need to log/count drops should check
+        :meth:`full` themselves before calling this.
+        """
+        if self._queue.full():
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+        self._queue.put_nowait(item)
+
+    def full(self) -> bool:
+        """Return ``True`` if the queue has reached ``maxsize``."""
+        return self._queue.full()
+
+    def empty(self) -> bool:
+        """Return ``True`` if the queue currently holds no items."""
+        return self._queue.empty()
+
+    def qsize(self) -> int:
+        """Return the current number of queued items."""
+        return self._queue.qsize()
+
+    def task_done(self) -> None:
+        """Mark a previously-fetched task as done (mirrors ``asyncio.Queue``)."""
+        self._queue.task_done()
+
+    @property
+    def maxsize(self) -> int:
+        """Return the configured maximum size."""
+        return self._queue.maxsize

--- a/src/icom_lan/_civ_rx.py
+++ b/src/icom_lan/_civ_rx.py
@@ -1164,12 +1164,7 @@ class CivRuntime:
     def _publish_scope_frame(self, frame: ScopeFrame) -> None:
         """Publish a complete scope frame to callback and bounded queue."""
         self._publish_civ_event(CivEvent(type=CivEventType.SCOPE_FRAME))
-        if self._host._scope_frame_queue.full():
-            try:
-                self._host._scope_frame_queue.get_nowait()
-            except asyncio.QueueEmpty:
-                pass
-        self._host._scope_frame_queue.put_nowait(frame)
+        self._host._scope_frame_queue.put_drop_oldest(frame)
         callback = self._host._scope_callback
         if callback is not None:
             try:
@@ -1179,12 +1174,7 @@ class CivRuntime:
 
     def _publish_civ_event(self, event: CivEvent) -> None:
         """Publish CI-V event to internal event queue (best effort)."""
-        if self._host._civ_event_queue.full():
-            try:
-                self._host._civ_event_queue.get_nowait()
-            except asyncio.QueueEmpty:
-                pass
-        self._host._civ_event_queue.put_nowait(event)
+        self._host._civ_event_queue.put_drop_oldest(event)
 
     def _check_connected(self) -> None:
         """Raise ConnectionError if not connected."""

--- a/src/icom_lan/_runtime_protocols.py
+++ b/src/icom_lan/_runtime_protocols.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from .audio import AudioPacket, AudioStream
     from .civ import CivEvent, CivRequestTracker
     from .commander import IcomCommander
+    from ._bounded_queue import BoundedQueue
     from ._civ_rx import CivRuntime
     from ._state_cache import StateCache
     from .radio_state import RadioState
@@ -67,11 +68,11 @@ class CivRuntimeHost(Protocol):
 
     # Scope and CI-V event queues
     _scope_assembler: "ScopeAssembler"
-    _scope_frame_queue: "asyncio.Queue[ScopeFrame]"
+    _scope_frame_queue: "BoundedQueue[ScopeFrame]"
     _scope_callback: "Callable[[ScopeFrame], Any] | None"
     _scope_activity_counter: int
     _scope_activity_event: asyncio.Event
-    _civ_event_queue: "asyncio.Queue[CivEvent]"
+    _civ_event_queue: "BoundedQueue[CivEvent]"
 
     # State cache / last-known values
     _state_cache: "StateCache"

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 from ._audio_recovery import AudioRecoveryRuntime, AudioRecoveryState
 from ._audio_runtime_mixin import AudioRuntimeMixin
 from ._audio_transcoder import PcmOpusTranscoder
+from ._bounded_queue import BoundedQueue
 from ._civ_rx import CivRuntime
 from ._dual_rx_runtime import DualRxRuntimeMixin
 from ._scope_runtime import ScopeRuntimeMixin
@@ -725,10 +726,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._civ_data_watchdog_task: asyncio.Task[None] | None = None
         self._civ_request_tracker = CivRequestTracker()
         self._civ_epoch = self._civ_request_tracker.generation
-        self._scope_frame_queue: asyncio.Queue[ScopeFrame] = asyncio.Queue(maxsize=64)
+        self._scope_frame_queue: BoundedQueue[ScopeFrame] = BoundedQueue(maxsize=64)
         self._scope_activity_counter: int = 0
         self._scope_activity_event = asyncio.Event()
-        self._civ_event_queue: asyncio.Queue[CivEvent] = asyncio.Queue(maxsize=256)
+        self._civ_event_queue: BoundedQueue[CivEvent] = BoundedQueue(maxsize=256)
         self._civ_ack_sink_grace: float = (
             float(os.environ.get("ICOM_CIV_ACK_SINK_GRACE_MS", "120")) / 1000.0
         )

--- a/src/icom_lan/transport.py
+++ b/src/icom_lan/transport.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 from enum import StrEnum
 
+from ._bounded_queue import BoundedQueue
 from ._queue_pressure import PRESSURE_THRESHOLD
 from .exceptions import TimeoutError as _TimeoutError
 from .types import HEADER_SIZE, PacketType
@@ -109,7 +110,7 @@ class IcomTransport:
         self._ping_task: asyncio.Task[None] | None = None
         self._idle_task: asyncio.Task[None] | None = None
         self._retransmit_task: asyncio.Task[None] | None = None
-        self._packet_queue: asyncio.Queue[bytes] = asyncio.Queue(
+        self._packet_queue: BoundedQueue[bytes] = BoundedQueue(
             maxsize=PACKET_QUEUE_MAXSIZE
         )
         # Optional callback invoked when queue pressure exceeds 75%.

--- a/src/icom_lan/web/handlers/control.py
+++ b/src/icom_lan/web/handlers/control.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from ..._bounded_queue import BoundedQueue
 from ...profiles import RadioProfile
 from ...radio_state import RadioState
 from ..protocol import (  # noqa: TID251
@@ -374,7 +375,7 @@ class ControlHandler:
         self._server = server
         self._read_only = read_only
         self._subscribed_streams: set[str] = set()
-        self._event_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
+        self._event_queue: BoundedQueue[dict[str, Any]] = BoundedQueue(
             maxsize=100,
         )
         # Per-command rate limiting: command_name -> (last_time, drop_count)

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -32,6 +32,7 @@ from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any, cast
 
 from .. import __version__
+from .._bounded_queue import BoundedQueue
 from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO, CAP_SCOPE
 from ..audio_analyzer import AudioAnalyzer
@@ -325,7 +326,7 @@ class WebServer:
         self._radio_poller: RadioPoller | None = None
         self._yaesu_poller: Any | None = None  # YaesuCatPoller (lazy)
         # Control handler event queues
-        self._control_event_queues: set[asyncio.Queue[dict[str, Any]]] = set()
+        self._control_event_queues: set[BoundedQueue[dict[str, Any]]] = set()
         # State broadcast throttle
         self._last_state_broadcast: float = 0.0
         # Delta encoder for efficient state broadcasting
@@ -579,11 +580,11 @@ class WebServer:
         """Command queue consumed by RadioPoller."""
         return self._command_queue
 
-    def register_control_event_queue(self, q: asyncio.Queue[dict[str, Any]]) -> None:
+    def register_control_event_queue(self, q: BoundedQueue[dict[str, Any]]) -> None:
         """Register a ControlHandler event queue for broadcast."""
         self._control_event_queues.add(q)
 
-    def unregister_control_event_queue(self, q: asyncio.Queue[dict[str, Any]]) -> None:
+    def unregister_control_event_queue(self, q: BoundedQueue[dict[str, Any]]) -> None:
         """Unregister a ControlHandler event queue."""
         self._control_event_queues.discard(q)
 

--- a/tests/test_bounded_queue.py
+++ b/tests/test_bounded_queue.py
@@ -1,0 +1,103 @@
+"""Unit tests for ``icom_lan._bounded_queue.BoundedQueue``."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from icom_lan._bounded_queue import BoundedQueue
+
+
+def test_put_get_preserves_fifo_order() -> None:
+    q: BoundedQueue[int] = BoundedQueue(maxsize=4)
+    for i in range(4):
+        q.put_nowait(i)
+    out = [q.get_nowait() for _ in range(4)]
+    assert out == [0, 1, 2, 3]
+
+
+def test_qsize_full_empty_maxsize() -> None:
+    q: BoundedQueue[str] = BoundedQueue(maxsize=2)
+    assert q.empty() is True
+    assert q.full() is False
+    assert q.qsize() == 0
+    assert q.maxsize == 2
+
+    q.put_nowait("a")
+    assert q.empty() is False
+    assert q.full() is False
+    assert q.qsize() == 1
+
+    q.put_nowait("b")
+    assert q.full() is True
+    assert q.qsize() == 2
+
+
+def test_put_nowait_raises_when_full() -> None:
+    q: BoundedQueue[int] = BoundedQueue(maxsize=1)
+    q.put_nowait(1)
+    with pytest.raises(asyncio.QueueFull):
+        q.put_nowait(2)
+
+
+def test_get_nowait_raises_when_empty() -> None:
+    q: BoundedQueue[int] = BoundedQueue(maxsize=1)
+    with pytest.raises(asyncio.QueueEmpty):
+        q.get_nowait()
+
+
+def test_put_drop_oldest_evicts_when_full() -> None:
+    q: BoundedQueue[int] = BoundedQueue(maxsize=3)
+    for i in range(3):
+        q.put_nowait(i)
+    assert q.full()
+
+    q.put_drop_oldest(99)
+    assert q.full()
+    assert q.qsize() == 3
+    out = [q.get_nowait() for _ in range(3)]
+    assert out == [1, 2, 99]
+
+
+def test_put_drop_oldest_does_not_evict_when_not_full() -> None:
+    q: BoundedQueue[int] = BoundedQueue(maxsize=3)
+    q.put_nowait(1)
+    q.put_drop_oldest(2)
+    assert q.qsize() == 2
+    assert q.get_nowait() == 1
+    assert q.get_nowait() == 2
+
+
+@pytest.mark.asyncio
+async def test_async_get_returns_item() -> None:
+    q: BoundedQueue[str] = BoundedQueue(maxsize=2)
+    q.put_nowait("hello")
+    assert await q.get() == "hello"
+
+
+@pytest.mark.asyncio
+async def test_async_put_blocks_until_space() -> None:
+    q: BoundedQueue[int] = BoundedQueue(maxsize=1)
+    q.put_nowait(1)
+
+    async def consume_after_delay() -> None:
+        await asyncio.sleep(0.01)
+        assert q.get_nowait() == 1
+
+    consumer = asyncio.create_task(consume_after_delay())
+    await q.put(2)
+    await consumer
+    assert q.get_nowait() == 2
+
+
+@pytest.mark.asyncio
+async def test_task_done_allows_join() -> None:
+    q: BoundedQueue[int] = BoundedQueue(maxsize=2)
+    q.put_nowait(1)
+    q.put_nowait(2)
+    assert q.get_nowait() == 1
+    q.task_done()
+    assert q.get_nowait() == 2
+    q.task_done()
+    await asyncio.wait_for(q._queue.join(), timeout=0.1)


### PR DESCRIPTION
## Summary
- New `_bounded_queue.py` module with a minimal asyncio `BoundedQueue[T]` wrapper.
- Migrated 4 asyncio callsites: transport RX, radio scope queue, radio civ-event queue, web fanout queues.
- The genuine DRY win is `put_drop_oldest()` — encapsulates the `if full: get_nowait(); put_nowait()` recipe used by the radio scope-frame and CI-V event publishers (sites 2 & 3).
- Sites 1 (transport) and 4 (web fanout) keep their custom drop logic inline (different log messages / fast-path branching / pressure callback) — only the type annotation changes.
- No behavior change; drop policies preserved per callsite. No policy knob introduced.

## Per-callsite summary
| Site | File | Drop policy | Change |
|------|------|-------------|--------|
| 1 | `transport.py` (RX, maxsize=4096) | drop scope newest / evict control oldest, with logging + pressure callback | type only: `asyncio.Queue[bytes]` -> `BoundedQueue[bytes]` |
| 2 | `radio.py` scope queue (maxsize=64) | drop oldest, silent | `put_drop_oldest()` (5 lines -> 1) |
| 3 | `radio.py` civ-event queue (maxsize=256) | drop oldest, silent | `put_drop_oldest()` (5 lines -> 1) |
| 4 | `web/server.py` fanout (maxsize=100/client) | drop newest with per-broadcast logging | type only: `asyncio.Queue[dict]` -> `BoundedQueue[dict]` |

## Test plan
- [x] `uv run pytest tests/ -q --tb=short` — 5075 passed, 0 failed
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] New `tests/test_bounded_queue.py` — 9 tests cover put/get/qsize/full/empty/maxsize/drop-oldest/async-put/task-done

Closes #1230
Refs #1063 (Tier 1)
Refs #1229 (Tier 1 mini-epic)