### PR TITLE
refactor(#1244,frontend): migrate Cw/Dsp/Meter/Tx capability flags (batch 1/5)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`transport._handle_packet` decomposed into dispatch table (#1239).**
   Six packet types (single/multi retransmit, ping req/reply, scope fast-path,
   generic data) now dispatch via a dict; behavior preserved.
+- **Batch 1 of panel→adapter migration (#1244).** `CwPanel`, `DspPanel`,
+  `MeterPanel`, `TxPanel` no longer import from `$lib/stores/capabilities`
+  directly; capability flags now flow via panel-props from the wiring layer.
+  Tier 2 batch 1 of #1063.
 
 ### Docs
 

--- a/frontend/src/components-v2/panels/CwPanel.svelte
+++ b/frontend/src/components-v2/panels/CwPanel.svelte
@@ -2,7 +2,6 @@
   import '../controls/control-button.css';
   import { HardwareButton } from '$lib/Button';
   import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
-  import { hasCapability } from '$lib/stores/capabilities.svelte';
 
   import { formatBreakIn, isBreakInActive, isApfActive } from './cw-panel-logic';
   import { deriveCwProps, getCwHandlers } from '$lib/runtime/adapters/panel-adapters';
@@ -25,15 +24,16 @@
   const onApfChange = handlers.onApfChange;
   const onTwinPeakToggle = handlers.onTwinPeakToggle;
   const onAutoTune = handlers.onAutoTune;
-  let showBreakIn = $derived(hasCapability('break_in'));
-  let showApf = $derived(hasCapability('apf'));
-  let showTwinPeak = $derived(hasCapability('twin_peak'));
+  let showCw = $derived(p.hasCw);
+  let showBreakIn = $derived(p.hasBreakIn);
+  let showApf = $derived(p.hasApf);
+  let showTwinPeak = $derived(p.hasTwinPeak);
   let breakInActive = $derived(isBreakInActive(breakIn));
   let apfActive = $derived(isApfActive(apfMode));
   let breakInLabel = $derived(formatBreakIn(breakIn));
 </script>
 
-{#if hasCapability('cw')}
+{#if showCw}
   <div class="panel-body">
     <div class="cw-mode-line">
       <span class="cw-mode-label">RX mode</span>

--- a/frontend/src/components-v2/panels/DspPanel.svelte
+++ b/frontend/src/components-v2/panels/DspPanel.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
   import { HardwareButton } from '$lib/Button';
-  import { hasCapability } from '$lib/stores/capabilities.svelte';
   import { buildNrOptions, buildNotchOptions } from './dsp-utils';
   import {
     AGC_TIME_LABELS,
@@ -41,8 +40,8 @@
 
   /* NOTCH_WIDTH_LABELS, AGC_TIME_LABELS imported from dsp-panel-logic */
 
-  let showNr = $derived(hasCapability('nr'));
-  let showNb = $derived(hasCapability('nb'));
+  let showNr = $derived(p.hasNr);
+  let showNb = $derived(p.hasNb);
 
   let nrOptions = $derived(buildNrOptions());
   let notchOptions = $derived(buildNotchOptions());

--- a/frontend/src/components-v2/panels/MeterPanel.svelte
+++ b/frontend/src/components-v2/panels/MeterPanel.svelte
@@ -2,7 +2,6 @@
   import '../controls/control-button.css';
   import BarGauge from '../meters/BarGauge.svelte';
   import NeedleGauge from '../meters/NeedleGauge.svelte';
-  import { hasTx } from '$lib/stores/capabilities.svelte';
   import {
     normalize,
     formatPowerWatts,
@@ -20,6 +19,7 @@
     alc: number;
     txActive: boolean;
     meterSource: MeterSource;
+    hasTx: boolean;
     onMeterSourceChange: (v: string) => void;
   }
 
@@ -30,6 +30,7 @@
     alc,
     txActive,
     meterSource,
+    hasTx,
     onMeterSourceChange,
   }: Props = $props();
 
@@ -80,7 +81,7 @@
         style="--control-accent:var(--v2-accent-cyan); --control-active-text:var(--v2-text-bright)"
         onclick={() => onMeterSourceChange('S')}
       >S</button>
-      {#if hasTx()}
+      {#if hasTx}
         <button
           type="button"
           class="source-btn v2-control-button"

--- a/frontend/src/components-v2/panels/TxPanel.svelte
+++ b/frontend/src/components-v2/panels/TxPanel.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { HardwareButton } from '$lib/Button';
   import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
-  import { hasTx, hasCapability } from '$lib/stores/capabilities.svelte';
   import { txStatusColor } from './tx-utils';
   import { getTxAudioControl } from '$lib/runtime/adapters/tx-adapter';
   import { deriveTxProps, getTxHandlers } from '$lib/runtime/adapters/panel-adapters';
@@ -35,7 +34,9 @@
   const onPttOff = handlers.onPttOff;
 
   let tuneButtonColor = $derived(txStatusColor(atuActive, atuTuning));
-  let showMon = $derived(hasCapability('monitor'));
+  let showTx = $derived(p.hasTx);
+  let showTuner = $derived(p.hasTuner);
+  let showMon = $derived(p.hasMonitor);
 
   // ── PTT (hold-to-talk + double-tap latch) ──
   const PTT_DOUBLE_TAP_MS = 300;
@@ -108,7 +109,7 @@
   }
 </script>
 
-{#if hasTx()}
+{#if showTx}
   <div class="tx-panel" bind:this={modalAnchor}>
     <!-- TX indicator strip -->
     <div class="tx-strip" class:tx-active={txActive}>
@@ -129,7 +130,7 @@
     {/if}
 
     <div class="tx-button-grid">
-      {#if hasCapability('tuner')}
+      {#if showTuner}
         <HardwareButton
           active={atuActive}
           indicator="edge-left"

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
@@ -10,6 +10,9 @@ const mockProps = {
   twinPeak: false,
   currentMode: 'CW',
   hasCw: true,
+  hasBreakIn: true,
+  hasApf: true,
+  hasTwinPeak: true,
 };
 
 const mockHandlers = {
@@ -26,10 +29,6 @@ const mockHandlers = {
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveCwProps: () => mockProps,
   getCwHandlers: () => mockHandlers,
-}));
-
-vi.mock('$lib/stores/capabilities.svelte', () => ({
-  hasCapability: vi.fn(() => true),
 }));
 
 import CwPanel from '../CwPanel.svelte';
@@ -50,7 +49,8 @@ beforeEach(() => {
   components = [];
   Object.assign(mockProps, {
     cwPitch: 600, keySpeed: 12, breakIn: 0, breakInDelay: 0,
-    apfMode: 0, twinPeak: false, currentMode: 'CW', hasCw: true,
+    apfMode: 0, twinPeak: false, currentMode: 'CW',
+    hasCw: true, hasBreakIn: true, hasApf: true, hasTwinPeak: true,
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -12,6 +12,8 @@ const mockProps = {
   nbWidth: 0,
   manualNotchWidth: 0,
   agcTimeConstant: 0,
+  hasNr: true,
+  hasNb: true,
 };
 
 const mockHandlers = {
@@ -26,10 +28,6 @@ const mockHandlers = {
   onManualNotchWidthChange: vi.fn(),
   onAgcTimeChange: vi.fn(),
 };
-
-vi.mock('$lib/stores/capabilities.svelte', () => ({
-  hasCapability: vi.fn(() => true),
-}));
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveDspProps: () => mockProps,
@@ -56,6 +54,7 @@ beforeEach(() => {
     nrMode: 0, nrLevel: 5, nbActive: false, nbLevel: 128,
     notchMode: 'off', notchFreq: 1000, nbDepth: 0, nbWidth: 0,
     manualNotchWidth: 0, agcTimeConstant: 0,
+    hasNr: true, hasNb: true,
   });
   mockHandlers.onNrModeChange = vi.fn();
   mockHandlers.onNrLevelChange = vi.fn();

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.test.ts
@@ -13,6 +13,8 @@ const mockProps = {
   nbWidth: 0,
   manualNotchWidth: 0,
   agcTimeConstant: 0,
+  hasNr: true,
+  hasNb: true,
 };
 
 const mockHandlers = {
@@ -27,10 +29,6 @@ const mockHandlers = {
   onManualNotchWidthChange: vi.fn(),
   onAgcTimeChange: vi.fn(),
 };
-
-vi.mock('$lib/stores/capabilities.svelte', () => ({
-  hasCapability: vi.fn(() => true),
-}));
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveDspProps: () => mockProps,
@@ -105,6 +103,7 @@ beforeEach(() => {
     nrMode: 0, nrLevel: 128, nbActive: false, nbLevel: 128,
     notchMode: 'off', notchFreq: 1000, nbDepth: 0, nbWidth: 0,
     manualNotchWidth: 0, agcTimeConstant: 0,
+    hasNr: true, hasNb: true,
   });
   mockHandlers.onNrModeChange = vi.fn();
   mockHandlers.onNrLevelChange = vi.fn();

--- a/frontend/src/components-v2/panels/__tests__/MeterPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MeterPanel.test.ts
@@ -157,12 +157,9 @@ describe('getNeedleMarks POWER', () => {
 // ---------------------------------------------------------------------------
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
-  hasTx: vi.fn(() => true),
   getMeterCalibration: vi.fn(() => null),
   getMeterRedline: vi.fn(() => null),
 }));
-
-import { hasTx } from '$lib/stores/capabilities.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
@@ -177,7 +174,6 @@ function mountPanel(props: ComponentProps<typeof MeterPanel>) {
 
 beforeEach(() => {
   components = [];
-  vi.mocked(hasTx).mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -192,6 +188,7 @@ const baseProps: ComponentProps<typeof MeterPanel> = {
   alc: 64,
   txActive: false,
   meterSource: 'S',
+  hasTx: true,
   onMeterSourceChange: vi.fn(),
 };
 
@@ -259,9 +256,8 @@ describe('TX meters visibility', () => {
 });
 
 describe('TX source buttons visibility', () => {
-  it('hides SWR and Po buttons when hasTx returns false', () => {
-    vi.mocked(hasTx).mockReturnValue(false);
-    const t = mountPanel(baseProps);
+  it('hides SWR and Po buttons when hasTx prop is false', () => {
+    const t = mountPanel({ ...baseProps, hasTx: false });
     const btns = Array.from(t.querySelectorAll('.source-btn'));
     expect(btns.every((b) => b.textContent?.trim() === 'S')).toBe(true);
     expect(btns).toHaveLength(1);

--- a/frontend/src/components-v2/panels/__tests__/TxPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/TxPanel.test.ts
@@ -55,6 +55,9 @@ const mockProps = {
   monActive: false,
   monLevel: 64,
   driveGain: 128,
+  hasTx: true,
+  hasTuner: true,
+  hasMonitor: true,
 };
 
 const mockHandlers = {
@@ -72,12 +75,6 @@ const mockHandlers = {
   onPttOff: vi.fn(),
 };
 
-// Mock hasTx so we can control its return value
-vi.mock('$lib/stores/capabilities.svelte', () => ({
-  hasTx: vi.fn(() => true),
-  hasCapability: vi.fn(() => true),
-}));
-
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveTxProps: () => mockProps,
   getTxHandlers: () => mockHandlers,
@@ -90,7 +87,6 @@ vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
   }),
 }));
 
-import { hasTx } from '$lib/stores/capabilities.svelte';
 import TxPanel from '../TxPanel.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
@@ -114,11 +110,11 @@ function openTxSettings(container: HTMLElement) {
 
 beforeEach(() => {
   components = [];
-  vi.mocked(hasTx).mockReturnValue(true);
   Object.assign(mockProps, {
     txActive: false, rfPower: 128, micGain: 128, atuActive: false,
     atuTuning: false, voxActive: false, compActive: false, compLevel: 64,
     monActive: false, monLevel: 64, driveGain: 128,
+    hasTx: true, hasTuner: true, hasMonitor: true,
   });
   mockHandlers.onRfPowerChange = vi.fn();
   mockHandlers.onMicGainChange = vi.fn();
@@ -191,15 +187,13 @@ describe('panel structure', () => {
 });
 
 describe('hasTx gating', () => {
-  it('renders panel content when hasTx returns true', () => {
-    vi.mocked(hasTx).mockReturnValue(true);
-    const t = mountPanel();
+  it('renders panel content when hasTx prop is true', () => {
+    const t = mountPanel({ hasTx: true });
     expect(t.querySelector('.tx-panel')).not.toBeNull();
   });
 
-  it('hides panel content when hasTx returns false', () => {
-    vi.mocked(hasTx).mockReturnValue(false);
-    const t = mountPanel();
+  it('hides panel content when hasTx prop is false', () => {
+    const t = mountPanel({ hasTx: false });
     expect(t.querySelector('.tx-panel')).toBeNull();
   });
 });

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -74,7 +74,7 @@ export function getScanHandlers() { return _scanHandlers; }
 
 // ── Meter ──
 export function deriveMeterProps() {
-  return toMeterProps(runtime.state);
+  return toMeterProps(runtime.state, runtime.caps);
 }
 const _meterHandlers = makeMeterHandlers();
 export function getMeterHandlers() { return _meterHandlers; }

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -336,11 +336,13 @@ export interface DspProps {
   notchFreq: number;
   manualNotchWidth: number;
   agcTimeConstant: number;
+  hasNr: boolean;
+  hasNb: boolean;
 }
 
 export function toDspProps(
   state: ServerState | null,
-  _caps: Capabilities | null,
+  caps: Capabilities | null,
 ): DspProps {
   const rx = state ? activeRx(state) : null;
 
@@ -359,6 +361,8 @@ export function toDspProps(
     notchFreq: state?.notchFilter ?? 0,
     manualNotchWidth: rx?.manualNotchWidth ?? 0,
     agcTimeConstant: rx?.agcTimeConstant ?? 0,
+    hasNr: hasCap(caps, 'nr'),
+    hasNb: hasCap(caps, 'nb'),
   };
 }
 
@@ -376,11 +380,14 @@ export interface TxProps {
   monActive: boolean;
   monLevel: number;
   driveGain: number;
+  hasTx: boolean;
+  hasTuner: boolean;
+  hasMonitor: boolean;
 }
 
 export function toTxProps(
   state: ServerState | null,
-  _caps: Capabilities | null,
+  caps: Capabilities | null,
 ): TxProps {
   return {
     txActive: state?.ptt ?? false,
@@ -394,6 +401,9 @@ export function toTxProps(
     monActive: state?.monitorOn ?? false,
     monLevel: state?.monitorGain ?? 128,
     driveGain: state?.driveGain ?? 128,
+    hasTx: caps?.tx ?? false,
+    hasTuner: hasCap(caps, 'tuner'),
+    hasMonitor: hasCap(caps, 'monitor'),
   };
 }
 
@@ -414,6 +424,9 @@ export interface CwProps {
   reversePaddle: boolean;
   keyerType: number;
   hasCw: boolean;
+  hasBreakIn: boolean;
+  hasApf: boolean;
+  hasTwinPeak: boolean;
 }
 
 export function toCwProps(
@@ -436,7 +449,10 @@ export function toCwProps(
     sidetoneLevel: state?.monitorGain ?? 128,
     reversePaddle: (state?.dashRatio ?? 0) < 0,
     keyerType: 0,
-    hasCw: caps?.capabilities?.includes('cw') ?? false,
+    hasCw: hasCap(caps, 'cw'),
+    hasBreakIn: hasCap(caps, 'break_in'),
+    hasApf: hasCap(caps, 'apf'),
+    hasTwinPeak: hasCap(caps, 'twin_peak'),
   };
 }
 
@@ -453,9 +469,13 @@ export interface MeterProps {
   id: number;
   txActive: boolean;
   meterSource: string;
+  hasTx: boolean;
 }
 
-export function toMeterProps(state: ServerState | null): MeterProps {
+export function toMeterProps(
+  state: ServerState | null,
+  caps: Capabilities | null,
+): MeterProps {
   const rx = state ? activeRx(state) : null;
   return {
     sValue: rx?.sMeter ?? 0,
@@ -468,6 +488,7 @@ export function toMeterProps(state: ServerState | null): MeterProps {
     id: state?.idMeter ?? 0,
     txActive: state?.ptt ?? false,
     meterSource: (state as { meterSource?: string } | null)?.meterSource ?? 'S',
+    hasTx: caps?.tx ?? false,
   };
 }
 


### PR DESCRIPTION
## Summary
- 4 panels (CwPanel, DspPanel, MeterPanel, TxPanel) no longer import `$lib/stores/capabilities`
- Capability flags now flow through wiring/state-adapter as panel-props
- No behavior change in production UI

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/` clean
- [x] `npx vitest run` pass (1687/1687)
- [x] `npm run build` succeeds
- [x] `uv run pytest tests/` zero failures (5297 passed)
- [x] `uv run mypy src/` clean
- [x] `uv run ruff check src/ tests/` clean

Closes #1244
Refs #1063 (Tier 2 batch 1/5). Parent: #1238