### PR TITLE
refactor(#1246,frontend): per-panel radio-state adapters (batch 3/5)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MeterPanel`, `TxPanel` no longer import from `$lib/stores/capabilities`
   directly; capability flags now flow via panel-props from the wiring layer.
   Tier 2 batch 1 of #1063.
+- **Batch 3 of panel→adapter migration (#1246).** `AudioSpectrumPanel`,
+  `MemoryPanel`, `AmberTelemetryStrip`, `VfoControlPanel` no longer import
+  from `$lib/stores/*` directly; live radio state now flows via per-panel
+  adapters in `panel-adapters.ts`. Tier 2 batch 3 of #1063.
 
 ### Docs
 

--- a/frontend/src/components-v2/panels/MemoryPanel.svelte
+++ b/frontend/src/components-v2/panels/MemoryPanel.svelte
@@ -7,8 +7,10 @@
    * controls for recall, store, clear, and channel selection.
    */
   import { runtime } from '$lib/runtime';
-  import { radio } from '$lib/stores/radio.svelte';
+  import { deriveMemoryPanelProps } from '$lib/runtime/adapters/panel-adapters';
   import { formatFrequencyString } from '../display/frequency-format';
+
+  let p = $derived(deriveMemoryPanelProps());
 
   const STORAGE_KEY = 'icom-lan:memory-channels';
   const MAX_CHANNELS = 99;
@@ -60,10 +62,8 @@
   }
 
   function storeVfoToChannel(ch: number) {
-    const state = radio.current;
-    const rx = state?.active === 'SUB' ? state?.sub : state?.main;
-    const freq = rx?.freqHz ?? 0;
-    const mode = rx?.mode ?? '';
+    const freq = p.activeFreqHz;
+    const mode = p.activeMode;
 
     runtime.send('set_memory_mode', { channel: ch });
     runtime.send('memory_write', {});

--- a/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
+++ b/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
@@ -1,29 +1,11 @@
 <script lang="ts">
-  import { radio } from '$lib/stores/radio.svelte';
-  import { resolveFilterModeConfig } from '../../wiring/state-adapter';
-  import { getCapabilities } from '$lib/stores/capabilities.svelte';
   import { runtime } from '$lib/runtime';
+  import { deriveAudioSpectrumProps } from '$lib/runtime/adapters/panel-adapters';
   import AudioSpectrumCanvas from './AudioSpectrumCanvas.svelte';
 
-  // ── Radio state extraction ──
+  // ── Radio state extraction (via runtime adapter) ──
 
-  let radioState = $derived(radio.current);
-  let rx = $derived(radioState?.active === 'SUB' ? radioState?.sub : radioState?.main);
-
-  let filterWidthHz = $derived(rx?.filterWidth ?? 2400);
-  let filterWidthMax = $derived.by(() => {
-    const caps = getCapabilities();
-    const config = resolveFilterModeConfig(caps, rx?.mode, rx?.dataMode);
-    if (config?.table?.length) return config.table[config.table.length - 1];
-    return config?.maxHz ?? caps?.filterWidthMax ?? 4000;
-  });
-
-  let pbtInner = $derived(rx?.pbtInner ?? 128);
-  let pbtOuter = $derived(rx?.pbtOuter ?? 128);
-  let manualNotchOn = $derived(rx?.manualNotch ?? false);
-  let notchFreqRaw = $derived(radioState?.notchFilter ?? 0);
-  let contourLevel = $derived(rx?.contour ?? 0);
-  let contourFreqRaw = $derived(128); // Default center; contourFreq not exposed in state yet
+  let p = $derived(deriveAudioSpectrumProps());
 
   // ── Scope WS connection ──
 
@@ -48,14 +30,14 @@
     data={fftPixels}
     onRegisterPush={(fn) => { fftPush = fn; }}
     bandwidth={fftBandwidth}
-    filterWidth={filterWidthHz}
-    filterWidthMax={filterWidthMax}
-    pbtInner={pbtInner}
-    pbtOuter={pbtOuter}
-    manualNotch={manualNotchOn}
-    notchFreq={notchFreqRaw}
-    contour={contourLevel}
-    contourFreq={contourFreqRaw}
+    filterWidth={p.filterWidth}
+    filterWidthMax={p.filterWidthMax}
+    pbtInner={p.pbtInner}
+    pbtOuter={p.pbtOuter}
+    manualNotch={p.manualNotch}
+    notchFreq={p.notchFreq}
+    contour={p.contour}
+    contourFreq={p.contourFreq}
   />
 </div>
 

--- a/frontend/src/components-v2/panels/lcd/AmberTelemetryStrip.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberTelemetryStrip.svelte
@@ -15,7 +15,7 @@
   Part of #837 / epic #818 LCD telemetry strip.
 -->
 <script lang="ts">
-  import { radio } from '$lib/stores/radio.svelte';
+  import { deriveAmberTelemetryProps } from '$lib/runtime/adapters/panel-adapters';
   import AmberSparkline from './AmberSparkline.svelte';
 
   const BUFFER_SIZE = 30;
@@ -26,15 +26,12 @@
   // the incoming stream so every frame doesn't push through.
   const PUSH_MIN_INTERVAL_MS = 1000;
 
-  let radioState = $derived(radio.current);
+  let p = $derived(deriveAmberTelemetryProps());
 
   // Raw readings (nullable — backend may not provide all three).
-  let vdRaw = $derived<number | null>(radioState?.vdMeter ?? null);
-  let idRaw = $derived<number | null>(radioState?.idMeter ?? null);
-  // TEMP isn't yet on ServerState; read defensively for forward compat.
-  let tempRaw = $derived<number | null>(
-    (radioState as { tempMeter?: number } | null)?.tempMeter ?? null,
-  );
+  let vdRaw = $derived<number | null>(p.vdRaw);
+  let idRaw = $derived<number | null>(p.idRaw);
+  let tempRaw = $derived<number | null>(p.tempRaw);
 
   // Local ring buffers — $state so Svelte tracks them as arrays.
   let vdHistory = $state<number[]>([]);

--- a/frontend/src/components-v2/panels/lcd/VfoControlPanel.svelte
+++ b/frontend/src/components-v2/panels/lcd/VfoControlPanel.svelte
@@ -9,12 +9,11 @@
    * relocated here unchanged. Commands dispatched via the same
    * wiring/command-bus handlers as before.
    */
-  import { radio } from '$lib/stores/radio.svelte';
-  import { hasCapability } from '$lib/stores/capabilities.svelte';
   import {
-    toRitXitProps,
-    toVfoOpsProps,
-  } from '../../wiring/state-adapter';
+    deriveVfoControlProps,
+    deriveRitXitProps,
+  } from '$lib/runtime/adapters/panel-adapters';
+  import { deriveVfoOps } from '$lib/runtime/adapters/vfo-adapter';
   import {
     makeVfoHandlers,
     makeRitXitHandlers,
@@ -26,33 +25,29 @@
   const ritXitHandlers = makeRitXitHandlers();
   const cwHandlers = makeCwPanelHandlers();
 
-  let radioState = $derived(radio.current);
-  let ritXit = $derived(toRitXitProps(radioState, null));
-  let vfoOps = $derived(toVfoOpsProps(radioState, null));
-  let rx = $derived(radioState?.active === 'SUB' ? radioState?.sub : radioState?.main);
-  let mode = $derived(rx?.mode ?? '---');
-  let isCwMode = $derived(mode === 'CW' || mode === 'CW-R');
-  let breakInMode = $derived(radioState?.breakIn ?? 0);
+  let p = $derived(deriveVfoControlProps());
+  let ritXit = $derived(deriveRitXitProps());
+  let vfoOps = $derived(deriveVfoOps());
 </script>
 
 <div class="vfo-ctrl-panel">
   <button class="lcd-btn" onclick={vfoHandlers.onSwap}>A↔B</button>
   <button class="lcd-btn" onclick={vfoHandlers.onEqual}>A=B</button>
-  {#if hasCapability('dual_rx')}
+  {#if p.hasDualRx}
     <button class="lcd-btn" class:active={vfoOps.dualWatch} onclick={() => vfoHandlers.onDualWatchToggle(!vfoOps.dualWatch)}>DW</button>
   {/if}
-  {#if hasCapability('split')}
+  {#if p.hasSplit}
     <button class="lcd-btn" class:active={vfoOps.splitActive} onclick={vfoHandlers.onSplitToggle}>SPLIT</button>
   {/if}
-  {#if hasCapability('rit')}
+  {#if p.hasRit}
     <button class="lcd-btn" class:active={ritXit.xitActive} onclick={ritXitHandlers.onXitToggle}>XIT</button>
     <button class="lcd-btn" onclick={ritXitHandlers.onClear}>CLR</button>
   {/if}
-  {#if hasCapability('tuner')}
+  {#if p.hasTuner}
     <button class="lcd-btn" onclick={() => runtime.send('set_tuner_status', { value: 2 })}>TUNE</button>
   {/if}
-  {#if isCwMode && hasCapability('cw') && hasCapability('break_in')}
-    <button class="lcd-btn" class:active={breakInMode > 0} onclick={() => cwHandlers.onBreakInModeChange(breakInMode === 0 ? 1 : breakInMode === 1 ? 2 : 0)}>{breakInMode === 0 ? 'BK-OFF' : breakInMode === 1 ? 'SEMI' : 'FULL'}</button>
+  {#if p.isCwMode && p.hasCw && p.hasBreakIn}
+    <button class="lcd-btn" class:active={p.breakInMode > 0} onclick={() => cwHandlers.onBreakInModeChange(p.breakInMode === 0 ? 1 : p.breakInMode === 1 ? 2 : 0)}>{p.breakInMode === 0 ? 'BK-OFF' : p.breakInMode === 1 ? 'SEMI' : 'FULL'}</button>
   {/if}
 </div>
 

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -13,6 +13,8 @@ import {
   toRfFrontEndProps, toRitXitProps, toScanProps,
   toMeterProps, toCwProps, toDspProps, toTxProps,
   toFilterProps, toBandSelectorProps,
+  toAudioSpectrumProps, toMemoryPanelProps,
+  toAmberTelemetryProps, toVfoControlProps,
 } from '../props/panel-props';
 import {
   makeAgcHandlers, makeModeHandlers, makeAntennaHandlers,
@@ -28,6 +30,8 @@ export type {
   RfFrontEndProps, RitXitProps, ScanProps,
   MeterProps, CwProps, DspProps, TxProps,
   FilterProps, BandSelectorProps,
+  AudioSpectrumProps, MemoryPanelProps,
+  AmberTelemetryProps, VfoControlProps,
 } from '../props/panel-props';
 
 // ── AGC ──
@@ -115,3 +119,23 @@ const _bandHandlers = makeBandHandlers();
 export function getBandHandlers() { return _bandHandlers; }
 const _presetHandlers = makePresetHandlers();
 export function getPresetHandlers() { return _presetHandlers; }
+
+// ── Audio Spectrum ──
+export function deriveAudioSpectrumProps() {
+  return toAudioSpectrumProps(runtime.state, runtime.caps);
+}
+
+// ── Memory Panel ──
+export function deriveMemoryPanelProps() {
+  return toMemoryPanelProps(runtime.state);
+}
+
+// ── Amber Telemetry ──
+export function deriveAmberTelemetryProps() {
+  return toAmberTelemetryProps(runtime.state);
+}
+
+// ── VFO Control Panel ──
+export function deriveVfoControlProps() {
+  return toVfoControlProps(runtime.state, runtime.caps);
+}

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -585,3 +585,106 @@ export function toScanProps(state: ServerState | null): ScanProps {
     scanResumeMode: (state?.scanResumeMode ?? 0) & 0x0f,
   };
 }
+
+/* ── Audio Spectrum Panel ────────────────────────────────────── */
+
+export interface AudioSpectrumProps {
+  filterWidth: number;
+  filterWidthMax: number;
+  pbtInner: number;
+  pbtOuter: number;
+  manualNotch: boolean;
+  notchFreq: number;
+  contour: number;
+  contourFreq: number;
+}
+
+export function toAudioSpectrumProps(
+  state: ServerState | null,
+  caps: Capabilities | null,
+): AudioSpectrumProps {
+  const rx = state ? activeRx(state) : null;
+  const filterConfig = resolveFilterModeConfig(caps, rx?.mode, rx?.dataMode);
+  const filterWidthMax = filterConfig?.table?.length
+    ? filterConfig.table[filterConfig.table.length - 1]
+    : (filterConfig?.maxHz ?? caps?.filterWidthMax ?? 4000);
+
+  return {
+    filterWidth: rx?.filterWidth ?? 2400,
+    filterWidthMax,
+    pbtInner: rx?.pbtInner ?? 128,
+    pbtOuter: rx?.pbtOuter ?? 128,
+    manualNotch: rx?.manualNotch ?? false,
+    notchFreq: state?.notchFilter ?? 0,
+    contour: rx?.contour ?? 0,
+    // contourFreq is not yet exposed in ServerState; default to centre.
+    contourFreq: 128,
+  };
+}
+
+/* ── Memory Panel ────────────────────────────────────────────── */
+
+export interface MemoryPanelProps {
+  /** Active receiver frequency (Hz) — used by "store VFO → channel". */
+  activeFreqHz: number;
+  /** Active receiver mode — used by "store VFO → channel". */
+  activeMode: string;
+}
+
+export function toMemoryPanelProps(state: ServerState | null): MemoryPanelProps {
+  const rx = state ? activeRx(state) : null;
+  return {
+    activeFreqHz: rx?.freqHz ?? 0,
+    activeMode: rx?.mode ?? '',
+  };
+}
+
+/* ── Amber Telemetry Strip ───────────────────────────────────── */
+
+export interface AmberTelemetryProps {
+  vdRaw: number | null;
+  idRaw: number | null;
+  tempRaw: number | null;
+}
+
+export function toAmberTelemetryProps(state: ServerState | null): AmberTelemetryProps {
+  return {
+    vdRaw: state?.vdMeter ?? null,
+    idRaw: state?.idMeter ?? null,
+    // tempMeter isn't yet on ServerState; read defensively for forward compat.
+    tempRaw: (state as { tempMeter?: number } | null)?.tempMeter ?? null,
+  };
+}
+
+/* ── VFO Control Panel ───────────────────────────────────────── */
+
+export interface VfoControlProps {
+  mode: string;
+  isCwMode: boolean;
+  breakInMode: number;
+  hasDualRx: boolean;
+  hasSplit: boolean;
+  hasRit: boolean;
+  hasTuner: boolean;
+  hasCw: boolean;
+  hasBreakIn: boolean;
+}
+
+export function toVfoControlProps(
+  state: ServerState | null,
+  caps: Capabilities | null,
+): VfoControlProps {
+  const rx = state ? activeRx(state) : null;
+  const mode = rx?.mode ?? '---';
+  return {
+    mode,
+    isCwMode: mode === 'CW' || mode === 'CW-R',
+    breakInMode: state?.breakIn ?? 0,
+    hasDualRx: hasCap(caps, 'dual_rx'),
+    hasSplit: hasCap(caps, 'split'),
+    hasRit: hasCap(caps, 'rit'),
+    hasTuner: hasCap(caps, 'tuner'),
+    hasCw: hasCap(caps, 'cw'),
+    hasBreakIn: hasCap(caps, 'break_in'),
+  };
+}


### PR DESCRIPTION
## Summary
- 4 panels (AudioSpectrum, Memory, AmberTelemetry, VfoControl) migrated from direct store reads to per-panel adapters in `panel-adapters.ts`
- Wiring layer updated to forward adapter outputs as panel-props
- Coexists with batch 1 capability-flag plumbing (already merged via #1249)
- No behavior change

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/` clean
- [x] `npx vitest run` pass (1687/1687)
- [x] `npm run build` succeeds
- [x] `uv run pytest tests/` zero failures (5297 pass)

Closes #1246
Refs #1063 (Tier 2 batch 3/5). Parent: #1238