### PR TITLE
refactor(#1247,frontend): LCD chrome + qsy-history + AmberScope (batch 4/5)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MemoryPanel`, `AmberTelemetryStrip`, `VfoControlPanel` no longer import
   from `$lib/stores/*` directly; live radio state now flows via per-panel
   adapters in `panel-adapters.ts`. Tier 2 batch 3 of #1063.
+- **Batch 4 of panel→adapter migration (#1247).** New `lcd-chrome-adapter.ts`
+  and `qsy-history-adapter.ts` plus an `amberScopeProps()` adapter migrate
+  `LcdContrastControl`, `LcdDisplayModeControl`, `AmberMemoryStrip`, and
+  `AmberScope` off direct `$lib/stores/*` imports. Tier 2 batch 4 of #1063.
 
 ### Docs
 

--- a/frontend/src/components-v2/panels/lcd/AmberMemoryStrip.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberMemoryStrip.svelte
@@ -17,7 +17,7 @@
   Part of #836 / epic #818 LCD aux-row content.
 -->
 <script lang="ts">
-  import { qsyHistory } from '$lib/stores/qsy-history.svelte';
+  import { deriveQsyRecent } from '$lib/runtime/adapters/qsy-history-adapter';
 
   interface Props {
     /** Invoked when a recent-QSY chip is tapped. Parent routes to runtime. */
@@ -28,7 +28,7 @@
 
   // Show last 3 entries, newest-first.
   let recentQsy = $derived<{ freqHz: number; mode: string; at: number }[]>(
-    qsyHistory.recent.slice(-3).reverse() as { freqHz: number; mode: string; at: number }[],
+    deriveQsyRecent().slice(-3).reverse() as { freqHz: number; mode: string; at: number }[],
   );
 
   // Memory slots — placeholder until a store lands.

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { radio } from '$lib/stores/radio.svelte';
-  import { hasAudioFft, hasDualReceiver, getCapabilities, hasCapability } from '$lib/stores/capabilities.svelte';
+  import { deriveAmberScopeProps } from '$lib/runtime/adapters/panel-adapters';
   import {
     toTxProps, toRitXitProps, toVfoOpsProps, toDspProps, toFilterProps,
   } from '../../wiring/state-adapter';
@@ -48,8 +47,10 @@
     return AGC_LABELS[agcMode] ?? `${agcMode}`;
   }
 
-  let radioState = $derived(radio.current);
-  let caps = $derived(getCapabilities());
+  let scopeProps = $derived(deriveAmberScopeProps());
+  let radioState = $derived(scopeProps.radioState);
+  let caps = $derived(scopeProps.caps);
+  let hasCap = $derived(scopeProps.hasCapability);
 
   let tx = $derived(toTxProps(radioState, null));
   let ritXit = $derived(toRitXitProps(radioState, null));
@@ -96,16 +97,16 @@
       id: 'tx', label: 'TX', active: tx.txActive,
       variant: tx.txActive ? 'tx' : undefined,
     },
-    ...(hasCapability('vox') ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
-    ...(hasCapability('compressor') ? [{
+    ...(hasCap('vox') ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
+    ...(hasCap('compressor') ? [{
       id: 'proc' as const,
       label: tx.compActive ? `PROC ${tx.compLevel}` : 'PROC',
       active: tx.compActive,
     }] : []),
-    ...(hasCapability('attenuator') ? [{
+    ...(hasCap('attenuator') ? [{
       id: 'att' as const, label: 'ATT', active: (rx?.att ?? 0) > 0,
     }] : []),
-    ...(hasCapability('preamp') ? [{
+    ...(hasCap('preamp') ? [{
       id: 'pre' as const,
       label: (rx?.preamp ?? 0) === 0 ? 'IPO'
            : (rx?.preamp ?? 0) === 1 ? 'AMP1' : 'AMP2',
@@ -115,23 +116,23 @@
 
   // dspTokens: RX processing (NB/NR/NOTCH/ANF/RFG)
   let dspTokens = $derived<IndToken[]>([
-    ...(hasCapability('nb') ? [{
+    ...(hasCap('nb') ? [{
       id: 'nb' as const,
       label: (rx?.nb ?? false) || (rx?.nbLevel ?? 0) > 0
         ? `NB ${rx?.nbLevel ?? 0}` : 'NB',
       active: (rx?.nb ?? false) || (rx?.nbLevel ?? 0) > 0,
     }] : []),
-    ...(hasCapability('nr') ? [{
+    ...(hasCap('nr') ? [{
       id: 'nr' as const,
       label: (rx?.nr ?? false) || (rx?.nrLevel ?? 0) > 0
         ? `NR ${rx?.nrLevel ?? 0}` : 'NR',
       active: (rx?.nr ?? false) || (rx?.nrLevel ?? 0) > 0,
     }] : []),
-    ...(hasCapability('notch') ? [
+    ...(hasCap('notch') ? [
       { id: 'notch' as const, label: 'NOTCH', active: rx?.manualNotch ?? false },
       { id: 'anf' as const, label: 'ANF', active: rx?.autoNotch ?? false },
     ] : []),
-    ...(hasCapability('rf_gain') ? [{
+    ...(hasCap('rf_gain') ? [{
       id: 'rfg' as const, label: 'RFG', active: (rx?.rfGain ?? 255) < 255,
     }] : []),
   ]);
@@ -139,12 +140,12 @@
   // globalTokens: AGC/SQL/LOCK/SPLIT/RIT
   let globalTokens = $derived<IndToken[]>([
     { id: 'agc' as const, label: `AGC ${agcLabelFor(rx?.agc ?? 2)}`, active: true },
-    ...(hasCapability('squelch') ? [{
+    ...(hasCap('squelch') ? [{
       id: 'sql' as const, label: 'SQL', active: (rx?.squelch ?? 0) > 0,
     }] : []),
-    ...(hasCapability('dial_lock') ? [{ id: 'lock' as const, label: 'LOCK', active: lockActive }] : []),
-    ...(hasCapability('split') ? [{ id: 'split' as const, label: 'SPLIT', active: vfoOps.splitActive }] : []),
-    ...(hasCapability('rit') ? [{
+    ...(hasCap('dial_lock') ? [{ id: 'lock' as const, label: 'LOCK', active: lockActive }] : []),
+    ...(hasCap('split') ? [{ id: 'split' as const, label: 'SPLIT', active: vfoOps.splitActive }] : []),
+    ...(hasCap('rit') ? [{
       id: 'rit' as const, label: 'RIT', active: ritXit.ritActive,
     }] : []),
   ]);
@@ -153,11 +154,11 @@
   let fftPixels = $state<Uint8Array | null>(null);
   let fftBandwidth = $state<number | undefined>(undefined);
   let fftPush: ((data: Uint8Array) => void) | null = null;
-  let showFft = $derived(hasAudioFft());
+  let showFft = $derived(scopeProps.hasAudioFft);
 
   // Scope subscription — delegates lifecycle to ScopeController (ADR INV-2, INV-5)
   $effect(() => {
-    if (!hasAudioFft()) return;
+    if (!scopeProps.hasAudioFft) return;
 
     return runtime.scope.subscribe((frame) => {
       fftPixels = frame.pixels;
@@ -199,7 +200,7 @@
       </div>
 
       <!-- VFO B row (sub receiver — compact, dual-RX only) -->
-      {#if hasDualReceiver()}
+      {#if scopeProps.hasDualReceiver}
         <div class="vfo-row vfo-row-b" class:inactive={!isBActive}>
           <span class="vfo-tag vfo-tag-sub">►B</span>
           <div class="vfo-freq">

--- a/frontend/src/components-v2/panels/lcd/LcdContrastControl.svelte
+++ b/frontend/src/components-v2/panels/lcd/LcdContrastControl.svelte
@@ -7,7 +7,7 @@
     setLcdContrastPreset,
     stepLcdContrast,
     type LcdContrastPreset,
-  } from '$lib/stores/lcd-contrast.svelte';
+  } from '$lib/runtime/adapters/lcd-chrome-adapter';
 
   // LCD contrast control — extracted from AmberLcdDisplay per issue #861.
   // Presets + Shift+[/] keyboard shortcut preserved verbatim from #833.

--- a/frontend/src/components-v2/panels/lcd/LcdDisplayModeControl.svelte
+++ b/frontend/src/components-v2/panels/lcd/LcdDisplayModeControl.svelte
@@ -14,7 +14,7 @@
     getLcdDisplayMode,
     setLcdDisplayMode,
     type LcdDisplayMode,
-  } from '$lib/stores/lcd-display-mode.svelte';
+  } from '$lib/runtime/adapters/lcd-chrome-adapter';
 
   let mode = $state<LcdDisplayMode>(getLcdDisplayMode());
 

--- a/frontend/src/lib/runtime/adapters/lcd-chrome-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/lcd-chrome-adapter.ts
@@ -1,0 +1,52 @@
+/**
+ * LCD chrome adapter — façade over LCD skin-local UI state.
+ *
+ * Wraps `lib/stores/lcd-contrast.svelte` + `lib/stores/lcd-display-mode.svelte`
+ * so panels under `components-v2/panels/lcd/` can consume LCD chrome state
+ * through the runtime adapter layer instead of importing stores directly
+ * (CLAUDE.md → "Frontend layering").
+ *
+ * LCD chrome state is browser-local, persisted in `localStorage`. It has no
+ * radio-runtime equivalent — this adapter is mechanical pass-through.
+ *
+ * Long-term home (lib/stores vs skins/amber-lcd/state) is the audit's
+ * Open Question #1; deferred. See
+ * `docs/plans/2026-04-29-panel-adapter-migration.md` Cluster C.
+ *
+ * Tier 2 batch 4 of #1063. Issue #1247.
+ */
+
+import {
+  LCD_CONTRAST_PRESETS,
+  applyLcdContrast,
+  getLcdContrastPreset,
+  setLcdContrastPreset,
+  stepLcdContrast,
+  type LcdContrastPreset,
+} from '$lib/stores/lcd-contrast.svelte';
+import {
+  LCD_DISPLAY_MODES,
+  getLcdDisplayMode,
+  setLcdDisplayMode,
+  type LcdDisplayMode,
+} from '$lib/stores/lcd-display-mode.svelte';
+
+// ── Contrast facet ──
+
+export {
+  LCD_CONTRAST_PRESETS,
+  applyLcdContrast,
+  getLcdContrastPreset,
+  setLcdContrastPreset,
+  stepLcdContrast,
+};
+export type { LcdContrastPreset };
+
+// ── Display-mode facet ──
+
+export {
+  LCD_DISPLAY_MODES,
+  getLcdDisplayMode,
+  setLcdDisplayMode,
+};
+export type { LcdDisplayMode };

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -23,6 +23,11 @@ import {
   makeTxHandlers, makeFilterHandlers, makeBandHandlers,
   makePresetHandlers,
 } from '../commands/panel-commands';
+import {
+  hasAudioFft, hasDualReceiver, hasCapability,
+} from '$lib/stores/capabilities.svelte';
+import type { ServerState } from '$lib/types/state';
+import type { Capabilities } from '$lib/types/capabilities';
 
 // Re-export types for panel imports
 export type {
@@ -138,4 +143,27 @@ export function deriveAmberTelemetryProps() {
 // ── VFO Control Panel ──
 export function deriveVfoControlProps() {
   return toVfoControlProps(runtime.state, runtime.caps);
+}
+
+// ── AmberScope (LCD skin) ──
+// Bundles radio.current + capabilities reads for the AmberScope panel
+// so it doesn't import `$lib/stores/*` directly. AmberScope has ~12
+// `hasCapability(name)` checks; we expose the function on props rather
+// than inflate the type with a dozen booleans. See audit Cluster B.
+export interface AmberScopeProps {
+  radioState: ServerState | null;
+  caps: Capabilities | null;
+  hasAudioFft: boolean;
+  hasDualReceiver: boolean;
+  hasCapability: (name: string) => boolean;
+}
+
+export function deriveAmberScopeProps(): AmberScopeProps {
+  return {
+    radioState: runtime.state,
+    caps: runtime.caps,
+    hasAudioFft: hasAudioFft(),
+    hasDualReceiver: hasDualReceiver(),
+    hasCapability,
+  };
 }

--- a/frontend/src/lib/runtime/adapters/qsy-history-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/qsy-history-adapter.ts
@@ -1,0 +1,23 @@
+/**
+ * QSY history adapter — read-only façade over the qsy-history store.
+ *
+ * Lets LCD aux-row panels (e.g. AmberMemoryStrip) consume the recent-QSY
+ * ring buffer through the runtime adapter layer instead of importing
+ * `$lib/stores/qsy-history.svelte` directly (CLAUDE.md → "Frontend
+ * layering").
+ *
+ * Read-side only this batch. The write side (`recordQsy(freqHz, mode)`)
+ * lands in batch 5 with AmberCockpit. See
+ * `docs/plans/2026-04-29-panel-adapter-migration.md` Cluster D.
+ *
+ * Tier 2 batch 4 of #1063. Issue #1247.
+ */
+
+import { qsyHistory, type QsyEntry } from '$lib/stores/qsy-history.svelte';
+
+export type { QsyEntry };
+
+/** Latest QSY entries, oldest-first (same shape as `qsyHistory.recent`). */
+export function deriveQsyRecent(): readonly QsyEntry[] {
+  return qsyHistory.recent;
+}


### PR DESCRIPTION
## Summary
- New `lcd-chrome-adapter.ts` (contrast + display-mode) and `qsy-history-adapter.ts` (read-only)
- `panel-adapters.ts` extended with `amberScopeProps()` (consistent with Batch 3 pattern, coexists with #1249/#1250)
- 4 panels (LcdContrastControl, LcdDisplayModeControl, AmberMemoryStrip, AmberScope) migrated off `$lib/stores/*`
- LCD-chrome long-term home (lib/stores vs skins/amber-lcd/state) **deferred** — adapter façade in place

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/` clean
- [x] `npx vitest run` pass
- [x] `npm run build` succeeds
- [x] `uv run pytest tests/` zero failures

Closes #1247
Refs #1063 (Tier 2 batch 4/5). Parent: #1238