### PR TITLE
refactor(#1245,frontend): capabilities-adapter (batch 2/5)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MeterPanel`, `TxPanel` no longer import from `$lib/stores/capabilities`
   directly; capability flags now flow via panel-props from the wiring layer.
   Tier 2 batch 1 of #1063.
+- **Batch 2 of panel→adapter migration (#1245).** New `capabilities-adapter.ts`
+  centralizes capability-derived state. `RfFrontEnd`, `AudioRoutingControl`,
+  and the `filter-controls.ts` / `meter-utils.ts` helpers no longer import
+  `$lib/stores/capabilities` directly. Tier 2 batch 2 of #1063.
 - **Batch 3 of panel→adapter migration (#1246).** `AudioSpectrumPanel`,
   `MemoryPanel`, `AmberTelemetryStrip`, `VfoControlPanel` no longer import
   from `$lib/stores/*` directly; live radio state now flows via per-panel

--- a/frontend/src/components-v2/panels/AudioRoutingControl.svelte
+++ b/frontend/src/components-v2/panels/AudioRoutingControl.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { makeAudioRoutingHandlers } from '../wiring/command-bus';
-  import { receiverLabel } from '$lib/stores/capabilities.svelte';
+  import { getReceiverLabel } from '$lib/runtime/adapters/capabilities-adapter';
 
   type AudioFocus = 'main' | 'sub' | 'both';
 
@@ -37,8 +37,8 @@
   }
 
   const FOCUS_OPTIONS: Array<{ value: AudioFocus; label: string }> = [
-    { value: 'main', label: receiverLabel('MAIN') },
-    { value: 'sub', label: receiverLabel('SUB') },
+    { value: 'main', label: getReceiverLabel('MAIN') },
+    { value: 'sub', label: getReceiverLabel('SUB') },
     { value: 'both', label: 'Both' },
   ];
 </script>
@@ -70,7 +70,7 @@
   </button>
 
   <label class="gain-row">
-    <span class="gain-label">{receiverLabel('MAIN')}</span>
+    <span class="gain-label">{getReceiverLabel('MAIN')}</span>
     <input
       type="range"
       min="-60"
@@ -84,7 +84,7 @@
   </label>
 
   <label class="gain-row">
-    <span class="gain-label">{receiverLabel('SUB')}</span>
+    <span class="gain-label">{getReceiverLabel('SUB')}</span>
     <input
       type="range"
       min="-60"

--- a/frontend/src/components-v2/panels/RfFrontEnd.svelte
+++ b/frontend/src/components-v2/panels/RfFrontEnd.svelte
@@ -3,8 +3,7 @@
   import DualParamRenderer from '../controls/value-control/DualParamRenderer.svelte';
   import AttenuatorControl from '../controls/AttenuatorControl.svelte';
   import { HardwareButton } from '$lib/Button';
-  import { hasCapability, getAttValues, getAttLabels, getPreValues, getPreLabels } from '$lib/stores/capabilities.svelte';
-  import { buildPreOptions, shouldShowPanel } from './rf-frontend-utils';
+  import { shouldShowPanel } from './rf-frontend-utils';
   import { getShortcutHint } from '../layout/shortcut-hints';
 
   import { deriveRfFrontEndProps, getRfFrontEndHandlers } from '$lib/runtime/adapters/panel-adapters';
@@ -25,18 +24,18 @@
   const onDigiSelToggle = handlers.onDigiSelToggle;
   const onIpPlusToggle = handlers.onIpPlusToggle;
 
-  let showRfGain = $derived(hasCapability('rf_gain'));
-  let showSquelch = $derived(hasCapability('squelch'));
-  let showAtt = $derived(hasCapability('attenuator'));
-  let showPre = $derived(hasCapability('preamp'));
-  let showDigiSel = $derived(hasCapability('digisel'));
-  let showIpPlus = $derived(hasCapability('ip_plus'));
+  let showRfGain = $derived(p.showRfGain);
+  let showSquelch = $derived(p.showSquelch);
+  let showAtt = $derived(p.showAtt);
+  let showPre = $derived(p.showPre);
+  let showDigiSel = $derived(p.showDigiSel);
+  let showIpPlus = $derived(p.showIpPlus);
   let showRfSqlDual = $derived(showRfGain && showSquelch);
   let visible = $derived(shouldShowPanel(showRfGain, showAtt, showPre, showSquelch));
 
-  let attValues = $derived(getAttValues());
-  let attLabels = $derived(getAttLabels());
-  let preOptions = $derived(buildPreOptions(getPreValues(), getPreLabels()));
+  let attValues = $derived(p.attValues);
+  let attLabels = $derived(p.attLabels);
+  let preOptions = $derived(p.preOptions);
   const rfGainShortcut = getShortcutHint('adjust_rf_gain');
   const attShortcut = getShortcutHint('cycle_att');
   const preShortcut = getShortcutHint('cycle_preamp');

--- a/frontend/src/components-v2/panels/__tests__/MeterPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MeterPanel.test.ts
@@ -156,7 +156,7 @@ describe('getNeedleMarks POWER', () => {
 // MeterPanel component
 // ---------------------------------------------------------------------------
 
-vi.mock('$lib/stores/capabilities.svelte', () => ({
+vi.mock('$lib/runtime/adapters/capabilities-adapter', () => ({
   getMeterCalibration: vi.fn(() => null),
   getMeterRedline: vi.fn(() => null),
 }));

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
@@ -15,6 +15,8 @@ import {
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   hasTx: vi.fn(() => true),
+}));
+vi.mock('$lib/runtime/adapters/capabilities-adapter', () => ({
   getMeterCalibration: vi.fn(() => null),
   getMeterRedline: vi.fn(() => null),
 }));

--- a/frontend/src/components-v2/panels/filter-controls.ts
+++ b/frontend/src/components-v2/panels/filter-controls.ts
@@ -5,8 +5,12 @@ export const FILTER_WIDTH_MAX = 3600;
 export const FILTER_WIDTH_STEP = 50;
 
 // PBT raw <-> display conversion
-// Reads range from capabilities if available, falls back to IC-7610 defaults
-import { getControlRange } from '$lib/stores/capabilities.svelte';
+// Reads range from capabilities if available, falls back to IC-7610 defaults.
+// Routed through the runtime capabilities adapter (Tier 2 batch 2) so this
+// helper no longer reaches into `$lib/stores/*` directly. The adapter
+// returns `null` when capabilities haven't loaded; the try/catch keeps the
+// helper safe in tests where the runtime is absent.
+import { getControlRange } from '$lib/runtime/adapters/capabilities-adapter';
 
 // Default PBT range (IC-7610 / standard CI-V)
 const PBT_DEFAULTS = { rawCenter: 128, displayMin: -1200, displayMax: 1200 } as const;

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -1,4 +1,12 @@
-import { getMeterCalibration, getMeterRedline } from '$lib/stores/capabilities.svelte';
+// Capability-derived calibration and redline data is routed through the
+// runtime adapter (Tier 2 batch 2) so this helper no longer reaches into
+// `$lib/stores/*` directly. The adapter returns `null` when capabilities
+// haven't loaded — formatters fall back to the hardcoded IC-7610 knots
+// defined below.
+import {
+  getMeterCalibration,
+  getMeterRedline,
+} from '$lib/runtime/adapters/capabilities-adapter';
 
 export type MeterSource = 'S' | 'SWR' | 'POWER' | 'po';
 

--- a/frontend/src/lib/runtime/adapters/capabilities-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/capabilities-adapter.ts
@@ -1,0 +1,69 @@
+/**
+ * Capabilities adapter — exposes capability-derived helpers that don't fit
+ * a single panel's typed view-model.
+ *
+ * Tier 2 batch 2 of the panel→adapter migration (audit doc:
+ * `docs/plans/2026-04-29-panel-adapter-migration.md`). The four exports
+ * below cover exactly the capability surface that the in-scope helpers
+ * (`meter-utils.ts`, `filter-controls.ts`) and panels
+ * (`AudioRoutingControl.svelte`) currently read from
+ * `$lib/stores/capabilities.svelte` directly. Per-panel capability flags
+ * already live on `derive*Props()` (see `panel-adapters.ts`); this adapter
+ * is intentionally thin, not a parallel hierarchy.
+ *
+ * Reads delegate directly to the capabilities store (the same pattern
+ * other adapters use, e.g. `qsy-history-adapter.ts`, `lcd-chrome-adapter.ts`)
+ * — going through the runtime singleton would pull in the full transport
+ * stack and break tests that mock the store layer in isolation.
+ */
+
+import {
+  getControlRange as _getControlRange,
+  getMeterCalibration as _getMeterCalibration,
+  getMeterRedline as _getMeterRedline,
+} from '$lib/stores/capabilities.svelte';
+import type { ControlRange } from '$lib/types/capabilities';
+
+export interface MeterCalPoint {
+  raw: number;
+  actual: number;
+  label: string;
+}
+
+/**
+ * Calibration knot points for a meter (e.g. `'s_meter'`, `'power'`,
+ * `'swr'`). Returns `null` when capabilities haven't loaded or when the
+ * radio doesn't expose calibration for this meter — callers should fall
+ * back to hardcoded IC-7610 defaults in that case.
+ */
+export function getMeterCalibration(meterType: string): MeterCalPoint[] | null {
+  return _getMeterCalibration(meterType);
+}
+
+/**
+ * Redline raw value for a meter (e.g. `'alc'`). Returns `null` when no
+ * capability data is available — callers fall back to hardcoded defaults.
+ */
+export function getMeterRedline(meterType: string): number | null {
+  return _getMeterRedline(meterType);
+}
+
+/**
+ * Control range descriptor for a named control (e.g. `'pbt_inner'`).
+ * Used by filter helpers to derive raw↔display unit conversions. Returns
+ * `null` when capabilities haven't loaded or when the control isn't
+ * exposed.
+ */
+export function getControlRange(name: string): ControlRange | null {
+  return _getControlRange(name);
+}
+
+/**
+ * Display label for a receiver (`'MAIN'` / `'SUB'`). Currently a passthrough
+ * of the requested id, but routed through the adapter so panels stay
+ * agnostic to where the label comes from — future radios may want
+ * localized or model-specific labels.
+ */
+export function getReceiverLabel(id: 'MAIN' | 'SUB'): string {
+  return id;
+}

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -132,6 +132,11 @@ export function toVfoOpsProps(
 
 /* ── RF Front End ────────────────────────────────────────────── */
 
+export interface PreOption {
+  value: number;
+  label: string;
+}
+
 export interface RfFrontEndProps {
   rfGain: number;
   squelch: number;
@@ -140,7 +145,21 @@ export interface RfFrontEndProps {
   digiSel: boolean;
   ipPlus: boolean;
   attValues: number[];
+  attLabels: Record<string, string>;
   preValues: number[];
+  preOptions: PreOption[];
+  showRfGain: boolean;
+  showSquelch: boolean;
+  showAtt: boolean;
+  showPre: boolean;
+  showDigiSel: boolean;
+  showIpPlus: boolean;
+}
+
+function formatPreLabel(level: number, labels: Record<string, string>): string {
+  const key = String(level);
+  if (key in labels) return labels[key];
+  return level === 0 ? 'OFF' : `P${level}`;
 }
 
 export function toRfFrontEndProps(
@@ -148,6 +167,10 @@ export function toRfFrontEndProps(
   caps: Capabilities | null,
 ): RfFrontEndProps {
   const rx = state ? activeRx(state) : null;
+  const attValues = caps?.attValues ?? [0, 6, 12, 18];
+  const attLabels = caps?.attLabels ?? {};
+  const preValues = caps?.preValues ?? [0, 1, 2];
+  const preLabels = caps?.preLabels ?? {};
   return {
     rfGain: rx?.rfGain ?? 255,
     squelch: rx?.squelch ?? 0,
@@ -155,8 +178,19 @@ export function toRfFrontEndProps(
     digiSel: rx?.digisel ?? false,
     ipPlus: rx?.ipplus ?? false,
     pre: rx?.preamp ?? 0,
-    attValues: caps?.attValues ?? [0, 6, 12, 18],
-    preValues: caps?.preValues ?? [0, 1, 2],
+    attValues,
+    attLabels,
+    preValues,
+    preOptions: preValues.map((value) => ({
+      value,
+      label: formatPreLabel(value, preLabels),
+    })),
+    showRfGain: hasCap(caps, 'rf_gain'),
+    showSquelch: hasCap(caps, 'squelch'),
+    showAtt: hasCap(caps, 'attenuator'),
+    showPre: hasCap(caps, 'preamp'),
+    showDigiSel: hasCap(caps, 'digisel'),
+    showIpPlus: hasCap(caps, 'ip_plus'),
   };
 }
 


### PR DESCRIPTION
## Summary
- New `frontend/src/lib/runtime/adapters/capabilities-adapter.ts` (69 LOC) exposing `getMeterCalibration`, `getMeterRedline`, `getControlRange`, `getReceiverLabel`.
- 4 files migrated off `$lib/stores/capabilities` (`RfFrontEnd.svelte`, `AudioRoutingControl.svelte`, `filter-controls.ts`, `meter-utils.ts`).
- `RfFrontEndProps` (in `panel-props.ts`) extended with capability flags + `attLabels` / `preOptions`, matching Batch 1's pattern (#1244). The new adapter intentionally stays thin.
- Helper modules keep their public function signatures unchanged but route capability reads through the adapter — the audit doc explicitly permits this as the alternative to threading caps through every out-of-batch caller (`DockMeterPanel`, `MetersDockPanel`, `command-bus.ts`, `state-adapter.ts`, `SpectrumPanel.svelte`, `passband-geometry.ts`).
- Adapter delegates directly to `$lib/stores/capabilities.svelte` (matching `qsy-history-adapter.ts` / `lcd-chrome-adapter.ts`) rather than going through `runtime.caps` — that path would pull the full transport singleton chain into modules whose tests mock the store layer in isolation.
- No behavior change.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/` clean
- [x] `npx vitest run` — 1687 tests pass (92 files)
- [x] `npm run build` succeeds
- [x] `uv run pytest tests/` — 5297 passed
- [x] `uv run mypy src/` clean
- [x] `uv run ruff check src/ tests/` clean
- [x] `grep '$lib/stores' RfFrontEnd.svelte AudioRoutingControl.svelte filter-controls.ts meter-utils.ts` — zero hits

Closes #1245
Refs #1063 (Tier 2 batch 2/5). Parent: #1238