### PR TITLE
refactor(#1248,frontend): AmberCockpit + RxAudioPanel finisher (batch 5/5)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `qsy-history-adapter.ts` plus an `amberScopeProps()` adapter migrate
   `LcdContrastControl`, `LcdDisplayModeControl`, `AmberMemoryStrip`, and
   `AmberScope` off direct `$lib/stores/*` imports. Tier 2 batch 4 of #1063.
+- **Batch 5 (finisher) of panel→adapter migration (#1248).** `AmberCockpit`
+  and `RxAudioPanel` migrated off direct `$lib/stores/*` imports. After this
+  batch, no non-test panel under `components-v2/panels/` imports from
+  `$lib/stores/*`. Tier 2 batch 5/5 of #1063 — unblocks #1241 (ESLint
+  lockdown).
 
 ### Docs
 

--- a/frontend/src/components-v2/panels/RxAudioPanel.svelte
+++ b/frontend/src/components-v2/panels/RxAudioPanel.svelte
@@ -4,8 +4,6 @@
   import { deriveRxAudioProps, getRxAudioHandlers } from '$lib/runtime/adapters/audio-adapter';
   import { buildMonitorOptions, formatMonitorStatus } from './audio-utils';
   import { getShortcutHint } from '../layout/shortcut-hints';
-  import { isAudioConnected } from '$lib/stores/connection.svelte';
-  import { hasDualReceiver } from '$lib/stores/capabilities.svelte';
   import AudioRoutingControl from './AudioRoutingControl.svelte';
 
   const handlers = getRxAudioHandlers();
@@ -16,8 +14,9 @@
   const monitorShortcut = getShortcutHint('toggle_monitor');
   const afShortcut = getShortcutHint('adjust_af_level');
   let isMuted = $derived(props.monitorMode === 'mute');
-  let audioWsConnected = $derived(isAudioConnected());
-  let showDisconnected = $derived(props.hasLiveAudio && props.monitorMode === 'live' && !audioWsConnected);
+  let showDisconnected = $derived(
+    props.hasLiveAudio && props.monitorMode === 'live' && !props.isAudioConnected,
+  );
 </script>
 
 {#if props.hasLiveAudio}
@@ -53,7 +52,7 @@
       <div class="output-indicator" class:audio-disconnected={showDisconnected}>
         {#if showDisconnected}Audio link lost — reconnecting…{:else}{statusText}{/if}
       </div>
-      {#if hasDualReceiver()}
+      {#if props.hasDualReceiver}
         <AudioRoutingControl />
       {/if}
     </div>

--- a/frontend/src/components-v2/panels/__tests__/RxAudioPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RxAudioPanel.test.ts
@@ -11,6 +11,8 @@ const mockProps = {
   monitorMode: 'local' as 'local' | 'live' | 'mute',
   afLevel: 128,
   hasLiveAudio: false,
+  isAudioConnected: true,
+  hasDualReceiver: false,
 };
 
 const mockHandlers = {
@@ -21,10 +23,6 @@ const mockHandlers = {
 vi.mock('$lib/runtime/adapters/audio-adapter', () => ({
   deriveRxAudioProps: () => mockProps,
   getRxAudioHandlers: () => mockHandlers,
-}));
-
-vi.mock('$lib/stores/connection.svelte', () => ({
-  isAudioConnected: vi.fn(() => true),
 }));
 
 // ---------------------------------------------------------------------------
@@ -128,6 +126,8 @@ beforeEach(() => {
   mockProps.monitorMode = 'local';
   mockProps.afLevel = 128;
   mockProps.hasLiveAudio = false;
+  mockProps.isAudioConnected = true;
+  mockProps.hasDualReceiver = false;
   mockHandlers.onMonitorModeChange = vi.fn();
   mockHandlers.onAfLevelChange = vi.fn();
 });

--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { radio } from '$lib/stores/radio.svelte';
-  import { hasAudioFft, hasDualReceiver, getCapabilities, hasCapability } from '$lib/stores/capabilities.svelte';
+  import {
+    deriveAmberCockpitProps, getAmberCockpitHandlers,
+  } from '$lib/runtime/adapters/panel-adapters';
   import {
     toTxProps, toRitXitProps, toVfoOpsProps, toMeterProps,
     toDspProps, toFilterProps,
@@ -13,8 +14,9 @@
   import AmberTelemetryStrip from './AmberTelemetryStrip.svelte';
   import AmberMemoryStrip from './AmberMemoryStrip.svelte';
   import type { IndToken } from './AmberIndStrip.svelte';
-  import { qsyHistory } from '$lib/stores/qsy-history.svelte';
   import { runtime } from '$lib/runtime';
+
+  const handlers = getAmberCockpitHandlers();
 
   // Band lookup by frequency (LCD-specific)
   const BANDS: [string, number, number][] = [
@@ -44,8 +46,10 @@
     return '';
   }
 
-  let radioState = $derived(radio.current);
-  let caps = $derived(getCapabilities());
+  let cockpitProps = $derived(deriveAmberCockpitProps());
+  let radioState = $derived(cockpitProps.radioState);
+  let caps = $derived(cockpitProps.caps);
+  let hasCap = $derived(cockpitProps.hasCapability);
 
   // ── Adapter-derived state ──
   let tx = $derived(toTxProps(radioState, null));
@@ -92,7 +96,7 @@
   let fftPixels = $state<Uint8Array | null>(null);
   let fftBandwidth = $state<number | undefined>(undefined);
   let fftPush: ((data: Uint8Array) => void) | null = null;
-  let showFft = $derived(hasAudioFft());
+  let showFft = $derived(cockpitProps.hasAudioFft);
 
   // FTX-1 AGC: 0=OFF, 1=FAST, 2=MID, 3=SLOW, 4=AUTO-F, 5=AUTO-M, 6=AUTO-S
   const AGC_LABELS: Record<number, string> = {
@@ -107,22 +111,22 @@
       id: 'tx', label: 'TX', active: tx.txActive,
       variant: tx.txActive ? 'tx' : undefined,
     },
-    ...(hasCapability('vox') ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
-    ...(hasCapability('compressor') ? [{
+    ...(hasCap('vox') ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
+    ...(hasCap('compressor') ? [{
       id: 'proc' as const,
       label: tx.compActive ? `PROC ${tx.compLevel}` : 'PROC',
       active: tx.compActive,
     }] : []),
-    ...(hasCapability('tuner') ? [{
+    ...(hasCap('tuner') ? [{
       id: 'atu' as const,
       label: tx.atuTuning ? 'TUNE' : 'ATU',
       active: tx.atuActive,
       variant: tx.atuTuning ? ('tuning' as const) : undefined,
     }] : []),
-    ...(hasCapability('split') ? [{ id: 'split' as const, label: 'SPLIT', active: vfoOps.splitActive }] : []),
-    ...(hasCapability('dial_lock') ? [{ id: 'lock' as const, label: 'LOCK', active: lockActive }] : []),
+    ...(hasCap('split') ? [{ id: 'split' as const, label: 'SPLIT', active: vfoOps.splitActive }] : []),
+    ...(hasCap('dial_lock') ? [{ id: 'lock' as const, label: 'LOCK', active: lockActive }] : []),
     ...(dataActive ? [{ id: 'data' as const, label: 'DATA', active: true }] : []),
-    ...(hasCapability('ip_plus') ? [{
+    ...(hasCap('ip_plus') ? [{
       // IP+ is a per-receiver setting on IC-7610 (codex P2 on PR #906).
       // Bind to the active RX so SUB's IP+ state is reflected when SUB is active.
       id: 'ipPlus' as const, label: 'IP+', active: rx?.ipplus ?? false,
@@ -136,96 +140,96 @@
 
   // vfoATokens: per-receiver indicators for VFO A (main)
   let vfoATokens = $derived<IndToken[]>([
-    ...(hasCapability('attenuator') ? [{
+    ...(hasCap('attenuator') ? [{
       id: 'att' as const, label: 'ATT', active: (radioState?.main?.att ?? 0) > 0,
     }] : []),
-    ...(hasCapability('preamp') ? [{
+    ...(hasCap('preamp') ? [{
       id: 'pre' as const,
       label: (radioState?.main?.preamp ?? 0) === 0 ? 'IPO'
            : (radioState?.main?.preamp ?? 0) === 1 ? 'AMP1' : 'AMP2',
       active: true,
     }] : []),
-    ...(hasCapability('digisel') ? [{
+    ...(hasCap('digisel') ? [{
       id: 'digisel' as const, label: 'DIGI-SEL', active: radioState?.main?.digisel ?? false,
     }] : []),
-    ...(hasCapability('nb') ? [{
+    ...(hasCap('nb') ? [{
       id: 'nb' as const,
       label: (radioState?.main?.nb ?? false) || (radioState?.main?.nbLevel ?? 0) > 0
         ? `NB ${radioState?.main?.nbLevel ?? 0}` : 'NB',
       active: (radioState?.main?.nb ?? false) || (radioState?.main?.nbLevel ?? 0) > 0,
     }] : []),
-    ...(hasCapability('nr') ? [{
+    ...(hasCap('nr') ? [{
       id: 'nr' as const,
       label: (radioState?.main?.nr ?? false) || (radioState?.main?.nrLevel ?? 0) > 0
         ? `NR ${radioState?.main?.nrLevel ?? 0}` : 'NR',
       active: (radioState?.main?.nr ?? false) || (radioState?.main?.nrLevel ?? 0) > 0,
     }] : []),
-    ...(hasCapability('contour') ? [{
+    ...(hasCap('contour') ? [{
       id: 'cont' as const, label: 'CONT',
       active: (radioState?.main?.contour ?? 0) > 0,
     }] : []),
-    ...(hasCapability('notch') ? [
+    ...(hasCap('notch') ? [
       { id: 'notch' as const, label: 'NOTCH', active: radioState?.main?.manualNotch ?? false },
       { id: 'anf' as const, label: 'ANF', active: radioState?.main?.autoNotch ?? false },
     ] : []),
     { id: 'agc' as const, label: `AGC ${agcLabelFor(radioState?.main?.agc ?? 2)}`, active: true },
-    ...(hasCapability('rf_gain') ? [{
+    ...(hasCap('rf_gain') ? [{
       id: 'rfg' as const, label: 'RFG', active: (radioState?.main?.rfGain ?? 255) < 255,
     }] : []),
-    ...(hasCapability('squelch') ? [{
+    ...(hasCap('squelch') ? [{
       id: 'sql' as const, label: 'SQL', active: (radioState?.main?.squelch ?? 0) > 0,
     }] : []),
-    ...(hasCapability('rit') ? [{
+    ...(hasCap('rit') ? [{
       id: 'rit' as const, label: 'RIT', active: ritXit.ritActive,
     }] : []),
   ]);
 
   // vfoBTokens: per-receiver indicators for VFO B (sub)
   let vfoBTokens = $derived<IndToken[]>([
-    ...(hasCapability('attenuator') ? [{
+    ...(hasCap('attenuator') ? [{
       id: 'att' as const, label: 'ATT', active: (radioState?.sub?.att ?? 0) > 0,
     }] : []),
-    ...(hasCapability('preamp') ? [{
+    ...(hasCap('preamp') ? [{
       id: 'pre' as const,
       label: (radioState?.sub?.preamp ?? 0) === 0 ? 'IPO'
            : (radioState?.sub?.preamp ?? 0) === 1 ? 'AMP1' : 'AMP2',
       active: true,
     }] : []),
-    ...(hasCapability('digisel') ? [{
+    ...(hasCap('digisel') ? [{
       id: 'digisel' as const, label: 'DIGI-SEL', active: radioState?.sub?.digisel ?? false,
     }] : []),
-    ...(hasCapability('nb') ? [{
+    ...(hasCap('nb') ? [{
       id: 'nb' as const,
       label: (radioState?.sub?.nb ?? false) || (radioState?.sub?.nbLevel ?? 0) > 0
         ? `NB ${radioState?.sub?.nbLevel ?? 0}` : 'NB',
       active: (radioState?.sub?.nb ?? false) || (radioState?.sub?.nbLevel ?? 0) > 0,
     }] : []),
-    ...(hasCapability('nr') ? [{
+    ...(hasCap('nr') ? [{
       id: 'nr' as const,
       label: (radioState?.sub?.nr ?? false) || (radioState?.sub?.nrLevel ?? 0) > 0
         ? `NR ${radioState?.sub?.nrLevel ?? 0}` : 'NR',
       active: (radioState?.sub?.nr ?? false) || (radioState?.sub?.nrLevel ?? 0) > 0,
     }] : []),
-    ...(hasCapability('contour') ? [{
+    ...(hasCap('contour') ? [{
       id: 'cont' as const, label: 'CONT',
       active: (radioState?.sub?.contour ?? 0) > 0,
     }] : []),
-    ...(hasCapability('notch') ? [
+    ...(hasCap('notch') ? [
       { id: 'notch' as const, label: 'NOTCH', active: radioState?.sub?.manualNotch ?? false },
       { id: 'anf' as const, label: 'ANF', active: radioState?.sub?.autoNotch ?? false },
     ] : []),
     { id: 'agc' as const, label: `AGC ${agcLabelFor(radioState?.sub?.agc ?? 2)}`, active: true },
-    ...(hasCapability('rf_gain') ? [{
+    ...(hasCap('rf_gain') ? [{
       id: 'rfg' as const, label: 'RFG', active: (radioState?.sub?.rfGain ?? 255) < 255,
     }] : []),
-    ...(hasCapability('squelch') ? [{
+    ...(hasCap('squelch') ? [{
       id: 'sql' as const, label: 'SQL', active: (radioState?.sub?.squelch ?? 0) > 0,
     }] : []),
   ]);
 
   // Scope subscription — delegates lifecycle to ScopeController (ADR INV-2, INV-5)
   $effect(() => {
-    if (!hasAudioFft()) return;
+    if (!cockpitProps.hasAudioFft) return;
 
     return runtime.scope.subscribe((frame) => {
       fftPixels = frame.pixels;
@@ -235,12 +239,13 @@
   });
 
   // Record active-receiver frequency changes into the local QSY history
-  // ring buffer (#836). `qsyHistory.record()` internally debounces +
-  // filters by Δ ≥ 500 Hz so dial-hunting doesn't pollute the buffer.
+  // ring buffer (#836). The handler delegates to `recordQsy()` in the
+  // adapter, which preserves the store-internal debounce + Δ ≥ 500 Hz
+  // filter so dial-hunting doesn't pollute the buffer.
   $effect(() => {
     const freq = rx?.freqHz ?? 0;
     const mode = rx?.mode ?? '';
-    if (freq > 0) qsyHistory.record(freq, mode);
+    handlers.onTuningChange(freq, mode);
   });
 
   function handleQsyRecall(freqHz: number, mode: string): void {
@@ -291,7 +296,7 @@
   - Indicators (status tokens) placed in aux row, full-width in both modes.
 -->
 <div class="amber-lcd" class:tx-active={tx.txActive}>
-  <div class="lcd-screen" class:dual={hasDualReceiver()}>
+  <div class="lcd-screen" class:dual={cockpitProps.hasDualReceiver}>
     <div class="lcd-scanlines"></div>
 
     <!-- ═══ Global indicator strip (TX/VOX/PROC/ATU/SPLIT/LOCK/DATA/IP+) ═══ -->
@@ -342,7 +347,7 @@
     </div>
 
     <!-- ═══ VFO B cockpit (sub receiver — equal peer on dual-RX) ═══ -->
-    {#if hasDualReceiver()}
+    {#if cockpitProps.hasDualReceiver}
       <div
         class="lcd-vfo-col lcd-vfo-b"
         class:inactive={!vfoBActive}

--- a/frontend/src/lib/runtime/adapters/audio-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/audio-adapter.ts
@@ -13,7 +13,10 @@ export function deriveRxAudioProps(): RxAudioProps {
   const state = runtime.state;
   const caps = runtime.caps;
   const audio = runtime.audio;
-  return toRxAudioProps(state, caps, audio);
+  // Audio-WS connection health — surfaced as a prop so RxAudioPanel
+  // doesn't have to import `$lib/stores/connection.svelte` directly.
+  const audioConnected = runtime.connectionAudio;
+  return toRxAudioProps(state, caps, audio, audioConnected);
 }
 
 // Stable handler object — delegates to existing command-bus logic.

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -26,6 +26,7 @@ import {
 import {
   hasAudioFft, hasDualReceiver, hasCapability,
 } from '$lib/stores/capabilities.svelte';
+import { recordQsy } from './qsy-history-adapter';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 
@@ -166,4 +167,47 @@ export function deriveAmberScopeProps(): AmberScopeProps {
     hasDualReceiver: hasDualReceiver(),
     hasCapability,
   };
+}
+
+// ── AmberCockpit (LCD skin) ──
+// Merge point for Cluster B (radio.current), Cluster A (capabilities), and
+// Cluster D (qsy-history write) — see audit doc Batch 5. Same shape as
+// AmberScope (~16 hasCapability(name) checks → expose the function rather
+// than inflate the type). The qsy-history write happens via the handler
+// bundle below (`onTuningChange`) so the panel never imports the qsy store.
+export interface AmberCockpitProps {
+  radioState: ServerState | null;
+  caps: Capabilities | null;
+  hasAudioFft: boolean;
+  hasDualReceiver: boolean;
+  hasCapability: (name: string) => boolean;
+}
+
+export function deriveAmberCockpitProps(): AmberCockpitProps {
+  return {
+    radioState: runtime.state,
+    caps: runtime.caps,
+    hasAudioFft: hasAudioFft(),
+    hasDualReceiver: hasDualReceiver(),
+    hasCapability,
+  };
+}
+
+export interface AmberCockpitHandlers {
+  /**
+   * Record a tuning change into the QSY history ring buffer (#836). The
+   * underlying store debounces internally — caller may invoke this from a
+   * reactive `$effect` whenever active-receiver freq/mode changes.
+   */
+  onTuningChange: (freqHz: number, mode: string) => void;
+}
+
+const _amberCockpitHandlers: AmberCockpitHandlers = {
+  onTuningChange: (freqHz: number, mode: string) => {
+    if (freqHz > 0) recordQsy(freqHz, mode);
+  },
+};
+
+export function getAmberCockpitHandlers(): AmberCockpitHandlers {
+  return _amberCockpitHandlers;
 }

--- a/frontend/src/lib/runtime/adapters/qsy-history-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/qsy-history-adapter.ts
@@ -1,16 +1,19 @@
 /**
- * QSY history adapter — read-only façade over the qsy-history store.
+ * QSY history adapter — façade over the qsy-history store.
  *
- * Lets LCD aux-row panels (e.g. AmberMemoryStrip) consume the recent-QSY
- * ring buffer through the runtime adapter layer instead of importing
- * `$lib/stores/qsy-history.svelte` directly (CLAUDE.md → "Frontend
- * layering").
+ * Lets LCD aux-row panels (e.g. AmberMemoryStrip, AmberCockpit) consume
+ * and update the recent-QSY ring buffer through the runtime adapter layer
+ * instead of importing `$lib/stores/qsy-history.svelte` directly
+ * (CLAUDE.md → "Frontend layering").
  *
- * Read-side only this batch. The write side (`recordQsy(freqHz, mode)`)
- * lands in batch 5 with AmberCockpit. See
- * `docs/plans/2026-04-29-panel-adapter-migration.md` Cluster D.
+ * Read side: `deriveQsyRecent()` (Tier 2 batch 4, #1247).
+ * Write side: `recordQsy(freqHz, mode)` (Tier 2 batch 5, #1248).
  *
- * Tier 2 batch 4 of #1063. Issue #1247.
+ * The write side is a thin passthrough — debounce semantics (≥ 500 Hz
+ * delta + 1.5s stability, see issue #836) live inside `qsyHistory.record()`
+ * itself and are preserved unchanged.
+ *
+ * See `docs/plans/2026-04-29-panel-adapter-migration.md` Cluster D.
  */
 
 import { qsyHistory, type QsyEntry } from '$lib/stores/qsy-history.svelte';
@@ -20,4 +23,13 @@ export type { QsyEntry };
 /** Latest QSY entries, oldest-first (same shape as `qsyHistory.recent`). */
 export function deriveQsyRecent(): readonly QsyEntry[] {
   return qsyHistory.recent;
+}
+
+/**
+ * Record a potential QSY (frequency / mode). Thin passthrough to
+ * `qsyHistory.record()` — the store internally debounces and filters
+ * by Δ ≥ 500 Hz so dial-hunting doesn't pollute the buffer (#836).
+ */
+export function recordQsy(freqHz: number, mode: string): void {
+  qsyHistory.record(freqHz, mode);
 }

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -532,6 +532,10 @@ export interface RxAudioProps {
   monitorMode: 'local' | 'live' | 'mute';
   afLevel: number;
   hasLiveAudio: boolean;
+  /** Audio-WS connection health — used to render a "link lost" indicator. */
+  isAudioConnected: boolean;
+  /** Capability flag — gates the dual-receiver routing sub-control. */
+  hasDualReceiver: boolean;
 }
 
 export interface AudioUiState {
@@ -544,6 +548,7 @@ export function toRxAudioProps(
   state: ServerState | null,
   caps: Capabilities | null,
   audioState: AudioUiState,
+  audioConnected: boolean,
 ): RxAudioProps {
   const rx = state ? activeRx(state) : null;
   const hasLiveAudio = hasCap(caps, 'audio');
@@ -556,10 +561,13 @@ export function toRxAudioProps(
     monitorMode === 'live'
       ? Math.round((audioState.volume / 100) * 255)
       : (rx?.afLevel ?? 128);
+  const hasDualReceiver = caps?.capabilities?.includes('dual_rx') ?? false;
   return {
     monitorMode,
     afLevel,
     hasLiveAudio,
+    isAudioConnected: audioConnected,
+    hasDualReceiver,
   };
 }
 


### PR DESCRIPTION
## Summary

- **AmberCockpit** migrates to `deriveAmberCockpitProps()` + `getAmberCockpitHandlers()` (new in `panel-adapters.ts`). The tuning `$effect` now routes `onTuningChange(freq, mode)` through the handler bundle, which calls `recordQsy()` in the qsy-history adapter — so the panel never imports the qsy store. Mirrors the existing `deriveAmberScopeProps` shape.
- **RxAudioPanel** migrates to an extended `RxAudioProps` with `isAudioConnected` (from `runtime.connectionAudio`) and `hasDualReceiver` (from `caps.capabilities.includes('dual_rx')`). Drops the direct `connection.svelte` + `capabilities.svelte` imports.
- **`qsy-history-adapter.ts`** grows the write side: `recordQsy(freqHz, mode)` — a thin passthrough so the debounce + Δ ≥ 500 Hz semantics from #836 stay inside `qsyHistory.record()` itself.
- **After this PR, zero non-test panels in `components-v2/panels/` import `$lib/stores/*`.** Verified via `grep -rEn "import\s+.*\\\$lib/stores" frontend/src/components-v2/panels/ | grep -v __tests__` — empty result. Unblocks #1241 (ESLint lockdown).

## Notes on the audit doc

The original task brief mentioned that `AmberMemoryStrip.svelte`, `filter-controls.ts`, and `meter-utils.ts` "still import `$lib/stores/*`". On inspection these were **false positives** — the matches are docstring/comment references explaining the previous migration ("no longer reaches into `$lib/stores/*` directly"), not actual `import` statements. Batch 4 (#1247) handled all of those. Confirmed with a stricter regex; only the two scoped panels remained.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/` clean
- [x] `npx vitest run` — 92 files, 1687 tests, all passing
- [x] `npm run build` succeeds
- [x] `uv run pytest tests/` — 5297 passed, no new failures
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `grep -rEn "import\s+.*\\\$lib/stores" frontend/src/components-v2/panels/ | grep -v __tests__` returns empty

Closes #1248
Refs #1063 (Tier 2 batch 5/5). Parent: #1238