### PR TITLE
refactor(#1241,frontend): ESLint lockdown — panels banned from $lib/stores/*

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   batch, no non-test panel under `components-v2/panels/` imports from
   `$lib/stores/*`. Tier 2 batch 5/5 of #1063 — unblocks #1241 (ESLint
   lockdown).
+- **ESLint lockdown: panels banned from `$lib/stores/*` (#1241).** With all
+  18 panels migrated to adapters across batches 1-5, the boundary is now
+  enforced at lint time. Tests remain exempt for mocking purposes. Closes
+  Tier 2 of #1063.
 
 ### Docs
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -44,6 +44,50 @@ const FORBIDDEN_RUNTIME_IMPORTS = {
   ],
 };
 
+/**
+ * Panel-specific lockdown (Tier 2 — issue #1241).
+ *
+ * After all 18 panels migrated to adapters across batches 1-5
+ * (#1244, #1245, #1246, #1247, #1248), the boundary is enforced at lint time.
+ * Panels must route store reads through `lib/runtime/adapters/*` (state + commands).
+ *
+ * Note: this is panel-only on purpose. Other presentation layers (layout, display,
+ * meters, vfo, controls, skins) have their own Tier-N migrations tracked under #1063.
+ */
+const FORBIDDEN_PANEL_IMPORTS = {
+  patterns: [
+    {
+      group: ['$lib/stores/*', '$lib/stores', '**/lib/stores/*', '**/lib/stores'],
+      message:
+        'Panels must not import from $lib/stores/* — route via lib/runtime/adapters/* instead. ' +
+        'See docs/plans/2026-04-29-panel-adapter-migration.md and ADR 2026-04-12.',
+    },
+    {
+      group: ['$lib/transport/*', '**/lib/transport/*'],
+      message:
+        'Presentation components must not import transport modules (sendCommand, getChannel). ' +
+        'Use callback props from the adapter/wiring layer instead. ' +
+        'See ADR 2026-04-12.',
+    },
+    {
+      group: ['**/lib/audio/audio-manager'],
+      message:
+        'Presentation components must not import audioManager directly (relative paths included). ' +
+        'Use callback props from the adapter/wiring layer instead. ' +
+        'See ADR 2026-04-12.',
+    },
+  ],
+  paths: [
+    {
+      name: '$lib/audio/audio-manager',
+      message:
+        'Presentation components must not import audioManager directly. ' +
+        'Use callback props from the adapter/wiring layer instead. ' +
+        'See ADR 2026-04-12.',
+    },
+  ],
+};
+
 export default [
   // ── Global ignores ──
   {
@@ -115,6 +159,21 @@ export default [
     ],
     rules: {
       'no-restricted-imports': ['error', FORBIDDEN_RUNTIME_IMPORTS],
+    },
+  },
+
+  // ── Import boundary: panels (Tier 2 lockdown — issue #1241) ──
+  // Adds `$lib/stores/*` to the panel-specific ban list. All 18 panels were migrated
+  // to adapters across batches 1-5 (#1244, #1245, #1246, #1247, #1248); this block
+  // freezes the boundary so it cannot regress. Other presentation layers retain the
+  // looser FORBIDDEN_RUNTIME_IMPORTS rule until their own tier migrates (#1063).
+  {
+    files: [
+      'src/components-v2/panels/**/*.svelte',
+      'src/components-v2/panels/**/*.ts',
+    ],
+    rules: {
+      'no-restricted-imports': ['error', FORBIDDEN_PANEL_IMPORTS],
     },
   },
 


### PR DESCRIPTION
## Summary
- `no-restricted-imports` rule extended to ban `$lib/stores/*` in `components-v2/panels/**`
- All 18 panels were migrated in batches 1-5 (#1244, #1245, #1246, #1247, #1248)
- Test files remain exempt for mocking
- Closes Tier 2 of #1063

## Test plan
- [x] `npx eslint src/` — zero violations
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` pass (1687 tests)
- [x] `npm run build` succeeds
- [x] `uv run pytest tests/ --ignore=tests/integration` — 5025 passed

Closes #1241
Refs #1063 (Tier 2). Parent: #1238