### PR TITLE
refactor(#1261): extract web_startup.py from web/server.py

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   18 panels migrated to adapters across batches 1-5, the boundary is now
   enforced at lint time. Tests remain exempt for mocking purposes. Closes
   Tier 2 of #1063.
+- **`WebServer.start()` / `stop()` orchestration extracted to `web_startup.py`
+  (#1261).** The 200+ LOC of startup/shutdown logic now lives in a dedicated
+  module; `WebServer.start()` / `stop()` are thin delegators. Public API
+  unchanged. Tier 3 wave 4 of #1063.
 
 ### Docs
 

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -29,7 +29,7 @@ import pathlib
 import urllib.parse
 from dataclasses import dataclass, field
 from collections.abc import Coroutine
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from .. import __version__
 from .._bounded_queue import BoundedQueue
@@ -39,7 +39,7 @@ from ..audio_analyzer import AudioAnalyzer
 from ..audio_fft_scope import AudioFftScope
 from ..startup_checks import assert_radio_startup_ready
 from ._delta_encoder import DeltaEncoder  # noqa: TID251
-from .discovery import DiscoveryResponder, RadioInfo  # noqa: TID251
+from .discovery import DiscoveryResponder  # noqa: TID251
 from .dx_cluster import DXClusterClient, SpotBuffer  # noqa: TID251
 from .handlers import AudioBroadcaster, AudioHandler, ControlHandler, ScopeHandler  # noqa: TID251
 from .rtc import handle_rtc_offer, rtc_capability_info, webrtc_available  # noqa: TID251
@@ -917,129 +917,9 @@ class WebServer:
 
     async def start(self) -> None:
         """Start the HTTP/WS listener and RadioPoller (if radio is connected)."""
-        # Load band plan TOML files
-        # Try project-level band-plans/ directory first, then package fallback
-        from pathlib import Path
+        from .web_startup import start_web_server  # noqa: TID251
 
-        project_bp = Path(__file__).resolve().parents[3] / "band-plans"
-        if project_bp.is_dir():
-            self._band_plan.load(project_bp)
-        else:
-            logger.info("band-plan: no band-plans/ directory found")
-
-        # Load EiBi cache if available (non-blocking)
-        try:
-            result = await self._eibi.load_cache()
-            if result.get("status") == "ok":
-                logger.info(
-                    "eibi: loaded %d stations from cache (season %s)",
-                    self._eibi.station_count,
-                    self._eibi.season,
-                )
-        except Exception:
-            logger.debug("eibi: no cache to load at startup")
-
-        ssl_ctx = None
-        if self._config.tls:
-            from .tls import build_ssl_context  # noqa: TID251
-
-            ssl_ctx = build_ssl_context(
-                cert_path=self._config.tls_cert or None,
-                key_path=self._config.tls_key or None,
-            )
-
-        assert_radio_startup_ready(self._radio, component="web startup")
-
-        self._server = await asyncio.start_server(
-            self._accept_client,
-            host=self._config.host,
-            port=self._config.port,
-            ssl=ssl_ctx,
-            reuse_address=True,
-            reuse_port=True,
-        )
-        addr = self._server.sockets[0].getsockname()
-        scheme = "https" if ssl_ctx else "http"
-        logger.info("web server listening on %s://%s:%d", scheme, addr[0], addr[1])
-        if self._radio is not None:
-            from ..radio_protocol import StateNotifyCapable
-
-            # --- Yaesu CAT backend: use YaesuCatPoller (request-response) ---
-            _is_yaesu = getattr(self._radio, "backend_id", None) == "yaesu_cat"
-
-            if _is_yaesu:
-                from ..backends.yaesu_cat.poller import YaesuCatPoller
-
-                def _yaesu_state_cb(state: "RadioState") -> None:
-                    self._radio_state = state
-                    self._broadcast_state_update()
-
-                from ..backends.yaesu_cat.radio import YaesuCatRadio as _YaesuCatRadio
-
-                self._yaesu_poller = YaesuCatPoller(
-                    cast(_YaesuCatRadio, self._radio),
-                    callback=_yaesu_state_cb,
-                    command_queue=self._command_queue,
-                )
-                self._spawn(self._yaesu_poller.start())
-                logger.info("Yaesu CAT poller started")
-            else:
-                # --- Icom CI-V backend: fire-and-forget RadioPoller ---
-                if isinstance(self._radio, StateNotifyCapable):
-                    # Register callback so CI-V RX stream can notify us of state changes.
-                    self._radio.set_state_change_callback(self._on_radio_state_change)
-                    # Re-enable scope after soft_reconnect (CI-V stream reset loses scope state)
-                    self._radio.set_reconnect_callback(self._on_radio_reconnect)
-                self._radio_poller = RadioPoller(
-                    self._radio,
-                    self._command_queue,
-                    on_state_event=self._on_poller_state_event,
-                    radio_state=self._radio_state,
-                )
-                self._radio_poller.start()
-            if _supports_scope(self._radio):
-                self._scope_health_task = asyncio.get_running_loop().create_task(
-                    self._scope_health_monitor(), name="scope-health"
-                )
-        self._zombie_reaper_task = asyncio.get_running_loop().create_task(
-            self._zombie_reaper(), name="zombie-reaper"
-        )
-        if self._config.dx_cluster_host:
-            self._dx_client = DXClusterClient(
-                self._config.dx_cluster_host,
-                self._config.dx_cluster_port,
-                self._config.dx_callsign,
-                on_spot=self._broadcast_dx_spot,
-            )
-            self._dx_client_task = asyncio.get_running_loop().create_task(
-                self._dx_client.start(), name="dx-cluster"
-            )
-            logger.info(
-                "dx-cluster: connecting to %s:%d as %s",
-                self._config.dx_cluster_host,
-                self._config.dx_cluster_port,
-                self._config.dx_callsign,
-            )
-
-        # Start UDP discovery responder
-        if self._config.discovery:
-            radio = self._radio
-
-            def _radio_provider() -> RadioInfo | None:
-                if radio is None:
-                    return None
-                return RadioInfo(
-                    model=getattr(radio, "model", None) or self._config.radio_model,
-                    connected=bool(getattr(radio, "connected", False)),
-                )
-
-            self._discovery = DiscoveryResponder(
-                web_port=self._config.port,
-                tls=self._config.tls,
-                radio_provider=_radio_provider,
-                discovery_port=self._config.discovery_port,
-            )
-            await self._discovery.start()
+        await start_web_server(self)
 
     # ------------------------------------------------------------------
     # Audio Bridge (virtual device integration)
@@ -1106,83 +986,9 @@ class WebServer:
 
     async def stop(self) -> None:
         """Close the listener, stop RadioPoller, disconnect radio, cancel tasks."""
-        # 1. Stop poller first (no more CI-V queries)
-        if self._radio_poller is not None:
-            self._radio_poller.stop()
-            self._radio_poller = None
-        if self._yaesu_poller is not None:
-            try:
-                await asyncio.wait_for(self._yaesu_poller.stop(), timeout=2.0)
-            except TimeoutError:
-                logger.warning("yaesu poller stop timed out")
-            self._yaesu_poller = None
+        from .web_startup import stop_web_server  # noqa: TID251
 
-        # 2. Stop audio relay (stops AudioBus subscription → stop_audio_rx_opus)
-        try:
-            await asyncio.wait_for(self._audio_broadcaster._stop_relay(), timeout=2.0)
-        except (TimeoutError, Exception) as exc:
-            logger.warning("audio relay stop: %s", exc)
-        if self._audio_bridge is not None:
-            await self.stop_audio_bridge()
-
-        # 3. Stop discovery responder
-        if self._discovery is not None:
-            await self._discovery.stop()
-            self._discovery = None
-
-        # 4. Stop DX cluster
-        if self._dx_client is not None:
-            await self._dx_client.stop()
-            self._dx_client = None
-        if self._dx_client_task is not None:
-            self._dx_client_task.cancel()
-            try:
-                await self._dx_client_task
-            except asyncio.CancelledError:
-                pass
-            self._dx_client_task = None
-
-        # 5. Cancel housekeeping tasks
-        for task in (
-            self._zombie_reaper_task,
-            self._scope_health_task,
-            self._scope_reenable_task,
-        ):
-            if task is not None:
-                task.cancel()
-        self._zombie_reaper_task = None
-        self._scope_health_task = None
-        self._scope_reenable_task = None
-
-        # 6. Cancel all background + client tasks first
-        all_tasks = list(self._bg_tasks) + list(self._client_tasks)
-        for task in all_tasks:
-            task.cancel()
-
-        # 7. Close TCP listener (now that client tasks are cancelled,
-        #    wait_closed() won't block on open connections)
-        if self._server is not None:
-            self._server.close()
-            try:
-                await asyncio.wait_for(self._server.wait_closed(), timeout=2.0)
-            except TimeoutError:
-                logger.warning("server.wait_closed() timed out after 2s")
-            self._server = None
-
-        # 8. Wait for cancelled tasks to finish (with timeout)
-        if all_tasks:
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*all_tasks, return_exceptions=True),
-                    timeout=3.0,
-                )
-            except TimeoutError:
-                logger.warning("tasks did not finish in 3s, continuing shutdown")
-        self._bg_tasks.clear()
-
-        # Radio disconnect is handled by the caller's context manager
-        # (async with radio: in _run). Do NOT disconnect here.
-        logger.info("web server stopped")
+        await stop_web_server(self)
 
     async def serve_forever(self) -> None:
         """Start and block until cancelled.  Handles SIGTERM/SIGINT gracefully."""

--- a/src/icom_lan/web/web_startup.py
+++ b/src/icom_lan/web/web_startup.py
@@ -1,0 +1,247 @@
+"""Startup/shutdown orchestration for :class:`icom_lan.web.server.WebServer`.
+
+Extracted from ``web/server.py`` to keep ``WebServer.start()`` /
+``WebServer.stop()`` as thin delegators (issue #1261, Tier 3 wave 4 of #1063).
+
+The functions here access ``WebServer`` state via the ``server`` argument
+(clean dependency injection — no module-level state).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from ..radio_state import RadioState
+from ..startup_checks import assert_radio_startup_ready
+from .discovery import DiscoveryResponder, RadioInfo  # noqa: TID251
+from .dx_cluster import DXClusterClient  # noqa: TID251
+from .radio_poller import RadioPoller  # noqa: TID251
+from .runtime_helpers import runtime_capabilities  # noqa: TID251
+
+if TYPE_CHECKING:
+    from .server import WebServer  # noqa: TID251
+
+__all__ = ["start_web_server", "stop_web_server"]
+
+logger = logging.getLogger(__name__)
+
+
+def _supports_scope_local(server: WebServer) -> bool:
+    return "scope" in runtime_capabilities(server._radio)
+
+
+async def start_web_server(server: WebServer) -> None:
+    """Start the HTTP/WS listener and RadioPoller (if radio is connected).
+
+    Mirrors the original :meth:`WebServer.start` body verbatim — the method
+    now delegates here so the public API is preserved.
+    """
+    # Load band plan TOML files
+    # Try project-level band-plans/ directory first, then package fallback
+    project_bp = Path(__file__).resolve().parents[3] / "band-plans"
+    if project_bp.is_dir():
+        server._band_plan.load(project_bp)
+    else:
+        logger.info("band-plan: no band-plans/ directory found")
+
+    # Load EiBi cache if available (non-blocking)
+    try:
+        result = await server._eibi.load_cache()
+        if result.get("status") == "ok":
+            logger.info(
+                "eibi: loaded %d stations from cache (season %s)",
+                server._eibi.station_count,
+                server._eibi.season,
+            )
+    except Exception:
+        logger.debug("eibi: no cache to load at startup")
+
+    ssl_ctx = None
+    if server._config.tls:
+        from .tls import build_ssl_context  # noqa: TID251
+
+        ssl_ctx = build_ssl_context(
+            cert_path=server._config.tls_cert or None,
+            key_path=server._config.tls_key or None,
+        )
+
+    assert_radio_startup_ready(server._radio, component="web startup")
+
+    server._server = await asyncio.start_server(
+        server._accept_client,
+        host=server._config.host,
+        port=server._config.port,
+        ssl=ssl_ctx,
+        reuse_address=True,
+        reuse_port=True,
+    )
+    addr = server._server.sockets[0].getsockname()
+    scheme = "https" if ssl_ctx else "http"
+    logger.info("web server listening on %s://%s:%d", scheme, addr[0], addr[1])
+    if server._radio is not None:
+        from ..radio_protocol import StateNotifyCapable
+
+        # --- Yaesu CAT backend: use YaesuCatPoller (request-response) ---
+        _is_yaesu = getattr(server._radio, "backend_id", None) == "yaesu_cat"
+
+        if _is_yaesu:
+            from ..backends.yaesu_cat.poller import YaesuCatPoller
+
+            def _yaesu_state_cb(state: RadioState) -> None:
+                server._radio_state = state
+                server._broadcast_state_update()
+
+            from ..backends.yaesu_cat.radio import YaesuCatRadio as _YaesuCatRadio
+
+            server._yaesu_poller = YaesuCatPoller(
+                cast(_YaesuCatRadio, server._radio),
+                callback=_yaesu_state_cb,
+                command_queue=server._command_queue,
+            )
+            server._spawn(server._yaesu_poller.start())
+            logger.info("Yaesu CAT poller started")
+        else:
+            # --- Icom CI-V backend: fire-and-forget RadioPoller ---
+            if isinstance(server._radio, StateNotifyCapable):
+                # Register callback so CI-V RX stream can notify us of state changes.
+                server._radio.set_state_change_callback(server._on_radio_state_change)
+                # Re-enable scope after soft_reconnect (CI-V stream reset loses scope state)
+                server._radio.set_reconnect_callback(server._on_radio_reconnect)
+            server._radio_poller = RadioPoller(
+                server._radio,
+                server._command_queue,
+                on_state_event=server._on_poller_state_event,
+                radio_state=server._radio_state,
+            )
+            server._radio_poller.start()
+        if _supports_scope_local(server):
+            server._scope_health_task = asyncio.get_running_loop().create_task(
+                server._scope_health_monitor(), name="scope-health"
+            )
+    server._zombie_reaper_task = asyncio.get_running_loop().create_task(
+        server._zombie_reaper(), name="zombie-reaper"
+    )
+    if server._config.dx_cluster_host:
+        server._dx_client = DXClusterClient(
+            server._config.dx_cluster_host,
+            server._config.dx_cluster_port,
+            server._config.dx_callsign,
+            on_spot=server._broadcast_dx_spot,
+        )
+        server._dx_client_task = asyncio.get_running_loop().create_task(
+            server._dx_client.start(), name="dx-cluster"
+        )
+        logger.info(
+            "dx-cluster: connecting to %s:%d as %s",
+            server._config.dx_cluster_host,
+            server._config.dx_cluster_port,
+            server._config.dx_callsign,
+        )
+
+    # Start UDP discovery responder
+    if server._config.discovery:
+        radio = server._radio
+
+        def _radio_provider() -> RadioInfo | None:
+            if radio is None:
+                return None
+            return RadioInfo(
+                model=getattr(radio, "model", None) or server._config.radio_model,
+                connected=bool(getattr(radio, "connected", False)),
+            )
+
+        server._discovery = DiscoveryResponder(
+            web_port=server._config.port,
+            tls=server._config.tls,
+            radio_provider=_radio_provider,
+            discovery_port=server._config.discovery_port,
+        )
+        await server._discovery.start()
+
+
+async def stop_web_server(server: WebServer) -> None:
+    """Close the listener, stop RadioPoller, disconnect radio, cancel tasks.
+
+    Mirrors the original :meth:`WebServer.stop` body verbatim — the method
+    now delegates here so the public API is preserved.
+    """
+    # 1. Stop poller first (no more CI-V queries)
+    if server._radio_poller is not None:
+        server._radio_poller.stop()
+        server._radio_poller = None
+    if server._yaesu_poller is not None:
+        try:
+            await asyncio.wait_for(server._yaesu_poller.stop(), timeout=2.0)
+        except TimeoutError:
+            logger.warning("yaesu poller stop timed out")
+        server._yaesu_poller = None
+
+    # 2. Stop audio relay (stops AudioBus subscription → stop_audio_rx_opus)
+    try:
+        await asyncio.wait_for(server._audio_broadcaster._stop_relay(), timeout=2.0)
+    except (TimeoutError, Exception) as exc:
+        logger.warning("audio relay stop: %s", exc)
+    if server._audio_bridge is not None:
+        await server.stop_audio_bridge()
+
+    # 3. Stop discovery responder
+    if server._discovery is not None:
+        await server._discovery.stop()
+        server._discovery = None
+
+    # 4. Stop DX cluster
+    if server._dx_client is not None:
+        await server._dx_client.stop()
+        server._dx_client = None
+    if server._dx_client_task is not None:
+        server._dx_client_task.cancel()
+        try:
+            await server._dx_client_task
+        except asyncio.CancelledError:
+            pass
+        server._dx_client_task = None
+
+    # 5. Cancel housekeeping tasks
+    for task in (
+        server._zombie_reaper_task,
+        server._scope_health_task,
+        server._scope_reenable_task,
+    ):
+        if task is not None:
+            task.cancel()
+    server._zombie_reaper_task = None
+    server._scope_health_task = None
+    server._scope_reenable_task = None
+
+    # 6. Cancel all background + client tasks first
+    all_tasks = list(server._bg_tasks) + list(server._client_tasks)
+    for task in all_tasks:
+        task.cancel()
+
+    # 7. Close TCP listener (now that client tasks are cancelled,
+    #    wait_closed() won't block on open connections)
+    if server._server is not None:
+        server._server.close()
+        try:
+            await asyncio.wait_for(server._server.wait_closed(), timeout=2.0)
+        except TimeoutError:
+            logger.warning("server.wait_closed() timed out after 2s")
+        server._server = None
+
+    # 8. Wait for cancelled tasks to finish (with timeout)
+    if all_tasks:
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*all_tasks, return_exceptions=True),
+                timeout=3.0,
+            )
+        except TimeoutError:
+            logger.warning("tasks did not finish in 3s, continuing shutdown")
+    server._bg_tasks.clear()
+
+    # Radio disconnect is handled by the caller's context manager
+    # (async with radio: in _run). Do NOT disconnect here.
+    logger.info("web server stopped")

--- a/tests/test_dx_cluster.py
+++ b/tests/test_dx_cluster.py
@@ -523,7 +523,7 @@ class TestWebServerDXBroadcast:
         )
         srv = WebServer(None, config)
 
-        with patch("icom_lan.web.server.DXClusterClient") as MockClient:
+        with patch("icom_lan.web.web_startup.DXClusterClient") as MockClient:
             mock_instance = MagicMock()
             mock_instance.start = AsyncMock()
             mock_instance.stop = AsyncMock()

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -135,10 +135,10 @@ async def test_start_and_stop_with_radio_sets_callbacks() -> None:
     srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
     with (
         patch(
-            "icom_lan.web.server.asyncio.start_server",
+            "icom_lan.web.web_startup.asyncio.start_server",
             new=AsyncMock(return_value=fake_server),
         ),
-        patch("icom_lan.web.server.RadioPoller", return_value=fake_poller),
+        patch("icom_lan.web.web_startup.RadioPoller", return_value=fake_poller),
     ):
         await srv.start()
         assert srv.port == 4242
@@ -182,11 +182,11 @@ async def test_start_aborts_before_listening_when_radio_not_ready() -> None:
 
     with (
         patch(
-            "icom_lan.web.server.assert_radio_startup_ready",
+            "icom_lan.web.web_startup.assert_radio_startup_ready",
             side_effect=RuntimeError("web startup aborted"),
         ),
         patch(
-            "icom_lan.web.server.asyncio.start_server", new=AsyncMock()
+            "icom_lan.web.web_startup.asyncio.start_server", new=AsyncMock()
         ) as start_server,
     ):
         with pytest.raises(RuntimeError, match="web startup aborted"):


### PR DESCRIPTION
## Summary
- New `src/icom_lan/web/web_startup.py` with `start_web_server` / `stop_web_server` orchestration functions (~200 LOC moved verbatim).
- `WebServer.start()` / `.stop()` are now thin delegators (public API stable).
- No behavior change.

## Test plan
- [x] `uv run pytest tests/` — 5297 passed, 57 skipped, 9 xfailed, 1 xpassed
- [x] `uv run mypy src/` — clean (146 files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` on touched files — clean

## Test adjustments
- `tests/test_dx_cluster.py` — patch path `icom_lan.web.server.DXClusterClient` → `icom_lan.web.web_startup.DXClusterClient`.
- `tests/test_web_server_coverage.py` — same redirect for `asyncio.start_server`, `RadioPoller`, `assert_radio_startup_ready` patches (the symbols are now resolved in `web_startup`).

Closes #1261
Refs #1063 (Tier 3 wave 4). Parent: #1255