### PR TITLE
refactor(#1258): extract radio_state_snapshot.py from radio.py

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`snapshot_state` / `restore_state` extracted to `radio_state_snapshot.py`
+  (#1258).** ~150 LOC moved out of `radio.py` god-object; `IcomRadio` methods
+  are thin delegators. Public API unchanged. Tier 3 wave 3 of #1063.
 - **`_civ_rx._update_radio_state_from_frame` decomposed into table-driven
   dispatch (#1257).** The 400-line if/elif over CI-V commands now dispatches
   via `_HANDLERS: dict[int, Callable]`; each branch is a small private

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from ._runtime_protocols import ControlPhaseHost
 
+from . import radio_state_snapshot as _state_snapshot
 from ._audio_recovery import AudioRecoveryRuntime, AudioRecoveryState
 from ._audio_runtime_mixin import AudioRuntimeMixin
 from ._audio_transcoder import PcmOpusTranscoder
@@ -3568,139 +3569,18 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
 
     async def snapshot_state(self) -> dict[str, object]:
-        """Best-effort snapshot of core rig state for safe restore."""
-        self._check_connected()
-        state: dict[str, object] = {}
+        """Best-effort snapshot of core rig state for safe restore.
 
-        try:
-            state["frequency"] = await self.get_freq()
-        except Exception:
-            logger.debug("snapshot: get_freq failed, using cache", exc_info=True)
-            if self._last_freq_hz is not None:
-                state["frequency"] = self._last_freq_hz
-
-        try:
-            mode, filt = await self.get_mode_info()
-            state["mode"] = mode
-            if filt is not None:
-                state["filter"] = filt
-        except Exception:
-            logger.debug("snapshot: get_mode_info failed, using cache", exc_info=True)
-            if self._last_mode is not None:
-                state["mode"] = self._last_mode
-            if self._filter_width is not None:
-                state["filter"] = self._filter_width
-
-        try:
-            state["power"] = await self.get_rf_power()
-        except Exception:
-            logger.debug("snapshot: get_rf_power failed, using cache", exc_info=True)
-            if self._last_power is not None:
-                state["power"] = self._last_power
-
-        if self._last_split is not None:
-            state["split"] = self._last_split
-        if self._last_vfo is not None:
-            state["vfo"] = self._last_vfo
-        if self._attenuator_state is not None:
-            state["attenuator"] = self._attenuator_state
-        if self._preamp_level is not None:
-            state["preamp"] = self._preamp_level
-        try:
-            state["vox"] = await self.get_vox()
-        except Exception:
-            logger.debug("snapshot: get_vox failed", exc_info=True)
-        try:
-            state["data_mode"] = await self.get_data_mode()
-        except Exception:
-            logger.debug("snapshot: get_data_mode failed", exc_info=True)
-        try:
-            state["data_off_mod_input"] = await self.get_data_off_mod_input()
-        except Exception:
-            logger.debug("snapshot: get_data_off_mod_input failed", exc_info=True)
-        try:
-            state["data1_mod_input"] = await self.get_data1_mod_input()
-        except Exception:
-            logger.debug("snapshot: get_data1_mod_input failed", exc_info=True)
-
-        return state
+        Implementation lives in :mod:`icom_lan.radio_state_snapshot` (#1258).
+        """
+        return await _state_snapshot.snapshot_state(self)
 
     async def restore_state(self, state: dict[str, object]) -> None:
-        """Best-effort restore of state produced by snapshot_state()."""
-        self._check_connected()
+        """Best-effort restore of state produced by :meth:`snapshot_state`.
 
-        if "split" in state:
-            try:
-                await self.set_split(bool(state["split"]))
-            except Exception:
-                logger.debug("restore_state: set_split failed", exc_info=True)
-        if "vfo" in state:
-            try:
-                # Internal: ``_set_vfo_wire`` accepts the full
-                # "A"/"B"/"MAIN"/"SUB" alphabet that snapshots may carry
-                # (the public ``set_vfo`` overload was removed in v0.20,
-                # see #1206 — ``set_vfo_slot`` only accepts A/B).
-                await self._set_vfo_wire(str(state["vfo"]))
-            except Exception:
-                logger.debug("restore_state: set_vfo failed", exc_info=True)
-
-        if "power" in state:
-            try:
-                await self.set_rf_power(int(cast(int, state["power"])))
-            except Exception:
-                logger.debug("restore_state: set_rf_power failed", exc_info=True)
-
-        mode = state.get("mode")
-        filt = state.get("filter")
-        if isinstance(mode, Mode):
-            try:
-                await self.set_mode(
-                    mode, filter_width=int(filt) if isinstance(filt, int) else None
-                )
-            except Exception:
-                logger.debug("restore_state: set_mode failed", exc_info=True)
-
-        if "frequency" in state:
-            try:
-                await self.set_freq(int(cast(int, state["frequency"])))
-            except Exception:
-                logger.debug("restore_state: set_frequency failed", exc_info=True)
-
-        if "attenuator" in state:
-            try:
-                await self.set_attenuator(bool(state["attenuator"]))
-            except Exception:
-                logger.debug("restore_state: set_attenuator failed", exc_info=True)
-
-        if "preamp" in state:
-            try:
-                await self.set_preamp(int(cast(int, state["preamp"])))
-            except Exception:
-                logger.debug("restore_state: set_preamp failed", exc_info=True)
-        if "vox" in state:
-            try:
-                await self.set_vox(bool(state["vox"]))
-            except Exception:
-                logger.debug("restore_state: set_vox failed", exc_info=True)
-        if "data_mode" in state:
-            try:
-                await self.set_data_mode(bool(state["data_mode"]))
-            except Exception:
-                logger.debug("restore_state: set_data_mode failed", exc_info=True)
-        if "data_off_mod_input" in state:
-            try:
-                await self.set_data_off_mod_input(
-                    int(cast(int, state["data_off_mod_input"]))
-                )
-            except Exception:
-                logger.debug(
-                    "restore_state: set_data_off_mod_input failed", exc_info=True
-                )
-        if "data1_mod_input" in state:
-            try:
-                await self.set_data1_mod_input(int(cast(int, state["data1_mod_input"])))
-            except Exception:
-                logger.debug("restore_state: set_data1_mod_input failed", exc_info=True)
+        Implementation lives in :mod:`icom_lan.radio_state_snapshot` (#1258).
+        """
+        await _state_snapshot.restore_state(self, state)
 
     async def run_state_transaction(
         self,

--- a/src/icom_lan/radio_state_snapshot.py
+++ b/src/icom_lan/radio_state_snapshot.py
@@ -1,0 +1,163 @@
+"""Snapshot/restore helpers for :class:`IcomRadio` state.
+
+Extracted from ``radio.py`` (issue #1258, Tier 3 wave 3 of #1063) to slim down
+the god-object module. The two functions here read from / write to a radio
+instance using only its public API (``get_*``/``set_*``) plus a small number of
+documented internal attributes (``_last_*`` caches, ``_attenuator_state``,
+``_preamp_level``, ``_filter_width``) and the wire-level helper
+``_set_vfo_wire``.
+
+The behaviour is intentionally identical to the previous ``IcomRadio.snapshot_state``
+and ``IcomRadio.restore_state`` methods: best-effort, with all per-field failures
+swallowed and logged at DEBUG level. The public ``IcomRadio.snapshot_state`` /
+``IcomRadio.restore_state`` methods now delegate here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, cast
+
+from .types import Mode
+
+if TYPE_CHECKING:
+    # Internal implementation module for IcomRadio — the TID251 ban targets
+    # external consumers (web/, rigctld/), not radio.py's own helpers.
+    from .radio import IcomRadio  # type: ignore[attr-defined]  # noqa: TID251
+
+logger = logging.getLogger(__name__)
+
+
+async def snapshot_state(radio: IcomRadio) -> dict[str, object]:
+    """Best-effort snapshot of core rig state for safe restore."""
+    radio._check_connected()
+    state: dict[str, object] = {}
+
+    try:
+        state["frequency"] = await radio.get_freq()
+    except Exception:
+        logger.debug("snapshot: get_freq failed, using cache", exc_info=True)
+        if radio._last_freq_hz is not None:
+            state["frequency"] = radio._last_freq_hz
+
+    try:
+        mode, filt = await radio.get_mode_info()
+        state["mode"] = mode
+        if filt is not None:
+            state["filter"] = filt
+    except Exception:
+        logger.debug("snapshot: get_mode_info failed, using cache", exc_info=True)
+        if radio._last_mode is not None:
+            state["mode"] = radio._last_mode
+        if radio._filter_width is not None:
+            state["filter"] = radio._filter_width
+
+    try:
+        state["power"] = await radio.get_rf_power()
+    except Exception:
+        logger.debug("snapshot: get_rf_power failed, using cache", exc_info=True)
+        if radio._last_power is not None:
+            state["power"] = radio._last_power
+
+    if radio._last_split is not None:
+        state["split"] = radio._last_split
+    if radio._last_vfo is not None:
+        state["vfo"] = radio._last_vfo
+    if radio._attenuator_state is not None:
+        state["attenuator"] = radio._attenuator_state
+    if radio._preamp_level is not None:
+        state["preamp"] = radio._preamp_level
+    try:
+        state["vox"] = await radio.get_vox()
+    except Exception:
+        logger.debug("snapshot: get_vox failed", exc_info=True)
+    try:
+        state["data_mode"] = await radio.get_data_mode()
+    except Exception:
+        logger.debug("snapshot: get_data_mode failed", exc_info=True)
+    try:
+        state["data_off_mod_input"] = await radio.get_data_off_mod_input()
+    except Exception:
+        logger.debug("snapshot: get_data_off_mod_input failed", exc_info=True)
+    try:
+        state["data1_mod_input"] = await radio.get_data1_mod_input()
+    except Exception:
+        logger.debug("snapshot: get_data1_mod_input failed", exc_info=True)
+
+    return state
+
+
+async def restore_state(radio: IcomRadio, state: dict[str, object]) -> None:
+    """Best-effort restore of state produced by :func:`snapshot_state`."""
+    radio._check_connected()
+
+    if "split" in state:
+        try:
+            await radio.set_split(bool(state["split"]))
+        except Exception:
+            logger.debug("restore_state: set_split failed", exc_info=True)
+    if "vfo" in state:
+        try:
+            # Internal: ``_set_vfo_wire`` accepts the full
+            # "A"/"B"/"MAIN"/"SUB" alphabet that snapshots may carry
+            # (the public ``set_vfo`` overload was removed in v0.20,
+            # see #1206 — ``set_vfo_slot`` only accepts A/B).
+            await radio._set_vfo_wire(str(state["vfo"]))
+        except Exception:
+            logger.debug("restore_state: set_vfo failed", exc_info=True)
+
+    if "power" in state:
+        try:
+            await radio.set_rf_power(int(cast(int, state["power"])))
+        except Exception:
+            logger.debug("restore_state: set_rf_power failed", exc_info=True)
+
+    mode = state.get("mode")
+    filt = state.get("filter")
+    if isinstance(mode, Mode):
+        try:
+            await radio.set_mode(
+                mode, filter_width=int(filt) if isinstance(filt, int) else None
+            )
+        except Exception:
+            logger.debug("restore_state: set_mode failed", exc_info=True)
+
+    if "frequency" in state:
+        try:
+            await radio.set_freq(int(cast(int, state["frequency"])))
+        except Exception:
+            logger.debug("restore_state: set_frequency failed", exc_info=True)
+
+    if "attenuator" in state:
+        try:
+            await radio.set_attenuator(bool(state["attenuator"]))
+        except Exception:
+            logger.debug("restore_state: set_attenuator failed", exc_info=True)
+
+    if "preamp" in state:
+        try:
+            await radio.set_preamp(int(cast(int, state["preamp"])))
+        except Exception:
+            logger.debug("restore_state: set_preamp failed", exc_info=True)
+    if "vox" in state:
+        try:
+            await radio.set_vox(bool(state["vox"]))
+        except Exception:
+            logger.debug("restore_state: set_vox failed", exc_info=True)
+    if "data_mode" in state:
+        try:
+            await radio.set_data_mode(bool(state["data_mode"]))
+        except Exception:
+            logger.debug("restore_state: set_data_mode failed", exc_info=True)
+    if "data_off_mod_input" in state:
+        try:
+            await radio.set_data_off_mod_input(
+                int(cast(int, state["data_off_mod_input"]))
+            )
+        except Exception:
+            logger.debug("restore_state: set_data_off_mod_input failed", exc_info=True)
+    if "data1_mod_input" in state:
+        try:
+            await radio.set_data1_mod_input(int(cast(int, state["data1_mod_input"])))
+        except Exception:
+            logger.debug("restore_state: set_data1_mod_input failed", exc_info=True)


### PR DESCRIPTION
## Summary
- `snapshot_state` and `restore_state` moved to new `src/icom_lan/radio_state_snapshot.py`
- `IcomRadio.snapshot_state()` / `.restore_state()` are thin delegators (public API stable)
- ~120 LOC out of `radio.py` god-object (3963 → 3843); new module is 163 LOC
- No behavior change — same best-effort try/except-per-field semantics, same DEBUG logging

## Implementation notes
- New module imports `IcomRadio` only under `TYPE_CHECKING` to avoid circular imports; the radio module imports the new module eagerly as `_state_snapshot`.
- `# noqa: TID251` on the TYPE_CHECKING import: the ban targets external consumers (web/, rigctld/), but this is an internal `radio.py` helper module — same exception pattern as `_dual_rx_runtime.py`.
- `Mode` is imported from `.types` (not `.commands`) to match where it's defined.

## Out of scope
- Other private extractions (`_reconnect_loop`, `_fetch_initial_state`, `_watchdog_loop`) live in #1259 / #1260.
- 6 pre-existing `ruff format` violations on `origin/main` (`web/radio_poller.py`, 5 test files) are unrelated and out of scope for this 3-file refactor.

## Test plan
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5147 passed (same as baseline)
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/icom_lan/radio_state_snapshot.py src/icom_lan/radio.py` — clean
- [x] Targeted: `pytest tests/test_radio_coverage.py tests/test_sync_coverage.py tests/test_ic705.py tests/test_profiles_runtime.py` — 179 passed

Closes #1258
Refs #1063 (Tier 3 wave 3). Parent: #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)