### PR TITLE
refactor(#1259): extract radio_reconnect.py from radio.py

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`_reconnect_loop` / `_watchdog_loop` extracted to `radio_reconnect.py`
+  (#1259).** ~130 LOC moved out of `radio.py` god-object; `IcomRadio` methods
+  remain as thin delegators. Public API unchanged. Tier 3 wave 3 of #1063.
 - **`snapshot_state` / `restore_state` extracted to `radio_state_snapshot.py`
   (#1258).** ~150 LOC moved out of `radio.py` god-object; `IcomRadio` methods
   are thin delegators. Public API unchanged. Tier 3 wave 3 of #1063.

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from ._runtime_protocols import ControlPhaseHost
 
+from . import radio_reconnect as _reconnect
 from . import radio_state_snapshot as _state_snapshot
 from ._audio_recovery import AudioRecoveryRuntime, AudioRecoveryState
 from ._audio_runtime_mixin import AudioRuntimeMixin
@@ -261,7 +262,7 @@ from .commands import set_repeater_tsql as _set_repeater_tsql_cmd
 from .commands import set_tone_freq as _set_tone_freq_cmd
 from .commands import set_tsql_freq as _set_tsql_freq_cmd
 from .commands import set_vfo as _select_vfo_cmd
-from .exceptions import AuthenticationError, CommandError, TimeoutError
+from .exceptions import CommandError, TimeoutError
 from .meter_cal import interpolate_swr
 from .profiles import RadioProfile, resolve_radio_profile
 from .radio_state import RadioState
@@ -1224,134 +1225,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     # ------------------------------------------------------------------
 
     async def _watchdog_loop(self) -> None:
-        """Monitor connection health via transport packet queue activity.
-
-        If no packets are received for ``watchdog_timeout`` seconds,
-        triggers a reconnect attempt.
-
-        Reference: wfview icomudpaudio.cpp watchdog() — 30s timeout.
-        """
-        last_activity = time.monotonic()
-        last_health_log = time.monotonic()
-        last_rx_count = self._ctrl_transport.rx_packet_count
-        last_civ_count = (
-            self._civ_transport.rx_packet_count if self._civ_transport else 0
-        )
-        try:
-            while self._connected:
-                await asyncio.sleep(self.WATCHDOG_CHECK_INTERVAL)
-                if not self._connected:
-                    break
-
-                # Check if any transport has received new packets since last check
-                ctrl_count = self._ctrl_transport.rx_packet_count
-                civ_count = (
-                    self._civ_transport.rx_packet_count if self._civ_transport else 0
-                )
-                if ctrl_count != last_rx_count or civ_count != last_civ_count:
-                    last_activity = time.monotonic()
-                    last_rx_count = ctrl_count
-                    last_civ_count = civ_count
-
-                now = time.monotonic()
-                idle = now - last_activity
-
-                # Periodic health status log
-                if now - last_health_log >= self._WATCHDOG_HEALTH_LOG_INTERVAL:
-                    logger.info(
-                        "Transport health: ctrl_rx=%d civ_rx=%d idle=%.1fs",
-                        ctrl_count,
-                        civ_count,
-                        idle,
-                    )
-                    last_health_log = now
-
-                if idle > self._watchdog_timeout:
-                    logger.warning(
-                        "Watchdog: no activity for %.1fs, triggering reconnect",
-                        idle,
-                    )
-                    self._conn_state = RadioConnectionState.RECONNECTING
-                    self._civ_runtime.advance_generation("watchdog-timeout")
-                    self._reconnect_task = asyncio.create_task(self._reconnect_loop())
-                    return
-        except asyncio.CancelledError:
-            pass
+        """Monitor connection health (delegates to ``radio_reconnect``)."""
+        await _reconnect.watchdog_loop(self)
 
     async def _reconnect_loop(self) -> None:
-        """Attempt to reconnect with exponential backoff."""
-        delay = self._reconnect_delay
-        attempt = 0
-        try:
-            while self._conn_state != RadioConnectionState.DISCONNECTED:
-                attempt += 1
-                logger.info("Reconnect attempt %d (delay=%.1fs)", attempt, delay)
-                try:
-                    self._civ_runtime.advance_generation("reconnect-attempt")
-                    # Capture audio state for auto-recovery.
-                    audio_snapshot = self._audio_runtime.capture_snapshot()
-                    # Clean up old transports
-                    self._stop_token_renewal()
-                    if self._audio_stream is not None:
-                        try:
-                            await self._audio_stream.stop_rx()
-                            await self._audio_stream.stop_tx()
-                        except Exception:
-                            logger.debug(
-                                "reconnect: audio_stream stop failed", exc_info=True
-                            )
-                        self._audio_stream = None
-                    if self._audio_transport is not None:
-                        try:
-                            await self._audio_transport.disconnect()
-                        except Exception:
-                            logger.debug(
-                                "reconnect: audio_transport disconnect failed",
-                                exc_info=True,
-                            )
-                        self._audio_transport = None
-                    if self._civ_transport is not None:
-                        try:
-                            await self._civ_transport.disconnect()
-                        except Exception:
-                            logger.debug(
-                                "reconnect: civ_transport disconnect failed",
-                                exc_info=True,
-                            )
-                        self._civ_transport = None
-                    try:
-                        await self._send_token(0x01)
-                    except Exception:
-                        logger.debug("reconnect: token remove failed", exc_info=True)
-                    try:
-                        await self._ctrl_transport.disconnect()
-                    except Exception:
-                        logger.debug(
-                            "reconnect: ctrl_transport disconnect failed", exc_info=True
-                        )
-
-                    # Re-initialize transport
-                    self._ctrl_transport = IcomTransport()
-                    await self.connect()
-                    logger.info("Reconnected successfully after %d attempts", attempt)
-                    if self._auto_recover_audio and audio_snapshot is not None:
-                        await self._audio_runtime.recover(audio_snapshot)
-                    return
-                except (AuthenticationError, ValueError, TypeError) as exc:
-                    logger.error(
-                        "Reconnect aborted — permanent error after %d attempt(s): %s",
-                        attempt,
-                        exc,
-                    )
-                    self._conn_state = RadioConnectionState.DISCONNECTED
-                    return
-                except Exception as exc:
-                    self._conn_state = RadioConnectionState.RECONNECTING
-                    logger.warning("Reconnect attempt %d failed: %s", attempt, exc)
-                    await asyncio.sleep(delay)
-                    delay = min(delay * 2, self._reconnect_max_delay)
-        except asyncio.CancelledError:
-            logger.info("Reconnect cancelled")
+        """Attempt to reconnect with exponential backoff (delegates)."""
+        await _reconnect.reconnect_loop(self)
 
     # ------------------------------------------------------------------
     # Public CI-V API

--- a/src/icom_lan/radio_reconnect.py
+++ b/src/icom_lan/radio_reconnect.py
@@ -1,0 +1,160 @@
+"""Watchdog and reconnect loops for :class:`IcomRadio`.
+
+Extracted from ``radio.py`` (issue #1259, Tier 3 wave 3 of #1063) to slim down
+the god-object module. The two coroutines here read/write radio state through
+internal attributes and helpers (``_check_connected``/``_connected``/
+``_advance_civ_generation`` are call hubs that stay on ``IcomRadio`` per the
+spike — they are invoked here via the ``radio`` parameter).
+
+Behaviour is intentionally identical to the previous ``IcomRadio._watchdog_loop``
+and ``IcomRadio._reconnect_loop`` methods; the public ``IcomRadio`` methods now
+delegate here. Public API, reconnect timing and watchdog cadence are unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from ._connection_state import RadioConnectionState
+from .exceptions import AuthenticationError
+from .transport import IcomTransport
+
+if TYPE_CHECKING:
+    # Internal implementation module for IcomRadio — the TID251 ban targets
+    # external consumers (web/, rigctld/), not radio.py's own helpers.
+    from .radio import IcomRadio  # type: ignore[attr-defined]  # noqa: TID251
+
+logger = logging.getLogger(__name__)
+
+
+async def watchdog_loop(radio: IcomRadio) -> None:
+    """Monitor connection health via transport packet queue activity.
+
+    If no packets are received for ``watchdog_timeout`` seconds,
+    triggers a reconnect attempt.
+
+    Reference: wfview icomudpaudio.cpp watchdog() — 30s timeout.
+    """
+    last_activity = time.monotonic()
+    last_health_log = time.monotonic()
+    last_rx_count = radio._ctrl_transport.rx_packet_count
+    last_civ_count = radio._civ_transport.rx_packet_count if radio._civ_transport else 0
+    try:
+        while radio._connected:
+            await asyncio.sleep(radio.WATCHDOG_CHECK_INTERVAL)
+            if not radio._connected:
+                break
+
+            # Check if any transport has received new packets since last check
+            ctrl_count = radio._ctrl_transport.rx_packet_count
+            civ_count = (
+                radio._civ_transport.rx_packet_count if radio._civ_transport else 0
+            )
+            if ctrl_count != last_rx_count or civ_count != last_civ_count:
+                last_activity = time.monotonic()
+                last_rx_count = ctrl_count
+                last_civ_count = civ_count
+
+            now = time.monotonic()
+            idle = now - last_activity
+
+            # Periodic health status log
+            if now - last_health_log >= radio._WATCHDOG_HEALTH_LOG_INTERVAL:
+                logger.info(
+                    "Transport health: ctrl_rx=%d civ_rx=%d idle=%.1fs",
+                    ctrl_count,
+                    civ_count,
+                    idle,
+                )
+                last_health_log = now
+
+            if idle > radio._watchdog_timeout:
+                logger.warning(
+                    "Watchdog: no activity for %.1fs, triggering reconnect",
+                    idle,
+                )
+                radio._conn_state = RadioConnectionState.RECONNECTING
+                radio._civ_runtime.advance_generation("watchdog-timeout")
+                radio._reconnect_task = asyncio.create_task(radio._reconnect_loop())
+                return
+    except asyncio.CancelledError:
+        pass
+
+
+async def reconnect_loop(radio: IcomRadio) -> None:
+    """Attempt to reconnect with exponential backoff."""
+    delay = radio._reconnect_delay
+    attempt = 0
+    try:
+        while radio._conn_state != RadioConnectionState.DISCONNECTED:
+            attempt += 1
+            logger.info("Reconnect attempt %d (delay=%.1fs)", attempt, delay)
+            try:
+                radio._civ_runtime.advance_generation("reconnect-attempt")
+                # Capture audio state for auto-recovery.
+                audio_snapshot = radio._audio_runtime.capture_snapshot()
+                # Clean up old transports
+                radio._stop_token_renewal()
+                if radio._audio_stream is not None:
+                    try:
+                        await radio._audio_stream.stop_rx()
+                        await radio._audio_stream.stop_tx()
+                    except Exception:
+                        logger.debug(
+                            "reconnect: audio_stream stop failed", exc_info=True
+                        )
+                    radio._audio_stream = None
+                if radio._audio_transport is not None:
+                    try:
+                        await radio._audio_transport.disconnect()
+                    except Exception:
+                        logger.debug(
+                            "reconnect: audio_transport disconnect failed",
+                            exc_info=True,
+                        )
+                    radio._audio_transport = None
+                if radio._civ_transport is not None:
+                    try:
+                        await radio._civ_transport.disconnect()
+                    except Exception:
+                        logger.debug(
+                            "reconnect: civ_transport disconnect failed",
+                            exc_info=True,
+                        )
+                    radio._civ_transport = None
+                try:
+                    await radio._send_token(0x01)
+                except Exception:
+                    logger.debug("reconnect: token remove failed", exc_info=True)
+                try:
+                    await radio._ctrl_transport.disconnect()
+                except Exception:
+                    logger.debug(
+                        "reconnect: ctrl_transport disconnect failed", exc_info=True
+                    )
+
+                # Re-initialize transport
+                radio._ctrl_transport = IcomTransport()
+                await radio.connect()
+                logger.info("Reconnected successfully after %d attempts", attempt)
+                if radio._auto_recover_audio and audio_snapshot is not None:
+                    await radio._audio_runtime.recover(audio_snapshot)
+                return
+            except (AuthenticationError, ValueError, TypeError) as exc:
+                logger.error(
+                    "Reconnect aborted — permanent error after %d attempt(s): %s",
+                    attempt,
+                    exc,
+                )
+                radio._conn_state = RadioConnectionState.DISCONNECTED
+                return
+            except Exception as exc:
+                radio._conn_state = RadioConnectionState.RECONNECTING
+                logger.warning("Reconnect attempt %d failed: %s", attempt, exc)
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, radio._reconnect_max_delay)
+    except asyncio.CancelledError:
+        logger.info("Reconnect cancelled")


### PR DESCRIPTION
## Summary
- `_reconnect_loop` and `_watchdog_loop` moved to new `radio_reconnect.py`
- `IcomRadio._watchdog_loop` / `_reconnect_loop` are thin delegators (public API stable)
- ~130 LOC out of `radio.py` god-object (3843 -> 3722); new module 162 LOC
- Pattern matches #1269 (radio_state_snapshot.py): free coroutines that take `radio: IcomRadio`, call back into `IcomRadio` for hub helpers (`_check_connected`, `_connected`, `_advance_civ_generation`) per spike Section B
- Removed unused `AuthenticationError` import from `radio.py` (only consumer was `_reconnect_loop`)
- No behavior change, no timing change, no public API change

## Test plan
- [x] `uv run pytest tests/` — 5369 passed, 57 skipped, 9 xfailed, 1 xpassed
- [x] `uv run pytest tests/test_reconnect.py tests/test_audio_recovery.py tests/test_radio_coverage.py` — 160 passed
- [x] `uv run mypy src/` — clean (149 source files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` on touched files — clean

Closes #1259
Refs #1063 (Tier 3 wave 3). Parent: #1255