### PR TITLE
docs(#1277): local-extensions/ as Pro-facing Tier 1 contract

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -93,6 +93,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
+- **`local-extensions/` host API documented as Tier 1 Pro-facing contract
+  (#1277).** `docs/api/public-api-surface.md` now lists the exported types
+  and functions from `frontend/src/lib/local-extensions/{host-api,manifest}.ts`
+  with breakage policy. Closes the contract-visibility gap identified
+  during the strategic-context analysis.
 - **Panel → adapter migration plan (#1240).** Doc at
   `docs/plans/2026-04-29-panel-adapter-migration.md` inventories the 18
   remaining panels with direct `$lib/stores/*` imports, groups them into

--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -120,6 +120,47 @@ available directly via `from icom_lan import …`.
 
 - `RadioState`, `RadioProfile`, `VfoSlotState`, `YaesuStateExtension`
 
+**Frontend extension host API (Pro-facing)**
+
+The `frontend/src/lib/local-extensions/` module exposes a versioned host API
+that downstream products (notably icom-lan-pro) inject UI extensions through.
+It is a stable Pro-facing contract — treat it as tier 1 in this document.
+
+From `frontend/src/lib/local-extensions/host-api.ts`:
+
+- `LOCAL_EXTENSION_HOST_API_VERSION` (numeric constant, currently `1`)
+- `RadioStateSubscriber` (type)
+- `LocalExtensionHostApiV1` (interface)
+- `LocalExtensionHostDependencies` (interface)
+- `LocalExtensionRegistration` (interface)
+- `LocalExtensionHostWindow` (interface)
+- `createLocalExtensionHostApi` (function)
+- `createDefaultLocalExtensionHostApi` (function)
+- `installLocalExtensionHostApi` (function)
+
+From `frontend/src/lib/local-extensions/manifest.ts`:
+
+- `LOCAL_EXTENSION_MANIFEST_URL` (constant)
+- `LOCAL_EXTENSION_MANIFEST_VERSION` (numeric constant)
+- `LOCAL_EXTENSION_HOST_API_VERSION` (string version, e.g. `"1.0"`,
+  mirrors the numeric constant in `host-api.ts`)
+- `LocalExtensionMount` (type)
+- `LocalExtensionDescriptor` (interface)
+- `LocalExtensionManifest` (interface)
+- `LoadManifestOptions` (interface)
+- `parseLocalExtensionManifest` (function)
+- `loadLocalExtensionManifest` (function)
+
+**Breakage policy.** Additive changes only between major versions. Bump
+`LOCAL_EXTENSION_HOST_API_VERSION` (numeric, in `host-api.ts`) on any
+breaking change to a function signature or interface shape. The string
+version in `manifest.ts` mirrors this and is bumped together. Pro relies
+on this contract — coordinate breaking changes through the icom-lan
+issue tracker before merging.
+
+See also `docs/architecture/open-core-policy.md` (when published as part
+of #1276) for the policy framing.
+
 Example (valid):
 
 ```python


### PR DESCRIPTION
## Summary
- New "Frontend extension host API (Pro-facing)" sub-section in `public-api-surface.md`
- Lists exported symbols from `host-api.ts` and `manifest.ts`
- Breakage policy: additive only; bump `LOCAL_EXTENSION_HOST_API_VERSION` to break
- No code change

## Test plan
- [x] doc updated
- [x] mkdocs build clean (if applicable)

Closes #1277
Refs #1272 (closure mini-epic).