### PR TITLE
docs(#1276): open-core-policy.md codifying hard constraints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ Never bare `python` or `pytest`. Worktrees: `uv sync --all-extras` first.
 - eslint `no-restricted-imports` enforces: panels/layouts cannot import `$lib/transport/*` or `$lib/audio/audio-manager`
 - ADR: `docs/plans/2026-04-12-target-frontend-architecture.md`
 
+**Open-core constraints:** see `docs/architecture/open-core-policy.md` — no telemetry, headless sacred, no hollowing out, Pro boundary at Radio protocol + `local-extensions/`.
+
 ---
 
 ## Testing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,6 +98,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and functions from `frontend/src/lib/local-extensions/{host-api,manifest}.ts`
   with breakage policy. Closes the contract-visibility gap identified
   during the strategic-context analysis.
+- **New `docs/architecture/open-core-policy.md` (#1276).** Codifies hard
+  constraints on icom-lan as the open-core half of a planned commercial
+  product: no telemetry, headless sacred, no hollowing out, Radio protocol
+  + `local-extensions/` as the Pro boundary, frontend WebKitGTK-floor
+  compatibility. CLAUDE.md gains a one-line cross-link.
 - **Panel → adapter migration plan (#1240).** Doc at
   `docs/plans/2026-04-29-panel-adapter-migration.md` inventories the 18
   remaining panels with direct `$lib/stores/*` imports, groups them into

--- a/docs/architecture/open-core-policy.md
+++ b/docs/architecture/open-core-policy.md
@@ -1,0 +1,239 @@
+# Open-core policy
+
+This document codifies the hard constraints that govern **icom-lan** as the
+open-core half of a planned commercial product. These rules are not advisory:
+they shape what may and may not land in this repository.
+
+If a contribution conflicts with anything below, the contribution loses. The
+correct response is to redesign — or, if the constraint is genuinely wrong, to
+open an issue and change this document first.
+
+---
+
+## 1. Project shape
+
+- **icom-lan** — open-core, MIT-licensed Python library + Web UI for Icom
+  transceivers over LAN/USB. Target users: hams, hobbyists, headless servers,
+  Raspberry Pi setups, anyone who wants a free, scriptable, embeddable radio
+  control plane.
+- **icom-lan-pro** — proprietary commercial layer, planned to ship roughly
+  2–3 months out. Architecturally a Tauri 2 single-signed installer that
+  spawns a Python sidecar (the icom-lan server) as a child process on
+  `127.0.0.1:8470`, plus a native integrations layer (USB HID for RC-28,
+  OS-level virtual audio routing, global hotkeys, license gating in
+  Tauri-Rust). Pro injects UI extensions into the open-core frontend through
+  `frontend/src/lib/local-extensions/`.
+- **One binary, two tiers.** The free experience is icom-lan rendered without
+  Pro extensions. Paid unlocks Pro features through the same shell.
+
+This document is about icom-lan. It exists so that the two halves can coexist
+without the open-core erosion that historically follows commercial spin-offs.
+
+---
+
+## 2. No telemetry, ever
+
+icom-lan does not phone home. No exceptions, no opt-in tracking, no anonymous
+usage statistics, no product analytics, no crash reporting beacon.
+
+**Forbidden in open-core dependencies and runtime:**
+
+- Sentry, Bugsnag, Rollbar, Honeybadger, or any hosted error reporter.
+- PostHog, Mixpanel, Amplitude, Heap, Segment, or any product analytics SDK.
+- Datadog RUM, New Relic Browser, or any commercial APM client.
+- Google Analytics (`gtag.js`, `analytics.js`), Google Tag Manager, Plausible,
+  Fathom, Matomo cloud, or any web-analytics tag.
+- Background HTTP calls to first- or third-party telemetry endpoints from the
+  Python server, the frontend bundle, or the rigctld bridge.
+
+If telemetry is desirable, it lives in **Pro**, where it is opt-in,
+self-hosted, disclosed up-front, and the user pays for the product partly to
+get it.
+
+### Caveat — "telemetry" as a domain term
+
+The word `telemetry` already appears in this codebase referring to **local
+radio data** that the radio sends back to us: drain voltage, currents, ALC,
+SWR, and similar meter readings surfaced in `radio_poller.py` and the
+`AmberTelemetryStrip` panel of the LCD skin. That is radio-domain telemetry,
+not analytics. It does not leave the user's machine and is not subject to
+this rule.
+
+---
+
+## 3. Headless mode is sacred
+
+icom-lan must run on a headless Linux box — including a Raspberry Pi
+acting as a remote radio gateway — without a display server, browser, or
+audio output device.
+
+- **Canonical entry point:** `--preset headless` in `cli.py`. This preset
+  brings up rigctld (and only rigctld); it does not assume a Web UI consumer,
+  a graphical environment, or local audio playback.
+- **No startup check** in the open-core may require `$DISPLAY`, a working
+  audio backend, a browser, or any GUI library being importable.
+- **No feature gate** may depend on a graphical environment. Any feature that
+  would degrade silently or fail loudly when run headless either belongs in
+  Pro, or must be made graceful (skip, log, continue) in open-core.
+- New CLI presets, daemons, and entry points must be tested against a
+  no-display environment before they are accepted.
+
+Headless is the deployment mode that distinguishes icom-lan from the dozens
+of GUI-only Icom utilities. Breaking it would be breaking the product.
+
+---
+
+## 4. No hollowing out
+
+We do not remove an existing open-core feature so that it can be re-sold in
+Pro. This is the canonical bait-and-switch of open-core projects, and it is
+forbidden here.
+
+The bar for moving (or keeping) something Pro-only is narrow:
+
+> **Pro-only test:** the feature requires desktop-only system integration
+> that fundamentally cannot live in a server.
+
+Examples that pass the test (acceptable Pro features):
+
+- RC-28 USB HID controller integration — needs a desktop OS USB stack.
+- OS-level virtual audio routing (BlackHole, VB-Cable, loopback devices) —
+  needs OS audio driver access.
+- Tauri global hotkeys, system tray, OS notifications — needs a desktop
+  shell.
+- Signed installer, code-signing, license activation flow — needs a native
+  binary boundary.
+
+Examples that fail the test (must stay open):
+
+- Radio control over LAN/USB (the entire CI-V command surface).
+- Audio streaming over the network (PCM and Opus paths).
+- Scope rendering and waterfall display.
+- Web UI, skins, panels, and frontend runtime.
+- Memory channels, presets, profiles, configuration.
+- rigctld bridge.
+
+Generic radio functionality that any consumer (script, hamlib client, web
+browser, mobile app) might want — stays open.
+
+---
+
+## 5. Radio Protocol and capability protocols are the primary boundary
+
+The Pro layer consumes icom-lan through one stable surface: the
+`Radio` protocol in `src/icom_lan/radio_protocol.py` plus the capability
+protocols (`LevelsCapable`, `MetersCapable`, `ScopeCapable`,
+`AudioCapable`, etc.).
+
+This surface is **tier-1 stable** under the public API stability commitment
+documented in `docs/api/public-api-surface.md`.
+
+- Pro builds against this contract. Breaking it breaks Pro.
+- Any change to a capability protocol — adding a method, renaming a method,
+  altering a return type, narrowing the accepted argument range — is a
+  breaking change.
+- Such changes are negotiated in an issue **before** a PR opens, not after.
+  The discussion answers: who depends on this, what is the migration
+  story, do we need a deprecation window.
+- Internal helpers under `radios/`, `commands/`, `commander.py`, and
+  transport are **not** part of the boundary. They may change freely as
+  long as the protocol surface is preserved.
+
+When in doubt about whether a refactor crosses the boundary, ask in an
+issue.
+
+---
+
+## 6. `local-extensions/` is a stable Pro-facing contract
+
+`frontend/src/lib/local-extensions/` exposes a versioned host API used by
+Pro to inject UI extensions (panels, dock items, keyboard scopes, manifest
+entries) into the open-core frontend.
+
+- The current version constant is `LOCAL_EXTENSION_HOST_API_VERSION = 1` in
+  `host-api.ts`.
+- Pro consumers call `installLocalExtensionHostApi()` and import types from
+  `host-api.ts` and `manifest.ts`.
+- **Additive changes only** between major versions. Adding a new method,
+  callback, or manifest field is fine. Removing one, renaming one, or
+  changing an existing signature requires bumping
+  `LOCAL_EXTENSION_HOST_API_VERSION`.
+- The full type list is documented in `docs/api/public-api-surface.md`
+  under "Frontend extension host API (Pro-facing)".
+
+Treat `local-extensions/` with the same discipline as the Python `Radio`
+protocol: it has external consumers, the changes ship to people who paid
+money, and silent breakage is not an option.
+
+---
+
+## 7. The frontend renders in four environments
+
+The icom-lan frontend ships into more than just a developer's Chrome tab.
+It must render correctly in:
+
+1. **Browsers** — Chrome, Safari, Firefox.
+2. **Tauri WebViews** —
+   - macOS: WKWebView (close to Safari).
+   - Windows: WebView2 (close to Edge / Chromium).
+   - Linux: WebKitGTK (closer to old Safari, the most restrictive of the
+     four).
+
+WebKitGTK is the floor. If a CSS feature, a Web API, or a font-rendering
+trick works in Chrome and breaks in WebKitGTK, the open-core frontend
+breaks for every Linux Tauri user — including the eventual Pro user on
+Linux.
+
+**Practical consequences:**
+
+- Verify exotic CSS (`backdrop-filter`, modern `color-mix()` functions,
+  newer `@property` registrations, container queries with deep nesting)
+  against WebKitGTK before merging — especially in the LCD-skin
+  typography panels (`AmberCockpit`, `AmberScope`, `AmberTelemetryStrip`),
+  which lean heavily on font and shadow effects.
+- Check new Web APIs (`AudioWorklet`, `WebCodecs`, `WebTransport`,
+  `OffscreenCanvas`) for WebKitGTK availability before adopting.
+- **Use relative paths only.** No hardcoded `localhost`, `127.0.0.1`, or
+  absolute URLs in the production frontend. The UI may be served through
+  Pro's reverse proxy at `127.0.0.1:8470`, behind a tunnel, or from a
+  remote host; absolute URLs break all of these.
+- Stay proxy-friendly. WebSocket and HTTP routes resolve relative to the
+  current origin.
+
+---
+
+## 8. Form B (lib + app two-package split) — deferred
+
+Per the architecture review in
+`research/2026-04-27-architecture/05-recommendations.md`, the option of
+splitting icom-lan into separate `icom-lan-lib` and `icom-lan-app` packages
+(Form B) remains deferred.
+
+**Today.** Pro uses icom-lan as a separate Python server process via
+HTTP/WebSocket on `127.0.0.1:8470`, plus a narrow library import surface
+(`audio.backend`, `audio.dsp`, `dsp.*`) for the small handful of helpers
+that don't make sense as RPC. That surface is narrow enough that the
+single-package form (Form F) remains sufficient.
+
+**Triggers that activate Form B.** Either of:
+
+- Pro embeds icom-lan in-process for the radio loop (skipping the
+  server-process indirection), and the lib/app boundary becomes load-bearing
+  for cold-start and packaging size.
+- A second downstream Python consumer of icom-lan emerges (a third-party
+  application, a research tool, a different commercial product) that needs
+  the library without the Web UI / rigctld application code.
+
+Until one of those happens, Form F holds. Revisit when triggers activate.
+
+---
+
+## See also
+
+- `docs/api/public-api-surface.md` — the canonical list of tier-1 stable
+  Python and frontend surfaces.
+- `docs/PROJECT.md` — overall project context.
+- `docs/plans/2026-04-12-target-frontend-architecture.md` — frontend
+  layering ADR referenced by `CLAUDE.md`.
+- `research/2026-04-27-architecture/05-recommendations.md` — the form-F
+  vs form-B analysis backing section 8.


### PR DESCRIPTION
## Summary
- New `docs/architecture/open-core-policy.md` (239 lines) codifying the hard constraints on icom-lan as the open-core half of a planned commercial product
- Sections: project shape; no telemetry, ever; headless mode is sacred; no hollowing out; Radio protocol + capability protocols as the primary boundary; `local-extensions/` as a stable Pro-facing contract; frontend renders in 4 environments (WebKitGTK is the floor); Form B deferred
- CLAUDE.md gains a one-line cross-link in the Architecture section, right after the Frontend layering subsection
- CHANGELOG entry under `[Unreleased] → Docs`

## Test plan
- [x] doc lands at `docs/architecture/open-core-policy.md`
- [x] CLAUDE.md cross-link added (line 45)
- [x] mkdocs build --strict clean

Closes #1276
Refs #1272 (closure mini-epic).