### PR TITLE
docs(#1275): AudioBackend tier stability docstring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   product: no telemetry, headless sacred, no hollowing out, Radio protocol
   + `local-extensions/` as the Pro boundary, frontend WebKitGTK-floor
   compatibility. CLAUDE.md gains a one-line cross-link.
+- **`AudioBackend` Protocol docstring promoted to stability marker (#1275).**
+  The Protocol (and `PortAudioBackend` / `FakeAudioBackend` impls) now
+  document their tier and breakage policy in their own docstrings, matching
+  `docs/api/public-api-surface.md` (Tier 2 — Best-effort, lazily exposed via
+  PEP 562 `__getattr__`). Closes `05-recommendations.md` PR 4.
 - **Panel → adapter migration plan (#1240).** Doc at
   `docs/plans/2026-04-29-panel-adapter-migration.md` inventories the 18
   remaining panels with direct `$lib/stores/*` imports, groups them into

--- a/src/icom_lan/audio/backend.py
+++ b/src/icom_lan/audio/backend.py
@@ -92,7 +92,20 @@ class TxStream(Protocol):
 
 @runtime_checkable
 class AudioBackend(Protocol):
-    """Abstract audio backend capable of listing devices and opening streams."""
+    """Abstract audio backend capable of listing devices and opening streams.
+
+    **Tier 2 — Best-effort.** Import path:
+    ``from icom_lan.audio.backend import AudioBackend`` (also lazily exposed
+    on the top-level ``icom_lan`` package via PEP 562 ``__getattr__``).
+
+    The contract is the four methods declared below: :meth:`list_devices`,
+    :meth:`check_sample_rate`, :meth:`open_rx`, :meth:`open_tx`. Streams
+    returned by ``open_rx`` / ``open_tx`` follow the :class:`RxStream` and
+    :class:`TxStream` protocols.
+
+    Stability: breaking changes require a CHANGELOG note plus a minor version
+    bump per ``docs/api/public-api-surface.md``. No strict semver guarantee.
+    """
 
     def list_devices(self) -> list[AudioDeviceInfo]: ...
 
@@ -324,7 +337,18 @@ class _PortAudioTxStream:
 
 
 class PortAudioBackend:
-    """AudioBackend backed by PortAudio via *sounddevice*."""
+    """AudioBackend backed by PortAudio via *sounddevice*.
+
+    **Tier 2 — Best-effort.** Import path:
+    ``from icom_lan.audio.backend import PortAudioBackend``. Implements the
+    :class:`AudioBackend` protocol on top of the optional ``[bridge]`` extras
+    (``sounddevice`` + ``numpy``); dependencies are loaded lazily on first
+    method call so importing this class does not require PortAudio at import
+    time.
+
+    Stability: breaking changes require a CHANGELOG note plus a minor version
+    bump per ``docs/api/public-api-surface.md``. No strict semver guarantee.
+    """
 
     def __init__(
         self,
@@ -519,7 +543,17 @@ class FakeTxStream:
 
 
 class FakeAudioBackend:
-    """Deterministic AudioBackend for tests — no real audio hardware."""
+    """Deterministic AudioBackend for tests — no real audio hardware.
+
+    **Tier 2 — Best-effort.** Import path:
+    ``from icom_lan.audio.backend import FakeAudioBackend``. Implements the
+    :class:`AudioBackend` protocol with in-memory :class:`FakeRxStream` /
+    :class:`FakeTxStream` doubles so consumer code can be exercised without
+    PortAudio or any optional extras.
+
+    Stability: breaking changes require a CHANGELOG note plus a minor version
+    bump per ``docs/api/public-api-surface.md``. No strict semver guarantee.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- Added stability tier and breakage policy to `AudioBackend` Protocol docstring (and `PortAudioBackend` / `FakeAudioBackend`).
- Tier matches `docs/api/public-api-surface.md` — **Tier 2 — Best-effort** (lazy via PEP 562 `__getattr__`).
- No code change beyond docstrings.

> Note: issue #1275 body claims "Tier 1", but the source-of-truth doc
> `docs/api/public-api-surface.md` lists `audio.backend.AudioBackend`,
> `audio.backend.PortAudioBackend`, and `audio.backend.FakeAudioBackend`
> under Tier 2 — Best-effort. Used the doc as truth per the task spec.
> Maintainer can correct the issue body if needed.

## Test plan
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5147 passed, zero failures
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/icom_lan/audio/backend.py` — clean

Closes #1275
Refs #1272 (closure mini-epic).