### PR TITLE
refactor(#1274): _require_* helpers for optional deps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`_require_*()` helpers for optional deps (#1274).** New
+  `src/icom_lan/_optional_deps.py` provides `_require_numpy`,
+  `_require_sounddevice`, `_require_opuslib`, `_require_pillow` (and
+  others where applicable). Ad-hoc `try/except ImportError` blocks across
+  the codebase now share uniform error messages. Closes
+  `05-recommendations.md` PR 3 (Form A enforcement).
 - **`_fetch_initial_state` extracted to `radio_initial_state.py` (#1260).**
   ~75 LOC moved out of `radio.py` god-object; `IcomRadio._fetch_initial_state`
   is now a thin delegator. Public API unchanged. Final Tier 3 wave 3 sub-issue

--- a/src/icom_lan/_optional_deps.py
+++ b/src/icom_lan/_optional_deps.py
@@ -1,0 +1,84 @@
+"""Helpers for optional / heavy dependencies.
+
+Centralises the ``try: import X / except ImportError: raise ImportError(...)``
+pattern so that error messages stay uniform across the codebase.
+
+Each helper is a no-op if the dependency is already importable; on failure it
+re-raises ``ImportError`` with a friendly install hint.
+
+Notes
+-----
+- ``numpy``, ``sounddevice`` and ``opuslib`` ship with the core install since
+  #1090 — the ``[bridge]`` / ``[audio]`` extras are no-op aliases.  The
+  install hint therefore omits any extra.
+- ``Pillow`` lives behind ``[scope]`` and ``pyserial-asyncio`` behind
+  ``[serial]``.
+
+Helpers raise ``ImportError`` chained from the original failure (``from exc``)
+so callers can introspect ``__cause__`` for richer diagnostics.
+"""
+
+from __future__ import annotations
+
+
+def _require_numpy() -> None:
+    """Ensure ``numpy`` is importable, otherwise raise ``ImportError``."""
+    try:
+        import numpy  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "numpy is required for this feature. Install with: pip install icom-lan"
+        ) from exc
+
+
+def _require_sounddevice() -> None:
+    """Ensure ``sounddevice`` is importable, otherwise raise ``ImportError``."""
+    try:
+        import sounddevice  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "sounddevice is required for audio device access. "
+            "Install with: pip install icom-lan"
+        ) from exc
+
+
+def _require_opuslib() -> None:
+    """Ensure ``opuslib`` is importable, otherwise raise ``ImportError``."""
+    try:
+        import opuslib  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "opuslib is required for Opus audio codec support. "
+            "Install with: pip install icom-lan"
+        ) from exc
+
+
+def _require_pillow() -> None:
+    """Ensure ``Pillow`` is importable, otherwise raise ``ImportError``."""
+    try:
+        import PIL  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "Pillow is required for scope rendering. "
+            "Install with: pip install icom-lan[scope]"
+        ) from exc
+
+
+def _require_pyserial_asyncio() -> None:
+    """Ensure ``pyserial-asyncio`` is importable, otherwise raise ``ImportError``."""
+    try:
+        import serial_asyncio  # type: ignore[import-untyped]  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "pyserial-asyncio is required for serial backends. "
+            "Install with: pip install icom-lan[serial]"
+        ) from exc
+
+
+__all__ = [
+    "_require_numpy",
+    "_require_sounddevice",
+    "_require_opuslib",
+    "_require_pillow",
+    "_require_pyserial_asyncio",
+]

--- a/src/icom_lan/audio_bridge.py
+++ b/src/icom_lan/audio_bridge.py
@@ -40,6 +40,7 @@ import math
 
 from ._bridge_metrics import BridgeMetrics
 from ._bridge_state import BridgeState, BridgeStateChange
+from ._optional_deps import _require_opuslib, _require_sounddevice
 from .audio.backend import (
     AudioBackend,
     AudioDeviceInfo,
@@ -142,13 +143,8 @@ def find_loopback_device(name: str | None = None) -> dict[str, Any] | None:
         Use :class:`AudioBridge` with an :class:`AudioBackend` instead.
         This function is kept for backward compatibility.
     """
-    try:
-        import sounddevice as sd  # noqa: F401
-    except ImportError:
-        raise ImportError(
-            "sounddevice is required for audio bridge. "
-            "Install with: pip install icom-lan[bridge]"
-        ) from None
+    _require_sounddevice()
+    import sounddevice as sd
 
     devices = sd.query_devices()
     search_names = [name] if name else list(_LOOPBACK_CANDIDATES)
@@ -163,12 +159,8 @@ def find_loopback_device(name: str | None = None) -> dict[str, Any] | None:
 
 def list_audio_devices() -> list[dict[str, Any]]:
     """List all available audio devices."""
-    try:
-        import sounddevice as sd  # noqa: F401
-    except ImportError:
-        raise ImportError(
-            "sounddevice is required. Install with: pip install icom-lan[bridge]"
-        ) from None
+    _require_sounddevice()
+    import sounddevice as sd
 
     return list(sd.query_devices())
 
@@ -415,13 +407,9 @@ class AudioBridge:
         )
 
         if self._is_opus:
-            try:
-                import opuslib
-            except ImportError:
-                raise ImportError(
-                    "opuslib is required for audio bridge with Opus codec. "
-                    "Install with: pip install icom-lan[bridge]"
-                ) from None
+            _require_opuslib()
+            import opuslib
+
             self._decoder = opuslib.Decoder(self._sample_rate, self._channels)
         else:
             self._decoder = None

--- a/src/icom_lan/audio_fft_scope.py
+++ b/src/icom_lan/audio_fft_scope.py
@@ -41,14 +41,12 @@ _DB_CEIL = -15.0  # clipping level dB
 
 def _import_numpy() -> Any:
     """Lazy-import numpy to avoid hard dependency at module level."""
-    try:
-        import numpy as np
+    from ._optional_deps import _require_numpy
 
-        return np
-    except ImportError:
-        raise ImportError(
-            "Audio FFT scope requires numpy. Install with: pip install numpy"
-        ) from None
+    _require_numpy()
+    import numpy as np
+
+    return np
 
 
 class AudioFftScope:

--- a/src/icom_lan/backends/icom7610/drivers/serial_civ_link.py
+++ b/src/icom_lan/backends/icom7610/drivers/serial_civ_link.py
@@ -15,10 +15,6 @@ logger = logging.getLogger(__name__)
 _SOF = b"\xfe\xfe"
 _EOF = 0xFD
 _ABORT = 0xFC
-_DEPENDENCY_HINT = (
-    "Serial backend requires optional dependencies pyserial and pyserial-asyncio. "
-    "Install with: pip install icom-lan[serial]"
-)
 
 
 class SerialFrameError(RuntimeError):
@@ -375,11 +371,10 @@ class SerialCivLink:
         return _open
 
     def _ensure_serial_dependencies(self) -> None:
-        try:
-            importlib.import_module("serial")
-            importlib.import_module("serial_asyncio")
-        except ImportError as exc:
-            raise ImportError(_DEPENDENCY_HINT) from exc
+        from icom_lan._optional_deps import _require_pyserial_asyncio
+
+        # pyserial-asyncio depends on pyserial, so a single check covers both.
+        _require_pyserial_asyncio()
 
     def _reset_session_buffers(self) -> None:
         """Drop buffered RX/TX data between sessions."""

--- a/src/icom_lan/cw_auto_tuner.py
+++ b/src/icom_lan/cw_auto_tuner.py
@@ -31,14 +31,12 @@ _NOISE_FLOOR_DB = -50.0
 
 def _import_numpy() -> Any:
     """Lazy-import numpy to avoid hard dependency at module level."""
-    try:
-        import numpy as np
+    from ._optional_deps import _require_numpy
 
-        return np
-    except ImportError:
-        raise ImportError(
-            "CwAutoTuner requires numpy. Install with: pip install numpy"
-        ) from None
+    _require_numpy()
+    import numpy as np
+
+    return np
 
 
 class CwAutoTuner:

--- a/src/icom_lan/discovery.py
+++ b/src/icom_lan/discovery.py
@@ -184,15 +184,12 @@ async def _try_baud(
 
 def _default_open_serial() -> _OpenSerial:
     """Return the real serial_asyncio opener, or raise ImportError with hint."""
-    try:
-        import serial_asyncio  # type: ignore[import-untyped]
+    from ._optional_deps import _require_pyserial_asyncio
 
-        return serial_asyncio.open_serial_connection  # type: ignore[no-any-return]
-    except ImportError as exc:
-        raise ImportError(
-            "CI-V probing requires pyserial-asyncio. "
-            "Install with: pip install icom-lan[serial]"
-        ) from exc
+    _require_pyserial_asyncio()
+    import serial_asyncio  # type: ignore[import-untyped]
+
+    return serial_asyncio.open_serial_connection  # type: ignore[no-any-return]
 
 
 def _parse_probe_response(port: str, baud: int, data: bytes) -> CivProbeResult | None:

--- a/src/icom_lan/dsp/resample.py
+++ b/src/icom_lan/dsp/resample.py
@@ -20,12 +20,12 @@ __all__ = ["resample_if_needed"]
 
 
 def _import_numpy() -> Any:
-    try:
-        import numpy as _np  # noqa: TID251
+    from .._optional_deps import _require_numpy
 
-        return _np
-    except ImportError as exc:
-        raise ImportError("resample_if_needed requires numpy") from exc
+    _require_numpy()
+    import numpy as _np  # noqa: TID251
+
+    return _np
 
 
 def resample_if_needed(

--- a/src/icom_lan/scope_render.py
+++ b/src/icom_lan/scope_render.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
+from ._optional_deps import _require_pillow
+
 if TYPE_CHECKING:
     from PIL.Image import Image as PILImage
     from .scope import ScopeFrame
@@ -102,17 +104,6 @@ THEMES: dict[str, _ThemeSpec] = {
         "colormap": _build_colormap(_GRAYSCALE_ANCHORS),
     },
 }
-
-
-def _require_pillow() -> None:
-    """Raise ImportError with install instructions if Pillow is missing."""
-    try:
-        import PIL  # noqa: F401
-    except ImportError:
-        raise ImportError(
-            "Pillow is required for scope rendering. "
-            "Install with: pip install icom-lan[scope]"
-        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `src/icom_lan/_optional_deps.py` (~85 LOC) with five helpers: `_require_numpy`, `_require_sounddevice`, `_require_opuslib`, `_require_pillow`, `_require_pyserial_asyncio`
- Migrated 8 callsites across 7 files to share uniform error messages
- Left 9 ImportError sites as-is (different exception type, fallback impl, feature flag, or different install-hint shape) — see *Out-of-scope*
- No behavior change beyond error-message text wording (numpy/sounddevice/opuslib hints drop the ad-hoc `[bridge]` extra since those deps are core since #1090)

## Migrated callsites
- `cw_auto_tuner.py` (numpy)
- `audio_fft_scope.py` (numpy)
- `audio_bridge.py` x3 (sounddevice x2, opuslib x1)
- `scope_render.py` — `_require_pillow` re-exported from new module (preserves the existing public name; test `test_scope_render_coverage.py` still imports it from `icom_lan.scope_render`)
- `dsp/resample.py` (numpy — first try/except only; the second one is a scipy-fallback pattern, intentionally untouched)
- `discovery.py` (pyserial-asyncio)
- `backends/icom7610/drivers/serial_civ_link.py` (pyserial-asyncio; module-local `_DEPENDENCY_HINT` removed)

## Out-of-scope (left as-is)
| File | Reason |
|---|---|
| `dsp/nodes/base.py`, `dsp/nodes/nr_scipy.py` x2, `dsp/pipeline.py` | raise `DSPBackendUnavailable`, not `ImportError` — migrating would be observable from tests |
| `backends/yaesu_cat/transport.py` | raises `CatTransportError`, not `ImportError` |
| `audio/backend.py` | module-local PortAudio install hint is more informative than the generic helper; this is the tier-1 surface Pro depends on |
| `web/tls.py` | catches `ImportError` to fall back to OpenSSL CLI |
| `web/rtc.py` x2 | feature-detection flag (`_aiortc_ok`) / race-condition fallback |
| `rigctld/__init__.py` | sets `__all__ = []` on missing optional deps |
| `usb_audio_resolve.py`, `discovery.py:298`, `dsp/resample.py:64`, `audio/backend.py:344` | silent fallback / debug-log only / returns `None` |
| `cli.py` x5 | print-and-`return 1` wrappers around already-migrated modules |

## Test plan
- [x] `uv run pytest tests/` — 5147 passed, 2 skipped, 9 xfailed, 1 xpassed
- [x] `uv run mypy src/` — clean (151 files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` on changed files — clean

Closes #1274
Refs #1272 (closure mini-epic).