### PR TITLE
refactor(#1286): [Modularization 3b/13] move radio_protocol to core/

### DIFF
--- a/src/icom_lan/core/radio_protocol.py
+++ b/src/icom_lan/core/radio_protocol.py
@@ -56,8 +56,8 @@ from .types import AudioCodec, BreakInMode, Mode
 
 if TYPE_CHECKING:
     from ._state_cache import StateCache
-    from .audio_bus import AudioBus
-    from .scope import ScopeFrame
+    from icom_lan.audio_bus import AudioBus
+    from icom_lan.scope import ScopeFrame
     from .types import BandStackRegister, MemoryChannel, ScopeFixedEdge
 
 __all__ = [

--- a/src/icom_lan/radio_protocol.py
+++ b/src/icom_lan/radio_protocol.py
@@ -1,0 +1,35 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.core.radio_protocol
+Do not add new symbols here — add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan.radio_protocol`` literally the same module object as
+``icom_lan.core.radio_protocol``. This preserves attribute walks (incl.
+stdlib names not in ``__all__``) and monkeypatch targets such as
+``unittest.mock.patch('icom_lan.radio_protocol.…', …)``.
+
+The two import lines below are BOTH load-bearing — do not remove
+either:
+
+* ``from icom_lan.core.radio_protocol import *`` — static-analysis
+  adapter. Mypy and ruff resolve re-exported names through
+  star-imports; they do not model the ``sys.modules`` mutation.
+  Without this line, every consumer of
+  ``from icom_lan.radio_protocol import X`` triggers ``attr-defined``
+  errors. At runtime this populates the temporary module object,
+  which is immediately superseded by the swap below.
+
+* ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+  Makes ``icom_lan.radio_protocol`` and ``icom_lan.core.radio_protocol``
+  the same module object so attribute lookups (including stdlib
+  names imported by the canonical module) flow to the canonical
+  module.
+"""
+
+import sys
+
+from icom_lan.core.radio_protocol import *  # noqa: F401, F403
+import icom_lan.core.radio_protocol as _canonical
+
+sys.modules[__name__] = _canonical


### PR DESCRIPTION
## Summary

Step 3b of 13. **Closes #1286** (completes Step 3).

Moves `radio_protocol.py` (1194 LOC, the largest single file in the migration) from `src/icom_lan/` to `src/icom_lan/core/`. Together with #1304 (Step 3a), this completes the move of the contract trio + transport primitives (`radio_protocol`, `radio_state`, `_state_cache`, `_queue_pressure`, `_bounded_queue`).

## TYPE_CHECKING import rewrites

Two `if TYPE_CHECKING:` imports rewritten from relative to absolute, because their targets stay at top level until later steps:

- `from .audio_bus import AudioBus` -> `from icom_lan.audio_bus import AudioBus` (audio_bus moves in Step 7).
- `from .scope import ScopeFrame` -> `from icom_lan.scope import ScopeFrame` (scope moves in Step 6).

These match the named `ignore_imports` exceptions documented in plan §3.3 (TYPE_CHECKING-only edges, semantically allowed via the linter exception when import-linter is integrated in Step 13).

## Verification
- Tests collect 5213; **all passing**.
- `uv run pytest tests/contracts/ -v` -> 3 passed.
- `ruff check`, `mypy src/` -> clean.
- Identity invariant verified.
- Top-level Tier 1 lazy resolution (`Radio`, `AudioCapable`, `ScopeCapable`, etc.) still works via the existing eager `__init__.py` import that now routes through the shim.

## What's NOT in this PR
- No LAZY_MAP changes (Step 13).
- No behaviour changes.

Closes #1286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)