### PR TITLE
refactor(#1289): [Modularization 6/13] create scope/ package, move scope+scope_render via Pattern A

### DIFF
--- a/src/icom_lan/scope/__init__.py
+++ b/src/icom_lan/scope/__init__.py
@@ -12,7 +12,7 @@ import logging
 import time
 from dataclasses import dataclass
 
-from .types import bcd_decode
+from icom_lan.types import bcd_decode
 
 __all__ = ["ScopeFrame", "ScopeAssembler"]
 

--- a/src/icom_lan/scope/render.py
+++ b/src/icom_lan/scope/render.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
-from ._optional_deps import _require_pillow
+from icom_lan._optional_deps import _require_pillow
 
 if TYPE_CHECKING:
     from PIL.Image import Image as PILImage
-    from .scope import ScopeFrame
+
+    from icom_lan.scope import ScopeFrame
 
 
 class _ThemeSpec(TypedDict):

--- a/src/icom_lan/scope_render.py
+++ b/src/icom_lan/scope_render.py
@@ -1,0 +1,23 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.scope.render
+Do not add new symbols here — add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan.scope_render`` literally the same module object as
+``icom_lan.scope.render``. This preserves attribute walks (incl.
+stdlib names not in ``__all__``) and monkeypatch targets.
+
+The two import lines below are BOTH load-bearing — do not remove
+either:
+
+* ``from icom_lan.scope.render import *`` — static-analysis adapter.
+* ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.scope.render import *  # noqa: F401, F403
+import icom_lan.scope.render as _canonical
+
+sys.modules[__name__] = _canonical


### PR DESCRIPTION
## Summary

Step 6 of 13. **Closes #1289**. Parallel sibling of Step 4 (#1287) per plan §4.2.

Creates the `src/icom_lan/scope/` package atomically by renaming `scope.py` → `scope/__init__.py` (Pattern A per plan §4.1, post-#1300). Moves `scope_render.py` → `scope/render.py`.

Three absolute-import rewrites (rather than the brief's listed two — see Deviation):

* `scope/__init__.py`: `from .types` → `from icom_lan.types`
* `scope/render.py`: `from ._optional_deps` → `from icom_lan._optional_deps`
* `scope/render.py` (TYPE_CHECKING): `from .scope import ScopeFrame` → `from icom_lan.scope import ScopeFrame`

Same Step 2b precedent (top-level absolute via existing core shims). Step 13 will canonicalize them later.

1 sys.modules-alias shim at `src/icom_lan/scope_render.py`. NO shim needed at `src/icom_lan/scope.py` because the package directly serves the `icom_lan.scope` dotted path (Pattern A).

## Verification
- Tests: 5201 passed, 2 skipped, 2 deselected, 9 xfailed, 1 xpassed (matches baseline).
- Contracts: 3 passed.
- ruff, mypy: clean (`Success: no issues found in 168 source files`).
- `core/radio_protocol.py`'s `from icom_lan.scope import ScopeFrame` (TYPE_CHECKING) still resolves via the new package (eager `Radio` import succeeds).
- `icom_lan.scope_render` and `icom_lan.scope.render` are the SAME module object (sys.modules-alias identity confirmed).
- Tier 1 `from icom_lan import ScopeFixedEdge` still works.

## Deviation

The brief listed 2 absolute-import rewrites; there are actually 3. The brief's `^(from \.|import \.)` grep missed the `from .scope import ScopeFrame` line because it sits indented inside an `if TYPE_CHECKING:` block. Without rewriting it, mypy would have failed (`.scope` would resolve to non-existent `icom_lan.scope.scope` after the move). Surfacing here in case other future steps (Step 4, Step 7+) have similar TYPE_CHECKING relative imports lurking.

## What's NOT in this PR
- No LAZY_MAP changes (Step 13).
- No behaviour changes.

Closes #1289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)