### PR TITLE
refactor(#1290): [Modularization 7b/13] move audio_bridge + audio_fft_scope into audio/

### DIFF
--- a/src/icom_lan/audio/bridge.py
+++ b/src/icom_lan/audio/bridge.py
@@ -38,10 +38,11 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import math
 
+from icom_lan._optional_deps import _require_opuslib, _require_sounddevice
+
 from ._bridge_metrics import BridgeMetrics
 from ._bridge_state import BridgeState, BridgeStateChange
-from ._optional_deps import _require_opuslib, _require_sounddevice
-from .audio.backend import (
+from .backend import (
     AudioBackend,
     AudioDeviceInfo,
     PortAudioBackend,
@@ -50,7 +51,7 @@ from .audio.backend import (
 )
 
 if TYPE_CHECKING:
-    from .radio_protocol import AudioCapable
+    from icom_lan.radio_protocol import AudioCapable
 
 logger = logging.getLogger(__name__)
 
@@ -398,7 +399,7 @@ class AudioBridge:
         await self._rx_stream.start()
 
         # Codec detection
-        from .types import AudioCodec
+        from icom_lan.types import AudioCodec
 
         _codec = getattr(self._radio, "audio_codec", None)
         self._is_opus = isinstance(_codec, AudioCodec) and _codec in (

--- a/src/icom_lan/audio/fft_scope.py
+++ b/src/icom_lan/audio/fft_scope.py
@@ -22,7 +22,7 @@ import logging
 import time
 from typing import Any, Callable
 
-from .scope import ScopeFrame
+from icom_lan.scope import ScopeFrame
 
 __all__ = ["AudioFftScope"]
 
@@ -41,7 +41,7 @@ _DB_CEIL = -15.0  # clipping level dB
 
 def _import_numpy() -> Any:
     """Lazy-import numpy to avoid hard dependency at module level."""
-    from ._optional_deps import _require_numpy
+    from icom_lan._optional_deps import _require_numpy
 
     _require_numpy()
     import numpy as np

--- a/src/icom_lan/audio_bridge.py
+++ b/src/icom_lan/audio_bridge.py
@@ -1,0 +1,23 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.audio.bridge
+Do not add new symbols here -- add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan.audio_bridge`` literally the same module object as
+``icom_lan.audio.bridge``. This preserves attribute walks (incl.
+stdlib names not in ``__all__``) and monkeypatch targets.
+
+The two import lines below are BOTH load-bearing -- do not remove
+either:
+
+* ``from icom_lan.audio.bridge import *`` -- static-analysis adapter.
+* ``sys.modules[__name__] = _canonical`` -- the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.audio.bridge import *  # noqa: F401, F403
+import icom_lan.audio.bridge as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/icom_lan/audio_fft_scope.py
+++ b/src/icom_lan/audio_fft_scope.py
@@ -1,0 +1,23 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.audio.fft_scope
+Do not add new symbols here -- add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan.audio_fft_scope`` literally the same module object as
+``icom_lan.audio.fft_scope``. This preserves attribute walks (incl.
+stdlib names not in ``__all__``) and monkeypatch targets.
+
+The two import lines below are BOTH load-bearing -- do not remove
+either:
+
+* ``from icom_lan.audio.fft_scope import *`` -- static-analysis adapter.
+* ``sys.modules[__name__] = _canonical`` -- the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.audio.fft_scope import *  # noqa: F401, F403
+import icom_lan.audio.fft_scope as _canonical
+
+sys.modules[__name__] = _canonical


### PR DESCRIPTION
## Summary

Step 7b of 13. **Closes #1290** (completes Step 7).

Moves the 2 complex audio top-level files (~1099 LOC) into `src/icom_lan/audio/`:
`audio_bridge` -> `audio.bridge`, `audio_fft_scope` -> `audio.fft_scope`.

8 import rewrites across the 2 files. Sibling-relative imports (`_bridge_metrics`, `_bridge_state`, `backend` after the `.audio.` redundancy collapse) stay relative. The other 5 imports become absolute (`from icom_lan.<m>`) -- same pattern as Step 2b's transport rewrites; deferred canonicalization to Step 13.

2 sys.modules-alias hybrid shims at the old top-level paths.

Together with #1309 (Step 7a), this completes Step 7 -- all 9 audio top-level files are now inside `src/icom_lan/audio/`.

## Verification
- Tests collect 5213; all green.
- Contracts: 3 passed.
- ruff, mypy: clean.
- Identity invariants verified.
- icom-lan-pro contract paths (`audio.backend`, `audio.dsp`, `dsp.pipeline`, `dsp.nodes.base`, `dsp.exceptions`) all resolve unchanged.

## What's NOT in this PR
- No LAZY_MAP changes (Step 13).
- No behaviour changes.

Closes #1290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)