### PR TITLE
refactor(#1291): [Modularization 8b/13] move radio.py to runtime/ with absolute-import rewrite + §5.1.1 underscore re-export pattern

### DIFF
--- a/docs/plans/2026-04-29-modularization-plan.md
+++ b/docs/plans/2026-04-29-modularization-plan.md
@@ -564,7 +564,36 @@ The "Re-export shim" header is a grep-able marker (`grep -rn
 "Re-export shim" src/icom_lan/`) and a signal to PR reviewers: do
 not edit by hand, file edits go to the canonical location.
 
-#### 5.1.1 Why sys.modules-alias (and not plain `from … import *`)
+#### 5.1.1 Underscore re-export for cross-module private consumers
+
+The hybrid template's `from … import *` excludes underscore-prefixed
+names by Python spec, so any private symbol that an *external*
+consumer imports through the shim path (e.g. `from icom_lan.<old>
+import _foo`) becomes invisible to mypy after the move — even though
+it works at runtime via the sys.modules alias. The fix is a single
+explicit underscore re-import line in the shim, between the
+`import *` and the alias assignment. The PEP 484 explicit re-export
+form (`X as X`) is required: mypy's default treats a plain `from X
+import _foo` as a non-explicit re-export and still reports
+`attr-defined` on consumers.
+
+```python
+from icom_lan.<canonical> import *  # noqa: F401, F403
+from icom_lan.<canonical> import _foo as _foo  # noqa: F401  # consumer: <where>
+import icom_lan.<canonical> as _canonical
+
+sys.modules[__name__] = _canonical
+```
+
+These explicit re-imports become dead after Step 13's global import
+canonicalization (consumers no longer reach through the shim) and
+can be removed at that time.
+
+First instance: `src/icom_lan/radio.py` shim re-exports
+`_DEFAULT_AUDIO_CODEC` for the consumer at `src/icom_lan/sync.py:23`
+(Step 8b).
+
+#### 5.1.2 Why sys.modules-alias (and not plain `from … import *`)
 
 The original verbatim template was a single-line `from
 icom_lan.<new_layer>.<module> import *`. It broke during Step 2b

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -1,0 +1,24 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.runtime.radio
+Do not add new symbols here — add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan.radio`` literally the same module object as
+``icom_lan.runtime.radio``. This preserves attribute walks (incl.
+stdlib names not in ``__all__``) and monkeypatch targets.
+
+The two import lines below are BOTH load-bearing — do not remove
+either:
+
+* ``from icom_lan.runtime.radio import *`` —
+  static-analysis adapter.
+* ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.runtime.radio import *  # noqa: F401, F403
+import icom_lan.runtime.radio as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -11,14 +11,22 @@ stdlib names not in ``__all__``) and monkeypatch targets.
 The two import lines below are BOTH load-bearing — do not remove
 either:
 
-* ``from icom_lan.runtime.radio import *`` —
-  static-analysis adapter.
+* ``from icom_lan.runtime.radio import *`` — static-analysis adapter.
 * ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+
+The third line below — the explicit underscore re-export — is needed
+for any private (``_``-prefixed) symbol that an external consumer
+imports through this shim. ``import *`` excludes underscores by
+Python spec, so mypy can't see the symbol statically through the
+shim. Explicit re-import makes the static graph match the runtime
+identity. As consumers migrate to canonical paths in Step 13, the
+underscore re-imports here become dead and can be removed.
 """
 
 import sys
 
 from icom_lan.runtime.radio import *  # noqa: F401, F403
+from icom_lan.runtime.radio import _DEFAULT_AUDIO_CODEC as _DEFAULT_AUDIO_CODEC  # noqa: F401  # consumer: sync.py
 import icom_lan.runtime.radio as _canonical
 
 sys.modules[__name__] = _canonical

--- a/src/icom_lan/runtime/radio.py
+++ b/src/icom_lan/runtime/radio.py
@@ -22,32 +22,32 @@ from typing import TYPE_CHECKING, cast
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable
 
-    from ._runtime_protocols import ControlPhaseHost
+    from icom_lan._runtime_protocols import ControlPhaseHost
 
 from . import radio_initial_state as _initial_state
 from . import radio_reconnect as _reconnect
 from . import radio_state_snapshot as _state_snapshot
-from ._audio_recovery import AudioRecoveryRuntime, AudioRecoveryState
-from ._audio_runtime_mixin import AudioRuntimeMixin
-from ._audio_transcoder import PcmOpusTranscoder
-from ._bounded_queue import BoundedQueue
-from ._civ_rx import CivRuntime
-from ._dual_rx_runtime import DualRxRuntimeMixin
-from ._scope_runtime import ScopeRuntimeMixin
+from icom_lan._audio_recovery import AudioRecoveryRuntime, AudioRecoveryState
+from icom_lan._audio_runtime_mixin import AudioRuntimeMixin
+from icom_lan._audio_transcoder import PcmOpusTranscoder
+from icom_lan._bounded_queue import BoundedQueue
+from icom_lan._civ_rx import CivRuntime
+from icom_lan._dual_rx_runtime import DualRxRuntimeMixin
+from icom_lan._scope_runtime import ScopeRuntimeMixin
 
 # Import split modules
-from ._connection_state import RadioConnectionState
-from ._control_phase import (
+from icom_lan._connection_state import RadioConnectionState
+from icom_lan._control_phase import (
     CONNINFO_SIZE,  # noqa: F401 (re-export for tests)
     OPENCLOSE_SIZE,  # noqa: F401 (re-export for tests)
     STATUS_SIZE,  # noqa: F401 (re-export for tests)
     TOKEN_ACK_SIZE,  # noqa: F401 (re-export for tests)
     ControlPhaseRuntime,
 )
-from .audio import AudioPacket, AudioStream
-from .civ import CivEvent, CivRequestTracker
-from .commander import IcomCommander, Priority
-from .commands import (
+from icom_lan.audio import AudioPacket, AudioStream
+from icom_lan.civ import CivEvent, CivRequestTracker
+from icom_lan.commander import IcomCommander, Priority
+from icom_lan.commands import (
     _SUB_REPEATER_TONE,
     _SUB_REPEATER_TSQL,
     CONTROLLER_ADDR,
@@ -246,31 +246,31 @@ from .commands import (
     set_xfc_status,
     stop_cw,
 )
-from .commands import (
+from icom_lan.commands import (
     get_attenuator as get_attenuator_cmd,  # Transceiver status family (#136); VFO / Dual Watch / Scanning (#132); Tone/TSQL (#134); System/Config commands (#135); Memory and band-stacking (#133)
 )
-from .commands import get_data_mode as get_data_mode_cmd
-from .commands import get_main_sub_tracking as _get_main_sub_tracking_cmd
-from .commands import get_preamp as get_preamp_cmd
-from .commands import get_repeater_tone as _get_repeater_tone_cmd
-from .commands import get_repeater_tsql as _get_repeater_tsql_cmd
-from .commands import get_tone_freq as _get_tone_freq_cmd
-from .commands import get_tsql_freq as _get_tsql_freq_cmd
-from .commands import set_data_mode as set_data_mode_cmd
-from .commands import set_main_sub_tracking as _set_main_sub_tracking_cmd
-from .commands import set_repeater_tone as _set_repeater_tone_cmd
-from .commands import set_repeater_tsql as _set_repeater_tsql_cmd
-from .commands import set_tone_freq as _set_tone_freq_cmd
-from .commands import set_tsql_freq as _set_tsql_freq_cmd
-from .commands import set_vfo as _select_vfo_cmd
-from .exceptions import CommandError, TimeoutError
-from .meter_cal import interpolate_swr
-from .profiles import RadioProfile, resolve_radio_profile
-from .radio_state import RadioState
-from ._state_cache import StateCache
-from .scope import ScopeAssembler, ScopeFrame
-from .transport import IcomTransport
-from .types import (
+from icom_lan.commands import get_data_mode as get_data_mode_cmd
+from icom_lan.commands import get_main_sub_tracking as _get_main_sub_tracking_cmd
+from icom_lan.commands import get_preamp as get_preamp_cmd
+from icom_lan.commands import get_repeater_tone as _get_repeater_tone_cmd
+from icom_lan.commands import get_repeater_tsql as _get_repeater_tsql_cmd
+from icom_lan.commands import get_tone_freq as _get_tone_freq_cmd
+from icom_lan.commands import get_tsql_freq as _get_tsql_freq_cmd
+from icom_lan.commands import set_data_mode as set_data_mode_cmd
+from icom_lan.commands import set_main_sub_tracking as _set_main_sub_tracking_cmd
+from icom_lan.commands import set_repeater_tone as _set_repeater_tone_cmd
+from icom_lan.commands import set_repeater_tsql as _set_repeater_tsql_cmd
+from icom_lan.commands import set_tone_freq as _set_tone_freq_cmd
+from icom_lan.commands import set_tsql_freq as _set_tsql_freq_cmd
+from icom_lan.commands import set_vfo as _select_vfo_cmd
+from icom_lan.exceptions import CommandError, TimeoutError
+from icom_lan.meter_cal import interpolate_swr
+from icom_lan.profiles import RadioProfile, resolve_radio_profile
+from icom_lan.radio_state import RadioState
+from icom_lan._state_cache import StateCache
+from icom_lan.scope import ScopeAssembler, ScopeFrame
+from icom_lan.transport import IcomTransport
+from icom_lan.types import (
     AgcMode,
     AudioCodec,
     AudioPeakFilter,
@@ -896,7 +896,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     def audio_bus(self) -> Any:
         """Lazy-initialized AudioBus for pub/sub audio distribution."""
         if self._audio_bus is None:
-            from .audio_bus import AudioBus
+            from icom_lan.audio_bus import AudioBus
 
             self._audio_bus = AudioBus(self)
         return self._audio_bus
@@ -1682,7 +1682,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_squelch",
         )
-        from .commands import set_squelch as _set_squelch
+        from icom_lan.commands import set_squelch as _set_squelch
 
         civ = _set_squelch(level, to_addr=self._radio_addr, receiver=receiver)
         await self._send_civ_raw(civ, wait_response=False)
@@ -1698,7 +1698,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="get_squelch",
         )
-        from .commands import get_squelch as _get_squelch
+        from icom_lan.commands import get_squelch as _get_squelch
 
         civ = _get_squelch(to_addr=self._radio_addr, receiver=receiver)
         return await self._get_bcd_level(
@@ -3606,7 +3606,7 @@ class IcomRadio(CoreRadio):
     @staticmethod
     async def _flush_queue(transport: IcomTransport, max_pkts: int = 200) -> int:
         """Flush receive queue on the given transport (delegates to ControlPhaseRuntime)."""
-        from ._control_phase import ControlPhaseRuntime
+        from icom_lan._control_phase import ControlPhaseRuntime
 
         return await ControlPhaseRuntime._flush_queue(transport, max_pkts)
 
@@ -3624,7 +3624,7 @@ def _check_protocol_compliance() -> None:
     Note: ``@runtime_checkable`` checks only method/attribute *existence*.
     It does not validate full runtime semantics.
     """
-    from .radio_protocol import (
+    from icom_lan.radio_protocol import (
         AudioCapable,
         DualReceiverCapable,
         Radio,


### PR DESCRIPTION
## Summary

Step 8b of 13. **Closes #1291** (completes Step 8).

Moves `radio.py` (3653 LOC, the largest single file in the codebase) from `src/icom_lan/` to `src/icom_lan/runtime/`. Together with #1311 (Step 8a), this completes Step 8.

~42 absolute-import rewrites — every `from .<X> import …` becomes `from icom_lan.<X> import …` EXCEPT the 3 sibling-relative imports of `radio_initial_state`, `radio_reconnect`, `radio_state_snapshot` (now in `runtime/` after Step 8a). Top-level absolute paths route directly today (or via shim once their targets migrate in Steps 9/10). Step 13 will canonicalize all of them.

## §5.1.1 underscore re-export pattern (new shim sub-template)

The hybrid sys.modules-alias shim's `from <canonical> import *` excludes underscore-prefixed names by Python spec. `src/icom_lan/sync.py:23` imports the private `_DEFAULT_AUDIO_CODEC` through the old `icom_lan.radio` path — invisible to mypy after the move. Fix: a one-line explicit underscore re-import in the shim, using the PEP 484 `X as X` form (plain `from X import _foo` still trips mypy's non-explicit-reexport rule). The plan §5.1.1 documents this as the standard fix when consumers reach private symbols through any shim. The pre-existing §5.1.1 ("Why sys.modules-alias…") was renumbered to §5.1.2. Underscore re-exports become dead after Step 13's global canonicalization.

## Verification
- Tests: 5201 passed, 2 skipped, 9 xfailed, 1 xpassed (5213 collected, all green).
- Contracts: 3 passed.
- ruff, mypy: clean (the §5.1.1 fix resolves the sole mypy regression caught by 8b's verification).
- Identity invariant + Tier 1 + Tier 2 lazy resolution chains verified.

## What's NOT in this PR
- No LAZY_MAP changes (Step 13).
- No behaviour changes.

Closes #1291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)