### PR TITLE
refactor(#1292): [Modularization 9/13] move 5 runtime mixins into runtime/

### DIFF
--- a/src/icom_lan/_audio_runtime_mixin.py
+++ b/src/icom_lan/_audio_runtime_mixin.py
@@ -1,0 +1,25 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.runtime._audio_runtime_mixin
+Do not add new symbols here — add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan._audio_runtime_mixin`` literally the same module
+object as ``icom_lan.runtime._audio_runtime_mixin``. This preserves
+attribute walks (incl. stdlib names not in ``__all__``) and
+monkeypatch targets.
+
+The two import lines below are BOTH load-bearing — do not remove
+either:
+
+* ``from icom_lan.runtime._audio_runtime_mixin import *`` —
+  static-analysis adapter.
+* ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.runtime._audio_runtime_mixin import *  # noqa: F401, F403
+import icom_lan.runtime._audio_runtime_mixin as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/icom_lan/_dual_rx_runtime.py
+++ b/src/icom_lan/_dual_rx_runtime.py
@@ -1,0 +1,25 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.runtime._dual_rx_runtime
+Do not add new symbols here — add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan._dual_rx_runtime`` literally the same module object
+as ``icom_lan.runtime._dual_rx_runtime``. This preserves attribute
+walks (incl. stdlib names not in ``__all__``) and monkeypatch
+targets.
+
+The two import lines below are BOTH load-bearing — do not remove
+either:
+
+* ``from icom_lan.runtime._dual_rx_runtime import *`` —
+  static-analysis adapter.
+* ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.runtime._dual_rx_runtime import *  # noqa: F401, F403
+import icom_lan.runtime._dual_rx_runtime as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/icom_lan/_runtime_protocols.py
+++ b/src/icom_lan/_runtime_protocols.py
@@ -1,0 +1,25 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.runtime._runtime_protocols
+Do not add new symbols here — add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan._runtime_protocols`` literally the same module
+object as ``icom_lan.runtime._runtime_protocols``. This preserves
+attribute walks (incl. stdlib names not in ``__all__``) and
+monkeypatch targets.
+
+The two import lines below are BOTH load-bearing — do not remove
+either:
+
+* ``from icom_lan.runtime._runtime_protocols import *`` —
+  static-analysis adapter.
+* ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.runtime._runtime_protocols import *  # noqa: F401, F403
+import icom_lan.runtime._runtime_protocols as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/icom_lan/_scope_runtime.py
+++ b/src/icom_lan/_scope_runtime.py
@@ -1,0 +1,25 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.runtime._scope_runtime
+Do not add new symbols here — add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan._scope_runtime`` literally the same module object
+as ``icom_lan.runtime._scope_runtime``. This preserves attribute
+walks (incl. stdlib names not in ``__all__``) and monkeypatch
+targets.
+
+The two import lines below are BOTH load-bearing — do not remove
+either:
+
+* ``from icom_lan.runtime._scope_runtime import *`` —
+  static-analysis adapter.
+* ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.runtime._scope_runtime import *  # noqa: F401, F403
+import icom_lan.runtime._scope_runtime as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/icom_lan/_shared_state_runtime.py
+++ b/src/icom_lan/_shared_state_runtime.py
@@ -1,0 +1,25 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.runtime._shared_state_runtime
+Do not add new symbols here — add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan._shared_state_runtime`` literally the same module
+object as ``icom_lan.runtime._shared_state_runtime``. This preserves
+attribute walks (incl. stdlib names not in ``__all__``) and
+monkeypatch targets.
+
+The two import lines below are BOTH load-bearing — do not remove
+either:
+
+* ``from icom_lan.runtime._shared_state_runtime import *`` —
+  static-analysis adapter.
+* ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.runtime._shared_state_runtime import *  # noqa: F401, F403
+import icom_lan.runtime._shared_state_runtime as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/icom_lan/runtime/_audio_runtime_mixin.py
+++ b/src/icom_lan/runtime/_audio_runtime_mixin.py
@@ -12,16 +12,17 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Callable
 
-    from .audio import AudioPacket
+    from icom_lan.audio import AudioPacket
+
     from .radio import CoreRadio as _MixinBase  # type: ignore[attr-defined]
 else:
     _MixinBase = object
 
-from ._audio_transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
-from .audio import AudioStats, AudioStream
-from .exceptions import ConnectionError
-from .transport import IcomTransport
-from .types import AudioCodec
+from icom_lan._audio_transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
+from icom_lan.audio import AudioStats, AudioStream
+from icom_lan.exceptions import ConnectionError
+from icom_lan.transport import IcomTransport
+from icom_lan.types import AudioCodec
 
 logger = logging.getLogger(__name__)
 

--- a/src/icom_lan/runtime/_dual_rx_runtime.py
+++ b/src/icom_lan/runtime/_dual_rx_runtime.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 else:
     _MixinBase = object
 
-from .commands import (
+from icom_lan.commands import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
     build_civ_frame,
@@ -27,14 +27,14 @@ from .commands import (
     set_freq,
     set_mode,
 )
-from .commands import get_selected_freq as _get_selected_freq_cmd
-from .commands import get_selected_mode as _get_selected_mode_cmd
-from .commands import get_unselected_freq as _get_unselected_freq_cmd
-from .commands import get_unselected_mode as _get_unselected_mode_cmd
-from .commands import parse_selected_freq_response as _parse_selected_freq_response
-from .commands import parse_selected_mode_response as _parse_selected_mode_response
-from .exceptions import CommandError, TimeoutError
-from .types import Mode
+from icom_lan.commands import get_selected_freq as _get_selected_freq_cmd
+from icom_lan.commands import get_selected_mode as _get_selected_mode_cmd
+from icom_lan.commands import get_unselected_freq as _get_unselected_freq_cmd
+from icom_lan.commands import get_unselected_mode as _get_unselected_mode_cmd
+from icom_lan.commands import parse_selected_freq_response as _parse_selected_freq_response
+from icom_lan.commands import parse_selected_mode_response as _parse_selected_mode_response
+from icom_lan.exceptions import CommandError, TimeoutError
+from icom_lan.types import Mode
 
 # CI-V command byte for VFO select / equal / swap (0x07).
 _CMD_VFO = 0x07

--- a/src/icom_lan/runtime/_runtime_protocols.py
+++ b/src/icom_lan/runtime/_runtime_protocols.py
@@ -14,16 +14,16 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Callable, Protocol
 
 if TYPE_CHECKING:
-    from .audio import AudioPacket, AudioStream
-    from .civ import CivEvent, CivRequestTracker
-    from .commander import IcomCommander
-    from ._bounded_queue import BoundedQueue
-    from ._civ_rx import CivRuntime
-    from ._state_cache import StateCache
-    from .radio_state import RadioState
-    from .scope import ScopeAssembler, ScopeFrame
-    from .transport import IcomTransport
-    from .types import Mode
+    from icom_lan._bounded_queue import BoundedQueue
+    from icom_lan._civ_rx import CivRuntime
+    from icom_lan._state_cache import StateCache
+    from icom_lan.audio import AudioPacket, AudioStream
+    from icom_lan.civ import CivEvent, CivRequestTracker
+    from icom_lan.commander import IcomCommander
+    from icom_lan.radio_state import RadioState
+    from icom_lan.scope import ScopeAssembler, ScopeFrame
+    from icom_lan.transport import IcomTransport
+    from icom_lan.types import Mode
 
 
 __all__ = [

--- a/src/icom_lan/runtime/_scope_runtime.py
+++ b/src/icom_lan/runtime/_scope_runtime.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 else:
     _MixinBase = object
 
-from .commands import (
+from icom_lan.commands import (
     parse_ack_nak,
     parse_civ_frame,
     parse_scope_center_type_response,
@@ -34,38 +34,38 @@ from .commands import (
     parse_scope_speed_response,
     parse_scope_vbw_response,
 )
-from .commands import get_scope_center_type as _get_scope_center_type_cmd
-from .commands import get_scope_during_tx as _get_scope_during_tx_cmd
-from .commands import get_scope_edge as _get_scope_edge_cmd
-from .commands import get_scope_fixed_edge as _get_scope_fixed_edge_cmd
-from .commands import get_scope_hold as _get_scope_hold_cmd
-from .commands import get_scope_main_sub as _get_scope_main_sub_cmd
-from .commands import get_scope_mode as _get_scope_mode_cmd
-from .commands import get_scope_rbw as _get_scope_rbw_cmd
-from .commands import get_scope_ref as _get_scope_ref_cmd
-from .commands import get_scope_single_dual as _get_scope_single_dual_cmd
-from .commands import get_scope_span as _get_scope_span_cmd
-from .commands import get_scope_speed as _get_scope_speed_cmd
-from .commands import get_scope_vbw as _get_scope_vbw_cmd
-from .commands import scope_data_output as _scope_data_output_cmd
-from .commands import scope_main_sub as _scope_main_sub_cmd
-from .commands import scope_on as _scope_on_cmd
-from .commands import scope_set_center_type as _scope_set_center_type_cmd
-from .commands import scope_set_during_tx as _scope_set_during_tx_cmd
-from .commands import scope_set_edge as _scope_set_edge_cmd
-from .commands import scope_set_fixed_edge as _scope_set_fixed_edge_cmd
-from .commands import scope_set_hold as _scope_set_hold_cmd
-from .commands import scope_set_mode as _scope_set_mode_cmd
-from .commands import scope_set_rbw as _scope_set_rbw_cmd
-from .commands import scope_set_ref as _scope_set_ref_cmd
-from .commands import scope_set_span as _scope_set_span_cmd
-from .commands import scope_set_speed as _scope_set_speed_cmd
-from .commands import scope_set_vbw as _scope_set_vbw_cmd
-from .commands import scope_single_dual as _scope_single_dual_cmd
-from .exceptions import CommandError, TimeoutError
-from .radio_state import ScopeControlsState
-from .scope import ScopeFrame
-from .types import ScopeCompletionPolicy, ScopeFixedEdge
+from icom_lan.commands import get_scope_center_type as _get_scope_center_type_cmd
+from icom_lan.commands import get_scope_during_tx as _get_scope_during_tx_cmd
+from icom_lan.commands import get_scope_edge as _get_scope_edge_cmd
+from icom_lan.commands import get_scope_fixed_edge as _get_scope_fixed_edge_cmd
+from icom_lan.commands import get_scope_hold as _get_scope_hold_cmd
+from icom_lan.commands import get_scope_main_sub as _get_scope_main_sub_cmd
+from icom_lan.commands import get_scope_mode as _get_scope_mode_cmd
+from icom_lan.commands import get_scope_rbw as _get_scope_rbw_cmd
+from icom_lan.commands import get_scope_ref as _get_scope_ref_cmd
+from icom_lan.commands import get_scope_single_dual as _get_scope_single_dual_cmd
+from icom_lan.commands import get_scope_span as _get_scope_span_cmd
+from icom_lan.commands import get_scope_speed as _get_scope_speed_cmd
+from icom_lan.commands import get_scope_vbw as _get_scope_vbw_cmd
+from icom_lan.commands import scope_data_output as _scope_data_output_cmd
+from icom_lan.commands import scope_main_sub as _scope_main_sub_cmd
+from icom_lan.commands import scope_on as _scope_on_cmd
+from icom_lan.commands import scope_set_center_type as _scope_set_center_type_cmd
+from icom_lan.commands import scope_set_during_tx as _scope_set_during_tx_cmd
+from icom_lan.commands import scope_set_edge as _scope_set_edge_cmd
+from icom_lan.commands import scope_set_fixed_edge as _scope_set_fixed_edge_cmd
+from icom_lan.commands import scope_set_hold as _scope_set_hold_cmd
+from icom_lan.commands import scope_set_mode as _scope_set_mode_cmd
+from icom_lan.commands import scope_set_rbw as _scope_set_rbw_cmd
+from icom_lan.commands import scope_set_ref as _scope_set_ref_cmd
+from icom_lan.commands import scope_set_span as _scope_set_span_cmd
+from icom_lan.commands import scope_set_speed as _scope_set_speed_cmd
+from icom_lan.commands import scope_set_vbw as _scope_set_vbw_cmd
+from icom_lan.commands import scope_single_dual as _scope_single_dual_cmd
+from icom_lan.exceptions import CommandError, TimeoutError
+from icom_lan.radio_state import ScopeControlsState
+from icom_lan.scope import ScopeFrame
+from icom_lan.types import ScopeCompletionPolicy, ScopeFixedEdge
 
 logger = logging.getLogger(__name__)
 

--- a/src/icom_lan/runtime/_shared_state_runtime.py
+++ b/src/icom_lan/runtime/_shared_state_runtime.py
@@ -20,10 +20,10 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Final
 
-from ._state_cache import CacheField, StateCache
+from icom_lan._state_cache import CacheField, StateCache
 
 if TYPE_CHECKING:
-    from .radio_protocol import Radio
+    from icom_lan.radio_protocol import Radio
 
 __all__ = [
     "DEFAULT_STATE_CACHE_TTL",
@@ -163,7 +163,7 @@ async def poll_powerstat(
     Returns:
         True if powered on, False if powered off, or ``None`` if the radio call failed.
     """
-    from .capabilities import CAP_POWER_CONTROL
+    from icom_lan.capabilities import CAP_POWER_CONTROL
 
     if is_cache_fresh(cache, "powerstat", ttl):
         return cache.powerstat


### PR DESCRIPTION
## Summary

Step 9 of 13. **Closes #1292**.

Moves the 5 runtime mixins (~2028 LOC) from `src/icom_lan/` into `src/icom_lan/runtime/`:
`_audio_runtime_mixin`, `_dual_rx_runtime`, `_scope_runtime`, `_shared_state_runtime`, `_runtime_protocols`.

~30+ absolute-import rewrites following the established pattern (top-level absolute via shim, deferred canonicalization to Step 13). The `from .radio import CoreRadio` TYPE_CHECKING imports in 3 of the mixins stay relative — `radio` is now a sibling inside `runtime/` after Step 8b.

5 sys.modules-alias hybrid shims at the old top-level paths.

## Verification
- Tests: 5213 collected, all green.
- Contracts: 3 passed.
- ruff, mypy: clean.
- Identity invariants verified for all 5 modules.
- IcomRadio MRO chain (which uses these mixins) still resolves correctly.

## What's NOT in this PR
- No LAZY_MAP changes (Step 13).
- No behaviour changes.

Closes #1292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)