### PR TITLE
refactor(#1294): [Modularization 11/13] move discovery.py to backends/

### DIFF
--- a/src/icom_lan/backends/discovery.py
+++ b/src/icom_lan/backends/discovery.py
@@ -184,7 +184,7 @@ async def _try_baud(
 
 def _default_open_serial() -> _OpenSerial:
     """Return the real serial_asyncio opener, or raise ImportError with hint."""
-    from ._optional_deps import _require_pyserial_asyncio
+    from icom_lan._optional_deps import _require_pyserial_asyncio
 
     _require_pyserial_asyncio()
     import serial_asyncio  # type: ignore[import-untyped]
@@ -260,7 +260,7 @@ _YaesuTransportFactory = Callable[..., Any]
 
 def _default_yaesu_transport_factory() -> _YaesuTransportFactory:
     """Return YaesuCatTransport class, or raise ImportError with hint."""
-    from .backends.yaesu_cat.transport import YaesuCatTransport
+    from .yaesu_cat.transport import YaesuCatTransport
 
     return YaesuCatTransport
 
@@ -511,7 +511,7 @@ async def discover_serial_radios(
     Returns:
         List of :class:`RadioDiscoveryResult` for all detected radios.
     """
-    from .radios import CIV_PROFILE_MAP, identify_radio
+    from icom_lan.radios import CIV_PROFILE_MAP, identify_radio
 
     candidates = enumerate_serial_ports()
     results: list[RadioDiscoveryResult] = []

--- a/src/icom_lan/discovery.py
+++ b/src/icom_lan/discovery.py
@@ -1,0 +1,24 @@
+"""Re-export shim for backwards compatibility.
+
+Canonical location: icom_lan.backends.discovery
+Do not add new symbols here — add them at the canonical location.
+
+This file uses the sys.modules-alias pattern: importing this shim
+makes ``icom_lan.discovery`` literally the same module object as
+``icom_lan.backends.discovery``. This preserves attribute walks
+(incl. stdlib names not in ``__all__``) and monkeypatch targets.
+
+The two import lines below are BOTH load-bearing — do not remove
+either:
+
+* ``from icom_lan.backends.discovery import *`` — static-analysis
+  adapter.
+* ``sys.modules[__name__] = _canonical`` — the runtime invariant.
+"""
+
+import sys
+
+from icom_lan.backends.discovery import *  # noqa: F401, F403
+import icom_lan.backends.discovery as _canonical
+
+sys.modules[__name__] = _canonical


### PR DESCRIPTION
## Summary

Step 11 of 13. **Closes #1294**.

Moves `discovery.py` (635 LOC) from `src/icom_lan/` to `src/icom_lan/backends/discovery.py`. Per plan §1.3, `discovery` is properly part of the `backends` layer — it auto-discovers which backend type to use, depending on `backends.yaesu_cat` and `runtime.radios`.

3 absolute-import rewrites in 3 function-local sites (lines 187, 263, 514). The `from .backends.yaesu_cat.transport` becomes `from .yaesu_cat.transport` — the only sibling-relative import left, since `discovery.py` is now inside `backends/`.

1 sys.modules-alias hybrid shim at `src/icom_lan/discovery.py`.

## Verification
- Tests: 5213 collected, all green.
- Contracts: 3 passed.
- ruff, mypy: clean.
- Identity invariant verified.

## What's NOT in this PR
- No LAZY_MAP changes (Step 13).
- No behaviour changes.

Closes #1294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)