### PR TITLE
refactor(#1297): migrate test imports to canonical layer paths

### DIFF
--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -9,8 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from icom_lan._bridge_metrics import BridgeMetrics
-from icom_lan._bridge_state import BridgeState, BridgeStateChange
+from icom_lan.audio._bridge_metrics import BridgeMetrics
+from icom_lan.audio._bridge_state import BridgeState, BridgeStateChange
 from icom_lan.audio.backend import (
     AudioDeviceId,
     AudioDeviceInfo,

--- a/tests/test_audio_codecs.py
+++ b/tests/test_audio_codecs.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from icom_lan._audio_codecs import decode_ulaw_to_pcm16
+from icom_lan.audio._codecs import decode_ulaw_to_pcm16
 
 
 class TestUlawDecoder:

--- a/tests/test_audio_transcoder.py
+++ b/tests/test_audio_transcoder.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from icom_lan._audio_transcoder import PcmAudioFormat, PcmOpusTranscoder
+from icom_lan.audio._transcoder import PcmAudioFormat, PcmOpusTranscoder
 from icom_lan.audio import AudioPacket
 from icom_lan.exceptions import (
     AudioCodecBackendError,

--- a/tests/test_audio_transcoder_coverage.py
+++ b/tests/test_audio_transcoder_coverage.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from icom_lan._audio_transcoder import (
+from icom_lan.audio._transcoder import (
     PcmAudioFormat,
     PcmOpusTranscoder,
     _OpuslibBackend,

--- a/tests/test_bounded_queue.py
+++ b/tests/test_bounded_queue.py
@@ -6,7 +6,7 @@ import asyncio
 
 import pytest
 
-from icom_lan._bounded_queue import BoundedQueue
+from icom_lan.core._bounded_queue import BoundedQueue
 
 
 def test_put_get_preserves_fifo_order() -> None:

--- a/tests/test_bsr_band_switching.py
+++ b/tests/test_bsr_band_switching.py
@@ -39,14 +39,14 @@ class TestCivExpectsResponseBSR:
 
     def test_bsr_read_expects_response(self) -> None:
         """BSR read (1A 01 with 2 data bytes) should expect a response."""
-        from icom_lan._civ_rx import CivRuntime
+        from icom_lan.runtime._civ_rx import CivRuntime
 
         frame = self._make_frame(cmd=0x1A, sub=0x01, data=bytes([0x05, 0x01]))
         assert CivRuntime._civ_expects_response(frame) is True
 
     def test_bsr_write_does_not_expect_response(self) -> None:
         """BSR write (1A 01 with >2 data bytes = full content) → fire-and-forget."""
-        from icom_lan._civ_rx import CivRuntime
+        from icom_lan.runtime._civ_rx import CivRuntime
 
         # Write: band(1) + register(1) + freq(5) + mode(1) + filter(1) = 9 bytes
         data = bytes([0x05, 0x01, 0x00, 0x40, 0x26, 0x14, 0x00, 0x01, 0x01])
@@ -55,7 +55,7 @@ class TestCivExpectsResponseBSR:
 
     def test_config_read_still_works(self) -> None:
         """Existing 1A 05 (config read, 2 data bytes) still expects response."""
-        from icom_lan._civ_rx import CivRuntime
+        from icom_lan.runtime._civ_rx import CivRuntime
 
         frame = self._make_frame(cmd=0x1A, sub=0x05, data=bytes([0x00, 0x71]))
         assert CivRuntime._civ_expects_response(frame) is True

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -38,7 +38,7 @@ import pytest
 from test_radio import MockTransport, _wrap_civ_in_udp
 
 from icom_lan import IC_7610_ADDR
-from icom_lan._civ_rx import CIV_HEADER_SIZE
+from icom_lan.runtime._civ_rx import CIV_HEADER_SIZE
 from icom_lan.commands import CONTROLLER_ADDR, build_civ_frame
 from icom_lan.exceptions import ConnectionError
 from icom_lan.radio import IcomRadio

--- a/tests/test_civ_rx_mixin_host.py
+++ b/tests/test_civ_rx_mixin_host.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from icom_lan._civ_rx import CivRuntime
+from icom_lan.runtime._civ_rx import CivRuntime
 from icom_lan.exceptions import ConnectionError
 
 

--- a/tests/test_docs_runtime_sync.py
+++ b/tests/test_docs_runtime_sync.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from icom_lan._connection_state import RadioConnectionState
+from icom_lan.runtime._connection_state import RadioConnectionState
 from icom_lan.radio import IcomRadio
 from icom_lan.web.handlers import ControlHandler
 from icom_lan.web.protocol import decode_json

--- a/tests/test_lifecycle_diagnostics.py
+++ b/tests/test_lifecycle_diagnostics.py
@@ -11,7 +11,7 @@ import logging
 
 import pytest
 
-from icom_lan._connection_state import RadioConnectionState
+from icom_lan.runtime._connection_state import RadioConnectionState
 from icom_lan.backends.icom7610.drivers.serial_stub import SerialMockRadio
 from icom_lan.radio import IcomRadio
 from icom_lan.rigctld.contract import RigctldConfig

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -119,7 +119,7 @@ def radio(mock_transport: MockTransport):
 
 
 def test_conn_state_returns_current_state(radio: IcomRadio) -> None:
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     assert radio.conn_state == RadioConnectionState.CONNECTED
 
@@ -158,7 +158,7 @@ def test_radio_ready_false_when_civ_data_is_stale(radio: IcomRadio) -> None:
 def test_intentional_disconnect_property_reflects_disconnected_state(
     radio: IcomRadio,
 ) -> None:
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     # CONNECTED → not intentional disconnect
     assert radio._intentional_disconnect is False
@@ -168,7 +168,7 @@ def test_intentional_disconnect_property_reflects_disconnected_state(
 
 
 def test_intentional_disconnect_setter_true_sets_disconnected(radio: IcomRadio) -> None:
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._intentional_disconnect = True
     assert radio._conn_state == RadioConnectionState.DISCONNECTED
@@ -177,7 +177,7 @@ def test_intentional_disconnect_setter_true_sets_disconnected(radio: IcomRadio) 
 def test_intentional_disconnect_setter_false_when_disconnected_sets_reconnecting(
     radio: IcomRadio,
 ) -> None:
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._conn_state = RadioConnectionState.DISCONNECTED
     radio._intentional_disconnect = False
@@ -201,7 +201,7 @@ def test_civ_stats_returns_dict(radio: IcomRadio) -> None:
 
 
 async def test_soft_disconnect_when_not_connected_is_noop(radio: IcomRadio) -> None:
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._conn_state = RadioConnectionState.DISCONNECTED
     # Should not raise
@@ -1279,7 +1279,7 @@ async def test_force_cleanup_civ_tears_down_transport(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
     """_force_cleanup_civ disconnects transport unconditionally (lines 407-417)."""
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     with (
         patch.object(radio._civ_runtime, "stop_data_watchdog", new=AsyncMock()),
@@ -1331,7 +1331,7 @@ async def test_soft_reconnect_reconnects_civ_when_ctrl_alive(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
     """soft_reconnect() opens new CI-V transport when ctrl is still alive (lines 434-472)."""
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._civ_transport = None
     # Make ctrl transport appear alive
@@ -1526,7 +1526,7 @@ async def test_watchdog_loop_triggers_reconnect_on_timeout(radio: IcomRadio) -> 
 
 async def test_reconnect_loop_succeeds_on_first_attempt(radio: IcomRadio) -> None:
     """_reconnect_loop reconnects successfully on first attempt (lines 553-581)."""
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._conn_state = RadioConnectionState.RECONNECTING
 
@@ -1550,7 +1550,7 @@ async def test_reconnect_loop_succeeds_on_first_attempt(radio: IcomRadio) -> Non
 
 async def test_reconnect_loop_handles_audio_stop_failure(radio: IcomRadio) -> None:
     """_reconnect_loop handles failure when stopping audio stream (lines 553-554)."""
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._conn_state = RadioConnectionState.RECONNECTING
 
@@ -1579,7 +1579,7 @@ async def test_reconnect_loop_handles_audio_stop_failure(radio: IcomRadio) -> No
 
 async def test_reconnect_loop_retries_on_failure(radio: IcomRadio) -> None:
     """_reconnect_loop retries with backoff when connect fails (lines 583-586)."""
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._conn_state = RadioConnectionState.RECONNECTING
     radio._reconnect_delay = 0.001  # very short delay
@@ -1608,7 +1608,7 @@ async def test_reconnect_loop_stops_audio_transport_on_reconnect(
     radio: IcomRadio,
 ) -> None:
     """_reconnect_loop disconnects audio transport during retry (lines 559-561)."""
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._conn_state = RadioConnectionState.RECONNECTING
 
@@ -1634,7 +1634,7 @@ async def test_reconnect_loop_stops_civ_transport_on_reconnect(
     radio: IcomRadio,
 ) -> None:
     """_reconnect_loop disconnects civ transport during retry (lines 564-567)."""
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._conn_state = RadioConnectionState.RECONNECTING
 
@@ -1657,7 +1657,7 @@ async def test_reconnect_loop_stops_ctrl_transport_on_reconnect(
     radio: IcomRadio,
 ) -> None:
     """_reconnect_loop disconnects ctrl transport during retry (lines 568-571)."""
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._conn_state = RadioConnectionState.RECONNECTING
 
@@ -1678,7 +1678,7 @@ async def test_reconnect_loop_attempts_token_remove(
     radio: IcomRadio,
 ) -> None:
     """_reconnect_loop sends token-remove before ctrl transport disconnect."""
-    from icom_lan._connection_state import RadioConnectionState
+    from icom_lan.runtime._connection_state import RadioConnectionState
 
     radio._conn_state = RadioConnectionState.RECONNECTING
     radio._audio_transport = None

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from icom_lan._connection_state import RadioConnectionState
+from icom_lan.runtime._connection_state import RadioConnectionState
 from icom_lan.exceptions import AuthenticationError
 from icom_lan.radio import IcomRadio
 

--- a/tests/test_shared_state_runtime.py
+++ b/tests/test_shared_state_runtime.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from icom_lan._shared_state_runtime import (
+from icom_lan.runtime._shared_state_runtime import (
     DEFAULT_STATE_CACHE_TTL,
     is_cache_fresh,
     poll_frequency,

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from icom_lan._state_queries import build_state_queries
+from icom_lan.runtime._state_queries import build_state_queries
 from icom_lan.profiles import resolve_radio_profile
 
 

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from icom_lan._connection_state import RadioConnectionState
+from icom_lan.runtime._connection_state import RadioConnectionState
 from icom_lan.sync import IcomRadio
 
 

--- a/tests/test_tx_band_edge.py
+++ b/tests/test_tx_band_edge.py
@@ -191,7 +191,7 @@ class TestCivRxTxBandEdge:
 
         rs = RadioState()
         # Import and call the parser directly
-        from icom_lan._civ_rx import CivRuntime
+        from icom_lan.runtime._civ_rx import CivRuntime
 
         # We need a minimal host to test the parser
         from unittest.mock import MagicMock
@@ -215,7 +215,7 @@ class TestCivRxTxBandEdge:
         frame = self._make_frame(sub=0x01, data=data)
 
         rs = RadioState()
-        from icom_lan._civ_rx import CivRuntime
+        from icom_lan.runtime._civ_rx import CivRuntime
         from unittest.mock import MagicMock
 
         host = MagicMock()
@@ -233,7 +233,7 @@ class TestCivRxTxBandEdge:
         frame = self._make_frame(sub=0x01, data=bytes(5))
 
         rs = RadioState()
-        from icom_lan._civ_rx import CivRuntime
+        from icom_lan.runtime._civ_rx import CivRuntime
         from unittest.mock import MagicMock
 
         host = MagicMock()

--- a/tests/test_web_audio_streaming_profile.py
+++ b/tests/test_web_audio_streaming_profile.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from icom_lan._audio_codecs import decode_ulaw_to_pcm16
+from icom_lan.audio._codecs import decode_ulaw_to_pcm16
 from icom_lan.types import AudioCodec
 from icom_lan.web.handlers import AudioBroadcaster
 from icom_lan.web.protocol import (

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -869,7 +869,7 @@ async def test_slow_poll_skips_fr_ft_without_dual_rx() -> None:
 @pytest.mark.asyncio
 async def test_execute_command_set_apf_dispatches_to_radio() -> None:
     """SetApf must reach radio.set_audio_peak_filter — used to be silently dropped."""
-    from icom_lan._poller_types import SetApf
+    from icom_lan.runtime._poller_types import SetApf
 
     radio = make_radio()
     radio.set_audio_peak_filter = AsyncMock()
@@ -883,7 +883,7 @@ async def test_execute_command_set_apf_dispatches_to_radio() -> None:
 @pytest.mark.asyncio
 async def test_execute_command_set_apf_off_dispatches_to_radio() -> None:
     """SetApf(mode=0) reaches the canonical entry point too."""
-    from icom_lan._poller_types import SetApf
+    from icom_lan.runtime._poller_types import SetApf
 
     radio = make_radio()
     radio.set_audio_peak_filter = AsyncMock()
@@ -902,7 +902,7 @@ async def test_execute_command_set_apf_off_dispatches_to_radio() -> None:
 @pytest.mark.asyncio
 async def test_execute_command_set_power_watts_unit_dispatches_to_radio() -> None:
     """SetPower(unit='watts') flows directly to radio.set_power(watts)."""
-    from icom_lan._poller_types import SetPower
+    from icom_lan.runtime._poller_types import SetPower
 
     radio = make_radio()
     radio.set_power = AsyncMock()
@@ -920,7 +920,7 @@ async def test_execute_command_set_power_raw_255_unit_rejected(
     """Default SetPower(unit='raw_255') is rejected by Yaesu poller and logs warning."""
     import logging
 
-    from icom_lan._poller_types import SetPower
+    from icom_lan.runtime._poller_types import SetPower
 
     radio = make_radio()
     radio.set_power = AsyncMock()


### PR DESCRIPTION
## Summary

**Closes #1297**, the post-modularization follow-up tagged `followup-after-modularization`.

Migrates 39 test-file imports across 18 files from the deprecated top-level private paths to canonical layer-subpackage paths:

- `icom_lan._bridge_metrics` / `_bridge_state` → `icom_lan.audio._bridge_metrics` / `._bridge_state`
- `icom_lan._audio_codecs` → `icom_lan.audio._codecs`
- `icom_lan._audio_transcoder` → `icom_lan.audio._transcoder`
- `icom_lan._bounded_queue` → `icom_lan.core._bounded_queue`
- `icom_lan._civ_rx` → `icom_lan.runtime._civ_rx`
- `icom_lan._connection_state` → `icom_lan.runtime._connection_state`
- `icom_lan._shared_state_runtime` → `icom_lan.runtime._shared_state_runtime`
- `icom_lan._state_queries` → `icom_lan.runtime._state_queries`
- `icom_lan._poller_types` → `icom_lan.runtime._poller_types`

The old top-level shims still work (sys.modules-alias hybrid pattern); this PR is hygiene — tests stop reaching through deprecation paths. No behaviour changes.

Note: the issue and discovery doc cited 43 sites across 15 files; the actual surface at HEAD `3a77a738` was 39 sites across 18 files (minor drift since the discovery survey, all rewrites mechanical).

## Verification
- Tests: 5213 collected, 5201 passed, 2 skipped, 9 xfailed, 1 xpassed (identical to baseline).
- Contracts: 3 passed (`tests/contracts/test_lazy_imports.py`).
- `uv run ruff check src/ tests/`: clean.
- `uv run mypy src/`: clean (205 source files, no issues).
- `uv run lint-imports`: 4 contracts kept, 0 broken.
- `grep -rnE 'from icom_lan\._|import icom_lan\._' tests/ | grep -v test_public_api_surface.py` → zero results.

## What's NOT in this PR
- No source-code changes.
- No public-API additions (the issue body called this out — replacing private API access with public requires separate design and is out of scope).
- The 2 transitional `web_startup → backends.yaesu_cat.*` `ignore_imports` are tracked separately by #1298.

Closes #1297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)