### PR TITLE
refactor(#1298): web_startup uses radio.create_state_poller; drop transitional ignore_imports

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -16,8 +16,6 @@ layers =
 ignore_imports =
     icom_lan.core.radio_protocol -> icom_lan.audio_bus
     icom_lan.core.radio_protocol -> icom_lan.scope
-    icom_lan.web.web_startup -> icom_lan.backends.yaesu_cat.poller
-    icom_lan.web.web_startup -> icom_lan.backends.yaesu_cat.radio
 
 [importlinter:contract:independence-top]
 name = top siblings must not depend on each other

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -22,10 +22,12 @@ from .parser import CatCommandParser, format_command
 from .transport import YaesuCatTransport
 
 if TYPE_CHECKING:
+    from ..._poller_types import CommandQueue
     from ...audio.usb_driver import UsbAudioDriver
     from ...audio_bus import AudioBus
     from ...profiles import RadioProfile
     from ...types import BandStackRegister, MemoryChannel
+    from .poller import YaesuCatPoller
 
 __all__ = ["YaesuCatRadio"]
 
@@ -1898,3 +1900,37 @@ class YaesuCatRadio:
 
     async def set_bsr(self, bsr: "BandStackRegister") -> None:
         raise NotImplementedError("Band stack register not supported on this radio")
+
+    def create_state_poller(
+        self,
+        *,
+        callback: Callable[[RadioState], None],
+        command_queue: "CommandQueue | None" = None,
+    ) -> "YaesuCatPoller":
+        """Construct a request-response state poller for this radio.
+
+        Used by the web layer to drive periodic state-change broadcasts
+        without depending on backend internals. Returns a
+        :class:`YaesuCatPoller` instance — the caller is responsible
+        for awaiting/spawning ``.start()``.
+
+        The lazy import keeps :class:`YaesuCatRadio` from depending on
+        its own poller at module-load time (the poller imports the
+        radio, so a top-level import here would be a cycle).
+
+        Args:
+            callback: Invoked with the current :class:`RadioState`
+                after every successful poll.
+            command_queue: Optional outbound command queue drained on
+                each poll cycle.
+
+        Returns:
+            A :class:`YaesuCatPoller` bound to this radio.
+        """
+        from .poller import YaesuCatPoller
+
+        return YaesuCatPoller(
+            self,
+            callback=callback,
+            command_queue=command_queue,
+        )

--- a/src/icom_lan/web/web_startup.py
+++ b/src/icom_lan/web/web_startup.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ..radio_state import RadioState
 from ..startup_checks import assert_radio_startup_ready
@@ -84,20 +84,17 @@ async def start_web_server(server: WebServer) -> None:
     if server._radio is not None:
         from ..radio_protocol import StateNotifyCapable
 
-        # --- Yaesu CAT backend: use YaesuCatPoller (request-response) ---
-        _is_yaesu = getattr(server._radio, "backend_id", None) == "yaesu_cat"
-
-        if _is_yaesu:
-            from ..backends.yaesu_cat.poller import YaesuCatPoller
+        # --- Yaesu CAT backend: use radio.create_state_poller (request-response) ---
+        if getattr(server._radio, "backend_id", None) == "yaesu_cat":
 
             def _yaesu_state_cb(state: RadioState) -> None:
                 server._radio_state = state
                 server._broadcast_state_update()
 
-            from ..backends.yaesu_cat.radio import YaesuCatRadio as _YaesuCatRadio
-
-            server._yaesu_poller = YaesuCatPoller(
-                cast(_YaesuCatRadio, server._radio),
+            # ``create_state_poller`` is a YaesuCatRadio-specific factory; the
+            # generic ``Radio`` protocol does not declare it, so cast to Any
+            # to express the duck-typed call without importing the concrete.
+            server._yaesu_poller = cast(Any, server._radio).create_state_poller(
                 callback=_yaesu_state_cb,
                 command_queue=server._command_queue,
             )


### PR DESCRIPTION
## Summary

**Closes #1298**, the post-modularization follow-up tagged `followup-after-modularization`.

The web layer no longer reaches into `backends.yaesu_cat.{poller,radio}` directly. Instead:

- **`YaesuCatRadio.create_state_poller(*, callback, command_queue)`** is a new instance method that constructs the request-response state poller. Lazy-imports `YaesuCatPoller` inside the method body to avoid a class-load-time cycle.
- **`web/web_startup.py`** discriminates on the existing `backend_id` attribute and delegates construction via `server._radio.create_state_poller(...)`. Icom CI-V radios continue to use the existing `RadioPoller` fire-and-forget path.

Removes the 2 transitional `ignore_imports` from `.importlinter`:

```diff
- icom_lan.web.web_startup -> icom_lan.backends.yaesu_cat.poller
- icom_lan.web.web_startup -> icom_lan.backends.yaesu_cat.radio
```

The layered-architecture contract is now uniformly enforced for `web` with zero `web -> backends.yaesu_cat.*` exceptions.

## Why a discriminator + factory method, not a Capability Protocol

Adding a new Capability Protocol (e.g. `StatePollerCapable`) would expand the public Radio Protocol surface — out of this followup's scope per the issue body. The smallest possible interface contract is one method on one concrete class, invoked via the radio's own interface. The `backend_id == "yaesu_cat"` discriminator preserves test-fixture compatibility (a generic `hasattr` check would always succeed on `MagicMock`); the architectural goal — no `web -> backends.yaesu_cat.*` imports — is met.

## Verification
- `uv run pytest tests/ -q --ignore=tests/integration`: 5201 passed, 2 skipped, 9 xfailed, 1 xpassed (matches baseline).
- `uv run pytest tests/contracts/ -v`: 3 passed.
- `uv run pytest tests/ -k "yaesu or web_startup"`: 229 passed.
- `uv run ruff check src/ tests/`: clean.
- `uv run mypy src/`: clean.
- **`uv run lint-imports`: 4 contracts kept, 0 broken — WITHOUT the 2 transitional `ignore_imports`.**
- `grep YaesuCat src/icom_lan/web/web_startup.py`: only a docstring/comment reference; no imports, no casts to the concrete class.

## What's NOT in this PR
- No new public-API surface (no Capability Protocol added).
- No behaviour changes — same poller class, same callback wiring, same start sequence.
- Phase 5 / `LAYER.md` / `ARCHITECTURE.md` work is separate.

Closes #1298.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>