### PR TITLE
feat(#1324): RigctldRoutable Protocol (Capability 2/4 of #1322)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -17,6 +17,8 @@ ignore_imports =
     icom_lan.core.radio_protocol -> icom_lan.audio_bus
     icom_lan.core.radio_protocol -> icom_lan.scope
     icom_lan.core.radio_protocol -> icom_lan.runtime._poller_types
+    icom_lan.core.radio_protocol -> icom_lan.rigctld.routing
+    icom_lan.backends.yaesu_cat.radio -> icom_lan.rigctld.routing
 
 [importlinter:contract:independence-top]
 name = top siblings must not depend on each other
@@ -24,6 +26,9 @@ type = independence
 modules =
     icom_lan.web
     icom_lan.rigctld
+ignore_imports =
+    icom_lan.core.radio_protocol -> icom_lan.rigctld.routing
+    icom_lan.backends.yaesu_cat.radio -> icom_lan.rigctld.routing
 
 [importlinter:contract:independence-mid]
 name = mid-tier siblings must not depend on each other

--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -99,7 +99,7 @@ available directly via `from icom_lan import …`.
 - `DualReceiverCapable`, `ReceiverBankCapable`, `TransceiverBankCapable`,
   `VfoSlotCapable`
 - `StateCacheCapable`, `StatePollable`, `StatePoller`,
-  `RecoverableConnection`
+  `RigctldRoutable`, `RecoverableConnection`
 - `DspControlCapable`, `AntennaControlCapable`, `CwControlCapable`,
   `VoiceControlCapable`
 - `SystemControlCapable`, `RepeaterControlCapable`, `AdvancedControlCapable`

--- a/src/icom_lan/__init__.py
+++ b/src/icom_lan/__init__.py
@@ -56,6 +56,7 @@ from .radio_protocol import (  # noqa: F401
     ReceiverBankCapable,
     RecoverableConnection,
     RepeaterControlCapable,
+    RigctldRoutable,
     RitXitCapable,
     ScopeCapable,
     SplitCapable,
@@ -90,7 +91,10 @@ _LAZY_MAP: dict[str, tuple[str, str]] = {
     # --- Connection / transport ---
     "ConnectionState": ("icom_lan.core.transport", "ConnectionState"),
     "IcomTransport": ("icom_lan.core.transport", "IcomTransport"),
-    "RadioConnectionState": ("icom_lan.runtime._connection_state", "RadioConnectionState"),
+    "RadioConnectionState": (
+        "icom_lan.runtime._connection_state",
+        "RadioConnectionState",
+    ),
     # --- Auth helpers ---
     "AuthResponse": ("icom_lan.core.auth", "AuthResponse"),
     "StatusResponse": ("icom_lan.core.auth", "StatusResponse"),
@@ -276,6 +280,7 @@ __all__ = [
     "ReceiverBankCapable",
     "RecoverableConnection",
     "RepeaterControlCapable",
+    "RigctldRoutable",
     "RitXitCapable",
     "ScopeCapable",
     "SplitCapable",

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -1934,3 +1934,41 @@ class YaesuCatRadio:
             callback=callback,
             command_queue=command_queue,
         )
+
+    def rigctld_routing(
+        self,
+        cache: Any,
+        max_power_w: float = 100.0,
+    ) -> Any:
+        """Construct a Yaesu-specific rigctld routing strategy.
+
+        Returns a :class:`~icom_lan.rigctld.routing.YaesuRouting` that
+        translates rigctl ``get_level``/``set_level``/``get_func``/
+        ``set_func``/``dump_state``/``get_info`` calls into the Yaesu CAT
+        protocol semantics expected by the FTX-1 (and compatible)
+        transceivers.
+
+        The lazy import keeps :class:`YaesuCatRadio` from depending on
+        the rigctld layer at module-load time (``rigctld`` sits above
+        ``backends`` in the import-linter layered architecture, so a
+        top-level import here would invert the layering). The argument
+        and return types are annotated as :class:`~typing.Any` for the
+        same reason; precise typing for the public surface lives on
+        :class:`~icom_lan.core.radio_protocol.RigctldRoutable`.
+
+        Args:
+            cache: Shared
+                :class:`~icom_lan.rigctld.handler._FallbackRigState`
+                cache used by the rigctld handler to remember
+                last-known meter/level values when the radio cannot
+                answer.
+            max_power_w: Rated maximum TX power in watts; used to scale
+                normalised RFPOWER readings (defaults to 100 W).
+
+        Returns:
+            A :class:`~icom_lan.rigctld.routing.YaesuRouting` instance
+            bound to this radio.
+        """
+        from ...rigctld.routing import YaesuRouting  # noqa: TID251
+
+        return YaesuRouting(self, cache, max_power_w)

--- a/src/icom_lan/core/radio_protocol.py
+++ b/src/icom_lan/core/radio_protocol.py
@@ -57,6 +57,15 @@ from .types import AudioCodec, BreakInMode, Mode
 if TYPE_CHECKING:
     from ._state_cache import StateCache
     from icom_lan.audio_bus import AudioBus
+
+    # ``_FallbackRigState`` actually lives in ``rigctld.handler`` and is
+    # re-exported through ``rigctld.routing``'s TYPE_CHECKING namespace; a
+    # single import edge keeps the import-linter exemption count to one
+    # per contract.
+    from icom_lan.rigctld.routing import (  # type: ignore[attr-defined]  # noqa: TID251
+        RigctldRouting,
+        _FallbackRigState,
+    )
     from icom_lan.runtime._poller_types import CommandQueue
     from icom_lan.scope import ScopeFrame
     from .types import BandStackRegister, MemoryChannel, ScopeFixedEdge
@@ -84,6 +93,7 @@ __all__ = [
     "LevelsCapable",
     "MetersCapable",
     "PowerControlCapable",
+    "RigctldRoutable",
     "SplitCapable",
     "StateNotifyCapable",
     "StatePollable",
@@ -544,6 +554,48 @@ class StatePollable(Protocol):
 
         Returns:
             A :class:`StatePoller` ready for ``await poller.start()``.
+        """
+        ...
+
+
+@runtime_checkable
+class RigctldRoutable(Protocol):
+    """Radio that provides a custom rigctld command-routing strategy.
+
+    The rigctld TCP server's handler ships with a built-in default
+    routing that works for Icom CI-V radios. Backends with significantly
+    different command semantics (Yaesu CAT today; future Kenwood TS-590
+    or other vendors) expose their own
+    :class:`~icom_lan.rigctld.routing.RigctldRouting` implementation via
+    this method.
+
+    Consumers (rigctld handler) check this with ``isinstance`` and pick
+    up the vendor-specific routing without importing concrete backend
+    classes::
+
+        if isinstance(radio, RigctldRoutable):
+            routing = radio.rigctld_routing(cache, max_power_w)
+        else:
+            routing = None  # fall through to the built-in Icom path
+    """
+
+    def rigctld_routing(
+        self,
+        cache: "_FallbackRigState",
+        max_power_w: float = 100.0,
+    ) -> "RigctldRouting":
+        """Construct a :class:`RigctldRouting` bound to this radio.
+
+        Args:
+            cache: Shared :class:`_FallbackRigState` cache used by the
+                rigctld handler to remember last-known meter/level
+                values when the radio cannot answer.
+            max_power_w: Rated maximum TX power in watts; used to scale
+                normalised RFPOWER readings (defaults to 100 W).
+
+        Returns:
+            A :class:`RigctldRouting` ready to serve get/set level,
+            get/set func, ``dump_state``, and ``get_info`` calls.
         """
         ...
 

--- a/src/icom_lan/rigctld/routing.py
+++ b/src/icom_lan/rigctld/routing.py
@@ -315,11 +315,18 @@ def create_routing(
     cache: "_FallbackRigState",
     max_power_w: float = 100.0,
 ) -> RigctldRouting | None:
-    """Create a YaesuRouting if the radio is Yaesu, else None.
+    """Create a vendor-specific :class:`RigctldRouting` for ``radio``.
 
-    Returns None for Icom radios — the handler's built-in Icom routing
-    is used as the default path.
+    Dispatches via the public
+    :class:`~icom_lan.core.radio_protocol.RigctldRoutable` Protocol:
+    radios that implement ``rigctld_routing(cache, max_power_w)`` get
+    their custom strategy (Yaesu CAT today; Kenwood TS-590 or others
+    in the future). Radios that do not — Icom CI-V — return ``None``
+    and the handler's built-in Icom routing is used as the default
+    path.
     """
-    if getattr(radio, "backend_id", None) == "yaesu_cat":
-        return YaesuRouting(radio, cache, max_power_w)
+    from icom_lan.core.radio_protocol import RigctldRoutable
+
+    if isinstance(radio, RigctldRoutable):
+        return radio.rigctld_routing(cache, max_power_w)
     return None

--- a/tests/contracts/test_lazy_imports.py
+++ b/tests/contracts/test_lazy_imports.py
@@ -42,6 +42,7 @@ TIER1_NAMES = [
     "ReceiverBankCapable",
     "RecoverableConnection",
     "RepeaterControlCapable",
+    "RigctldRoutable",
     "RitXitCapable",
     "ScopeCapable",
     "SplitCapable",

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -44,6 +44,7 @@ def test_public_api_surface() -> None:
         "ReceiverBankCapable",
         "RecoverableConnection",
         "RepeaterControlCapable",
+        "RigctldRoutable",
         "RitXitCapable",
         "ScopeCapable",
         "SplitCapable",

--- a/tests/test_public_api_surface.py
+++ b/tests/test_public_api_surface.py
@@ -54,6 +54,7 @@ TIER1_SYMBOLS: tuple[str, ...] = (
     "StateCacheCapable",
     "StatePollable",
     "StatePoller",
+    "RigctldRoutable",
     "RecoverableConnection",
     "DspControlCapable",
     "AntennaControlCapable",
@@ -133,9 +134,7 @@ def test_tier1_imports_do_not_pull_tier3() -> None:
     names; the test asserts the output is empty.
     """
     import_lines = ",\n    ".join(TIER1_SYMBOLS)
-    forbidden_check = " or ".join(
-        f"m.startswith({p!r})" for p in TIER3_PREFIXES
-    )
+    forbidden_check = " or ".join(f"m.startswith({p!r})" for p in TIER3_PREFIXES)
     code = (
         "import sys\n"
         "from icom_lan import (\n"

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1715,9 +1715,20 @@ class _FakeYaesuRadio(YaesuCatRadio):
 
 @pytest.fixture
 def yaesu_radio() -> AsyncMock:
-    """AsyncMock of a Yaesu CAT radio with backend_id discriminator."""
+    """AsyncMock of a Yaesu CAT radio with backend_id discriminator.
+
+    The mock is also wired to forward ``rigctld_routing`` to a real
+    :class:`YaesuRouting` so the handler's routing dispatch works
+    end-to-end (``AsyncMock(spec=…)`` would otherwise return a bare
+    MagicMock with non-awaitable ``get_level``/``get_func`` methods).
+    """
+    from icom_lan.rigctld.routing import YaesuRouting
+
     mock = AsyncMock(spec=_FakeYaesuRadio)
     mock.backend_id = "yaesu_cat"
+    mock.rigctld_routing = lambda cache, max_power_w=100.0: YaesuRouting(
+        mock, cache, max_power_w
+    )
     return mock
 
 
@@ -2650,10 +2661,15 @@ async def test_get_split_vfo_dual_rx_reflects_active_sub(
 
 def _yaesu_handler(get_attenuator_value: bool) -> RigctldHandler:
     """Build a handler with a Yaesu-tagged radio so create_routing returns YaesuRouting."""
-    radio = AsyncMock()
+    from icom_lan.rigctld.routing import YaesuRouting
+
+    radio = AsyncMock(spec=_FakeYaesuRadio)
     radio.backend_id = "yaesu_cat"
     radio.capabilities = set()
     radio.get_attenuator = AsyncMock(return_value=get_attenuator_value)
+    radio.rigctld_routing = lambda cache, max_power_w=100.0: YaesuRouting(
+        radio, cache, max_power_w
+    )
     return RigctldHandler(radio, RigctldConfig())
 
 

--- a/tests/test_rigctld_routable_extension.py
+++ b/tests/test_rigctld_routable_extension.py
@@ -1,0 +1,78 @@
+"""Forward-extension test for the :class:`RigctldRoutable` capability.
+
+The load-bearing assertion of epic #1322: the architecture admits new
+radio backends purely by **structural conformance** to the public
+Capability Protocols — no upper-layer (web/rigctld) code change needed.
+
+If a new backend implements ``rigctld_routing(cache, max_power_w)``
+returning an object that satisfies
+:class:`~icom_lan.rigctld.routing.RigctldRouting`, the rigctld handler's
+``isinstance(radio, RigctldRoutable)`` check picks it up without any
+registry, plugin mechanism, or string discriminator.
+"""
+
+from __future__ import annotations
+
+from icom_lan import RigctldRoutable
+from icom_lan.rigctld.contract import RigctldResponse
+from icom_lan.rigctld.handler import _FallbackRigState
+from icom_lan.rigctld.routing import RigctldRouting
+
+
+class _StubRouting:
+    """Structural stub that satisfies :class:`RigctldRouting`."""
+
+    async def get_level(self, level: str) -> RigctldResponse:
+        return RigctldResponse(values=["0"])
+
+    async def set_level(self, level: str, value: float) -> RigctldResponse:
+        return RigctldResponse(values=["RPRT 0"])
+
+    async def get_func(self, func: str) -> RigctldResponse:
+        return RigctldResponse(values=["0"])
+
+    async def set_func(self, func: str, on: bool) -> RigctldResponse:
+        return RigctldResponse(values=["RPRT 0"])
+
+    def dump_state(self) -> list[str]:
+        return []
+
+    def get_info(self) -> str:
+        return "Stub Rig"
+
+
+class _StubRoutableRadio:
+    """Structural stub that satisfies :class:`RigctldRoutable`."""
+
+    def rigctld_routing(
+        self,
+        cache: _FallbackRigState,
+        max_power_w: float = 100.0,
+    ) -> _StubRouting:
+        return _StubRouting()
+
+
+def test_stub_routable_satisfies_protocol() -> None:
+    """A new radio backend gets custom rigctld routing purely by
+    structural conformance — no upper-layer code change needed."""
+    stub = _StubRoutableRadio()
+    assert isinstance(stub, RigctldRoutable)
+
+    routing = stub.rigctld_routing(_FallbackRigState())
+    assert isinstance(routing, RigctldRouting)
+
+
+def test_stub_routing_satisfies_protocol() -> None:
+    """``RigctldRouting`` is satisfied by any object exposing the
+    six required get/set level + get/set func + dump_state + get_info
+    methods."""
+    routing = _StubRouting()
+    assert isinstance(routing, RigctldRouting)
+
+
+def test_yaesu_cat_radio_satisfies_rigctld_routable() -> None:
+    """The shipping Yaesu CAT backend already conforms to the public
+    :class:`RigctldRoutable` Protocol (no inheritance required)."""
+    from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
+
+    assert issubclass(YaesuCatRadio, RigctldRoutable)


### PR DESCRIPTION
## Summary

Capability 2/4 of epic #1322. **Closes #1324.**

Adds `RigctldRoutable` runtime-checkable Protocol to the public Radio Protocol surface. Radios with custom rigctld command-routing strategies implement `rigctld_routing(cache, max_power_w) -> RigctldRouting`.

Replaces fork point 4 of 4 (the `getattr(radio, "backend_id", None) == "yaesu_cat"` check at `rigctld/routing.py:323`) with typed `isinstance(radio, RigctldRoutable)`.

`YaesuCatRadio.rigctld_routing(...)` constructs the existing `YaesuRouting` strategy via lazy import. Unlike Capability 1 (`StatePollable`), this method did not previously exist on the radio — Capability 1 found the conformer already structurally complete; here we add it together with the Protocol so the load-bearing extension test (`issubclass(YaesuCatRadio, RigctldRoutable)`) passes from commit 1 onward.

New extension test `tests/test_rigctld_routable_extension.py` proves a stub class structurally satisfies the Protocol. The shipping `YaesuCatRadio` is also covered as a smoke test.

## Verification
- Tests: 5210 passed (+4 vs baseline 5206 — 3 new extension tests + 1 new parametrized `test_public_api_surface.py` case), all green.
- Contracts: `tests/contracts/` — 3 passed.
- ruff, mypy: clean.
- `lint-imports`: 4 contracts kept, 0 broken.
- `from icom_lan import RigctldRoutable` works.
- `issubclass(YaesuCatRadio, RigctldRoutable)` is `True` (structural).
- `getattr(.*backend_id.*"yaesu_cat")` grep on `rigctld/routing.py`: zero results.

## Deviations from spec

The architectural reality (`backends` sits below `rigctld` in the layered contract; `web` and `rigctld` are independence-contract siblings) forces the cross-layer edges to need `ignore_imports` in BOTH the layered and independence-top contracts:

1. **`.importlinter` additions: 5 lines** (not 1 as the spec template suggested):
   - `core.radio_protocol -> rigctld.routing` (layered + independence-top)
   - `backends.yaesu_cat.radio -> rigctld.routing` (layered + independence-top)
2. **One `# type: ignore[attr-defined]`** on the `_FallbackRigState` re-export through `rigctld.routing`'s TYPE_CHECKING namespace (keeps the import edge count at one per file rather than opening a second edge to `rigctld.handler`).
3. **`YaesuCatRadio.rigctld_routing` lands in commit 1 with the Protocol** (matches #1327's "Protocol + first structural conformer" pattern); commit 2 is a pure consumer refactor in `rigctld/routing.py`. The extension test would otherwise fail in the commit-1-only state.
4. **Two test fixtures** in `tests/test_rigctld_handler.py` (`yaesu_radio` and `_yaesu_handler`) needed wiring updates so `mock.rigctld_routing` returns a real `YaesuRouting`. The MagicMock auto-stub was non-awaitable inside the handler and would fail dispatch — same MagicMock pitfall called out in #1327's commit message.

## What's NOT in this PR
- Sub-issues 3 and 4 of #1322 (`web/handlers/control.py` power-unit check and any future USB-audio one). Other `backend_id == "yaesu_cat"` sites in `web/runtime_helpers.py:41` and `web/handlers/control.py:1406` are intentionally untouched.
- No behaviour changes — same routing strategy, same construction signature, same default-Icom fall-through.

Closes #1324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)