### PR TITLE
feat(#1325): PowerControlCapable.native_power_unit (Capability 3/4 of #1322)

### DIFF
--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -25,7 +25,7 @@ This page defines the **officially supported** public API of `icom_lan`. Use the
 | `DualReceiverCapable` | Protocol for dual-receiver (MAIN/SUB) support. |
 | `LevelsCapable` | Protocol for setting receiver levels: AF, RF gain, squelch. |
 | `MetersCapable` | Protocol for read-only meters: S-meter, SWR, TX power. |
-| `PowerControlCapable` | Protocol for power on/off and TX power level control. |
+| `PowerControlCapable` | Protocol for power on/off and TX power level control. Includes `native_power_unit: Literal["raw_255", "watts"]` so callers can dispatch wire-level scale (Icom CI-V vs Yaesu CAT) without backend-string discriminators. |
 | `StateNotifyCapable` | Protocol for state-change and reconnect callbacks (server integration). |
 
 **Note:** The core `Radio` protocol no longer includes meter, level, power, or state-notify methods; those live on the capability protocols above. Use `isinstance(radio, MetersCapable)` (etc.) before calling them.

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from ...audio import AudioPacket
 from ...command_spec import CatCommandSpec
@@ -72,6 +72,13 @@ class YaesuCatRadio:
             await radio.set_ptt(True)
             s = await radio.get_s_meter()
     """
+
+    # Yaesu CAT ``PC`` command takes a watt value (0-999, three-digit
+    # padded), not a raw 0-255 scale. Inspected by upper layers to
+    # avoid translating user-facing watt values into the Icom raw
+    # scale before queueing SetPower. See
+    # :class:`icom_lan.core.radio_protocol.PowerControlCapable`.
+    native_power_unit: Literal["raw_255", "watts"] = "watts"
 
     def __init__(
         self,

--- a/src/icom_lan/core/radio_protocol.py
+++ b/src/icom_lan/core/radio_protocol.py
@@ -47,6 +47,7 @@ from typing import (
     AsyncIterator,
     Awaitable,
     Callable,
+    Literal,
     Protocol,
     runtime_checkable,
 )
@@ -451,6 +452,23 @@ class PowerControlCapable(Protocol):
 
         Args:
             level: Power level in 0-255 scale.
+        """
+        ...
+
+    @property
+    def native_power_unit(self) -> Literal["raw_255", "watts"]:
+        """The wire-level unit used by this radio's power commands.
+
+        Icom CI-V radios use a raw 0-255 scale (``"raw_255"``); Yaesu
+        CAT ``PC`` commands use watts (0-999, three-digit padded).
+        Higher-level layers (web UI, rigctld) inspect this to decide
+        whether to translate from a user-friendly unit before queueing
+        a :class:`SetPower` command.
+
+        Implementations typically declare this as a class attribute
+        (``native_power_unit: Literal["raw_255", "watts"] = "raw_255"``)
+        — a class attribute structurally satisfies the property
+        requirement under :func:`runtime_checkable`.
         """
         ...
 

--- a/src/icom_lan/runtime/radio.py
+++ b/src/icom_lan/runtime/radio.py
@@ -17,7 +17,7 @@ import logging
 import os
 import socket as _socket
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable
@@ -363,6 +363,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     # Watchdog timing (used by _watchdog_loop)
     WATCHDOG_CHECK_INTERVAL = 0.5
     _WATCHDOG_HEALTH_LOG_INTERVAL = 30.0
+
+    # PowerControlCapable: Icom CI-V uses a raw 0-255 scale on the wire
+    # (cmd 0x14 0x0A). Inspected by upper layers to decide unit
+    # translation before queueing SetPower. See
+    # :class:`icom_lan.core.radio_protocol.PowerControlCapable`.
+    native_power_unit: Literal["raw_255", "watts"] = "raw_255"
 
     # All public commands supported by Icom CI-V backends.
     _KNOWN_COMMANDS: frozenset[str] = frozenset(

--- a/src/icom_lan/web/handlers/control.py
+++ b/src/icom_lan/web/handlers/control.py
@@ -1399,12 +1399,15 @@ class ControlHandler:
                         "(missing power_control capability)"
                     )
                 level = int(params["level"])
-                # Tag the unit per backend: Yaesu CAT expects watts (PC
-                # command, 0-999), Icom expects raw 0-255 CI-V scale.
-                unit: Literal["raw_255", "watts"] = (
-                    "watts"
-                    if getattr(radio, "backend_id", "") == "yaesu_cat"
-                    else "raw_255"
+                # Tag the unit per radio's wire-level scale. Icom CI-V
+                # backends expose ``native_power_unit = "raw_255"``,
+                # Yaesu CAT exposes ``"watts"`` — see
+                # :class:`PowerControlCapable.native_power_unit`. Falls
+                # back to ``"raw_255"`` when the attribute is missing
+                # (e.g. legacy mocks) to preserve prior default
+                # behaviour for Icom-shaped radios.
+                unit: Literal["raw_255", "watts"] = getattr(
+                    radio, "native_power_unit", "raw_255"
                 )
                 q.put(SetPower(level, unit=unit))
                 return {"level": level}

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -625,12 +625,17 @@ async def test_enqueue_command_variants(
 
 
 async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
-    """Yaesu CAT backend → SetPower(unit='watts'); Icom default → 'raw_255'."""
+    """Yaesu CAT backend → SetPower(unit='watts'); Icom default → 'raw_255'.
+
+    The handler now reads ``radio.native_power_unit`` (the Capability
+    Protocol property added in epic #1322) instead of the legacy
+    ``backend_id == "yaesu_cat"`` discriminator.
+    """
     queue = _QueueRecorder()
     server = SimpleNamespace(command_queue=queue)
 
     radio = _capable_radio()
-    radio.backend_id = "yaesu_cat"
+    radio.native_power_unit = "watts"
     handler = _control_handler(radio=radio, server=server)
     await handler._enqueue_command("set_rf_power", {"level": 50})
     assert isinstance(queue.items[-1], SetPower)
@@ -640,7 +645,7 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
     queue2 = _QueueRecorder()
     server2 = SimpleNamespace(command_queue=queue2)
     radio2 = _capable_radio()
-    radio2.backend_id = "icom_lan"
+    radio2.native_power_unit = "raw_255"
     handler2 = _control_handler(radio=radio2, server=server2)
     await handler2._enqueue_command("set_rf_power", {"level": 200})
     assert isinstance(queue2.items[-1], SetPower)

--- a/tests/test_power_unit_extension.py
+++ b/tests/test_power_unit_extension.py
@@ -1,0 +1,86 @@
+"""Forward-extension test for ``PowerControlCapable.native_power_unit``.
+
+The load-bearing assertion of epic #1322 (Capability 3/4): the
+architecture admits new radio backends purely by **structural
+conformance** to the public Capability Protocols — no upper-layer
+(web, rigctld) code change needed to dispatch on the wire-level
+power unit.
+
+A backend declares ``native_power_unit: Literal["raw_255", "watts"]``
+as a class attribute (or returns it from a ``@property``) and the
+control handler picks up the right unit tag for ``SetPower`` without
+ever looking at ``backend_id`` strings.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from icom_lan import PowerControlCapable
+
+
+class _RawIcomLikeRadio:
+    """Structural stub mimicking an Icom CI-V radio: raw 0-255 scale."""
+
+    native_power_unit: Literal["raw_255", "watts"] = "raw_255"
+
+    async def get_powerstat(self) -> bool:
+        return True
+
+    async def set_powerstat(self, on: bool) -> None:
+        return None
+
+    async def get_rf_power(self) -> int:
+        return 128
+
+    async def set_rf_power(self, level: int) -> None:
+        return None
+
+
+class _WattsYaesuLikeRadio:
+    """Structural stub mimicking a Yaesu CAT radio: watts."""
+
+    native_power_unit: Literal["raw_255", "watts"] = "watts"
+
+    async def get_powerstat(self) -> bool:
+        return True
+
+    async def set_powerstat(self, on: bool) -> None:
+        return None
+
+    async def get_rf_power(self) -> int:
+        return 50
+
+    async def set_rf_power(self, level: int) -> None:
+        return None
+
+
+def test_raw_stub_satisfies_protocol() -> None:
+    """A class attribute with the right Literal value satisfies the
+    ``@property``-shaped Protocol member under
+    :func:`runtime_checkable`."""
+    stub = _RawIcomLikeRadio()
+    assert isinstance(stub, PowerControlCapable)
+    assert stub.native_power_unit == "raw_255"
+
+
+def test_watts_stub_satisfies_protocol() -> None:
+    """The same Protocol admits a ``"watts"`` declaration — no
+    inheritance, no registry, no string discriminator."""
+    stub = _WattsYaesuLikeRadio()
+    assert isinstance(stub, PowerControlCapable)
+    assert stub.native_power_unit == "watts"
+
+
+def test_icom_core_radio_declares_raw_255() -> None:
+    """The shipping Icom :class:`CoreRadio` declares ``"raw_255"``."""
+    from icom_lan.runtime.radio import CoreRadio
+
+    assert CoreRadio.native_power_unit == "raw_255"
+
+
+def test_yaesu_cat_radio_declares_watts() -> None:
+    """The shipping :class:`YaesuCatRadio` declares ``"watts"``."""
+    from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
+
+    assert YaesuCatRadio.native_power_unit == "watts"

--- a/tests/test_radio_protocol.py
+++ b/tests/test_radio_protocol.py
@@ -85,6 +85,7 @@ class _PowerStub:
     async def set_powerstat(self, on: bool) -> None: ...
     async def get_rf_power(self) -> int: return 128
     async def set_rf_power(self, level: int) -> None: ...
+    native_power_unit = "raw_255"
     # MetersCapable surface
     async def get_s_meter(self, receiver: int = 0) -> int: return 0
     async def get_swr(self) -> float: return 1.0


### PR DESCRIPTION
## Summary

Capability 3/4 of epic #1322. **Closes #1325.**

Extends the existing `PowerControlCapable` Protocol with a `native_power_unit: Literal["raw_255", "watts"]` property. Implementations declare it as a class attribute (Python's `runtime_checkable` accepts a class attribute as a structural match for a `@property` member). Icom `CoreRadio` declares `"raw_255"` once and every Icom subclass (IC-705, IC-7300, IC-7610, IC-9700; LAN and serial flavours) inherits it; `YaesuCatRadio` declares `"watts"`.

Replaces fork point 3 of 4 (`getattr(radio, "backend_id", "") == "yaesu_cat"` at `web/handlers/control.py:~1400`) with `radio.native_power_unit` — typed `Literal["raw_255", "watts"]` access. The capability gate (`CAP_POWER_CONTROL not in radio.capabilities`) is unchanged; only the unit-discriminator was switched.

No new Protocol; this is an additive minor on Tier 1's existing `PowerControlCapable`. SemVer-minor compatible.

## Note on YaesuCatRadio's Protocol membership

`YaesuCatRadio` exposes `set_power(watts: int, head: int = 2)` — different name and signature than `PowerControlCapable.set_rf_power(level: int)`. It is therefore intentionally NOT a formal `PowerControlCapable` member, and the handler does not gate on `isinstance(radio, PowerControlCapable)`. The new `native_power_unit` attribute still travels on `YaesuCatRadio` because upper layers read it directly with `getattr(radio, "native_power_unit", "raw_255")`. Aligning Yaesu with the full `PowerControlCapable` shape (adding a `set_rf_power` adapter that converts raw 0-255 → watts) is out of scope for this PR.

## Verification

- Tests: 5214 collected, all green (+4 from new `tests/test_power_unit_extension.py`).
- Contracts: 3 passed (`tests/contracts/`).
- ruff, mypy, lint-imports: clean (4/0 — no new ignore_imports needed; `Literal` is from `typing`).
- All 9 Icom radio classes (`CoreRadio`, `IcomRadio`, `Ic705CoreRadio`, `Ic7300CoreRadio`, `Ic9700CoreRadio`, `Icom7610SerialRadio`, `Ic705SerialRadio`, `Ic7300SerialRadio`, `Ic9700SerialRadio`) and `YaesuCatRadio` declare `native_power_unit` correctly.
- `grep -nE 'getattr\(.*backend_id.*"yaesu_cat"' src/icom_lan/web/handlers/control.py`: zero results.

## What's NOT in this PR

- Sub-issue 4/4 (USB audio capability for `runtime_helpers`).
- No changes to wire format or `SetPower` DTO interface.
- No new public-API names (extension of existing `PowerControlCapable`).
- No alignment of `YaesuCatRadio` with the full `PowerControlCapable.set_rf_power` shape — see note above.

Closes #1325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)