### PR TITLE
feat(#1326): UsbAudioCapable Protocol (Capability 4/4 of #1322 - closes epic)

### DIFF
--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -105,6 +105,7 @@ available directly via `from icom_lan import …`.
 - `SystemControlCapable`, `RepeaterControlCapable`, `AdvancedControlCapable`
 - `TransceiverStatusCapable`, `RitXitCapable`, `MemoryCapable`
 - `SplitCapable` (new in v0.19)
+- `UsbAudioCapable` (new in v0.19)
 
 **Exceptions (from `icom_lan.exceptions`)**
 

--- a/src/icom_lan/__init__.py
+++ b/src/icom_lan/__init__.py
@@ -67,6 +67,7 @@ from .radio_protocol import (  # noqa: F401
     SystemControlCapable,
     TransceiverBankCapable,
     TransceiverStatusCapable,
+    UsbAudioCapable,
     VfoSlotCapable,
     VoiceControlCapable,
 )
@@ -291,6 +292,7 @@ __all__ = [
     "SystemControlCapable",
     "TransceiverBankCapable",
     "TransceiverStatusCapable",
+    "UsbAudioCapable",
     "VfoSlotCapable",
     "VoiceControlCapable",
     # --- Tier 1: Exceptions ---

--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -80,6 +80,15 @@ class YaesuCatRadio:
     # :class:`icom_lan.core.radio_protocol.PowerControlCapable`.
     native_power_unit: Literal["raw_255", "watts"] = "watts"
 
+    # Yaesu CAT radios connect over USB and expose audio as a separate
+    # USB Audio Class device handled by the OS, not through in-band
+    # CI-V/CAT framing. The web layer's ``runtime_capabilities`` helper
+    # uses this marker (via :class:`UsbAudioCapable`) to keep the
+    # ``"audio"`` UI capability advertised even for backends that don't
+    # implement the Radio Protocol's :class:`AudioCapable` surface.
+    # See :class:`icom_lan.core.radio_protocol.UsbAudioCapable`.
+    has_usb_audio: bool = True
+
     def __init__(
         self,
         device: str,

--- a/src/icom_lan/core/radio_protocol.py
+++ b/src/icom_lan/core/radio_protocol.py
@@ -101,6 +101,7 @@ __all__ = [
     "StatePoller",
     "RitXitCapable",
     "TransceiverStatusCapable",
+    "UsbAudioCapable",
     "MemoryCapable",
 ]
 
@@ -711,6 +712,57 @@ class AudioCapable(Protocol):
     async def get_audio_stats(self) -> dict[str, Any]: ...
     async def start_audio_tx_opus(self) -> None: ...
     async def stop_audio_tx_opus(self) -> None: ...
+
+
+@runtime_checkable
+class UsbAudioCapable(Protocol):
+    """Marker for radios whose audio is exposed as a separate OS-level
+    USB Audio Class device, NOT through the in-band Radio Protocol.
+
+    Yaesu CAT radios (FT-991A, FTX-1, …) connect over USB and expose
+    their audio as standard USB Audio Class endpoints; the application
+    layer (and the operating system) speaks to the audio device
+    directly, while CI-V/CAT commands flow through the serial port.
+    Higher layers (the web ``runtime_capabilities`` helper, future
+    rigctld extensions) use this Protocol to advertise the ``"audio"``
+    UI capability for backends that lack in-band :class:`AudioCapable`
+    audio but still let the user listen via the OS sound device.
+    Resolution of the actual USB audio device indices is independent of
+    this Protocol — see :mod:`icom_lan.audio._usb_resolve`, which keys
+    off the serial port path.
+
+    Implementations declare a ``has_usb_audio: bool`` class attribute
+    set to ``True``. The sentinel is required (rather than a pure
+    marker) because :func:`runtime_checkable` Protocols with no members
+    accept *any* object — see the
+    `"empty Protocol matches everything"
+    <https://docs.python.org/3/library/typing.html#typing.runtime_checkable>`_
+    note in the standard library docs. Backends that implement
+    :class:`AudioCapable` are still detected via that Protocol; this
+    one specifically captures backends that ONLY have OS-level audio
+    (e.g. classic CAT-only Yaesu radios). Note: the shipping
+    :class:`~icom_lan.backends.yaesu_cat.radio.YaesuCatRadio` already
+    structurally satisfies :class:`AudioCapable` because its
+    ``UsbAudioDriver`` is wrapped behind the same ``audio_bus`` /
+    ``start_audio_rx_*`` surface; declaring ``has_usb_audio = True``
+    documents the OS-level reality and provides a future-proof gate
+    for backends that don't (yet) wrap USB Audio behind the in-band
+    Protocol.
+    """
+
+    @property
+    def has_usb_audio(self) -> bool:
+        """``True`` if this radio's audio is delivered as a separate
+        USB Audio Class device handled by the OS (not by the Radio
+        Protocol's in-band audio methods).
+
+        Implementations typically declare this as a class attribute
+        (``has_usb_audio: bool = True``) — a class attribute
+        structurally satisfies the property requirement under
+        :func:`runtime_checkable`, mirroring the
+        :attr:`PowerControlCapable.native_power_unit` pattern.
+        """
+        ...
 
 
 @runtime_checkable

--- a/src/icom_lan/web/runtime_helpers.py
+++ b/src/icom_lan/web/runtime_helpers.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Any
 
-from ..radio_protocol import AudioCapable, DualReceiverCapable, ScopeCapable
+from ..radio_protocol import (
+    AudioCapable,
+    DualReceiverCapable,
+    ScopeCapable,
+    UsbAudioCapable,
+)
 from ..radio_state import RadioState
 
 if TYPE_CHECKING:
@@ -34,12 +39,13 @@ def runtime_capabilities(radio: "Radio | None") -> set[str]:
         caps = set(raw_caps)
         if "scope" in caps and not isinstance(radio, ScopeCapable):
             caps.discard("scope")
-        if "audio" in caps and not isinstance(radio, AudioCapable):
-            # Yaesu CAT radios declare "audio" via USB Audio Class (separate
-            # device), not through the Radio protocol.  Keep the capability
-            # so the frontend shows the audio controls.
-            if getattr(radio, "backend_id", None) != "yaesu_cat":
-                caps.discard("audio")
+        if "audio" in caps and not isinstance(radio, AudioCapable | UsbAudioCapable):
+            # Radios that don't implement in-band ``AudioCapable`` and
+            # don't expose OS-level USB Audio Class devices (via the
+            # ``UsbAudioCapable`` marker) cannot deliver audio to the
+            # frontend — drop the tag so the UI doesn't render dead
+            # controls.
+            caps.discard("audio")
         if "dual_rx" in caps and not isinstance(radio, DualReceiverCapable):
             caps.discard("dual_rx")
         return caps

--- a/tests/contracts/test_lazy_imports.py
+++ b/tests/contracts/test_lazy_imports.py
@@ -53,6 +53,7 @@ TIER1_NAMES = [
     "SystemControlCapable",
     "TransceiverBankCapable",
     "TransceiverStatusCapable",
+    "UsbAudioCapable",
     "VfoSlotCapable",
     "VoiceControlCapable",
     # --- Exceptions ---

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -55,6 +55,7 @@ def test_public_api_surface() -> None:
         "SystemControlCapable",
         "TransceiverBankCapable",
         "TransceiverStatusCapable",
+        "UsbAudioCapable",
         "VfoSlotCapable",
         "VoiceControlCapable",
         # --- Tier 1: Exceptions ---

--- a/tests/test_public_api_surface.py
+++ b/tests/test_public_api_surface.py
@@ -67,6 +67,7 @@ TIER1_SYMBOLS: tuple[str, ...] = (
     "RitXitCapable",
     "MemoryCapable",
     "SplitCapable",
+    "UsbAudioCapable",
     # Exceptions
     "IcomLanError",
     "AudioCodecBackendError",

--- a/tests/test_usb_audio_capable_extension.py
+++ b/tests/test_usb_audio_capable_extension.py
@@ -1,0 +1,55 @@
+"""Forward-extension test for the :class:`UsbAudioCapable` capability.
+
+The load-bearing assertion of epic #1322 (Capability 4/4): the
+architecture admits new radio backends purely by **structural
+conformance** to the public Capability Protocols — no upper-layer
+(web/rigctld) code change needed.
+
+If a new backend declares ``has_usb_audio: bool = True`` as a class
+attribute, the web layer's ``runtime_capabilities`` helper picks it
+up via ``isinstance(radio, AudioCapable | UsbAudioCapable)`` and keeps
+the ``"audio"`` UI capability advertised — without any registry,
+plugin mechanism, or string discriminator.
+"""
+
+from __future__ import annotations
+
+from icom_lan import UsbAudioCapable
+
+
+class _StubUsbAudioRadio:
+    """Structural stub that satisfies :class:`UsbAudioCapable`."""
+
+    has_usb_audio: bool = True
+
+
+class _StubNonUsbAudioRadio:
+    """Structural stub that does NOT satisfy :class:`UsbAudioCapable`."""
+
+    # Deliberately no has_usb_audio attribute.
+
+
+def test_stub_with_attribute_satisfies_protocol() -> None:
+    """A class attribute structurally satisfies the
+    ``@property``-shaped Protocol member under
+    :func:`runtime_checkable`."""
+    stub = _StubUsbAudioRadio()
+    assert isinstance(stub, UsbAudioCapable)
+    assert stub.has_usb_audio is True
+
+
+def test_stub_without_attribute_fails_protocol() -> None:
+    """The sentinel attribute matters: backends without it are NOT
+    detected as ``UsbAudioCapable`` (this is what keeps marker-style
+    Protocols from matching every object — see the docstring)."""
+    stub = _StubNonUsbAudioRadio()
+    assert not isinstance(stub, UsbAudioCapable)
+
+
+def test_yaesu_cat_radio_declares_usb_audio() -> None:
+    """The shipping :class:`YaesuCatRadio` declares
+    ``has_usb_audio = True``, so it satisfies :class:`UsbAudioCapable`
+    structurally."""
+    from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
+
+    assert YaesuCatRadio.has_usb_audio is True


### PR DESCRIPTION
## Summary

Capability 4/4 — **the final sub-issue** of epic #1322. **Closes #1326.** When this PR merges, the orchestrator will close epic #1322 with a summary comment.

Adds `UsbAudioCapable` runtime-checkable Protocol to the public Radio Protocol surface, using the sentinel-attribute pattern (`has_usb_audio: bool`) to avoid the "empty Protocol matches everything" trap. `YaesuCatRadio` declares `has_usb_audio = True`.

Replaces fork point 2 of 4 — the LAST remaining `getattr(radio, "backend_id", None) != "yaesu_cat"` discriminator in upper layers (`web/runtime_helpers.py:41`). Replaced by `isinstance(radio, AudioCapable | UsbAudioCapable)`.

## Honest disclosure: in-production reachability

Before the change, `YaesuCatRadio` already structurally satisfies the in-band `AudioCapable` Protocol (its `UsbAudioDriver` is wrapped behind `audio_bus`, `start_audio_rx_*`, etc.), so `isinstance(yaesu, AudioCapable)` was already `True`. That means the existing `backend_id != "yaesu_cat"` line was a **no-op safety net** today, not a reachable branch. The refactor's real value is:

- **Clarity** — the audio-discard intent is now expressed as a Protocol union, not a string check.
- **Forward extensibility** — a future backend that only delivers OS-level USB Audio (and does NOT wrap it behind in-band `AudioCapable`) can opt in with one class attribute, no upper-layer change.
- **Closes the epic** — the load-bearing assertion of #1322 is "zero `backend_id` discriminators in `web/`/`rigctld/`," and that grep is now empty.

## Design choice: `has_usb_audio` is NOT declared on Icom radios

Yaesu only. Icom radios are already covered by the `AudioCapable` arm of the union (their LAN audio is in-band). Declaring `has_usb_audio = True` on Icom would be redundant and would overstate the marker's architectural meaning (USB-connected Icom variants exist, but their audio is still surfaced through `AudioCapable`). Keeping the marker on Yaesu only makes the architectural intent precise: "this Protocol is the gate for backends whose audio is ONLY USB Audio Class."

## Verification

- Tests: **5218 passed**, 2 skipped, 2 deselected, 9 xfailed, 1 xpassed (+3 new extension tests).
- Contracts (`tests/contracts/`): 3 passed.
- `ruff check`, `mypy`: clean.
- `lint-imports`: **4 contracts kept, 0 broken** (no new ignore_imports needed).
- `from icom_lan import UsbAudioCapable` works.
- **Final epic-level grep**:
  ```
  grep -rnE 'getattr\(.*backend_id.*"yaesu_cat"' src/icom_lan/web/ src/icom_lan/rigctld/
  ```
  → **ZERO results**. Broader `grep -rn 'backend_id\|"yaesu_cat"' src/icom_lan/web/ src/icom_lan/rigctld/` also returns zero. All 4 fork points eliminated.

## Architecture milestone

With this PR, epic #1322 is functionally complete:

- **4 new Capability Protocols** on the Tier 1 surface: `StatePollable`, `StatePoller`, `RigctldRoutable`, `UsbAudioCapable`.
- **1 Protocol extension**: `PowerControlCapable.native_power_unit`.
- **Zero `backend_id` discriminators** in `web/` and `rigctld/`.
- Adding a new radio backend now requires only structural conformance to the relevant Capability Protocols — zero upper-layer code changes.

Closes #1326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)