### PR TITLE
fix(#1332): offload sync file I/O off the event loop in 2 async handlers

### DIFF
--- a/src/icom_lan/web/eibi.py
+++ b/src/icom_lan/web/eibi.py
@@ -305,6 +305,24 @@ def _download_url(url: str, ua: str = "icom-lan/1.0") -> bytes:
         return data
 
 
+def _load_cache_files_sync(
+    csv_path: Path, meta_path: Path
+) -> tuple[bytes, dict[str, Any]]:
+    """Synchronous helper for :meth:`EibiClient.load_cache`.
+
+    Reads the CSV bytes and (optionally) the JSON meta sidecar in a
+    single worker-thread hop, so the event loop is not blocked while
+    the disk I/O completes. Returns an empty ``meta`` dict when the
+    sidecar is absent — control flow matches the previous inline form.
+    """
+    raw = csv_path.read_bytes()
+    meta: dict[str, Any] = {}
+    if meta_path.is_file():
+        with open(meta_path) as f:
+            meta = json.load(f)
+    return raw, meta
+
+
 # ── FCC AM/FM lookup ──
 
 _FCC_AM_URL = "https://transition.fcc.gov/fcc-bin/amq"
@@ -558,13 +576,10 @@ class EiBiProvider:
         if not csv_path.is_file():
             return {"status": "no_cache", "error": "No cached data found"}
 
-        raw = csv_path.read_bytes()
+        raw, meta = await asyncio.to_thread(
+            _load_cache_files_sync, csv_path, meta_path
+        )
         count = self._parse_csv(raw.decode("latin-1", errors="replace"))
-
-        meta: dict[str, Any] = {}
-        if meta_path.is_file():
-            with open(meta_path) as f:
-                meta = json.load(f)
 
         self._season = meta.get("season")
         self._last_updated = meta.get("fetched_iso")

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -111,6 +111,37 @@ def _redact_token_in_path(path: str) -> str:
 # Mode/filter lists moved to RadioProfile (profiles.py)
 
 
+def _load_band_plan_config_sync(path: pathlib.Path) -> dict[str, Any]:
+    """Synchronous helper for :meth:`WebServer._handle_band_plan_config`.
+
+    Reads a TOML file from disk via :func:`tomllib.load`. Runs in a
+    worker thread so the event loop is not blocked.
+    """
+    import tomllib
+
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _format_band_plan_config(new_region: str, existing: dict[str, Any]) -> str:
+    """Render the band-plan ``_config.toml`` body as a single string.
+
+    Pure function — no I/O — so it is cheap to run on the event loop.
+    Output is byte-identical to the previous inline ``f.write()``
+    sequence in :meth:`WebServer._handle_band_plan_config`.
+    """
+    lines = [
+        "# Band plan configuration\n\n",
+        "[settings]\n",
+        f'region = "{new_region}"\n',
+    ]
+    if "layers" in existing:
+        lines.append("\n[layers]\n")
+        for k, v in existing["layers"].items():
+            lines.append(f"{k} = {'true' if v else 'false'}\n")
+    return "".join(lines)
+
+
 def _serialize_filter_config(profile: "RadioProfile") -> dict[str, dict[str, object]]:
     config = profile.filter_config or {}
     result: dict[str, dict[str, object]] = {}
@@ -1537,25 +1568,19 @@ class WebServer:
                 return
 
             # Write config and reload
-            import tomllib
             from pathlib import Path as _Path
 
             project_bp = _Path(__file__).resolve().parents[3] / "band-plans"
             config_path = project_bp / "_config.toml"
             existing: dict[str, Any] = {}
             if config_path.is_file():
-                with open(config_path, "rb") as f:
-                    existing = tomllib.load(f)
+                existing = await asyncio.to_thread(
+                    _load_band_plan_config_sync, config_path
+                )
 
             # Write back (simple format — tomli-w not required)
-            with open(config_path, "w") as f:
-                f.write("# Band plan configuration\n\n")
-                f.write("[settings]\n")
-                f.write(f'region = "{new_region}"\n')
-                if "layers" in existing:
-                    f.write("\n[layers]\n")
-                    for k, v in existing["layers"].items():
-                        f.write(f"{k} = {'true' if v else 'false'}\n")
+            content = _format_band_plan_config(new_region, existing)
+            await asyncio.to_thread(config_path.write_text, content)
 
             # Reload band plans
             self._band_plan.load(project_bp)


### PR DESCRIPTION
## Summary

**Closes #1332.**

Two async handlers (`EibiClient.load_cache` in `web/eibi.py`, `_handle_band_plan_config` in `web/server.py`) were doing direct `open()` / `read_bytes()` / `write_text` calls in the coroutine body, blocking the event loop while the I/O completed. Both now offload the I/O via `asyncio.to_thread(<sync_helper>, ...)` — the existing pattern in the codebase (`backends/discovery.py:492`, `web/eibi.py:401`, etc.).

3 new module-private helpers:
- `_load_cache_files_sync(csv_path, meta_path)` in `eibi.py` — combined CSV + meta load in one thread hop.
- `_load_band_plan_config_sync(path)` in `server.py` — TOML read.
- `_format_band_plan_config(region, existing)` in `server.py` — pure string builder (no I/O — cheap to run on event loop).

No new dependencies. No behaviour change — the TOML output and the EiBi cache parsing are byte-identical to the previous inline form.

## Out of scope

- 2 other `with open(...)` calls in `eibi.py` (inside `EibiClient.fetch`) follow the same pattern and could use the same fix; left alone per #1332's scope. Surface for a future cleanup if motivated.

## Verification
- Tests: 5218 passed, 2 skipped, 9 xfailed, 1 xpassed (matches baseline).
- Contracts: 3 passed.
- ruff, mypy, lint-imports: clean (4/0 contracts kept).
- Byte-identical TOML output verified via direct invocation of `_format_band_plan_config` across no-layers / with-layers / extra-keys cases.

Closes #1332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)