### PR TITLE
docs(modularization): Phase 5 — LAYER.md charters + ARCHITECTURE refresh + CHANGELOG + CLAUDE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,67 +4,52 @@
 
 ---
 
-## Уровни абстракции (снизу вверх)
+## Layered package structure
+
+`src/icom_lan/` is organised into 11 layered Python packages with
+explicit `import-linter`-enforced boundaries. Higher layers depend on
+lower ones; siblings are independent. See
+[`docs/plans/2026-04-29-modularization-plan.md`](docs/plans/2026-04-29-modularization-plan.md)
+§1 for the full layer matrix and `LAYER.md` inside each package for
+charter, public API, and forbidden patterns.
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                   Frontend (Web UI)                         │
-│  Svelte 5 + TypeScript → WebSocket /api/v1/ws state_update  │
-│  HTTP fallback for initial load; WS for commands + scope    │
-└─────────────────────────────────────────────────────────────┘
-                              ↕
-┌─────────────────────────────────────────────────────────────┐
-│              Web Server (src/icom_lan/web/)                 │
-│  • HTTP API: /api/v1/info, /api/v1/state, /api/v1/capabilities
-│  • WebSocket handlers: control, scope, audio                │
-│  • RadioPoller: 200ms state polling                         │
-│  • AudioBroadcaster: Opus → browser                         │
-│  • DX Cluster client (telnet)                               │
-└─────────────────────────────────────────────────────────────┘
-                              ↕
-┌─────────────────────────────────────────────────────────────┐
-│          Radio API Layer (src/icom_lan/radio.py)            │
-│  IcomRadio (high-level async API)                           │
-│  • get_frequency(), set_mode(), get_s_meter()               │
-│  • Scope management (enable/disable/data callbacks)         │
-│  • Audio RX/TX (start/stop/push)                            │
-│  • Commander queue (serialized CI-V commands)               │
-│  • State cache (TTL-based)                                  │
-│  Implements: Radio protocol + AudioCapable + ScopeCapable   │
-└─────────────────────────────────────────────────────────────┘
-                              ↕
-┌─────────────────────────────────────────────────────────────┐
-│       Backend Layer (LAN/USB Serial transport)              │
-│  • LanBackend (UDP 50001/2/3): auth + CI-V + audio          │
-│  • SerialBackend (USB): CI-V over serial + USB audio        │
-│  Transport abstraction: send_civ() / recv_civ()             │
-│  Connection FSM: IDLE → AUTH → PORTS_READY → READY          │
-└─────────────────────────────────────────────────────────────┘
-                              ↕
-┌─────────────────────────────────────────────────────────────┐
-│    Command Layer (src/icom_lan/commands.py)                 │
-│  • 134 CI-V command builders (get_freq, set_mode, etc)      │
-│  • Command parsers (parse_frequency_response, etc)          │
-│  • CommandMap: rig-specific overrides                       │
-│  • Command29 wrapper для dual-receiver (IC-7610)            │
-└─────────────────────────────────────────────────────────────┘
-                              ↕
-┌─────────────────────────────────────────────────────────────┐
-│   CI-V Protocol (src/icom_lan/civ.py)                       │
-│  Binary framing: FE FE [to] [from] [cmd] [sub] [data] FD    │
-│  BCD encoding (frequency), meter calibration                │
-└─────────────────────────────────────────────────────────────┘
-                              ↕
-┌─────────────────────────────────────────────────────────────┐
-│  Rig Profiles (rigs/*.toml) → Data-Driven Config            │
-│  • Capabilities (dual_rx, scope, nb, nr, etc)               │
-│  • Modes (USB, LSB, CW, FM, AM, RTTY)                       │
-│  • Filters (FIL1, FIL2, FIL3)                               │
-│  • Band stack (160m-10m BSR codes)                          │
-│  • Command overrides (IC-7300 vs IC-7610)                   │
-│  • AGC labels (FAST/MID/SLOW vs 1/2/3)                      │
-└─────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+│ cli/                       — Command-line entrypoints              │
+├────────────────────────────────────────────────────────────────────┤
+│ web/        rigctld/       — UI servers (siblings, independent)    │
+├────────────────────────────────────────────────────────────────────┤
+│ backends/                  — Factory + per-radio assembly          │
+├────────────────────────────────────────────────────────────────────┤
+│ runtime/                   — IcomRadio + state + mixins + pollers  │
+├────────────────────────────────────────────────────────────────────┤
+│ profiles/   audio/         — Rig profiles · Audio subsystem        │
+├────────────────────────────────────────────────────────────────────┤
+│ commands/   scope/   dsp/  — CI-V builders · scope · DSP pipeline  │
+├────────────────────────────────────────────────────────────────────┤
+│ core/                      — types, transport, civ, contracts      │
+└────────────────────────────────────────────────────────────────────┘
 ```
+
+**Rules of thumb (CLAUDE.md "Layer boundaries" section is canonical):**
+
+- Adding a new radio backend → conform to relevant Capability Protocols
+  (`AudioCapable`, `StatePollable`, `RigctldRoutable`, `UsbAudioCapable`,
+  …) in `core.radio_protocol`. Zero upper-layer changes if Protocols
+  are honoured.
+- New cross-layer imports must respect the matrix; `import-linter`
+  catches violations at CI.
+- The `Radio` Protocol (in `core.radio_protocol`) is the stable public
+  contract surfaced via `icom_lan` Tier 1; capability protocols
+  (`*Capable`, `StatePollable`, `StatePoller`, `RigctldRoutable`,
+  `UsbAudioCapable`) drive `isinstance`-based feature detection — see
+  [`docs/plans/2026-04-29-modularization-plan.md`](docs/plans/2026-04-29-modularization-plan.md)
+  §2 and `docs/api/public-api-surface.md`.
+
+`import-linter` (config at repo root `.importlinter`, run via
+`uv run lint-imports`) enforces one layered contract plus three
+sibling-independence contracts (`web`⊥`rigctld`,
+`profiles`⊥`audio`, `commands`⊥`scope`⊥`dsp`).
 
 ---
 
@@ -106,12 +91,13 @@ get_s_meter_sql_status = [0x15, 0x01]  # Override IC-7610 command
 
 ---
 
-### 2️⃣ **Rig Loader** (`src/icom_lan/rig_loader.py`)
+### 2️⃣ **Rig Loader** (`src/icom_lan/profiles/rig_loader.py`)
 
 Парсит TOML → валидирует → создаёт runtime объекты:
 
 ```python
-from icom_lan.rig_loader import load_rig
+from icom_lan.profiles.rig_loader import load_rig
+# (`from icom_lan.rig_loader import load_rig` also still works via shim)
 
 rig = load_rig("rigs/ic7610.toml")
 profile: RadioProfile = rig.to_profile()      # Runtime profile
@@ -120,11 +106,11 @@ cmd_map: CommandMap = rig.to_command_map()    # Command overrides
 
 **Выходные объекты:**
 - `RadioProfile` — capabilities, modes, filters, band stack, freq ranges
-- `CommandMap` — словарь wire bytes для команд (используется в `commands.py`)
+- `CommandMap` — словарь wire bytes для команд (используется в `commands/`)
 
 ---
 
-### 3️⃣ **Radio API** (`src/icom_lan/radio.py`)
+### 3️⃣ **Radio API** (`src/icom_lan/runtime/radio.py`)
 
 Высокоуровневый async API:
 
@@ -157,7 +143,7 @@ audio_frame = await radio.recv_audio()  # Opus/PCM bytes
 
 ---
 
-### 4️⃣ **Commands Layer** (`src/icom_lan/commands.py`)
+### 4️⃣ **Commands Layer** (`src/icom_lan/commands/`)
 
 **134 функции-builders** для CI-V команд:
 
@@ -196,7 +182,7 @@ get_frequency(receiver=RECEIVER_SUB)   # → 0x07 0xD1 prefix
 
 ### 5️⃣ **Backend Layer** (Transport)
 
-**LAN Backend** (`backends/icom7610/drivers/`):
+**LAN Backend** (`src/icom_lan/backends/icom7610/`):
 - UDP port 50001 → control (auth, token renewal)
 - UDP port 50002 → CI-V commands
 - UDP port 50003 → audio (Opus/PCM)
@@ -292,8 +278,13 @@ ws.send(JSON.stringify({
 - Command overrides через `CommandMap`
 
 ### 🔹 Protocol abstraction
-- `Radio` protocol — backend-agnostic API
-- `AudioCapable`, `ScopeCapable` — capability protocols
+- `Radio` protocol — backend-agnostic API (in `core.radio_protocol`)
+- Capability protocols (`AudioCapable`, `ScopeCapable`,
+  `MetersCapable`, `LevelsCapable`, `StatePollable`/`StatePoller`,
+  `RigctldRoutable`, `UsbAudioCapable`, …) — `isinstance`-based
+  feature detection so upper layers stay backend-agnostic; see
+  `docs/plans/2026-04-29-modularization-plan.md` §2 and
+  `docs/api/public-api-surface.md`
 - LAN vs Serial — одинаковый high-level API
 
 ### 🔹 Commander queue
@@ -376,7 +367,7 @@ RadioProfile passed to IcomRadio(profile=...)
 Used for:
   • Capability checks (if "scope" in profile.capabilities)
   • Mode/filter lists (frontend dropdown)
-  • Command overrides (cmd_map in commands.py)
+  • Command overrides (cmd_map in `commands/`)
   • Band stack (BSR codes)
 ```
 
@@ -391,7 +382,7 @@ Used for:
 4. Готово — библиотека автоматически поддержит модель
 
 ### ✅ Добавить новую команду
-1. Добавить builder в `commands.py`: `def get_new_feature()`
+1. Добавить builder в `commands/<domain>.py`: `def get_new_feature()`
 2. Добавить parser: `def parse_new_feature_response()`
 3. Добавить метод в `IcomRadio`: `async def get_new_feature()`
 4. Добавить в Web API handlers
@@ -406,7 +397,9 @@ Used for:
 
 ## Тестирование
 
-- **~4796 unit tests** (5 минут runtime)
+- **5230 unit tests** collected (5218 passed, 2 skipped, 9 xfailed,
+  1 xpassed) on `main` after epics #1283 (modularization) +
+  #1322 (capability protocols)
   - Command builders/parsers, protocol roundtrips
   - Rig profile validation (TOML schema)
   - Web API (HTTP + WebSocket)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,30 @@ Never bare `python` or `pytest`. Worktrees: `uv sync --all-extras` first.
 
 ---
 
+## Layer boundaries
+
+`src/icom_lan/` is organised into 11 layered packages with `import-linter`-enforced boundaries (config at repo root `.importlinter`; full matrix in `docs/plans/2026-04-29-modularization-plan.md` §1, §3; per-layer charters in `src/icom_lan/<layer>/LAYER.md`).
+
+Layers (top → bottom; higher = more dependent):
+
+| Layer | Purpose |
+|---|---|
+| `cli/` | Command-line entrypoints |
+| `web/`, `rigctld/` | UI servers (siblings — independent) |
+| `backends/` | Factory + per-radio assembly |
+| `runtime/` | IcomRadio + state + mixins + pollers |
+| `profiles/`, `audio/` | Rig profiles · audio subsystem (siblings) |
+| `commands/`, `scope/`, `dsp/` | CI-V builders · scope · DSP (siblings) |
+| `core/` | Foundational: types, transport, civ, contracts |
+
+When making changes:
+- Adding a new radio backend → conform to the relevant Capability Protocols in `core.radio_protocol` (`AudioCapable`, `StatePollable`, `RigctldRoutable`, `UsbAudioCapable`, …); zero upper-layer changes if the protocols are honoured.
+- New cross-layer imports must respect the matrix; if a sensible-looking import is rejected by the linter, the file is in the wrong layer.
+- Run `uv run lint-imports` before committing significant structural changes (CI gates every PR anyway).
+- Backwards compatibility: old top-level paths (`icom_lan.radio`, `icom_lan.commander`, `icom_lan.rig_loader`, …) keep working via `sys.modules`-aliased re-export shims; new code SHOULD use canonical paths (`icom_lan.runtime.radio`, etc.).
+
+---
+
 ## Testing
 
 - TDD — test first, implement second

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Internal: source code reorganized into explicit layered structure
+  (epic #1283).** `src/icom_lan/` is now organised into 11 layered
+  packages (`core/`, `commands/`, `profiles/`, `audio/`, `scope/`,
+  `dsp/`, `runtime/`, `backends/`, `web/`, `rigctld/`, `cli/`) with
+  per-layer charters in `LAYER.md` files and the full layout/matrix in
+  `docs/plans/2026-04-29-modularization-plan.md`. **No public API
+  changes** — every existing import path continues to work via
+  `sys.modules`-aliased re-export shims, and the Tier 1 / Tier 2 lazy
+  surface in `icom_lan/__init__.py` is unchanged.
+- **Tier 1 Capability Protocols extended (epic #1322).** Three new
+  protocols added to `icom_lan.radio_protocol` / re-exported from
+  `icom_lan` for `isinstance`-based feature detection:
+  `StatePollable` + `StatePoller` (replaces backend-id branching in
+  `web_startup`, see #1298 / #1323), `RigctldRoutable` (#1324),
+  `UsbAudioCapable` (#1326). `PowerControlCapable` gains
+  `native_power_unit` to drop the last `web/handlers/control.py`
+  backend-id discriminator (#1325).
+- **`import-linter` introduced for layer-boundary enforcement.**
+  Config at repo-root `.importlinter` declares one layered contract
+  + three sibling-independence contracts (`web`⊥`rigctld`,
+  `profiles`⊥`audio`, `commands`⊥`scope`⊥`dsp`); run locally via
+  `uv run lint-imports`. CI gates every PR.
 - **`_require_*()` helpers for optional deps (#1274).** New
   `src/icom_lan/_optional_deps.py` provides `_require_numpy`,
   `_require_sounddevice`, `_require_opuslib`, `_require_pillow` (and

--- a/src/icom_lan/audio/LAYER.md
+++ b/src/icom_lan/audio/LAYER.md
@@ -1,0 +1,77 @@
+# `audio` layer
+
+## Charter
+
+End-to-end audio subsystem: `AudioBackend` Protocol + PortAudio/Fake
+implementations, codecs (PCM / Opus / μ-law), transcoder, audio bridge,
+audio bus, FFT scope (panadapter), reconnect-time recovery, and platform
+USB audio resolution. The `audio.backend` and `audio.dsp` submodule paths
+are part of the icom-lan-pro contract and **must remain stable**.
+
+## Public API
+
+`audio/__init__.py` is split between an eager block (LAN audio wire
+types used by transport/radio/sync at import time) and a PEP 562
+`__getattr__` that lazy-loads the heavier abstractions:
+
+- **Eager (LAN audio)**: `AudioPacket`, `AudioStream`, `AudioState`,
+  `AudioStats`, `JitterBuffer`, `build_audio_packet`,
+  `parse_audio_packet`, `AUDIO_HEADER_SIZE`, `MAX_AUDIO_PAYLOAD`,
+  `RX_IDENT_0xA0`, `TX_IDENT`.
+- **Lazy — backend**: `AudioBackend`, `AudioDeviceId`,
+  `AudioDeviceInfo`, `RxStream`, `TxStream`, `PortAudioBackend`,
+  `FakeAudioBackend`, `FakeRxStream`, `FakeTxStream`.
+- **Lazy — config**: `AudioConfig`, `load_audio_config`,
+  `save_audio_config`.
+- **Lazy — DSP**: `DspPipeline`, `DspStage`, `Limiter`, `NoiseGate`,
+  `RmsNormalizer`.
+- **Lazy — resample**: `PcmResampler`, `SampleRateNegotiation`,
+  `negotiate_sample_rate`.
+- **Lazy — USB**: `UsbAudioDriver`, `UsbAudioDevice`,
+  `list_usb_audio_devices`, `select_usb_audio_devices`,
+  plus driver-lifecycle/selection exceptions.
+
+The `AudioBackend` Protocol is Tier 2 (best-effort; lazily exposed via
+PEP 562) — see #1275.
+
+## Allowed dependencies
+
+`core`, `scope` (plan §3 matrix row `audio`). The `audio → scope` edge
+is single-direction, used by `audio/fft_scope.py` to assemble panadapter
+frames from PCM. No `runtime`, no `commands`, no transport caller.
+
+## Forbidden patterns
+
+- `from icom_lan.runtime` / `from icom_lan.commands` — audio is a leaf
+  that runtime composes; the inverse direction is forbidden.
+- Eager imports of `numpy`, `sounddevice`, `opuslib`, or `pyaudio` at
+  module top level. Use `core._optional_deps._require_*()` and gate at
+  call time. The eager block in `audio/__init__.py` is intentionally
+  limited to wire-protocol types.
+- One-off mocks in audio tests. Use `FakeAudioBackend` only (per
+  CLAUDE.md project rule).
+
+## Common operations
+
+- **Add a new codec** → add to `audio/_codecs.py` plus a Python ID
+  constant in `core.types.AudioCodec`; verify wire-format roundtrip in
+  `tests/test_audio_codecs*.py`.
+- **Add an `AudioBackend` implementation** → conform to the Protocol
+  in `audio/backend.py`; add a probe under `tests/test_audio_backend*.py`
+  using the existing fixture set (no one-off mocks).
+- **Change the LAN audio packet layout** → wire format in
+  `audio/lan_stream.py`; update `AUDIO_HEADER_SIZE` and the parser/
+  builder; cross-check with wfview reference and the PCM/Opus codec ID
+  matrix (`docs/api/public-api-surface.md`).
+- **Touch `audio/usb_driver.py`** → keep platform paths gated behind
+  `_require_*()`; macOS uses `audio/_macos_uid.py` for IORegistry
+  matching.
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2 ("audio.backend
+  and audio.dsp paths are the icom-lan-pro contract"), §2.2, §3.
+- `docs/api/public-api-surface.md` — Tier 2 surface for AudioBackend.
+- `audio/backend.py` — the stable Protocol definition.
+- `tests/test_audio_*.py` — coverage; `FakeAudioBackend` lives in
+  `audio/backend.py`.

--- a/src/icom_lan/backends/LAYER.md
+++ b/src/icom_lan/backends/LAYER.md
@@ -1,0 +1,71 @@
+# `backends` layer
+
+## Charter
+
+Factory for assembling concrete radio implementations from typed configs
+plus per-radio adapters and the multi-protocol discovery utility.
+`backends.factory.create_radio(BackendConfig)` is the canonical
+entry point — it inspects the config's discriminator, builds the right
+transport stack, instantiates the correct radio class, and returns
+something that satisfies the `Radio` Protocol from `core`.
+
+## Public API
+
+`backends/__init__.py` exports the minimal assembly surface:
+
+- `BackendConfig` — common base for typed configs.
+- `LanBackendConfig`, `SerialBackendConfig`, `YaesuCatBackendConfig` —
+  the three currently supported backend kinds.
+- `create_radio(config)` — the factory, returns a Protocol-typed radio.
+
+Per-backend packages (`backends/icom7610/`, `backends/ic7300/`,
+`backends/ic9700/`, `backends/ic705/`, `backends/yaesu_cat/`) hold
+the concrete `Radio` adapters; `backends.discovery.discover()` walks
+the LAN for IC-7610-style discoverable radios.
+
+## Allowed dependencies
+
+`core`, `commands`, `profiles`, `audio`, `runtime` (plan §3 matrix row
+`backends`). Backends compose `runtime.IcomRadio` (or, for Yaesu CAT,
+their own Protocol-implementing class) and feed it the right transport
++ commander stack.
+
+`backends.yaesu_cat.radio` carries one named exception in
+`.importlinter`'s `ignore_imports` (`→ icom_lan.rigctld.routing`,
+`TYPE_CHECKING` only, added by epic #1322's RigctldRoutable work).
+
+## Forbidden patterns
+
+- `from icom_lan.web` / `from icom_lan.rigctld` / `from icom_lan.cli`.
+  Backends are below those layers; the inverse is the legal flow.
+- Direct instantiation of backend classes from upper layers. Always go
+  through `create_radio` so the discriminator + capability assembly is
+  consistent.
+- Hardcoding rig facts that already live in `profiles`. New rig
+  parameters → TOML, not Python.
+
+## Common operations
+
+- **Add a new radio backend** → create `backends/<rig>/` package with
+  `radio.py` (the adapter) plus any per-rig poller/commander; register
+  the assembly path inside `backends/factory.py`; conform to the
+  relevant Capability Protocols (`AudioCapable`, `ScopeCapable`,
+  `StatePollable`, `RigctldRoutable`, `UsbAudioCapable` …) so the
+  upper layers detect features via `isinstance` rather than backend-id
+  branching (epic #1322; see #1323-#1326 for the migration pattern).
+  Zero changes required in `web/` / `rigctld/` / `cli/` if the
+  Capability Protocols are honoured.
+- **Add a `BackendConfig` field** → extend the dataclass in
+  `backends/config.py`; route through `create_radio`; cover with
+  `tests/test_backends_factory*.py` and the relevant CLI factory tests.
+- **Discovery transport change** → `backends/discovery.py`; update the
+  CLI's `discover` subcommand (LAN-only) and `tests/test_discovery*.py`.
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2, §1.3 (the
+  deviation rationale: why `backends` is its own layer above
+  `runtime`), §2.2, §3.
+- `core/radio_protocol.py` — Capability Protocols backends implement.
+- `tests/test_backends_*.py`, `tests/test_factory*.py`,
+  `tests/test_yaesu_*.py`.

--- a/src/icom_lan/cli/LAYER.md
+++ b/src/icom_lan/cli/LAYER.md
@@ -1,0 +1,62 @@
+# `cli` layer
+
+## Charter
+
+Command-line entrypoints (`icom-lan` / `python -m icom_lan`). Wires CLI
+arguments to the `backends.factory.create_radio` assembly path and the
+`runtime.IcomRadio` API surface; provides one-shot status/control
+subcommands plus `audio` and `discover` helpers. The CLI is a consumer:
+no business logic lives here.
+
+## Public API
+
+`cli/__init__.py` exports:
+
+- `main` — argparse-driven entry; dispatches subcommands (`status`,
+  `freq`, `mode`, `power`, `meter`, `audio`, `att`, `preamp`, `ptt`,
+  `antenna`, `date`, `time`, `levels`, `discover`).
+- `check_ports_available` — pre-flight UDP port probe used by
+  `web`/`rigctld` integration.
+
+The `icom-lan` console script (`pyproject.toml` `[project.scripts]`)
+points at `icom_lan.cli:main`. The `python -m icom_lan` entry uses
+`icom_lan/__main__.py` which delegates to the same `main`.
+
+## Allowed dependencies
+
+`core`, `commands`, `profiles`, `audio`, `scope`, `runtime`, `backends`,
+`web`, `rigctld` (plan §3 matrix row `cli`). The CLI sits at the top of
+the layered stack and may consume any layer below it; nothing depends
+on `cli`.
+
+## Forbidden patterns
+
+- Adding business logic the runtime should own. Argparse → factory →
+  `IcomRadio` method call → format output. Anything richer belongs in
+  `runtime` or `backends`.
+- Direct backend instantiation. Use `_build_backend_config(args)` →
+  `create_radio(config)` (issue #147; LightRAG memory note: tests must
+  patch `icom_lan.cli.create_radio`, not `icom_lan.cli.IcomRadio`).
+- Hardware-specific branches. Probe via the Capability Protocols on
+  the resolved radio and surface graceful fallbacks.
+
+## Common operations
+
+- **Add a subcommand** → declare argparse subparser in `cli/__init__.py`,
+  implement the async handler, register in the dispatch dict; cover
+  with `tests/test_cli*.py`. Mock `icom_lan.cli.create_radio` to
+  isolate from hardware.
+- **Add a new backend flag** → extend `_build_backend_config(args)`;
+  the `--backend lan|serial` discriminator + per-backend flags are the
+  established pattern; `discover` is LAN-only.
+- **Touch the audio CLI subcommand** → `audio caps` /
+  `audio rx --out` / `audio tx --in` / `audio loopback` consume
+  `audio.AudioStats` and `runtime.IcomRadio` audio APIs; keep the wire
+  format stable.
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2, §2.2, §3.
+- `cli/__init__.py` module docstring — full subcommand inventory.
+- `backends/factory.py` — `create_radio` is the only assembly seam.
+- `tests/test_cli*.py`, `tests/test_yaesu_cli_factory.py`.

--- a/src/icom_lan/commands/LAYER.md
+++ b/src/icom_lan/commands/LAYER.md
@@ -1,0 +1,67 @@
+# `commands` layer
+
+## Charter
+
+CI-V command builders, parsers, and the high-level commander queue.
+Encodes/decodes wire bytes (`FE FE <to> <from> <cmd> [<sub>] [<data>...]
+FD`); does not own state, does not talk to a transport. Every function
+takes bytes/ints and returns bytes/ints — `commands` is reusable in any
+context that needs to build or parse a CI-V frame.
+
+## Public API
+
+`commands/__init__.py` re-exports the full builder/parser surface as a
+single import target. Highlights:
+
+- **Frame kernel** — `build_civ_frame`, `build_cmd29_frame`,
+  `parse_civ_frame`, `parse_ack_nak`, `CONTROLLER_ADDR`,
+  `RECEIVER_MAIN`, `RECEIVER_SUB`.
+- **Builders / parsers** by domain — `freq.py`, `mode.py`, `levels.py`,
+  `meters.py`, `ptt.py`, `vfo.py`, `dsp.py`, `scope.py`, `cw.py`,
+  `power.py`, `system.py`, `tone.py`, `memory.py`, `antenna.py`,
+  `tx_band.py`, `config.py`, `speech.py`.
+- **Commander** — `IcomCommander`, `Priority` (queue + send).
+- **Routing** — `CommandMap`, `CommandSpec` (rig-specific overrides).
+
+`__all__` enumerates ~250 names. Other layers import through this front
+door (`from icom_lan.commands import set_freq`) — direct sub-module
+imports are an internal detail.
+
+## Allowed dependencies
+
+`core` only (plan §3 matrix row `commands`). No `runtime`, no `audio`,
+no transport. Builders are pure; the commander queue's coupling to
+transport happens in the `runtime` layer that wires it up.
+
+## Forbidden patterns
+
+- `from icom_lan.runtime` — would make builders depend on the commander
+  caller; instead, the runtime calls `commands.*`.
+- Module-level state (no caches, no registries that mutate at import).
+  `CommandMap` is a runtime container constructed by `profiles`.
+- Hardcoding rig-specific bytes inside a builder. Rig differences live
+  in `commands/command_map.py` overrides applied via `CommandMap`.
+- I/O. No sockets, no file reads, no `await`. Everything is synchronous
+  byte assembly.
+
+## Common operations
+
+- **Add a CI-V command** → add a builder in the appropriate domain
+  module (`freq.py`, `levels.py`, …); add a parser if the radio
+  responds with bytes; export both from `__init__.py`'s `__all__`;
+  register the wire bytes in `command_map.py` if rig overrides exist.
+  Then add a runtime method in `runtime/radio.py` that calls the
+  builder via the commander.
+- **Override wire bytes for a rig** → extend the rig's TOML
+  `[commands]` table; loader maps to a `CommandSpec` injected into the
+  per-radio `CommandMap`.
+- **Add a `Priority` level** → extend the `Priority` enum in
+  `commander.py`; verify ordering invariants in the queue tests.
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2, §2.2, §3.
+- `commands/_frame.py` — the CI-V kernel; do not duplicate framing.
+- `commands/command_map.py` + `commands/command_spec.py` — TOML-driven
+  per-rig overrides.
+- `tests/test_commands*.py` — builder/parser roundtrip coverage.

--- a/src/icom_lan/core/LAYER.md
+++ b/src/icom_lan/core/LAYER.md
@@ -1,0 +1,72 @@
+# `core` layer
+
+## Charter
+
+Foundational layer with no internal dependencies. Holds the wire-protocol
+primitives (CI-V framing, transport, auth), base types/exceptions, the
+optional-dependency probes, and the abstract Radio Protocol surface that
+downstream consumers (incl. `icom-lan-pro`) treat as the stable contract.
+Anyone may import from `core`; `core` may import from no other layer.
+
+## Public API
+
+`core/__init__.py` keeps `__all__` empty by design — layers reach into
+canonical sub-module paths and the top-level `icom_lan` lazy-loader
+(`icom_lan/__init__.py`) re-exports the Tier 1 / Tier 2 surface. Notable
+canonical entries:
+
+- `core.types` — `Mode`, `AudioCodec`, `BreakInMode`, `RadioState`,
+  `VfoSlotState`, BCD helpers (`bcd_decode`, …).
+- `core.radio_protocol` — the `Radio` Protocol plus every `*Capable` /
+  `StatePollable` / `StatePoller` / `RigctldRoutable` Protocol used for
+  capability detection (see `docs/api/public-api-surface.md`).
+- `core.exceptions` — every public exception subclass.
+- `core.transport`, `core.auth`, `core.civ`, `core.protocol` — UDP
+  transport, authenticator, frame parser, packet-level types.
+- `core.capabilities` — Tier-1 `CAP_*` capability constants.
+- `core._optional_deps` — `_require_numpy`/`_require_sounddevice`/etc.
+  (see #1274).
+
+## Allowed dependencies
+
+None. Plan §3 matrix row `core`: every column is `—`. The single contract
+test `tests/contracts/test_lazy_imports.py` plus `import-linter`'s layered
+contract police this.
+
+`radio_protocol` carries four named exceptions in `.importlinter`'s
+`ignore_imports`: `→ icom_lan.audio_bus` and `→ icom_lan.scope` (both
+`TYPE_CHECKING`-only string annotations — see `radio_protocol.py:58`),
+plus `→ icom_lan.runtime._poller_types` and `→ icom_lan.rigctld.routing`
+(also `TYPE_CHECKING`, added by epic #1322).
+
+## Forbidden patterns
+
+- Any `from icom_lan.<other layer>` import outside a `TYPE_CHECKING`
+  block. New runtime imports here would create cycles instantly.
+- Side-effecting module-level code (no logger config, no env reads, no
+  network/IO at import time).
+- Stateful singletons. Types are dataclasses; protocols are pure
+  Protocols; helpers are stateless functions.
+
+## Common operations
+
+- **Add a capability protocol** → extend `core/radio_protocol.py`, list
+  the symbol in `tests/test_public_api_surface.py`, add to
+  `tests/contracts/test_lazy_imports.py` if Tier 1, register in
+  `icom_lan/__init__.py` `_LAZY_MAP` if Tier 2 (see #1322 commits).
+- **Add an exception** → add to `core/exceptions.py`, ensure it inherits
+  from the existing `IcomLanError` hierarchy, expose via the top-level
+  shim if it's part of the public Tier 1 surface.
+- **Add a transport primitive** → add to `core/transport.py` or a new
+  sub-module; verify zero `from icom_lan` imports remain.
+- **Touch `core/_optional_deps.py`** → run `uv run pytest
+  tests/test_optional_deps.py`; the helper API is shared by every layer
+  and breakage cascades.
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2 (charter), §2.2
+  (public API), §3 (matrix).
+- `docs/api/public-api-surface.md` — Tier 1 / Tier 2 / Tier 3 contract.
+- `tests/contracts/test_lazy_imports.py` — public-name regression gate.
+- `.importlinter` — layered contract + the four named exceptions.

--- a/src/icom_lan/dsp/LAYER.md
+++ b/src/icom_lan/dsp/LAYER.md
@@ -1,0 +1,62 @@
+# `dsp` layer
+
+## Charter
+
+Pure real-time DSP pipeline: nodes, resampler, tap registry, exception
+hierarchy. Independent of every other layer — `dsp` may be reused
+verbatim in any audio context that wants a chainable PCM processor.
+Audio-specific stages (NoiseGate / Limiter / RmsNormalizer) live in
+`audio/dsp.py` on top of this primitive layer.
+
+## Public API
+
+`dsp/__init__.py` exports:
+
+- `DSPNode`, `DSPPipeline` — the chain abstraction (`dsp/pipeline.py`).
+- `TapHandle`, `TapRegistry` — multi-consumer PCM analysis bus
+  (`dsp/tap_registry.py`).
+- `DSPBackendUnavailable`, `DSPConfigError` — error hierarchy
+  (`dsp/exceptions.py`).
+
+`dsp/nodes/` ships the built-in node implementations (`PassthroughNode`,
+`GainNode`, `NRScipyNode`, …); `dsp/resample.py` exposes the
+inter-node resampler used to bridge nodes that disagree on sample rate.
+
+The `icom-lan-pro` consumer reaches `dsp.pipeline`, `dsp.nodes.base`,
+and `dsp.exceptions` directly via canonical paths — these are part of
+the Tier 2 stable contract (plan §9).
+
+## Allowed dependencies
+
+None internally. `dsp` consults `core` only via `core._optional_deps`
+helpers (numpy/scipy), and even those are import-time-conditional.
+The `independence-low` contract in `.importlinter` enforces that
+`dsp` ⊥ `commands` ⊥ `scope`.
+
+## Forbidden patterns
+
+- `from icom_lan.audio` / `from icom_lan.runtime` — `audio` depends on
+  `dsp`, not the reverse. Audio-policy nodes live in `audio/dsp.py`.
+- Module-level numpy/scipy imports. Gate via `_require_numpy()` /
+  `_require_scipy()` at construction time; `DSPBackendUnavailable` is
+  the canonical failure mode.
+- Stateful global registries. `TapRegistry` instances are explicitly
+  passed; nodes are explicitly constructed.
+
+## Common operations
+
+- **Add a node** → subclass `DSPNode` under `dsp/nodes/`, implement
+  `process(frame)` and the rate/format invariants; export through
+  `dsp/nodes/__init__.py` if it is part of the public node catalog.
+- **Add a sample-rate path** → extend `dsp/resample.py`; verify
+  zero-copy fast paths and the `numpy`-availability gate.
+- **Tap a pipeline for telemetry** → `pipeline.add_tap(TapHandle(...))`;
+  consumers receive PCM frames via the registry, not by patching.
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2 ("`dsp` is
+  independent of the rest"), §3 (matrix), §9 (icom-lan-pro contract).
+- `audio/dsp.py` — audio-policy stages built on top.
+- `tests/test_dsp_*.py` — node + pipeline + tap coverage.
+- `.importlinter` `independence-low` contract.

--- a/src/icom_lan/profiles/LAYER.md
+++ b/src/icom_lan/profiles/LAYER.md
@@ -1,0 +1,65 @@
+# `profiles` layer
+
+## Charter
+
+Rig profiles, capability matrices, and the TOML rig-config loader.
+Profiles are loaded from `rigs/*.toml` — adding a new radio is a TOML
+file plus zero Python changes. Encodes the data-driven contract that
+runtime/backend layers consult for routing, validation, and UI surfacing.
+
+## Public API
+
+`profiles/__init__.py` exports:
+
+- `RadioProfile` — frozen dataclass: capabilities, modes, filters,
+  VFO codes, freq ranges, controls, meter calibrations, keyboard config.
+- `ControlSpec`, `RuleSpec`, `MeterCalibrationPoint`,
+  `FilterWidthRule`, `FilterWidthSegment` — TypedDict / dataclass shapes
+  consumed by runtime adapters.
+- `KeyboardBinding`, `KeyboardConfig` — UI-surfaced shortcut config.
+- `get_radio_profile(name_or_id)` — registry lookup by model or id.
+- `resolve_radio_profile(profile=, model=, radio_addr=)` — unified
+  resolution entry; falls back to IC-7610 / first LAN-capable profile.
+- `reload_profiles()` — test/dev helper that resets the lazy registry.
+
+`profiles/rig_loader.py` exposes `discover_rigs()` and the TOML schema
+parsing internals; consumers go through `profiles.__init__` rather than
+reaching into `rig_loader` directly.
+
+## Allowed dependencies
+
+`core`, `commands` (plan §3 matrix row `profiles`). The TOML loader
+constructs `CommandSpec`/`CommandMap` from the `[commands]` table, which
+forces the dependency on `commands`.
+
+A function-local cycle-breaker import lives at `profiles/__init__.py`
+inside `_ensure_loaded()` (`from .rig_loader import discover_rigs`). This
+is load-bearing — `rig_loader` imports from the profiles module-level
+types. **Do not hoist it to module top-level** (plan §6.2 no-touch list).
+
+## Forbidden patterns
+
+- `from icom_lan.runtime`, `from icom_lan.audio`, `from icom_lan.web` —
+  profiles are read-only data; consumers depend on profiles, not the
+  reverse.
+- Any I/O outside the lazy `_ensure_loaded()` path. Profile lookup must
+  not trigger network/disk on hot paths beyond the first load.
+- Hardcoded rig facts in Python. New rigs go to `rigs/<rig>.toml`.
+
+## Common operations
+
+- **Add a new radio** → write `rigs/<rig>.toml`, add a regression test
+  under `tests/test_rigs_*.py`. No Python changes required.
+- **Add a profile field** → extend `RadioProfile` in `profiles/__init__.py`,
+  extend the TOML schema in `rig_loader.py`, add a test fixture under
+  `tests/test_rig_loader*.py`.
+- **Change the registry resolution policy** → edit `resolve_radio_profile`
+  in `profiles/__init__.py`; the docstring documents the precedence
+  order (explicit > model > civ_addr > IC-7610 default).
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2, §2.2, §3.
+- `rigs/*.toml` — actual profile data.
+- `profiles/rig_loader.py` — TOML schema validation entry.
+- `tests/test_rigs_*.py`, `tests/test_rig_loader*.py` — coverage.

--- a/src/icom_lan/rigctld/LAYER.md
+++ b/src/icom_lan/rigctld/LAYER.md
@@ -1,0 +1,69 @@
+# `rigctld` layer
+
+## Charter
+
+Hamlib NET rigctld-compatible TCP server. Drop-in replacement for
+`rigctld` that bridges the line-based TCP protocol to an `IcomRadio`
+instance, so any Hamlib-aware client (WSJT-X, fldigi, JS8Call, etc.)
+works without modification.
+
+## Public API
+
+`rigctld/__init__.py` exports:
+
+- `RigctldServer` — async TCP server; `serve_forever()` enters the
+  accept loop. Module-level import is wrapped in `try/except
+  ImportError` so optional-dep absence (e.g. headless install without
+  the rigctld extras) does not break `import icom_lan`.
+
+Internal layout:
+
+- `rigctld/server.py` — accept loop and connection lifecycle.
+- `rigctld/handler.py` — per-connection rigctld command dispatcher.
+- `rigctld/protocol.py` — line-based protocol parser/formatter.
+- `rigctld/routing.py` — backend → rigctld feature mapping
+  (`RigctldRoutable` integration; see #1322, #1324).
+- `rigctld/poller.py`, `rigctld/state_cache.py` — telemetry plumbing.
+- `rigctld/circuit_breaker.py`, `rigctld/contract.py`,
+  `rigctld/audit.py`, `rigctld/utils.py` — operational helpers.
+
+## Allowed dependencies
+
+`core`, `commands`, `runtime` (plan §3 matrix row `rigctld`). No
+`audio`, no `scope`, no `dsp`, no `profiles` — rigctld is a thin radio
+adapter. `rigctld` ⊥ `web` is enforced by `independence-top` in
+`.importlinter`.
+
+`rigctld.routing` is named in `.importlinter`'s `ignore_imports` as a
+`TYPE_CHECKING`-only target of `core.radio_protocol` and
+`backends.yaesu_cat.radio` — both added by epic #1322's RigctldRoutable
+introduction (#1324, #688bda03).
+
+## Forbidden patterns
+
+- `from icom_lan.web` — independence contract.
+- `from icom_lan.audio` / `from icom_lan.scope` / `from icom_lan.dsp`
+  / `from icom_lan.profiles` — outside the matrix.
+- Backend-id discriminator branches. Use `isinstance(radio,
+  RigctldRoutable)` (#1324). Legacy `set_vfo` overload fallbacks live
+  in `rigctld/handler.py` strictly for third-party backends that don't
+  implement the receiver-tier protocols (#1192).
+- Telemetry or analytics. Open-core hard constraint.
+
+## Common operations
+
+- **Add a rigctld command** → extend the dispatcher in
+  `rigctld/handler.py`; map to the relevant Capability Protocol on the
+  `runtime.Radio` (do not branch on backend type); cover with
+  `tests/test_rigctld_*.py`.
+- **Change feature routing** → `rigctld/routing.py` consults the
+  `RigctldRoutable` Protocol on the radio; backends opt in by
+  implementing it.
+- **Touch the protocol parser** → `rigctld/protocol.py`; the rigctld
+  line format is stable and cross-tested with WSJT-X / fldigi clients.
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2, §3.
+- `core/radio_protocol.py` — `RigctldRoutable` Protocol (#1322).
+- `tests/test_rigctld_*.py` — handler + protocol coverage.

--- a/src/icom_lan/runtime/LAYER.md
+++ b/src/icom_lan/runtime/LAYER.md
@@ -1,0 +1,81 @@
+# `runtime` layer
+
+## Charter
+
+High-level radio orchestration: `IcomRadio` and its mixins (audio, dual
+RX, scope, shared-state, runtime protocols), state cache, state queries,
+pollers, command queue runtime, audio recovery on reconnect, sync
+wrapper, and per-rig runtime helpers (IC-705 data profile, meter
+calibration, CW auto-tuner, startup checks). This is the layer that
+turns wire-level primitives into the user-visible Radio object.
+
+## Public API
+
+`runtime/__init__.py` keeps `__all__` empty by design (plan §2.2). The
+top-level `icom_lan` lazy-loader and the legacy top-level shims surface
+the canonical types to consumers; layer-internal callers reach the
+sub-modules directly:
+
+- `runtime.radio.IcomRadio` — the async high-level API (Tier 1).
+- `runtime.sync.IcomRadio` — the synchronous wrapper.
+- `runtime.radio_state_snapshot.{snapshot_state, restore_state}`,
+  `runtime.radio_initial_state._fetch_initial_state`,
+  `runtime.radio_reconnect.*` — orchestration helpers extracted from
+  the historic `radio.py` god-object (#1258, #1259, #1260).
+- `runtime._poller_types`, `runtime._civ_rx`, `runtime._connection_state`,
+  `runtime._control_phase`, `runtime._audio_recovery` — internal
+  building blocks; 43 test files reach in via private paths and depend
+  on the migration shims.
+- `runtime._audio_runtime_mixin`, `runtime._scope_runtime`,
+  `runtime._dual_rx_runtime`, `runtime._shared_state_runtime`,
+  `runtime._runtime_protocols` — mixins composed onto `IcomRadio`.
+- `runtime.profiles_runtime`, `runtime.meter_cal`,
+  `runtime.cw_auto_tuner`, `runtime.startup_checks`, `runtime.proxy`,
+  `runtime.ic705`, `runtime.radios` — per-rig and helper utilities.
+
+## Allowed dependencies
+
+`core`, `commands`, `profiles`, `audio`, `scope` (plan §3 matrix row
+`runtime`). Note the deviation from the brief skeleton: `runtime`
+legitimately needs `audio` and `scope` because the IcomRadio mixins
+construct audio backends and the scope assembler at runtime
+(plan §1.3).
+
+## Forbidden patterns
+
+- `from icom_lan.backends` — backends compose runtime, not the reverse.
+  The backend factory is the assembly seam; `IcomRadio` does not know
+  which factory built it.
+- `from icom_lan.web` / `from icom_lan.rigctld` / `from icom_lan.cli` —
+  these are upper-tier consumers.
+- `from icom_lan.dsp` directly — DSP processing flows through `audio`,
+  which composes `dsp` internally.
+- New cross-layer imports without checking the matrix; `import-linter`
+  will catch them at CI but do not commit them.
+
+## Common operations
+
+- **Add a high-level Radio method** → declare on the corresponding
+  Capability Protocol in `core.radio_protocol` first, implement on
+  `runtime.radio.IcomRadio`, expose via `runtime.sync.IcomRadio`,
+  cover with `tests/test_radio*.py`. Web / rigctld surfaces consume
+  via `isinstance(radio, FooCapable)`.
+- **Add a poller** → conform to the `StatePoller` Protocol
+  (`core.radio_protocol`); register via `IcomRadio.create_state_poller`
+  per `StatePollable` so `web_startup` discovers it generically (#1298,
+  #1323).
+- **Touch `_civ_rx._update_radio_state_from_frame`** → it is the
+  table-driven dispatch (`_HANDLERS`); add a private handler, not an
+  if/elif branch (#1257). Run `tests/test_civ_rx_dispatch_golden.py`.
+- **Refactor a `radio.py` mixin** → preserve the public Radio Protocol
+  surface; verify `tests/test_public_api_surface.py` and
+  `tests/contracts/test_lazy_imports.py` still pass.
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2, §1.3 (deviation
+  rationale), §2.2, §3.
+- `core/radio_protocol.py` — every Capability Protocol the runtime
+  implements.
+- `tests/test_radio*.py`, `tests/contracts/`, `tests/test_civ_rx_*.py`.
+- `runtime/sync.py` — the synchronous facade.

--- a/src/icom_lan/scope/LAYER.md
+++ b/src/icom_lan/scope/LAYER.md
@@ -1,0 +1,57 @@
+# `scope` layer
+
+## Charter
+
+Spectrum/waterfall frame assembly and rendering. Reconstructs complete
+scope frames from multi-packet CI-V `0x27/0x00` sequences and renders
+them as PNG/canvas-friendly bitmaps. Pure assembly + rendering — no I/O,
+no radio interaction; consumers (web/runtime) feed raw payload bytes.
+
+## Public API
+
+`scope/__init__.py` exports:
+
+- `ScopeFrame` — dataclass: `receiver`, `mode`, `start_freq_hz`,
+  `end_freq_hz`, `pixels` (0–160 amplitude bytes), `out_of_range`.
+- `ScopeAssembler` — feeds CI-V scope packets, emits complete
+  `ScopeFrame` objects per receiver. Maintains independent state for
+  main/sub on dual-RX rigs. Handles 5-second assembly timeout for
+  partial frames.
+
+`scope/render.py` exports rendering helpers (`render_scope_image`, …)
+used by web's image endpoints.
+
+## Allowed dependencies
+
+`core` only (plan §3 matrix row `scope`). `scope` is a sibling of
+`commands` and `dsp` in the layer matrix — independent of both, enforced
+by the `independence-low` contract in `.importlinter`.
+
+## Forbidden patterns
+
+- `from icom_lan.audio` / `from icom_lan.runtime` / `from
+  icom_lan.commands`. Sibling/upper-tier imports break the layer.
+- `from icom_lan.dsp` — the bottom-tier independence contract bans it.
+  PCM-derived spectra live in `audio/fft_scope.py`, which uses `scope`,
+  not the reverse.
+- Maintaining radio I/O state. The assembler is fed bytes; it does not
+  know how they arrive.
+
+## Common operations
+
+- **Tweak assembly timeout** → `_DEFAULT_ASSEMBLY_TIMEOUT` in
+  `scope/__init__.py`; tests under `tests/test_scope*.py` check
+  partial-frame discard behaviour.
+- **Add a render output format** → add a function in `scope/render.py`;
+  verify pixel-encoding invariants against existing PNG goldens.
+- **Track a new wire-format field in `0x27/0x00`** → extend `ScopeFrame`
+  and the sequence-1 decode block in `_ReceiverState.feed`; cross-check
+  against wfview's `parseSpectrum()` (icomcommander.cpp:1921).
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2, §2.2, §3.
+- `audio/fft_scope.py` — PCM-derived panadapter (consumes `scope`).
+- `tests/test_scope*.py` — frame-assembly coverage incl. timeout/partial
+  cases.
+- `.importlinter` `independence-low` contract — sibling enforcement.

--- a/src/icom_lan/web/LAYER.md
+++ b/src/icom_lan/web/LAYER.md
@@ -1,0 +1,76 @@
+# `web` layer
+
+## Charter
+
+WebSocket + HTTP server for the icom-lan Web UI. Hosts the built-in
+browser app — real-time spectrum/waterfall, radio control, audio
+streaming — accessible from any browser on the LAN. No external web
+framework: pure stdlib HTTP + RFC 6455 WebSocket, by design (Tier-1
+Open-Core principle: zero-bloat headless server).
+
+## Public API
+
+`web/__init__.py` exports:
+
+- `WebServer` — async server class; entry point.
+- `WebConfig` — typed runtime config (host/port/TLS/auth/…).
+- `run_web_server(...)` — convenience runner used by the CLI.
+
+Internal layout:
+
+- `web/server.py` — server core; `start()`/`stop()` delegate to
+  `web/web_startup.py`; routing delegates to `web/web_routing.py`.
+- `web/handlers/` — control / scope / audio / state-update handlers.
+- `web/radio_poller.py` — 200ms state poller; emits delta-encoded
+  state_update over `/api/v1/ws`.
+- `web/_delta_encoder.py` — payload diffing.
+- `web/runtime_helpers.py`, `web/band_plan.py`, `web/dx_cluster.py`,
+  `web/eibi.py`, `web/discovery.py`, `web/tls.py`, `web/protocol.py`,
+  `web/rtc.py`, `web/websocket.py` — supporting modules.
+- `web/static/` — built frontend (symlinked from `frontend/dist/`).
+
+## Allowed dependencies
+
+`core`, `commands`, `profiles`, `audio`, `scope`, `dsp`, `runtime`
+(plan §3 matrix row `web`). Note `web` does **not** depend on
+`backends` — `web_startup` consumes `StatePollable.create_state_poller`
+and detects optional features via `isinstance(radio, *Capable)` rather
+than backend-id branching (#1298, #1323-#1326). The transitional
+`web → backends` ignores listed in plan §3.3 are gone.
+
+`web` ⊥ `rigctld` is enforced by `independence-top` in `.importlinter`.
+
+## Forbidden patterns
+
+- `from icom_lan.rigctld` — independence contract.
+- Direct transport calls. Web talks to `runtime.IcomRadio`, never to
+  `core.transport` directly. CLAUDE.md rule.
+- Direct backend-id checks (`if radio.backend_id == "yaesu_cat":`).
+  Use Capability Protocols + `isinstance` (epic #1322).
+- Telemetry or analytics. Open-core hard constraint
+  (`docs/architecture/open-core-policy.md`).
+- Direct store/transport imports inside `frontend/components-v2/panels/`
+  — the lint config bans them (frontend layering, see CLAUDE.md
+  Architecture section). This LAYER.md covers the Python web server;
+  frontend layering is enforced separately by ESLint.
+
+## Common operations
+
+- **Add a control endpoint** → handler in `web/handlers/control.py`
+  (read-only commands go through the dispatch table per #1263); wire
+  into `web_routing.py` if it is a new path; cover with
+  `tests/test_web_*.py`.
+- **Add a state field to the WS payload** → extend `RadioPoller`
+  / `_delta_encoder.py`; verify the schema test
+  `tests/test_web_state_*` and the frontend adapter accept it.
+- **Touch `web_startup.py`** → keep all backend-aware decisions behind
+  Capability Protocols; do not import from `backends/*` directly.
+
+## See also
+
+- `docs/plans/2026-04-29-modularization-plan.md` §1.2, §3.
+- `docs/architecture/open-core-policy.md` — no-telemetry, headless
+  sacred constraints.
+- `docs/plans/2026-04-12-target-frontend-architecture.md` — frontend
+  layering (separate concern).
+- `tests/test_web_*.py`, `tests/test_runtime_helpers*.py`.


### PR DESCRIPTION
## Summary

**Closes Phase 5 of internal-modularization epics #1283 and #1322.**

Final documentation pass per the orchestrator brief §"Phase 5 — Integration & Sign-off". Documentation-only — no source code, no test, no `.importlinter` changes.

## Deliverables

1. **11 `LAYER.md` charter files** — one per layer (`core/`, `commands/`, `profiles/`, `audio/`, `scope/`, `dsp/`, `runtime/`, `backends/`, `web/`, `rigctld/`, `cli/`). Each ~57–81 lines: charter, public API, allowed dependencies (cross-referencing plan §3 matrix), forbidden patterns, common operations, "see also".
2. **`ARCHITECTURE.md` refreshed**: stale "~4796 tests" → 5230 collected (5218 passed); pre-migration flat-structure diagram replaced with the layered overview (TL;DR + pointer to plan §1); stale import paths in data-flow examples updated to canonical post-migration paths (notes that legacy paths still work via shims); Capability Protocols mention expanded to include the three new ones from epic #1322; brief mention of `import-linter`.
3. **`CHANGELOG.md` entry** under the existing `[Unreleased]` / `### Changed` block: 3 bullets covering the modularization, Capability Protocols, and `import-linter` introduction. Existing style preserved.
4. **`CLAUDE.md` "Layer boundaries" section** placed right after the existing `## Architecture` section. Top-to-bottom layer map, contributor guidance for new backends/cross-layer imports, back-compat note about `sys.modules`-aliased shims.

## Verification

- Tests: 5230 collected (5218 passed, 2 skipped, 9 xfailed, 1 xpassed) — no source changes; behaviour unchanged.
- ruff: `All checks passed!`
- mypy: `Success: no issues found in 205 source files`
- lint-imports: `Contracts: 4 kept, 0 broken`.
- `find src/icom_lan -name LAYER.md | wc -l` → `11`.
- `grep -nE '~?4796' ARCHITECTURE.md` → zero hits.

## `.importlinter` sanity check vs plan §3

The live `.importlinter` matches plan §3 **as evolved by epic #1322**:

- **Matches plan §3.1 matrix**: layered contract + 3 sibling-independence contracts (`web`⊥`rigctld`, `profiles`⊥`audio`, `commands`⊥`scope`⊥`dsp`).
- **Diverges from plan §3.3 ignore list** (intentional — post-#1322 evolution; not a defect):
  - **Two stable plan ignores still present**: `radio_protocol → audio_bus`, `radio_protocol → scope` (both `TYPE_CHECKING`).
  - **Two transitional plan ignores resolved**: `web_startup → backends.yaesu_cat.{poller,radio}` were eliminated by follow-up #1298 (now uses `isinstance(StatePollable)`). Plan §3.1 row "web → backends (t)" is correspondingly obsolete.
  - **Three new permanent ignores added by epic #1322**: `radio_protocol → runtime._poller_types`, `radio_protocol → rigctld.routing`, `backends.yaesu_cat.radio → rigctld.routing` — all `TYPE_CHECKING` cycle-breakers introduced when the new Capability Protocols (`StatePollable`/`StatePoller`/`RigctldRoutable`) landed.

No `.importlinter` changes in this PR (per scope) — the discrepancy is recorded here so future readers see the spec → reality delta clearly.

## What's NOT in this PR

- No source-code changes.
- No `.importlinter` changes.
- No test additions/removals.
- The remaining open follow-up #1331 (YaesuCatRadio Protocol-conformance) is tracked separately and outside Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)