### PR TITLE
feat(#1331): YaesuCatRadio satisfies PowerControlCapable; web handler uses isinstance gate

### DIFF
--- a/src/icom_lan/backends/yaesu_cat/radio.py
+++ b/src/icom_lan/backends/yaesu_cat/radio.py
@@ -1303,6 +1303,15 @@ class YaesuCatRadio:
         """
         await self._write("set_power", head=str(head), watts=watts)
 
+    async def set_rf_power(self, level: int) -> None:
+        """Set TX power level — :class:`PowerControlCapable` interface.
+
+        Yaesu's :attr:`native_power_unit` is ``"watts"``, so ``level`` is
+        interpreted as watts directly. Internally delegates to
+        :meth:`set_power` with the default ``head=2`` selector.
+        """
+        await self.set_power(watts=level)
+
     async def get_mic_gain(self) -> int:
         """Get microphone gain (0–100)."""
         result = await self._query("get_mic_gain")

--- a/src/icom_lan/web/handlers/control.py
+++ b/src/icom_lan/web/handlers/control.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from ..._bounded_queue import BoundedQueue
 from ...profiles import RadioProfile
@@ -161,7 +161,7 @@ from ...capabilities import (
     CAP_TX,
     CAP_XFC,
 )
-from ...radio_protocol import MemoryCapable
+from ...radio_protocol import MemoryCapable, PowerControlCapable
 
 __all__ = ["ControlHandler"]
 
@@ -1393,23 +1393,21 @@ class ControlHandler:
             case "set_rf_power" | "set_power":
                 if radio is None:
                     raise RuntimeError("radio connection not available")
-                if CAP_POWER_CONTROL not in radio.capabilities:
+                if not isinstance(radio, PowerControlCapable):
                     raise ValueError(
                         "command set_rf_power is not supported by this radio "
-                        "(missing power_control capability)"
+                        "(radio does not implement PowerControlCapable)"
                     )
                 level = int(params["level"])
                 # Tag the unit per radio's wire-level scale. Icom CI-V
                 # backends expose ``native_power_unit = "raw_255"``,
                 # Yaesu CAT exposes ``"watts"`` — see
-                # :class:`PowerControlCapable.native_power_unit`. Falls
-                # back to ``"raw_255"`` when the attribute is missing
-                # (e.g. legacy mocks) to preserve prior default
-                # behaviour for Icom-shaped radios.
-                unit: Literal["raw_255", "watts"] = getattr(
-                    radio, "native_power_unit", "raw_255"
-                )
-                q.put(SetPower(level, unit=unit))
+                # :class:`PowerControlCapable.native_power_unit`.
+                # ``isinstance`` above narrows ``radio`` to
+                # :class:`PowerControlCapable`, so the attribute is
+                # typed ``Literal["raw_255", "watts"]`` with no
+                # ``getattr`` fallback needed.
+                q.put(SetPower(level, unit=radio.native_power_unit))
                 return {"level": level}
             case "set_powerstat":
                 if radio is None:

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -90,9 +90,16 @@ def _capable_radio() -> SimpleNamespace:
     return SimpleNamespace(
         capabilities=set(FULL_ICOM_CAPS),
         profile=resolve_radio_profile(model="IC-7610"),
+        # PowerControlCapable members — set_rf_power, get_rf_power,
+        # get_powerstat, set_powerstat, native_power_unit. Required
+        # in full so ``isinstance(radio, PowerControlCapable)`` in
+        # the control handler narrows correctly (gap previously
+        # masked by the legacy CAP_POWER_CONTROL string-cap gate).
         set_rf_power=AsyncMock(),
+        get_rf_power=AsyncMock(return_value=0),
         get_powerstat=AsyncMock(return_value=True),
         set_powerstat=AsyncMock(),
+        native_power_unit="raw_255",
         set_rf_gain=AsyncMock(),
         set_af_level=AsyncMock(),
         set_squelch=AsyncMock(),

--- a/tests/test_power_unit_extension.py
+++ b/tests/test_power_unit_extension.py
@@ -84,3 +84,22 @@ def test_yaesu_cat_radio_declares_watts() -> None:
     from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
 
     assert YaesuCatRadio.native_power_unit == "watts"
+
+
+def test_yaesu_cat_radio_satisfies_power_control_capable() -> None:
+    """Regression for #1331 — :class:`YaesuCatRadio` must structurally
+    satisfy :class:`PowerControlCapable` so the web handler's
+    ``isinstance(radio, PowerControlCapable)`` gate works.
+
+    The last residual gap was ``set_rf_power``; the existing
+    ``set_power(watts, head=2)`` method has a different name and an
+    extra parameter, so a thin Protocol-shaped wrapper was added.
+
+    Note: :class:`PowerControlCapable` includes the non-method member
+    ``native_power_unit``, so ``issubclass`` is unsupported by Python's
+    runtime Protocol machinery — verify on an instance.
+    """
+    from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
+
+    radio = YaesuCatRadio("/dev/null")
+    assert isinstance(radio, PowerControlCapable)


### PR DESCRIPTION
## Summary

**Closes #1331.** The last residual architectural gap from epic #1322 is closed: `YaesuCatRadio` now structurally satisfies `PowerControlCapable`, so the web handler at `web/handlers/control.py` switches from the legacy `CAP_POWER_CONTROL not in radio.capabilities` string-capability gate to the typed `isinstance(radio, PowerControlCapable)` gate.

## Changes

- `backends/yaesu_cat/radio.py`: adds `set_rf_power(level: int)` as a thin wrapper around the existing `set_power(watts=level, head=2)`. Yaesu's `native_power_unit = "watts"` (declared in #1325) means `level` is interpreted as watts directly. The other 4 `PowerControlCapable` members (`get_powerstat`, `set_powerstat`, `get_rf_power`, `native_power_unit`) were already present.
- `web/handlers/control.py`: `set_power` / `set_rf_power` case now gates on `isinstance(radio, PowerControlCapable)` and reads `radio.native_power_unit` directly. The `getattr(...)` fallback is gone — mypy narrows `radio` to the Protocol inside the `if` block. Unused `Literal` import removed. The `CAP_POWER_CONTROL` constant remains imported because the `set_powerstat` case still uses it (out of scope for #1331).
- Test fixture `_capable_radio()` in `tests/test_handlers_coverage.py` aligned with the `PowerControlCapable` Protocol it already claimed to satisfy — adds the previously-missing `get_rf_power` and `native_power_unit` members. This closes a coverage gap from #1325 that was previously masked by the string-capability gate.
- Regression test in `tests/test_power_unit_extension.py` asserts `isinstance(YaesuCatRadio("/dev/null"), PowerControlCapable)` — load-bearing for future radio backends. (`issubclass` is unsupported by Python's runtime Protocol machinery because `native_power_unit` is a non-method member.)

## Verification

- Tests: 5219 passed, 2 skipped, 9 xfailed, 1 xpassed (5218 baseline + 1 new regression test).
- Contracts: 3 passed (`tests/contracts/`).
- ruff, mypy, lint-imports: clean (4 contracts kept, 0 broken).
- `isinstance(YaesuCatRadio("/dev/null"), PowerControlCapable)` returns True.
- All Yaesu-related power tests pass; wire format unchanged (`set_power(watts, head=2)` signature preserved for old callers).
- `grep -nE 'getattr\(.*"native_power_unit"' src/icom_lan/web/handlers/control.py` → zero results (acceptance criterion).

## Deviation from spec

The orchestrator's spec assumed 3 modified files; 4 were needed. The fourth — `tests/test_handlers_coverage.py`'s `_capable_radio()` fixture — is necessitated by the gate change: the mock's docstring already promised `PowerControlCapable` conformance, but `get_rf_power` and `native_power_unit` were never added when the Protocol grew in #1325. The previous `CAP_POWER_CONTROL` string gate masked the gap; the new `isinstance` gate exposed it. Aligning the mock with the Protocol it claims to satisfy is in-scope and improves test honesty.

Closes #1331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)