### PR TITLE
refactor(#1337): remove dead underscore re-export from radio.py shim

### DIFF
--- a/src/icom_lan/radio.py
+++ b/src/icom_lan/radio.py
@@ -14,19 +14,17 @@ either:
 * ``from icom_lan.runtime.radio import *`` — static-analysis adapter.
 * ``sys.modules[__name__] = _canonical`` — the runtime invariant.
 
-The third line below — the explicit underscore re-export — is needed
-for any private (``_``-prefixed) symbol that an external consumer
-imports through this shim. ``import *`` excludes underscores by
-Python spec, so mypy can't see the symbol statically through the
-shim. Explicit re-import makes the static graph match the runtime
-identity. As consumers migrate to canonical paths in Step 13, the
-underscore re-imports here become dead and can be removed.
+If a future external consumer needs to reach a private (``_``-prefixed)
+symbol through this shim, add an explicit ``from icom_lan.runtime.radio
+import _foo as _foo`` line — ``import *`` excludes underscores by
+Python spec, so without it mypy can't see the symbol statically through
+the shim. The plan §5.1.1 hybrid pattern documents this case. No such
+re-export is currently needed.
 """
 
 import sys
 
 from icom_lan.runtime.radio import *  # noqa: F401, F403
-from icom_lan.runtime.radio import _DEFAULT_AUDIO_CODEC as _DEFAULT_AUDIO_CODEC  # noqa: F401  # consumer: sync.py
 import icom_lan.runtime.radio as _canonical
 
 sys.modules[__name__] = _canonical


### PR DESCRIPTION
## Summary

**Closes #1337.**

Removes the `from icom_lan.runtime.radio import _DEFAULT_AUDIO_CODEC as _DEFAULT_AUDIO_CODEC` line from `src/icom_lan/radio.py`. The line was added during epic #1322 (PR #1312) following plan §5.1.1 to keep mypy happy when `sync.py:23` reached for `_DEFAULT_AUDIO_CODEC` through the shim. After modularization Step 10a moved `sync.py` into `runtime/`, the consumer now uses a sibling-relative import (`from .radio import _DEFAULT_AUDIO_CODEC`) and bypasses the shim entirely. Plan §5.1.1 itself anticipated this: "[underscore re-exports] become dead after Step 13's global import canonicalization … and can be removed at that time."

The §5.1 + §5.1.1 design pattern stays in the plan and CLAUDE.md as documentation for any future shim that needs the same fix.

## Verification
- All 5219+ tests green.
- Contracts: 3 passed.
- ruff, mypy, lint-imports: clean (4/0).
- `from icom_lan.runtime.sync import IcomRadio` smoke succeeds (the consumer that historically needed the re-export still works via its current relative import).

Closes #1337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)