### PR TITLE
feat(#1343): Variant A 2/5 — parser supports leading VFO arg under chk_vfo=1

### DIFF
--- a/src/icom_lan/rigctld/contract.py
+++ b/src/icom_lan/rigctld/contract.py
@@ -90,14 +90,21 @@ class RigctldCommand:
     Attributes:
         short_cmd: Single-char command (e.g. 'f', 'F', 'm', 'q').
         long_cmd: Long-form name (e.g. 'get_freq', 'set_freq').
-        args: Tuple of string arguments.
+        args: Tuple of string arguments (with any leading VFO label
+            already stripped — see ``vfo_arg``).
         is_set: True if this is a write/set command.
+        vfo_arg: VFO label (``"VFOA"``/``"VFOB"``/``"currVFO"``) when the
+            client sent a leading VFO token under Hamlib chk_vfo=1, else
+            ``None``. Stripped from ``args`` by the parser; handlers in
+            sub-issue #1343 ignore it (single-VFO routing) and per-VFO
+            routing arrives in #1344.
     """
 
     short_cmd: str
     long_cmd: str
     args: tuple[str, ...] = ()
     is_set: bool = False
+    vfo_arg: str | None = None
 
 
 @dataclass(slots=True)
@@ -126,13 +133,32 @@ class RigctldResponse:
 
 @dataclass(frozen=True, slots=True)
 class CommandDef:
-    """Definition of a rigctld command."""
+    """Definition of a rigctld command.
+
+    Attributes:
+        short: Single-character form (e.g. ``"f"``).
+        long: Long-form name (e.g. ``"get_freq"``).
+        is_set: True for write/set commands.
+        min_args: Minimum number of *payload* arguments (after any
+            leading VFO token has been stripped by the parser).
+        max_args: Maximum number of payload arguments (same convention).
+        accepts_vfo_arg: True when Hamlib prefixes the command with a
+            leading ``VFOA``/``VFOB``/``currVFO`` token under
+            ``chk_vfo=1``. Per ``rigctl(1)``: ``f m t j s l u`` (read)
+            and ``F M T L U S`` (write). The parser uses this flag to
+            decide whether to attempt to strip a leading VFO label
+            before the min/max arg check. Note: ``v`` (get_vfo) and
+            ``V`` (set_vfo) are NOT prefixed — VFO is the data, not a
+            prefix.
+        description: Free-form documentation.
+    """
 
     short: str
     long: str
     is_set: bool
     min_args: int = 0
     max_args: int = 0
+    accepts_vfo_arg: bool = False
     description: str = ""
 
 
@@ -148,17 +174,42 @@ def _register(*defs: CommandDef) -> None:
 
 _register(
     # Get commands
-    CommandDef("f", "get_freq", is_set=False, description="Get frequency in Hz"),
-    CommandDef("m", "get_mode", is_set=False, description="Get mode and passband"),
-    CommandDef("t", "get_ptt", is_set=False, description="Get PTT status"),
+    CommandDef(
+        "f",
+        "get_freq",
+        is_set=False,
+        accepts_vfo_arg=True,
+        description="Get frequency in Hz",
+    ),
+    CommandDef(
+        "m",
+        "get_mode",
+        is_set=False,
+        accepts_vfo_arg=True,
+        description="Get mode and passband",
+    ),
+    CommandDef(
+        "t",
+        "get_ptt",
+        is_set=False,
+        accepts_vfo_arg=True,
+        description="Get PTT status",
+    ),
     CommandDef("v", "get_vfo", is_set=False, description="Get current VFO"),
-    CommandDef("j", "get_rit", is_set=False, description="Get RIT offset"),
+    CommandDef(
+        "j",
+        "get_rit",
+        is_set=False,
+        accepts_vfo_arg=True,
+        description="Get RIT offset",
+    ),
     CommandDef(
         "l",
         "get_level",
         is_set=False,
         min_args=1,
         max_args=1,
+        accepts_vfo_arg=True,
         description="Get level (STRENGTH, RFPOWER, SWR, AF, RF, NR, NB, COMP, etc.)",
     ),
     CommandDef(
@@ -167,9 +218,16 @@ _register(
         is_set=False,
         min_args=1,
         max_args=1,
+        accepts_vfo_arg=True,
         description="Get function (NB, NR, COMP, VOX, TONE, TSQL, ANF, LOCK, MON, APF)",
     ),
-    CommandDef("s", "get_split_vfo", is_set=False, description="Get split VFO status"),
+    CommandDef(
+        "s",
+        "get_split_vfo",
+        is_set=False,
+        accepts_vfo_arg=True,
+        description="Get split VFO status",
+    ),
     # Set commands
     CommandDef(
         "F",
@@ -177,6 +235,7 @@ _register(
         is_set=True,
         min_args=1,
         max_args=1,
+        accepts_vfo_arg=True,
         description="Set frequency in Hz",
     ),
     CommandDef(
@@ -185,6 +244,7 @@ _register(
         is_set=True,
         min_args=1,
         max_args=2,
+        accepts_vfo_arg=True,
         description="Set mode and optional passband",
     ),
     CommandDef(
@@ -193,6 +253,7 @@ _register(
         is_set=True,
         min_args=1,
         max_args=1,
+        accepts_vfo_arg=True,
         description="Set PTT on/off",
     ),
     CommandDef(
@@ -204,6 +265,7 @@ _register(
         is_set=True,
         min_args=2,
         max_args=2,
+        accepts_vfo_arg=True,
         description="Set level (RFPOWER, AF, RF, NR, NB, COMP, MICGAIN, KEYSPD, etc.)",
     ),
     CommandDef(
@@ -212,6 +274,7 @@ _register(
         is_set=True,
         min_args=2,
         max_args=2,
+        accepts_vfo_arg=True,
         description="Set function (NB, NR, COMP, VOX, TONE, TSQL, ANF, LOCK, MON, APF)",
     ),
     CommandDef(
@@ -220,6 +283,7 @@ _register(
         is_set=True,
         min_args=2,
         max_args=2,
+        accepts_vfo_arg=True,
         description="Set split VFO",
     ),
     # Control / info commands (not set, not get — special)
@@ -286,7 +350,16 @@ class ClientSession:
     client_id: int = 0
     peername: str = ""
     extended_mode: bool = False
-    vfo_mode: bool = False  # Whether VFO arg is required
+    vfo_mode: bool = False
+    """Set to ``True`` once Hamlib has been told (via ``\\chk_vfo`` →
+    ``"1"`` or ``\\set_vfo_opt 1``) that this server speaks vfo_opt.
+    The parser uses this as a hint for diagnostics; the actual VFO-token
+    strip is driven by ``CommandDef.accepts_vfo_arg`` plus a label
+    match (Hamlib only emits the prefix under chk_vfo=1, so the label
+    match is sufficient on its own). Wired but dormant on `main`:
+    ``_cmd_chk_vfo`` still returns ``"0"`` (Variant B band-aid for
+    #1319) so this stays ``False`` for every client until #1346 (A5)
+    flips chk_vfo back to ``"1"`` for dual-RX rigs."""
 
 
 # ---------------------------------------------------------------------------

--- a/src/icom_lan/rigctld/protocol.py
+++ b/src/icom_lan/rigctld/protocol.py
@@ -31,22 +31,46 @@ from .contract import (  # noqa: TID251
     RigctldResponse,
 )
 
-__all__ = ["parse_line", "format_response", "format_error"]
+__all__ = ["parse_line", "format_response", "format_error", "VFO_LABELS"]
 
 logger = logging.getLogger(__name__)
 
 
-def parse_line(line: bytes) -> RigctldCommand:
+# Hamlib VFO labels that may appear as a leading prefix under chk_vfo=1.
+# Per ``rigctl(1)`` Hamlib emits one of these for every command listed in
+# the "Reading"/"Writing" groups when ``chk_vfo`` returned ``"1"``.
+# (``MEM`` / ``Main`` / ``Sub`` etc. exist in Hamlib but are not emitted
+# by the chk_vfo=1 path — we deliberately keep this set tight.)
+VFO_LABELS: frozenset[str] = frozenset({"VFOA", "VFOB", "currVFO"})
+
+
+def parse_line(
+    line: bytes,
+    session: ClientSession | None = None,
+) -> RigctldCommand:
     """Parse a rigctld command line into a RigctldCommand.
 
     Args:
         line: Raw bytes, already stripped of the trailing newline.
+        session: Optional per-client session state. Currently consulted
+            only for diagnostic logging — the VFO-prefix strip itself
+            is driven by ``CommandDef.accepts_vfo_arg`` plus a label
+            match against :data:`VFO_LABELS`. Hamlib only emits the
+            prefix under chk_vfo=1, so the label match is sufficient
+            on its own; ``session`` is threaded through for future
+            per-mode parsing decisions.
 
     Returns:
-        Parsed RigctldCommand.
+        Parsed RigctldCommand. When the command is VFO-prefixable
+        (``CommandDef.accepts_vfo_arg=True``) and the first arg matches
+        a known VFO label, that label is stripped from ``args`` and
+        stashed on ``cmd.vfo_arg``. Handlers in #1343 ignore
+        ``vfo_arg`` and continue to route to the active VFO; per-VFO
+        routing arrives in #1344.
 
     Raises:
-        ValueError: Unknown command, or wrong number of arguments.
+        ValueError: Unknown command, or wrong number of arguments
+            (counted *after* the VFO-token strip).
     """
     text = line.rstrip(b"\r").decode("ascii", errors="replace").strip()
 
@@ -68,6 +92,24 @@ def parse_line(line: bytes) -> RigctldCommand:
     if defn is None:
         raise ValueError(f"Unknown command: {token!r}")
 
+    # VFO-prefix strip — must happen BEFORE the min/max args check so
+    # that ``f VFOA`` (post-strip args=()) doesn't fail max_args=0.
+    # See contract.CommandDef.accepts_vfo_arg for the canonical list.
+    vfo_arg: str | None = None
+    if defn.accepts_vfo_arg and args and args[0] in VFO_LABELS:
+        vfo_arg = args[0]
+        args = args[1:]
+        if session is not None and not session.vfo_mode:
+            # Defensive: real Hamlib only emits the VFO prefix after
+            # ``chk_vfo`` → ``"1"``, but accept it either way to keep
+            # the parser tolerant of clients that pre-emptively send
+            # vfo_opt traffic. Logged at debug level only.
+            logger.debug(
+                "leading VFO token %r seen on %s while session.vfo_mode=False",
+                vfo_arg,
+                token,
+            )
+
     n = len(args)
     if n < defn.min_args:
         raise ValueError(
@@ -78,13 +120,14 @@ def parse_line(line: bytes) -> RigctldCommand:
             f"Command {token!r} accepts at most {defn.max_args} arg(s), got {n}"
         )
 
-    logger.debug("parsed command %r args=%r", token, args)
+    logger.debug("parsed command %r vfo_arg=%r args=%r", token, vfo_arg, args)
 
     return RigctldCommand(
         short_cmd=defn.short,
         long_cmd=defn.long,
         args=args,
         is_set=defn.is_set,
+        vfo_arg=vfo_arg,
     )
 
 

--- a/src/icom_lan/rigctld/server.py
+++ b/src/icom_lan/rigctld/server.py
@@ -350,7 +350,7 @@ class RigctldServer:
 
                 # ── parse ────────────────────────────────────────────
                 try:
-                    cmd = proto.parse_line(raw)
+                    cmd = proto.parse_line(raw, session)
                 except ValueError as exc:
                     # Unknown command or bad args → ENIMPL, not EPROTO
                     # (WSJT-X sends commands we don't support yet)
@@ -415,6 +415,19 @@ class RigctldServer:
                             except Exception:
                                 logger.debug("hold_for failed", exc_info=True)
                         self._poller.write_busy = False
+
+                # ── session-state wiring (vfo_opt handshake) ─────────
+                # When the handler advertised vfo_opt via ``\chk_vfo`` →
+                # ``"1"``, Hamlib will start prefixing every command
+                # with ``VFOA``/``VFOB``/``currVFO``. Flip the session
+                # bit so the parser knows it's expected and so the
+                # diagnostic in protocol.parse_line stays quiet. Wired
+                # here (rather than in handler.py) to keep the leaf
+                # handlers free of session arguments. Dormant on `main`
+                # because Variant B (#1340) keeps chk_vfo at ``"0"``;
+                # #1346 (A5) flips it back to ``"1"`` for dual-RX.
+                if cmd.long_cmd == "chk_vfo" and resp.values == ["1"]:
+                    session.vfo_mode = True
 
                 # ── send response ────────────────────────────────────
                 out = proto.format_response(cmd, resp, session)

--- a/tests/test_rigctld_consistency.py
+++ b/tests/test_rigctld_consistency.py
@@ -24,15 +24,15 @@ test fails immediately — preventing another #1319.
 
 Lifecycle
 ---------
-- Today (`main`, post-Variant-B): ``chk_vfo`` returns ``"0"``
-  unconditionally → property is vacuously true. The test is xfailed
-  because the *parser* still cannot accept ``f VFOA`` (max_args=0).
-  This deliberate over-strict reading of the property locks A2 into
-  fixing the parser before re-enabling chk_vfo.
-- After A2 (#1343): parser accepts the prefix → test passes naturally.
-  A2's PR removes the xfail marker.
+- Pre-A2: ``chk_vfo`` returns ``"0"`` unconditionally → property is
+  vacuously true. The test was xfailed because the *parser* could not
+  yet accept ``f VFOA`` (``max_args=0``).
+- After A2 (#1343, this state): parser accepts the prefix → test
+  passes naturally; the xfail marker has been removed. ``chk_vfo``
+  still returns ``"0"`` per Variant B, so the guard is currently
+  vacuously satisfied.
 - After A5 (#1346): chk_vfo flips back to ``"1"`` for dual-RX → guard
-  is now load-bearing; future re-regressions fail this test.
+  becomes load-bearing; future re-regressions fail this test.
 
 References
 ----------
@@ -61,15 +61,6 @@ VFO_PREFIXABLE_SHORTS: frozenset[str] = frozenset(
 )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "A2 (#1343) — parser must accept ``<short> VFOA`` for every "
-        "VFO-prefixable command. Today max_args=0/1/2 rejects the leading "
-        "VFO token. Re-becomes load-bearing once A5 (#1346) flips chk_vfo "
-        "back to '1'."
-    ),
-    strict=False,
-)
 @pytest.mark.parametrize("short", sorted(VFO_PREFIXABLE_SHORTS))
 def test_chk_vfo_implies_parser_accepts_vfo_arg(short: str) -> None:
     """``parse_line(b"<short> VFOA ...")`` must not raise ``ValueError``.

--- a/tests/test_rigctld_protocol.py
+++ b/tests/test_rigctld_protocol.py
@@ -295,64 +295,62 @@ class TestParseLineErrors:
 
 
 class TestParseLineVfoPrefix:
-    """Parser must accept leading VFO arg under chk_vfo=1 (#1319).
+    """Parser accepts leading VFO arg under chk_vfo=1 (#1319, A2/#1343).
 
-    Variant A precondition. All cases here are xfailed until A2 (#1343)
-    teaches ``parse_line`` to consume a leading ``VFOA``/``VFOB``/
-    ``currVFO`` token. The exact attribute layout (kept in ``args`` vs.
-    stripped into a new ``vfo`` field) is up to A2 — the assertions
-    here lock in the *short_cmd* and *non-VFO args*; A2's PR updates
-    the ``args`` shape and removes the xfail marker.
-
-    Hamlib spec — https://hamlib.sourceforge.net/manuals/4.5.5/rigctl.1.html
-    lists the VFO-prefixable commands under "rigctl Reading commands"
-    and "rigctl Writing commands". The 13 short forms covered here
-    correspond 1:1 with the wsjtx/fldigi/JS8Call init traces.
-
-    xfail strategy: ``strict=False`` so each subsequent A2-A5 PR may
-    flip individual cases to xpass without breaking CI; the marker is
-    removed in A2's PR once all cases pass cleanly.
+    The 13 wire forms below correspond 1:1 with the
+    wsjtx/fldigi/JS8Call init traces under chk_vfo=1, per the
+    `rigctl(1) <https://hamlib.sourceforge.net/manuals/4.5.5/rigctl.1.html>`_
+    "Reading"/"Writing" command groups. After #1343 the parser strips
+    the leading ``VFOA``/``VFOB``/``currVFO`` token and stashes it on
+    ``cmd.vfo_arg``. Handlers in #1343 still ignore ``vfo_arg`` and
+    route to the active VFO; per-VFO routing arrives in #1344 (A3).
     """
 
-    @pytest.mark.xfail(
-        reason="A2 (#1343) — parser VFO-prefix support not yet landed",
-        strict=False,
-    )
     @pytest.mark.parametrize(
-        "wire,expected_short,expected_long",
+        "wire,expected_short,expected_long,expected_vfo,expected_args",
         [
             # GET commands — Hamlib prefixes VFO under chk_vfo=1.
-            (b"f VFOA", "f", "get_freq"),
-            (b"f VFOB", "f", "get_freq"),
-            (b"f currVFO", "f", "get_freq"),
-            (b"m VFOA", "m", "get_mode"),
-            (b"m VFOB", "m", "get_mode"),
-            (b"t VFOA", "t", "get_ptt"),
-            (b"j VFOA", "j", "get_rit"),
-            (b"s VFOA", "s", "get_split_vfo"),
-            (b"l VFOA STRENGTH", "l", "get_level"),
-            (b"u VFOA NB", "u", "get_func"),
+            (b"f VFOA", "f", "get_freq", "VFOA", ()),
+            (b"f VFOB", "f", "get_freq", "VFOB", ()),
+            (b"f currVFO", "f", "get_freq", "currVFO", ()),
+            (b"m VFOA", "m", "get_mode", "VFOA", ()),
+            (b"m VFOB", "m", "get_mode", "VFOB", ()),
+            (b"t VFOA", "t", "get_ptt", "VFOA", ()),
+            (b"j VFOA", "j", "get_rit", "VFOA", ()),
+            (b"s VFOA", "s", "get_split_vfo", "VFOA", ()),
+            (b"l VFOA STRENGTH", "l", "get_level", "VFOA", ("STRENGTH",)),
+            (b"u VFOA NB", "u", "get_func", "VFOA", ("NB",)),
             # SET commands — Hamlib prefixes VFO under chk_vfo=1.
-            (b"F VFOA 14250000", "F", "set_freq"),
-            (b"M VFOA USB 2400", "M", "set_mode"),
-            (b"T VFOA 1", "T", "set_ptt"),
-            (b"L VFOA RFPOWER 0.5", "L", "set_level"),
-            (b"U VFOA NB 1", "U", "set_func"),
-            (b"S VFOA 1 VFOB", "S", "set_split_vfo"),
+            (b"F VFOA 14250000", "F", "set_freq", "VFOA", ("14250000",)),
+            (b"M VFOA USB 2400", "M", "set_mode", "VFOA", ("USB", "2400")),
+            (b"T VFOA 1", "T", "set_ptt", "VFOA", ("1",)),
+            (
+                b"L VFOA RFPOWER 0.5",
+                "L",
+                "set_level",
+                "VFOA",
+                ("RFPOWER", "0.5"),
+            ),
+            (b"U VFOA NB 1", "U", "set_func", "VFOA", ("NB", "1")),
+            (b"S VFOA 1 VFOB", "S", "set_split_vfo", "VFOA", ("1", "VFOB")),
         ],
     )
     def test_parses_vfo_prefix(
-        self, wire: bytes, expected_short: str, expected_long: str
+        self,
+        wire: bytes,
+        expected_short: str,
+        expected_long: str,
+        expected_vfo: str,
+        expected_args: tuple[str, ...],
     ) -> None:
-        """A2 must accept the wire form without raising ``ValueError``.
-
-        Today these all raise because the get-command CommandDefs have
-        ``max_args=0`` and the set-commands have ``max_args=1`` or 2 —
-        none of them leave room for a leading VFO token.
+        """Parser strips leading VFO token onto ``cmd.vfo_arg`` and
+        validates min/max against the *remaining* args.
         """
         cmd = parse_line(wire)
         assert cmd.short_cmd == expected_short
         assert cmd.long_cmd == expected_long
+        assert cmd.vfo_arg == expected_vfo
+        assert cmd.args == expected_args
 
 
 class TestParseLineBareFormStillWorks:

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -12,7 +12,7 @@ Strategy
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
@@ -234,7 +234,7 @@ class TestAcceptResponse:
 
         data = await asyncio.wait_for(r.read(4096), timeout=1.0)
         assert data == _RESPONSE_BYTES
-        proto.parse_line.assert_called_once_with(b"f")
+        proto.parse_line.assert_called_once_with(b"f", ANY)
 
         await _close(w)
 
@@ -293,7 +293,7 @@ class TestAcceptResponse:
         await w.drain()
         data = await asyncio.wait_for(r.read(4096), timeout=1.0)
         assert data == _RESPONSE_BYTES
-        proto.parse_line.assert_called_once_with(b"f")
+        proto.parse_line.assert_called_once_with(b"f", ANY)
         await _close(w)
 
     async def test_crlf_line_ending_accepted(
@@ -304,7 +304,7 @@ class TestAcceptResponse:
         await w.drain()
         data = await asyncio.wait_for(r.read(4096), timeout=1.0)
         assert data == _RESPONSE_BYTES
-        proto.parse_line.assert_called_once_with(b"f")
+        proto.parse_line.assert_called_once_with(b"f", ANY)
         await _close(w)
 
 


### PR DESCRIPTION
## Summary

Variant A 2/5 of epic #1341 — **closes #1343**. Parser layer of the proper fix for #1319.

The parser (`src/icom_lan/rigctld/protocol.py`) now strips the leading `VFOA`/`VFOB`/`currVFO` token from arg lists when the matching `CommandDef.accepts_vfo_arg` is `True` (the 13 short forms Hamlib prefixes under chk_vfo=1 per `rigctl(1)`: `f m t j s l u` read, `F M T L U S` write). The label is stashed on a new `RigctldCommand.vfo_arg` field for handlers to read. Bare-form parsing (no VFO prefix) is unchanged — single-RX path unaffected.

Handlers in this PR continue to ignore `cmd.vfo_arg` and route to the active VFO. Per-VFO routing comes in A3 (#1344).

`ClientSession.vfo_mode` is wired in `server.py`: after every handler call, if `\chk_vfo` returned `"1"` the bit flips on. Dormant on `main` because Variant B (#1340) keeps chk_vfo at `"0"`; #1346 (A5) flips it back to `"1"` for dual-RX and the wiring becomes load-bearing.

## A1 xfails resolved

- `TestParseLineVfoPrefix` (16 cases) → passing. Now also pins `cmd.vfo_arg` and post-strip `args`.
- `test_chk_vfo_implies_parser_accepts_vfo_arg` (13 cases) → passing. Vacuously satisfied today; load-bearing after A5.
- Integration golden replays (3) → still xfailed (await A3 + A5).

Net xfail count: 38 → 9 (3 integration + 6 deferred to A3-A5).

## Verification

- `uv run pytest tests/ --ignore=tests/integration`: **5263 passed, 9 xfailed, 1 xpassed**.
- `uv run pytest tests/test_rigctld_protocol.py tests/test_rigctld_consistency.py`: 108 passed, 0 xfailed.
- `uv run pytest tests/integration/test_rigctld_golden_replay.py`: 3 passed, 3 xfailed (unchanged).
- `uv run ruff check src/ tests/`: clean.
- `uv run mypy src/`: clean (205 files).
- `uv run lint-imports`: 4 kept, 0 broken.

Closes #1343, refs #1341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)