### PR TITLE
feat(#1344): Variant A 3/5 — per-VFO routing for f/m/t (freq, mode, PTT)

### DIFF
--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ..commands import build_civ_frame
 from ..exceptions import ConnectionError, TimeoutError
@@ -445,6 +445,20 @@ class RigctldHandler:
     # ------------------------------------------------------------------
 
     async def _cmd_get_freq(self, cmd: RigctldCommand) -> RigctldResponse:
+        try:
+            target = self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+
+        # Per-VFO routing for VFOB on dual-RX: read SUB receiver state directly.
+        # Skip pending/cache (those track MAIN only — see _PendingRigState).
+        if target == "VFOB":
+            state = self._radio_state()
+            if state is not None:
+                return RigctldResponse(values=[str(state.sub.freq)])
+            # No state available — fall through to bare get_freq() for MAIN
+            # rather than fabricate a SUB read path. Legacy behaviour.
+
         main_state = self._main_receiver_state()
         pending_freq = self._effective_pending_freq(main_state)
         if pending_freq is not None:
@@ -466,9 +480,18 @@ class RigctldHandler:
             freq = int(float(cmd.args[0]))
         except ValueError:
             return _err(HamlibError.EINVAL)
-        await self._radio.set_freq(freq)
-        self._pending.freq = freq
-        self._cache.update_freq(freq)
+        try:
+            target = self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+
+        receiver = 1 if target == "VFOB" else 0
+        await self._radio.set_freq(freq, receiver=receiver)
+        # Pending/cache track MAIN only — only update on the MAIN path so
+        # subsequent ``f VFOA`` reads coalesce against the just-written value.
+        if target == "VFOA":
+            self._pending.freq = freq
+            self._cache.update_freq(freq)
         return _ok()
 
     # ------------------------------------------------------------------
@@ -476,6 +499,30 @@ class RigctldHandler:
     # ------------------------------------------------------------------
 
     async def _cmd_get_mode(self, cmd: RigctldCommand) -> RigctldResponse:
+        try:
+            target = self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+
+        # Per-VFO routing for VFOB on dual-RX: read SUB receiver state directly.
+        # Skip pending/cache (those track MAIN only — see _PendingRigState).
+        if target == "VFOB":
+            state = self._radio_state()
+            if state is not None:
+                sub = state.sub
+                mode_str = sub.mode.upper()
+                passband = _filter_to_passband(sub.filter)
+                data_mode = sub.data_mode
+                if data_mode:
+                    if mode_str == "USB":
+                        mode_str = "PKTUSB"
+                    elif mode_str == "LSB":
+                        mode_str = "PKTLSB"
+                    elif mode_str == "RTTY":
+                        mode_str = "PKTRTTY"
+                return RigctldResponse(values=[mode_str, str(passband)])
+            # No state available — fall through to legacy MAIN read path.
+
         main_state = self._main_receiver_state()
         pending_mode = self._effective_pending_mode(main_state)
         if pending_mode is not None:
@@ -539,6 +586,23 @@ class RigctldHandler:
         filter_width = _passband_to_filter(passband_hz)
         packet_modes = {"PKTUSB", "PKTLSB", "PKTRTTY"}
 
+        try:
+            target = self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+
+        # Per-VFO routing for VFOB on dual-RX: dispatch to SUB receiver and
+        # skip the MAIN-only pending/cache + read-back sync (those track MAIN).
+        if target == "VFOB":
+            await self._radio.set_mode(
+                base_mode_str, filter_width=filter_width, receiver=1
+            )
+            if requested_mode in packet_modes:
+                set_data_mode = getattr(self._radio, "set_data_mode", None)
+                if set_data_mode is not None:
+                    await set_data_mode(True, receiver=1)
+            return _ok()
+
         await self._radio.set_mode(base_mode_str, filter_width=filter_width)
 
         # Only set DATA mode explicitly for packet modes.
@@ -589,6 +653,16 @@ class RigctldHandler:
     # ------------------------------------------------------------------
 
     async def _cmd_get_ptt(self, cmd: RigctldCommand) -> RigctldResponse:
+        # Validate VFO arg (rejects ``t VFOB`` on single-RX, unknown labels).
+        # The Icom radio exposes a single global PTT state — there is no
+        # per-VFO PTT register — so the answer is the same for VFOA / VFOB
+        # / currVFO once the request is accepted. (See PR #1349 / issue
+        # #1344 for the rationale.)
+        try:
+            self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+
         state = self._radio_state()
         if state is not None:
             self._cache.update_ptt(state.ptt)
@@ -607,6 +681,12 @@ class RigctldHandler:
             on = bool(int(cmd.args[0]))
         except ValueError:
             return _err(HamlibError.EINVAL)
+        # Validate VFO arg — radio PTT is global so the VFO label is honoured
+        # only insofar as it must name a receiver this profile actually has.
+        try:
+            self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
         await self._radio.set_ptt(on)
         self._ptt_state = on
         self._cache.update_ptt(on)
@@ -647,6 +727,35 @@ class RigctldHandler:
         if rc >= 2:
             return "VFOB" if state.active == "SUB" else "VFOA"
         return "VFOB" if state.main.active_slot == "B" else "VFOA"
+
+    def _resolve_target_vfo(self, vfo_arg: str | None) -> Literal["VFOA", "VFOB"]:
+        """Map a Hamlib VFO arg to the canonical VFO name for routing.
+
+        Used by handlers that need per-VFO routing (freq, mode, PTT) when
+        the client sends a leading VFO token under ``chk_vfo=1``.
+
+        Returns:
+            ``"VFOA"`` if the request targets MAIN (or no arg / ``currVFO``
+            and the active receiver is MAIN). ``"VFOB"`` if the request
+            targets SUB.
+
+        Raises:
+            ValueError: ``vfo_arg`` is unrecognised, OR ``"VFOB"`` was
+                requested on a single-receiver profile. Callers map this
+                to ``HamlibError.EVFO``.
+        """
+        if vfo_arg is None or vfo_arg == "currVFO":
+            return cast(Literal["VFOA", "VFOB"], self._active_vfo_name())
+        if vfo_arg == "VFOA":
+            return "VFOA"
+        if vfo_arg == "VFOB":
+            info = self._profile_vfo_info()
+            if info is None or info[0] < 2:
+                raise ValueError(
+                    f"VFOB requested on single-receiver profile (info={info!r})"
+                )
+            return "VFOB"
+        raise ValueError(f"Unknown VFO arg: {vfo_arg!r}")
 
     async def _cmd_get_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
         return RigctldResponse(values=[self._active_vfo_name()])

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -155,7 +155,7 @@ async def test_set_freq_calls_radio(
 ) -> None:
     resp = await handler.execute(set_cmd("set_freq", "14074000"))
     assert resp.ok
-    mock_radio.set_freq.assert_awaited_once_with(14_074_000)
+    mock_radio.set_freq.assert_awaited_once_with(14_074_000, receiver=0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -2692,3 +2692,266 @@ async def test_yaesu_routing_get_level_att_off_returns_zero() -> None:
     resp = await handler.execute(get_cmd("get_level", "ATT"))
     assert resp.ok
     assert resp.values == ["0"]
+
+
+# ---------------------------------------------------------------------------
+# Per-VFO routing for f/F, m/M, t/T (issue #1344, Variant A 3/5)
+# ---------------------------------------------------------------------------
+
+
+def _vfo_get_cmd(long_cmd: str, vfo_arg: str | None, *args: str) -> RigctldCommand:
+    """``RigctldCommand`` with an explicit ``vfo_arg`` (chk_vfo=1 path)."""
+    return RigctldCommand(
+        short_cmd="",
+        long_cmd=long_cmd,
+        args=tuple(args),
+        is_set=False,
+        vfo_arg=vfo_arg,
+    )
+
+
+def _vfo_set_cmd(long_cmd: str, vfo_arg: str | None, *args: str) -> RigctldCommand:
+    return RigctldCommand(
+        short_cmd="",
+        long_cmd=long_cmd,
+        args=tuple(args),
+        is_set=True,
+        vfo_arg=vfo_arg,
+    )
+
+
+def _dual_rx_state(
+    *,
+    main_freq: int = 14_250_000,
+    sub_freq: int = 7_100_000,
+    main_mode: str = "USB",
+    sub_mode: str = "CW",
+    main_filter: int | None = 1,
+    sub_filter: int | None = 2,
+) -> RadioState:
+    """Build a populated RadioState with distinct MAIN / SUB values."""
+    state = RadioState()
+    state.main.freq = main_freq
+    state.main.mode = main_mode
+    state.main.filter = main_filter
+    state.sub.freq = sub_freq
+    state.sub.mode = sub_mode
+    state.sub.filter = sub_filter
+    return state
+
+
+class TestPerVfoRoutingFreq:
+    """`f`/`F` per-VFO routing under chk_vfo=1 (issue #1344)."""
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_freq_vfoa_returns_main(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.radio_state = _dual_rx_state()
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_freq", "VFOA"))
+        assert resp.ok
+        assert resp.values == ["14250000"]
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_freq_vfob_returns_sub(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.radio_state = _dual_rx_state()
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_freq", "VFOB"))
+        assert resp.ok
+        assert resp.values == ["7100000"]
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_freq_currvfo_follows_active(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        state = _dual_rx_state()
+        state.active = "SUB"
+        dual_rx_radio.radio_state = state
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_freq", "currVFO"))
+        assert resp.ok
+        assert resp.values == ["7100000"]
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_freq_no_arg_uses_legacy_main_path(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # Without a VFO arg the active VFO is MAIN by default (state.active),
+        # so behaviour matches the pre-#1344 single-VFO path: MAIN freq.
+        dual_rx_radio.radio_state = _dual_rx_state()
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_freq", None))
+        assert resp.ok
+        assert resp.values == ["14250000"]
+
+    @pytest.mark.asyncio
+    async def test_single_rx_get_freq_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        # A single-receiver profile cannot satisfy a VFOB request — Hamlib's
+        # chk_vfo=1 path expects EVFO so the client falls back gracefully.
+        single_rx_radio.radio_state = RadioState()
+        resp = await single_rx_handler.execute(_vfo_get_cmd("get_freq", "VFOB"))
+        assert resp.error == HamlibError.EVFO
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_set_freq_vfoa_routes_to_main(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_freq", "VFOA", "14080000")
+        )
+        assert resp.ok
+        dual_rx_radio.set_freq.assert_awaited_once_with(14_080_000, receiver=0)
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_set_freq_vfob_routes_to_sub(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_freq", "VFOB", "7080000")
+        )
+        assert resp.ok
+        dual_rx_radio.set_freq.assert_awaited_once_with(7_080_000, receiver=1)
+
+    @pytest.mark.asyncio
+    async def test_single_rx_set_freq_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        resp = await single_rx_handler.execute(
+            _vfo_set_cmd("set_freq", "VFOB", "7080000")
+        )
+        assert resp.error == HamlibError.EVFO
+        single_rx_radio.set_freq.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_freq_unknown_vfo_arg_returns_evfo(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.radio_state = _dual_rx_state()
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_freq", "VFOC"))
+        assert resp.error == HamlibError.EVFO
+
+
+class TestPerVfoRoutingMode:
+    """`m`/`M` per-VFO routing under chk_vfo=1 (issue #1344)."""
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_mode_vfoa_returns_main(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.radio_state = _dual_rx_state()
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_mode", "VFOA"))
+        assert resp.ok
+        # MAIN: USB, filter 1 → 3000 Hz passband.
+        assert resp.values == ["USB", "3000"]
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_mode_vfob_returns_sub(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.radio_state = _dual_rx_state()
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_mode", "VFOB"))
+        assert resp.ok
+        # SUB: CW, filter 2 → 2400 Hz passband.
+        assert resp.values == ["CW", "2400"]
+
+    @pytest.mark.asyncio
+    async def test_single_rx_get_mode_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        single_rx_radio.radio_state = RadioState()
+        resp = await single_rx_handler.execute(_vfo_get_cmd("get_mode", "VFOB"))
+        assert resp.error == HamlibError.EVFO
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_set_mode_vfoa_routes_to_main(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_mode", "VFOA", "USB", "2400")
+        )
+        assert resp.ok
+        # MAIN path: ``set_mode`` called WITHOUT receiver kwarg (legacy default).
+        dual_rx_radio.set_mode.assert_awaited_once_with("USB", filter_width=2)
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_set_mode_vfob_routes_to_sub(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_mode", "VFOB", "CW", "1800")
+        )
+        assert resp.ok
+        # SUB path uses receiver=1 explicitly; passband 1800 Hz → filter 3.
+        dual_rx_radio.set_mode.assert_awaited_once_with(
+            "CW", filter_width=3, receiver=1
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_rx_set_mode_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        resp = await single_rx_handler.execute(
+            _vfo_set_cmd("set_mode", "VFOB", "USB", "2400")
+        )
+        assert resp.error == HamlibError.EVFO
+        single_rx_radio.set_mode.assert_not_awaited()
+
+
+class TestPerVfoRoutingPtt:
+    """`t`/`T` per-VFO routing under chk_vfo=1 (issue #1344).
+
+    The Icom radio exposes a single global PTT state, so the answer for
+    ``t VFOA`` and ``t VFOB`` is the same once the request is accepted.
+    The VFO arg is validated only against the profile (single-RX rejects
+    VFOB with EVFO; dual-RX accepts both).
+    """
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_ptt_vfoa(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        state = RadioState()
+        state.ptt = True
+        dual_rx_radio.radio_state = state
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_ptt", "VFOA"))
+        assert resp.ok
+        assert resp.values == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_ptt_vfob_returns_global_ptt(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # Radio PTT is global — VFOB query returns the same global state.
+        state = RadioState()
+        state.ptt = True
+        dual_rx_radio.radio_state = state
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_ptt", "VFOB"))
+        assert resp.ok
+        assert resp.values == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_single_rx_get_ptt_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        single_rx_radio.radio_state = RadioState()
+        resp = await single_rx_handler.execute(_vfo_get_cmd("get_ptt", "VFOB"))
+        assert resp.error == HamlibError.EVFO
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_set_ptt_vfob_keys_radio_pt_t(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # ``T VFOB 1`` is honoured: Hamlib expects per-VFO PTT but Icom only
+        # has one PTT path — pragmatic choice is to key it regardless.
+        resp = await dual_rx_handler.execute(_vfo_set_cmd("set_ptt", "VFOB", "1"))
+        assert resp.ok
+        dual_rx_radio.set_ptt.assert_awaited_once_with(True)
+
+    @pytest.mark.asyncio
+    async def test_single_rx_set_ptt_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        resp = await single_rx_handler.execute(_vfo_set_cmd("set_ptt", "VFOB", "1"))
+        assert resp.error == HamlibError.EVFO
+        single_rx_radio.set_ptt.assert_not_awaited()


### PR DESCRIPTION
## Summary

Variant A 3/5 of epic #1341 — closes #1344. Per-VFO routing for `f`/`F` (freq), `m`/`M` (mode), `t`/`T` (PTT). After this PR:

- `f VFOA` → MAIN frequency, `f VFOB` → SUB frequency (on dual-RX).
- `F VFOB 7080000` writes to SUB receiver via `set_freq(receiver=1)`.
- Same per-VFO behaviour for `m`/`M`.
- Single-RX profiles return `RPRT -16` (`HamlibError.EVFO`) on `f VFOB`/`m VFOB`/`t VFOB` requests.
- `t VFOA`/`t VFOB` accepted (modulo profile validation) and answered with the global radio PTT — Icom hardware exposes a single PTT register; per-VFO virtualisation would add complexity without value.

## Key changes

- **`_resolve_target_vfo` helper** (in `rigctld/handler.py`) — maps Hamlib's `VFOA`/`VFOB`/`currVFO`/`None` to the canonical name and validates against `radio.profile.receiver_count`. Unknown labels or `VFOB` on a single-RX profile raise `ValueError`; callers translate to `HamlibError.EVFO`.
- **`_cmd_get_freq` / `_cmd_set_freq`** — VFOB reads come from `radio_state.sub.freq` directly. VFOB writes dispatch through the existing `Radio.set_freq(..., receiver=1)` kwarg (no Protocol change needed; `receiver: int = 0` already exists in `core/radio_protocol.py` and `runtime/radio.py`). The MAIN-only `_PendingRigState`/`_FallbackRigState` are still updated only on the VFOA path — pending coalescing is best-effort under the chk_vfo=1 path, intentionally not extended to per-VFO complexity.
- **`_cmd_get_mode` / `_cmd_set_mode`** — same pattern. VFOB reads use `radio_state.sub.mode`/`filter`/`data_mode`. VFOB writes call `set_mode(..., receiver=1)` and (for packet modes) `set_data_mode(True, receiver=1)`. The packet-mode read-back sync only runs on VFOA — it depends on `_PendingRigState` which tracks MAIN.
- **`_cmd_get_ptt` / `_cmd_set_ptt`** — validate the VFO arg (so `t VFOB` on single-RX returns EVFO) but do not branch on it. The radio's PTT is global; honouring `T VFO_X 1` keys the radio regardless of the requested VFO.

## What's NOT in this PR

- Split / RIT / level / func per-VFO routing — A4 (#1345).
- `dump_state` extension and the `chk_vfo="1"` flip — A5 (#1346).

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → 5283 passed, 2 skipped, 9 xfailed, 1 xpassed (all golden-replay xfails are non-strict; they continue to fail at the `chk_vfo='0'` step until A5).
- 20 new unit tests in `TestPerVfoRoutingFreq` / `TestPerVfoRoutingMode` / `TestPerVfoRoutingPtt` (`tests/test_rigctld_handler.py`).
- `uv run ruff check src/ tests/`, `uv run mypy src/`, `uv run lint-imports` (4 kept, 0 broken) — all clean.

Closes #1344, refs #1341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)