### PR TITLE
feat(#1345): Variant A 4/5 — per-VFO routing for split/RIT/level/func

### DIFF
--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -342,6 +342,12 @@ class RigctldHandler:
         self._radio = radio
         self._config = config
         self._ptt_state: bool | None = None
+        # Hamlib-protocol concept: TX VFO label tracked across S/s commands.
+        # Not radio state (CI-V has no per-VFO TX-routing register on most
+        # Icoms — set_vfo_split routing is via active receiver). Initial
+        # value mirrors the Hamlib default ("VFOA"). Updated by
+        # ``_cmd_set_split_vfo`` on every ``S`` request. (Issue #1345.)
+        self._split_tx_vfo: Literal["VFOA", "VFOB"] = "VFOA"
         self._cache = _FallbackRigState()
         self._pending = _PendingRigState()
         self._routing = create_routing(
@@ -812,8 +818,17 @@ class RigctldHandler:
             return _err(HamlibError.EINVAL)
         level = cmd.args[0].upper()
 
+        # Validate the (optional) leading VFO label up-front — even for
+        # globally-scoped levels, an unknown label or VFOB on a single-RX
+        # profile must error before any radio call (issue #1345).
+        try:
+            target = self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+        receiver = 1 if target == "VFOB" else 0
+
         if self._routing is not None:
-            return await self._routing.get_level(level)
+            return await self._routing.get_level(level, vfo=cmd.vfo_arg)
 
         all_levels = (
             {"STRENGTH", "RFPOWER", "SWR", "PREAMP", "ATT", "KEYSPD", "CWPITCH"}
@@ -824,8 +839,23 @@ class RigctldHandler:
             return _err(HamlibError.EINVAL)
         main_state = self._main_receiver_state()
 
-        # STRENGTH — prefer RadioState, then meter call
+        # STRENGTH — per-receiver on dual-RX. VFOB reads SUB s_meter
+        # directly from RadioState (don't update _cache — it tracks MAIN
+        # only, mirroring the freq routing in #1344).
         if level == "STRENGTH":
+            if target == "VFOB":
+                state = self._radio_state()
+                if state is not None:
+                    raw = state.sub.s_meter
+                    return RigctldResponse(
+                        values=[str(round((raw / 241.0) * 114.0 - 54.0))]
+                    )
+                if CAP_METERS in self._radio.capabilities:
+                    raw = await self._radio.get_s_meter(receiver=1)
+                    return RigctldResponse(
+                        values=[str(round((raw / 241.0) * 114.0 - 54.0))]
+                    )
+                return _err(HamlibError.ENIMPL)
             if main_state is not None:
                 raw = main_state.s_meter
                 self._cache.update_s_meter(raw)
@@ -874,7 +904,13 @@ class RigctldHandler:
 
         # Simple 0-255 → 0.0-1.0 float levels
         if level in _GET_LEVEL_FLOAT:
-            raw = await getattr(self._radio, _GET_LEVEL_FLOAT[level])()
+            method = getattr(self._radio, _GET_LEVEL_FLOAT[level])
+            # NB / NR are per-receiver on dual-RX Icoms — pass receiver=
+            # when targeting VFOB. Other levels are radio-global.
+            if level in ("NB", "NR") and target == "VFOB":
+                raw = await method(receiver=receiver)
+            else:
+                raw = await method()
             return RigctldResponse(values=[f"{raw / 255.0:.6f}"])
 
         # Integer levels (WPM, Hz)
@@ -904,8 +940,15 @@ class RigctldHandler:
         except ValueError:
             return _err(HamlibError.EINVAL)
 
+        # Validate the (optional) leading VFO label up-front (issue #1345).
+        try:
+            target = self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+        receiver = 1 if target == "VFOB" else 0
+
         if self._routing is not None:
-            return await self._routing.set_level(level, value)
+            return await self._routing.set_level(level, value, vfo=cmd.vfo_arg)
 
         if level == "RFPOWER":
             await self._radio.set_rf_power(round(value * 255))
@@ -913,7 +956,12 @@ class RigctldHandler:
 
         if level in _SET_LEVEL_FLOAT:
             raw = max(0, min(255, round(value * 255)))
-            await getattr(self._radio, _SET_LEVEL_FLOAT[level])(raw)
+            method = getattr(self._radio, _SET_LEVEL_FLOAT[level])
+            # NB / NR are per-receiver on dual-RX Icoms.
+            if level in ("NB", "NR") and target == "VFOB":
+                await method(raw, receiver=receiver)
+            else:
+                await method(raw)
             return _ok()
 
         if level == "KEYSPD":
@@ -953,12 +1001,25 @@ class RigctldHandler:
             return _err(HamlibError.EINVAL)
         func = cmd.args[0].upper()
 
+        # Validate the (optional) leading VFO label (issue #1345).
+        try:
+            target = self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+        receiver = 1 if target == "VFOB" else 0
+
         if self._routing is not None:
-            return await self._routing.get_func(func)
+            return await self._routing.get_func(func, vfo=cmd.vfo_arg)
 
         if func not in _FUNC_GET:
             return _err(HamlibError.EINVAL)
-        result = await getattr(self._radio, _FUNC_GET[func])()
+        method = getattr(self._radio, _FUNC_GET[func])
+        # NB / NR are per-receiver on dual-RX Icoms.  Other funcs are
+        # radio-global — VFO arg is validated above but ignored.
+        if func in ("NB", "NR") and target == "VFOB":
+            result = await method(receiver=receiver)
+        else:
+            result = await method()
         # APF returns AudioPeakFilter int enum (0=off); others return bool
         return RigctldResponse(values=[str(int(bool(result)))])
 
@@ -971,14 +1032,24 @@ class RigctldHandler:
         except ValueError:
             return _err(HamlibError.EINVAL)
 
+        # Validate the (optional) leading VFO label (issue #1345).
+        try:
+            target = self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+        receiver = 1 if target == "VFOB" else 0
+
         if self._routing is not None:
-            return await self._routing.set_func(func, on)
+            return await self._routing.set_func(func, on, vfo=cmd.vfo_arg)
 
         if func not in _FUNC_SET:
             return _err(HamlibError.EINVAL)
         if func == "APF":
             # APF takes an int mode: 0=off, 1=soft
             await self._radio.set_audio_peak_filter(1 if on else 0)
+        elif func in ("NB", "NR") and target == "VFOB":
+            # Per-receiver NB / NR on dual-RX.
+            await getattr(self._radio, _FUNC_SET[func])(on, receiver=receiver)
         else:
             await getattr(self._radio, _FUNC_SET[func])(on)
         return _ok()
@@ -988,12 +1059,28 @@ class RigctldHandler:
     # ------------------------------------------------------------------
 
     async def _cmd_get_split_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
+        # Validate the (optional) leading VFO label. Split is a global
+        # CI-V concept on Icom — the answer is the same for VFOA / VFOB —
+        # but the request must still name a receiver this profile has.
+        try:
+            self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
         state = self._radio_state()
         split = state.split if state is not None else False
-        return RigctldResponse(values=[str(int(split)), self._active_vfo_name()])
+        # ``_split_tx_vfo`` is handler-local Hamlib-protocol state, set by
+        # the most recent ``S`` command (issue #1345 — fixes #1319 finding
+        # #2 where this used to leak the active VFO instead of TX_VFO).
+        return RigctldResponse(values=[str(int(split)), self._split_tx_vfo])
 
     async def _cmd_set_split_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
-        # Args: <split 0|1> <tx_vfo>
+        # Validate the (optional) leading VFO label first — VFOB on a
+        # single-RX profile must error before any radio call.
+        try:
+            self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
+        # Args after vfo_arg strip: <split 0|1> <tx_vfo>
         if len(cmd.args) < 2:
             return _ok()
         try:
@@ -1042,6 +1129,12 @@ class RigctldHandler:
                     )
                     await self._rollback_split(set_split)
                     return _err(HamlibError.EINTERNAL)
+        # Record the requested TX VFO for the next ``s`` (get_split_vfo)
+        # query — Hamlib protocol expects the TX VFO label round-trip
+        # (issue #1345). Validate the label so a malformed request never
+        # poisons the cached value.
+        if tx_vfo in ("VFOA", "VFOB"):
+            self._split_tx_vfo = cast(Literal["VFOA", "VFOB"], tx_vfo)
         return _ok()
 
     async def _rollback_split(self, set_split: Any) -> None:
@@ -1068,6 +1161,15 @@ class RigctldHandler:
     # ------------------------------------------------------------------
 
     async def _cmd_get_rit(self, cmd: RigctldCommand) -> RigctldResponse:
+        # Validate the (optional) leading VFO label. Most Icom radios
+        # expose a single global RIT register (CI-V 0x21 0x00) — the
+        # answer is the same for VFOA / VFOB. Hamlib clients tolerate
+        # this. Per-VFO RIT would require a RadioState extension; out of
+        # scope for #1345 (tracked as a follow-up under epic #1341).
+        try:
+            self._resolve_target_vfo(cmd.vfo_arg)
+        except ValueError:
+            return _err(HamlibError.EVFO)
         state = self._radio_state()
         rit = state.rit_freq if state is not None else 0
         return RigctldResponse(values=[str(rit)])

--- a/src/icom_lan/rigctld/routing.py
+++ b/src/icom_lan/rigctld/routing.py
@@ -121,9 +121,7 @@ class YaesuRouting:
 
     # -- levels --------------------------------------------------------------
 
-    async def get_level(
-        self, level: str, *, vfo: str | None = None
-    ) -> RigctldResponse:
+    async def get_level(self, level: str, *, vfo: str | None = None) -> RigctldResponse:
         # ``vfo`` accepted for protocol conformance (issue #1345). Yaesu CAT
         # is single-receiver; routing per VFO is not meaningful, ignore.
         del vfo
@@ -261,9 +259,7 @@ class YaesuRouting:
 
     # -- funcs ---------------------------------------------------------------
 
-    async def get_func(
-        self, func: str, *, vfo: str | None = None
-    ) -> RigctldResponse:
+    async def get_func(self, func: str, *, vfo: str | None = None) -> RigctldResponse:
         # ``vfo`` accepted for protocol conformance (issue #1345); ignored.
         del vfo
         radio = self._radio

--- a/src/icom_lan/rigctld/routing.py
+++ b/src/icom_lan/rigctld/routing.py
@@ -47,12 +47,28 @@ def _err(code: HamlibError) -> RigctldResponse:
 
 @runtime_checkable
 class RigctldRouting(Protocol):
-    """Vendor-specific rigctl level/func routing."""
+    """Vendor-specific rigctl level/func routing.
 
-    async def get_level(self, level: str) -> RigctldResponse: ...
-    async def set_level(self, level: str, value: float) -> RigctldResponse: ...
-    async def get_func(self, func: str) -> RigctldResponse: ...
-    async def set_func(self, func: str, on: bool) -> RigctldResponse: ...
+    The optional ``vfo`` keyword on ``get_level``/``set_level``/
+    ``get_func``/``set_func`` carries the Hamlib VFO label
+    (``"VFOA"``/``"VFOB"``/``"currVFO"`` or ``None``) for vendors
+    that need per-receiver routing under ``vfo_opt`` (see issue #1345).
+    Defaults to ``None`` for backwards compatibility — implementers
+    that do not care about VFO routing may safely ignore it.
+    """
+
+    async def get_level(
+        self, level: str, *, vfo: str | None = None
+    ) -> RigctldResponse: ...
+    async def set_level(
+        self, level: str, value: float, *, vfo: str | None = None
+    ) -> RigctldResponse: ...
+    async def get_func(
+        self, func: str, *, vfo: str | None = None
+    ) -> RigctldResponse: ...
+    async def set_func(
+        self, func: str, on: bool, *, vfo: str | None = None
+    ) -> RigctldResponse: ...
     def dump_state(self) -> list[str]: ...
     def get_info(self) -> str: ...
 
@@ -105,7 +121,12 @@ class YaesuRouting:
 
     # -- levels --------------------------------------------------------------
 
-    async def get_level(self, level: str) -> RigctldResponse:
+    async def get_level(
+        self, level: str, *, vfo: str | None = None
+    ) -> RigctldResponse:
+        # ``vfo`` accepted for protocol conformance (issue #1345). Yaesu CAT
+        # is single-receiver; routing per VFO is not meaningful, ignore.
+        del vfo
         radio = self._radio
 
         if level in ("STRENGTH", "RAWSTR"):
@@ -176,7 +197,11 @@ class YaesuRouting:
 
         return _err(HamlibError.EINVAL)
 
-    async def set_level(self, level: str, value: float) -> RigctldResponse:
+    async def set_level(
+        self, level: str, value: float, *, vfo: str | None = None
+    ) -> RigctldResponse:
+        # ``vfo`` accepted for protocol conformance (issue #1345); ignored.
+        del vfo
         radio = self._radio
 
         if level == "RFPOWER":
@@ -236,7 +261,11 @@ class YaesuRouting:
 
     # -- funcs ---------------------------------------------------------------
 
-    async def get_func(self, func: str) -> RigctldResponse:
+    async def get_func(
+        self, func: str, *, vfo: str | None = None
+    ) -> RigctldResponse:
+        # ``vfo`` accepted for protocol conformance (issue #1345); ignored.
+        del vfo
         radio = self._radio
 
         if func == "VOX":
@@ -259,7 +288,11 @@ class YaesuRouting:
             return RigctldResponse(values=[str(int(await radio.get_agc() > 0))])
         return _err(HamlibError.EINVAL)
 
-    async def set_func(self, func: str, on: bool) -> RigctldResponse:
+    async def set_func(
+        self, func: str, on: bool, *, vfo: str | None = None
+    ) -> RigctldResponse:
+        # ``vfo`` accepted for protocol conformance (issue #1345); ignored.
+        del vfo
         radio = self._radio
 
         if func == "VOX":

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -2645,9 +2645,20 @@ async def test_set_split_vfo_rollback_swallows_rollback_failure(
 
 
 @pytest.mark.asyncio
-async def test_get_split_vfo_dual_rx_reflects_active_sub(
+async def test_get_split_vfo_dual_rx_returns_tracked_tx_vfo(
     dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
 ) -> None:
+    """``s`` returns the TX_VFO label set by the most recent ``S`` command.
+
+    Issue #1345 (research finding #2 in #1319): the prior implementation
+    returned ``self._active_vfo_name()`` here, but the Hamlib protocol
+    expects the TX_VFO that the client itself selected via ``S`` — not
+    the active receiver. After #1345 the handler tracks the requested
+    TX VFO in ``_split_tx_vfo`` (handler-local Hamlib-protocol state).
+    """
+    # Drive the handler through ``S 1 VFOB`` so the TX VFO is recorded.
+    set_resp = await dual_rx_handler.execute(set_cmd("set_split_vfo", "1", "VFOB"))
+    assert set_resp.ok
     state = RadioState()
     state.split = True
     state.active = "SUB"
@@ -2955,3 +2966,319 @@ class TestPerVfoRoutingPtt:
         resp = await single_rx_handler.execute(_vfo_set_cmd("set_ptt", "VFOB", "1"))
         assert resp.error == HamlibError.EVFO
         single_rx_radio.set_ptt.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Per-VFO routing for s/S, j, l/L, u/U (issue #1345, Variant A 4/5)
+# ---------------------------------------------------------------------------
+
+
+class TestPerVfoSplit:
+    """`s`/`S` per-VFO routing under chk_vfo=1 (issue #1345).
+
+    Split is a Hamlib-protocol concept — the handler tracks the requested
+    TX_VFO label in handler-local state (``_split_tx_vfo``), set by the
+    most recent ``S`` command and returned by ``s``. This fixes a standing
+    bug (research finding #2 in #1319) where ``s`` previously returned
+    the active receiver label rather than the TX_VFO.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_split_vfo_default_tx_vfo_is_vfoa(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # No prior S command — the default Hamlib TX_VFO label is VFOA.
+        state = RadioState()
+        state.split = False
+        dual_rx_radio.radio_state = state
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_split_vfo", "VFOA"))
+        assert resp.ok
+        assert resp.values == ["0", "VFOA"]
+
+    @pytest.mark.asyncio
+    async def test_set_split_vfo_records_tx_vfo_for_get(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # ``S VFOA 1 VFOB`` — split on, TX VFO = VFOB.  The follow-up
+        # ``s`` request must return the recorded TX VFO label, not the
+        # active receiver.
+        set_resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_split_vfo", "VFOA", "1", "VFOB")
+        )
+        assert set_resp.ok
+        dual_rx_radio.set_split.assert_awaited_once_with(True)
+
+        state = RadioState()
+        state.split = True
+        state.active = "MAIN"  # active receiver is MAIN — TX_VFO is still VFOB
+        dual_rx_radio.radio_state = state
+        get_resp = await dual_rx_handler.execute(_vfo_get_cmd("get_split_vfo", "VFOA"))
+        assert get_resp.ok
+        assert get_resp.values == ["1", "VFOB"]
+
+    @pytest.mark.asyncio
+    async def test_get_split_vfo_unknown_vfo_arg_returns_evfo(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_split_vfo", "VFOC"))
+        assert resp.error == HamlibError.EVFO
+
+    @pytest.mark.asyncio
+    async def test_get_split_vfo_single_rx_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        single_rx_radio.radio_state = RadioState()
+        resp = await single_rx_handler.execute(_vfo_get_cmd("get_split_vfo", "VFOB"))
+        assert resp.error == HamlibError.EVFO
+
+    @pytest.mark.asyncio
+    async def test_set_split_vfo_single_rx_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        resp = await single_rx_handler.execute(
+            _vfo_set_cmd("set_split_vfo", "VFOB", "1", "VFOA")
+        )
+        assert resp.error == HamlibError.EVFO
+        single_rx_radio.set_split.assert_not_awaited()
+
+
+class TestPerVfoRit:
+    """`j` (get_rit) per-VFO routing (issue #1345).
+
+    Most Icom radios expose a single global RIT register (CI-V 0x21 0x00),
+    so the answer is the same for VFOA / VFOB.  Hamlib clients tolerate
+    this. The VFO arg is validated only for profile compatibility.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_rit_vfoa_returns_global_rit(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        state = RadioState()
+        state.rit_freq = 250
+        dual_rx_radio.radio_state = state
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_rit", "VFOA"))
+        assert resp.ok
+        assert resp.values == ["250"]
+
+    @pytest.mark.asyncio
+    async def test_get_rit_vfob_returns_same_global_rit(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # Per-VFO RIT is not modelled in RadioState — VFOB returns the
+        # same global value as VFOA. Documented limitation.
+        state = RadioState()
+        state.rit_freq = 250
+        dual_rx_radio.radio_state = state
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_rit", "VFOB"))
+        assert resp.ok
+        assert resp.values == ["250"]
+
+    @pytest.mark.asyncio
+    async def test_get_rit_single_rx_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        single_rx_radio.radio_state = RadioState()
+        resp = await single_rx_handler.execute(_vfo_get_cmd("get_rit", "VFOB"))
+        assert resp.error == HamlibError.EVFO
+
+
+class TestPerVfoLevel:
+    """`l`/`L` per-VFO routing (issue #1345).
+
+    Per-receiver levels (STRENGTH, NB, NR) route via ``receiver=`` kwarg.
+    Radio-global levels (RFPOWER, MICGAIN, etc.) ignore the VFO arg but
+    still validate it against the profile.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_strength_vfoa_reads_main(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        state = RadioState()
+        state.main.freq = 14_250_000
+        state.main.s_meter = 120  # S9
+        state.sub.s_meter = 60  # different value to detect mis-routing
+        dual_rx_radio.radio_state = state
+        resp = await dual_rx_handler.execute(
+            _vfo_get_cmd("get_level", "VFOA", "STRENGTH")
+        )
+        assert resp.ok
+        # 120 / 241 * 114 - 54 ≈ 2.78 → rounds to 3
+        assert resp.values == [str(round((120 / 241.0) * 114.0 - 54.0))]
+
+    @pytest.mark.asyncio
+    async def test_get_strength_vfob_reads_sub(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        state = RadioState()
+        state.main.freq = 14_250_000
+        state.main.s_meter = 120
+        state.sub.s_meter = 60
+        dual_rx_radio.radio_state = state
+        resp = await dual_rx_handler.execute(
+            _vfo_get_cmd("get_level", "VFOB", "STRENGTH")
+        )
+        assert resp.ok
+        assert resp.values == [str(round((60 / 241.0) * 114.0 - 54.0))]
+
+    @pytest.mark.asyncio
+    async def test_get_rfpower_ignores_vfo_arg(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # RFPOWER is radio-global — VFOB request must succeed and return
+        # the global value, not error out (defeating vfo_opt).
+        state = RadioState()
+        state.main.freq = 14_250_000
+        state.power_level = 128
+        dual_rx_radio.radio_state = state
+        resp = await dual_rx_handler.execute(
+            _vfo_get_cmd("get_level", "VFOB", "RFPOWER")
+        )
+        assert resp.ok
+        assert resp.values == [f"{128 / 255.0:.6f}"]
+
+    @pytest.mark.asyncio
+    async def test_get_nb_level_vfob_routes_to_sub(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.get_nb_level = AsyncMock(return_value=120)
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_level", "VFOB", "NB"))
+        assert resp.ok
+        dual_rx_radio.get_nb_level.assert_awaited_once_with(receiver=1)
+
+    @pytest.mark.asyncio
+    async def test_get_nb_level_vfoa_no_receiver_kwarg(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.get_nb_level = AsyncMock(return_value=120)
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_level", "VFOA", "NB"))
+        assert resp.ok
+        # MAIN path: legacy call without receiver kwarg.
+        dual_rx_radio.get_nb_level.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_get_level_unknown_vfo_arg_returns_evfo(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(
+            _vfo_get_cmd("get_level", "VFOC", "STRENGTH")
+        )
+        assert resp.error == HamlibError.EVFO
+
+    @pytest.mark.asyncio
+    async def test_get_strength_single_rx_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        single_rx_radio.radio_state = RadioState()
+        resp = await single_rx_handler.execute(
+            _vfo_get_cmd("get_level", "VFOB", "STRENGTH")
+        )
+        assert resp.error == HamlibError.EVFO
+
+    @pytest.mark.asyncio
+    async def test_set_rfpower_ignores_vfo_arg(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_level", "VFOB", "RFPOWER", "0.5")
+        )
+        assert resp.ok
+        # RFPOWER is global — call without receiver kwarg.
+        dual_rx_radio.set_rf_power.assert_awaited_once_with(round(0.5 * 255))
+
+    @pytest.mark.asyncio
+    async def test_set_nb_level_vfob_routes_to_sub(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_level", "VFOB", "NB", "0.5")
+        )
+        assert resp.ok
+        dual_rx_radio.set_nb_level.assert_awaited_once_with(
+            round(0.5 * 255), receiver=1
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_level_single_rx_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        resp = await single_rx_handler.execute(
+            _vfo_set_cmd("set_level", "VFOB", "RFPOWER", "0.5")
+        )
+        assert resp.error == HamlibError.EVFO
+        single_rx_radio.set_rf_power.assert_not_awaited()
+
+
+class TestPerVfoFunc:
+    """`u`/`U` per-VFO routing (issue #1345).
+
+    Per-receiver funcs (NB, NR) route via ``receiver=`` kwarg.  Radio-
+    global funcs (VOX, TUNER, COMP, etc.) ignore the VFO arg.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_nb_vfob_routes_to_sub(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.get_nb = AsyncMock(return_value=True)
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_func", "VFOB", "NB"))
+        assert resp.ok
+        dual_rx_radio.get_nb.assert_awaited_once_with(receiver=1)
+
+    @pytest.mark.asyncio
+    async def test_get_nb_vfoa_no_receiver_kwarg(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.get_nb = AsyncMock(return_value=True)
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_func", "VFOA", "NB"))
+        assert resp.ok
+        dual_rx_radio.get_nb.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_get_vox_ignores_vfo_arg(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # VOX is radio-global.
+        dual_rx_radio.get_vox = AsyncMock(return_value=True)
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_func", "VFOB", "VOX"))
+        assert resp.ok
+        dual_rx_radio.get_vox.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_set_nb_vfob_routes_to_sub(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_func", "VFOB", "NB", "1")
+        )
+        assert resp.ok
+        dual_rx_radio.set_nb.assert_awaited_once_with(True, receiver=1)
+
+    @pytest.mark.asyncio
+    async def test_set_vox_ignores_vfo_arg(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_func", "VFOB", "VOX", "1")
+        )
+        assert resp.ok
+        # VOX is global — no receiver kwarg.
+        dual_rx_radio.set_vox.assert_awaited_once_with(True)
+
+    @pytest.mark.asyncio
+    async def test_get_func_unknown_vfo_arg_returns_evfo(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_func", "VFOC", "NB"))
+        assert resp.error == HamlibError.EVFO
+
+    @pytest.mark.asyncio
+    async def test_set_func_single_rx_vfob_returns_evfo(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        resp = await single_rx_handler.execute(
+            _vfo_set_cmd("set_func", "VFOB", "NB", "1")
+        )
+        assert resp.error == HamlibError.EVFO
+        single_rx_radio.set_nb.assert_not_awaited()

--- a/tests/test_rigctld_routable_extension.py
+++ b/tests/test_rigctld_routable_extension.py
@@ -27,9 +27,7 @@ class _StubRouting:
     structural conformance to the extended Protocol surface.
     """
 
-    async def get_level(
-        self, level: str, *, vfo: str | None = None
-    ) -> RigctldResponse:
+    async def get_level(self, level: str, *, vfo: str | None = None) -> RigctldResponse:
         return RigctldResponse(values=["0"])
 
     async def set_level(
@@ -37,9 +35,7 @@ class _StubRouting:
     ) -> RigctldResponse:
         return RigctldResponse(values=["RPRT 0"])
 
-    async def get_func(
-        self, func: str, *, vfo: str | None = None
-    ) -> RigctldResponse:
+    async def get_func(self, func: str, *, vfo: str | None = None) -> RigctldResponse:
         return RigctldResponse(values=["0"])
 
     async def set_func(

--- a/tests/test_rigctld_routable_extension.py
+++ b/tests/test_rigctld_routable_extension.py
@@ -20,18 +20,31 @@ from icom_lan.rigctld.routing import RigctldRouting
 
 
 class _StubRouting:
-    """Structural stub that satisfies :class:`RigctldRouting`."""
+    """Structural stub that satisfies :class:`RigctldRouting`.
 
-    async def get_level(self, level: str) -> RigctldResponse:
+    Accepts the optional ``vfo`` kwarg added in #1345 for per-VFO routing
+    under ``vfo_opt``. The stub ignores ``vfo`` — it only exists to verify
+    structural conformance to the extended Protocol surface.
+    """
+
+    async def get_level(
+        self, level: str, *, vfo: str | None = None
+    ) -> RigctldResponse:
         return RigctldResponse(values=["0"])
 
-    async def set_level(self, level: str, value: float) -> RigctldResponse:
+    async def set_level(
+        self, level: str, value: float, *, vfo: str | None = None
+    ) -> RigctldResponse:
         return RigctldResponse(values=["RPRT 0"])
 
-    async def get_func(self, func: str) -> RigctldResponse:
+    async def get_func(
+        self, func: str, *, vfo: str | None = None
+    ) -> RigctldResponse:
         return RigctldResponse(values=["0"])
 
-    async def set_func(self, func: str, on: bool) -> RigctldResponse:
+    async def set_func(
+        self, func: str, on: bool, *, vfo: str | None = None
+    ) -> RigctldResponse:
         return RigctldResponse(values=["RPRT 0"])
 
     def dump_state(self) -> list[str]:


### PR DESCRIPTION
## Summary

Variant A 4/5 of epic #1341. Per-VFO routing for the remaining VFO-prefixable rigctld commands not covered by A3: split (`s`/`S`), RIT (`j`), levels (`l`/`L`), functions (`u`/`U`).

Also fixes a standing bug (research finding #2 in #1319): `_cmd_get_split_vfo` returned the active VFO label instead of TX_VFO. Now tracks `_split_tx_vfo` as handler-local Hamlib-protocol state, set by `_cmd_set_split_vfo`.

## Per-VFO behaviour matrix

| Command | Per-VFO | Behaviour |
|---|---|---|
| `s` / `S` | Yes (TX_VFO label) | Tracked via handler-local `_split_tx_vfo`; set by `S`, returned by `s` |
| `j` (get_rit) | No (radio-global) | Returns same value for VFOA/VFOB. Per-VFO RIT would need RadioState extension; out of scope |
| `l STRENGTH` | Yes | VFOB reads `state.sub.s_meter` directly |
| `l NB` / `l NR` | Yes | Per-receiver via `receiver=1` kwarg on `get_nb_level` / `get_nr_level` |
| `l RFPOWER` etc. | No (radio-global) | VFO arg validated but ignored for routing |
| `L` (set_level) | Per-level | Same as get |
| `u NB` / `u NR` | Yes | Per-receiver via `receiver=1` kwarg on `get_nb` / `get_nr` |
| `u VOX` / `u TUNER` etc. | No | Validated, ignored |
| `U` (set_func) | Per-func | Same as get |

All paths validate `cmd.vfo_arg` via `_resolve_target_vfo` up-front, even for radio-global commands — a malformed label or VFOB on a single-RX profile produces `EVFO` before any radio call (so `vfo_opt` clients fall back gracefully).

## Scope notes

- `J` (set_rit) and `x`/`X` (get/set_xit) mentioned in the issue narrative are **not** registered in `command_map.py` / contract — kept out of dispatch scope per issue acceptance criteria.
- `RadioState` is **not** extended for per-VFO RIT/XIT — that would be a larger architectural change. Documented limitation.

## RigctldRouting Protocol extension (Tier 1 capability surface)

`RigctldRouting.get_level` / `set_level` / `get_func` / `set_func` gain an optional `vfo: str | None = None` keyword. Back-compat default. Existing `YaesuRouting` implementer accepts and ignores the kwarg (single-receiver). Additive change — third-party implementers continue to work as long as they accept extra kwargs explicitly (the test stub does).

## Verification

- Tests: 5308 passed (was 5283; +25 new), 9 xfailed unchanged.
- New `TestPerVfoSplit` / `TestPerVfoRit` / `TestPerVfoLevel` / `TestPerVfoFunc` classes in `test_rigctld_handler.py`.
- A1 integration golden replays still xfailed at file scope (chk_vfo flips to `"1"` only in A5 — Variant A 5/5).
- ruff (check + format), mypy, lint-imports: clean (`4 kept, 0 broken`).

Closes #1345, refs #1341.

Generated with [Claude Code](https://claude.com/claude-code)