### PR TITLE
ci: include tests/contracts/ + other subdirectories in CI test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         id: tests
         run: |
-          uv run pytest tests/test_*.py -v --tb=short --timeout=300 --timeout-method=thread \
+          uv run pytest tests/ --ignore=tests/integration -v --tb=short --timeout=300 --timeout-method=thread \
             | tee pytest-output.txt
           SUMMARY=$(tail -1 pytest-output.txt)
           PASSED=$(echo "$SUMMARY" | grep -oP '\d+ passed' | grep -oP '\d+' || echo "0")


### PR DESCRIPTION
## Summary

**P1 fix surfaced by Codex review on PR #1301.**

`.github/workflows/test.yml`'s `tests/test_*.py` glob is non-recursive — it silently skips:
- `tests/contracts/test_lazy_imports.py` (3 load-bearing public-API contract tests from #1342)
- any future subdirectory test

Local collection counts (Python 3.13, this worktree):
- `pytest tests/test_*.py --collect-only -q` -> **5317/5319 collected**
- `pytest tests/ --ignore=tests/integration --collect-only -q` -> **5320/5322 collected**
- Diff: **3 contract tests silently skipped by CI**

The orchestrator note referenced ~287 tests; the larger gap shows up only when you compare against `tests/` without `--ignore=tests/integration` (which would also pull in hardware-only tests). The right fix is the `--ignore=tests/integration` form: it preserves the original intent of excluding hardware integration tests while picking up `tests/contracts/` and any future subdir.

This means our load-bearing contract tests for the public API surface (Tier 1 + Tier 2 lazy resolution from epic #1283) have not been running in CI. They pass locally; the problem is invisible without explicit checking.

## Fix

Change `pytest tests/test_*.py` to `pytest tests/ --ignore=tests/integration`. Recursive collection picks up subdir tests; `--ignore=tests/integration` preserves the intent of skipping integration-level tests requiring hardware.

## Verification

- Local recursive collection now matches expected count (5320 collected, vs 5317 before).
- `pytest tests/ --ignore=tests/integration -q` passes locally: `5308 passed, 2 skipped, 2 deselected, 9 xfailed, 1 xpassed`.
- Tests in `tests/contracts/` now included.
- `tests/integration/` continues to be excluded.

No source-code or test changes — purely CI configuration fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)