### PR TITLE
feat(#1346): Variant A 5/5 — re-enable chk_vfo + audit vfo column + mock fix (closes epic #1341)

### DIFF
--- a/src/icom_lan/backends/icom7610/drivers/serial_stub.py
+++ b/src/icom_lan/backends/icom7610/drivers/serial_stub.py
@@ -181,6 +181,17 @@ class SerialMockRadio:
             receiver: _ReceiverState()
             for receiver in range(self._profile.receiver_count)
         }
+        # Seed RadioState's MAIN/SUB receivers from the per-receiver
+        # _ReceiverState defaults so the rigctld handler's per-VFO reads
+        # (which go through ``radio.radio_state.{main,sub}.{freq,mode,filter}``)
+        # see the same values as the bare ``radio.get_freq()`` / ``get_mode()``
+        # paths. Without this, ``f VFOB`` on a freshly-connected dual-RX
+        # mock returns ``0`` (the VfoSlotState default) instead of the
+        # canonical 14_074_000. See ``set_freq`` / ``set_mode`` below for
+        # the matching write-side mirror.
+        self._sync_radio_state_from_rx(0)
+        if 1 in self._rx:
+            self._sync_radio_state_from_rx(1)
 
     @property
     def connected(self) -> bool:
@@ -236,6 +247,22 @@ class SerialMockRadio:
             f"{self._profile.model} (receivers={self._profile.receiver_count})"
         )
 
+    def _sync_radio_state_from_rx(self, receiver: int) -> None:
+        """Mirror per-receiver state into ``RadioState.{main,sub}``.
+
+        rigctld's per-VFO read paths (``f VFOB``, ``m VFOB``) read from
+        ``radio.radio_state.sub.{freq,mode,filter}`` directly, bypassing
+        the radio coroutines. Keep that view in sync with ``self._rx``
+        whenever a write touches a specific receiver.
+        """
+        rx = self._rx.get(receiver)
+        if rx is None:
+            return
+        target = self._radio_state.main if receiver == 0 else self._radio_state.sub
+        target.freq = rx.freq
+        target.mode = rx.mode.name
+        target.filter = rx.filter_width
+
     def set_state_change_callback(self, callback: Any | None) -> None:
         self._state_change_callback = callback
 
@@ -265,6 +292,7 @@ class SerialMockRadio:
 
     async def set_freq(self, freq: int, receiver: int = 0) -> None:
         self._receiver_state(receiver, operation="set_freq").freq = freq
+        self._sync_radio_state_from_rx(receiver)
         if receiver == 0:
             self._state_cache.update_freq(freq)
 
@@ -283,6 +311,7 @@ class SerialMockRadio:
         receiver_state.mode = parsed_mode
         if filter_width is not None:
             receiver_state.filter_width = filter_width
+        self._sync_radio_state_from_rx(receiver)
         if receiver == 0:
             self._state_cache.update_mode(parsed_mode.name, receiver_state.filter_width)
 

--- a/src/icom_lan/rigctld/audit.py
+++ b/src/icom_lan/rigctld/audit.py
@@ -32,6 +32,11 @@ class AuditRecord:
         cmd: Short (single-char or ``\\name``) command string.
         long_cmd: Long-form command name (e.g. ``"get_freq"``).
         args: Tuple of string arguments supplied with the command.
+        vfo: Leading VFO token (``"VFOA"``, ``"VFOB"``, ``"currVFO"`` …)
+            captured by the parser when the client uses ``chk_vfo=1``
+            mode, else ``None``. Distinguishes ``F VFOB 14080000`` from
+            ``F VFOA 14080000`` from bare-form ``F 14080000`` in audit
+            logs (issue #1346).
         duration_ms: Wall-clock time from execute-start to response-sent, ms.
         rprt: Hamlib ``RPRT`` code (0 = success, negative = error).
         is_set: ``True`` if this was a write/set command.
@@ -46,6 +51,7 @@ class AuditRecord:
     duration_ms: float
     rprt: int
     is_set: bool
+    vfo: str | None = None
 
 
 class RigctldAuditFormatter(logging.Formatter):
@@ -69,6 +75,7 @@ class RigctldAuditFormatter(logging.Formatter):
                 "cmd": audit.cmd,
                 "long_cmd": audit.long_cmd,
                 "args": list(audit.args),
+                "vfo": audit.vfo,
                 "duration_ms": audit.duration_ms,
                 "rprt": audit.rprt,
                 "is_set": audit.is_set,

--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -1196,18 +1196,18 @@ class RigctldHandler:
     async def _cmd_chk_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
         """Hamlib chk_vfo handshake.
 
-        Returns ``"0"`` unconditionally. The dual-RX ``"1"`` advertising
-        introduced in #722 was rolled back in 0.19.1 (issue #1319) because
-        Hamlib then prefixes every command with a VFO token (e.g.
-        ``f VFOA``) which the parser does not yet accept and the handlers
-        do not yet route per-VFO. Result before rollback: dual-RX models
-        (IC-7610, IC-9700, FTX-1) returned ``RPRT -4`` for any get/set,
-        breaking WSJT-X / fldigi / JS8Call.
+        Returns ``"1"`` for dual-RX profiles (advertises ``vfo_opt``
+        support); ``"0"`` for single-RX (legacy behaviour).
 
-        Re-enabled to ``"1"`` once full ``vfo_opt`` support lands —
-        tracked as a follow-up to #1319.
+        Re-enabled in Variant A 5/5 (#1346) after the full ``vfo_opt``
+        stack landed: parser support (#1343), per-VFO routing for
+        freq/mode/PTT (#1344), per-VFO split/RIT/level/func (#1345).
+        Variant B's unconditional ``"0"`` (PR #1340) is now correctly
+        superseded.
         """
-        return RigctldResponse(values=["0"])
+        info = self._profile_vfo_info()
+        dual = info is not None and info[0] >= 2
+        return RigctldResponse(values=["1" if dual else "0"])
 
     async def _cmd_get_powerstat(self, cmd: RigctldCommand) -> RigctldResponse:
         on = await self._radio.get_powerstat()

--- a/src/icom_lan/rigctld/server.py
+++ b/src/icom_lan/rigctld/server.py
@@ -447,6 +447,7 @@ class RigctldServer:
                         cmd=cmd.short_cmd,
                         long_cmd=cmd.long_cmd,
                         args=cmd.args,
+                        vfo=cmd.vfo_arg,
                         duration_ms=duration_ms,
                         rprt=resp.error,
                         is_set=cmd.is_set,

--- a/tests/integration/test_rigctld_golden_replay.py
+++ b/tests/integration/test_rigctld_golden_replay.py
@@ -1,8 +1,8 @@
 """Wire-level golden-replay tests for rigctld vfo_opt sessions.
 
 Variant A 1/5 of epic #1341 — closes #1342. **Load-bearing assertion**
-of the entire epic: every A2-A5 PR must keep the chk_vfo=0 lines green
-and progressively flip xfailed lines to xpass.
+of the entire epic: every A2-A5 PR must keep the chk_vfo=0 lines green;
+A5 (#1346) flipped the remaining xfailed traces to xpass.
 
 How it works
 ------------
@@ -19,30 +19,22 @@ client (WSJT-X 3.1, fldigi, JS8Call). The replay runner:
    where the snapshot test owns its content).
 3. Compares actual vs. expected, logging the first divergence point.
 
-Why xfail
----------
-Variant B (PR #1340) currently makes ``chk_vfo`` return ``"0"``
-unconditionally — the wsjtx golden's first expectation (``< 1``) does
-not match the actual response (``0``) and the assertion fails on the
-first check. Even after A5 flips ``chk_vfo`` back to ``"1"``, every
-subsequent VFO-prefixed command (``f VFOA``, ``m VFOA``, ...) still
-trips ``parse_line`` until A2 (#1343) teaches it to accept the leading
-VFO token. So the replay only goes fully green once the entire
-A2-A5 stack has landed.
-
-The test is wrapped with ``@pytest.mark.xfail(strict=False)`` so:
-
-- Today: counts as xfailed in the suite — does not fail CI.
-- After A2 lands: parser accepts ``f VFOA`` but ``chk_vfo=0`` still
-  short-circuits the test at the very first ``< 1`` — still xfailed.
-- After A5 lands and ``chk_vfo`` flips to ``"1"``: the trace passes
-  end-to-end, becomes xpassed (``strict=False`` → still green, but the
-  marker is now stale). A5's PR removes the xfail decorator.
+History
+-------
+- A1 (#1342) added the scaffolding with ``@pytest.mark.xfail`` — every
+  trace failed at the first ``< 1`` because Variant B (PR #1340) made
+  ``chk_vfo`` return ``"0"`` unconditionally.
+- A2 (#1343) parser accepts the leading VFO token.
+- A3 (#1344) per-VFO routing for freq/mode/PTT.
+- A4 (#1345) per-VFO routing for split/RIT/level/func.
+- A5 (#1346) re-enabled ``chk_vfo='1'`` for dual-RX, fixed
+  ``SerialMockRadio`` to mirror per-VFO state into ``RadioState``,
+  and removed the xfail markers — replays now pass end-to-end.
 
 References
 ----------
 - Issue #1319 — the bug the scaffolding catches.
-- Epic #1341 — five-PR plan; this is sub-issue 1/5 (#1342).
+- Epic #1341 — five-PR plan; A1 is sub-issue 1/5 (#1342).
 - Hamlib spec — https://hamlib.sourceforge.net/manuals/4.5.5/rigctl.1.html
 """
 
@@ -223,51 +215,25 @@ async def _replay(server: RigctldServer, steps: list[_Step]) -> None:
 class TestGoldenReplayDualRx:
     """Replay each canonical client's chk_vfo=1 wire trace.
 
-    All three replays are xfailed at file scope until Variant A 5/5
-    lands. The xfail is intentionally non-strict — strict=True would
-    fight A2-A5 incremental landings (e.g. A2 may make the parser
-    accept ``f VFOA`` but the test still trips at chk_vfo until A5).
-    Each subsequent A2-A5 PR removes its xfail decorator once the
-    relevant slice of the trace becomes green end-to-end.
+    All three replays now pass end-to-end — Variant A 5/5 (#1346)
+    re-enabled ``chk_vfo='1'`` and the SerialMockRadio mirrors per-VFO
+    state into ``RadioState``, so the dual-RX path works without xfail.
+    Earlier slices: A2 (#1343) parser support, A3 (#1344) per-VFO
+    freq/mode/PTT routing, A4 (#1345) per-VFO split/RIT/level/func.
     """
 
-    @pytest.mark.xfail(
-        reason=(
-            "Variant A 1/5 (#1342) — full chk_vfo=1 path lands across "
-            "A2 (#1343) parser, A3 (#1344) per-VFO routing, A4 (#1345) "
-            "split, A5 (#1346) dump_state + chk_vfo flip. xfail removed "
-            "in A5."
-        ),
-        strict=False,
-    )
     async def test_wsjtx_dual_rx_golden_replay(
         self, rigctld_dual_rx_server: RigctldServer
     ) -> None:
         steps = _parse_golden(GOLDEN_DIR / "wsjtx_dual_rx_session.txt")
         await _replay(rigctld_dual_rx_server, steps)
 
-    @pytest.mark.xfail(
-        reason=(
-            "Variant A 1/5 (#1342) — fldigi golden replay xfailed until "
-            "A5 (#1346) flips chk_vfo back to '1' and prior parser/routing "
-            "PRs land."
-        ),
-        strict=False,
-    )
     async def test_fldigi_dual_rx_golden_replay(
         self, rigctld_dual_rx_server: RigctldServer
     ) -> None:
         steps = _parse_golden(GOLDEN_DIR / "fldigi_dual_rx_session.txt")
         await _replay(rigctld_dual_rx_server, steps)
 
-    @pytest.mark.xfail(
-        reason=(
-            "Variant A 1/5 (#1342) — JS8Call golden replay xfailed until "
-            "A5 (#1346) flips chk_vfo back to '1' and prior parser/routing "
-            "PRs land."
-        ),
-        strict=False,
-    )
     async def test_js8call_dual_rx_golden_replay(
         self, rigctld_dual_rx_server: RigctldServer
     ) -> None:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -89,6 +89,16 @@ class TestAuditRecord:
         rec = _sample_record(args=("USB", "2400"), long_cmd="set_mode", cmd="M")
         assert rec.args == ("USB", "2400")
 
+    def test_vfo_defaults_to_none(self) -> None:
+        """``AuditRecord.vfo`` defaults to ``None`` (bare-form path)."""
+        rec = _sample_record()
+        assert rec.vfo is None
+
+    def test_vfo_captures_token(self) -> None:
+        """``vfo`` captures the leading VFO token under ``chk_vfo=1``."""
+        rec = _sample_record(vfo="VFOB")
+        assert rec.vfo == "VFOB"
+
 
 # ---------------------------------------------------------------------------
 # RigctldAuditFormatter
@@ -112,6 +122,7 @@ class TestRigctldAuditFormatter:
             "cmd",
             "long_cmd",
             "args",
+            "vfo",
             "duration_ms",
             "rprt",
             "is_set",
@@ -160,6 +171,20 @@ class TestRigctldAuditFormatter:
         fmt = RigctldAuditFormatter()
         line = fmt.format(_make_record(_sample_record()))
         assert "\n" not in line
+
+    def test_vfo_serialised_when_present(self) -> None:
+        """``vfo`` field is included in JSON output under ``chk_vfo=1``."""
+        rec = _sample_record(vfo="VFOB", cmd="F", long_cmd="set_freq")
+        fmt = RigctldAuditFormatter()
+        data = json.loads(fmt.format(_make_record(rec)))
+        assert data["vfo"] == "VFOB"
+
+    def test_vfo_serialised_as_null_when_absent(self) -> None:
+        """``vfo`` is JSON ``null`` for bare-form (non-VFO-prefixed) commands."""
+        rec = _sample_record()
+        fmt = RigctldAuditFormatter()
+        data = json.loads(fmt.format(_make_record(rec)))
+        assert data["vfo"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -2345,20 +2345,33 @@ def single_rx_handler(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("handler_fixture", ["single_rx_handler", "dual_rx_handler"])
-async def test_chk_vfo_returns_0_unconditionally(
-    handler_fixture: str, request: pytest.FixtureRequest
+async def test_chk_vfo_returns_1_for_dual_rx(
+    dual_rx_handler: RigctldHandler,
 ) -> None:
-    """``chk_vfo`` returns ``"0"`` for every profile (issue #1319).
+    """``chk_vfo`` returns ``"1"`` for dual-RX profiles (issue #1346).
 
-    The dual-RX ``"1"`` advertising introduced in v0.17.0 (#722) was rolled
-    back in v0.19.1 because Hamlib's ``vfo_opt`` mode prefixes every command
-    with a VFO token that the rigctld parser/handlers do not yet support —
-    breaking WSJT-X / fldigi / JS8Call on IC-7610, IC-9700, and FTX-1. Will
-    be re-enabled to ``"1"`` once full ``vfo_opt`` support lands.
+    Re-enabled in Variant A 5/5 after the full ``vfo_opt`` stack landed:
+    parser support (#1343), per-VFO routing for freq/mode/PTT (#1344),
+    per-VFO split/RIT/level/func (#1345). Variant B's unconditional
+    ``"0"`` (PR #1340) is now correctly superseded for dual-RX models.
     """
-    handler: RigctldHandler = request.getfixturevalue(handler_fixture)
-    resp = await handler.execute(get_cmd("chk_vfo"))
+    resp = await dual_rx_handler.execute(get_cmd("chk_vfo"))
+    assert resp.ok
+    assert resp.values == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_chk_vfo_returns_0_for_single_rx(
+    single_rx_handler: RigctldHandler,
+) -> None:
+    """``chk_vfo`` stays ``"0"`` on single-RX profiles (issue #1346).
+
+    Single-receiver radios (IC-7300, IC-705, …) do not need ``vfo_opt``
+    advertising — their A/B VFO scheme is handled by the bare-form
+    Hamlib path. Avoids needlessly forcing VFO tokenisation on clients
+    that were happy without it.
+    """
+    resp = await single_rx_handler.execute(get_cmd("chk_vfo"))
     assert resp.ok
     assert resp.values == ["0"]
 


### PR DESCRIPTION
## Summary

**Final sub-issue of Variant A epic #1341.** Closes #1346. After merge, the orchestrator closes epic #1341 AND bug #1319.

### Reduced scope vs original spec

The original A5 spec called for extending `_IC7610_DUMP_STATE` and `_YAESU_DUMP_STATE` with `vfo_list` / `vfo_ops` / `targetable_vfo` / `status_flags` blocks. Primary-source research against Hamlib 4.7.1 (`rigs/dummy/netrigctl.c:621`, `tests/rigctl_parse.c:4673-4790`) showed:

- **dump_state v0 format ends at `has_set_parm`.** Hamlib's reference client returns immediately after parsing entry 25 when `prot_ver == 0`. No additional positional fields exist in v0.
- **`vfo_list` is client-derived** from `rx_range_list` / `tx_range_list` `vfo` bits — already `0x3` (VFOA|VFOB) on line 4 of our existing dump_state.
- **`vfo_ops` / `targetable_vfo`** are protocol-1 `key=value` lines, NOT v0 positional fields.

The dump_state extension was therefore unnecessary and is dropped from A5. Empirical verification (throwaway local edit, reverted): with `chk_vfo` flipped to `"1"` and no dump_state changes, fldigi + js8call golden replays pass. WSJT-X failed for an unrelated reason (mock bug, fixed below).

### Three actual changes

1. **`chk_vfo="1"` re-enabled for dual-RX** — rolls back Variant B (PR #1340). Now safe because A2 added parser support, A3+A4 added per-VFO routing.

2. **`AuditRecord.vfo` column** — distinguishes `F VFOB 14080000` from `F VFOA 14080000` from bare-form `F 14080000` in audit logs. Optional `str | None` field defaulting to `None`; populated in the server's audit hook from `cmd.vfo_arg`. Back-compat for any external callers constructing `AuditRecord` directly.

3. **`SerialMockRadio` per-VFO state sync** — `set_freq(freq, receiver=N)` was writing to `self._rx[N].freq` but not mirroring to `self._radio_state.{main,sub}.freq`. The rigctld per-VFO handler reads `radio.radio_state.sub.freq` for `f VFOB` directly, which stayed at the `RadioState()` default of `0`. Pre-existing mock incompleteness (real radios populate this state via their state-cache write paths), surfaced by the WSJT-X golden replay test added in A1. Fix: small `_sync_radio_state_from_rx` helper called both at construction (initial seeding) and from `set_freq` / `set_mode`.

### A1 integration golden replays — flipping xfail to xpass

- `test_wsjtx_dual_rx_golden_replay`: now passes.
- `test_fldigi_dual_rx_golden_replay`: now passes.
- `test_js8call_dual_rx_golden_replay`: now passes.

Total xfail count went from 12 (9 unrelated `#295` naming + 3 integration replays) to 9 (only `#295` naming remains). The 3 integration replays are now plain passes (xfail markers removed entirely, not left as xpass).

## Verification

- `uv run pytest tests/ -q --tb=short` — 5541 passed, 9 xfailed (all `#295` naming), 1 xpassed (`#295` naming, pre-existing).
- `uv run pytest tests/integration/test_rigctld_golden_replay.py -v` — 6/6 passed.
- `uv run pytest tests/test_rigctld_handler.py -k 'TestChkVfo or chk_vfo' -v` — `returns_1_for_dual_rx` + `returns_0_for_single_rx` + bare `test_chk_vfo` all green.
- `uv run ruff check src/ tests/` — clean.
- `uv run mypy src/` — clean (205 source files).
- `uv run lint-imports` — 4 contracts kept, 0 broken.

WSJT-X 3.1 + Hamlib 4.7.1 + IC-7610 dual-RX golden replay passes end-to-end.

## Test plan

- [x] `chk_vfo` returns `"1"` for dual-RX, `"0"` for single-RX.
- [x] `AuditRecord` has `vfo` column populated from `cmd.vfo_arg`.
- [x] `SerialMockRadio` mirrors per-VFO state into `RadioState` at init and on writes.
- [x] All 3 A1 integration golden replays now pass plainly (no xfail).
- [x] No regressions in non-integration suite.

Closes #1346, refs #1341. **Epic complete after this merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)