### PR TITLE
fix(web): runtime_capabilities recognises UsbAudioCapable in fallback path (closes #1356)

### DIFF
--- a/src/icom_lan/web/runtime_helpers.py
+++ b/src/icom_lan/web/runtime_helpers.py
@@ -53,7 +53,7 @@ def runtime_capabilities(radio: "Radio | None") -> set[str]:
     result: set[str] = set()
     if isinstance(radio, ScopeCapable):
         result.add("scope")
-    if isinstance(radio, AudioCapable):
+    if isinstance(radio, AudioCapable | UsbAudioCapable):
         result.add("audio")
     if isinstance(radio, DualReceiverCapable):
         result.add("dual_rx")

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -97,6 +97,25 @@ def test_runtime_capabilities_falls_back_to_protocols_when_caps_missing() -> Non
     assert caps == {"scope", "audio", "dual_rx"}
 
 
+def test_runtime_capabilities_fallback_recognises_usb_audio_only() -> None:
+    """Fallback path (no `capabilities` set) must recognise USB-audio backends.
+
+    Regression for #1356: Yaesu CAT radios that satisfy only ``UsbAudioCapable``
+    (and not in-band ``AudioCapable``) must still get the ``"audio"`` tag when
+    capabilities are derived purely from Protocol checks.
+    """
+    from icom_lan.radio_protocol import UsbAudioCapable
+
+    class _UsbOnlyRadio(UsbAudioCapable):  # type: ignore[misc]
+        has_usb_audio: bool = True
+
+    radio = _UsbOnlyRadio()
+    # Sanity: no `capabilities` attribute → fallback path is used.
+    assert not hasattr(radio, "capabilities")
+    caps = runtime_capabilities(radio)
+    assert caps == {"audio"}
+
+
 def test_runtime_capabilities_filters_incompatible_tags() -> None:
     radio = _FakeRadio(caps={"scope", "audio", "dual_rx", "tx"})
     caps = runtime_capabilities(radio)


### PR DESCRIPTION
## Problem

`web.runtime_helpers.runtime_capabilities()` has two branches:

- **Primary** (radio exposes a `capabilities: set[str]`): filters tags via `isinstance(radio, AudioCapable | UsbAudioCapable)`.
- **Fallback** (no `capabilities` attribute, derive purely from Protocols): only checked `AudioCapable`.

As a result, a backend that satisfies only `UsbAudioCapable` (e.g. a CAT-only Yaesu radio whose audio is exposed as a separate OS-level USB Audio Class device, with no in-band `AudioCapable`) got an empty `"audio"` tag in the fallback path — the UI rendered without audio controls even though OS-level audio was available.

## Fix

One-line change in `src/icom_lan/web/runtime_helpers.py`: align the fallback isinstance check with the primary path —

```python
if isinstance(radio, AudioCapable | UsbAudioCapable):
    result.add("audio")
```

`UsbAudioCapable` is already imported at the top of the file; no other edits required.

## Test

`tests/test_web_runtime_helpers.py::test_runtime_capabilities_fallback_recognises_usb_audio_only` — constructs a class that subclasses only `UsbAudioCapable` (with `has_usb_audio = True`) and has no `capabilities` attribute, asserts that the fallback path returns `{"audio"}`.

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5313 passed, 2 skipped, 9 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — clean
- `uv run mypy src/` — clean (205 files)
- `uv run lint-imports` — 4 contracts kept, 0 broken

Closes #1356