### PR TITLE
fix: add UsbAudioCapable to fallback path in runtime_capabilities()

### DIFF
--- a/src/icom_lan/web/runtime_helpers.py
+++ b/src/icom_lan/web/runtime_helpers.py
@@ -53,7 +53,7 @@ def runtime_capabilities(radio: "Radio | None") -> set[str]:
     result: set[str] = set()
     if isinstance(radio, ScopeCapable):
         result.add("scope")
-    if isinstance(radio, AudioCapable):
+    if isinstance(radio, AudioCapable | UsbAudioCapable):
         result.add("audio")
     if isinstance(radio, DualReceiverCapable):
         result.add("dual_rx")


### PR DESCRIPTION
Fixed the bug described in issue #1356. The fallback path in `runtime_capabilities()` was only checking `AudioCapable` when deriving the `audio` tag, missing `UsbAudioCapable`. The primary path (when `radio.capabilities` is a set) correctly checks `AudioCapable | UsbAudioCapable`. The fix changes line 56 from:

```python
if isinstance(radio, AudioCapable):
```

to:

```python
if isinstance(radio, AudioCapable | UsbAudioCapable):
```

This ensures radios that implement only `UsbAudioCapable` (no in-band CI-V audio — e.g. FTX-1 over USB) and don't expose `radio.capabilities` are correctly tagged with `audio` capability by the fallback path. Without this fix, the UI would render a dead audio panel or hide controls that should work.

Fixes #1356