### PR TITLE
fix(rigctld): VFO routing edge cases (closes #1354 #1355)

### DIFF
--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -464,8 +464,13 @@ class RigctldHandler:
             state = self._radio_state()
             if state is not None:
                 return RigctldResponse(values=[str(state.sub.freq)])
-            # No state available — fall through to bare get_freq() for MAIN
-            # rather than fabricate a SUB read path. Legacy behaviour.
+            # State unavailable. For an EXPLICIT VFOB request under chk_vfo=1
+            # surface ENIMPL rather than silently returning MAIN data labelled
+            # as VFOB (issue #1355). For implicit/legacy requests (vfo_arg
+            # is None or "currVFO") the legacy MAIN fall-through is more
+            # forgiving and remains the documented behaviour.
+            if cmd.vfo_arg == "VFOB":
+                return _err(HamlibError.ENIMPL)
 
         main_state = self._main_receiver_state()
         pending_freq = self._effective_pending_freq(main_state)
@@ -531,7 +536,13 @@ class RigctldHandler:
                     elif mode_str == "RTTY":
                         mode_str = "PKTRTTY"
                 return RigctldResponse(values=[mode_str, str(passband)])
-            # No state available — fall through to legacy MAIN read path.
+            # State unavailable. For an EXPLICIT VFOB request under chk_vfo=1
+            # surface ENIMPL rather than silently returning MAIN data labelled
+            # as VFOB (issue #1355). For implicit/legacy requests (vfo_arg
+            # is None or "currVFO") the legacy MAIN fall-through is more
+            # forgiving and remains the documented behaviour.
+            if cmd.vfo_arg == "VFOB":
+                return _err(HamlibError.ENIMPL)
 
         main_state = self._main_receiver_state()
         pending_mode = self._effective_pending_mode(main_state)

--- a/src/icom_lan/rigctld/handler.py
+++ b/src/icom_lan/rigctld/handler.py
@@ -458,7 +458,9 @@ class RigctldHandler:
 
         # Per-VFO routing for VFOB on dual-RX: read SUB receiver state directly.
         # Skip pending/cache (those track MAIN only — see _PendingRigState).
-        if target == "VFOB":
+        # Gate on _receiver_index_for so single-RX active_slot="B" falls through
+        # to the MAIN path (slot selection is via set_vfo_slot, not receiver=).
+        if self._receiver_index_for(target) == 1:
             state = self._radio_state()
             if state is not None:
                 return RigctldResponse(values=[str(state.sub.freq)])
@@ -491,11 +493,11 @@ class RigctldHandler:
         except ValueError:
             return _err(HamlibError.EVFO)
 
-        receiver = 1 if target == "VFOB" else 0
+        receiver = self._receiver_index_for(target)
         await self._radio.set_freq(freq, receiver=receiver)
         # Pending/cache track MAIN only — only update on the MAIN path so
         # subsequent ``f VFOA`` reads coalesce against the just-written value.
-        if target == "VFOA":
+        if receiver == 0:
             self._pending.freq = freq
             self._cache.update_freq(freq)
         return _ok()
@@ -512,7 +514,9 @@ class RigctldHandler:
 
         # Per-VFO routing for VFOB on dual-RX: read SUB receiver state directly.
         # Skip pending/cache (those track MAIN only — see _PendingRigState).
-        if target == "VFOB":
+        # Gate on _receiver_index_for so single-RX active_slot="B" falls through
+        # to the MAIN path (slot selection is via set_vfo_slot, not receiver=).
+        if self._receiver_index_for(target) == 1:
             state = self._radio_state()
             if state is not None:
                 sub = state.sub
@@ -599,7 +603,9 @@ class RigctldHandler:
 
         # Per-VFO routing for VFOB on dual-RX: dispatch to SUB receiver and
         # skip the MAIN-only pending/cache + read-back sync (those track MAIN).
-        if target == "VFOB":
+        # Gate on _receiver_index_for so single-RX active_slot="B" falls through
+        # to the MAIN path (slot selection is via set_vfo_slot, not receiver=).
+        if self._receiver_index_for(target) == 1:
             await self._radio.set_mode(
                 base_mode_str, filter_width=filter_width, receiver=1
             )
@@ -734,6 +740,25 @@ class RigctldHandler:
             return "VFOB" if state.active == "SUB" else "VFOA"
         return "VFOB" if state.main.active_slot == "B" else "VFOA"
 
+    def _receiver_index_for(self, target: Literal["VFOA", "VFOB"]) -> int:
+        """Map a resolved VFO target to a backend receiver index.
+
+        Dual-RX profiles (``receiver_count >= 2``) honour the per-VFO
+        routing introduced in #1344 — ``VFOB`` -> ``receiver=1``.
+
+        Single-RX profiles only have ``receiver=0``; per-VFO state is
+        selected via ``set_vfo_slot("A"/"B")`` on the *same* receiver
+        (issue #1354). ``_active_vfo_name`` may legitimately return
+        ``VFOB`` on single-RX when ``state.main.active_slot == "B"`` —
+        the slot is already selected, so the caller must still route
+        the I/O to ``receiver=0`` rather than to a non-existent
+        ``receiver=1``.
+        """
+        info = self._profile_vfo_info()
+        if info is not None and info[0] >= 2:
+            return 1 if target == "VFOB" else 0
+        return 0
+
     def _resolve_target_vfo(self, vfo_arg: str | None) -> Literal["VFOA", "VFOB"]:
         """Map a Hamlib VFO arg to the canonical VFO name for routing.
 
@@ -825,7 +850,9 @@ class RigctldHandler:
             target = self._resolve_target_vfo(cmd.vfo_arg)
         except ValueError:
             return _err(HamlibError.EVFO)
-        receiver = 1 if target == "VFOB" else 0
+        # Single-RX profiles only have receiver=0; per-VFO state is selected
+        # via set_vfo_slot, not receiver= (issue #1354).
+        receiver = self._receiver_index_for(target)
 
         if self._routing is not None:
             return await self._routing.get_level(level, vfo=cmd.vfo_arg)
@@ -843,7 +870,7 @@ class RigctldHandler:
         # directly from RadioState (don't update _cache — it tracks MAIN
         # only, mirroring the freq routing in #1344).
         if level == "STRENGTH":
-            if target == "VFOB":
+            if receiver == 1:
                 state = self._radio_state()
                 if state is not None:
                     raw = state.sub.s_meter
@@ -906,8 +933,8 @@ class RigctldHandler:
         if level in _GET_LEVEL_FLOAT:
             method = getattr(self._radio, _GET_LEVEL_FLOAT[level])
             # NB / NR are per-receiver on dual-RX Icoms — pass receiver=
-            # when targeting VFOB. Other levels are radio-global.
-            if level in ("NB", "NR") and target == "VFOB":
+            # when targeting SUB. Other levels are radio-global.
+            if level in ("NB", "NR") and receiver == 1:
                 raw = await method(receiver=receiver)
             else:
                 raw = await method()
@@ -945,7 +972,9 @@ class RigctldHandler:
             target = self._resolve_target_vfo(cmd.vfo_arg)
         except ValueError:
             return _err(HamlibError.EVFO)
-        receiver = 1 if target == "VFOB" else 0
+        # Single-RX profiles only have receiver=0; per-VFO state is selected
+        # via set_vfo_slot, not receiver= (issue #1354).
+        receiver = self._receiver_index_for(target)
 
         if self._routing is not None:
             return await self._routing.set_level(level, value, vfo=cmd.vfo_arg)
@@ -958,7 +987,7 @@ class RigctldHandler:
             raw = max(0, min(255, round(value * 255)))
             method = getattr(self._radio, _SET_LEVEL_FLOAT[level])
             # NB / NR are per-receiver on dual-RX Icoms.
-            if level in ("NB", "NR") and target == "VFOB":
+            if level in ("NB", "NR") and receiver == 1:
                 await method(raw, receiver=receiver)
             else:
                 await method(raw)
@@ -1006,7 +1035,9 @@ class RigctldHandler:
             target = self._resolve_target_vfo(cmd.vfo_arg)
         except ValueError:
             return _err(HamlibError.EVFO)
-        receiver = 1 if target == "VFOB" else 0
+        # Single-RX profiles only have receiver=0; per-VFO state is selected
+        # via set_vfo_slot, not receiver= (issue #1354).
+        receiver = self._receiver_index_for(target)
 
         if self._routing is not None:
             return await self._routing.get_func(func, vfo=cmd.vfo_arg)
@@ -1016,7 +1047,7 @@ class RigctldHandler:
         method = getattr(self._radio, _FUNC_GET[func])
         # NB / NR are per-receiver on dual-RX Icoms.  Other funcs are
         # radio-global — VFO arg is validated above but ignored.
-        if func in ("NB", "NR") and target == "VFOB":
+        if func in ("NB", "NR") and receiver == 1:
             result = await method(receiver=receiver)
         else:
             result = await method()
@@ -1037,7 +1068,9 @@ class RigctldHandler:
             target = self._resolve_target_vfo(cmd.vfo_arg)
         except ValueError:
             return _err(HamlibError.EVFO)
-        receiver = 1 if target == "VFOB" else 0
+        # Single-RX profiles only have receiver=0; per-VFO state is selected
+        # via set_vfo_slot, not receiver= (issue #1354).
+        receiver = self._receiver_index_for(target)
 
         if self._routing is not None:
             return await self._routing.set_func(func, on, vfo=cmd.vfo_arg)
@@ -1047,7 +1080,7 @@ class RigctldHandler:
         if func == "APF":
             # APF takes an int mode: 0=off, 1=soft
             await self._radio.set_audio_peak_filter(1 if on else 0)
-        elif func in ("NB", "NR") and target == "VFOB":
+        elif func in ("NB", "NR") and receiver == 1:
             # Per-receiver NB / NR on dual-RX.
             await getattr(self._radio, _FUNC_SET[func])(on, receiver=receiver)
         else:

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -3295,3 +3295,104 @@ class TestPerVfoFunc:
         )
         assert resp.error == HamlibError.EVFO
         single_rx_radio.set_nb.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Issue #1354 — single-RX active_slot="B" must not route to receiver=1
+# ---------------------------------------------------------------------------
+#
+# Regression introduced by #1344 (per-VFO routing). When the active slot on
+# a single-receiver radio is "B", ``_active_vfo_name()`` returns "VFOB" —
+# which is correct for the get_vfo question. But the per-VFO routing then
+# treated VFOB as ``receiver=1``, i.e. the SUB receiver of a *dual-RX*
+# rig, which does not exist on a single-RX backend. Slot selection on
+# single-RX is via ``set_vfo_slot`` and lives on the same ``receiver=0``.
+
+
+class TestSingleRxActiveSlotBRouting:
+    """Bare ``F``/``M``/``T`` on single-RX with active_slot="B" routes to
+    receiver=0 (issue #1354). Without a VFO arg the handler may legitimately
+    resolve target to VFOB via the active-slot mirror, but the I/O kwarg
+    must still target the single available receiver (receiver=0)."""
+
+    @pytest.mark.asyncio
+    async def test_set_freq_no_vfo_arg_routes_to_receiver_0(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        state = RadioState()
+        state.main.active_slot = "B"
+        single_rx_radio.radio_state = state
+
+        resp = await single_rx_handler.execute(
+            _vfo_set_cmd("set_freq", None, "14074000")
+        )
+
+        assert resp.ok
+        single_rx_radio.set_freq.assert_awaited_once_with(14_074_000, receiver=0)
+
+    @pytest.mark.asyncio
+    async def test_set_mode_no_vfo_arg_routes_to_receiver_0(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        state = RadioState()
+        state.main.active_slot = "B"
+        single_rx_radio.radio_state = state
+
+        resp = await single_rx_handler.execute(
+            _vfo_set_cmd("set_mode", None, "USB", "2400")
+        )
+
+        assert resp.ok
+        # MAIN path: ``set_mode`` called WITHOUT a receiver kwarg (legacy
+        # default == receiver=0). Critically, NOT ``receiver=1``.
+        single_rx_radio.set_mode.assert_awaited_once_with("USB", filter_width=2)
+
+    @pytest.mark.asyncio
+    async def test_set_ptt_no_vfo_arg_keys_radio(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        # PTT is global on the Icom CI-V — no receiver kwarg is involved.
+        # Regression-guard: bare ``T 1`` under active_slot="B" on single-RX
+        # must succeed (not EVFO) and reach the radio.
+        state = RadioState()
+        state.main.active_slot = "B"
+        single_rx_radio.radio_state = state
+
+        resp = await single_rx_handler.execute(_vfo_set_cmd("set_ptt", None, "1"))
+
+        assert resp.ok
+        single_rx_radio.set_ptt.assert_awaited_once_with(True)
+
+    @pytest.mark.asyncio
+    async def test_get_freq_no_vfo_arg_reads_main_path(
+        self, single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
+    ) -> None:
+        # The single-RX MAIN slot mirror is wfview's contract — main.freq
+        # always reflects the *currently selected* slot (A or B) on a
+        # single-RX backend (see SerialMockRadio). So the legacy MAIN path
+        # is correct even when active_slot="B" — what we must NOT do is
+        # branch into the SUB-state read intended for dual-RX VFOB.
+        state = RadioState()
+        state.main.active_slot = "B"
+        state.main.freq = 14_074_000
+        # state.sub.freq stays 0 to detect mis-routing through SUB.
+        single_rx_radio.radio_state = state
+
+        resp = await single_rx_handler.execute(_vfo_get_cmd("get_freq", None))
+
+        assert resp.ok
+        assert resp.values == ["14074000"]
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_vfob_still_routes_to_receiver_1(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # Dual-RX path is unchanged: explicit ``F VFOB <freq>`` still
+        # uses receiver=1. This guards against the helper accidentally
+        # collapsing dual-RX routing to receiver=0.
+        resp = await dual_rx_handler.execute(
+            _vfo_set_cmd("set_freq", "VFOB", "7080000")
+        )
+
+        assert resp.ok
+        dual_rx_radio.set_freq.assert_awaited_once_with(7_080_000, receiver=1)

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -3396,3 +3396,44 @@ class TestSingleRxActiveSlotBRouting:
 
         assert resp.ok
         dual_rx_radio.set_freq.assert_awaited_once_with(7_080_000, receiver=1)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1355 — explicit VFOB get with no radio_state must not fall through
+# ---------------------------------------------------------------------------
+#
+# When ``chk_vfo=1`` and a client sends ``f VFOB`` / ``m VFOB`` against a
+# backend whose ``radio_state`` is ``None``, the handler used to silently
+# fall through to the MAIN read path and return MAIN data labelled as
+# VFOB. That is a contract violation. After #1355 the handler returns
+# ``ENIMPL`` for *explicit* VFOB requests so the client surfaces the
+# failure rather than acting on wrong data. Implicit/legacy paths
+# (``vfo_arg is None`` / ``"currVFO"``) keep the forgiving MAIN
+# fall-through.
+
+
+class TestExplicitVfobNoStateReturnsEnimpl:
+    @pytest.mark.asyncio
+    async def test_get_freq_explicit_vfob_no_state_returns_enimpl(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        # Dual-RX profile but no RadioState wired up.
+        dual_rx_radio.radio_state = None
+
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_freq", "VFOB"))
+
+        assert resp.error == HamlibError.ENIMPL
+        # Critically, the handler must NOT call ``get_freq()`` and return
+        # MAIN data labelled as VFOB.
+        dual_rx_radio.get_freq.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_mode_explicit_vfob_no_state_returns_enimpl(
+        self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
+    ) -> None:
+        dual_rx_radio.radio_state = None
+
+        resp = await dual_rx_handler.execute(_vfo_get_cmd("get_mode", "VFOB"))
+
+        assert resp.error == HamlibError.ENIMPL
+        dual_rx_radio.get_mode.assert_not_awaited()


### PR DESCRIPTION
## Problem

Two related rigctld VFO-routing bugs surfaced in codex review of PR #1350 (A3 per-VFO routing). Both must land before v1.0.0.

### Bug 1 — #1354 (P1 regression)

On a single-receiver rig with ``state.main.active_slot == "B"``, a bare ``F <freq>`` (no VFO arg, ``chk_vfo=0``) resolves the target to ``VFOB`` via ``_active_vfo_name`` (correct) and was then dispatched to ``receiver=1``. Single-RX backends only have ``receiver=0`` — SerialMockRadio raises IndexError; real radios write to a non-existent slot. Affects ``set_freq`` / ``set_mode`` and the read paths that branch on ``target == "VFOB"``.

### Bug 2 — #1355 (P2 silent fallback)

When ``chk_vfo=1`` and a client sends ``f VFOB`` / ``m VFOB`` against a backend whose ``radio_state`` is ``None``, the handler used to silently fall through to the MAIN read path and return MAIN data labelled as VFOB. Silent corruption — the client cannot detect this.

## Fix

Introduce a tiny helper:

\`\`\`python
def _receiver_index_for(self, target: Literal["VFOA", "VFOB"]) -> int:
    info = self._profile_vfo_info()
    if info is not None and info[0] >= 2:
        return 1 if target == "VFOB" else 0
    return 0
\`\`\`

- Replaces every ``receiver = 1 if target == "VFOB" else 0`` site (set_freq, set_mode, get_level, set_level, get_func, set_func).
- Also gates the SUB read branches in ``_cmd_get_freq``, ``_cmd_get_mode``, and ``_cmd_get_level`` (STRENGTH) on ``_receiver_index_for(target) == 1`` so single-RX active_slot="B" naturally falls through to the MAIN path. Single-RX slot selection happens via ``set_vfo_slot``, not ``receiver=``.

For Bug 2, ``_cmd_get_freq`` and ``_cmd_get_mode`` return ``HamlibError.ENIMPL`` *only* when ``cmd.vfo_arg == "VFOB"`` is explicit AND ``radio_state`` is None. Implicit/legacy paths (``vfo_arg`` is None or ``"currVFO"``) keep the forgiving MAIN fall-through. After Bug 1 is fixed, single-RX never reaches this code, so the ENIMPL path is dual-RX-only.

## Commits

1. ``fix(#1354): single-RX with active slot B no longer routes to receiver=1`` — helper introduction + 5 new regression tests in ``TestSingleRxActiveSlotBRouting``.
2. ``fix(#1355): VFOB read returns ENIMPL when radio_state is unavailable`` — 2 new tests in ``TestExplicitVfobNoStateReturnsEnimpl``.

## Test count delta

- Handler tests: 279 → 286 (+7)
- All 5319 unit tests pass (excl. integration)
- All 6 ``test_rigctld_golden_replay`` integration tests pass (WSJT-X, fldigi, JS8Call)

## Verification

- ``uv run pytest tests/ -q --tb=short --ignore=tests/integration`` — 5319 passed
- ``uv run pytest tests/integration/test_rigctld_golden_replay.py -q`` — 6 passed
- ``uv run ruff check src/ tests/`` — clean
- ``uv run mypy src/`` — clean
- ``uv run lint-imports`` — 4 kept, 0 broken

Closes #1354
Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)