### PR TITLE
refactor(#1338): canonicalize internal imports + mkdocstrings refs off shim paths

### DIFF
--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -17,7 +17,7 @@ Deprecated aliases still work during the deprecation window (two minor releases)
 
 ## AudioStream
 
-::: icom_lan.audio.AudioStream
+::: icom_lan.audio.lan_stream.AudioStream
 
 ## Runtime Audio Stats (`get_audio_stats`)
 
@@ -53,21 +53,21 @@ print(stats["packet_loss_percent"], stats["reorder_depth_ema_ms"])
 
 ## AudioPacket
 
-::: icom_lan.audio.AudioPacket
+::: icom_lan.audio.lan_stream.AudioPacket
 
 ## AudioState
 
-::: icom_lan.audio.AudioState
+::: icom_lan.audio.lan_stream.AudioState
 
 ## JitterBuffer
 
-::: icom_lan.audio.JitterBuffer
+::: icom_lan.audio.lan_stream.JitterBuffer
 
 ## Packet Functions
 
-::: icom_lan.audio.parse_audio_packet
+::: icom_lan.audio.lan_stream.parse_audio_packet
 
-::: icom_lan.audio.build_audio_packet
+::: icom_lan.audio.lan_stream.build_audio_packet
 
 ## Internal Transcoder Layer
 
@@ -83,8 +83,8 @@ future high-level PCM APIs.
 
 ## AudioBus (pub/sub multi-consumer)
 
-::: icom_lan.audio_bus.AudioBus
-::: icom_lan.audio_bus.AudioSubscription
+::: icom_lan.audio.bus.AudioBus
+::: icom_lan.audio.bus.AudioSubscription
 
 The AudioBus provides pub/sub distribution for radio RX audio. Multiple consumers (WebSocket broadcaster, audio bridge, recorders) share a single radio RX stream.
 

--- a/docs/api/commander.md
+++ b/docs/api/commander.md
@@ -4,8 +4,8 @@ Serialized CI-V command executor with priority queuing (wfview-style).
 Most users should use the high-level **Radio** API (via [`create_radio`](public-api-surface.md)), which
 manages an `IcomCommander` internally.
 
-::: icom_lan.commander.IcomCommander
+::: icom_lan.commands.commander.IcomCommander
 
 ## Priority Levels
 
-::: icom_lan.commander.Priority
+::: icom_lan.commands.commander.Priority

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -2,7 +2,7 @@
 
 LAN-specific radio class. For new code, prefer the backend-neutral **[create_radio](public-api-surface.md)** + **Radio** API so the same code works over LAN or USB serial. Use `IcomRadio` when you need direct LAN control or are migrating from older examples.
 
-::: icom_lan.radio.IcomRadio
+::: icom_lan.runtime.radio.IcomRadio
 
 ## Reference
 

--- a/docs/api/sync.md
+++ b/docs/api/sync.md
@@ -2,7 +2,7 @@
 
 Blocking wrapper around the async `IcomRadio` for use without `async/await`.
 
-::: icom_lan.sync.IcomRadio
+::: icom_lan.runtime.sync.IcomRadio
 
 ## Usage
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -4,7 +4,7 @@ Core data types used throughout the library.
 
 ## StateCache
 
-::: icom_lan.rigctld.state_cache.StateCache
+::: icom_lan.core._state_cache.StateCache
 
 ## Enums
 

--- a/src/icom_lan/audio/_transcoder.py
+++ b/src/icom_lan/audio/_transcoder.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Protocol
 
-from icom_lan.exceptions import AudioCodecBackendError, AudioFormatError, AudioTranscodeError
+from icom_lan.core.exceptions import AudioCodecBackendError, AudioFormatError, AudioTranscodeError
 
 __all__ = [
     "PcmAudioFormat",

--- a/src/icom_lan/audio/bridge.py
+++ b/src/icom_lan/audio/bridge.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import math
 
-from icom_lan._optional_deps import _require_opuslib, _require_sounddevice
+from icom_lan.core._optional_deps import _require_opuslib, _require_sounddevice
 
 from ._bridge_metrics import BridgeMetrics
 from ._bridge_state import BridgeState, BridgeStateChange

--- a/src/icom_lan/cli/__init__.py
+++ b/src/icom_lan/cli/__init__.py
@@ -46,7 +46,7 @@ from icom_lan.backends.config import (  # noqa: E402
     YaesuCatBackendConfig,
 )
 from icom_lan.backends.factory import create_radio  # noqa: E402
-from icom_lan.capabilities import (  # noqa: E402
+from icom_lan.core.capabilities import (  # noqa: E402
     CAP_AF_LEVEL,
     CAP_ANTENNA,
     CAP_ATTENUATOR,
@@ -60,8 +60,8 @@ from icom_lan.capabilities import (  # noqa: E402
     CAP_SYSTEM_SETTINGS,
     CAP_TUNER,
 )
-from icom_lan.radio_protocol import Radio  # noqa: E402
-from icom_lan.types import Mode, get_audio_capabilities  # noqa: E402
+from icom_lan.core.radio_protocol import Radio  # noqa: E402
+from icom_lan.core.types import Mode, get_audio_capabilities  # noqa: E402
 
 _AUDIO_FRAME_MS = 20
 _PCM_SAMPLE_WIDTH_BYTES = 2

--- a/src/icom_lan/commands/commander.py
+++ b/src/icom_lan/commands/commander.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import TypeVar
 
-from icom_lan.exceptions import ConnectionError
-from icom_lan.types import CivFrame
+from icom_lan.core.exceptions import ConnectionError
+from icom_lan.core.types import CivFrame
 
 __all__ = ["IcomCommander", "Priority"]
 

--- a/src/icom_lan/core/transport.py
+++ b/src/icom_lan/core/transport.py
@@ -14,8 +14,8 @@ from collections.abc import Callable
 from enum import StrEnum
 from typing import ClassVar
 
-from icom_lan._bounded_queue import BoundedQueue
-from icom_lan._queue_pressure import PRESSURE_THRESHOLD
+from icom_lan.core._bounded_queue import BoundedQueue
+from icom_lan.core._queue_pressure import PRESSURE_THRESHOLD
 from .exceptions import TimeoutError as _TimeoutError
 from .types import HEADER_SIZE, PacketType
 

--- a/src/icom_lan/core/types.py
+++ b/src/icom_lan/core/types.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 
-from icom_lan.env_config import get_audio_sample_rate
+from icom_lan.core.env_config import get_audio_sample_rate
 
 __all__ = [
     "PacketType",

--- a/src/icom_lan/profiles/rig_loader.py
+++ b/src/icom_lan/profiles/rig_loader.py
@@ -9,11 +9,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from icom_lan.capabilities import KNOWN_CAPABILITIES
-from icom_lan.command_map import CommandMap
+from icom_lan.core.capabilities import KNOWN_CAPABILITIES
+from icom_lan.commands.command_map import CommandMap
 
 __all__ = ["RigConfig", "RigLoadError", "load_rig", "discover_rigs"]
-from icom_lan.command_spec import CatCommandSpec, CivCommandSpec, CommandSpec
+from icom_lan.commands.command_spec import CatCommandSpec, CivCommandSpec, CommandSpec
 from icom_lan.profiles import (
     BandInfo,
     ControlSpec,

--- a/src/icom_lan/rigctld/state_cache.py
+++ b/src/icom_lan/rigctld/state_cache.py
@@ -1,4 +1,4 @@
 # rigctld/state_cache.py — backward-compat re-export
-from icom_lan._state_cache import CacheField, StateCache  # noqa: F401
+from icom_lan.core._state_cache import CacheField, StateCache  # noqa: F401
 
 __all__ = ["CacheField", "StateCache"]

--- a/src/icom_lan/runtime/_audio_runtime_mixin.py
+++ b/src/icom_lan/runtime/_audio_runtime_mixin.py
@@ -18,11 +18,11 @@ if TYPE_CHECKING:
 else:
     _MixinBase = object
 
-from icom_lan._audio_transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
+from icom_lan.audio._transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
 from icom_lan.audio import AudioStats, AudioStream
-from icom_lan.exceptions import ConnectionError
-from icom_lan.transport import IcomTransport
-from icom_lan.types import AudioCodec
+from icom_lan.core.exceptions import ConnectionError
+from icom_lan.core.transport import IcomTransport
+from icom_lan.core.types import AudioCodec
 
 logger = logging.getLogger(__name__)
 

--- a/src/icom_lan/runtime/_civ_rx.py
+++ b/src/icom_lan/runtime/_civ_rx.py
@@ -7,8 +7,8 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from icom_lan.civ import CivEvent, CivEventType, iter_civ_frames, request_key_from_frame
-from icom_lan.commander import IcomCommander, Priority
+from icom_lan.core.civ import CivEvent, CivEventType, iter_civ_frames, request_key_from_frame
+from icom_lan.commands.commander import IcomCommander, Priority
 from icom_lan.commands import (
     CONTROLLER_ADDR,
     parse_bool_response,
@@ -30,9 +30,9 @@ from icom_lan.commands import (
     parse_scope_speed_response,
     parse_scope_vbw_response,
 )
-from icom_lan.exceptions import ConnectionError, TimeoutError
+from icom_lan.core.exceptions import ConnectionError, TimeoutError
 from icom_lan.scope import ScopeFrame
-from icom_lan.types import CivFrame
+from icom_lan.core.types import CivFrame
 
 if TYPE_CHECKING:
     from ._runtime_protocols import CivRuntimeHost

--- a/src/icom_lan/runtime/_control_phase.py
+++ b/src/icom_lan/runtime/_control_phase.py
@@ -9,17 +9,17 @@ import struct
 import time
 from typing import TYPE_CHECKING
 
-from icom_lan.auth import (
+from icom_lan.core.auth import (
     build_conninfo_packet,
     build_login_packet,
     parse_auth_response,
     parse_status_response,
 )
 from ._connection_state import RadioConnectionState
-from icom_lan.exceptions import AuthenticationError, ConnectionError, TimeoutError
+from icom_lan.core.exceptions import AuthenticationError, ConnectionError, TimeoutError
 from .startup_checks import wait_for_radio_startup_ready
-from icom_lan.transport import ConnectionState, IcomTransport
-from icom_lan.types import AudioCodec
+from icom_lan.core.transport import ConnectionState, IcomTransport
+from icom_lan.core.types import AudioCodec
 
 if TYPE_CHECKING:
     from ._runtime_protocols import ControlPhaseHost

--- a/src/icom_lan/runtime/_dual_rx_runtime.py
+++ b/src/icom_lan/runtime/_dual_rx_runtime.py
@@ -33,8 +33,8 @@ from icom_lan.commands import get_unselected_freq as _get_unselected_freq_cmd
 from icom_lan.commands import get_unselected_mode as _get_unselected_mode_cmd
 from icom_lan.commands import parse_selected_freq_response as _parse_selected_freq_response
 from icom_lan.commands import parse_selected_mode_response as _parse_selected_mode_response
-from icom_lan.exceptions import CommandError, TimeoutError
-from icom_lan.types import Mode
+from icom_lan.core.exceptions import CommandError, TimeoutError
+from icom_lan.core.types import Mode
 
 # CI-V command byte for VFO select / equal / swap (0x07).
 _CMD_VFO = 0x07

--- a/src/icom_lan/runtime/_scope_runtime.py
+++ b/src/icom_lan/runtime/_scope_runtime.py
@@ -62,10 +62,10 @@ from icom_lan.commands import scope_set_span as _scope_set_span_cmd
 from icom_lan.commands import scope_set_speed as _scope_set_speed_cmd
 from icom_lan.commands import scope_set_vbw as _scope_set_vbw_cmd
 from icom_lan.commands import scope_single_dual as _scope_single_dual_cmd
-from icom_lan.exceptions import CommandError, TimeoutError
-from icom_lan.radio_state import ScopeControlsState
+from icom_lan.core.exceptions import CommandError, TimeoutError
+from icom_lan.core.radio_state import ScopeControlsState
 from icom_lan.scope import ScopeFrame
-from icom_lan.types import ScopeCompletionPolicy, ScopeFixedEdge
+from icom_lan.core.types import ScopeCompletionPolicy, ScopeFixedEdge
 
 logger = logging.getLogger(__name__)
 

--- a/src/icom_lan/runtime/_shared_state_runtime.py
+++ b/src/icom_lan/runtime/_shared_state_runtime.py
@@ -20,7 +20,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Final
 
-from icom_lan._state_cache import CacheField, StateCache
+from icom_lan.core._state_cache import CacheField, StateCache
 
 if TYPE_CHECKING:
     from icom_lan.radio_protocol import Radio

--- a/src/icom_lan/runtime/ic705.py
+++ b/src/icom_lan/runtime/ic705.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from icom_lan.profiles_runtime import OperatingProfile, apply_profile
-from icom_lan.types import ScopeCompletionPolicy
+from icom_lan.runtime.profiles_runtime import OperatingProfile, apply_profile
+from icom_lan.core.types import ScopeCompletionPolicy
 
 
 async def prepare_ic705_data_profile(

--- a/src/icom_lan/runtime/profiles_runtime.py
+++ b/src/icom_lan/runtime/profiles_runtime.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
-from icom_lan.types import ScopeCompletionPolicy
+from icom_lan.core.types import ScopeCompletionPolicy
 
 logger = logging.getLogger(__name__)
 

--- a/src/icom_lan/runtime/radio.py
+++ b/src/icom_lan/runtime/radio.py
@@ -27,17 +27,17 @@ if TYPE_CHECKING:
 from . import radio_initial_state as _initial_state
 from . import radio_reconnect as _reconnect
 from . import radio_state_snapshot as _state_snapshot
-from icom_lan._audio_recovery import AudioRecoveryRuntime, AudioRecoveryState
-from icom_lan._audio_runtime_mixin import AudioRuntimeMixin
-from icom_lan._audio_transcoder import PcmOpusTranscoder
-from icom_lan._bounded_queue import BoundedQueue
-from icom_lan._civ_rx import CivRuntime
-from icom_lan._dual_rx_runtime import DualRxRuntimeMixin
-from icom_lan._scope_runtime import ScopeRuntimeMixin
+from icom_lan.runtime._audio_recovery import AudioRecoveryRuntime, AudioRecoveryState
+from icom_lan.runtime._audio_runtime_mixin import AudioRuntimeMixin
+from icom_lan.audio._transcoder import PcmOpusTranscoder
+from icom_lan.core._bounded_queue import BoundedQueue
+from icom_lan.runtime._civ_rx import CivRuntime
+from icom_lan.runtime._dual_rx_runtime import DualRxRuntimeMixin
+from icom_lan.runtime._scope_runtime import ScopeRuntimeMixin
 
 # Import split modules
-from icom_lan._connection_state import RadioConnectionState
-from icom_lan._control_phase import (
+from icom_lan.runtime._connection_state import RadioConnectionState
+from icom_lan.runtime._control_phase import (
     CONNINFO_SIZE,  # noqa: F401 (re-export for tests)
     OPENCLOSE_SIZE,  # noqa: F401 (re-export for tests)
     STATUS_SIZE,  # noqa: F401 (re-export for tests)
@@ -45,8 +45,8 @@ from icom_lan._control_phase import (
     ControlPhaseRuntime,
 )
 from icom_lan.audio import AudioPacket, AudioStream
-from icom_lan.civ import CivEvent, CivRequestTracker
-from icom_lan.commander import IcomCommander, Priority
+from icom_lan.core.civ import CivEvent, CivRequestTracker
+from icom_lan.commands.commander import IcomCommander, Priority
 from icom_lan.commands import (
     _SUB_REPEATER_TONE,
     _SUB_REPEATER_TSQL,
@@ -263,14 +263,14 @@ from icom_lan.commands import set_repeater_tsql as _set_repeater_tsql_cmd
 from icom_lan.commands import set_tone_freq as _set_tone_freq_cmd
 from icom_lan.commands import set_tsql_freq as _set_tsql_freq_cmd
 from icom_lan.commands import set_vfo as _select_vfo_cmd
-from icom_lan.exceptions import CommandError, TimeoutError
-from icom_lan.meter_cal import interpolate_swr
+from icom_lan.core.exceptions import CommandError, TimeoutError
+from icom_lan.runtime.meter_cal import interpolate_swr
 from icom_lan.profiles import RadioProfile, resolve_radio_profile
-from icom_lan.radio_state import RadioState
-from icom_lan._state_cache import StateCache
+from icom_lan.core.radio_state import RadioState
+from icom_lan.core._state_cache import StateCache
 from icom_lan.scope import ScopeAssembler, ScopeFrame
-from icom_lan.transport import IcomTransport
-from icom_lan.types import (
+from icom_lan.core.transport import IcomTransport
+from icom_lan.core.types import (
     AgcMode,
     AudioCodec,
     AudioPeakFilter,

--- a/src/icom_lan/runtime/radio_reconnect.py
+++ b/src/icom_lan/runtime/radio_reconnect.py
@@ -18,9 +18,9 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-from icom_lan._connection_state import RadioConnectionState
-from icom_lan.exceptions import AuthenticationError
-from icom_lan.transport import IcomTransport
+from icom_lan.runtime._connection_state import RadioConnectionState
+from icom_lan.core.exceptions import AuthenticationError
+from icom_lan.core.transport import IcomTransport
 
 if TYPE_CHECKING:
     # Internal implementation module for IcomRadio — the TID251 ban targets

--- a/src/icom_lan/runtime/radio_state_snapshot.py
+++ b/src/icom_lan/runtime/radio_state_snapshot.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, cast
 
-from icom_lan.types import Mode
+from icom_lan.core.types import Mode
 
 if TYPE_CHECKING:
     # Internal implementation module for IcomRadio — the TID251 ban targets

--- a/src/icom_lan/runtime/sync.py
+++ b/src/icom_lan/runtime/sync.py
@@ -21,8 +21,8 @@ from .ic705 import (
     restore_ic705_data_profile as _restore_ic705_data_profile,
 )
 from .radio import IcomRadio as _AsyncIcomRadio, _DEFAULT_AUDIO_CODEC  # noqa: TID251
-from icom_lan.capabilities import CAP_METERS, CAP_POWER_CONTROL
-from icom_lan.types import AudioCodec, Mode, ScopeCompletionPolicy
+from icom_lan.core.capabilities import CAP_METERS, CAP_POWER_CONTROL
+from icom_lan.core.types import AudioCodec, Mode, ScopeCompletionPolicy
 
 T = TypeVar("T")
 

--- a/src/icom_lan/scope/__init__.py
+++ b/src/icom_lan/scope/__init__.py
@@ -12,7 +12,7 @@ import logging
 import time
 from dataclasses import dataclass
 
-from icom_lan.types import bcd_decode
+from icom_lan.core.types import bcd_decode
 
 __all__ = ["ScopeFrame", "ScopeAssembler"]
 

--- a/src/icom_lan/scope/render.py
+++ b/src/icom_lan/scope/render.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
-from icom_lan._optional_deps import _require_pillow
+from icom_lan.core._optional_deps import _require_pillow
 
 if TYPE_CHECKING:
     from PIL.Image import Image as PILImage


### PR DESCRIPTION
## Summary

Finishes Plan §5.3 commit-3 of Step 13 (the optional global cleanup) plus the v1.0.0 docs-build hot-fix continuation flagged in the 2026-05-01 comment on #1338.

Two atomic commits:

1. **`refactor(#1338): canonicalize in-package imports off shim paths`** — replaces `from icom_lan.<old-toplevel> import …` with `from icom_lan.<canonical-layer>.<old-toplevel> import …` across 22 files inside `src/icom_lan/<layer>/`. Behavior unchanged; sys.modules-alias shims continue to exist for downstream backwards compatibility, but first-party code no longer routes through them. **60 import lines changed.**
2. **`docs(#1338): canonicalize mkdocstrings refs in api/*.md`** — replaces `::: icom_lan.<shim>.<symbol>` autorefs in 5 docs/api/ files with canonical layer paths so griffe doesn't have to traverse sys.modules-alias re-exports. **13 autorefs changed** across `audio.md` (10), `commander.md` (2), `radio.md` (1), `sync.md` (1), `types.md` (1).

### Out of scope (deliberately preserved)

- Top-level shim files at `src/icom_lan/<oldname>.py` — they continue to exist for downstream consumers.
- `_LAZY_MAP` and Tier 1 / Tier 2 blocks in `src/icom_lan/__init__.py`.
- `TYPE_CHECKING`-block imports — left as-is per the issue brief.
- Tutorial code examples in `docs/guide/*.md`, `docs/radio-protocol.md`, `docs/ROADMAP.md`, `docs/CHANGELOG.md`, `docs/plans/*.md` — those use the public-stable shim paths intentionally.
- Tests (already canonicalized in #1297).
- Relative-form (`from ..radio_state import …`) shim imports inside `web/` and `backends/` — not in the issue's `^from icom_lan\.<shim>` candidate-finding scope; potential follow-up.

## Verification

| Gate | Result |
|------|--------|
| `uv run lint-imports` | 4 contracts kept, 0 broken |
| `uv run pytest tests/ -q --tb=short --ignore=tests/integration` | 5320 passed, 2 skipped, 2 deselected, 9 xfailed, 1 xpassed |
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run mypy src/` | Success: no issues found in 205 source files |
| `uv run mkdocs build` | No new mkdocstrings/griffe warnings; all 5 affected api/*.md pages render with expected class/function content. (Pre-existing strict-mode warnings about `'Followup'` cross-refs in `plans/issue-drafts/00-epic.md` are unrelated.) |

### Acceptance grep (issue #1338)

```bash
grep -rn '^from icom_lan\.\(commander\|transport\|exceptions\|types\|civ\|auth\|protocol\|capabilities\|env_config\|_optional_deps\|_bounded_queue\|_queue_pressure\|_state_cache\|radio_protocol\|radio_state\|radio\|sync\|profiles_runtime\|rig_loader\|scope_render\|...\) ' src/icom_lan/
```

→ **zero results.**

## Test plan

- [x] `uv run lint-imports` clean
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` green (5320 passed; matches baseline)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run mypy src/` clean
- [x] `uv run mkdocs build` produces api/audio/, api/commander/, api/sync/, api/radio/, api/types/ with autorefs resolved
- [ ] CI `docs.yml` workflow green on this branch

Closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)