### PR TITLE
feat(#1363): make RX audio jitter buffer configurable (Wi-Fi/VPN resilience)

### DIFF
--- a/frontend/src/lib/audio/__tests__/rx-player.test.ts
+++ b/frontend/src/lib/audio/__tests__/rx-player.test.ts
@@ -206,3 +206,45 @@ describe('RxPlayer audio routing (#753)', () => {
     p.stop();
   });
 });
+
+describe('RxPlayer jitter bounds (#1363)', () => {
+  it('uses default 50/300 ms bounds without setJitterBounds', () => {
+    const p = new RxPlayer();
+    p.start();
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));
+    // Floor 50 ms → nextPlayTime resets to 0 + 0.05 = 0.05.
+    expect(ctx._lastSrc.start).toHaveBeenCalledTimes(1);
+    expect(ctx._lastSrc.start.mock.calls[0][0]).toBeCloseTo(0.05, 5);
+    p.stop();
+  });
+
+  it('setJitterBounds(100, 500) changes floor used by reset', () => {
+    const p = new RxPlayer();
+    p.start();
+    p.setJitterBounds(100, 500);
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));
+    // Floor 100 ms → nextPlayTime resets to 0 + 0.10 = 0.10.
+    expect(ctx._lastSrc.start).toHaveBeenCalledTimes(1);
+    expect(ctx._lastSrc.start.mock.calls[0][0]).toBeCloseTo(0.10, 5);
+    p.stop();
+  });
+
+  it('reset trigger uses floor/2 (derived, not hardcoded)', () => {
+    const p = new RxPlayer();
+    p.start();
+    // First feed with defaults (50/300): nextPlayTime → ~0.06 after start+duration.
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));
+    expect(ctx._lastSrc.start.mock.calls[0][0]).toBeCloseTo(0.05, 5);
+    // Switch to bounds where floor=200: floor/2 = 0.10. Current nextPlayTime
+    // (~0.06) is below floor/2, so a new feed must reset to 0 + 0.20 = 0.20.
+    p.setJitterBounds(200, 1000);
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));
+    expect(ctx._lastSrc.start).toHaveBeenCalledTimes(1);
+    expect(ctx._lastSrc.start.mock.calls[0][0]).toBeCloseTo(0.20, 5);
+    p.stop();
+  });
+});

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -12,6 +12,7 @@ import { RxPlayer, type RxAudioFocus } from './rx-player';
 import { TxMic } from './tx-mic';
 import { setAudioConnected } from '../stores/connection.svelte';
 import { setRxEnabled, setTxEnabled } from '../stores/audio.svelte';
+import { getCapabilities } from '$lib/stores/capabilities.svelte';
 
 export type AudioFocus = RxAudioFocus;
 
@@ -84,6 +85,10 @@ class AudioManager {
     if (this._rxEnabled) return;
     this._rxEnabled = true;
     setRxEnabled(true);
+    const audioCfg = getCapabilities()?.audioConfig;
+    if (audioCfg?.jitterFloorMs !== undefined && audioCfg?.jitterCeilingMs !== undefined) {
+      this.rxPlayer.setJitterBounds(audioCfg.jitterFloorMs, audioCfg.jitterCeilingMs);
+    }
     this.rxPlayer.start();
     this.connect();
     this.notify();

--- a/frontend/src/lib/audio/rx-player.ts
+++ b/frontend/src/lib/audio/rx-player.ts
@@ -46,6 +46,11 @@ export class RxPlayer {
   private _mainGainDb = 0;
   private _subGainDb = 0;
 
+  // Jitter buffer bounds (seconds) — defaults match env_config defaults
+  // (50 ms floor / 300 ms ceiling). Configurable via setJitterBounds().
+  private _floorSec = 0.05;
+  private _ceilingSec = 0.30;
+
   get volume(): number {
     return this._volume;
   }
@@ -86,6 +91,13 @@ export class RxPlayer {
     if (channel === 'main') this._mainGainDb = db;
     else if (channel === 'sub') this._subGainDb = db;
     this._applyGraphState();
+  }
+
+  /** Configure jitter buffer bounds. Call before first feed() — typically after
+   *  capabilities are fetched. Values must be in milliseconds (positive integers). */
+  setJitterBounds(floorMs: number, ceilingMs: number): void {
+    this._floorSec = floorMs / 1000;
+    this._ceilingSec = ceilingMs / 1000;
   }
 
   get active(): boolean {
@@ -235,10 +247,10 @@ export class RxPlayer {
     src.connect(this.preGain);
 
     const now = this.ctx.currentTime;
-    if (this.nextPlayTime < now + 0.01) {
-      this.nextPlayTime = now + 0.02;
+    if (this.nextPlayTime < now + this._floorSec / 2) {
+      this.nextPlayTime = now + this._floorSec;
     }
-    if (this.nextPlayTime > now + 0.15) return;
+    if (this.nextPlayTime > now + this._ceilingSec) return;
 
     src.start(this.nextPlayTime);
     this.nextPlayTime += buf.duration;

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -25,6 +25,8 @@ export interface AudioConfig {
   sampleRate: number;
   channels: number;
   codecs: string[];
+  jitterFloorMs?: number;
+  jitterCeilingMs?: number;
 }
 
 export interface FilterSegmentConfig {

--- a/src/icom_lan/core/env_config.py
+++ b/src/icom_lan/core/env_config.py
@@ -13,6 +13,8 @@ __all__ = [
     "get_audio_sample_rate",
     "get_audio_broadcaster_high_watermark",
     "get_audio_client_high_watermark",
+    "get_audio_rx_jitter_floor_ms",
+    "get_audio_rx_jitter_ceiling_ms",
 ]
 
 logger = logging.getLogger(__name__)
@@ -23,6 +25,8 @@ _DEFAULTS: dict[str, int] = {
     "ICOM_AUDIO_SAMPLE_RATE": 48000,
     "ICOM_AUDIO_BROADCASTER_HIGH_WATERMARK": 10,
     "ICOM_AUDIO_CLIENT_HIGH_WATERMARK": 10,
+    "ICOM_AUDIO_RX_JITTER_FLOOR_MS": 50,
+    "ICOM_AUDIO_RX_JITTER_CEILING_MS": 300,
 }
 
 
@@ -99,3 +103,53 @@ def get_audio_client_high_watermark() -> int:
     Reads ``ICOM_AUDIO_CLIENT_HIGH_WATERMARK``.  Must be a positive integer.
     """
     return _read_positive_int("ICOM_AUDIO_CLIENT_HIGH_WATERMARK")
+
+
+def _jitter_bounds() -> tuple[int, int]:
+    """Read and cross-validate jitter floor/ceiling.
+
+    Cross-validation: floor <= ceiling and ceiling <= 2000.  On any violation
+    BOTH values fall back to defaults (no half-apply).
+    """
+    floor_default = _DEFAULTS["ICOM_AUDIO_RX_JITTER_FLOOR_MS"]
+    ceiling_default = _DEFAULTS["ICOM_AUDIO_RX_JITTER_CEILING_MS"]
+    floor = _read_positive_int("ICOM_AUDIO_RX_JITTER_FLOOR_MS")
+    ceiling = _read_positive_int("ICOM_AUDIO_RX_JITTER_CEILING_MS")
+    if ceiling > 2000:
+        msg = (
+            f"env_config: ICOM_AUDIO_RX_JITTER_CEILING_MS={ceiling} must be <= 2000, "
+            f"reverting both to defaults ({floor_default}/{ceiling_default})"
+        )
+        logger.warning(msg)
+        print(f"Warning: {msg}", file=sys.stderr)
+        return floor_default, ceiling_default
+    if floor > ceiling:
+        msg = (
+            f"env_config: ICOM_AUDIO_RX_JITTER_FLOOR_MS={floor} > "
+            f"ICOM_AUDIO_RX_JITTER_CEILING_MS={ceiling}, "
+            f"reverting both to defaults ({floor_default}/{ceiling_default})"
+        )
+        logger.warning(msg)
+        print(f"Warning: {msg}", file=sys.stderr)
+        return floor_default, ceiling_default
+    return floor, ceiling
+
+
+def get_audio_rx_jitter_floor_ms() -> int:
+    """Return the configured RX jitter buffer floor in milliseconds.
+
+    Reads ``ICOM_AUDIO_RX_JITTER_FLOOR_MS``.  Must be a positive integer
+    and must not exceed the ceiling.  Falls back to 50 with a warning on
+    any violation.
+    """
+    return _jitter_bounds()[0]
+
+
+def get_audio_rx_jitter_ceiling_ms() -> int:
+    """Return the configured RX jitter buffer ceiling in milliseconds.
+
+    Reads ``ICOM_AUDIO_RX_JITTER_CEILING_MS``.  Must be a positive integer,
+    must not exceed 2000, and must not be less than the floor.  Falls back
+    to 300 with a warning on any violation.
+    """
+    return _jitter_bounds()[1]

--- a/src/icom_lan/web/server.py
+++ b/src/icom_lan/web/server.py
@@ -37,6 +37,10 @@ from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO, CAP_SCOPE
 from ..audio_analyzer import AudioAnalyzer
 from ..audio_fft_scope import AudioFftScope
+from ..env_config import (
+    get_audio_rx_jitter_ceiling_ms,
+    get_audio_rx_jitter_floor_ms,
+)
 from ..startup_checks import assert_radio_startup_ready
 from ._delta_encoder import DeltaEncoder  # noqa: TID251
 from .discovery import DiscoveryResponder  # noqa: TID251
@@ -1414,6 +1418,8 @@ class WebServer:
                     "sampleRate": 48000,
                     "channels": 1,
                     "codecs": ["opus"],
+                    "jitterFloorMs": get_audio_rx_jitter_floor_ms(),
+                    "jitterCeilingMs": get_audio_rx_jitter_ceiling_ms(),
                 },
                 "antennas": profile.antenna_tx_count,
                 "webrtc": rtc_capability_info(),

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -111,6 +111,121 @@ class TestGetAudioClientHighWatermark:
         assert result == 10
 
 
+class TestGetAudioRxJitterBounds:
+    def test_floor_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", raising=False)
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", raising=False)
+        from icom_lan.env_config import get_audio_rx_jitter_floor_ms
+
+        assert get_audio_rx_jitter_floor_ms() == 50
+
+    def test_ceiling_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", raising=False)
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", raising=False)
+        from icom_lan.env_config import get_audio_rx_jitter_ceiling_ms
+
+        assert get_audio_rx_jitter_ceiling_ms() == 300
+
+    def test_floor_valid_override(self, monkeypatch):
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", "80")
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", raising=False)
+        from icom_lan.env_config import get_audio_rx_jitter_floor_ms
+
+        assert get_audio_rx_jitter_floor_ms() == 80
+
+    def test_ceiling_valid_override(self, monkeypatch):
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", raising=False)
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "500")
+        from icom_lan.env_config import get_audio_rx_jitter_ceiling_ms
+
+        assert get_audio_rx_jitter_ceiling_ms() == 500
+
+    def test_floor_invalid_string_falls_back(self, monkeypatch, caplog):
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", "bad")
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", raising=False)
+        from icom_lan.env_config import get_audio_rx_jitter_floor_ms
+
+        with caplog.at_level(logging.WARNING, logger="icom_lan.env_config"):
+            result = get_audio_rx_jitter_floor_ms()
+        assert result == 50
+        assert "ICOM_AUDIO_RX_JITTER_FLOOR_MS" in caplog.text
+
+    def test_ceiling_invalid_string_falls_back(self, monkeypatch, caplog):
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", raising=False)
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "bad")
+        from icom_lan.env_config import get_audio_rx_jitter_ceiling_ms
+
+        with caplog.at_level(logging.WARNING, logger="icom_lan.env_config"):
+            result = get_audio_rx_jitter_ceiling_ms()
+        assert result == 300
+        assert "ICOM_AUDIO_RX_JITTER_CEILING_MS" in caplog.text
+
+    def test_floor_zero_falls_back(self, monkeypatch):
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", "0")
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", raising=False)
+        from icom_lan.env_config import get_audio_rx_jitter_floor_ms
+
+        assert get_audio_rx_jitter_floor_ms() == 50
+
+    def test_ceiling_zero_falls_back(self, monkeypatch):
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", raising=False)
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "0")
+        from icom_lan.env_config import get_audio_rx_jitter_ceiling_ms
+
+        assert get_audio_rx_jitter_ceiling_ms() == 300
+
+    def test_cross_floor_greater_than_ceiling_falls_back_both(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", "200")
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "100")
+        from icom_lan.env_config import (
+            get_audio_rx_jitter_ceiling_ms,
+            get_audio_rx_jitter_floor_ms,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="icom_lan.env_config"):
+            floor = get_audio_rx_jitter_floor_ms()
+            ceiling = get_audio_rx_jitter_ceiling_ms()
+        assert floor == 50
+        assert ceiling == 300
+        assert "ICOM_AUDIO_RX_JITTER_FLOOR_MS" in caplog.text
+        assert "ICOM_AUDIO_RX_JITTER_CEILING_MS" in caplog.text
+
+    def test_cross_ceiling_exceeds_2000_falls_back_both(self, monkeypatch, caplog):
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", raising=False)
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "2001")
+        from icom_lan.env_config import (
+            get_audio_rx_jitter_ceiling_ms,
+            get_audio_rx_jitter_floor_ms,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="icom_lan.env_config"):
+            floor = get_audio_rx_jitter_floor_ms()
+            ceiling = get_audio_rx_jitter_ceiling_ms()
+        assert floor == 50
+        assert ceiling == 300
+        assert "ICOM_AUDIO_RX_JITTER_CEILING_MS" in caplog.text
+
+    def test_cross_floor_equals_ceiling_allowed(self, monkeypatch):
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", "100")
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "100")
+        from icom_lan.env_config import (
+            get_audio_rx_jitter_ceiling_ms,
+            get_audio_rx_jitter_floor_ms,
+        )
+
+        assert get_audio_rx_jitter_floor_ms() == 100
+        assert get_audio_rx_jitter_ceiling_ms() == 100
+
+    def test_cross_ceiling_exactly_2000_allowed(self, monkeypatch):
+        monkeypatch.delenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", raising=False)
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "2000")
+        from icom_lan.env_config import get_audio_rx_jitter_ceiling_ms
+
+        assert get_audio_rx_jitter_ceiling_ms() == 2000
+
+
 class TestHandlerIntegration:
     """Verify that env vars are picked up when handlers are instantiated."""
 


### PR DESCRIPTION
## Summary

- New env vars `ICOM_AUDIO_RX_JITTER_FLOOR_MS` (default **50**) and `ICOM_AUDIO_RX_JITTER_CEILING_MS` (default **300**) make the browser-side jitter buffer tunable. Old hardcoded values were 20 ms / 150 ms — too tight for Wi-Fi/VPN/cellular, causing synchronized stuttering across audio + scope + AF FFT.
- Values propagate through the existing `/api/v1/capabilities` endpoint (no new endpoints, no WS protocol changes). TS-side defaults match env defaults so frontend-only upgrades against old servers still benefit.
- Reset-trigger threshold derived as `floorSec / 2` rather than a third env var, preserving the original 2:1 ratio without proliferating knobs.
- Cross-validation: `floor ≤ ceiling` and `ceiling ≤ 2000`; on any violation BOTH values revert to defaults (no half-apply) with a warning.

## Behavior change

Default RX jitter buffer is now 50 ms floor / 300 ms ceiling on **all** deployments, including LAN. The +30 ms floor sits below the human perception threshold for general listening and the wider ceiling absorbs typical Wi-Fi micro-bursts. Operators with hard latency requirements can override via env.

## File-count guardrail breach (documented)

7 files modified — exceeds the 3-file guardrail in `CLAUDE.md`. Accepted because this is one atomic cross-layer feature where each half is useless apart:

| File | LOC delta | Layer |
|---|---|---|
| `src/icom_lan/core/env_config.py` | +54 | backend (env) |
| `tests/test_env_config.py` | +115 | backend (tests) |
| `src/icom_lan/web/server.py` | +6 | backend (capabilities) |
| `frontend/src/lib/types/capabilities.ts` | +2 | frontend (type) |
| `frontend/src/lib/audio/rx-player.ts` | +18 | frontend (player) |
| `frontend/src/lib/audio/audio-manager.ts` | +5 | frontend (wiring) |
| `frontend/src/lib/audio/__tests__/rx-player.test.ts` | +42 | frontend (tests) |
| **Total** | **+239 / -3** | (production: 85, tests: 157) |

Splitting backend + frontend into two PRs would create a no-op intermediate state (server emits values nobody reads). Production-code LOC delta of 85 is well under the 200 LOC guardrail; the 239 raw insertion count is dominated by test verbosity matching the existing `TestGetAudioBroadcasterHighWatermark` style. `patterns.md` #788 explicitly licenses honest breaches when scope stays clean and LOC stays under budget.

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **5332 passed**, 2 skipped, 9 xfailed, 1 xpassed (12 new tests, 0 regressions)
- `uv run mypy src/` — clean (205 files)
- `uv run ruff check src/ tests/` — clean
- `uv run lint-imports` — 4 contracts kept, 0 broken
- `cd frontend && npx vitest run src/lib/audio/__tests__/rx-player.test.ts` — **21 passed** (3 new + 18 existing)
- `cd frontend && npm run build` — built in 2.90s

## Test plan

- [ ] Operator on Wi-Fi laptop confirms audible stuttering reduces with default 50/300 ms compared to old 20/150 ms.
- [ ] Override via env (`ICOM_AUDIO_RX_JITTER_CEILING_MS=600 uv run icom-lan ... web`) takes effect after browser refresh; check `/api/v1/capabilities` JSON.
- [ ] Cross-validation: setting `ICOM_AUDIO_RX_JITTER_FLOOR_MS=400` with `ICOM_AUDIO_RX_JITTER_CEILING_MS=200` warns and falls back to 50/300 (visible in server stderr).
- [ ] Old browser cache against new server: hard refresh, verify `RxPlayer` logs (or visible bound on dev tools) reflect the new defaults.

## Related

Closes #1363.
Companion cleanup: #1364 (dead `ICOM_AUDIO_CLIENT_HIGH_WATERMARK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)