### PR TITLE
fix(#1366): no half-apply when one jitter env var is invalid

### DIFF
--- a/src/icom_lan/core/env_config.py
+++ b/src/icom_lan/core/env_config.py
@@ -57,6 +57,26 @@ def _read_positive_int(var: str) -> int:
     return value
 
 
+def _try_read_positive_int(var: str) -> tuple[int, bool]:
+    """Read *var* and report parse success.
+
+    Returns ``(value, ok)`` where ``ok`` is False ONLY when the env var is
+    set but invalid (non-int or ``<= 0``). Absent vars return
+    ``(default, True)``.
+    """
+    default = _DEFAULTS[var]
+    raw = os.environ.get(var)
+    if raw is None:
+        return default, True
+    try:
+        value = int(raw)
+    except ValueError:
+        return default, False
+    if value <= 0:
+        return default, False
+    return value, True
+
+
 def get_audio_sample_rate() -> int:
     """Return the configured default audio sample rate in Hz.
 
@@ -108,13 +128,31 @@ def get_audio_client_high_watermark() -> int:
 def _jitter_bounds() -> tuple[int, int]:
     """Read and cross-validate jitter floor/ceiling.
 
-    Cross-validation: floor <= ceiling and ceiling <= 2000.  On any violation
-    BOTH values fall back to defaults (no half-apply).
+    If either env var is set but invalid (non-int or ``<= 0``), BOTH revert
+    to defaults. Then floor <= ceiling and ceiling <= 2000 are enforced; on
+    any violation BOTH revert to defaults (no half-apply).
     """
     floor_default = _DEFAULTS["ICOM_AUDIO_RX_JITTER_FLOOR_MS"]
     ceiling_default = _DEFAULTS["ICOM_AUDIO_RX_JITTER_CEILING_MS"]
-    floor = _read_positive_int("ICOM_AUDIO_RX_JITTER_FLOOR_MS")
-    ceiling = _read_positive_int("ICOM_AUDIO_RX_JITTER_CEILING_MS")
+    floor, floor_ok = _try_read_positive_int("ICOM_AUDIO_RX_JITTER_FLOOR_MS")
+    ceiling, ceiling_ok = _try_read_positive_int("ICOM_AUDIO_RX_JITTER_CEILING_MS")
+    if not (floor_ok and ceiling_ok):
+        invalid: list[str] = []
+        if not floor_ok:
+            invalid.append(
+                f"ICOM_AUDIO_RX_JITTER_FLOOR_MS={os.environ.get('ICOM_AUDIO_RX_JITTER_FLOOR_MS')!r}"
+            )
+        if not ceiling_ok:
+            invalid.append(
+                f"ICOM_AUDIO_RX_JITTER_CEILING_MS={os.environ.get('ICOM_AUDIO_RX_JITTER_CEILING_MS')!r}"
+            )
+        msg = (
+            f"env_config: invalid jitter env var(s) {', '.join(invalid)}, "
+            f"reverting both to defaults ({floor_default}/{ceiling_default})"
+        )
+        logger.warning(msg)
+        print(f"Warning: {msg}", file=sys.stderr)
+        return floor_default, ceiling_default
     if ceiling > 2000:
         msg = (
             f"env_config: ICOM_AUDIO_RX_JITTER_CEILING_MS={ceiling} must be <= 2000, "

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -225,6 +225,66 @@ class TestGetAudioRxJitterBounds:
 
         assert get_audio_rx_jitter_ceiling_ms() == 2000
 
+    def test_floor_valid_ceiling_invalid_string_reverts_both(self, monkeypatch, caplog):
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", "100")
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "bad")
+        from icom_lan.env_config import (
+            get_audio_rx_jitter_ceiling_ms,
+            get_audio_rx_jitter_floor_ms,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="icom_lan.env_config"):
+            floor = get_audio_rx_jitter_floor_ms()
+            ceiling = get_audio_rx_jitter_ceiling_ms()
+        assert floor == 50
+        assert ceiling == 300
+        assert "ICOM_AUDIO_RX_JITTER_CEILING_MS" in caplog.text
+
+    def test_floor_invalid_ceiling_valid_reverts_both(self, monkeypatch, caplog):
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", "bad")
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "500")
+        from icom_lan.env_config import (
+            get_audio_rx_jitter_ceiling_ms,
+            get_audio_rx_jitter_floor_ms,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="icom_lan.env_config"):
+            floor = get_audio_rx_jitter_floor_ms()
+            ceiling = get_audio_rx_jitter_ceiling_ms()
+        assert floor == 50
+        assert ceiling == 300
+        assert "ICOM_AUDIO_RX_JITTER_FLOOR_MS" in caplog.text
+
+    def test_floor_valid_ceiling_zero_reverts_both(self, monkeypatch, caplog):
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", "100")
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "0")
+        from icom_lan.env_config import (
+            get_audio_rx_jitter_ceiling_ms,
+            get_audio_rx_jitter_floor_ms,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="icom_lan.env_config"):
+            floor = get_audio_rx_jitter_floor_ms()
+            ceiling = get_audio_rx_jitter_ceiling_ms()
+        assert floor == 50
+        assert ceiling == 300
+        assert "ICOM_AUDIO_RX_JITTER_CEILING_MS" in caplog.text
+
+    def test_floor_zero_ceiling_valid_reverts_both(self, monkeypatch, caplog):
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_FLOOR_MS", "0")
+        monkeypatch.setenv("ICOM_AUDIO_RX_JITTER_CEILING_MS", "500")
+        from icom_lan.env_config import (
+            get_audio_rx_jitter_ceiling_ms,
+            get_audio_rx_jitter_floor_ms,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="icom_lan.env_config"):
+            floor = get_audio_rx_jitter_floor_ms()
+            ceiling = get_audio_rx_jitter_ceiling_ms()
+        assert floor == 50
+        assert ceiling == 300
+        assert "ICOM_AUDIO_RX_JITTER_FLOOR_MS" in caplog.text
+
 
 class TestHandlerIntegration:
     """Verify that env vars are picked up when handlers are instantiated."""


### PR DESCRIPTION
## Summary

- Fixes Codex P1 finding on PR #1365: `_jitter_bounds()` half-applied defaults when one of `ICOM_AUDIO_RX_JITTER_FLOOR_MS` / `ICOM_AUDIO_RX_JITTER_CEILING_MS` was invalid, contradicting the docstring promise of "no half-apply".
- Adds a private sibling helper `_try_read_positive_int(var) -> tuple[int, bool]` so `_jitter_bounds` can distinguish "absent" from "set but invalid" without disturbing `_read_positive_int`'s contract (still used by the watermark getters).
- Four new tests in `TestGetAudioRxJitterBounds` cover the previously-uncaught mixed-invalid combinations.

## Root cause

`_read_positive_int` returns the per-var default both for "unset" and "invalid". `_jitter_bounds` could not tell the two apart, so cross-validation always saw an internally-consistent pair and returned `(user_value, default)` instead of `(default, default)`.

## Reproducer (Codex's exact case)

```bash
ICOM_AUDIO_RX_JITTER_FLOOR_MS=100 ICOM_AUDIO_RX_JITTER_CEILING_MS=bad uv run python -c "
from icom_lan.env_config import get_audio_rx_jitter_floor_ms, get_audio_rx_jitter_ceiling_ms
print(get_audio_rx_jitter_floor_ms(), get_audio_rx_jitter_ceiling_ms())
"
```

| | Before | After |
|---|---|---|
| stdout | `100 300` | `50 300` |
| stderr | _(no warning — cross-validation passed silently)_ | `Warning: env_config: invalid jitter env var(s) ICOM_AUDIO_RX_JITTER_CEILING_MS='bad', reverting both to defaults (50/300)` |

## Why this approach (no half-apply, but minimal blast radius)

- Did NOT change `_read_positive_int` — it's shared with `get_audio_broadcaster_high_watermark` / `get_audio_client_high_watermark`, which have no pair semantics and want silent fallback. Changing the shared signature would touch unrelated tests.
- Helper is `_`-prefixed, not exported (`__all__` unchanged) — it's an internal implementation detail of jitter validation.
- Existing `ceiling > 2000` and `floor > ceiling` blocks are byte-identical to before.

## Tests

New cases (each asserts both `floor` and `ceiling`, plus the offending var name in `caplog.text`):

- `FLOOR=100, CEILING=bad`     → `(50, 300)`
- `FLOOR=bad, CEILING=500`     → `(50, 300)`
- `FLOOR=100, CEILING=0`       → `(50, 300)`
- `FLOOR=0,   CEILING=500`     → `(50, 300)`

Existing single-var invalid tests (`test_floor_invalid_string_falls_back`, `test_ceiling_invalid_string_falls_back`) remain — unset partner ≠ invalid per the docstring intent.

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → 5336 passed, 2 skipped, 9 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` → clean
- `uv run mypy src/icom_lan/core/env_config.py` → clean
- `uv run lint-imports` → 4 kept, 0 broken
- Manual reproducer above → expected `50 300`

## Scope

- 2 files modified (≤3 ✓)
- +102 / -4 LOC (≤200 ✓)
- No protocol/transport/state/public-API changes

Closes #1366

## Test plan

- [x] Mixed-invalid env vars revert both to defaults
- [x] Single-var invalid still works (unset partner case)
- [x] Cross-validation `> 2000` and `floor > ceiling` paths unchanged
- [x] Watermark getters and other helpers unaffected
- [x] No format / lint / type / import-linter regressions