### PR TITLE
chore: ruff format sweep (12 files)

### DIFF
--- a/src/icom_lan/audio/_transcoder.py
+++ b/src/icom_lan/audio/_transcoder.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Protocol
 
-from icom_lan.core.exceptions import AudioCodecBackendError, AudioFormatError, AudioTranscodeError
+from icom_lan.core.exceptions import (
+    AudioCodecBackendError,
+    AudioFormatError,
+    AudioTranscodeError,
+)
 
 __all__ = [
     "PcmAudioFormat",

--- a/src/icom_lan/cli/__init__.py
+++ b/src/icom_lan/cli/__init__.py
@@ -2387,7 +2387,11 @@ async def _cmd_scope(radio: Radio, args: argparse.Namespace) -> int:
 async def _cmd_audio_bridge(radio: Radio, args: argparse.Namespace) -> int:
     """Bridge radio audio to a virtual audio device."""
     try:
-        from icom_lan.audio_bridge import AudioBridge, derive_bridge_label, list_audio_devices
+        from icom_lan.audio_bridge import (
+            AudioBridge,
+            derive_bridge_label,
+            list_audio_devices,
+        )
     except ImportError:
         print(
             "Error: audio bridge requires icom-lan[bridge].\n"
@@ -2774,7 +2778,11 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
 
 async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
     """Discover Icom radios on LAN and/or serial ports."""
-    from icom_lan.discovery import dedupe_radios, discover_lan_radios, discover_serial_radios
+    from icom_lan.discovery import (
+        dedupe_radios,
+        discover_lan_radios,
+        discover_serial_radios,
+    )
 
     serial_only: bool = getattr(args, "serial_only", False)
     lan_only: bool = getattr(args, "lan_only", False)

--- a/src/icom_lan/profiles/__init__.py
+++ b/src/icom_lan/profiles/__init__.py
@@ -250,7 +250,8 @@ _by_civ_addr: dict[int, RadioProfile] = {}
 
 # Search paths for rig TOML files (first existing directory wins).
 _RIG_DIRS: list[Path] = [
-    Path(__file__).resolve().parent.parent.parent.parent / "rigs",  # dev: repo root/rigs/
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "rigs",  # dev: repo root/rigs/
     Path(__file__).resolve().parent.parent / "rigs",  # installed: package/rigs/
 ]
 

--- a/src/icom_lan/runtime/_civ_rx.py
+++ b/src/icom_lan/runtime/_civ_rx.py
@@ -7,7 +7,12 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from icom_lan.core.civ import CivEvent, CivEventType, iter_civ_frames, request_key_from_frame
+from icom_lan.core.civ import (
+    CivEvent,
+    CivEventType,
+    iter_civ_frames,
+    request_key_from_frame,
+)
 from icom_lan.commands.commander import IcomCommander, Priority
 from icom_lan.commands import (
     CONTROLLER_ADDR,

--- a/src/icom_lan/runtime/_dual_rx_runtime.py
+++ b/src/icom_lan/runtime/_dual_rx_runtime.py
@@ -31,8 +31,12 @@ from icom_lan.commands import get_selected_freq as _get_selected_freq_cmd
 from icom_lan.commands import get_selected_mode as _get_selected_mode_cmd
 from icom_lan.commands import get_unselected_freq as _get_unselected_freq_cmd
 from icom_lan.commands import get_unselected_mode as _get_unselected_mode_cmd
-from icom_lan.commands import parse_selected_freq_response as _parse_selected_freq_response
-from icom_lan.commands import parse_selected_mode_response as _parse_selected_mode_response
+from icom_lan.commands import (
+    parse_selected_freq_response as _parse_selected_freq_response,
+)
+from icom_lan.commands import (
+    parse_selected_mode_response as _parse_selected_mode_response,
+)
 from icom_lan.core.exceptions import CommandError, TimeoutError
 from icom_lan.core.types import Mode
 

--- a/src/icom_lan/web/eibi.py
+++ b/src/icom_lan/web/eibi.py
@@ -576,9 +576,7 @@ class EiBiProvider:
         if not csv_path.is_file():
             return {"status": "no_cache", "error": "No cached data found"}
 
-        raw, meta = await asyncio.to_thread(
-            _load_cache_files_sync, csv_path, meta_path
-        )
+        raw, meta = await asyncio.to_thread(_load_cache_files_sync, csv_path, meta_path)
         count = self._parse_csv(raw.decode("latin-1", errors="replace"))
 
         self._season = meta.get("season")

--- a/src/icom_lan/web/radio_poller.py
+++ b/src/icom_lan/web/radio_poller.py
@@ -1315,9 +1315,7 @@ class RadioPoller:
                     select_receiver = getattr(radio, "select_receiver", None)
                     if select_receiver is not None:
                         await select_receiver(target_name)
-                        logger.info(
-                            "radio-poller: select_receiver=%s", target_name
-                        )
+                        logger.info("radio-poller: select_receiver=%s", target_name)
                     else:
                         legacy_set_vfo = getattr(radio, "set_vfo", None)
                         if legacy_set_vfo is None:

--- a/tests/test_audio_bus.py
+++ b/tests/test_audio_bus.py
@@ -195,8 +195,7 @@ async def test_async_iteration(bus, mock_radio):
     await sub.start()
 
     pkts = [
-        AudioPacket(ident=0x80, send_seq=i, data=f"pkt{i}".encode())
-        for i in range(3)
+        AudioPacket(ident=0x80, send_seq=i, data=f"pkt{i}".encode()) for i in range(3)
     ]
     for p in pkts:
         bus._on_opus_packet(p)

--- a/tests/test_audio_rx_tx_transition.py
+++ b/tests/test_audio_rx_tx_transition.py
@@ -166,9 +166,7 @@ async def test_ptt_off_handles_audio_errors_gracefully(
 
 
 @pytest.mark.asyncio
-async def test_multiple_ptt_cycles(
-    poller: RadioPoller, radio: SimpleNamespace
-) -> None:
+async def test_multiple_ptt_cycles(poller: RadioPoller, radio: SimpleNamespace) -> None:
     """Множественные PTT циклы должны работать стабильно."""
     for i in range(3):
         # PTT ON

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 import pytest
 
 from icom_lan import IcomRadio, create_radio
-from icom_lan.backends.config import LanBackendConfig, SerialBackendConfig, YaesuCatBackendConfig
+from icom_lan.backends.config import (
+    LanBackendConfig,
+    SerialBackendConfig,
+    YaesuCatBackendConfig,
+)
 from icom_lan.backends.icom7610 import Icom7610SerialRadio
 from icom_lan.backends.yaesu_cat.radio import YaesuCatRadio
 from icom_lan.backends.icom7610.drivers.contracts import (

--- a/tests/test_radio_protocol.py
+++ b/tests/test_radio_protocol.py
@@ -48,13 +48,23 @@ class _StubRadio:
 
     async def connect(self) -> None: ...
     async def disconnect(self) -> None: ...
-    async def __aenter__(self) -> "_StubRadio": return self
+    async def __aenter__(self) -> "_StubRadio":
+        return self
+
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None: ...
-    async def get_freq(self, receiver: int = 0) -> int: return 0
+    async def get_freq(self, receiver: int = 0) -> int:
+        return 0
+
     async def set_freq(self, freq: int, receiver: int = 0) -> None: ...
-    async def get_mode(self, receiver: int = 0) -> tuple[str, int | None]: return ("USB", None)
-    async def set_mode(self, mode: str, filter_width: int | None = None, receiver: int = 0) -> None: ...
-    async def get_data_mode(self) -> bool: return False
+    async def get_mode(self, receiver: int = 0) -> tuple[str, int | None]:
+        return ("USB", None)
+
+    async def set_mode(
+        self, mode: str, filter_width: int | None = None, receiver: int = 0
+    ) -> None: ...
+    async def get_data_mode(self) -> bool:
+        return False
+
     async def set_data_mode(self, on: int | bool, receiver: int = 0) -> None: ...
     async def set_ptt(self, on: bool) -> None: ...
 
@@ -81,20 +91,41 @@ class _PowerStub:
     checks must still pass for backends that implement the read+write pair.
     """
 
-    async def get_powerstat(self) -> bool: return True
+    async def get_powerstat(self) -> bool:
+        return True
+
     async def set_powerstat(self, on: bool) -> None: ...
-    async def get_rf_power(self) -> int: return 128
+    async def get_rf_power(self) -> int:
+        return 128
+
     async def set_rf_power(self, level: int) -> None: ...
+
     native_power_unit = "raw_255"
+
     # MetersCapable surface
-    async def get_s_meter(self, receiver: int = 0) -> int: return 0
-    async def get_swr(self) -> float: return 1.0
-    async def get_comp_meter(self) -> int: return 0
-    async def get_id_meter(self) -> int: return 0
-    async def get_vd_meter(self) -> int: return 0
-    async def get_power_meter(self) -> int: return 0
-    async def get_alc_meter(self) -> int: return 0
-    async def get_swr_meter(self) -> int: return 0
+    async def get_s_meter(self, receiver: int = 0) -> int:
+        return 0
+
+    async def get_swr(self) -> float:
+        return 1.0
+
+    async def get_comp_meter(self) -> int:
+        return 0
+
+    async def get_id_meter(self) -> int:
+        return 0
+
+    async def get_vd_meter(self) -> int:
+        return 0
+
+    async def get_power_meter(self) -> int:
+        return 0
+
+    async def get_alc_meter(self) -> int:
+        return 0
+
+    async def get_swr_meter(self) -> int:
+        return 0
 
 
 def test_get_rf_power_visible_on_power_control_capable() -> None:
@@ -225,18 +256,26 @@ def test_voice_compressor_round_trip_protocol_typed() -> None:
 class _RitXitStub:
     """Minimal stub that satisfies RitXitCapable (six methods)."""
 
-    async def get_rit_frequency(self) -> int: return 0
+    async def get_rit_frequency(self) -> int:
+        return 0
+
     async def set_rit_frequency(self, freq_hz: int) -> None: ...
-    async def get_rit_status(self) -> bool: return False
+    async def get_rit_status(self) -> bool:
+        return False
+
     async def set_rit_status(self, on: bool) -> None: ...
-    async def get_rit_tx_status(self) -> bool: return False
+    async def get_rit_tx_status(self) -> bool:
+        return False
+
     async def set_rit_tx_status(self, on: bool) -> None: ...
 
 
 class _TxMonitorStub:
     """Minimal stub that satisfies the reduced TransceiverStatusCapable."""
 
-    async def get_tx_freq_monitor(self) -> bool: return False
+    async def get_tx_freq_monitor(self) -> bool:
+        return False
+
     async def set_tx_freq_monitor(self, on: bool) -> None: ...
 
 

--- a/tests/test_serial_backend_smoke.py
+++ b/tests/test_serial_backend_smoke.py
@@ -356,9 +356,7 @@ async def test_rigctld_smoke_with_serial_mock_backend() -> None:
             radio.set_vfo = _spy  # type: ignore[method-assign]
             writer.write(b"V VFOA\n")
             await writer.drain()
-            set_vfo_resp = await asyncio.wait_for(
-                reader.readuntil(b"\n"), timeout=2.0
-            )
+            set_vfo_resp = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=2.0)
             assert set_vfo_resp.strip() == b"RPRT 0"
             assert calls == ["MAIN"], (
                 f"V VFOA must reach legacy set_vfo (got calls={calls!r})"


### PR DESCRIPTION
## Summary

Mechanical `uv run ruff format src/ tests/` — no logic, no signature, no behaviour changes. Clears persistent `ruff format --check` drift on main (12 files).

## Files

- `src/icom_lan/audio/_transcoder.py`
- `src/icom_lan/cli/__init__.py`
- `src/icom_lan/profiles/__init__.py`
- `src/icom_lan/runtime/_civ_rx.py`
- `src/icom_lan/runtime/_dual_rx_runtime.py`
- `src/icom_lan/web/eibi.py`
- `src/icom_lan/web/radio_poller.py`
- `tests/test_audio_bus.py`
- `tests/test_audio_rx_tx_transition.py`
- `tests/test_backend_factory.py`
- `tests/test_radio_protocol.py`
- `tests/test_serial_backend_smoke.py`

## Verification

- `uv run ruff check src/ tests/` → clean
- `uv run ruff format --check src/ tests/` → clean
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → 5336 passed, 2 skipped, 9 xfailed, 1 xpassed

## Test plan

- [x] No logic changes; only whitespace/import-grouping
- [x] Full pytest suite passes
- [x] ruff format --check clean afterwards