### PR TITLE
fix(#1371): migrate vi.fn generic to one-arg form (Cluster B)

### DIFF
--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -79,8 +79,8 @@ describe('ScopeController', () => {
   });
 
   it('both subscribers receive parsed frames', () => {
-    const h1 = vi.fn<[ScopeFrame], void>();
-    const h2 = vi.fn<[ScopeFrame], void>();
+    const h1 = vi.fn<(frame: ScopeFrame) => void>();
+    const h2 = vi.fn<(frame: ScopeFrame) => void>();
 
     ctrl.subscribe(h1);
     ctrl.subscribe(h2);
@@ -131,7 +131,7 @@ describe('ScopeController', () => {
   });
 
   it('counts subscriptions: same handler reference subscribed twice requires two unsubscribes', () => {
-    const handler = vi.fn<[ScopeFrame], void>();
+    const handler = vi.fn<(frame: ScopeFrame) => void>();
 
     const unsub1 = ctrl.subscribe(handler);
     const unsub2 = ctrl.subscribe(handler);


### PR DESCRIPTION
## Summary

Sub-issue **B** of #1369 — clears 9 of remaining 20 frontend `npm run check` errors.

Vitest 4 changed `vi.fn` generic from legacy two-arg `vi.fn<TArgs, TReturn>()` to one-arg `vi.fn<(...args) => Return>()`. `scope-controller.test.ts` still used the legacy form in 3 places.

## Fix

Three replacements in one file:

```diff
- const h1 = vi.fn<[ScopeFrame], void>();
+ const h1 = vi.fn<(frame: ScopeFrame) => void>();
```

## Verification

- `npm run check`: **20 → 11 errors**, zero in `scope-controller.test.ts`
- `npx vitest run scope-controller.test.ts`: 8/8 pass (was already passing — types were the issue)

## Scope

1 file, +3 / −3 LOC. Trivial.

Closes #1371