### PR TITLE
fix(#1372): narrow nullable result + drop misshaped Promise generic (Cluster C)

### DIFF
--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -67,8 +67,9 @@ describe('fetchState', () => {
 
     const { fetchState } = await import('../http-client');
     const result = await fetchState();
-    expect(result.revision).toBe(1);
-    expect(result.main.freqHz).toBe(14074000);
+    expect(result).not.toBeNull();
+    expect(result!.revision).toBe(1);
+    expect(result!.main.freqHz).toBe(14074000);
   });
 
   it('throws on non-ok response', async () => {
@@ -301,7 +302,7 @@ describe('startPolling', () => {
 
     globalThis.fetch = vi.fn().mockImplementation(() => {
       callCount++;
-      return new Promise<{ ok: boolean; json: () => Promise<ServerState> }>((resolve) => {
+      return new Promise((resolve) => {
         resolvePending = () =>
           resolve({ ok: true, status: 200, headers: { get: () => '"' + callCount + '"' }, json: () => Promise.resolve(makeState(callCount)) });
       });


### PR DESCRIPTION
## Summary

Sub-issue **C** of #1369 — clears 3 of remaining 11 frontend `npm run check` errors.

## Fix

- **L70-71:** `fetchState()` returns `ServerState | null` (304 path). Added `expect(result).not.toBeNull()` + `result!` narrowing on success path (mirrors the symmetric `toBeNull()` assertion at L89).
- **L304:** dropped explicit `Promise<{ ok, json }>` generic that omitted `status`/`headers` from the resolve payload. TS infers from `resolve(...)`. Matches local style — surrounding mock-fetches (L61, L81, L145, L164, L205, L224, L278) all use plain inline objects without Promise generics.

## Verification

- `npm run check`: 11 → 8 errors total, zero in `http-client.test.ts`
- `npx vitest run http-client.test.ts`: 14/14 pass

## Scope

1 file, +4 / −3 LOC.

Closes #1372