### PR TITLE
fix(#1374): clear 8 misc svelte-check errors across 6 files (Cluster E)

### DIFF
--- a/frontend/src/components-v2/controls/__tests__/BottomSheet.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/BottomSheet.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mount, unmount, flushSync } from 'svelte';
+import { mount, unmount, flushSync, type Snippet } from 'svelte';
 import BottomSheet from '../BottomSheet.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
@@ -17,7 +17,7 @@ function mountSheet(props: {
     target,
     props: {
       ...props,
-      children: (anchor: any) => {
+      children: ((anchor: any) => {
         const div = document.createElement('div');
         div.className = 'test-child';
         div.textContent = 'Sheet content';
@@ -26,7 +26,7 @@ function mountSheet(props: {
           update: () => {},
           destroy: () => div.remove(),
         };
-      },
+      }) as unknown as Snippet,
     },
   });
   flushSync();

--- a/frontend/src/components-v2/panels/TxPanel.svelte
+++ b/frontend/src/components-v2/panels/TxPanel.svelte
@@ -116,18 +116,16 @@
       {txActive ? '● TX' : '○ RX'}
     </div>
 
-    {#if onPttOn}
-      <button
-        class="ptt-button"
-        class:ptt-held={pttMode === 'held'}
-        class:ptt-latched={pttMode === 'latched'}
-        onpointerdown={(e) => { e.preventDefault(); pttDown(); }}
-        onpointerup={(e) => { e.preventDefault(); pttUp(); }}
-        onpointerleave={() => { if (pttMode === 'held') pttUp(); }}
-      >
-        {pttMode === 'latched' ? 'TX 🔒' : pttMode === 'held' ? 'TX' : 'PTT'}
-      </button>
-    {/if}
+    <button
+      class="ptt-button"
+      class:ptt-held={pttMode === 'held'}
+      class:ptt-latched={pttMode === 'latched'}
+      onpointerdown={(e) => { e.preventDefault(); pttDown(); }}
+      onpointerup={(e) => { e.preventDefault(); pttUp(); }}
+      onpointerleave={() => { if (pttMode === 'held') pttUp(); }}
+    >
+      {pttMode === 'latched' ? 'TX 🔒' : pttMode === 'held' ? 'TX' : 'PTT'}
+    </button>
 
     <div class="tx-button-grid">
       {#if showTuner}

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -85,8 +85,8 @@ export function makeVfoHandlers() {
         const mainSnap: Partial<ReceiverState> = {};
         const subSnap: Partial<ReceiverState> = {};
         for (const f of _MAIN_SUB_EQUALIZE_FIELDS) {
-          mainSnap[f] = s.sub[f];
-          subSnap[f] = s.main[f];
+          Object.assign(mainSnap, { [f]: s.sub[f] });
+          Object.assign(subSnap, { [f]: s.main[f] });
         }
         patchReceiver(0, mainSnap);
         patchReceiver(1, subSnap);
@@ -102,7 +102,7 @@ export function makeVfoHandlers() {
       if (s?.main) {
         const snap: Partial<ReceiverState> = {};
         for (const f of _MAIN_SUB_EQUALIZE_FIELDS) {
-          snap[f] = s.main[f];
+          Object.assign(snap, { [f]: s.main[f] });
         }
         patchReceiver(1, snap);
       }

--- a/frontend/src/lib/media/__tests__/media-session.test.ts
+++ b/frontend/src/lib/media/__tests__/media-session.test.ts
@@ -183,9 +183,8 @@ describe('media-session', () => {
 
     // All handlers should be cleared (set to null)
     const setHandler = navigator.mediaSession.setActionHandler as ReturnType<typeof vi.fn>;
-    const nullCalls = setHandler.mock.calls.filter(
-      (call: [string, MediaSessionActionHandler | null]) => call[1] === null,
-    );
+    const calls = setHandler.mock.calls as Array<[string, MediaSessionActionHandler | null]>;
+    const nullCalls = calls.filter((call) => call[1] === null);
     expect(nullCalls.length).toBe(4);
     expect(mockAudio.oscillator.stop).toHaveBeenCalled();
     expect(mockAudio.ctx.close).toHaveBeenCalled();

--- a/frontend/src/lib/types/protocol.ts
+++ b/frontend/src/lib/types/protocol.ts
@@ -29,11 +29,12 @@ export type WsIncoming =
   | { type: 'hello'; proto: number; server: string; version: string; radio: string; connected: boolean; capabilities: string[] }
   | { type: 'state'; data: Record<string, unknown> }
   | { type: 'state_update'; data: Record<string, unknown> }
+  | { type: 'companion_state'; tuning_step_hz?: number; [key: string]: unknown }
   | { type: 'event'; name?: string; event?: string; data?: Record<string, unknown>; connected?: boolean; radio_ready?: boolean };
 
 // Incoming: server → client (base interface for typed sub-interfaces)
 export interface WsMessage {
-  type: 'dx_spot' | 'dx_spots' | 'notification' | 'ack' | 'error' | 'response' | 'hello' | 'state' | 'state_update' | 'event';
+  type: 'dx_spot' | 'dx_spots' | 'notification' | 'ack' | 'error' | 'response' | 'hello' | 'state' | 'state_update' | 'companion_state' | 'event';
   [key: string]: unknown;
 }
 

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -77,5 +77,5 @@ export function resolvePersistedSkinId(id: PersistedSkinId): SkinId {
 }
 
 export async function loadSkin(id: SkinId): Promise<Component> {
-  return (await SKIN_LOADERS[id]).default;
+  return (await SKIN_LOADERS[id]()).default;
 }


### PR DESCRIPTION
## Summary

Final code cluster of #1369 frontend tech-debt sweep. After this lands, `npm run check` runs **clean** (0 errors); only Cluster F (#1375 — CI gating) remains to actually enforce it going forward.

## Per-error fixes

| # | File | Line | Fix |
|---|---|---|---|
| 1 | `command-bus.ts` | 88, 89, 105 | `Object.assign(obj, {[f]: v})` instead of indexed-write `obj[f] = v` (sidesteps `Partial<T>[union-key]` collapse to `undefined` without `as any`) |
| 2 | `protocol.ts` | (type source) | Added `'companion_state'` variant to `WsIncoming` and `WsMessage.type` — the type source was incomplete; the handler in `ws-client.ts:292` is real (RC-28 tuning-step injection) |
| 3 | `registry.ts` | 80 | `(await SKIN_LOADERS[id]()).default` — call the loader function before awaiting |
| 4 | `TxPanel.svelte` | 119 | Drop `{#if onPttOn}` wrapper — `onPttOn` is always defined after the self-wiring migration in #1370. Outer `{#if showTx}` still gates the panel |
| 5 | `BottomSheet.test.ts` | 20 | Cast legacy mount-style children via `as unknown as Snippet` — component prop type is correct (`Snippet`, zero-arg `{@render children()}`); test legitimately uses Svelte's internal anchor-mount API for DOM assertions |
| 6 | `media-session.test.ts` | 187 | Cast `mock.calls` to `Array<[string, MediaSessionActionHandler \| null]>` once, then filter with inferred parameter |

## Files breach note

6 files instead of the 3-file guardrail. Licensed by `patterns.md` #788/#1363:
- Production-code LOC well under 200 (+21 / −23 net)
- Each file has a single, non-overlapping responsibility (one error class per file)
- No unrelated refactoring, no `as any`, no `@ts-expect-error` silencing
- Per-error reasoning above is auditable

Splitting further into 3 PRs of 2 files each would be churn — these are mechanical micro-fixes, not interrelated.

## Verification

| Check | Before | After |
|---|---|---|
| `npm run check` | 8 errors / 8 files | **0 / 0 ✓** |
| `npx vitest run` | 1690 passed | 1690 passed (unchanged) |
| `npm run build` | OK | OK (clean) |

## Behaviour-change risk

- **TxPanel `{#if onPttOn}` removal:** verified `onPttOn` is unconditionally defined via `getTxHandlers()` post-#1370. The outer `{#if showTx}` still gates the entire panel. No user-visible change.
- **`'companion_state'` added to type source:** purely additive — existing handlers continue to work, new variant matches existing runtime handler in `ws-client.ts`. Does NOT enable a feature; documents one that was already running untyped.
- All other fixes are trivially type-only (cast, function-call, idiom swap).

Closes #1374