### PR TITLE
fix(#1375): gate npm run check + vitest in CI (Cluster F, closes #1369)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,24 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Build frontend
+      - name: Install frontend dependencies
         run: |
           cd frontend
           npm ci
+
+      - name: Frontend type-check
+        run: |
+          cd frontend
+          npm run check
+
+      - name: Frontend tests
+        run: |
+          cd frontend
+          npx vitest run
+
+      - name: Build frontend
+        run: |
+          cd frontend
           npm run build
           rm -f ../src/icom_lan/web/static
           mkdir -p ../src/icom_lan/web/static


### PR DESCRIPTION
## Summary

Final cluster of #1369 frontend tech-debt sweep. Adds two CI gates to `.github/workflows/test.yml` so the regressions that produced #1369 cannot land again:

- `npm run check` (svelte-check + tsc) — gates type errors
- `npx vitest run` — gates unit-test failures

After this PR, every push/PR to main must pass both before reaching the build step.

## Change shape

Splits the single existing `Build frontend` step into four:

```yaml
- Install frontend dependencies   (npm ci)
- Frontend type-check             (npm run check)   ← NEW
- Frontend tests                  (npx vitest run)  ← NEW
- Build frontend                  (npm run build + copy to web/static)
```

Each step appears separately in CI logs, so failures land on the obvious step name.

## Verification

- YAML valid (`yaml.safe_load` succeeds)
- All four step names present and in correct order
- Only `.github/workflows/test.yml` touched

## Why now

The earlier clusters (A–E) all landed because nothing in CI ran `npm run check` or `vitest`. With the codebase now clean (`npm run check` → 0 errors after #1376 #1377 #1378 #1379), this gate enforces that state. F was deliberately last in the sub-issue sequence so the gate didn't block its own remediation PRs.

## Closes #1369 too

After this PR merges, all 5 acceptance criteria of the parent #1369 are satisfied:

- [x] `npm run check` exits 0 (#1376, #1377, #1378, #1379)
- [x] `npx vitest run` exits 0 (was already green; #1373 closed as phantom)
- [x] CI gates `npm run check` and `vitest` (this PR)
- [x] No regressions in `vite build`
- [x] No behavior changes — verified per-fix in each sub-issue

## Scope

1 file, +15 / -1 LOC.

## Follow-up flag (not in scope)

`docs.yml` and `publish.yml` may also build the frontend on deploy/publish paths. They were left alone per scope, but worth checking whether a broken frontend could still ship through those — separate issue if so.

Closes #1375
Closes #1369