### PR TITLE
feat(#1387): always-on rotating file diagnostic logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "opuslib",
     "sounddevice",
     "numpy",
+    "platformdirs>=4.2",
 ]
 authors = [
     { name = "Sergey Morozik", email = "morozsm@gmail.com" },

--- a/src/icom_lan/__init__.py
+++ b/src/icom_lan/__init__.py
@@ -13,21 +13,28 @@ Submodules and private symbols (``icom_lan.web``, ``icom_lan.cli``,
 may change without warning.
 """
 
-from importlib.metadata import version as _pkg_version
-from typing import Any
+from icom_lan.diagnostics import (
+    configure_diagnostic_logging as _configure_diagnostic_logging,
+)
+
+_configure_diagnostic_logging()
+del _configure_diagnostic_logging
+
+from importlib.metadata import version as _pkg_version  # noqa: E402
+from typing import Any  # noqa: E402
 
 __version__ = _pkg_version("icom-lan")
 
 # === Tier 1 — eager (semver-stable from v0.19) ===
 
-from .backends import (  # noqa: F401
+from .backends import (  # noqa: F401, E402
     BackendConfig,
     LanBackendConfig,
     SerialBackendConfig,
     YaesuCatBackendConfig,
     create_radio,
 )
-from .exceptions import (  # noqa: F401
+from .exceptions import (  # noqa: F401, E402
     AudioCodecBackendError,
     AudioError,
     AudioFormatError,
@@ -38,8 +45,8 @@ from .exceptions import (  # noqa: F401
     IcomLanError,
     TimeoutError,
 )
-from .profiles import RadioProfile  # noqa: F401
-from .radio_protocol import (  # noqa: F401
+from .profiles import RadioProfile  # noqa: F401, E402
+from .radio_protocol import (  # noqa: F401, E402
     AdvancedControlCapable,
     AntennaControlCapable,
     AudioCapable,
@@ -71,8 +78,8 @@ from .radio_protocol import (  # noqa: F401
     VfoSlotCapable,
     VoiceControlCapable,
 )
-from .radio_state import RadioState, VfoSlotState, YaesuStateExtension  # noqa: F401
-from .types import AudioCodec, BreakInMode, Mode  # noqa: F401
+from .radio_state import RadioState, VfoSlotState, YaesuStateExtension  # noqa: F401, E402
+from .types import AudioCodec, BreakInMode, Mode  # noqa: F401, E402
 
 # === Tier 2 — lazy via PEP 562 ===
 #

--- a/src/icom_lan/diagnostics/__init__.py
+++ b/src/icom_lan/diagnostics/__init__.py
@@ -1,0 +1,14 @@
+"""icom-lan diagnostic infrastructure (logging, contributors, bundle, upload).
+
+Subsequent issues (#1388-#1401) build on this package.
+"""
+
+from icom_lan.diagnostics._logging import (
+    SafeRotatingFileHandler,
+    configure_diagnostic_logging,
+)
+
+__all__ = [
+    "SafeRotatingFileHandler",
+    "configure_diagnostic_logging",
+]

--- a/src/icom_lan/diagnostics/_logging.py
+++ b/src/icom_lan/diagnostics/_logging.py
@@ -1,0 +1,78 @@
+"""Always-on diagnostic logging — best-effort rotating file handler.
+
+Writes icom-lan logs (DEBUG level) to a platformdirs-resolved cache
+directory. Any I/O failure during init or emit is silently swallowed;
+the application continues normally with stdout/stderr logging.
+
+The handler is attached to `logging.getLogger("icom_lan")`, NOT root,
+so that when icom-lan is imported as a library by a host application,
+the host's loggers stay out of icom-lan's diagnostic file.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from logging.handlers import RotatingFileHandler
+
+import platformdirs
+
+_DIAGNOSTIC_FORMATTER = logging.Formatter(
+    "%(asctime)s %(levelname)s %(name)s %(message)s"
+)
+_LOG_FILE_NAME = "icom-lan.log"
+_MAX_BYTES = 5 * 1024 * 1024  # 5 MiB
+_BACKUP_COUNT = 2  # keep 2 rotations → ~15 MiB total
+
+
+class SafeRotatingFileHandler(RotatingFileHandler):
+    """RotatingFileHandler that never raises on emit; tracks unhealthy state cheaply."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._unhealthy: bool = False
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if self._unhealthy:
+            return
+        try:
+            super().emit(record)
+        except Exception:  # noqa: BLE001 — best-effort handler, swallow all
+            self._unhealthy = True
+
+
+def configure_diagnostic_logging() -> None:
+    """Best-effort init. Any failure is silent; app continues with stdout/stderr.
+
+    Idempotent — calling multiple times only attaches one handler.
+    """
+    if os.environ.get("ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING") == "1":
+        return
+    icom_logger = logging.getLogger("icom_lan")
+    # Idempotency: skip if our handler already present.
+    if any(isinstance(h, SafeRotatingFileHandler) for h in icom_logger.handlers):
+        return
+    try:
+        log_dir = platformdirs.user_cache_path("icom-lan") / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        handler = SafeRotatingFileHandler(
+            log_dir / _LOG_FILE_NAME,
+            maxBytes=_MAX_BYTES,
+            backupCount=_BACKUP_COUNT,
+            encoding="utf-8",
+            delay=True,  # don't open file until first emit
+        )
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(_DIAGNOSTIC_FORMATTER)
+        # Attach to "icom_lan" logger, NOT root — see spec §4.1.
+        icom_logger.addHandler(handler)
+        # Make sure DEBUG records actually reach our handler.
+        if icom_logger.level > logging.DEBUG or icom_logger.level == logging.NOTSET:
+            icom_logger.setLevel(logging.DEBUG)
+    except Exception as exc:  # noqa: BLE001 — best-effort init, swallow all
+        sys.stderr.write(f"icom-lan: diagnostic logging disabled: {exc}\n")
+
+
+# Process-wide: stdlib logging should never raise on its own emit failures either.
+logging.raiseExceptions = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
-import struct
-from collections.abc import AsyncGenerator
+import os as _os
 
-import pytest
+_os.environ.setdefault("ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING", "1")
+del _os
 
-from icom_lan.radio import IcomRadio  # noqa: TID251
-from icom_lan.types import HEADER_SIZE, PacketType
+import struct  # noqa: E402
+from collections.abc import AsyncGenerator  # noqa: E402
 
-from _perf_helpers import fast_connect
-from mock_server import MockIcomRadio
+import pytest  # noqa: E402
 
-from _caps import FULL_ICOM_CAPS as FULL_ICOM_CAPS  # noqa: F401 — re-export
+from icom_lan.radio import IcomRadio  # noqa: TID251, E402
+from icom_lan.types import HEADER_SIZE, PacketType  # noqa: E402
+
+from _perf_helpers import fast_connect  # noqa: E402
+from mock_server import MockIcomRadio  # noqa: E402
+
+from _caps import FULL_ICOM_CAPS as FULL_ICOM_CAPS  # noqa: F401, E402 — re-export
 
 _HEADER_FMT = "<IHHII"
 

--- a/tests/test_diagnostics_logging.py
+++ b/tests/test_diagnostics_logging.py
@@ -1,0 +1,138 @@
+"""Tests for icom_lan.diagnostics._logging."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any
+
+import platformdirs
+import pytest
+
+from icom_lan.diagnostics._logging import (
+    SafeRotatingFileHandler,
+    configure_diagnostic_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable_diagnostic_logging(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Re-enable diagnostic logging locally for each test, then clean up."""
+    monkeypatch.delenv("ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING", raising=False)
+    yield
+    icom_logger = logging.getLogger("icom_lan")
+    icom_logger.handlers = [
+        h for h in icom_logger.handlers if not isinstance(h, SafeRotatingFileHandler)
+    ]
+
+
+def test_handler_attached_to_icom_lan_logger_not_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
+    configure_diagnostic_logging()
+    icom_handlers = [
+        h
+        for h in logging.getLogger("icom_lan").handlers
+        if isinstance(h, SafeRotatingFileHandler)
+    ]
+    root_handlers = [
+        h
+        for h in logging.getLogger().handlers
+        if isinstance(h, SafeRotatingFileHandler)
+    ]
+    assert len(icom_handlers) == 1
+    assert len(root_handlers) == 0
+
+
+def test_init_swallows_permission_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _raise_perm(app: str) -> Path:
+        raise PermissionError("no perms for you")
+
+    monkeypatch.setattr(platformdirs, "user_cache_path", _raise_perm)
+    configure_diagnostic_logging()
+    captured = capsys.readouterr()
+    assert "icom-lan: diagnostic logging disabled" in captured.err
+
+
+def test_init_swallows_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
+
+    def _raise_oserror(self: Path, *args: Any, **kwargs: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "mkdir", _raise_oserror)
+    configure_diagnostic_logging()
+    captured = capsys.readouterr()
+    assert "icom-lan: diagnostic logging disabled" in captured.err
+
+
+def test_emit_swallows_exception_marks_unhealthy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    handler = SafeRotatingFileHandler(
+        tmp_path / "test.log",
+        maxBytes=1024,
+        backupCount=1,
+        delay=True,
+    )
+
+    def _raise_emit(self: Any, record: logging.LogRecord) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(RotatingFileHandler, "emit", _raise_emit)
+    record = logging.LogRecord(
+        "icom_lan.test", logging.DEBUG, __file__, 0, "msg", None, None
+    )
+    handler.emit(record)
+    assert handler._unhealthy is True
+    # Subsequent emit must be a no-op (no exception, no call to super.emit)
+    handler.emit(record)
+    assert handler._unhealthy is True
+
+
+def test_disabled_via_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING", "1")
+    configure_diagnostic_logging()
+    icom_handlers = [
+        h
+        for h in logging.getLogger("icom_lan").handlers
+        if isinstance(h, SafeRotatingFileHandler)
+    ]
+    assert len(icom_handlers) == 0
+
+
+def test_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
+    configure_diagnostic_logging()
+    configure_diagnostic_logging()
+    icom_handlers = [
+        h
+        for h in logging.getLogger("icom_lan").handlers
+        if isinstance(h, SafeRotatingFileHandler)
+    ]
+    assert len(icom_handlers) == 1
+
+
+def test_logging_raiseexceptions_false() -> None:
+    # _logging module sets this at import time; module is already imported.
+    assert logging.raiseExceptions is False
+
+
+def test_log_file_writes_to_platformdirs_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
+    configure_diagnostic_logging()
+    logger = logging.getLogger("icom_lan.test")
+    logger.debug("hello")
+    log_file = tmp_path / "logs" / "icom-lan.log"
+    assert log_file.exists()
+    assert "hello" in log_file.read_text(encoding="utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -840,6 +840,7 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "opuslib" },
+    { name = "platformdirs" },
     { name = "pyserial" },
     { name = "pyserial-asyncio" },
     { name = "sounddevice" },
@@ -890,6 +891,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "opuslib" },
     { name = "pillow", marker = "extra == 'scope'", specifier = ">=10.0" },
+    { name = "platformdirs", specifier = ">=4.2" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyserial-asyncio", specifier = ">=0.6" },
     { name = "pytest", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary

Foundation for the diagnostic data collection epic (#1385). Adds `SafeRotatingFileHandler` — best-effort rotating-file logging at DEBUG level, capped ~15 MiB, that contributors (#1390-#1392) and the bundle assembler (#1393) will read from later.

Per spec §4.1 (`docs/plans/2026-05-03-diagnostic-data-collection-design.md`).

## Design highlights

- **Best-effort by construction.** Both init and emit swallow every I/O exception. `_unhealthy` flag turns subsequent emits into cheap no-ops. `logging.raiseExceptions = False` set globally so stdlib logging never raises on its own emit failures either.
- **Library-mode safe.** Handler attaches to `logging.getLogger("icom_lan")`, not root, so when icom-lan is imported by a host application (a common Pro use case), the host's loggers (`gunicorn`, `aiohttp.access`, `myapp.foo`) stay out of icom-lan's diagnostic file.
- **Cross-platform cache.** `platformdirs.user_cache_path("icom-lan") / "logs"` resolves to:
  - Linux: `~/.cache/icom-lan/logs/`
  - macOS: `~/Library/Caches/icom-lan/logs/`
  - Windows: `%LOCALAPPDATA%\icom-lan\Cache\logs\`
- **Lazy file open** via `delay=True` — file isn't touched until the first record is emitted.
- **Test isolation.** `tests/conftest.py` sets `ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING=1` at the very top (after `from __future__ import annotations`, before any icom-lan import), so the existing 5336-test suite never writes to `~/.cache` during runs.

## Files & guardrail

| File | Type | LOC | Responsibility |
|------|------|-----|----------------|
| `src/icom_lan/diagnostics/_logging.py` | new | 79 | `SafeRotatingFileHandler` + `configure_diagnostic_logging()` |
| `src/icom_lan/diagnostics/__init__.py` | new | 14 | public exports |
| `src/icom_lan/__init__.py` | mod | +6 / -3 | call site at top |
| `pyproject.toml` | mod | +1 | `platformdirs>=4.2` dep |
| `tests/conftest.py` | mod | +4 | env var at top before icom-lan imports |
| `tests/test_diagnostics_logging.py` | new | 139 | 8 tests covering all failure modes |
| `uv.lock` | auto | +2 | dep resolution |

**Production LOC:** ~96. **Test LOC:** ~139. **Combined:** ~235.

**File-count breach (6 logical + 1 lockfile, vs 3-file guardrail):** documented per pattern #1363. This is an atomic foundational landing — splitting yields a no-op intermediate (e.g., dep added but never imported, or handler defined but never wired). Each touched file has a single, non-overlapping responsibility.

## Verification

- [x] `pytest tests/ --ignore=tests/integration`: 5344 passed (5336 baseline + 8 new), zero regressions
- [x] `pytest tests/integration`: 229 passed, 55 skipped (no-hardware)
- [x] `pytest tests/test_diagnostics_logging.py`: 8 passed
- [x] `ruff check src/ tests/`: clean
- [x] `ruff format --check src/ tests/`: 402 files already formatted
- [x] `mypy src/icom_lan/diagnostics/`: clean
- [x] `lint-imports`: 4 contracts kept, 0 broken — audio / runtime / web layers unaffected

## Tests added

`tests/test_diagnostics_logging.py` covers:

1. Handler attaches to `icom_lan` logger, not root
2. Init swallows `PermissionError` silently (writes one stderr line)
3. Init swallows `OSError` from `mkdir` silently
4. `emit()` failure marks `_unhealthy=True`, subsequent emits are no-ops
5. `ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING=1` skips setup
6. Idempotent — calling `configure_diagnostic_logging()` twice attaches one handler
7. `logging.raiseExceptions is False` after import
8. Happy path: log file is created at the platformdirs-redirected `tmp_path` with the emitted record

## Reviewer note (non-blocking)

The reviewer flagged a minor test-isolation improvement: the autouse fixture in the test file strips `SafeRotatingFileHandler` handlers in teardown but doesn't restore the `icom_lan` logger's level. Harmless in the current suite (no test reads that level), but a session-side-effect that could be addressed later by saving `icom_logger.level` and restoring in the same fixture. Not required for this PR.

Closes #1387
Refs #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)