### PR TITLE
feat(#1389): DiagnosticContributor protocol + entry-points discovery + runtime register

### DIFF
--- a/src/icom_lan/diagnostics/__init__.py
+++ b/src/icom_lan/diagnostics/__init__.py
@@ -3,12 +3,18 @@
 Subsequent issues (#1388-#1401) build on this package.
 """
 
+from icom_lan.diagnostics._discovery import discover, register
 from icom_lan.diagnostics._logging import (
     SafeRotatingFileHandler,
     configure_diagnostic_logging,
 )
+from icom_lan.diagnostics.contributor import BundleContext, DiagnosticContributor
 
 __all__ = [
+    "BundleContext",
+    "DiagnosticContributor",
     "SafeRotatingFileHandler",
     "configure_diagnostic_logging",
+    "discover",
+    "register",
 ]

--- a/src/icom_lan/diagnostics/_discovery.py
+++ b/src/icom_lan/diagnostics/_discovery.py
@@ -1,0 +1,85 @@
+"""Diagnostic contributor discovery — built-in + entry points + runtime register."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from icom_lan.diagnostics.contributor import DiagnosticContributor
+
+logger = logging.getLogger(__name__)
+
+_ENTRY_POINT_GROUP = "icom_lan.diagnostics"
+
+# Built-in contributors are populated by #1390-#1392 (this issue ships an empty list).
+_BUILT_IN_CONTRIBUTORS: list[type["DiagnosticContributor"]] = []
+
+_RUNTIME_REGISTERED: list[type["DiagnosticContributor"]] = []
+
+
+def register(contributor_cls: type["DiagnosticContributor"]) -> None:
+    """Programmatically register a contributor (for testing or dynamic plugins).
+
+    Runtime-registered contributors win over entry points and built-ins
+    when names collide.
+    """
+    _RUNTIME_REGISTERED.append(contributor_cls)
+
+
+def discover() -> list["DiagnosticContributor"]:
+    """Return contributor instances (built-in + entry-point + runtime), dedup by ``name``.
+
+    Precedence (last wins on name collision):
+        built-in  <  entry-point  <  runtime-registered
+    """
+    instances: dict[str, DiagnosticContributor] = {}
+
+    for cls in _BUILT_IN_CONTRIBUTORS:
+        try:
+            inst = cls()
+            instances[inst.name] = inst
+        except Exception:
+            logger.warning(
+                "diagnostics: failed to instantiate built-in contributor %s",
+                cls.__name__,
+                exc_info=True,
+            )
+
+    eps: Iterable[importlib.metadata.EntryPoint]
+    try:
+        eps = importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP)
+    except Exception:
+        logger.warning(
+            "diagnostics: failed to enumerate entry points %s",
+            _ENTRY_POINT_GROUP,
+            exc_info=True,
+        )
+        eps = ()
+
+    for ep in eps:
+        try:
+            cls = ep.load()
+            inst = cls()
+            instances[inst.name] = inst
+        except Exception:
+            logger.warning(
+                "diagnostics: failed to load entry point %s",
+                ep.name,
+                exc_info=True,
+            )
+
+    for cls in _RUNTIME_REGISTERED:
+        try:
+            inst = cls()
+            instances[inst.name] = inst
+        except Exception:
+            logger.warning(
+                "diagnostics: failed to instantiate runtime-registered %s",
+                cls.__name__,
+                exc_info=True,
+            )
+
+    return list(instances.values())

--- a/src/icom_lan/diagnostics/contributor.py
+++ b/src/icom_lan/diagnostics/contributor.py
@@ -1,0 +1,49 @@
+"""Diagnostic contributor protocol and bundle context."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DiagnosticContributor(Protocol):
+    """A pluggable source of diagnostic data.
+
+    Discovered by the bundle generator via setuptools entry points
+    (``icom_lan.diagnostics`` group) or runtime ``register()``.
+
+    Implementations should be cheap to instantiate (no heavy work in
+    ``__init__``) and idempotent on ``contribute()``.
+    """
+
+    name: str
+
+    def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+        """Write diagnostic data files into ``output_dir``.
+
+        May raise on recoverable failure; the bundler logs to
+        ``manifest.warnings`` and continues with other contributors.
+        """
+
+
+@dataclass(frozen=True)
+class BundleContext:
+    """Read-only context handed to every contributor.
+
+    ``radio`` is typed as ``Any | None`` to avoid a circular import
+    between ``icom_lan.diagnostics`` and ``icom_lan.runtime`` /
+    ``icom_lan.radio_protocol``. Contributors that need radio-specific
+    behaviour do ``isinstance(ctx.radio, AudioCapable)`` themselves.
+    """
+
+    radio: Any | None
+    config_dir: Path
+    log_dir: Path
+    user_description: str | None
+    issue_ref: str | None
+    contact_email: str | None
+    contact_callsign: str | None
+    submission_id: str
+    generated_at_unix: int

--- a/tests/test_diagnostics_contributor.py
+++ b/tests/test_diagnostics_contributor.py
@@ -1,0 +1,218 @@
+"""Tests for ``icom_lan.diagnostics`` contributor protocol and discovery."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from icom_lan.diagnostics import (
+    BundleContext,
+    DiagnosticContributor,
+    discover,
+    register,
+)
+from icom_lan.diagnostics import _discovery
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime_registered() -> Any:
+    """Ensure runtime-registered contributors don't leak between tests."""
+    _discovery._RUNTIME_REGISTERED.clear()
+    yield
+    _discovery._RUNTIME_REGISTERED.clear()
+
+
+def _make_ctx(**overrides: Any) -> BundleContext:
+    base: dict[str, Any] = {
+        "radio": None,
+        "config_dir": Path("/tmp/cfg"),
+        "log_dir": Path("/tmp/log"),
+        "user_description": None,
+        "issue_ref": None,
+        "contact_email": None,
+        "contact_callsign": None,
+        "submission_id": "sub-123",
+        "generated_at_unix": 1700000000,
+    }
+    base.update(overrides)
+    return BundleContext(**base)
+
+
+class _CompliantContributor:
+    name = "compliant"
+
+    def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+        return None
+
+
+class _MissingNameContributor:
+    def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+        return None
+
+
+def test_protocol_runtime_checkable_accepts_compliant_class() -> None:
+    obj = _CompliantContributor()
+    assert isinstance(obj, DiagnosticContributor)
+
+
+def test_protocol_rejects_missing_attributes() -> None:
+    obj = _MissingNameContributor()
+    assert not isinstance(obj, DiagnosticContributor)
+
+
+def test_bundle_context_is_frozen() -> None:
+    ctx = _make_ctx()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ctx.submission_id = "other"  # type: ignore[misc]
+
+
+def test_bundle_context_is_hashable() -> None:
+    ctx = _make_ctx()
+    bucket = {ctx: "ok"}
+    assert bucket[ctx] == "ok"
+
+
+def test_register_appends_runtime_contributor() -> None:
+    register(_CompliantContributor)
+    found = discover()
+    assert any(isinstance(c, _CompliantContributor) for c in found)
+
+
+def test_discover_dedupes_by_name() -> None:
+    class A:
+        name = "dup"
+
+        def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+            return None
+
+    class B:
+        name = "dup"
+
+        def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+            return None
+
+    register(A)
+    register(B)
+    found = discover()
+    dups = [c for c in found if c.name == "dup"]
+    assert len(dups) == 1
+    assert isinstance(dups[0], B)
+
+
+def test_discover_includes_entry_points(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FromEp:
+        name = "from-ep"
+
+        def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+            return None
+
+    class _FakeEP:
+        name = "ep-fake"
+
+        def load(self) -> type:
+            return FromEp
+
+    def fake_entry_points(*, group: str) -> tuple[Any, ...]:
+        assert group == _discovery._ENTRY_POINT_GROUP
+        return (_FakeEP(),)
+
+    monkeypatch.setattr(
+        _discovery.importlib.metadata, "entry_points", fake_entry_points
+    )
+
+    found = discover()
+    assert any(isinstance(c, FromEp) for c in found)
+
+
+def test_discover_swallows_entry_point_load_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class GoodEpClass:
+        name = "good"
+
+        def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+            return None
+
+    class _BadEP:
+        name = "bad-ep"
+
+        def load(self) -> type:
+            raise RuntimeError("boom")
+
+    class _GoodEP:
+        name = "good-ep"
+
+        def load(self) -> type:
+            return GoodEpClass
+
+    def fake_entry_points(*, group: str) -> tuple[Any, ...]:
+        return (_BadEP(), _GoodEP())
+
+    monkeypatch.setattr(
+        _discovery.importlib.metadata, "entry_points", fake_entry_points
+    )
+
+    found = discover()
+    assert any(isinstance(c, GoodEpClass) for c in found)
+
+
+def test_discover_swallows_instantiation_error() -> None:
+    class Boom:
+        name = "boom"
+
+        def __init__(self) -> None:
+            raise RuntimeError("nope")
+
+        def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+            return None
+
+    class Ok:
+        name = "ok"
+
+        def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+            return None
+
+    register(Boom)
+    register(Ok)
+    found = discover()
+    names = {c.name for c in found}
+    assert "ok" in names
+    assert "boom" not in names
+
+
+def test_discover_precedence_runtime_wins_over_entry_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FromEp:
+        name = "shared"
+
+        def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+            return None
+
+    class FromRuntime:
+        name = "shared"
+
+        def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+            return None
+
+    class _FakeEP:
+        name = "ep"
+
+        def load(self) -> type:
+            return FromEp
+
+    def fake_entry_points(*, group: str) -> tuple[Any, ...]:
+        return (_FakeEP(),)
+
+    monkeypatch.setattr(
+        _discovery.importlib.metadata, "entry_points", fake_entry_points
+    )
+    register(FromRuntime)
+
+    found = discover()
+    shared = [c for c in found if c.name == "shared"]
+    assert len(shared) == 1
+    assert isinstance(shared[0], FromRuntime)


### PR DESCRIPTION
## Summary

Foundation contract layer for the diagnostic data collection epic (#1385). Defines the protocol and discovery mechanism that:

- **#1390-#1392** (built-in contributors) implement.
- **#1393** (bundle assembler) consumes via `discover()`.
- **icom-lan-pro** plugs into via setuptools entry points (`icom_lan.diagnostics` group).

Per spec §4.2 + §4.3 (`docs/plans/2026-05-03-diagnostic-data-collection-design.md`).

## Public API added

```python
@runtime_checkable
class DiagnosticContributor(Protocol):
    name: str
    def contribute(self, ctx: BundleContext, output_dir: Path) -> None: ...

@dataclass(frozen=True)
class BundleContext:
    radio: Any | None              # avoid circular import with icom_lan.runtime
    config_dir: Path
    log_dir: Path
    user_description: str | None
    issue_ref: str | None
    contact_email: str | None
    contact_callsign: str | None
    submission_id: str
    generated_at_unix: int

def register(cls: type[DiagnosticContributor]) -> None: ...
def discover() -> list[DiagnosticContributor]: ...
```

## Discovery semantics

- Three sources: built-in (`_BUILT_IN_CONTRIBUTORS` — empty here, populated by #1390-#1392), setuptools entry points (`icom_lan.diagnostics`), runtime `register()`.
- Dedup by `name`. Precedence: built-in → entry-points → runtime-registered (last wins).
- Per-contributor `try/except` so one broken plug-in doesn't crash discovery.
- Entry-point group `icom_lan.diagnostics` is the public extension surface; Pro adds:
  ```toml
  [project.entry-points."icom_lan.diagnostics"]
  pro_tauri_logs = "icom_lan_pro.diagnostics:ProTauriLogsContributor"
  ```

## Files & guardrail

| File | Type | LOC | Responsibility |
|------|------|-----|----------------|
| `src/icom_lan/diagnostics/contributor.py` | new | 47 | Protocol + BundleContext types |
| `src/icom_lan/diagnostics/_discovery.py` | new | 86 | discover() + register() + dedup |
| `src/icom_lan/diagnostics/__init__.py` | mod | +6 | new exports alongside #1387 |
| `tests/test_diagnostics_contributor.py` | new | 218 | 10 tests |

**Production LOC:** ~139. **Test LOC:** ~218.

**File-count breach (4 logical, vs 3-file guardrail):** documented per pattern #1363 — atomic foundation landing, each file has a single non-overlapping responsibility (types vs discovery vs exports vs tests). Splitting yields a no-op intermediate (e.g., types defined but no discovery using them).

## Verification

- [x] `pytest tests/ --ignore=tests/integration`: 5354 passed (5344 baseline +10), zero regressions
- [x] `pytest tests/integration`: 229 passed, 55 skipped (no-hardware)
- [x] `pytest tests/test_diagnostics_contributor.py`: 10 passed
- [x] `ruff check`: clean
- [x] `ruff format --check`: 405 files already formatted
- [x] `mypy src/icom_lan/diagnostics/`: clean
- [x] `lint-imports`: 4 contracts kept, 0 broken

## Tests

10 cases:
1. Protocol `runtime_checkable` accepts compliant class
2. Protocol rejects class missing `name` attribute
3. `BundleContext` is frozen (raises on mutation)
4. `BundleContext` is hashable (usable as dict key)
5. `register()` round-trip through `discover()`
6. `discover()` dedupes by `name`
7. `discover()` includes entry points (monkeypatched)
8. `discover()` swallows entry-point load error
9. `discover()` swallows runtime contributor instantiation error
10. Precedence: runtime wins over entry-point on `name` collision

Autouse fixture clears `_RUNTIME_REGISTERED` both before and after each test → no order dependency.

## Layer boundaries

`diagnostics/` continues to depend only on stdlib (and `platformdirs` from #1387). No imports from `audio/`, `runtime/`, `web/`, etc. `BundleContext.radio: Any | None` is the deliberate workaround — contributors do `isinstance(ctx.radio, AudioCapable)` themselves.

Closes #1389
Refs #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)