### PR TITLE
feat(#1388): PII redaction utilities (paths, IPs, credentials, tokens)

### DIFF
--- a/src/icom_lan/diagnostics/__init__.py
+++ b/src/icom_lan/diagnostics/__init__.py
@@ -9,12 +9,24 @@ from icom_lan.diagnostics._logging import (
     configure_diagnostic_logging,
 )
 from icom_lan.diagnostics.contributor import BundleContext, DiagnosticContributor
+from icom_lan.diagnostics.redaction import (
+    REDACTORS,
+    redact_credentials,
+    redact_ips,
+    redact_paths,
+    redact_tokens,
+)
 
 __all__ = [
+    "REDACTORS",
     "BundleContext",
     "DiagnosticContributor",
     "SafeRotatingFileHandler",
     "configure_diagnostic_logging",
     "discover",
+    "redact_credentials",
+    "redact_ips",
+    "redact_paths",
+    "redact_tokens",
     "register",
 ]

--- a/src/icom_lan/diagnostics/redaction.py
+++ b/src/icom_lan/diagnostics/redaction.py
@@ -1,0 +1,166 @@
+"""PII redaction utilities for diagnostic bundles.
+
+Module-level regex patterns for safety: pre-compiled, no per-call cost.
+Each redactor is a pure function: input string → scrubbed output string.
+
+Used by built-in contributors and exported for Pro extensions.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+
+# --- Paths ----------------------------------------------------------
+
+# /Users/<user>/...  (macOS), /home/<user>/...  (Linux), C:\Users\<user>\...  (Windows).
+# Negative lookbehind `(?<![/:\w])` skips URL contexts (e.g. ``https://.../Users/...``)
+# and avoids matching ``/Users`` when preceded by ``/``, ``:`` or a word character.
+_PATH_UNIX = re.compile(r"(?<![/:\w])(/(?:Users|home))/[^/\s\"']+")
+_PATH_WIN = re.compile(r"([A-Za-z]:\\Users\\)[^\\\s\"']+", re.IGNORECASE)
+
+
+def redact_paths(text: str) -> str:
+    """Replace home-directory prefixes with ``<USER>``.
+
+    Examples
+    --------
+    /Users/moroz/foo  →  /Users/<USER>/foo
+    /home/sergey/bar  →  /home/<USER>/bar
+    C:\\Users\\Bob\\baz → C:\\Users\\<USER>\\baz
+    """
+    if not text:
+        return ""
+    text = _PATH_UNIX.sub(r"\1/<USER>", text)
+    text = _PATH_WIN.sub(r"\1<USER>", text)
+    return text
+
+
+# --- IP addresses ---------------------------------------------------
+
+# IPv4 octets (0-255). RFC 1918 + loopback are kept (radio LAN address).
+_IPV4 = re.compile(
+    r"\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b"
+)
+# Permissive IPv6 candidate matcher. We then validate via ``ipaddress`` —
+# the regex only finds plausible substrings (``::``-compressed and full forms);
+# stdlib determines if it's a real address and whether it's private/loopback.
+_IPV6 = re.compile(
+    r"\b(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{0,4}){2,7})\b"
+    r"|"
+    r"\b(?:[A-Fa-f0-9]{1,4}:){1,7}:(?:[A-Fa-f0-9]{1,4})?\b"
+    r"|"
+    r"\b::(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4})*)?\b"
+)
+
+_RFC1918_PREFIXES = ("10.", "192.168.", "127.")
+# 172.16.x – 172.31.x
+_RFC1918_172 = re.compile(r"^172\.(1[6-9]|2\d|3[01])\.")
+
+# IPv6 ULA range (fc00::/7 covers fd00::/8 and fc00::/8). Loopback ``::1`` and
+# link-local ``fe80::/10`` are detected via ``IPv6Address.is_loopback`` /
+# ``is_link_local``. We deliberately do NOT use ``is_private`` because Python's
+# stdlib classifies the RFC 3849 documentation range ``2001:db8::/32`` as
+# private; for diagnostic redaction those are public-shaped and must redact.
+_ULA_V6 = ipaddress.IPv6Network("fc00::/7")
+
+
+def _is_private_ipv4(ip: str) -> bool:
+    if any(ip.startswith(p) for p in _RFC1918_PREFIXES):
+        return True
+    return bool(_RFC1918_172.match(ip))
+
+
+def redact_ips(text: str) -> str:
+    """Replace public IPv4/IPv6 addresses with ``<IP>``; keep private/LAN.
+
+    RFC 1918 private (10/8, 172.16/12, 192.168/16), loopback (127.x),
+    and IPv6 link-local (fe80::/10) / ULA (fd::/8) / loopback (::1) are
+    kept — they're the radio's address and the local network, useful
+    for triage.
+    """
+    if not text:
+        return ""
+
+    def _v4(match: re.Match[str]) -> str:
+        ip = match.group(0)
+        return ip if _is_private_ipv4(ip) else "<IP>"
+
+    def _v6(match: re.Match[str]) -> str:
+        candidate = match.group(0)
+        try:
+            addr = ipaddress.ip_address(candidate)
+        except ValueError:
+            return candidate  # not a valid IP — leave it alone
+        if not isinstance(addr, ipaddress.IPv6Address):
+            return candidate
+        if addr.is_loopback or addr.is_link_local or addr in _ULA_V6:
+            return candidate
+        return "<IP>"
+
+    text = _IPV4.sub(_v4, text)
+    text = _IPV6.sub(_v6, text)
+    return text
+
+
+# --- Credentials ----------------------------------------------------
+
+# password=, pwd=, passwd= (case-insensitive). Match value up to whitespace or end.
+_PASSWORD_KV = re.compile(r"\b(passw(?:ord|d)?|pwd)\s*[=:]\s*\S+", re.IGNORECASE)
+# Authorization: Bearer <token>
+_BEARER = re.compile(r"\b(Authorization\s*:\s*Bearer)\s+\S+", re.IGNORECASE)
+# AWS keys
+_AWS_KEY = re.compile(
+    r"\b(aws_(?:access_key_id|secret_access_key))\s*[=:]\s*\S+",
+    re.IGNORECASE,
+)
+# Raw activation codes (per license-authority-v0)
+_ACTIVATION_CODE = re.compile(r"\bcode_[A-Z0-9]{26}\b")
+# PEM private key blocks
+_PRIVATE_KEY_BLOCK = re.compile(
+    r"-----BEGIN (?:RSA |EC |OPENSSH |PGP |DSA |ENCRYPTED )?PRIVATE KEY-----"
+    r"[\s\S]*?"
+    r"-----END (?:RSA |EC |OPENSSH |PGP |DSA |ENCRYPTED )?PRIVATE KEY-----",
+)
+
+
+def redact_credentials(text: str) -> str:
+    """Redact passwords, AWS keys, Bearer tokens, activation codes, PEM keys."""
+    if not text:
+        return ""
+    text = _PASSWORD_KV.sub(r"\1=<REDACTED>", text)
+    text = _BEARER.sub(r"\1 <REDACTED>", text)
+    text = _AWS_KEY.sub(r"\1=<REDACTED>", text)
+    text = _ACTIVATION_CODE.sub("<ACTIVATION_CODE>", text)
+    text = _PRIVATE_KEY_BLOCK.sub("<PRIVATE KEY REDACTED>", text)
+    return text
+
+
+# --- Tokens (high-entropy near trigger keywords) --------------------
+
+# token=..., api_key=..., apikey=..., or "Bearer XYZ" — high-entropy [A-Za-z0-9_-]{32,}.
+_TOKEN_KV = re.compile(
+    r"\b(token|api[_-]?key|apikey)\s*[=:]\s*[A-Za-z0-9_\-]{32,}",
+    re.IGNORECASE,
+)
+_BEARER_TOKEN = re.compile(r"\bBearer\s+[A-Za-z0-9_\-]{32,}")
+
+
+def redact_tokens(text: str) -> str:
+    """Redact high-entropy tokens near token=/api_key=/Bearer keywords."""
+    if not text:
+        return ""
+
+    def _kv(match: re.Match[str]) -> str:
+        return f"{match.group(1)}=<REDACTED>"
+
+    text = _TOKEN_KV.sub(_kv, text)
+    text = _BEARER_TOKEN.sub("Bearer <REDACTED>", text)
+    return text
+
+
+# --- Catalogue ------------------------------------------------------
+
+REDACTORS: tuple[str, ...] = ("paths", "ips", "credentials", "tokens")
+"""Names of the scrubbers run on a bundle, recorded in
+``manifest.redactions_applied``."""

--- a/tests/test_diagnostics_redaction.py
+++ b/tests/test_diagnostics_redaction.py
@@ -1,0 +1,260 @@
+"""Golden tests for icom-lan diagnostics redaction utilities (#1388)."""
+
+from __future__ import annotations
+
+import pytest
+
+from icom_lan.diagnostics.redaction import (
+    REDACTORS,
+    redact_credentials,
+    redact_ips,
+    redact_paths,
+    redact_tokens,
+)
+
+
+# --- Paths ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("/Users/moroz/foo", "/Users/<USER>/foo"),
+        ("/Users/jane.doe/Library/x", "/Users/<USER>/Library/x"),
+        ("path is /Users/admin/file.log here", "path is /Users/<USER>/file.log here"),
+    ],
+)
+def test_redact_paths_unix_macos(raw: str, expected: str) -> None:
+    assert redact_paths(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("/home/sergey/bar", "/home/<USER>/bar"),
+        ("/home/ubuntu/.config/foo", "/home/<USER>/.config/foo"),
+    ],
+)
+def test_redact_paths_unix_linux(raw: str, expected: str) -> None:
+    assert redact_paths(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (r"C:\Users\Bob\baz", r"C:\Users\<USER>\baz"),
+        (r"d:\users\Alice\Desktop", r"d:\users\<USER>\Desktop"),
+    ],
+)
+def test_redact_paths_windows(raw: str, expected: str) -> None:
+    assert redact_paths(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "/var/log/foo",
+        "/etc/hosts",
+        "/opt/icom-lan/bin",
+        "no path here at all",
+        "https://api.example.com/Users/profile/config",
+    ],
+)
+def test_redact_paths_no_false_positive(raw: str) -> None:
+    assert redact_paths(raw) == raw
+
+
+# --- IPv4 -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("8.8.8.8", "<IP>"),
+        ("connect to 1.1.1.1 now", "connect to <IP> now"),
+        ("203.0.113.5", "<IP>"),
+    ],
+)
+def test_redact_ipv4_public_redacted(raw: str, expected: str) -> None:
+    assert redact_ips(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "192.168.55.40",
+        "10.0.0.1",
+        "172.16.5.1",
+        "172.31.255.254",
+        "127.0.0.1",
+        "radio at 192.168.1.100 listening",
+    ],
+)
+def test_redact_ipv4_private_kept(raw: str) -> None:
+    assert redact_ips(raw) == raw
+
+
+# --- IPv6 -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Compressed (dominant real-world) forms.
+        ("2001:db8::1", "<IP>"),
+        ("2001:db8::2", "<IP>"),
+        ("address 2607:f8b0::200e here", "address <IP> here"),
+        # Fully-expanded 8-group forms.
+        ("2001:db8:0:0:0:0:0:1", "<IP>"),
+        (
+            "address 2607:f8b0:4005:80a:0:0:0:200e here",
+            "address <IP> here",
+        ),
+    ],
+)
+def test_redact_ipv6_public_redacted(raw: str, expected: str) -> None:
+    assert redact_ips(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "fe80::1",
+        "::1",
+        "fd00::1",
+        "fd12:3456:789a::1",
+    ],
+)
+def test_redact_ipv6_private_kept(raw: str) -> None:
+    assert redact_ips(raw) == raw
+
+
+# --- Credentials ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("password=secret123", "password=<REDACTED>"),
+        ("pwd=hunter2", "pwd=<REDACTED>"),
+        ("Passwd=anything", "Passwd=<REDACTED>"),
+        ("PASSWORD: topsecret", "PASSWORD=<REDACTED>"),
+    ],
+)
+def test_redact_credentials_password_kv(raw: str, expected: str) -> None:
+    assert redact_credentials(raw) == expected
+
+
+def test_redact_credentials_bearer() -> None:
+    raw = "Authorization: Bearer abc123def456ghi"
+    assert redact_credentials(raw) == "Authorization: Bearer <REDACTED>"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "aws_access_key_id=AKIAIOSFODNN7EXAMPLE",
+            "aws_access_key_id=<REDACTED>",
+        ),
+        (
+            "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "aws_secret_access_key=<REDACTED>",
+        ),
+    ],
+)
+def test_redact_credentials_aws_keys(raw: str, expected: str) -> None:
+    assert redact_credentials(raw) == expected
+
+
+def test_redact_credentials_activation_code() -> None:
+    raw = "license code_01JZ7F4YV7B2Q6G2K8Q7QY6S3H valid"
+    assert redact_credentials(raw) == "license <ACTIVATION_CODE> valid"
+
+
+def test_redact_credentials_private_key_block() -> None:
+    raw = (
+        "before\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdef\n"
+        "moreLines==\n"
+        "-----END RSA PRIVATE KEY-----\n"
+        "after"
+    )
+    expected = "before\n<PRIVATE KEY REDACTED>\nafter"
+    assert redact_credentials(raw) == expected
+
+
+# --- Tokens ---------------------------------------------------------
+
+
+def test_redact_tokens_kv() -> None:
+    raw = "token=AbCdEfGhIjKlMnOpQrStUvWxYz012345"
+    assert redact_tokens(raw) == "token=<REDACTED>"
+
+
+def test_redact_tokens_bearer() -> None:
+    raw = "Bearer AbCdEfGhIjKlMnOpQrStUvWxYz012345"
+    assert redact_tokens(raw) == "Bearer <REDACTED>"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "token=foo",
+        "api_key=short",
+        "apikey=tiny",
+        "Bearer abc",
+    ],
+)
+def test_redact_tokens_no_false_positive_short_value(raw: str) -> None:
+    assert redact_tokens(raw) == raw
+
+
+# --- REDACTORS catalogue -------------------------------------------
+
+
+def test_redactors_constant() -> None:
+    assert REDACTORS == ("paths", "ips", "credentials", "tokens")
+
+
+# --- Empty / None / idempotency ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "func",
+    [redact_paths, redact_ips, redact_credentials, redact_tokens],
+)
+def test_empty_input_returns_empty(func) -> None:  # type: ignore[no-untyped-def]
+    assert func("") == ""
+
+
+@pytest.mark.parametrize(
+    ("func", "raw"),
+    [
+        (redact_paths, "/Users/moroz/file"),
+        (redact_ips, "public 8.8.8.8 and lan 192.168.1.1"),
+        (redact_credentials, "password=secret"),
+        (redact_tokens, "token=AbCdEfGhIjKlMnOpQrStUvWxYz012345"),
+    ],
+)
+def test_idempotent(func, raw: str) -> None:  # type: ignore[no-untyped-def]
+    once = func(raw)
+    twice = func(once)
+    assert once == twice
+
+
+# --- Realistic log line --------------------------------------------
+
+
+def test_realistic_log_line_no_false_positive() -> None:
+    raw = (
+        "INFO icom_lan.audio: codec=PCM_2CH_16BIT freq=14074000 mode=USB "
+        "callsign=DL9EAC ip=192.168.55.40 device='IC-7610 USB Audio'"
+    )
+    out = raw
+    out = redact_paths(out)
+    out = redact_ips(out)
+    out = redact_credentials(out)
+    out = redact_tokens(out)
+    assert out == raw


### PR DESCRIPTION
## Summary

Pure-function content scrubbers used by the diagnostic bundle generator (epic #1385). Built-in contributors (#1390-#1392) and Pro extensions import these to redact sensitive content before it reaches a bundle. Per spec §4.5.

## Public API

```python
from icom_lan.diagnostics.redaction import (
    redact_paths,         # /Users/<name>/... → /Users/<USER>/...
    redact_ips,           # public v4/v6 → <IP>; RFC 1918 / loopback / link-local / ULA kept
    redact_credentials,   # passwords, Bearer, AWS keys, activation codes, PEM blocks
    redact_tokens,        # high-entropy values near token=/api_key=/Bearer
    REDACTORS,            # ("paths", "ips", "credentials", "tokens")
)
```

Also re-exported from `icom_lan.diagnostics` (top-level package).

## Notable design decisions

**IPv6 handled via `ipaddress.ip_address()` validation** rather than pure regex. The spec allowed expanded forms, but `2001:db8::1`-style compressed addresses are the dominant real-world representation. Permissive candidate regex feeds matches into stdlib `ipaddress` for correct classification across all forms.

**Spec contradiction resolution.** Python stdlib's `is_private` predicate flags `2001:db8::/32` (RFC 3849 documentation range) as private, which would conflict with the spec's intent to redact public addresses (the spec's own example was `2001:db8::1`). The keep-private predicate is therefore split: `is_loopback or is_link_local or addr in IPv6Network("fc00::/7")`. This precisely matches the spec's test cases. Rationale documented in source.

**URL guard on path redactor.** `_PATH_UNIX = (?<![/:\w])(/(?:Users|home))/...`. The negative lookbehind prevents matching `/Users` when preceded by `/`, `:`, or a word character — so `https://api.example.com/Users/profile/config` passes through unchanged, while `/Users/moroz/foo` redacts correctly.

## Files

| File | Type | LOC |
|------|------|-----|
| `src/icom_lan/diagnostics/redaction.py` | new | 152 |
| `src/icom_lan/diagnostics/__init__.py` | mod | +12 |
| `tests/test_diagnostics_redaction.py` | new | ~270 |

3 files (within ≤3 guardrail). Production LOC ~152.

## Verification

- [x] `pytest tests/test_diagnostics_redaction.py`: **55 parametrised cases pass**
- [x] `pytest tests/ --ignore=tests/integration`: **5409 passed** (5354 baseline +55 new), zero regressions
- [x] `pytest tests/integration`: 229 passed, 55 skipped
- [x] `ruff check`: clean
- [x] `ruff format --check`: 407 files already formatted
- [x] `mypy src/icom_lan/diagnostics/`: clean
- [x] `lint-imports`: 4 contracts kept, 0 broken

## Tests

20 named groups, 55 parametrised cases:

- **Paths:** macOS `/Users/`, Linux `/home/`, Windows `C:\Users\`. URL no-FP. Unrelated path no-FP.
- **IPs:** public IPv4 + IPv6 (compressed AND expanded) → `<IP>`. RFC 1918 + loopback + link-local + ULA kept (compressed forms tested).
- **Credentials:** `password=` keyword variants, `Bearer`, AWS keys, activation codes, PEM key blocks.
- **Tokens:** keyword-bound high-entropy. Short values pass through.
- **Cross-cutting:** idempotency (running twice = once), empty input, `REDACTORS` constant, realistic log line with frequency / callsign / model / private IP all preserved.

## Review iterations

Reviewer found a critical IPv6 bug in iteration 1: the original regex `(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}|::1\b|::\b` matched the trailing `::1` substring of public addresses like `2001:db8::1` and routed them through the loopback-keep branch — actively misclassifying public IPv6 as loopback. Iteration 2 replaces it with `ipaddress.ip_address()` validation. Tests restored to use compressed forms as primary inputs.

URL false positive in `_PATH_UNIX` and the corresponding dropped test were also fixed in iteration 2.

Closes #1388
Refs #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)