### PR TITLE
chore(#1385): address Codex review findings on diagnostic-data-collection PRs

### DIFF
--- a/docs/contracts/diagnostic-bundle-v1.md
+++ b/docs/contracts/diagnostic-bundle-v1.md
@@ -82,6 +82,7 @@ The anonymous tier sends no authentication headers.
 
 - `schema_version`
 - `submission_id`
+- `generated_at_unix` — bundle assembly time as Unix epoch seconds.
 - `app.name`
 - `app.version`
 - `platform.os`

--- a/src/icom_lan/diagnostics/_error_ring.py
+++ b/src/icom_lan/diagnostics/_error_ring.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import threading
 import time
 import traceback
 from collections import deque
@@ -77,18 +78,24 @@ def get_ring() -> ExceptionRing:
 
 
 _PREVIOUS_EXCEPTHOOK: Any = None
+_PREVIOUS_THREADING_EXCEPTHOOK: Any = None
 
 
 def install_hooks() -> None:
-    """Wire ``sys.excepthook`` to record into the global ring.
+    """Wire ``sys.excepthook`` and ``threading.excepthook`` into the global ring.
 
-    Idempotent — safe to call multiple times. Preserves the prior excepthook
-    so default reporting still happens.
+    Idempotent — safe to call multiple times. Preserves the prior hooks so
+    default reporting (stderr traceback, threading default) still happens.
+
+    ``threading.excepthook`` (PEP 565, Python 3.8+) is required to capture
+    uncaught exceptions raised in worker threads — they do NOT flow through
+    ``sys.excepthook``.
     """
-    global _PREVIOUS_EXCEPTHOOK
+    global _PREVIOUS_EXCEPTHOOK, _PREVIOUS_THREADING_EXCEPTHOOK
     if _PREVIOUS_EXCEPTHOOK is not None:
         return  # already installed
     _PREVIOUS_EXCEPTHOOK = sys.excepthook
+    _PREVIOUS_THREADING_EXCEPTHOOK = threading.excepthook
 
     def _hook(exc_type: type[BaseException], exc: BaseException, tb: Any) -> None:
         try:
@@ -98,13 +105,31 @@ def install_hooks() -> None:
         if _PREVIOUS_EXCEPTHOOK is not None:
             _PREVIOUS_EXCEPTHOOK(exc_type, exc, tb)
 
+    def _threading_hook(args: threading.ExceptHookArgs) -> None:
+        # ``threading.ExceptHookArgs`` is a named tuple of
+        # (exc_type, exc_value, exc_traceback, thread).
+        exc_type = args.exc_type
+        exc_value = args.exc_value
+        exc_tb = args.exc_traceback
+        try:
+            if exc_type is not None and exc_value is not None:
+                _GLOBAL_RING.record(exc_type, exc_value, exc_tb)
+        except Exception:
+            logger.warning("error_ring: threading record failed", exc_info=True)
+        if _PREVIOUS_THREADING_EXCEPTHOOK is not None:
+            _PREVIOUS_THREADING_EXCEPTHOOK(args)
+
     sys.excepthook = _hook
+    threading.excepthook = _threading_hook
 
 
 def uninstall_hooks() -> None:
-    """For tests — restore the previous excepthook."""
-    global _PREVIOUS_EXCEPTHOOK
+    """For tests — restore the previous ``sys`` and ``threading`` excepthooks."""
+    global _PREVIOUS_EXCEPTHOOK, _PREVIOUS_THREADING_EXCEPTHOOK
     if _PREVIOUS_EXCEPTHOOK is None:
         return
     sys.excepthook = _PREVIOUS_EXCEPTHOOK
     _PREVIOUS_EXCEPTHOOK = None
+    if _PREVIOUS_THREADING_EXCEPTHOOK is not None:
+        threading.excepthook = _PREVIOUS_THREADING_EXCEPTHOOK
+        _PREVIOUS_THREADING_EXCEPTHOOK = None

--- a/src/icom_lan/diagnostics/_logging.py
+++ b/src/icom_lan/diagnostics/_logging.py
@@ -67,8 +67,12 @@ def configure_diagnostic_logging() -> None:
         handler.setFormatter(_DIAGNOSTIC_FORMATTER)
         # Attach to "icom_lan" logger, NOT root — see spec §4.1.
         icom_logger.addHandler(handler)
-        # Make sure DEBUG records actually reach our handler.
-        if icom_logger.level > logging.DEBUG or icom_logger.level == logging.NOTSET:
+        # Only force DEBUG if the host application has not expressed an opinion
+        # (level == NOTSET). If the app has explicitly raised the level (e.g. to
+        # WARNING), respect it: only WARNING+ records reach the diagnostic file.
+        # The handler's own level is DEBUG, so any record the logger doesn't
+        # filter still hits the file — see spec §4.1.
+        if icom_logger.level == logging.NOTSET:
             icom_logger.setLevel(logging.DEBUG)
     except Exception as exc:  # noqa: BLE001 — best-effort init, swallow all
         sys.stderr.write(f"icom-lan: diagnostic logging disabled: {exc}\n")

--- a/src/icom_lan/diagnostics/bundle.py
+++ b/src/icom_lan/diagnostics/bundle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -40,6 +41,14 @@ def build_bundle(ctx: BundleContext, output_path: Path) -> Path:
                     "diagnostics: contributor %s failed: %r", contributor.name, exc
                 )
                 manifest.record_warning(contributor, repr(exc))
+                # Drop any partial files the contributor wrote before raising,
+                # so the bundle does not archive half-written / inconsistent
+                # output. Best-effort: cleanup failures are silent.
+                try:
+                    if contributor_dir.exists():
+                        shutil.rmtree(contributor_dir)
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    pass
 
         manifest.write(staging_dir / "manifest.json")
         return _zip_directory(staging_dir, output_path)

--- a/src/icom_lan/diagnostics/contributors/audio.py
+++ b/src/icom_lan/diagnostics/contributors/audio.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -20,16 +21,28 @@ def _safe_attr(obj: Any, name: str, default: Any = None) -> Any:
         return default
 
 
+# macOS device labels embed the local account name in parens, e.g.
+# ``"BlackHole 2ch (moroz's Mac)"`` or ``"... (Alice's MacBook Pro)"``.
+# Match the wrapping ``(... 's <Mac variant> ...)`` and replace with a
+# stable redacted token. The non-greedy class avoids spanning closing parens.
+_MACOS_USER_LABEL = re.compile(
+    r"\([^()]*?'s\s+(?:Mac|MacBook|iMac|Mini|Pro)\b[^()]*?\)",
+    re.IGNORECASE,
+)
+
+
 def _redact_device_name(name: str | None) -> str | None:
     """Redact OS-level device names that may embed usernames.
 
-    macOS device names often embed the OS username (e.g.,
-    ``"BlackHole 2ch (moroz's Mac)"``); apply :func:`redact_paths`
-    to also catch ``/Users/<name>`` if present.
+    macOS device names often embed the OS username — both as path-shaped
+    strings (``/Users/<name>``) and as freeform parenthetical labels
+    (``"(<name>'s Mac)"``). Apply both scrubbers so neither form leaks.
     """
     if name is None:
         return None
-    return redact_paths(name)
+    name = redact_paths(name)
+    name = _MACOS_USER_LABEL.sub("(<USER>'s Mac)", name)
+    return name
 
 
 class AudioContributor:

--- a/src/icom_lan/diagnostics/contributors/invocation.py
+++ b/src/icom_lan/diagnostics/contributors/invocation.py
@@ -50,9 +50,14 @@ def _filtered_env() -> dict[str, str]:
         if value is None:
             continue
         if key == "PATH":
+            # Redact each segment individually before re-joining: if we joined
+            # first, ``redact_paths``'s lookbehind ``(?<![/:\w])`` would skip
+            # every segment after the first ``:`` separator and leak
+            # ``/Users/<name>`` paths past the first entry.
             entries = value.split(os.pathsep)[:_PATH_ENTRY_LIMIT]
-            value = os.pathsep.join(entries)
-        out[key] = _redact_string(value)
+            out[key] = os.pathsep.join(_redact_string(entry) for entry in entries)
+        else:
+            out[key] = _redact_string(value)
     return out
 
 

--- a/src/icom_lan/diagnostics/contributors/radio.py
+++ b/src/icom_lan/diagnostics/contributors/radio.py
@@ -12,7 +12,12 @@ from icom_lan.core.radio_protocol import (
     StatePollable,
     UsbAudioCapable,
 )
-from icom_lan.diagnostics.redaction import redact_credentials, redact_ips, redact_paths
+from icom_lan.diagnostics.redaction import (
+    redact_credentials,
+    redact_hostnames,
+    redact_ips,
+    redact_paths,
+)
 
 if TYPE_CHECKING:
     from icom_lan.diagnostics.contributor import BundleContext
@@ -29,6 +34,19 @@ def _redact(s: str | None) -> str | None:
     if s is None:
         return None
     return redact_credentials(redact_ips(redact_paths(s)))
+
+
+def _redact_host(s: str | None) -> str | None:
+    """Host-field redactor: full chain plus hostname scrubbing.
+
+    ``redact_hostnames`` is intentionally NOT in the generic ``_redact`` chain
+    because it would over-redact common identifiers (``radio.json``,
+    ``IC-7610.fw``, etc.) on other fields. Apply only where DNS-shape values
+    are expected — the radio's ``host``/``_host`` connection field.
+    """
+    if s is None:
+        return None
+    return redact_credentials(redact_hostnames(redact_ips(redact_paths(s))))
 
 
 def _capabilities(radio: Any) -> list[str]:
@@ -73,8 +91,14 @@ class RadioContributor:
                 ),
                 "capabilities": _capabilities(radio),
                 "audio_codec": str(_safe_attr(radio, "audio_codec") or "unknown"),
-                "host": _redact(_safe_attr(radio, "host")),
-                "port": _safe_attr(radio, "port"),
+                # Live runtimes store connection info as ``_host``/``_port``
+                # (private attrs). Try public first for stub-friendliness,
+                # then fall back so an active LAN session reports its real
+                # endpoint.
+                "host": _redact_host(
+                    _safe_attr(radio, "host") or _safe_attr(radio, "_host")
+                ),
+                "port": _safe_attr(radio, "port") or _safe_attr(radio, "_port"),
             }
         text = json.dumps(payload, indent=2, sort_keys=True)
         (output_dir / "radio.json").write_text(text + "\n", encoding="utf-8")

--- a/src/icom_lan/diagnostics/redaction.py
+++ b/src/icom_lan/diagnostics/redaction.py
@@ -45,10 +45,17 @@ _IPV4 = re.compile(
 # Permissive IPv6 candidate matcher. We then validate via ``ipaddress`` —
 # the regex only finds plausible substrings (``::``-compressed and full forms);
 # stdlib determines if it's a real address and whether it's private/loopback.
+#
+# Boundary handling: trailing ``\b`` does NOT fire after a final ``:`` because
+# ``:`` is non-word — ``\b`` requires a word/non-word transition. Use
+# ``(?![\w:])`` instead so trailing-``::`` forms (``2001:db8::``,
+# ``2607:f8b0:4002::``) match in full without leaking. Without this, alt 1
+# greedily matched the leading ``2607:f8b0:4002`` prefix, which is not a
+# valid IP and was passed through unchanged.
 _IPV6 = re.compile(
-    r"\b(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{0,4}){2,7})\b"
+    r"\b(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{0,4}){2,7})(?![\w:])"
     r"|"
-    r"\b(?:[A-Fa-f0-9]{1,4}:){1,7}:(?:[A-Fa-f0-9]{1,4})?\b"
+    r"\b(?:[A-Fa-f0-9]{1,4}:){1,7}:(?:[A-Fa-f0-9]{1,4})?(?![\w:])"
     r"|"
     r"\b::(?:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4})*)?\b"
 )
@@ -159,8 +166,45 @@ def redact_tokens(text: str) -> str:
     return text
 
 
+# --- Hostnames ------------------------------------------------------
+
+# DNS-style names: 1+ labels of ASCII alnum/hyphen joined by dots, ending in
+# a 2–63-letter "TLD". ``localhost`` is preserved (not PII, useful for triage).
+#
+# WARNING: this matcher is intentionally narrow but still over-eager — it
+# matches ``radio.json``, ``audio.log``, ``script.py``, etc. Apply ONLY at
+# call sites where the value is known to be a hostname (e.g. the radio's
+# ``host`` connection field). Do NOT add to a generic ``_redact`` chain.
+_HOSTNAME = re.compile(
+    r"\b(?!localhost\b)"
+    r"(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+"
+    r"[a-zA-Z]{2,63}\b"
+)
+
+
+def redact_hostnames(text: str) -> str:
+    """Replace DNS-shape hostnames with ``<HOSTNAME>``.
+
+    Preserves ``localhost`` and bare hostnames without a TLD (e.g. ``IC-7610``).
+
+    .. warning::
+
+       This redactor will scrub anything matching ``label.tld`` shape, including
+       filenames like ``radio.json`` and ``script.py``. Apply only to fields
+       known to carry hostnames. See the ``_redact_host`` helper in
+       :mod:`icom_lan.diagnostics.contributors.radio` for the safe call site.
+    """
+    if not text:
+        return ""
+    return _HOSTNAME.sub("<HOSTNAME>", text)
+
+
 # --- Catalogue ------------------------------------------------------
 
 REDACTORS: tuple[str, ...] = ("paths", "ips", "credentials", "tokens")
 """Names of the scrubbers run on a bundle, recorded in
-``manifest.redactions_applied``."""
+``manifest.redactions_applied``.
+
+``hostnames`` is intentionally NOT in this catalogue: :func:`redact_hostnames`
+is opt-in per call-site (currently only the radio host field) because the
+``label.tld`` shape over-matches generic identifiers like ``radio.json``."""

--- a/src/icom_lan/diagnostics/upload.py
+++ b/src/icom_lan/diagnostics/upload.py
@@ -120,7 +120,9 @@ async def upload_bundle(
                 extra = await header_provider()
             except Exception as exc:  # noqa: BLE001 — Pro signer error → typed
                 raise NetworkError(f"header_provider failed: {exc}") from exc
-            if not isinstance(extra, dict):
+            if not isinstance(extra, dict) or not all(
+                isinstance(k, str) and isinstance(v, str) for k, v in extra.items()
+            ):
                 raise NetworkError("header_provider must return dict[str, str]")
             headers.update(extra)
         return await _do_upload(session, url, bundle_path, metadata, headers)
@@ -135,6 +137,11 @@ async def upload_bundle(
                 body = await resp.json(content_type=None)
             except (aiohttp.ContentTypeError, json.JSONDecodeError):
                 body = {}
+            # 2xx body must be a JSON object for ``body.get`` to work; a
+            # non-object body (null, list, string) would otherwise raise
+            # ``AttributeError`` and bypass typed-exception handling.
+            if not isinstance(body, dict):
+                body = {}
             if 200 <= resp.status < 300:
                 return ReportSubmitted(
                     report_id=str(body.get("report_id", "")),
@@ -142,7 +149,7 @@ async def upload_bundle(
                     received_at_unix=int(body.get("received_at_unix", 0)),
                     auth_class=str(body.get("auth_class", "anonymous")),
                 )
-            _raise_for_error(resp.status, body if isinstance(body, dict) else {})
+            _raise_for_error(resp.status, body)
             raise UploadFailed(status=resp.status, code=None, message="unreachable")
     except (aiohttp.ClientError, TimeoutError) as exc:
         raise NetworkError(f"upload failed: {exc}") from exc

--- a/tests/test_diagnostics_bundle.py
+++ b/tests/test_diagnostics_bundle.py
@@ -95,6 +95,16 @@ class _RadioNoneAssertContributor:
         (output_dir / "ok.txt").write_text("ok", encoding="utf-8")
 
 
+class _FlakyContributor:
+    """Writes a file then raises — exercises partial-output cleanup."""
+
+    name = "flaky"
+
+    def contribute(self, ctx: BundleContext, output_dir: Path) -> None:
+        (output_dir / "partial.txt").write_text("half-written", encoding="utf-8")
+        raise RuntimeError("died after partial write")
+
+
 def _read_manifest(zip_path: Path) -> dict[str, Any]:
     with zipfile.ZipFile(zip_path) as zf:
         return json.loads(zf.read("manifest.json"))
@@ -254,3 +264,27 @@ def test_record_warning_message_uses_repr(tmp_path: Path) -> None:
     msg = warnings[0]["message"]
     assert "ValueError" in msg
     assert "kaboom" in msg
+
+
+def test_partial_failure_cleans_up_partial_output(tmp_path: Path) -> None:
+    """A contributor that writes files then raises must NOT leak those files into the zip.
+
+    Regression for Codex review on PR #1408: previously, a per-contributor
+    failure recorded a manifest warning but left the partial files in the
+    staging directory, so they ended up in the bundle alongside the warning.
+    """
+    register(_FlakyContributor)
+    output_path = tmp_path / "report.zip"
+    result = build_bundle(_make_ctx(), output_path)
+
+    manifest = _read_manifest(result)
+    # Warning was recorded.
+    warnings = manifest.get("warnings", [])
+    matching = [w for w in warnings if w["contributor"] == "flaky"]
+    assert len(matching) == 1
+    # And NO partial file leaked into the zip.
+    with zipfile.ZipFile(result) as zf:
+        names = zf.namelist()
+    assert not any(n.startswith("flaky/") for n in names), (
+        f"partial files leaked: {names}"
+    )

--- a/tests/test_diagnostics_contributors_batch1.py
+++ b/tests/test_diagnostics_contributors_batch1.py
@@ -186,6 +186,41 @@ def test_invocation_path_truncated_to_five_entries(
     assert len(captured) == 5
 
 
+def test_invocation_path_redacts_each_segment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each PATH segment is redacted individually, not as one joined string.
+
+    Regression for Codex review on PR #1409: previously the join-then-redact
+    sequence let ``redact_paths``'s ``(?<![/:\\w])`` lookbehind skip every
+    segment after the first ``:``, leaking ``/Users/<name>`` from positions
+    2..N.
+    """
+    import os
+
+    monkeypatch.setenv(
+        "PATH",
+        os.pathsep.join(
+            [
+                "/Users/alice/bin",
+                "/Users/bob/bin",
+                "/usr/local/bin",
+            ]
+        ),
+    )
+    InvocationContributor().contribute(_make_ctx(), tmp_path)
+    text = (tmp_path / "invocation.json").read_text()
+    payload = json.loads(text)
+    path_value = payload["env"]["PATH"]
+    # Neither real username may leak.
+    assert "/Users/alice" not in path_value
+    assert "/Users/bob" not in path_value
+    # Both home prefixes must show the redacted form.
+    assert path_value.count("/Users/<USER>/bin") == 2
+    # The non-home segment is preserved.
+    assert "/usr/local/bin" in path_value
+
+
 # --------------------------------------------------------------- dependencies
 
 

--- a/tests/test_diagnostics_contributors_batch2.py
+++ b/tests/test_diagnostics_contributors_batch2.py
@@ -195,6 +195,61 @@ def test_radio_safe_attr_handles_missing_attributes(tmp_path: Path) -> None:
     assert payload["backend"] == "FakeRadio"
 
 
+def test_radio_falls_back_to_private_host_port(tmp_path: Path) -> None:
+    """Live LAN runtimes store connection info as ``_host``/``_port`` (private).
+
+    Regression for Codex review on PR #1410: previously only public
+    ``host``/``port`` were read, so an active ``IcomRadio`` reported
+    ``host=null``/``port=null``.
+    """
+
+    class FakeRadio:
+        # Only private attrs — no public ``host``/``port``.
+        _host = "192.168.55.40"
+        _port = 50001
+
+    RadioContributor().contribute(_make_ctx(radio=FakeRadio()), tmp_path)
+    payload = json.loads((tmp_path / "radio.json").read_text())
+    # Private RFC 1918 IP is preserved; port comes through.
+    assert payload["host"] == "192.168.55.40"
+    assert payload["port"] == 50001
+
+
+def test_radio_redacts_hostname_in_host_field(tmp_path: Path) -> None:
+    """DNS-shape host values are scrubbed via ``redact_hostnames``.
+
+    Regression for Codex review on PR #1410: previously only
+    ``redact_paths``/``redact_ips``/``redact_credentials`` ran, so a
+    hostname like ``radio.example.com`` was emitted unchanged.
+    """
+
+    class FakeRadio:
+        host = "radio.example.com"
+
+    RadioContributor().contribute(_make_ctx(radio=FakeRadio()), tmp_path)
+    payload = json.loads((tmp_path / "radio.json").read_text())
+    assert payload["host"] == "<HOSTNAME>"
+
+
+def test_radio_model_field_not_over_redacted_by_hostname(tmp_path: Path) -> None:
+    """``redact_hostnames`` must NOT run on non-host fields like ``model``.
+
+    The hostname pattern matches ``label.tld`` shapes including filenames; we
+    only apply it to the ``host`` field. Model strings like ``IC-7610`` (no
+    dot) and synthetic ``radio.json``-shaped values must pass through other
+    fields unscrubbed by hostname rules.
+    """
+
+    class FakeRadio:
+        model = "IC-7610"
+        backend_id = "icom_lan"
+
+    RadioContributor().contribute(_make_ctx(radio=FakeRadio()), tmp_path)
+    payload = json.loads((tmp_path / "radio.json").read_text())
+    assert payload["model"] == "IC-7610"
+    assert payload["backend"] == "icom_lan"
+
+
 def test_radio_credentials_redacted_in_string_field(tmp_path: Path) -> None:
     """Per-value redaction preserves valid JSON (regex can't span structural chars)."""
 
@@ -248,6 +303,39 @@ def test_audio_redacts_device_name_with_username(tmp_path: Path) -> None:
     payload = json.loads(text)
     assert "/Users/foo" not in text
     assert "<USER>" in payload["rx_device"]
+
+
+def test_audio_redacts_macos_user_label_in_device_name(tmp_path: Path) -> None:
+    """macOS device labels embed usernames in ``(<name>'s Mac)``.
+
+    Regression for Codex review on PR #1410: previously only
+    ``redact_paths`` ran, so the ``(moroz's Mac)`` form leaked the username.
+    """
+
+    class FakeAudioRadio(_AudioCapableStub):
+        audio_rx_device = "BlackHole 2ch (moroz's Mac)"
+        audio_tx_device = "USB Audio (Alice's MacBook Pro)"
+
+    AudioContributor().contribute(_make_ctx(radio=FakeAudioRadio()), tmp_path)
+    text = (tmp_path / "audio.json").read_text()
+    payload = json.loads(text)
+    assert "moroz" not in text
+    assert "Alice" not in text
+    assert payload["rx_device"] == "BlackHole 2ch (<USER>'s Mac)"
+    assert payload["tx_device"] == "USB Audio (<USER>'s Mac)"
+
+
+def test_audio_no_false_positive_on_normal_device_name(tmp_path: Path) -> None:
+    """Normal device names without the ``'s Mac`` form are kept verbatim."""
+
+    class FakeAudioRadio(_AudioCapableStub):
+        audio_rx_device = "Built-in Output"
+        audio_tx_device = "External USB"
+
+    AudioContributor().contribute(_make_ctx(radio=FakeAudioRadio()), tmp_path)
+    payload = json.loads((tmp_path / "audio.json").read_text())
+    assert payload["rx_device"] == "Built-in Output"
+    assert payload["tx_device"] == "External USB"
 
 
 def test_audio_json_loads_round_trip(tmp_path: Path) -> None:

--- a/tests/test_diagnostics_contributors_batch3.py
+++ b/tests/test_diagnostics_contributors_batch3.py
@@ -115,6 +115,52 @@ def test_install_hooks_idempotent() -> None:
     assert len(snap) == 1
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+def test_install_hooks_captures_threading_excepthook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worker-thread uncaught exceptions go through ``threading.excepthook``.
+
+    Regression for Codex review on PR #1411: previously only ``sys.excepthook``
+    was installed, so exceptions raised in ``threading.Thread`` workers were
+    silently dropped by the error ring.
+    """
+    import threading
+
+    # Suppress the chained default print-to-stderr — we only care that the
+    # ring captured the exception, not that the default reporter ran.
+    monkeypatch.setattr(_error_ring, "_PREVIOUS_THREADING_EXCEPTHOOK", None)
+    _error_ring.install_hooks()
+    # Re-suppress the previous-hook reference recorded inside install_hooks
+    # so the wrapped hook does not chain to the default printer.
+    monkeypatch.setattr(
+        _error_ring, "_PREVIOUS_THREADING_EXCEPTHOOK", lambda args: None
+    )
+
+    def _worker() -> None:
+        raise ValueError("from worker thread")
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    t.join()
+
+    snap = _error_ring.get_ring().snapshot()
+    assert len(snap) == 1
+    assert snap[0].type_name == "ValueError"
+    assert snap[0].message == "from worker thread"
+
+
+def test_uninstall_hooks_restores_threading_excepthook() -> None:
+    """``uninstall_hooks`` must restore the original ``threading.excepthook``."""
+    import threading
+
+    saved = threading.excepthook
+    _error_ring.install_hooks()
+    assert threading.excepthook is not saved
+    _error_ring.uninstall_hooks()
+    assert threading.excepthook is saved
+
+
 # --------------------------------------------------------------------- logs
 
 

--- a/tests/test_diagnostics_logging.py
+++ b/tests/test_diagnostics_logging.py
@@ -136,3 +136,34 @@ def test_log_file_writes_to_platformdirs_cache(
     log_file = tmp_path / "logs" / "icom-lan.log"
     assert log_file.exists()
     assert "hello" in log_file.read_text(encoding="utf-8")
+
+
+def test_preset_logger_level_preserved(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Host-app-set level must be respected — diagnostic init must NOT force DEBUG.
+
+    Regression test for Codex review on PR #1402: previously the init would
+    overwrite any level >= DEBUG (including WARNING/INFO), leaking icom_lan
+    DEBUG records into host-application handlers.
+    """
+    monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
+    icom_logger = logging.getLogger("icom_lan")
+    icom_logger.setLevel(logging.WARNING)
+    try:
+        configure_diagnostic_logging()
+        # Init must NOT have downgraded the host-app's WARNING level to DEBUG.
+        assert icom_logger.level == logging.WARNING
+    finally:
+        icom_logger.setLevel(logging.NOTSET)
+
+
+def test_unset_logger_level_set_to_debug(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When the logger level is NOTSET, init promotes it to DEBUG."""
+    monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
+    icom_logger = logging.getLogger("icom_lan")
+    icom_logger.setLevel(logging.NOTSET)
+    configure_diagnostic_logging()
+    assert icom_logger.level == logging.DEBUG

--- a/tests/test_diagnostics_redaction.py
+++ b/tests/test_diagnostics_redaction.py
@@ -7,6 +7,7 @@ import pytest
 from icom_lan.diagnostics.redaction import (
     REDACTORS,
     redact_credentials,
+    redact_hostnames,
     redact_ips,
     redact_paths,
     redact_tokens,
@@ -129,6 +130,22 @@ def test_redact_ipv6_private_kept(raw: str) -> None:
     assert redact_ips(raw) == raw
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Trailing ``::`` (zero compression at end) — used to slip through.
+        # Codex review on PR #1404.
+        ("2001:db8::", "<IP>"),
+        ("2607:f8b0:4002::", "<IP>"),
+        ("address 2001:db8:: here", "address <IP> here"),
+        ("foo 2001:db8::", "foo <IP>"),
+        ("(2001:db8::,)", "(<IP>,)"),
+    ],
+)
+def test_redact_ipv6_trailing_double_colon(raw: str, expected: str) -> None:
+    assert redact_ips(raw) == expected
+
+
 # --- Credentials ----------------------------------------------------
 
 
@@ -209,6 +226,39 @@ def test_redact_tokens_bearer() -> None:
 )
 def test_redact_tokens_no_false_positive_short_value(raw: str) -> None:
     assert redact_tokens(raw) == raw
+
+
+# --- Hostnames ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("radio.example.com", "<HOSTNAME>"),
+        ("alice-mac.local", "<HOSTNAME>"),
+        ("connect to mac.local now", "connect to <HOSTNAME> now"),
+        ("foo.bar.baz.com", "<HOSTNAME>"),
+    ],
+)
+def test_redact_hostnames_dns_shape(raw: str, expected: str) -> None:
+    assert redact_hostnames(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "localhost",
+        "IC-7610",  # bare label, no TLD
+        "192.168.55.40",  # IPv4 — last octet is digits-only, not a TLD
+        "no host here",
+    ],
+)
+def test_redact_hostnames_no_false_positive(raw: str) -> None:
+    assert redact_hostnames(raw) == raw
+
+
+def test_redact_hostnames_empty_input() -> None:
+    assert redact_hostnames("") == ""
 
 
 # --- REDACTORS catalogue -------------------------------------------

--- a/tests/test_diagnostics_upload.py
+++ b/tests/test_diagnostics_upload.py
@@ -362,3 +362,54 @@ async def test_upload_header_provider_returns_non_dict_raises_network_error(
         await upload_bundle(
             bundle_file, {}, endpoint=_url(server), header_provider=provider
         )
+
+
+async def test_upload_header_provider_non_string_value_raises_network_error(
+    make_server: Callable[[HandlerType], Awaitable[TestServer]],
+    bundle_file: Path,
+) -> None:
+    """Non-string header values must raise typed NetworkError, not aiohttp TypeError.
+
+    Regression for Codex review on PR #1405: previously, a header dict with a
+    non-string value (e.g. ``{"X-Test": 42}``) would pass the dict-isinstance
+    check, then trip aiohttp's internal TypeError outside the typed exception
+    handler.
+    """
+
+    async def handler(_request: web.Request) -> web.Response:
+        return web.json_response(_success_body())
+
+    server = await make_server(handler)
+
+    async def provider() -> dict[str, str]:
+        return {"X-Test": 42}  # type: ignore[dict-item]
+
+    with pytest.raises(NetworkError):
+        await upload_bundle(
+            bundle_file, {}, endpoint=_url(server), header_provider=provider
+        )
+
+
+@pytest.mark.parametrize("body", [[], "string-body", 42, None])
+async def test_upload_2xx_non_object_body_returns_defaults(
+    make_server: Callable[[HandlerType], Awaitable[TestServer]],
+    bundle_file: Path,
+    body: Any,
+) -> None:
+    """2xx response with a non-object JSON body must NOT raise AttributeError.
+
+    Regression for Codex review on PR #1405: previously, ``body.get(...)`` was
+    called without verifying ``isinstance(body, dict)`` and a 2xx response
+    containing ``[]``/string/null bypassed typed exception handling.
+    """
+
+    async def handler(_request: web.Request) -> web.Response:
+        return web.json_response(body)
+
+    server = await make_server(handler)
+    result = await upload_bundle(bundle_file, {"k": "v"}, endpoint=_url(server))
+    assert isinstance(result, ReportSubmitted)
+    assert result.report_id == ""
+    assert result.support_url == ""
+    assert result.received_at_unix == 0
+    assert result.auth_class == "anonymous"


### PR DESCRIPTION
## Summary

Hardening pass closing 11 P1/P2 Codex review findings on already-merged PRs in the diagnostic-data-collection epic. Single coherent purpose; 16 files (9 src + 1 doc + 6 tests) — scope justified per pattern #1363.

## Findings addressed

| # | Sev | Origin PR | Fix |
|---|-----|-----------|-----|
| 1 | P1 | [#1402](https://github.com/morozsm/icom-lan/pull/1402) | `_logging.py` only forces DEBUG when logger level is `NOTSET`; host-app policy respected. |
| 2 | P1 | [#1404](https://github.com/morozsm/icom-lan/pull/1404) | IPv6 regex now matches trailing-`::` addresses (`2001:db8::`, `2607:f8b0:4002::`). Switched `\b` to `(?![\w:])`. |
| 3 | P2 | [#1405](https://github.com/morozsm/icom-lan/pull/1405) | `upload.py` 2xx body type-guarded to `dict` before `.get()` (handles `null`/list/string body). |
| 4 | P2 | [#1405](https://github.com/morozsm/icom-lan/pull/1405) | `upload.py` `header_provider` values validated to be `str`; non-string raises typed `NetworkError`. |
| 5 | P1 | [#1406](https://github.com/morozsm/icom-lan/pull/1406) | Added `generated_at_unix` to required-fields list in `docs/contracts/diagnostic-bundle-v1.md`. |
| 6 | P1 | [#1408](https://github.com/morozsm/icom-lan/pull/1408) | `bundle.py` cleans up partial output via `shutil.rmtree` on per-contributor failure; no half-written files in zip. |
| 7 | P1 | [#1409](https://github.com/morozsm/icom-lan/pull/1409) | `invocation.py` redacts PATH segments individually, defeating `redact_paths`' `:`-prefix lookbehind. |
| 8 | P1 | [#1410](https://github.com/morozsm/icom-lan/pull/1410) | New `redact_hostnames` + `_redact_host` (radio.py) — applied only to host field to avoid over-redacting other strings. |
| 9 | P2 | [#1410](https://github.com/morozsm/icom-lan/pull/1410) | `radio.py` reads `host`/`port` then falls back to `_host`/`_port` for live LAN runtimes. |
| 10 | P1 | [#1410](https://github.com/morozsm/icom-lan/pull/1410) | `audio.py` redacts macOS device labels of shape `(<name>'s Mac)` via new `_MACOS_USER_LABEL` pattern. |
| 11 | P1 | [#1411](https://github.com/morozsm/icom-lan/pull/1411) | `_error_ring.install_hooks()` now wires `threading.excepthook` alongside `sys.excepthook` so worker-thread exceptions land in the ring. |

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 5553 passed (baseline 5523, +30 new tests)
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format src/ tests/` — formatted
- [x] `uv run mypy src/icom_lan/diagnostics/` — no issues
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run mkdocs build --strict` — clean

Closes #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)