### PR TITLE
chore(#1385): close fresh Codex findings on diagnostic-data-collection PRs

### DIFF
--- a/frontend/src/components-v2/dialogs/SendReportDialog.svelte
+++ b/frontend/src/components-v2/dialogs/SendReportDialog.svelte
@@ -154,6 +154,12 @@
   }
 
   async function handleCancel(): Promise<void> {
+    // While an in-flight previewBundle/sendBundle/saveBundle is awaiting,
+    // cancelling would race the server-side preview state (the preview may
+    // not yet exist, or the upload may already have started). Block Escape
+    // and backdrop closes for the duration; the explicit close buttons are
+    // already disabled via `disabled={busy}`.
+    if (busy) return;
     // Best-effort cleanup of server-side preview; ignore failures.
     if (preview) {
       try {

--- a/frontend/src/components-v2/dialogs/__tests__/SendReportDialog.test.ts
+++ b/frontend/src/components-v2/dialogs/__tests__/SendReportDialog.test.ts
@@ -394,6 +394,66 @@ describe('SendReportDialog', () => {
     unmount(component);
   });
 
+  it('ignores Escape while a request is in flight (busy guard)', async () => {
+    // Regression for #1397 follow-up: the explicit close buttons gate on
+    // `disabled={busy}`, but Escape and backdrop clicks reached
+    // handleCancel() unguarded, so a user pressing Escape mid-preview
+    // could trigger a stray deletePreview() against a server preview that
+    // either did not yet exist or was about to be consumed by send.
+    let resolvePreview!: (v: ReturnType<typeof makePreview>) => void;
+    previewSpy.mockReturnValue(
+      new Promise<ReturnType<typeof makePreview>>((resolve) => {
+        resolvePreview = resolve;
+      }),
+    );
+
+    const onClose = vi.fn();
+    const { target, component } = setup({ open: true, onClose });
+
+    // Let the mount-time ``$effect(() => { if (open) reset(); })`` flush
+    // BEFORE we click. In Svelte 5 the initial $effect runs on the next
+    // microtask, not synchronously inside ``mount()``. If we click first,
+    // the effect would fire afterwards and reset busy=false mid-test.
+    await tick();
+    flushSync();
+
+    // Kick off the preview request — busy becomes true and stays true
+    // because the promise above never resolves on its own.
+    (target.querySelector('[data-testid="btn-generate"]') as HTMLButtonElement).click();
+    await tick();
+    flushSync();
+
+    // Sanity: previewBundle was kicked off (so handleGeneratePreview did set
+    // busy=true before awaiting). The promise is unresolved, so busy stays
+    // true throughout the rest of the assertions.
+    expect(previewSpy).toHaveBeenCalledTimes(1);
+
+    // Press Escape while busy — must not call deletePreview, must not close.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await tick();
+    flushSync();
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Click the backdrop while still busy — same expectation.
+    const backdrop = target.querySelector(
+      '[data-testid="send-report-backdrop"]',
+    ) as HTMLElement;
+    backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await tick();
+    flushSync();
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Resolve the dangling promise so vitest doesn't complain about
+    // unhandled rejections / pending timers, then unmount.
+    resolvePreview(makePreview());
+    await tick();
+    await tick();
+    flushSync();
+    unmount(component);
+  });
+
   it('shows forbidden_content message on that error code', async () => {
     previewSpy.mockResolvedValue(makePreview());
     sendSpy.mockRejectedValue(

--- a/src/icom_lan/cli/_diagnose.py
+++ b/src/icom_lan/cli/_diagnose.py
@@ -248,19 +248,17 @@ def _interactive_collect(args: argparse.Namespace) -> None:
 
 
 async def _run_async(args: argparse.Namespace) -> int:
-    # Lazy imports — see module-level NOTE. These names land in the local
-    # scope, so test fixtures must patch ``icom_lan.diagnostics`` (the
-    # source module) rather than ``icom_lan.cli._diagnose``.
-    from icom_lan.diagnostics import (
-        BundleTooLarge,
-        ForbiddenContent,
-        MetadataInvalid,
-        NetworkError,
-        RateLimited,
-        UploadFailed,
-        build_bundle,
-        upload_bundle,
-    )
+    # Lazy imports — see module-level NOTE. ``build_bundle`` plus the typed
+    # error classes live in non-aiohttp submodules, so importing them here is
+    # cheap. ``upload_bundle`` (and the other ``upload``-module re-exports)
+    # transitively imports ``aiohttp`` via the lazy hook in
+    # ``icom_lan.diagnostics.__init__``; that import is deferred into the
+    # ``args.upload`` branch below so ``icom-lan diagnose`` (save-only) works
+    # for runtime-only installs without ``aiohttp``.
+    # These names land in the local scope, so test fixtures must patch
+    # ``icom_lan.diagnostics`` (the source module) rather than
+    # ``icom_lan.cli._diagnose``.
+    from icom_lan.diagnostics import build_bundle
 
     if args.include or args.exclude:
         print(
@@ -320,6 +318,23 @@ async def _run_async(args: argparse.Namespace) -> int:
             return 0
 
     # Upload (either --no-confirm path or user typed y/yes after preview).
+    # Lazy import — accessing ``upload_bundle`` is what triggers the aiohttp
+    # import via the :pep:`562` hook in ``icom_lan.diagnostics.__init__``.
+    # Keeping it inside the ``args.upload`` branch lets ``icom-lan diagnose``
+    # (save-only) run on installs that omit aiohttp. The error classes are
+    # imported alongside for symmetry; they live in non-aiohttp submodules
+    # and would be cheap to hoist, but bundling them here keeps the upload
+    # path self-contained.
+    from icom_lan.diagnostics import (
+        BundleTooLarge,
+        ForbiddenContent,
+        MetadataInvalid,
+        NetworkError,
+        RateLimited,
+        UploadFailed,
+        upload_bundle,
+    )
+
     metadata = _read_manifest(bundle_path)
     try:
         result: ReportSubmitted = await upload_bundle(

--- a/src/icom_lan/web/handlers/diagnostics.py
+++ b/src/icom_lan/web/handlers/diagnostics.py
@@ -68,7 +68,11 @@ class _PreviewSession:
     metadata: dict[str, Any]
     filename: str
     created_at_unix: int
-    consumed: bool = False  # True after a successful send
+    # True after a send ATTEMPT (success or failure). The flag is set inside
+    # the handler lock, before ``upload_bundle`` runs, to make the consumed
+    # check atomic against concurrent sends. A failed upload therefore still
+    # burns the CSRF — the caller must regenerate the preview to retry.
+    consumed: bool = False
 
     def is_expired(self, now: int | None = None) -> bool:
         if now is None:
@@ -359,6 +363,12 @@ class DiagnosticsHandler:
                 raise _ClientError(403, "csrf_missing", "CSRF token already consumed")
             if not _ct_eq(csrf_token, sess.csrf_token):
                 raise _ClientError(403, "csrf_missing", "CSRF token invalid")
+            # Atomic check-and-set: mark consumed BEFORE releasing the lock so
+            # a concurrent send (double-click, retry) sees the consumed flag
+            # and is rejected, even though upload_bundle() has not yet run.
+            # If the upload then fails, the flag stays set — the caller must
+            # regenerate the preview to retry. This is the documented contract.
+            sess.consumed = True
 
         # Upload outside the lock — network call is slow.
         try:
@@ -373,12 +383,6 @@ class DiagnosticsHandler:
             DiagnosticUploadError,
         ):
             raise
-
-        # Mark consumed only on success.
-        async with self._lock:
-            current = self._sessions.get(preview_id)
-            if current is sess:
-                current.consumed = True
 
         return _report_to_dict(report)
 

--- a/tests/test_cli_diagnose_lazy_import.py
+++ b/tests/test_cli_diagnose_lazy_import.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 
 def test_cli_module_loads_without_aiohttp() -> None:
@@ -69,3 +70,74 @@ def test_cli_module_loads_without_aiohttp() -> None:
         f"stderr:\n{result.stderr}"
     )
     assert "OK" in result.stdout
+
+
+def test_diagnose_save_only_runs_without_aiohttp(tmp_path: Path) -> None:
+    """``icom-lan diagnose --output ...`` (no --upload) must run without aiohttp.
+
+    Regression for the follow-up bug on PR-A (#1417): the lazy-import work
+    moved diagnostics symbols out of module level into ``_run_async``, but
+    the imports happened at the TOP of ``_run_async``, BEFORE checking
+    ``args.upload``. Result: even ``icom-lan diagnose`` (save-only) would
+    pull ``aiohttp`` via the lazy ``upload_bundle`` re-export and crash for
+    ``pip install icom-lan`` users (aiohttp is dev-only).
+
+    This test executes the full save-only path in a subprocess with
+    ``aiohttp`` blocked on ``sys.meta_path`` and asserts:
+
+    - exit code 0 (the bundle was built),
+    - the output zip exists,
+    - ``aiohttp`` was never imported.
+    """
+    out_zip = tmp_path / "diag.zip"
+
+    script = textwrap.dedent(
+        f"""
+        import sys
+
+        # Block aiohttp BEFORE any icom_lan import.
+        class _AiohttpBlocker:
+            def find_spec(self, name, path=None, target=None):
+                if name == "aiohttp" or name.startswith("aiohttp."):
+                    raise ImportError(
+                        f"aiohttp blocked by lazy-import regression test: {{name}}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, _AiohttpBlocker())
+
+        from icom_lan.cli import _build_parser
+        from icom_lan.cli._diagnose import run as run_diagnose
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["diagnose", "--output", {str(out_zip)!r}, "--no-confirm"]
+        )
+        rc = run_diagnose(args)
+        if rc != 0:
+            print(f"FAIL rc={{rc}}", file=sys.stderr)
+            sys.exit(rc)
+
+        leaked = [m for m in sys.modules if m == "aiohttp" or m.startswith("aiohttp.")]
+        if leaked:
+            print(f"FAIL aiohttp leaked: {{leaked}}", file=sys.stderr)
+            sys.exit(2)
+
+        print("OK")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"diagnose save-only crashed without aiohttp.\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout
+    assert out_zip.exists(), f"bundle was not created at {out_zip}"

--- a/tests/test_web_diagnostics.py
+++ b/tests/test_web_diagnostics.py
@@ -606,7 +606,13 @@ async def test_api_auth_inherited(
 async def test_send_translates_rate_limited(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """upload_bundle raising RateLimited → 429 with retry_after_seconds."""
+    """upload_bundle raising RateLimited → 429 with retry_after_seconds.
+
+    Also covers the contract corollary of the atomic check-and-set fix in
+    ``handle_send``: a failed upload still consumes the CSRF, so a retry
+    with the same preview_id+csrf returns 403 ``csrf_missing``. The caller
+    must regenerate a preview to retry.
+    """
     _register_test_contributor()
     _stub_dirs(monkeypatch, tmp_path)
     srv = _make_server()
@@ -630,6 +636,18 @@ async def test_send_translates_rate_limited(
             assert writer.response_status == 429
             assert writer.response_json["error"] == "rate_limited"
             assert writer.response_json.get("retry_after_seconds") == 42
+
+            # Contract: failed upload burns the CSRF (consumed-on-attempt).
+            writer2 = _FakeWriter()
+            await srv._handle_diagnose_send(
+                writer2,  # type: ignore[arg-type]
+                headers=_post_headers(
+                    body, **{"x-diagnostic-csrf": preview["csrf_token"]}
+                ),
+                reader=_make_reader(body),
+            )
+            assert writer2.response_status == 403
+            assert writer2.response_json["error"] == "csrf_missing"
     finally:
         await srv._diagnostics.stop()
 
@@ -824,3 +842,74 @@ async def test_handler_preview_endpoint_url_matches_resolved() -> None:
 def test_diagnostics_upload_error_subtype_translation() -> None:
     """Sanity: typed errors are subclasses of DiagnosticUploadError."""
     assert issubclass(RateLimited, DiagnosticUploadError)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_send_uploads_only_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Two concurrent sends with the same valid CSRF must upload exactly once.
+
+    Regression for the race in ``handle_send`` where the consumed flag was
+    set only AFTER ``upload_bundle`` returned. Two requests slipping through
+    the lock window (double-click, retry) would BOTH pass the ``consumed``
+    check before either marked the session consumed → bundle uploaded twice.
+
+    The test mocks ``upload_bundle`` with a small ``asyncio.sleep`` so the
+    first coroutine reliably yields (releasing its event-loop slot) after
+    releasing the handler lock, giving the second coroutine a window to
+    enter the critical section. Without the fix, both reach
+    ``upload_bundle``; with the fix, the second sees ``consumed=True`` set
+    inside the lock by the first and is rejected.
+    """
+    _register_test_contributor()
+    _stub_dirs(monkeypatch, tmp_path)
+    srv = _make_server()
+    try:
+        preview = await _do_preview(srv)
+        report = ReportSubmitted("r1", "https://x", 0, "anonymous")
+
+        async def _slow_upload(*_args: Any, **_kwargs: Any) -> ReportSubmitted:
+            # Yield once so the second coroutine can enter handle_send and
+            # try to acquire the lock while the first is awaiting upload.
+            await asyncio.sleep(0.01)
+            return report
+
+        with patch(
+            "icom_lan.web.handlers.diagnostics.upload_bundle",
+            new=AsyncMock(side_effect=_slow_upload),
+        ) as mock_upload:
+            body = json.dumps(
+                {"preview_id": preview["preview_id"], "consent": True}
+            ).encode()
+
+            async def _send() -> _FakeWriter:
+                writer = _FakeWriter()
+                await srv._handle_diagnose_send(
+                    writer,  # type: ignore[arg-type]
+                    headers=_post_headers(
+                        body, **{"x-diagnostic-csrf": preview["csrf_token"]}
+                    ),
+                    reader=_make_reader(body),
+                )
+                return writer
+
+            writer1, writer2 = await asyncio.gather(_send(), _send())
+
+            statuses = sorted([writer1.response_status, writer2.response_status])
+            assert statuses == [200, 403], (
+                f"expected one 200 and one 403, got {statuses}: "
+                f"w1={writer1.response_body!r} w2={writer2.response_body!r}"
+            )
+            # The defining assertion: the bundle was uploaded EXACTLY ONCE.
+            assert mock_upload.await_count == 1, (
+                f"upload_bundle was awaited {mock_upload.await_count} times; "
+                f"expected exactly 1 — race regressed"
+            )
+
+            # The 403 must carry the consumed/csrf_missing code (same as a
+            # second send after a successful first one).
+            losing = writer1 if writer1.response_status == 403 else writer2
+            assert losing.response_json["error"] == "csrf_missing"
+    finally:
+        await srv._diagnostics.stop()


### PR DESCRIPTION
## Summary

Three independent fresh Codex review findings on the diagnostic-data-collection epic PRs, each with a regression test verified to fail on the prior baseline. Continuation of #1418 cleanup.

## Findings addressed

### 1. P1 — Race condition in `handle_send` (PR #1414)

`src/icom_lan/web/handlers/diagnostics.py` — `handle_send` read `sess.consumed` under the session lock, released the lock before awaiting `upload_bundle()`, then marked the session consumed afterward. Two concurrent POSTs (double-click, retry) could both pass the consumed check before either marked it consumed → bundle uploaded twice.

**Fix:** atomic check-and-set under the lock — `sess.consumed = True` set BEFORE releasing the lock. If the upload then fails, the consumed flag stays set; caller must regenerate the preview to retry.

Regression test in `tests/test_web_diagnostics.py::test_concurrent_send_uploads_only_once` — `asyncio.gather` two POSTs with the same CSRF, asserts statuses `[200, 403]` and `mock_upload.await_count == 1`. Fails on baseline.

### 2. P2 — Modal cancel bypasses busy guard (PR #1416)

`frontend/src/components-v2/dialogs/SendReportDialog.svelte` — `disabled={busy}` only guarded the explicit close buttons. `handleCancel()` was still reachable from Escape key and backdrop click while requests were in flight, leaking preview state.

**Fix:** `if (busy) return;` at the top of `handleCancel()`.

Vitest test in `SendReportDialog.test.ts` — never-resolving promise keeps `busy=true`; dispatches Escape and backdrop click; asserts `deletePreview` and `onClose` are NOT called.

### 3. P1 — Save-only diagnose still loaded aiohttp (PR #1417 follow-up)

`src/icom_lan/cli/_diagnose.py` — my own PR-A (#1417) moved diagnostics imports from module level into `_run_async()`, but the imports happened at the TOP of `_run_async`, before checking `args.upload`. So `icom-lan diagnose` (save-only, no `--upload`) still imported `upload_bundle` → triggered `aiohttp` via the lazy loader → crashed for `pip install icom-lan` users without aiohttp.

**Fix:** split the imports. `build_bundle` (no aiohttp transitively) imported at the top of `_run_async`. `upload_bundle` + typed error classes imported inside the `if args.upload:` branch.

Regression test in `tests/test_cli_diagnose_lazy_import.py` — subprocess with `aiohttp` blocked on `sys.meta_path`; runs `diagnose --output ... --no-confirm` (no `--upload`); asserts exit 0, zip created, `aiohttp` not in `sys.modules`. Fails on baseline.

## Verification

- [x] `pytest tests/ --ignore=tests/integration`: **5555 passed** (5553 baseline + 2 new)
- [x] `ruff check` / `ruff format --check`: clean
- [x] `lint-imports`: 4 contracts kept, 0 broken
- [x] `mypy src/icom_lan/{cli,web,diagnostics}`: 1 pre-existing unrelated error on `cli/__init__.py:2441` (not introduced)
- [x] `npx vitest run SendReportDialog.test.ts`: 13 passed (+1 new)

## Files (6 — documented breach per pattern #1363)

| File | Type | Reason |
|------|------|--------|
| `src/icom_lan/web/handlers/diagnostics.py` | mod | Finding 1 |
| `tests/test_web_diagnostics.py` | mod | Test for finding 1 |
| `frontend/src/components-v2/dialogs/SendReportDialog.svelte` | mod | Finding 2 |
| `frontend/src/components-v2/dialogs/__tests__/SendReportDialog.test.ts` | mod | Test for finding 2 |
| `src/icom_lan/cli/_diagnose.py` | mod | Finding 3 |
| `tests/test_cli_diagnose_lazy_import.py` | mod | Test for finding 3 |

Source-only delta is ~25 LOC across 3 files; the bulk is tests (~190 LOC). Three independent findings bundled into a single PR follows the pattern of #1418 (previous Codex cleanup).

Closes Codex findings on #1414, #1416, #1417.
Refs #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)