### PR TITLE
fix: friendly error when icom-lan diagnose --upload runs without aiohttp

### DIFF
--- a/src/icom_lan/cli/_diagnose.py
+++ b/src/icom_lan/cli/_diagnose.py
@@ -144,14 +144,28 @@ def _default_config_dir() -> Path:
     return Path(platformdirs.user_config_path("icom-lan"))
 
 
-def _resolve_endpoint(endpoint_arg: str | None) -> str:
-    # Lazy import — keeps ``aiohttp`` out of the import path of bare CLI
-    # commands. Only fired on the diagnose codepath.
-    from icom_lan.diagnostics import DEFAULT_ENDPOINT
+_FALLBACK_ENDPOINT = "https://reports.msmsoft.net/v1/diagnostics/upload"
 
+
+def _resolve_endpoint(endpoint_arg: str | None) -> str:
     if endpoint_arg:
         return endpoint_arg
-    return os.environ.get("ICOM_LAN_REPORT_ENDPOINT", DEFAULT_ENDPOINT)
+    env = os.environ.get("ICOM_LAN_REPORT_ENDPOINT")
+    if env:
+        return env
+    # Try the canonical constant from the diagnostics package. On installs that
+    # omit ``aiohttp`` (a dev-only dep) the lazy ``__getattr__`` hook in
+    # ``icom_lan.diagnostics.__init__`` raises ``ImportError`` while loading
+    # ``upload.py`` — silently fall back to the well-known default URL so
+    # endpoint resolution still works in the preview / save-locally display
+    # path. The actual upload (which DOES need aiohttp) will fail later with
+    # a friendly message; the duplicated string is the price of decoupling
+    # the CLI's display path from the upload module's import requirements.
+    try:
+        from icom_lan.diagnostics import DEFAULT_ENDPOINT
+    except ImportError:
+        return _FALLBACK_ENDPOINT
+    return str(DEFAULT_ENDPOINT)
 
 
 def _is_tty() -> bool:
@@ -325,15 +339,41 @@ async def _run_async(args: argparse.Namespace) -> int:
     # imported alongside for symmetry; they live in non-aiohttp submodules
     # and would be cheap to hoist, but bundling them here keeps the upload
     # path self-contained.
-    from icom_lan.diagnostics import (
-        BundleTooLarge,
-        ForbiddenContent,
-        MetadataInvalid,
-        NetworkError,
-        RateLimited,
-        UploadFailed,
-        upload_bundle,
-    )
+    try:
+        from icom_lan.diagnostics import (
+            BundleTooLarge,
+            ForbiddenContent,
+            MetadataInvalid,
+            NetworkError,
+            RateLimited,
+            UploadFailed,
+            upload_bundle,
+        )
+    except ImportError as exc:
+        # `aiohttp` is a dev-only / optional dependency. Pip-install users who
+        # try `--upload` without it get here. Don't show a Python traceback —
+        # they need an actionable message + the local bundle path so they can
+        # still attach it to a GitHub issue manually.
+        if "aiohttp" in str(exc):
+            print(
+                "Upload requires the 'aiohttp' package, which is not installed.",
+                file=sys.stderr,
+            )
+            print(
+                "  Install it with:  pip install aiohttp",
+                file=sys.stderr,
+            )
+            print(
+                f"  Bundle saved locally: {bundle_path}",
+                file=sys.stderr,
+            )
+            print(
+                "  You can attach it to a GitHub issue manually, or re-run "
+                "with `pip install aiohttp` to enable upload.",
+                file=sys.stderr,
+            )
+            return 9
+        raise
 
     metadata = _read_manifest(bundle_path)
     try:

--- a/tests/test_cli_diagnose_lazy_import.py
+++ b/tests/test_cli_diagnose_lazy_import.py
@@ -141,3 +141,80 @@ def test_diagnose_save_only_runs_without_aiohttp(tmp_path: Path) -> None:
     )
     assert "OK" in result.stdout
     assert out_zip.exists(), f"bundle was not created at {out_zip}"
+
+
+def test_diagnose_upload_without_aiohttp_emits_friendly_error(tmp_path: Path) -> None:
+    """``icom-lan diagnose --upload`` without aiohttp must NOT show a traceback.
+
+    Regression for the L1.8 UX finding: when ``aiohttp`` is missing and the
+    user explicitly passes ``--upload``, the command should print a short
+    actionable message (install hint + path of the locally-saved bundle)
+    and exit with a documented non-zero code, rather than dump a Python
+    traceback. The bundle is built before the upload import and remains
+    on disk so the user can attach it to a GitHub issue manually.
+
+    Asserts:
+
+    - exit code is 9 (the dedicated "aiohttp missing" code),
+    - stderr contains the install hint,
+    - stderr contains the bundle path,
+    - stderr contains NO ``Traceback`` line,
+    - the bundle was created on disk despite the upload failure.
+    """
+    out_zip = tmp_path / "diag-upload.zip"
+
+    script = textwrap.dedent(
+        f"""
+        import sys
+
+        class _AiohttpBlocker:
+            def find_spec(self, name, path=None, target=None):
+                if name == "aiohttp" or name.startswith("aiohttp."):
+                    raise ImportError(
+                        f"aiohttp blocked by upload UX regression test: {{name}}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, _AiohttpBlocker())
+
+        from icom_lan.cli import _build_parser
+        from icom_lan.cli._diagnose import run as run_diagnose
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "diagnose",
+                "--upload",
+                "--no-confirm",
+                "--description", "upload-without-aiohttp UX test",
+                "--output", {str(out_zip)!r},
+            ]
+        )
+        rc = run_diagnose(args)
+        sys.exit(rc)
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 9, (
+        f"expected exit code 9 (aiohttp missing), got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "Upload requires the 'aiohttp' package" in result.stderr
+    assert "pip install aiohttp" in result.stderr
+    assert str(out_zip) in result.stderr
+    assert "Traceback" not in result.stderr, (
+        f"a friendly error must not include a Python traceback.\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert out_zip.exists(), (
+        f"bundle was not created at {out_zip} despite upload failure; "
+        f"the local file should be preserved so the user can attach manually"
+    )


### PR DESCRIPTION
## Summary

Replaces a raw Python traceback with a short actionable message when a `pip install icom-lan` user (no aiohttp, since it's a dev-only dep) runs `icom-lan diagnose --upload`. Discovered during L1.8 of the post-merge verification pass on the diagnostic-data-collection epic.

## Behaviour change

**Before:**

```
$ icom-lan diagnose --upload --no-confirm
Building diagnostic bundle...
Traceback (most recent call last):
  File ".../icom-lan", line 10, in <module>
    sys.exit(main())
  ...
  File ".../upload.py", line 12, in <module>
    import aiohttp
ModuleNotFoundError: No module named 'aiohttp'
```

**After:**

```
$ icom-lan diagnose --upload --no-confirm
Building diagnostic bundle...
Upload requires the 'aiohttp' package, which is not installed.
  Install it with:  pip install aiohttp
  Bundle saved locally: /Users/.../icom-lan-report-20260503-231035.zip
  You can attach it to a GitHub issue manually, or re-run with
  `pip install aiohttp` to enable upload.

$ echo $?
9
```

The bundle is still built and saved locally — only the upload fails — so the user retains everything needed to attach to a GitHub issue manually. Exit code `9` is dedicated to this condition for scripted users.

## Implementation

Two surgical changes in `src/icom_lan/cli/_diagnose.py`:

1. **The lazy import block in `_run_async`'s upload branch** is wrapped in `try/except ImportError`. If `"aiohttp"` appears in the error message, emit the friendly text and `return 9`. Other ImportErrors re-raise (unrelated bugs still surface).

2. **`_resolve_endpoint` falls back to a hardcoded constant** when the lazy load of `DEFAULT_ENDPOINT` fails. Required because `_resolve_endpoint` is called before the upload branch's import (the endpoint is shown in the preview), and pulling `DEFAULT_ENDPOINT` from the lazy hook also triggers the aiohttp load. The duplicated string is a deliberate trade-off to decouple the display path from the upload module's import requirements.

## Tests

New regression test `test_diagnose_upload_without_aiohttp_emits_friendly_error` in `tests/test_cli_diagnose_lazy_import.py`. Subprocess-isolated; blocks aiohttp on `sys.meta_path`; runs `diagnose --upload --no-confirm`; asserts:

- exit code 9
- stderr contains the install hint
- stderr contains the bundle path
- stderr contains **no** `Traceback` line
- the bundle was created on disk

## Verification

- [x] `pytest tests/test_cli_diagnose_lazy_import.py`: 3 passed
- [x] `pytest tests/test_cli_diagnose.py`: 27 passed
- [x] `pytest tests/ --ignore=tests/integration`: 5556 passed (5555 baseline + 1 new)
- [x] `ruff check` / `ruff format --check`: clean
- [x] `mypy src/icom_lan/cli/_diagnose.py`: clean
- [x] `lint-imports`: 4 contracts kept, 0 broken
- [x] Manual smoke test in fresh `pip install icom-lan` venv (without aiohttp) — friendly message printed, bundle saved, exit 9

## Files

| File | Type | LOC |
|------|------|-----|
| `src/icom_lan/cli/_diagnose.py` | mod | +30 / -8 |
| `tests/test_cli_diagnose_lazy_import.py` | mod | +77 |

2 files. Within ≤3 guardrail.

Refs #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)