### PR TITLE
rebrand(wave2): persistent state migration (PR-2C)

### DIFF
--- a/frontend/src/components-v2/controls/CollapsiblePanel.svelte
+++ b/frontend/src/components-v2/controls/CollapsiblePanel.svelte
@@ -36,7 +36,7 @@
 
   let effectiveCollapsed = $derived(collapsed || (autoCollapseWhen && !userExpanded));
 
-  const STORAGE_KEY = 'icom-lan:panel-collapsed';
+  const STORAGE_KEY = 'rigplane:panel-collapsed';
 
   // Load collapsed state from localStorage
   onMount(() => {

--- a/frontend/src/components-v2/controls/__tests__/CollapsiblePanel.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/CollapsiblePanel.test.ts
@@ -120,14 +120,14 @@ describe('CollapsiblePanel', () => {
     header?.click();
     flushSync();
 
-    const stored = localStorage.getItem('icom-lan:panel-collapsed');
+    const stored = localStorage.getItem('rigplane:panel-collapsed');
     expect(stored).not.toBeNull();
     const data = JSON.parse(stored!);
     expect(data['test-panel']).toBe(true);
   });
 
   it('restores collapsed state from localStorage', () => {
-    localStorage.setItem('icom-lan:panel-collapsed', JSON.stringify({ 'test-panel': true }));
+    localStorage.setItem('rigplane:panel-collapsed', JSON.stringify({ 'test-panel': true }));
 
     const target = mountPanel({ title: 'Test', panelId: 'test-panel' });
     const chevron = target.querySelector('.chevron');
@@ -317,7 +317,7 @@ describe('CollapsiblePanel', () => {
       // ``collapsed`` to false but left ``userExpanded`` false, so the derived
       // ``effectiveCollapsed`` stayed true.
       localStorage.setItem(
-        'icom-lan:panel-collapsed',
+        'rigplane:panel-collapsed',
         JSON.stringify({ 'auto-cw-persisted': true }),
       );
 

--- a/frontend/src/components-v2/controls/__tests__/InstallPrompt.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/InstallPrompt.test.ts
@@ -136,7 +136,7 @@ describe('dismissal', () => {
 
   it('uses correct localStorage key', () => {
     setDismissed();
-    expect(localStorage.getItem('icom-lan:install-dismissed')).toBe('true');
+    expect(localStorage.getItem('rigplane:install-dismissed')).toBe('true');
   });
 });
 

--- a/frontend/src/components-v2/controls/install-prompt-utils.ts
+++ b/frontend/src/components-v2/controls/install-prompt-utils.ts
@@ -6,7 +6,7 @@
 
 export type Platform = 'ios' | 'android' | 'desktop';
 
-const STORAGE_KEY = 'icom-lan:install-dismissed';
+const STORAGE_KEY = 'rigplane:install-dismissed';
 
 /** Detect platform from user-agent string. */
 export function detectPlatform(ua: string): Platform {

--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -22,7 +22,7 @@
 
   // --- Panel reorder (shared logic) ---
   const drag = createDragReorder({
-    storageKey: 'icom-lan:panel-order',
+    storageKey: 'rigplane:panel-order',
     defaults: ['rf-front-end', 'mode', 'filter', 'agc', 'rit-xit', 'band', 'antenna', 'scan'],
     containerSelector: '.left-sidebar',
   });

--- a/frontend/src/components-v2/layout/RightSidebar.svelte
+++ b/frontend/src/components-v2/layout/RightSidebar.svelte
@@ -22,7 +22,7 @@
 
   // --- Panel reorder (shared logic) ---
   const drag = createDragReorder({
-    storageKey: 'icom-lan:right-panel-order',
+    storageKey: 'rigplane:right-panel-order',
     defaults: ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'],
     containerSelector: '.right-sidebar',
   });

--- a/frontend/src/components-v2/layout/__tests__/LeftSidebar.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/LeftSidebar.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
  * mounting the full component (which pulls in radio stores, command-bus, etc.).
  */
 
-const PANEL_ORDER_KEY = 'icom-lan:panel-order';
+const PANEL_ORDER_KEY = 'rigplane:panel-order';
 const DEFAULT_ORDER = ['rf-front-end', 'mode', 'filter', 'agc', 'rit-xit', 'band', 'antenna'];
 
 // Mirror the loadPanelOrder logic from LeftSidebar.svelte

--- a/frontend/src/components-v2/panels/MemoryPanel.svelte
+++ b/frontend/src/components-v2/panels/MemoryPanel.svelte
@@ -12,7 +12,7 @@
 
   let p = $derived(deriveMemoryPanelProps());
 
-  const STORAGE_KEY = 'icom-lan:memory-channels';
+  const STORAGE_KEY = 'rigplane:memory-channels';
   const MAX_CHANNELS = 99;
 
   interface MemoryEntry {

--- a/frontend/src/components-v2/theme/theme-switcher.ts
+++ b/frontend/src/components-v2/theme/theme-switcher.ts
@@ -5,9 +5,9 @@ export interface ThemeInfo {
   preview: string[]; // 5 colors for swatch
 }
 
-const STORAGE_KEY = 'icom-lan:theme';
-const USER_CHOICE_KEY = 'icom-lan:theme-user-choice';
-const VFO_STORAGE_KEY = 'icom-lan:vfo-theme';
+const STORAGE_KEY = 'rigplane:theme';
+const USER_CHOICE_KEY = 'rigplane:theme-user-choice';
+const VFO_STORAGE_KEY = 'rigplane:vfo-theme';
 
 const THEMES: ThemeInfo[] = [
   // Dark themes

--- a/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.test.ts
@@ -103,12 +103,12 @@ describe('makeKeyboardHandlers', () => {
 
   it('emits a filter-settings UI event when requested', () => {
     const listener = vi.fn();
-    window.addEventListener('icom-lan:open-filter-settings', listener as EventListener);
+    window.addEventListener('rigplane:open-filter-settings', listener as EventListener);
 
     makeKeyboardHandlers().dispatch(makeAction('open_filter_settings'));
 
     expect(listener).toHaveBeenCalledTimes(1);
-    window.removeEventListener('icom-lan:open-filter-settings', listener as EventListener);
+    window.removeEventListener('rigplane:open-filter-settings', listener as EventListener);
   });
 
   it('tunes frequency by the current frontend step', () => {

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -875,7 +875,7 @@ export function makeKeyboardHandlers() {
           return;
         }
         case 'open_filter_settings': {
-          window.dispatchEvent(new CustomEvent('icom-lan:open-filter-settings'));
+          window.dispatchEvent(new CustomEvent('rigplane:open-filter-settings'));
           return;
         }
         case 'mode_select': {

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -63,13 +63,13 @@
   let showEiBi = $state(false);
   let hiddenLayers = $state<string[]>(
     typeof localStorage !== 'undefined'
-      ? JSON.parse(localStorage.getItem('icom-lan-hidden-layers') || '[]')
+      ? JSON.parse(localStorage.getItem('rigplane-hidden-layers') || '[]')
       : []
   );
   // Persist hidden layers to localStorage
   $effect(() => {
     if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('icom-lan-hidden-layers', JSON.stringify(hiddenLayers));
+      localStorage.setItem('rigplane-hidden-layers', JSON.stringify(hiddenLayers));
     }
   });
   let dxSpots = $state<DxSpot[]>([]);

--- a/frontend/src/lib/__tests__/migrate-legacy-storage.test.ts
+++ b/frontend/src/lib/__tests__/migrate-legacy-storage.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  __resetMigrationStateForTests,
+  migrateLegacyStorage,
+} from '../migrate-legacy-storage';
+
+const SENTINEL_KEY = 'rigplane:storage-migrated-from-icom-lan';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (k: string): string | null => (k in store ? store[k] : null),
+    setItem: (k: string, v: string): void => {
+      store[k] = v;
+    },
+    removeItem: (k: string): void => {
+      delete store[k];
+    },
+    clear: (): void => {
+      store = {};
+    },
+    key: (i: number): string | null => Object.keys(store)[i] ?? null,
+    get length(): number {
+      return Object.keys(store).length;
+    },
+    _dump: (): Record<string, string> => ({ ...store }),
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
+describe('migrateLegacyStorage', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    __resetMigrationStateForTests();
+  });
+
+  it('copies a hyphenated legacy key to its new key and removes the legacy entry', () => {
+    localStorageMock.setItem('icom-lan-auth-token', 'tok-abc');
+
+    migrateLegacyStorage();
+
+    expect(localStorageMock.getItem('rigplane-auth-token')).toBe('tok-abc');
+    expect(localStorageMock.getItem('icom-lan-auth-token')).toBeNull();
+    expect(localStorageMock.getItem(SENTINEL_KEY)).toBe('1');
+  });
+
+  it('copies a colon-namespaced legacy key to its new key', () => {
+    localStorageMock.setItem('icom-lan:theme', 'amber-lcd');
+    localStorageMock.setItem('icom-lan:theme-user-choice', 'amber-lcd');
+    localStorageMock.setItem('icom-lan:vfo-theme', 'green');
+
+    migrateLegacyStorage();
+
+    expect(localStorageMock.getItem('rigplane:theme')).toBe('amber-lcd');
+    expect(localStorageMock.getItem('rigplane:theme-user-choice')).toBe('amber-lcd');
+    expect(localStorageMock.getItem('rigplane:vfo-theme')).toBe('green');
+    expect(localStorageMock.getItem('icom-lan:theme')).toBeNull();
+    expect(localStorageMock.getItem('icom-lan:theme-user-choice')).toBeNull();
+    expect(localStorageMock.getItem('icom-lan:vfo-theme')).toBeNull();
+  });
+
+  it('migrates the dock-layout key with the v1 suffix preserved', () => {
+    const payload = JSON.stringify({ version: 1, extensions: {} });
+    localStorageMock.setItem('icom-lan:local-extension-dock-layout:v1', payload);
+
+    migrateLegacyStorage();
+
+    expect(localStorageMock.getItem('rigplane:local-extension-dock-layout:v1')).toBe(payload);
+    expect(localStorageMock.getItem('icom-lan:local-extension-dock-layout:v1')).toBeNull();
+  });
+
+  it('is a no-op when sentinel is already set', () => {
+    localStorageMock.setItem(SENTINEL_KEY, '1');
+    localStorageMock.setItem('icom-lan-auth-token', 'should-not-migrate');
+
+    migrateLegacyStorage();
+
+    // Already-migrated sentinel means we don't touch the legacy key.
+    expect(localStorageMock.getItem('icom-lan-auth-token')).toBe('should-not-migrate');
+    expect(localStorageMock.getItem('rigplane-auth-token')).toBeNull();
+  });
+
+  it('does not overwrite existing new-key data when both legacy and new are present', () => {
+    localStorageMock.setItem('icom-lan-auth-token', 'old-token');
+    localStorageMock.setItem('rigplane-auth-token', 'new-token-already-set');
+
+    migrateLegacyStorage();
+
+    expect(localStorageMock.getItem('rigplane-auth-token')).toBe('new-token-already-set');
+    // Legacy still removed so it can't drift.
+    expect(localStorageMock.getItem('icom-lan-auth-token')).toBeNull();
+  });
+
+  it('repeated calls in the same session do not re-do work', () => {
+    localStorageMock.setItem('icom-lan-layout', 'standard');
+
+    migrateLegacyStorage();
+    expect(localStorageMock.getItem('rigplane-layout')).toBe('standard');
+
+    // Simulate user setting the new key, then calling migrate again.
+    localStorageMock.setItem('rigplane-layout', 'lcd');
+    migrateLegacyStorage();
+
+    expect(localStorageMock.getItem('rigplane-layout')).toBe('lcd');
+  });
+
+  it('handles missing legacy keys gracefully (no errors, sentinel still set)', () => {
+    migrateLegacyStorage();
+
+    expect(localStorageMock.getItem(SENTINEL_KEY)).toBe('1');
+  });
+
+  it('migrates a representative sample of all key categories at once', () => {
+    localStorageMock.setItem('icom-lan-auth-token', 'tok');
+    localStorageMock.setItem('icom-lan-layout', 'lcd');
+    localStorageMock.setItem('icom-lan-lcd-display-mode', 'dim');
+    localStorageMock.setItem('icom-lan-hidden-layers', '[]');
+    localStorageMock.setItem('icom-lan:panel-collapsed', '{}');
+    localStorageMock.setItem('icom-lan:panel-order', '[]');
+    localStorageMock.setItem('icom-lan:right-panel-order', '[]');
+    localStorageMock.setItem('icom-lan:install-dismissed', 'true');
+    localStorageMock.setItem('icom-lan:memory-channels', '[]');
+    localStorageMock.setItem('icom-lan:lcd-contrast', '0.5');
+
+    migrateLegacyStorage();
+
+    expect(localStorageMock.getItem('rigplane-auth-token')).toBe('tok');
+    expect(localStorageMock.getItem('rigplane-layout')).toBe('lcd');
+    expect(localStorageMock.getItem('rigplane-lcd-display-mode')).toBe('dim');
+    expect(localStorageMock.getItem('rigplane-hidden-layers')).toBe('[]');
+    expect(localStorageMock.getItem('rigplane:panel-collapsed')).toBe('{}');
+    expect(localStorageMock.getItem('rigplane:panel-order')).toBe('[]');
+    expect(localStorageMock.getItem('rigplane:right-panel-order')).toBe('[]');
+    expect(localStorageMock.getItem('rigplane:install-dismissed')).toBe('true');
+    expect(localStorageMock.getItem('rigplane:memory-channels')).toBe('[]');
+    expect(localStorageMock.getItem('rigplane:lcd-contrast')).toBe('0.5');
+
+    // All legacy keys cleared.
+    const dump = localStorageMock._dump();
+    for (const k of Object.keys(dump)) {
+      expect(k.startsWith('icom-lan')).toBe(false);
+    }
+  });
+});

--- a/frontend/src/lib/api/__tests__/diagnostics.test.ts
+++ b/frontend/src/lib/api/__tests__/diagnostics.test.ts
@@ -94,7 +94,7 @@ describe('previewBundle', () => {
   it('includes Authorization header when auth token is stored', async () => {
     // Stub a minimal localStorage — robust against earlier tests that may
     // have replaced globalThis.localStorage (vitest fast-pool isolate:false).
-    const store: Record<string, string> = { 'icom-lan-auth-token': 'tok-secret' };
+    const store: Record<string, string> = { 'rigplane-auth-token': 'tok-secret' };
     const stub = {
       getItem: (k: string) => (k in store ? store[k] : null),
       setItem: (k: string, v: string) => {

--- a/frontend/src/lib/api/diagnostics.ts
+++ b/frontend/src/lib/api/diagnostics.ts
@@ -81,7 +81,7 @@ function getAuthHeaders(): Record<string, string> {
   if (!storage || typeof storage.getItem !== 'function') {
     return {};
   }
-  const token = storage.getItem('icom-lan-auth-token');
+  const token = storage.getItem('rigplane-auth-token');
   if (token) return { Authorization: `Bearer ${token}` };
   return {};
 }

--- a/frontend/src/lib/drag-reorder.svelte.ts
+++ b/frontend/src/lib/drag-reorder.svelte.ts
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   const drag = createDragReorder({
- *     storageKey: 'icom-lan:panel-order',
+ *     storageKey: 'rigplane:panel-order',
  *     defaults: ['rf-front-end', 'mode', ...],
  *     containerSelector: '.left-sidebar',
  *   });

--- a/frontend/src/lib/local-extensions/__tests__/host-api.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/host-api.test.ts
@@ -4,7 +4,10 @@ import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import {
   createLocalExtensionHostApi,
+  installLocalExtensionHostApi,
   LOCAL_EXTENSION_HOST_API_VERSION,
+  type LocalExtensionHostApiV1,
+  type LocalExtensionHostWindow,
   type RadioStateSubscriber,
 } from '../host-api';
 import {
@@ -136,5 +139,60 @@ describe('createLocalExtensionHostApi', () => {
     api.register(extension);
 
     expect(register).toHaveBeenCalledWith(extension);
+  });
+});
+
+describe('installLocalExtensionHostApi', () => {
+  function makeApi(): LocalExtensionHostApiV1 {
+    return createLocalExtensionHostApi({
+      getState: () => null,
+      getCapabilities: () => null,
+      subscribeState: vi.fn(),
+      dispatchCommand: vi.fn().mockReturnValue(true),
+      setKeyboardScope: vi.fn(),
+      register: vi.fn(),
+    });
+  }
+
+  it('exposes the api as both window.rigplaneExtensionHost and window.icomLanExtensionHost', () => {
+    const api = makeApi();
+    const fakeWindow = {} as LocalExtensionHostWindow;
+
+    const uninstall = installLocalExtensionHostApi(fakeWindow, api);
+
+    expect(fakeWindow.rigplaneExtensionHost).toBe(api);
+    expect(fakeWindow.icomLanExtensionHost).toBe(api);
+    // Same instance under both names — Pro extensions written against v1.x
+    // see exactly the same object as new code reading the v2.x global.
+    expect(fakeWindow.rigplaneExtensionHost).toBe(fakeWindow.icomLanExtensionHost);
+
+    uninstall();
+  });
+
+  it('clears both globals on uninstall when the api still matches', () => {
+    const api = makeApi();
+    const fakeWindow = {} as LocalExtensionHostWindow;
+
+    const uninstall = installLocalExtensionHostApi(fakeWindow, api);
+    uninstall();
+
+    expect(fakeWindow.rigplaneExtensionHost).toBeUndefined();
+    expect(fakeWindow.icomLanExtensionHost).toBeUndefined();
+  });
+
+  it('does not clear globals that have been re-bound to a different api', () => {
+    const api1 = makeApi();
+    const api2 = makeApi();
+    const fakeWindow = {} as LocalExtensionHostWindow;
+
+    const uninstall1 = installLocalExtensionHostApi(fakeWindow, api1);
+    // Simulate a second installation that swaps the live api (HMR / reinit).
+    fakeWindow.rigplaneExtensionHost = api2;
+    fakeWindow.icomLanExtensionHost = api2;
+    uninstall1();
+
+    // The first uninstall must not blow away the live api2.
+    expect(fakeWindow.rigplaneExtensionHost).toBe(api2);
+    expect(fakeWindow.icomLanExtensionHost).toBe(api2);
   });
 });

--- a/frontend/src/lib/local-extensions/dock-layout.ts
+++ b/frontend/src/lib/local-extensions/dock-layout.ts
@@ -1,4 +1,4 @@
-export const LOCAL_EXTENSION_DOCK_LAYOUT_STORAGE_KEY = 'icom-lan:local-extension-dock-layout:v1';
+export const LOCAL_EXTENSION_DOCK_LAYOUT_STORAGE_KEY = 'rigplane:local-extension-dock-layout:v1';
 export const LOCAL_EXTENSION_DOCK_LAYOUT_VERSION = 1;
 
 export type LocalExtensionDockMode =

--- a/frontend/src/lib/local-extensions/host-api.ts
+++ b/frontend/src/lib/local-extensions/host-api.ts
@@ -40,6 +40,13 @@ export interface LocalExtensionRegistration {
 }
 
 export interface LocalExtensionHostWindow extends Window {
+  /** Primary v2.x global. Pro local-extensions written for rigplane should read this. */
+  rigplaneExtensionHost?: LocalExtensionHostApiV1;
+  /**
+   * @deprecated Alias kept for v1.x extensions written against icom-lan.
+   * Will be removed in a future major. New code should use
+   * `rigplaneExtensionHost` instead.
+   */
   icomLanExtensionHost?: LocalExtensionHostApiV1;
 }
 
@@ -98,8 +105,16 @@ export function installLocalExtensionHostApi(
   targetWindow: LocalExtensionHostWindow = window as LocalExtensionHostWindow,
   api: LocalExtensionHostApiV1 = createDefaultLocalExtensionHostApi(),
 ): () => void {
+  // Primary v2.x global.
+  targetWindow.rigplaneExtensionHost = api;
+  // Backwards-compat: Pro local-extensions written for v1.x icom-lan read
+  // `window.icomLanExtensionHost`. Expose the same instance under both names
+  // so existing extensions keep working without modification.
   targetWindow.icomLanExtensionHost = api;
   return () => {
+    if (targetWindow.rigplaneExtensionHost === api) {
+      delete targetWindow.rigplaneExtensionHost;
+    }
     if (targetWindow.icomLanExtensionHost === api) {
       delete targetWindow.icomLanExtensionHost;
     }

--- a/frontend/src/lib/migrate-legacy-storage.ts
+++ b/frontend/src/lib/migrate-legacy-storage.ts
@@ -1,9 +1,17 @@
 /**
  * One-shot migration of v1.x icom-lan localStorage keys to v2.x rigplane keys.
  *
- * Must be invoked at the very top of `main.ts` (before `App.svelte` and any
- * stores are imported), because several stores read localStorage at module
- * init (e.g. `layout.svelte.ts`, `theme-switcher.ts`, `lcd-contrast.svelte.ts`).
+ * **Boot-order critical.** Several stores read localStorage at module init
+ * (e.g. `layout.svelte.ts`, `theme-switcher.ts`, `lcd-contrast.svelte.ts`,
+ * `lcd-display-mode.svelte.ts`). Per ES module spec, all transitive imports
+ * of `main.ts` evaluate BEFORE main.ts's body runs — which means a function
+ * call from main.ts's body would race the stores' reads.
+ *
+ * The fix is to run migration as a **top-level side-effect of THIS module**
+ * (see the bottom of the file). Then `main.ts` only needs to import this
+ * file *first*, before any other import: source-order of sibling imports is
+ * preserved during module evaluation, so this module's body (including the
+ * auto-call) runs before `App.svelte` and its store dependencies resolve.
  *
  * Idempotent — running twice is safe. Once the sentinel is written the
  * migration short-circuits.
@@ -88,3 +96,13 @@ export function migrateLegacyStorage(): void {
     // already-migrated keys are no-ops.
   }
 }
+
+// Auto-run on first import. This is what makes the migration race-free: the
+// stores that read localStorage at module init are *transitive imports* of
+// `main.ts`, and the migration module is the FIRST import of `main.ts`. ES
+// module evaluation is in source order for sibling imports, so this body
+// runs before the App / stores are evaluated.
+//
+// Idempotent via `migrationDone`. Tests call `__resetMigrationStateForTests`
+// in `beforeEach` to reset and then explicitly invoke `migrateLegacyStorage`.
+migrateLegacyStorage();

--- a/frontend/src/lib/migrate-legacy-storage.ts
+++ b/frontend/src/lib/migrate-legacy-storage.ts
@@ -1,0 +1,90 @@
+/**
+ * One-shot migration of v1.x icom-lan localStorage keys to v2.x rigplane keys.
+ *
+ * Must be invoked at the very top of `main.ts` (before `App.svelte` and any
+ * stores are imported), because several stores read localStorage at module
+ * init (e.g. `layout.svelte.ts`, `theme-switcher.ts`, `lcd-contrast.svelte.ts`).
+ *
+ * Idempotent — running twice is safe. Once the sentinel is written the
+ * migration short-circuits.
+ *
+ * Removes the legacy keys after copying so they don't drift over time.
+ */
+
+const LEGACY_TO_NEW: Record<string, string> = {
+  // Hyphenated (legacy v1) — auth token, layout, LCD modes, hidden layers,
+  // skin selection. Some keys (`icom-lan-skin`, `icom-lan-lcd-variant`,
+  // `icom-lan-skin-migrated-0.18`) are not currently produced by this
+  // codebase, but v1.x users may still have them in browser storage.
+  'icom-lan-auth-token': 'rigplane-auth-token',
+  'icom-lan-layout': 'rigplane-layout',
+  'icom-lan-lcd-display-mode': 'rigplane-lcd-display-mode',
+  'icom-lan-hidden-layers': 'rigplane-hidden-layers',
+  'icom-lan-lcd-variant': 'rigplane-lcd-variant',
+  'icom-lan-skin': 'rigplane-skin',
+  'icom-lan-skin-migrated-0.18': 'rigplane-skin-migrated-0.18',
+  // Colon-namespaced (newer v1) — panels, install prompt, theme, memory,
+  // contrast, dock layout. Note the dock-layout key carries a `:v1` suffix.
+  'icom-lan:panel-collapsed': 'rigplane:panel-collapsed',
+  'icom-lan:panel-order': 'rigplane:panel-order',
+  'icom-lan:right-panel-order': 'rigplane:right-panel-order',
+  'icom-lan:install-dismissed': 'rigplane:install-dismissed',
+  'icom-lan:memory-channels': 'rigplane:memory-channels',
+  'icom-lan:theme': 'rigplane:theme',
+  'icom-lan:theme-user-choice': 'rigplane:theme-user-choice',
+  'icom-lan:vfo-theme': 'rigplane:vfo-theme',
+  'icom-lan:lcd-contrast': 'rigplane:lcd-contrast',
+  'icom-lan:local-extension-dock-layout:v1': 'rigplane:local-extension-dock-layout:v1',
+};
+
+const MIGRATION_SENTINEL_KEY = 'rigplane:storage-migrated-from-icom-lan';
+
+let migrationDone = false;
+
+/**
+ * Test-only: reset the in-process flag so a unit test can re-run the
+ * migration after manipulating localStorage. Production code must never
+ * call this.
+ */
+export function __resetMigrationStateForTests(): void {
+  migrationDone = false;
+}
+
+export function migrateLegacyStorage(): void {
+  if (migrationDone) return;
+  migrationDone = true;
+
+  // SSR / non-browser bail-out.
+  if (typeof localStorage === 'undefined') return;
+
+  try {
+    if (localStorage.getItem(MIGRATION_SENTINEL_KEY) === '1') return;
+  } catch {
+    // localStorage may throw in some sandboxed contexts; abort gracefully.
+    return;
+  }
+
+  for (const [oldKey, newKey] of Object.entries(LEGACY_TO_NEW)) {
+    try {
+      if (localStorage.getItem(newKey) !== null) {
+        // New key already populated — don't overwrite. Just remove the legacy
+        // copy so it doesn't drift.
+        localStorage.removeItem(oldKey);
+        continue;
+      }
+      const value = localStorage.getItem(oldKey);
+      if (value === null) continue;
+      localStorage.setItem(newKey, value);
+      localStorage.removeItem(oldKey);
+    } catch {
+      // Per-key failures are swallowed; migration is best-effort.
+    }
+  }
+
+  try {
+    localStorage.setItem(MIGRATION_SENTINEL_KEY, '1');
+  } catch {
+    // Ignore: next boot will retry — keys not yet migrated will be picked up,
+    // already-migrated keys are no-ops.
+  }
+}

--- a/frontend/src/lib/stores/layout.svelte.ts
+++ b/frontend/src/lib/stores/layout.svelte.ts
@@ -9,7 +9,7 @@
  * Legacy 'lcd' persisted values are mapped to 'lcd-cockpit' by resolveSkinId().
  */
 
-const STORAGE_KEY = 'icom-lan-layout';
+const STORAGE_KEY = 'rigplane-layout';
 
 export type LayoutMode = 'auto' | 'lcd' | 'lcd-cockpit' | 'lcd-scope' | 'standard' | 'sdr-test';
 

--- a/frontend/src/lib/stores/lcd-contrast.svelte.ts
+++ b/frontend/src/lib/stores/lcd-contrast.svelte.ts
@@ -6,11 +6,11 @@
  * `--lcd-alpha-*` custom properties on the `.lcd-screen` root. This is
  * the foundation mechanism — see docs/plans/2026-04-18-lcd-display-enhancements.md §2.
  *
- * Persistence is intentionally separate from theme (`icom-lan:lcd-contrast`):
+ * Persistence is intentionally separate from theme (`rigplane:lcd-contrast`):
  * contrast tracks ambient light, theme is aesthetic.
  */
 
-const STORAGE_KEY = 'icom-lan:lcd-contrast';
+const STORAGE_KEY = 'rigplane:lcd-contrast';
 
 export type LcdContrastPreset = 'DIM' | 'LOW' | 'MID' | 'HIGH' | 'MAX';
 

--- a/frontend/src/lib/stores/lcd-display-mode.svelte.ts
+++ b/frontend/src/lib/stores/lcd-display-mode.svelte.ts
@@ -21,7 +21,7 @@ export const LCD_DISPLAY_MODES: readonly LcdDisplayMode[] = [
   'flicker',
 ] as const;
 
-const STORAGE_KEY = 'icom-lan-lcd-display-mode';
+const STORAGE_KEY = 'rigplane-lcd-display-mode';
 
 let mode = $state<LcdDisplayMode>(loadMode());
 

--- a/frontend/src/lib/transport/http-client.ts
+++ b/frontend/src/lib/transport/http-client.ts
@@ -18,7 +18,7 @@ function getStoredToken(): string | null {
   if (!storage || typeof storage.getItem !== 'function') {
     return null;
   }
-  return storage.getItem('icom-lan-auth-token');
+  return storage.getItem('rigplane-auth-token');
 }
 
 function getAuthHeaders(): Record<string, string> {
@@ -30,7 +30,7 @@ function getAuthHeaders(): Record<string, string> {
 function handleUnauthorized(): void {
   const token = prompt('Enter auth token:');
   if (token) {
-    localStorage.setItem('icom-lan-auth-token', token);
+    localStorage.setItem('rigplane-auth-token', token);
     location.reload();
   }
 }

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -301,7 +301,7 @@ _ctrl.onMessage((msg) => {
 
 export function connect(url: string = '/api/v1/ws') {
   const token = typeof globalThis.localStorage?.getItem === 'function'
-    ? globalThis.localStorage.getItem('icom-lan-auth-token')
+    ? globalThis.localStorage.getItem('rigplane-auth-token')
     : null;
   const wsUrl = token ? `${url}?token=${encodeURIComponent(token)}` : url;
   _ctrl.connect(wsUrl);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,10 +1,14 @@
-// IMPORTANT: localStorage migration MUST run before any other import.
-// Several stores (`layout.svelte.ts`, `theme-switcher.ts`,
-// `lcd-contrast.svelte.ts`, ...) read localStorage at module init, so
-// the migration has to happen before they evaluate. Putting the call
-// at the top of main.ts is the only reliable ordering.
-import { migrateLegacyStorage } from './lib/migrate-legacy-storage'
-migrateLegacyStorage()
+// IMPORTANT: this side-effect import MUST be first.
+//
+// `migrate-legacy-storage` runs the v1.x → v2.x localStorage migration as a
+// module-top side-effect. ES modules evaluate transitive imports BEFORE the
+// importing module's body runs, so a function call here in main.ts's body
+// would race against stores that read localStorage at module init
+// (`layout.svelte.ts`, `theme-switcher.ts`, `lcd-contrast.svelte.ts`,
+// `lcd-display-mode.svelte.ts`). By making this import the first sibling,
+// its body — including the migration call — runs before any other import
+// is evaluated.
+import './lib/migrate-legacy-storage'
 
 import { mount } from 'svelte'
 import './app.css'

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,3 +1,11 @@
+// IMPORTANT: localStorage migration MUST run before any other import.
+// Several stores (`layout.svelte.ts`, `theme-switcher.ts`,
+// `lcd-contrast.svelte.ts`, ...) read localStorage at module init, so
+// the migration has to happen before they evaluate. Putting the call
+// at the top of main.ts is the only reliable ordering.
+import { migrateLegacyStorage } from './lib/migrate-legacy-storage'
+migrateLegacyStorage()
+
 import { mount } from 'svelte'
 import './app.css'
 import App from './App.svelte'

--- a/src/rigplane/_platformdirs_migration.py
+++ b/src/rigplane/_platformdirs_migration.py
@@ -1,0 +1,100 @@
+"""One-shot migration of v1.x icom-lan platformdirs paths to v2.x rigplane.
+
+When v2.0.0 starts on a host that has v1.x data under ``icom-lan`` paths
+(``~/.cache/icom-lan``, ``~/.config/icom-lan``, etc.), copy the contents
+to the new ``rigplane`` paths so logs and configuration carry over.
+Idempotent — runs once per process; subsequent calls are no-ops.
+
+The legacy paths are left in place (read-only after migration) so users
+can manually clean them up. We do NOT delete legacy contents.
+
+Best-effort: any failure (broken FS permissions, missing platformdirs,
+etc.) is logged at DEBUG and swallowed so a broken migration cannot
+break startup.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Final
+
+import platformdirs
+
+_logger = logging.getLogger("rigplane.platformdirs_migration")
+_LEGACY_APP: Final = "icom-lan"
+_NEW_APP: Final = "rigplane"
+_SENTINEL_FILENAME: Final = ".migrated-from-icom-lan-v1"
+
+_done = False
+
+
+def __reset_for_tests() -> None:
+    """Test-only: reset the in-process flag so a unit test can re-run."""
+    global _done
+    _done = False
+
+
+def migrate_legacy_platformdirs() -> None:
+    """Copy contents of legacy icom-lan platformdirs to rigplane paths.
+
+    Best-effort: failures are logged at DEBUG and swallowed so a broken
+    migration cannot break startup. Idempotent — calling multiple times
+    in the same process is a no-op after the first call.
+    """
+    global _done
+    if _done:
+        return
+    _done = True
+
+    pairs = (
+        (
+            Path(platformdirs.user_cache_path(_LEGACY_APP)),
+            Path(platformdirs.user_cache_path(_NEW_APP)),
+        ),
+        (
+            Path(platformdirs.user_config_path(_LEGACY_APP)),
+            Path(platformdirs.user_config_path(_NEW_APP)),
+        ),
+        (
+            Path(platformdirs.user_log_path(_LEGACY_APP)),
+            Path(platformdirs.user_log_path(_NEW_APP)),
+        ),
+        (
+            Path(platformdirs.user_state_path(_LEGACY_APP)),
+            Path(platformdirs.user_state_path(_NEW_APP)),
+        ),
+    )
+
+    for legacy, new in pairs:
+        try:
+            _migrate_one(legacy, new)
+        except Exception as exc:  # noqa: BLE001 — best-effort, swallow all
+            _logger.debug(
+                "platformdirs migration %s -> %s failed: %s",
+                legacy,
+                new,
+                exc,
+            )
+
+
+def _migrate_one(legacy: Path, new: Path) -> None:
+    if not legacy.exists() or not legacy.is_dir():
+        return
+    sentinel = new / _SENTINEL_FILENAME
+    if sentinel.exists():
+        return  # already migrated this directory
+    new.mkdir(parents=True, exist_ok=True)
+    for child in legacy.iterdir():
+        target = new / child.name
+        if target.exists():
+            continue  # don't overwrite anything in the new location
+        if child.is_dir():
+            shutil.copytree(child, target)
+        else:
+            shutil.copy2(child, target)
+    sentinel.write_text(
+        "platformdirs migration from icom-lan v1.x complete\n",
+        encoding="utf-8",
+    )

--- a/src/rigplane/cli/_diagnose.py
+++ b/src/rigplane/cli/_diagnose.py
@@ -137,10 +137,20 @@ def _default_output_path() -> Path:
 
 
 def _default_log_dir() -> Path:
+    # Defense in depth: the same call already runs inside
+    # `configure_diagnostic_logging()` at `import rigplane` time, but a CLI
+    # entry point that bypasses that path (or runs before logging init) still
+    # benefits from the migration. The helper is idempotent.
+    from rigplane._platformdirs_migration import migrate_legacy_platformdirs
+
+    migrate_legacy_platformdirs()
     return Path(platformdirs.user_cache_path("rigplane")) / "logs"
 
 
 def _default_config_dir() -> Path:
+    from rigplane._platformdirs_migration import migrate_legacy_platformdirs
+
+    migrate_legacy_platformdirs()
     return Path(platformdirs.user_config_path("rigplane"))
 
 

--- a/src/rigplane/diagnostics/_logging.py
+++ b/src/rigplane/diagnostics/_logging.py
@@ -53,6 +53,15 @@ def configure_diagnostic_logging() -> None:
     # Idempotency: skip if our handler already present.
     if any(isinstance(h, SafeRotatingFileHandler) for h in icom_logger.handlers):
         return
+    # Migrate any legacy v1 platformdirs contents BEFORE we resolve the
+    # rigplane log path, so existing log files come along on the very first
+    # start of v2.0.0. The helper is idempotent and best-effort.
+    try:
+        from rigplane._platformdirs_migration import migrate_legacy_platformdirs
+
+        migrate_legacy_platformdirs()
+    except Exception:  # noqa: BLE001 — best-effort, swallow all
+        pass
     try:
         log_dir = platformdirs.user_cache_path("rigplane") / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2040,6 +2040,12 @@ class WebServer:
         """
         import platformdirs
 
+        # Defense in depth — already runs at package init via
+        # ``configure_diagnostic_logging()``. Idempotent here.
+        from rigplane._platformdirs_migration import migrate_legacy_platformdirs
+
+        migrate_legacy_platformdirs()
+
         config_dir = pathlib.Path(platformdirs.user_config_path("rigplane"))
         log_dir = pathlib.Path(platformdirs.user_cache_path("rigplane")) / "logs"
         return config_dir, log_dir

--- a/tests/test_platformdirs_migration.py
+++ b/tests/test_platformdirs_migration.py
@@ -1,0 +1,175 @@
+"""Tests for rigplane._platformdirs_migration.
+
+The migration helper copies the contents of v1.x ``icom-lan`` platformdirs
+into v2.x ``rigplane`` platformdirs so existing users keep their logs and
+configuration on first start of v2.0.0.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import platformdirs
+import pytest
+
+from rigplane import _platformdirs_migration as mig
+from rigplane._platformdirs_migration import (
+    _SENTINEL_FILENAME,
+    migrate_legacy_platformdirs,
+)
+
+
+@pytest.fixture
+def fake_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect every platformdirs.user_*_path call to a tmp_path subtree.
+
+    Each app gets its own subdirectory keyed by app name, e.g.
+    ``tmp_path/cache/icom-lan`` vs ``tmp_path/cache/rigplane``.
+    """
+    cache_root = tmp_path / "cache"
+    config_root = tmp_path / "config"
+    log_root = tmp_path / "log"
+    state_root = tmp_path / "state"
+
+    monkeypatch.setattr(
+        platformdirs,
+        "user_cache_path",
+        lambda app: cache_root / app,
+    )
+    monkeypatch.setattr(
+        platformdirs,
+        "user_config_path",
+        lambda app: config_root / app,
+    )
+    monkeypatch.setattr(
+        platformdirs,
+        "user_log_path",
+        lambda app: log_root / app,
+    )
+    monkeypatch.setattr(
+        platformdirs,
+        "user_state_path",
+        lambda app: state_root / app,
+    )
+    # Reset in-process guard so each test gets a fresh run.
+    mig.__reset_for_tests()
+    return tmp_path
+
+
+def test_legacy_dir_with_files_migrates_into_new_dir(fake_dirs: Path) -> None:
+    legacy_cache = fake_dirs / "cache" / "icom-lan"
+    legacy_cache.mkdir(parents=True)
+    (legacy_cache / "app.log").write_text("legacy log", encoding="utf-8")
+    sub = legacy_cache / "logs"
+    sub.mkdir()
+    (sub / "rigplane.log").write_text("nested log", encoding="utf-8")
+
+    migrate_legacy_platformdirs()
+
+    new_cache = fake_dirs / "cache" / "rigplane"
+    assert (new_cache / "app.log").read_text(encoding="utf-8") == "legacy log"
+    assert (new_cache / "logs" / "rigplane.log").read_text(
+        encoding="utf-8"
+    ) == "nested log"
+    assert (new_cache / _SENTINEL_FILENAME).exists()
+
+
+def test_existing_new_files_are_not_overwritten(fake_dirs: Path) -> None:
+    legacy_cfg = fake_dirs / "config" / "icom-lan"
+    legacy_cfg.mkdir(parents=True)
+    (legacy_cfg / "settings.json").write_text("legacy settings", encoding="utf-8")
+    (legacy_cfg / "fresh.json").write_text("legacy fresh", encoding="utf-8")
+
+    new_cfg = fake_dirs / "config" / "rigplane"
+    new_cfg.mkdir(parents=True)
+    (new_cfg / "settings.json").write_text("new settings", encoding="utf-8")
+
+    migrate_legacy_platformdirs()
+
+    # Existing new-side file is preserved (collision: don't overwrite).
+    assert (new_cfg / "settings.json").read_text(encoding="utf-8") == "new settings"
+    # Non-conflicting legacy file is migrated.
+    assert (new_cfg / "fresh.json").read_text(encoding="utf-8") == "legacy fresh"
+    # Sentinel was still written so this dir won't be revisited.
+    assert (new_cfg / _SENTINEL_FILENAME).exists()
+
+
+def test_no_legacy_dir_is_a_quiet_noop(fake_dirs: Path) -> None:
+    # No legacy dirs exist anywhere.
+    migrate_legacy_platformdirs()
+
+    # No new dirs should have been created either — nothing to copy means
+    # nothing to do.
+    assert not (fake_dirs / "cache" / "rigplane").exists()
+    assert not (fake_dirs / "config" / "rigplane").exists()
+    assert not (fake_dirs / "log" / "rigplane").exists()
+    assert not (fake_dirs / "state" / "rigplane").exists()
+
+
+def test_second_call_in_same_process_is_a_noop(fake_dirs: Path) -> None:
+    legacy_cache = fake_dirs / "cache" / "icom-lan"
+    legacy_cache.mkdir(parents=True)
+    (legacy_cache / "first.log").write_text("first", encoding="utf-8")
+
+    migrate_legacy_platformdirs()
+    new_cache = fake_dirs / "cache" / "rigplane"
+    assert (new_cache / "first.log").exists()
+
+    # Drop a fresh file into legacy AFTER the first migration.
+    (legacy_cache / "second.log").write_text("second", encoding="utf-8")
+    migrate_legacy_platformdirs()
+
+    # Second call short-circuits via the in-process flag, so the
+    # newly added legacy file is NOT copied over.
+    assert not (new_cache / "second.log").exists()
+
+
+def test_sentinel_short_circuits_per_directory(fake_dirs: Path) -> None:
+    # Pre-create the new dir with a sentinel — simulating a prior process
+    # that already migrated. Even with new content in legacy, this dir is
+    # skipped at the per-directory level.
+    legacy_state = fake_dirs / "state" / "icom-lan"
+    legacy_state.mkdir(parents=True)
+    (legacy_state / "should-not-copy.txt").write_text("nope", encoding="utf-8")
+
+    new_state = fake_dirs / "state" / "rigplane"
+    new_state.mkdir(parents=True)
+    (new_state / _SENTINEL_FILENAME).write_text("done", encoding="utf-8")
+
+    migrate_legacy_platformdirs()
+
+    assert not (new_state / "should-not-copy.txt").exists()
+
+
+def test_function_never_raises_on_io_error(
+    fake_dirs: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_cache = fake_dirs / "cache" / "icom-lan"
+    legacy_cache.mkdir(parents=True)
+    (legacy_cache / "broken.log").write_text("data", encoding="utf-8")
+
+    # Force an exception inside the migration loop.
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated permission failure")
+
+    monkeypatch.setattr("shutil.copy2", boom)
+    monkeypatch.setattr("shutil.copytree", boom)
+
+    # Must NOT raise.
+    migrate_legacy_platformdirs()
+
+
+def test_legacy_path_that_is_a_file_not_dir_is_skipped(fake_dirs: Path) -> None:
+    # If something weird made the legacy path a regular file, the migration
+    # must not crash and must not try to migrate it.
+    legacy_cache_parent = fake_dirs / "cache"
+    legacy_cache_parent.mkdir(parents=True)
+    legacy_cache = legacy_cache_parent / "icom-lan"
+    legacy_cache.write_text("not a dir", encoding="utf-8")
+
+    migrate_legacy_platformdirs()
+
+    new_cache = fake_dirs / "cache" / "rigplane"
+    # No new dir created because there was nothing to migrate.
+    assert not new_cache.exists()


### PR DESCRIPTION
## Summary

Wave 2 **PR-2C**: keep v1.1.0 (icom-lan) users from losing data on upgrade to v2.0.0 (rigplane). Touches frontend localStorage keys, frontend window globals, frontend custom events, and Python `platformdirs` paths.

## What's in here

### 1. Frontend localStorage migration helper
`frontend/src/lib/migrate-legacy-storage.ts` — one-shot, idempotent, sentinel-guarded copy of every `icom-lan-*` / `icom-lan:*` key to `rigplane-*` / `rigplane:*`.

**Auto-runs as a module-top side-effect**, imported as the first sibling of `main.ts`. This ordering is **boot-order critical**: stores like `layout.svelte.ts`, `theme-switcher.ts`, `lcd-contrast.svelte.ts`, and `lcd-display-mode.svelte.ts` read localStorage at module init — so a function call from main.ts's body would lose the race against module evaluation. Only side-effect-during-import wins.

### 2. Frontend storage-key rename
Every literal `icom-lan-*` / `icom-lan:*` storage key in core code (and the test fixtures that hard-coded them) is now `rigplane-*` / `rigplane:*`. v1.x user data carries over via the migration helper above.

### 3. Frontend custom event rename
`icom-lan:open-filter-settings` → `rigplane:open-filter-settings` (the only listener is in the same codebase; no emit-both transition needed).

### 4. `window.*ExtensionHost` dual-register
`installLocalExtensionHostApi()` now exposes the host API under BOTH `window.rigplaneExtensionHost` (primary, v2.x) AND `window.icomLanExtensionHost` (deprecated alias). Pro local-extensions written against v1.x continue to work without modification.

### 5. Python `platformdirs` migration
`src/rigplane/_platformdirs_migration.py` — best-effort, idempotent, per-directory-sentinel-guarded copy of every v1.x `icom-lan` platformdirs path (cache / config / log / state) into the corresponding `rigplane` path.

**Wired into:**
- `diagnostics._logging.configure_diagnostic_logging()` — primary (runs early at `import rigplane`)
- `cli._diagnose._default_log_dir()` / `_default_config_dir()` — defense in depth
- `web.server.WebServer._resolve_diagnostic_dirs()` — defense in depth

Existing files at the destination are NOT overwritten. Legacy contents are NOT deleted (users can manually clean). All exceptions swallowed at DEBUG so a broken migration cannot break startup.

## Test plan

- [x] `uv run pytest tests/ -q --ignore=tests/integration` → **5677 passed** (+7 from baseline; 7 new platformdirs migration tests)
- [x] `uv run ruff check src/ tests/` → clean
- [x] `uv run ruff format --check src/ tests/` → clean
- [x] `uv run mypy src/` → clean
- [x] `uv run lint-imports` → 4/4 contracts kept
- [x] `cd frontend && npx vitest run` → **1726 passed** (+11; 8 storage-migration + 3 host-api tests)
- [x] `cd frontend && npm run build` → succeeds
- [ ] Manual smoke: install v1.x, populate localStorage + platformdirs, upgrade to this branch, verify auth token / theme / panel order / memory channels carry over and `~/.cache/rigplane/logs` inherits old logs

## Surprises

1. **Boot-order race fixed via auto-run on import, not function call.** First implementation called `migrateLegacyStorage()` from main.ts body; that loses the race against module-init localStorage reads. Fix: side-effect-during-import. See commit `6d281552` for full reasoning. Caught by advisor mid-run.

2. **dock-layout key has `:v1` suffix** — actual key is `'icom-lan:local-extension-dock-layout:v1'`, not what the inventory implied. Migration map updated.

## Notes for reviewer

- `LAYER.md` docs in `src/rigplane/{audio,cli,core,dsp,web}/` still reference `icom-lan` / `icom_lan` — out of PR-2C scope, deferred to **PR-2E**.
- `icom-lan-diag/1` in `frontend/src/lib/api/__tests__/diagnostics.test.ts:18` is the manifest wire-format string analogous to the Python-side `icom-lan-bundle-v1` schema preserved per spec — handled in **PR-2G**.

## Stats

```
31 files changed, 671 insertions(+), 29 deletions(-)
```
6 commits, branch `feat/rebrand/wave2-state-migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)