### PR TITLE
rebrand(wave2): documentation prose rewrite (PR-2E)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,4 +1,4 @@
-# Release icom-lan
+# Release rigplane
 
 Automate the full release process.
 
@@ -14,7 +14,7 @@ User-facing messages in Russian. Code / commit / release text in English.
 
 ## Step 1 — Determine target version
 
-1. Read current version from `pyproject.toml` (`version = "..."`) and `src/icom_lan/__init__.py` (`__version__ = "..."`). If mismatched, report both and proceed to sync.
+1. Read current version from `pyproject.toml` (`version = "..."`) and `src/rigplane/__init__.py` (`__version__ = "..."`). If mismatched, report both and proceed to sync.
 2. Get previous tag: `git tag --list 'v*' --sort=-version:refname | head -1`.
 3. If no bump argument passed, **auto-suggest**:
    - Run `git log vPREV..HEAD --no-merges --format='%s'`
@@ -114,7 +114,7 @@ Release plan for vNEW_VERSION:
 
   Bump:          vCURRENT → vNEW (TYPE)
   Commits:       N (X feat, Y fix, Z other)
-  Files to edit: pyproject.toml, src/icom_lan/__init__.py, CHANGELOG.md, RELEASE_NOTES.md [, CLAUDE.md]
+  Files to edit: pyproject.toml, src/rigplane/__init__.py, CHANGELOG.md, RELEASE_NOTES.md [, CLAUDE.md]
   Changelog:     [count] Added / [count] Changed / [count] Fixed entries
   Tag:           vNEW_VERSION
   Push target:   origin/main (atomic --follow-tags)
@@ -133,7 +133,7 @@ On dry-run → print what would be done and STOP here.
 All writes local — nothing pushed yet.
 
 1. `pyproject.toml` — `version = "OLD"` → `version = "NEW"`
-2. `src/icom_lan/__init__.py` — `__version__ = "OLD"` → `__version__ = "NEW"`
+2. `src/rigplane/__init__.py` — `__version__ = "OLD"` → `__version__ = "NEW"`
 3. `CLAUDE.md` — `| **Version** | OLD |` → `| **Version** | NEW |` (if the row exists)
 4. `CHANGELOG.md`:
    - Keep `## [Unreleased]` header (now empty) at top
@@ -142,7 +142,7 @@ All writes local — nothing pushed yet.
 5. `RELEASE_NOTES.md`: **derive from the CHANGELOG section you just inserted** — do NOT regenerate from commits.
    Structure:
    ```markdown
-   # icom-lan NEW_VERSION
+   # rigplane NEW_VERSION
 
    **Release date:** Month Day, Year
 
@@ -151,9 +151,9 @@ All writes local — nothing pushed yet.
    ## Install / Upgrade
 
    ```bash
-   pip install icom-lan==NEW_VERSION
+   pip install rigplane==NEW_VERSION
    # or upgrade:
-   pip install --upgrade icom-lan
+   pip install --upgrade rigplane
    ```
    ```
 
@@ -211,7 +211,7 @@ CI will now:
   - Publish to PyPI (publish.yml)
   - Deploy docs (docs.yml)
 
-Monitor: https://github.com/morozsm/icom-lan/actions
+Monitor: https://github.com/rigplane/rigplane-core/actions
 ```
 
 ---

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,12 +1,12 @@
-# icom-lan — High-Level Architecture
+# rigplane — High-Level Architecture
 
-**Краткое описание:** Python библиотека + Web UI для управления трансиверами Icom через LAN (UDP) или USB serial.
+**Краткое описание:** мульти-вендорная Python-библиотека + Web UI для управления любительскими трансиверами — Icom (CI-V over LAN/USB), Yaesu (CAT) и совместимыми (Kenwood-style CAT).
 
 ---
 
 ## Layered package structure
 
-`src/icom_lan/` is organised into 11 layered Python packages with
+`src/rigplane/` is organised into 11 layered Python packages with
 explicit `import-linter`-enforced boundaries. Higher layers depend on
 lower ones; siblings are independent. See
 [`docs/plans/2026-04-29-modularization-plan.md`](docs/plans/2026-04-29-modularization-plan.md)
@@ -40,7 +40,7 @@ charter, public API, and forbidden patterns.
 - New cross-layer imports must respect the matrix; `import-linter`
   catches violations at CI.
 - The `Radio` Protocol (in `core.radio_protocol`) is the stable public
-  contract surfaced via `icom_lan` Tier 1; capability protocols
+  contract surfaced via `rigplane` Tier 1; capability protocols
   (`*Capable`, `StatePollable`, `StatePoller`, `RigctldRoutable`,
   `UsbAudioCapable`) drive `isinstance`-based feature detection — see
   [`docs/plans/2026-04-29-modularization-plan.md`](docs/plans/2026-04-29-modularization-plan.md)
@@ -91,13 +91,13 @@ get_s_meter_sql_status = [0x15, 0x01]  # Override IC-7610 command
 
 ---
 
-### 2️⃣ **Rig Loader** (`src/icom_lan/profiles/rig_loader.py`)
+### 2️⃣ **Rig Loader** (`src/rigplane/profiles/rig_loader.py`)
 
 Парсит TOML → валидирует → создаёт runtime объекты:
 
 ```python
-from icom_lan.profiles.rig_loader import load_rig
-# (`from icom_lan.rig_loader import load_rig` also still works via shim)
+from rigplane.profiles.rig_loader import load_rig
+# (`from rigplane.rig_loader import load_rig` also still works via shim)
 
 rig = load_rig("rigs/ic7610.toml")
 profile: RadioProfile = rig.to_profile()      # Runtime profile
@@ -110,7 +110,7 @@ cmd_map: CommandMap = rig.to_command_map()    # Command overrides
 
 ---
 
-### 3️⃣ **Radio API** (`src/icom_lan/runtime/radio.py`)
+### 3️⃣ **Radio API** (`src/rigplane/runtime/radio.py`)
 
 Высокоуровневый async API:
 
@@ -143,7 +143,7 @@ audio_frame = await radio.recv_audio()  # Opus/PCM bytes
 
 ---
 
-### 4️⃣ **Commands Layer** (`src/icom_lan/commands/`)
+### 4️⃣ **Commands Layer** (`src/rigplane/commands/`)
 
 **134 функции-builders** для CI-V команд:
 
@@ -182,7 +182,7 @@ get_frequency(receiver=RECEIVER_SUB)   # → 0x07 0xD1 prefix
 
 ### 5️⃣ **Backend Layer** (Transport)
 
-**LAN Backend** (`src/icom_lan/backends/icom7610/`):
+**LAN Backend** (`src/rigplane/backends/icom7610/`):
 - UDP port 50001 → control (auth, token renewal)
 - UDP port 50002 → CI-V commands
 - UDP port 50003 → audio (Opus/PCM)
@@ -198,7 +198,7 @@ IDLE → AUTH → TOKEN_RENEW → PORTS_READY → AUDIO_NEG → READY
 
 ---
 
-### 6️⃣ **Web Server** (`src/icom_lan/web/server.py`)
+### 6️⃣ **Web Server** (`src/rigplane/web/server.py`)
 
 **HTTP API:**
 ```
@@ -225,7 +225,7 @@ GET /api/v1/state
 
 ---
 
-### 7️⃣ **Frontend** (`src/icom_lan/web/static/`)
+### 7️⃣ **Frontend** (`src/rigplane/web/static/`)
 
 **Svelte 5 + TypeScript**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Control Plane
 
-**icom-lan** v1.0.1 — Python 3.11+ asyncio library + Web UI for Icom transceivers over LAN/USB.
+**rigplane** v2.0.0 — Python 3.11+ asyncio library + Web UI for Icom transceivers over LAN/USB.
 IC-7610 at `192.168.55.40`, CI-V `0x98`. Context: `docs/PROJECT.md`.
 
 ---
@@ -24,7 +24,7 @@ Three workflows, tiered by cost:
 
 | Workflow | Trigger | Scope |
 |---|---|---|
-| `quick.yml` | push/PR to `main` only when `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, or `.github/workflows/**` change | Python 3.11 only · ruff · import-linter · pytest (no integration) · frontend block runs **only** if `frontend/**` or `src/icom_lan/web/**` changed · badges |
+| `quick.yml` | push/PR to `main` only when `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, or `.github/workflows/**` change | Python 3.11 only · ruff · import-linter · pytest (no integration) · frontend block runs **only** if `frontend/**` or `src/rigplane/web/**` changed · badges |
 | `full.yml` | cron Mon/Wed/Fri 03:00 UTC + `workflow_dispatch` + push with `[full-ci]` in commit message | Full matrix 3.11/3.12/3.13, everything |
 | `publish.yml` | `release: published` | New `validate` job (full matrix) → `build` → `publish`. No publish if validate fails. |
 
@@ -64,7 +64,7 @@ Don't add per-push matrix builds back without explicit reason — the goal is mi
 
 ## Layer boundaries
 
-`src/icom_lan/` is organised into 11 layered packages with `import-linter`-enforced boundaries (config at repo root `.importlinter`; full matrix in `docs/plans/2026-04-29-modularization-plan.md` §1, §3; per-layer charters in `src/icom_lan/<layer>/LAYER.md`).
+`src/rigplane/` is organised into 11 layered packages with `import-linter`-enforced boundaries (config at repo root `.importlinter`; full matrix in `docs/plans/2026-04-29-modularization-plan.md` §1, §3; per-layer charters in `src/rigplane/<layer>/LAYER.md`).
 
 Layers (top → bottom; higher = more dependent):
 
@@ -82,7 +82,7 @@ When making changes:
 - Adding a new radio backend → conform to the relevant Capability Protocols in `core.radio_protocol` (`AudioCapable`, `StatePollable`, `RigctldRoutable`, `UsbAudioCapable`, …); zero upper-layer changes if the protocols are honoured.
 - New cross-layer imports must respect the matrix; if a sensible-looking import is rejected by the linter, the file is in the wrong layer.
 - Run `uv run lint-imports` before committing significant structural changes (CI gates every PR anyway).
-- Backwards compatibility: old top-level paths (`icom_lan.radio`, `icom_lan.commander`, `icom_lan.rig_loader`, …) keep working via `sys.modules`-aliased re-export shims; new code SHOULD use canonical paths (`icom_lan.runtime.radio`, etc.).
+- Backwards compatibility: old top-level paths (`rigplane.radio`, `rigplane.commander`, `rigplane.rig_loader`, …) keep working via `sys.modules`-aliased re-export shims; new code SHOULD use canonical paths (`rigplane.runtime.radio`, etc.).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,35 @@
-# icom-lan
+# rigplane
 
-[![PyPI](https://img.shields.io/pypi/v/icom-lan.svg)](https://pypi.org/project/icom-lan/)
+[![PyPI](https://img.shields.io/pypi/v/rigplane.svg)](https://pypi.org/project/rigplane/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
-[![CI](https://github.com/morozsm/icom-lan/actions/workflows/test.yml/badge.svg)](https://github.com/morozsm/icom-lan/actions/workflows/test.yml)
-[![Docs](https://img.shields.io/badge/docs-morozsm.github.io%2Ficom--lan-blue.svg)](https://morozsm.github.io/icom-lan)
+[![CI](https://github.com/rigplane/rigplane-core/actions/workflows/test.yml/badge.svg)](https://github.com/rigplane/rigplane-core/actions/workflows/test.yml)
+[![Docs](https://img.shields.io/badge/docs-rigplane.dev-blue.svg)](https://rigplane.dev)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-**icom-lan** is a Python asyncio library and Web UI for controlling Icom
-transceivers over LAN (UDP) or USB serial — and now Yaesu CAT radios over
-USB. Direct connection to your radio: no wfview, no hamlib daemon, no RS-BA1.
-A capability-driven runtime renders the same Web UI and `rigctld`-compatible
-network bridge across IC-7610, IC-7300, FTX-1, and any future backend that
-honours the public `Radio` protocol. Tested in production against WSJT-X,
-fldigi, and JS8Call.
+> **v2.0.0 — renamed from `icom-lan`.** The package, console script, repo,
+> and docs now ship as `rigplane`. Existing `from icom_lan import ...` calls
+> keep working through a deprecation shim. Migration guide:
+> [rigplane.dev/migrate](https://rigplane.dev/migrate).
+
+**rigplane** is a multi-vendor radio control library and Web UI — Python
+asyncio core plus a self-contained browser front-end. It speaks Icom CI-V
+(LAN UDP and USB), Yaesu CAT, and Kenwood-style CAT, with stable backends
+for IC-7610, IC-7300, and Yaesu FTX-1, and profile-based support for IC-705,
+IC-9700, Xiegu X6100, and Lab599 TX-500. Direct connection to your radio:
+no wfview, no hamlib daemon, no RS-BA1. A capability-driven runtime renders
+the same Web UI and `rigctld`-compatible network bridge across every backend
+that honours the public `Radio` protocol. Tested in production against
+WSJT-X, fldigi, and JS8Call.
 
 <p align="center">
-  <img src="docs/screenshots/hero.png" alt="icom-lan Web UI — IC-7610 dual-RX desktop with scope and waterfall" width="100%">
+  <img src="docs/screenshots/hero.png" alt="rigplane Web UI — IC-7610 dual-RX desktop with scope and waterfall" width="100%">
 </p>
 
 ## Quickstart
 
 ```bash
-pip install icom-lan
-icom-lan web                # auto-discovers a radio on the LAN
+pip install rigplane
+rigplane web                # auto-discovers a radio on the LAN
 # open http://localhost:8080
 ```
 
@@ -30,7 +37,7 @@ Or as a library:
 
 ```python
 import asyncio
-from icom_lan import create_radio, LanBackendConfig
+from rigplane import create_radio, LanBackendConfig
 
 async def main():
     async with create_radio(LanBackendConfig(host="192.168.1.100",
@@ -43,9 +50,9 @@ async def main():
 asyncio.run(main())
 ```
 
-Full guides: [getting started](https://morozsm.github.io/icom-lan/guide/quickstart/),
-[CLI](https://morozsm.github.io/icom-lan/guide/cli/),
-[public API surface](https://morozsm.github.io/icom-lan/api/public-api-surface/).
+Full guides: [getting started](https://rigplane.dev/guide/quickstart/),
+[CLI](https://rigplane.dev/guide/cli/),
+[public API surface](https://rigplane.dev/api/public-api-surface/).
 
 ## Supported radios
 
@@ -62,7 +69,7 @@ Full guides: [getting started](https://morozsm.github.io/icom-lan/guide/quicksta
 Radio capabilities are declared in `rigs/*.toml` — adding a new model is
 typically a profile change, not Python code. Three protocol families are
 supported: CI-V (Icom binary), Kenwood CAT (text), Yaesu CAT (text). See
-[adding a new radio](https://morozsm.github.io/icom-lan/guide/rig-profiles/).
+[adding a new radio](https://rigplane.dev/guide/rig-profiles/).
 
 ## Why 1.0
 
@@ -84,7 +91,7 @@ supported: CI-V (Icom binary), Kenwood CAT (text), Yaesu CAT (text). See
 
 ## Web UI
 
-`icom-lan web` boots a self-contained HTTP + WebSocket server. The frontend
+`rigplane web` boots a self-contained HTTP + WebSocket server. The frontend
 is a Svelte 5 single-page app served from the same process; no native
 shell, no Electron, no Tauri — just a browser tab.
 
@@ -109,15 +116,15 @@ Four user-facing skins resolve from `frontend/src/skins/registry.ts`:
 
 ## Architecture
 
-`src/icom_lan/` is organised into 11 layered Python packages
+`src/rigplane/` is organised into 11 layered Python packages
 (`core/`, `commands/`, `profiles/`, `audio/`, `scope/`, `dsp/`,
 `runtime/`, `backends/`, `web/`, `rigctld/`, `cli/`) with explicit
 boundaries enforced by `import-linter`. Higher layers depend on lower
 ones; siblings are independent. See [`ARCHITECTURE.md`](ARCHITECTURE.md)
-for the layout and per-layer charters in `src/icom_lan/<layer>/LAYER.md`.
+for the layout and per-layer charters in `src/rigplane/<layer>/LAYER.md`.
 
 Extensibility is centred on **Capability Protocols** in
-`icom_lan.radio_protocol`. A new backend implements the protocols it
+`rigplane.radio_protocol`. A new backend implements the protocols it
 supports; consumers (Web UI, rigctld, CLI, third-party scripts) feature-detect
 via `isinstance(radio, ScopeCapable)` and never branch on backend identity.
 The `Radio` protocol plus the capability suite is the **stable contract**
@@ -130,14 +137,14 @@ scopes into the open-core shell.
 
 ## Documentation
 
-- [Quickstart](https://morozsm.github.io/icom-lan/guide/quickstart/)
-- [CLI reference](https://morozsm.github.io/icom-lan/guide/cli/)
+- [Quickstart](https://rigplane.dev/guide/quickstart/)
+- [CLI reference](https://rigplane.dev/guide/cli/)
 - [Public API surface (Tier 1 stability)](docs/api/public-api-surface.md)
-- [Adding a new radio (TOML profiles)](https://morozsm.github.io/icom-lan/guide/rig-profiles/)
+- [Adding a new radio (TOML profiles)](https://rigplane.dev/guide/rig-profiles/)
 - [Architecture overview](ARCHITECTURE.md)
 - [Open-core policy](docs/architecture/open-core-policy.md)
 - [Diagnostic reports guide](docs/guide/diagnostic-reports.md) — how to send a one-click bug report when you hit an issue.
-- [Protocol internals](https://morozsm.github.io/icom-lan/internals/protocol/)
+- [Protocol internals](https://rigplane.dev/internals/protocol/)
 - [Security](docs/SECURITY.md)
 
 ## License
@@ -150,8 +157,8 @@ GPLv3 code. Icom™ and IC-* product names are registered trademarks of
 fair-use compatibility identification only — this project is not affiliated
 with, endorsed by, or sponsored by Icom.
 
-icom-lan is the **open-core** half of a planned product split. A
-proprietary commercial layer (`icom-lan-pro`) is under development and
+rigplane is the **open-core** half of a planned product split. A
+proprietary commercial layer (`rigplane-pro`) is under development and
 will integrate with this library through the public `Radio` protocol and
 the `local-extensions/` host API. Open-core constraints — no telemetry,
 headless mode is sacred, no hollowing out — are codified in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@
 - [x] E2E tests for PCM API and CLI
 - [x] Runtime audio stats (`get_audio_stats`)
 - [x] Auto-recover audio streams after reconnect (#7)
-- [x] Capability negotiation UX + `icom-lan audio caps`
+- [x] Capability negotiation UX + `rigplane audio caps`
 - [x] Task-oriented docs/recipes
 - [x] API naming consistency + deprecation plan
 - [x] AudioBus pub/sub (v0.12.0, #106)
@@ -96,7 +96,7 @@
 - [x] Type annotations (`py.typed`)
 
 ### Documentation
-- [x] MkDocs site (morozsm.github.io/icom-lan)
+- [x] MkDocs site (rigplane.dev)
 - [x] Protocol internals deep-dive
 - [x] CLI reference
 - [x] API reference

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,4 +1,4 @@
-# icom-lan — Project Documentation
+# rigplane — Project Documentation
 
 ## Goal
 
@@ -25,7 +25,7 @@ No intermediary software (wfview, RS-BA1, hamlib) is required for supported path
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│                           icom-lan                           │
+│                           rigplane                           │
 │                                                              │
 │  Consumers: API / CLI / Web / rigctld                       │
 │                 │                                            │
@@ -133,7 +133,7 @@ Each UDP packet has a fixed-format header (see `packettypes.h` in wfview):
 - [x] Audio auto-recovery after reconnect
 - [x] Runtime audio stats API
 - [x] Audio capability negotiation
-- [x] CLI: `icom-lan audio rx/tx/loopback`
+- [x] CLI: `rigplane audio rx/tx/loopback`
 
 **Result:** Full audio stack — Opus and PCM API, CLI, stats, auto-recovery. ✅
 
@@ -143,7 +143,7 @@ Each UDP packet has a fixed-format header (see `packettypes.h` in wfview):
 - [x] Sync + async API
 - [x] Autodiscovery of radios on the network
 - [x] Multi-model support (IC-7610, IC-705, IC-7300, IC-9700)
-- [x] CLI utility (`icom-lan status`, `icom-lan freq 14074000`)
+- [x] CLI utility (`rigplane status`, `rigplane freq 14074000`)
 - [x] Documentation + MkDocs site
 - [x] PyPI publication (v0.8.0)
 
@@ -412,7 +412,7 @@ IC-7610 parity matrix (issue #139, 2026-03-06): 134 implemented, 0 partial, 0 mi
 - Budget constraints for hardware
 - Team capacity for feature development
   recovery, collision/abort handling, timeout/overflow guardrails, writer backpressure handling,
-  and optional dependency guard (`pip install icom-lan[serial]`).
+  and optional dependency guard (`pip install rigplane[serial]`).
 - Added production `UsbAudioDriver` for IC-7610 serial backend with deterministic device probe/
   selection (auto-detect + explicit RX/TX overrides), RX/TX lifecycle guardrails, actionable
   optional dependency errors (`sounddevice`/`numpy`), and serial-audio contract coverage for web

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,19 +2,19 @@
 
 ## Overview
 
-icom-lan implements Icom's proprietary LAN protocol for controlling amateur radio transceivers. This document describes security properties, known limitations, and best practices.
+rigplane implements Icom's proprietary LAN protocol for controlling amateur radio transceivers. This document describes security properties, known limitations, and best practices.
 
 ## Threat Model
 
 The library is designed for use on **trusted local networks** (home LAN, shack network). The Icom protocol was designed for convenience, not security.
 
-### What icom-lan protects
+### What rigplane protects
 
 - ✅ **No credential storage** — credentials are passed as parameters or environment variables, never written to disk by the library
 - ✅ **No hardcoded secrets** — no default passwords or keys in the codebase
 - ✅ **Clean exception handling** — errors don't leak credentials in tracebacks
 - ✅ **Minimal attack surface** — core requires only `pyserial`; optional extras are well-scoped
-- ✅ **Controlled network listeners** — the library initiates outbound UDP connections; the optional web server (`icom-lan web`) and rigctld server (`icom-lan serve`) bind to configurable addresses and support auth tokens
+- ✅ **Controlled network listeners** — the library initiates outbound UDP connections; the optional web server (`rigplane web`) and rigctld server (`rigplane serve`) bind to configurable addresses and support auth tokens
 
 ### What the Icom protocol does NOT provide
 
@@ -95,7 +95,7 @@ Runtime: **`pyserial`** and **`pyserial-asyncio`** (core); optional extras (`opu
 If you discover a security vulnerability, please report it responsibly:
 
 1. **Do not** open a public GitHub issue
-2. Email: **morozsm@gmail.com** with subject line `[SECURITY] icom-lan`
+2. Email: **morozsm@gmail.com** with subject line `[SECURITY] rigplane`
 3. Include: description, reproduction steps, potential impact
 4. Allow 90 days for a fix before public disclosure
 

--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -17,7 +17,7 @@ Deprecated aliases still work during the deprecation window (two minor releases)
 
 ## AudioStream
 
-::: icom_lan.audio.lan_stream.AudioStream
+::: rigplane.audio.lan_stream.AudioStream
 
 ## Runtime Audio Stats (`get_audio_stats`)
 
@@ -53,29 +53,29 @@ print(stats["packet_loss_percent"], stats["reorder_depth_ema_ms"])
 
 ## AudioPacket
 
-::: icom_lan.audio.lan_stream.AudioPacket
+::: rigplane.audio.lan_stream.AudioPacket
 
 ## AudioState
 
-::: icom_lan.audio.lan_stream.AudioState
+::: rigplane.audio.lan_stream.AudioState
 
 ## JitterBuffer
 
-::: icom_lan.audio.lan_stream.JitterBuffer
+::: rigplane.audio.lan_stream.JitterBuffer
 
 ## Packet Functions
 
-::: icom_lan.audio.lan_stream.parse_audio_packet
+::: rigplane.audio.lan_stream.parse_audio_packet
 
-::: icom_lan.audio.lan_stream.build_audio_packet
+::: rigplane.audio.lan_stream.build_audio_packet
 
 ## Internal Transcoder Layer
 
-`icom_lan` now includes an internal PCM<->Opus transcoder foundation used for
+`rigplane` now includes an internal PCM<->Opus transcoder foundation used for
 future high-level PCM APIs.
 
-- Module: `icom_lan._audio_transcoder` (internal, no stability guarantee yet)
-- Backend: optional `opuslib` (`pip install icom-lan[audio]`)
+- Module: `rigplane._audio_transcoder` (internal, no stability guarantee yet)
+- Backend: optional `opuslib` (`pip install rigplane[audio]`)
 - Typed failures:
   - `AudioCodecBackendError` for missing backend
   - `AudioFormatError` for invalid PCM/Opus frame formats
@@ -83,15 +83,15 @@ future high-level PCM APIs.
 
 ## AudioBus (pub/sub multi-consumer)
 
-::: icom_lan.audio.bus.AudioBus
-::: icom_lan.audio.bus.AudioSubscription
+::: rigplane.audio.bus.AudioBus
+::: rigplane.audio.bus.AudioSubscription
 
 The AudioBus provides pub/sub distribution for radio RX audio. Multiple consumers (WebSocket broadcaster, audio bridge, recorders) share a single radio RX stream.
 
 ### Basic Usage
 
 ```python
-from icom_lan import create_radio, LanBackendConfig
+from rigplane import create_radio, LanBackendConfig
 
 config = LanBackendConfig(host="192.168.1.100", username="u", password="p")
 async with create_radio(config) as radio:
@@ -132,7 +132,7 @@ await bridge.start()
 ### `MAX_AUDIO_PAYLOAD`
 
 ```
-icom_lan.audio.MAX_AUDIO_PAYLOAD: int = 1364
+rigplane.audio.MAX_AUDIO_PAYLOAD: int = 1364
 ```
 
 Maximum audio payload in bytes per TX UDP packet.
@@ -161,7 +161,7 @@ is accepted.
 ### RX Audio (callback-based)
 
 ```python
-from icom_lan import create_radio, LanBackendConfig
+from rigplane import create_radio, LanBackendConfig
 
 config = LanBackendConfig(host="192.168.1.100", username="u", password="p")
 async with create_radio(config) as radio:
@@ -231,7 +231,7 @@ async with create_radio(config) as radio:
 ### Codec Selection
 
 ```python
-from icom_lan import create_radio, LanBackendConfig, AudioCodec
+from rigplane import create_radio, LanBackendConfig, AudioCodec
 
 config = LanBackendConfig(
     host="192.168.1.100",
@@ -249,7 +249,7 @@ async with create_radio(config) as radio:
 Use the capability API to inspect negotiated client-side audio options and defaults. The same API is available on the **Radio** returned by `create_radio` and on **IcomRadio** (legacy):
 
 ```python
-from icom_lan import create_radio, get_audio_capabilities, LanBackendConfig
+from rigplane import create_radio, get_audio_capabilities, LanBackendConfig
 
 config = LanBackendConfig(host="192.168.1.100", username="u", password="p")
 # Static defaults (no connection required):
@@ -264,7 +264,7 @@ For legacy LAN-only code, `IcomRadio.audio_capabilities()` returns the same stru
 
 Deterministic default selection rules:
 
-1. Codec: first supported codec in icom-lan preference order.
+1. Codec: first supported codec in rigplane preference order.
 2. Sample rate: highest supported sample rate.
 3. Channels: the channel count implied by default codec (fallback: minimum supported channels).
 

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -28,7 +28,7 @@ def build_login_packet(
     receiver_id: int,
     tok_request: int = 0,
     auth_seq: int = 0,
-    computer_name: str = "icom-lan",
+    computer_name: str = "rigplane",
 ) -> bytes
 ```
 

--- a/docs/api/commander.md
+++ b/docs/api/commander.md
@@ -4,8 +4,8 @@ Serialized CI-V command executor with priority queuing (wfview-style).
 Most users should use the high-level **Radio** API (via [`create_radio`](public-api-surface.md)), which
 manages an `IcomCommander` internally.
 
-::: icom_lan.commands.commander.IcomCommander
+::: rigplane.commands.commander.IcomCommander
 
 ## Priority Levels
 
-::: icom_lan.commands.commander.Priority
+::: rigplane.commands.commander.Priority

--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -11,7 +11,7 @@ This is how rig profile support works at the lowest level.
 ### Hardcoded path (default)
 
 ```python
-from icom_lan.commands import get_af_level
+from rigplane.commands import get_af_level
 
 # Uses hardcoded IC-7610 wire bytes: [0x14, 0x01]
 frame = get_af_level(to_addr=0x98)
@@ -21,8 +21,8 @@ frame = get_af_level(to_addr=0x98)
 
 ```python
 from pathlib import Path
-from icom_lan.rig_loader import load_rig
-from icom_lan.commands import get_af_level
+from rigplane.rig_loader import load_rig
+from rigplane.commands import get_af_level
 
 cfg = load_rig(Path("rigs/ic7300.toml"))
 cmd_map = cfg.to_command_map()
@@ -54,8 +54,8 @@ preserving full backward compatibility.
 - **Custom radios** — pass `cmd_map` explicitly when building frames for non-IC-7610 radios.
 
 ```python
-from icom_lan.command_map import CommandMap
-from icom_lan.commands import get_attenuator
+from rigplane.command_map import CommandMap
+from rigplane.commands import get_attenuator
 
 # Custom CommandMap for testing
 cm = CommandMap({"get_attenuator": (0x11,)})
@@ -64,7 +64,7 @@ frame = get_attenuator(to_addr=0x94, cmd_map=cm)
 
 See [`docs/api/rig-loader.md`](rig-loader.md) for the `CommandMap` class reference.
 
-::: icom_lan.commands
+::: rigplane.commands
 
 ## CI-V Frame Format
 
@@ -83,7 +83,7 @@ FE FE <to> <from> <cmd> [<sub>] [<data>...] FD
 ## Constants
 
 ```python
-from icom_lan import IC_7610_ADDR, CONTROLLER_ADDR
+from rigplane import IC_7610_ADDR, CONTROLLER_ADDR
 
 IC_7610_ADDR   # 0x98 — IC-7610's default CI-V address
 CONTROLLER_ADDR  # 0xE0 — Controller address (us)

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,11 +1,11 @@
 # Exceptions
 
-All exceptions inherit from `IcomLanError` for easy catch-all handling.
+All exceptions inherit from `RigplaneError` for easy catch-all handling.
 
 ## Hierarchy
 
 ```
-IcomLanError
+RigplaneError
 ├── ConnectionError
 ├── AuthenticationError
 ├── CommandError
@@ -18,26 +18,26 @@ IcomLanError
 
 ## Classes
 
-### `IcomLanError`
+### `RigplaneError`
 
 ```python
-from icom_lan import IcomLanError
+from rigplane import RigplaneError
 ```
 
-Base exception for all icom-lan errors. Catch this to handle any library error.
+Base exception for all rigplane errors. Catch this to handle any library error.
 
 ```python
 try:
     async with create_radio(config) as radio:
         ...
-except IcomLanError as e:
-    print(f"icom-lan error: {e}")
+except RigplaneError as e:
+    print(f"rigplane error: {e}")
 ```
 
 ### `ConnectionError`
 
 ```python
-from icom_lan import ConnectionError
+from rigplane import ConnectionError
 ```
 
 Raised when a connection to the radio fails or is lost.
@@ -47,12 +47,12 @@ Raised when a connection to the radio fails or is lost.
 - Radio dropped the connection
 
 !!! note
-    This is `icom_lan.ConnectionError`, not the built-in `builtins.ConnectionError`. Import explicitly to avoid shadowing.
+    This is `rigplane.ConnectionError`, not the built-in `builtins.ConnectionError`. Import explicitly to avoid shadowing.
 
 ### `AuthenticationError`
 
 ```python
-from icom_lan import AuthenticationError
+from rigplane import AuthenticationError
 ```
 
 Raised when authentication with the radio fails.
@@ -64,7 +64,7 @@ Raised when authentication with the radio fails.
 ### `CommandError`
 
 ```python
-from icom_lan import CommandError
+from rigplane import CommandError
 ```
 
 Raised when a CI-V command is rejected by the radio (NAK response).
@@ -76,7 +76,7 @@ Raised when a CI-V command is rejected by the radio (NAK response).
 ### `TimeoutError`
 
 ```python
-from icom_lan import TimeoutError
+from rigplane import TimeoutError
 ```
 
 Raised when an operation doesn't complete within the timeout period.
@@ -86,12 +86,12 @@ Raised when an operation doesn't complete within the timeout period.
 - Status packet not received during handshake
 
 !!! note "TimeoutError vs built-in and asyncio"
-    This is `icom_lan.exceptions.TimeoutError`, not the built-in `builtins.TimeoutError` (Python 3.10+). Import explicitly to avoid shadowing (e.g. `from icom_lan.exceptions import TimeoutError as IcomTimeoutError`). When handling timeouts, distinguish from `asyncio.TimeoutError`: the library converts asyncio timeouts to `icom_lan.TimeoutError` in its own code; if you use `asyncio.wait_for()` or similar, you may need to catch both.
+    This is `rigplane.exceptions.TimeoutError`, not the built-in `builtins.TimeoutError` (Python 3.10+). Import explicitly to avoid shadowing (e.g. `from rigplane.exceptions import TimeoutError as IcomTimeoutError`). When handling timeouts, distinguish from `asyncio.TimeoutError`: the library converts asyncio timeouts to `rigplane.TimeoutError` in its own code; if you use `asyncio.wait_for()` or similar, you may need to catch both.
 
 ### `AudioError`
 
 ```python
-from icom_lan import AudioError
+from rigplane import AudioError
 ```
 
 Base class for audio codec/transcoding failures.
@@ -99,7 +99,7 @@ Base class for audio codec/transcoding failures.
 ### `AudioCodecBackendError`
 
 ```python
-from icom_lan import AudioCodecBackendError
+from rigplane import AudioCodecBackendError
 ```
 
 Raised when no Opus backend is available for PCM/Opus conversion.
@@ -108,12 +108,12 @@ Raised when no Opus backend is available for PCM/Opus conversion.
 - backend failed initialization
 
 Typical actionable message:
-`Audio codec backend unavailable; install icom-lan[audio].`
+`Audio codec backend unavailable; install rigplane[audio].`
 
 ### `AudioFormatError`
 
 ```python
-from icom_lan import AudioFormatError
+from rigplane import AudioFormatError
 ```
 
 Raised when provided audio frame format is invalid.
@@ -125,7 +125,7 @@ Raised when provided audio frame format is invalid.
 ### `AudioTranscodeError`
 
 ```python
-from icom_lan import AudioTranscodeError
+from rigplane import AudioTranscodeError
 ```
 
 Raised when encode/decode fails in the codec backend.
@@ -135,8 +135,8 @@ Raised when encode/decode fails in the codec backend.
 ### Catch specific errors
 
 ```python
-from icom_lan import create_radio, LanBackendConfig
-from icom_lan.exceptions import (
+from rigplane import create_radio, LanBackendConfig
+from rigplane.exceptions import (
     ConnectionError,
     AuthenticationError,
     CommandError,
@@ -161,7 +161,7 @@ except TimeoutError:
 
 ```python
 import asyncio
-from icom_lan import create_radio, TimeoutError
+from rigplane import create_radio, TimeoutError
 
 async def get_frequency_with_retry(radio, retries=3):
     for attempt in range(retries):

--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -1,6 +1,6 @@
 # Public API Surface
 
-This page defines the **officially supported** public API of `icom_lan`. Use these exports for stable, documented behavior. Other symbols re-exported from `icom_lan` are available for advanced or legacy use but may have looser backward-compatibility guarantees.
+This page defines the **officially supported** public API of `rigplane`. Use these exports for stable, documented behavior. Other symbols re-exported from `rigplane` are available for advanced or legacy use but may have looser backward-compatibility guarantees.
 
 ## Supported exports (recommended)
 
@@ -34,15 +34,15 @@ This page defines the **officially supported** public API of `icom_lan`. Use the
 
 | Symbol | Description |
 |--------|-------------|
-| `IcomLanError` | Base exception. |
-| `ConnectionError`, `AuthenticationError`, `CommandError`, `TimeoutError` | Connection and command errors. When catching timeouts, use `icom_lan.exceptions.TimeoutError` explicitly; distinguish from `asyncio.TimeoutError` if needed (see [exceptions](exceptions.md)). |
+| `RigplaneError` | Base exception. |
+| `ConnectionError`, `AuthenticationError`, `CommandError`, `TimeoutError` | Connection and command errors. When catching timeouts, use `rigplane.exceptions.TimeoutError` explicitly; distinguish from `asyncio.TimeoutError` if needed (see [exceptions](exceptions.md)). |
 | `AudioError`, `AudioCodecBackendError`, `AudioFormatError`, `AudioTranscodeError` | Audio-related errors. |
 
 ### Sync wrapper and utilities
 
 | Symbol | Description |
 |--------|-------------|
-| `icom_lan.sync.IcomRadio` | Synchronous wrapper; use `from icom_lan.sync import IcomRadio` for blocking API. |
+| `rigplane.sync.IcomRadio` | Synchronous wrapper; use `from rigplane.sync import IcomRadio` for blocking API. |
 
 ### Common types
 
@@ -66,7 +66,7 @@ The following are re-exported for power users, scripts, or compatibility. Prefer
 - **Audio**: `AudioPacket`, `AudioState`, `AudioStats`, `AudioStream`, `JitterBuffer`, `AUDIO_HEADER_SIZE` — audio pipeline types.
 - **Scope**: `ScopeAssembler`, `ScopeFrame` — scope assembly; scope rendering (`SCOPE_THEMES`, `amplitude_to_color`, `render_scope_image`, etc.) when Pillow is available.
 
-When extending the library or writing integration code, prefer importing from the modules that define these symbols (e.g. `icom_lan.commands`, `icom_lan.transport`) rather than relying on `icom_lan` re-exports, so that future narrowing of the top-level `__all__` does not break your code.
+When extending the library or writing integration code, prefer importing from the modules that define these symbols (e.g. `rigplane.commands`, `rigplane.transport`) rather than relying on `rigplane` re-exports, so that future narrowing of the top-level `__all__` does not break your code.
 
 ---
 
@@ -80,8 +80,8 @@ subsystem.
 ### Tier 1 — Stable
 
 Public API. Breaking changes require a **major version bump**
-(semver-strict). Symbols are loaded eagerly by `icom_lan/__init__.py` and
-available directly via `from icom_lan import …`.
+(semver-strict). Symbols are loaded eagerly by `rigplane/__init__.py` and
+available directly via `from rigplane import …`.
 
 **Backend factory and configs**
 
@@ -90,7 +90,7 @@ available directly via `from icom_lan import …`.
 - `BackendConfig`, `LanBackendConfig`, `SerialBackendConfig`,
   `YaesuCatBackendConfig`
 
-**Capability protocols (from `icom_lan.radio_protocol`)**
+**Capability protocols (from `rigplane.radio_protocol`)**
 
 - `Radio`
 - `LevelsCapable`, `MetersCapable`, `PowerControlCapable`,
@@ -107,16 +107,16 @@ available directly via `from icom_lan import …`.
 - `SplitCapable` (new in v0.19)
 - `UsbAudioCapable` (new in v0.19)
 
-**Exceptions (from `icom_lan.exceptions`)**
+**Exceptions (from `rigplane.exceptions`)**
 
-- `IcomLanError`, `AudioCodecBackendError`, `AudioError`, `AudioFormatError`
+- `RigplaneError`, `AudioCodecBackendError`, `AudioError`, `AudioFormatError`
 - `AudioTranscodeError`, `AuthenticationError`, `CommandError`
 - `ConnectionError`, `TimeoutError`
 
-**Public types (from `icom_lan.types`)**
+**Public types (from `rigplane.types`)**
 
 - `Mode`, `AudioCodec`, `BreakInMode` (and the other symbols
-  currently re-exported from `icom_lan.types`)
+  currently re-exported from `rigplane.types`)
 
 **Public state types**
 
@@ -125,7 +125,7 @@ available directly via `from icom_lan import …`.
 **Frontend extension host API (Pro-facing)**
 
 The `frontend/src/lib/local-extensions/` module exposes a versioned host API
-that downstream products (notably icom-lan-pro) inject UI extensions through.
+that downstream products (notably rigplane-pro) inject UI extensions through.
 It is a stable Pro-facing contract — treat it as tier 1 in this document.
 
 From `frontend/src/lib/local-extensions/host-api.ts`:
@@ -157,7 +157,7 @@ From `frontend/src/lib/local-extensions/manifest.ts`:
 `LOCAL_EXTENSION_HOST_API_VERSION` (numeric, in `host-api.ts`) on any
 breaking change to a function signature or interface shape. The string
 version in `manifest.ts` mirrors this and is bumped together. Pro relies
-on this contract — coordinate breaking changes through the icom-lan
+on this contract — coordinate breaking changes through the rigplane
 issue tracker before merging.
 
 See also `docs/architecture/open-core-policy.md` (when published as part
@@ -166,12 +166,12 @@ of #1276) for the policy framing.
 Example (valid):
 
 ```python
-from icom_lan import create_radio, Radio, LanBackendConfig, MetersCapable
+from rigplane import create_radio, Radio, LanBackendConfig, MetersCapable
 ```
 
 ### Tier 2 — Best-effort
 
-Available via `from icom_lan import …`, but loaded lazily through PEP 562
+Available via `from rigplane import …`, but loaded lazily through PEP 562
 `__getattr__` so they do not pull their subsystem into memory until the name
 is actually accessed. Breaking changes require a **CHANGELOG note plus a
 minor version bump**. No semver guarantee — these may be reshaped or moved
@@ -188,7 +188,7 @@ without a major version.
 Example (valid, lazy-loaded):
 
 ```python
-from icom_lan import IcomRadio, IcomCommander  # tier-2 — works, but no semver guarantee
+from rigplane import IcomRadio, IcomCommander  # tier-2 — works, but no semver guarantee
 ```
 
 ### Tier 3 — Internal
@@ -198,19 +198,19 @@ package. Importing these from production source outside the owning
 subsystem triggers ruff `TID251`. Tests are exempt (see existing
 `tests/* per-file-ignores` in `pyproject.toml`).
 
-- `icom_lan.web.*` — internal to the web subsystem
-- `icom_lan.rigctld.*` — internal to the rigctld subsystem
-- `icom_lan.cli` — internal to the CLI
-- `icom_lan.radio.IcomRadio` — legacy direct-import path (use tier-2
-  re-export from `icom_lan` instead)
+- `rigplane.web.*` — internal to the web subsystem
+- `rigplane.rigctld.*` — internal to the rigctld subsystem
+- `rigplane.cli` — internal to the CLI
+- `rigplane.radio.IcomRadio` — legacy direct-import path (use tier-2
+  re-export from `rigplane` instead)
 - Most underscore-prefixed modules (`_connection_state`,
   `_shared_state_runtime`, …)
 
 Example (invalid — flagged by `TID251` outside the owning subsystem):
 
 ```python
-from icom_lan.web.handlers import ControlHandler  # tier-3 — forbidden in production
-from icom_lan.rigctld.server import RigctldServer  # tier-3 — forbidden in production
+from rigplane.web.handlers import ControlHandler  # tier-3 — forbidden in production
+from rigplane.rigctld.server import RigctldServer  # tier-3 — forbidden in production
 ```
 
 ### Migration policy
@@ -224,7 +224,7 @@ from icom_lan.rigctld.server import RigctldServer  # tier-3 — forbidden in pro
   two-minor-release deprecation cycle (`DeprecationWarning` for at least
   two minor releases before removal).
 - **Add a new tier-1 symbol.** PR + CHANGELOG entry under `### Added`. The
-  symbol must be re-exported from `icom_lan/__init__.py` and listed in this
+  symbol must be re-exported from `rigplane/__init__.py` and listed in this
   document.
 - **Tier 2 / tier 3 changes.** May happen in any minor release with a
   CHANGELOG note. No deprecation cycle is required, but a one-release

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -2,14 +2,14 @@
 
 LAN-specific radio class. For new code, prefer the backend-neutral **[create_radio](public-api-surface.md)** + **Radio** API so the same code works over LAN or USB serial. Use `IcomRadio` when you need direct LAN control or are migrating from older examples.
 
-::: icom_lan.runtime.radio.IcomRadio
+::: rigplane.runtime.radio.IcomRadio
 
 ## Reference
 
 ### Class: `IcomRadio`
 
 ```python
-from icom_lan import IcomRadio
+from rigplane import IcomRadio
 ```
 
 ### Constructor
@@ -120,7 +120,7 @@ This is a backend-managed readiness contract: clients should treat
 def audio_capabilities() -> AudioCapabilities
 ```
 
-Return the stable icom-lan audio capability structure:
+Return the stable rigplane audio capability structure:
 
 - `supported_codecs`
 - `supported_sample_rates_hz`
@@ -131,7 +131,7 @@ Return the stable icom-lan audio capability structure:
 
 Default values are deterministic:
 
-1. Codec: first supported codec in icom-lan preference order.
+1. Codec: first supported codec in rigplane preference order.
 2. Sample rate: highest supported sample rate.
 3. Channels: implied by default codec (fallback to minimum supported channels).
 
@@ -502,7 +502,7 @@ Register a callback for scope/waterfall data. The callback receives a complete `
 Pass `None` to unregister.
 
 ```python
-from icom_lan.scope import ScopeFrame
+from rigplane.scope import ScopeFrame
 
 def handle_scope(frame: ScopeFrame):
     print(f"Receiver {frame.receiver}: "
@@ -539,7 +539,7 @@ Disable scope data output. Sends CI-V `0x27 0x11 0x00`.
 ### `ScopeFrame`
 
 ```python
-from icom_lan.scope import ScopeFrame
+from rigplane.scope import ScopeFrame
 ```
 
 | Attribute | Type | Description |

--- a/docs/api/radios.md
+++ b/docs/api/radios.md
@@ -2,9 +2,9 @@
 
 Presets for known Icom radios with CI-V addresses and capabilities.
 
-::: icom_lan.runtime.radios.RadioModel
+::: rigplane.runtime.radios.RadioModel
 
-::: icom_lan.runtime.radios.get_civ_addr
+::: rigplane.runtime.radios.get_civ_addr
 
 ## Supported Models
 
@@ -20,7 +20,7 @@ Presets for known Icom radios with CI-V addresses and capabilities.
 ## Usage
 
 ```python
-from icom_lan import create_radio, LanBackendConfig, get_civ_addr
+from rigplane import create_radio, LanBackendConfig, get_civ_addr
 
 # Look up CI-V address by model name
 addr = get_civ_addr("IC-705")  # returns 0xA4

--- a/docs/api/rig-loader.md
+++ b/docs/api/rig-loader.md
@@ -2,10 +2,10 @@
 
 TOML rig file loading, validation, and runtime object construction.
 
-Module: `icom_lan.rig_loader`
+Module: `rigplane.rig_loader`
 
 ```python
-from icom_lan.rig_loader import load_rig, discover_rigs, RigConfig, RigLoadError
+from rigplane.rig_loader import load_rig, discover_rigs, RigConfig, RigLoadError
 ```
 
 ## Functions
@@ -31,7 +31,7 @@ fails schema validation (missing sections, unknown capability, invalid VFO schem
 
 ```python
 from pathlib import Path
-from icom_lan.rig_loader import load_rig
+from rigplane.rig_loader import load_rig
 
 cfg = load_rig(Path("rigs/ic7610.toml"))
 print(cfg.model)          # "IC-7610"
@@ -58,7 +58,7 @@ Files whose names start with `_` are skipped (e.g. `_schema.md`, `_template.toml
 
 ```python
 from pathlib import Path
-from icom_lan.rig_loader import discover_rigs
+from rigplane.rig_loader import discover_rigs
 
 rigs = discover_rigs(Path("rigs/"))
 for model, cfg in rigs.items():
@@ -187,7 +187,7 @@ Raised by `load_rig()` when the rig file is invalid. The message includes the fi
 and the specific field or section that failed validation.
 
 ```python
-from icom_lan.rig_loader import load_rig, RigLoadError
+from rigplane.rig_loader import load_rig, RigLoadError
 
 try:
     cfg = load_rig(Path("rigs/bad.toml"))

--- a/docs/api/rigctld.md
+++ b/docs/api/rigctld.md
@@ -1,6 +1,6 @@
 # Rigctld Server
 
-Hamlib NET rigctld-compatible TCP server for icom-lan.
+Hamlib NET rigctld-compatible TCP server for rigplane.
 
 Provides a drop-in replacement for `rigctld` that bridges the hamlib line-based TCP
 protocol to a **Radio** instance (from `create_radio`). Clients such as WSJT-X, JS8Call, fldigi, and
@@ -33,10 +33,10 @@ For timeout values, cache TTL semantics, and connection/readiness state, see
 
 ## Quick Start
 
-### Standalone rigctld server (`icom-lan serve`)
+### Standalone rigctld server (`rigplane serve`)
 
 ```bash
-icom-lan --host 192.168.1.10 --user admin --password secret serve
+rigplane --host 192.168.1.10 --user admin --password secret serve
 ```
 
 Options:
@@ -53,23 +53,23 @@ Options:
 | `--audit-log PATH` | disabled | Path for JSONL audit log |
 | `--rate-limit N` | unlimited | Max commands/second per client |
 
-### Embedded in the web server (`icom-lan web`)
+### Embedded in the web server (`rigplane web`)
 
 The `web` command starts the rigctld server on port 4532 by default alongside the
 HTTP UI. Disable it with `--no-rigctld`, or change the port with `--rigctld-port`.
 
 ```bash
-icom-lan --host 192.168.1.10 web --rigctld-port 4533
-icom-lan --host 192.168.1.10 web --no-rigctld
+rigplane --host 192.168.1.10 web --rigctld-port 4533
+rigplane --host 192.168.1.10 web --no-rigctld
 ```
 
 ### Embedded in Python
 
 ```python
 import asyncio
-from icom_lan import create_radio, LanBackendConfig
-from icom_lan.rigctld import RigctldServer
-from icom_lan.rigctld.contract import RigctldConfig
+from rigplane import create_radio, LanBackendConfig
+from rigplane.rigctld import RigctldServer
+from rigplane.rigctld.contract import RigctldConfig
 
 async def main() -> None:
     radio_config = LanBackendConfig(host="192.168.1.10", username="admin", password="secret")
@@ -86,7 +86,7 @@ asyncio.run(main())
 ## `RigctldServer`
 
 ```python
-from icom_lan.rigctld import RigctldServer
+from rigplane.rigctld import RigctldServer
 ```
 
 Asyncio TCP server implementing the hamlib NET rigctld protocol.
@@ -160,7 +160,7 @@ Current state of the internal circuit breaker, or `None` if not yet initialised
 ## `RigctldConfig`
 
 ```python
-from icom_lan.rigctld.contract import RigctldConfig
+from rigplane.rigctld.contract import RigctldConfig
 ```
 
 Dataclass holding all server configuration.
@@ -200,11 +200,11 @@ RigctldConfig(
 ## `RigctldHandler`
 
 ```python
-from icom_lan.rigctld.handler import RigctldHandler
+from rigplane.rigctld.handler import RigctldHandler
 ```
 
 Dispatches parsed rigctld commands to the **Radio** instance. Handles the read-only gate,
-frequency/mode cache, and translates icom-lan exceptions to Hamlib error codes.
+frequency/mode cache, and translates rigplane exceptions to Hamlib error codes.
 
 ### Constructor
 
@@ -320,7 +320,7 @@ Accepted input formats:
 Behavior details:
 
 - If backend exposes `_send_civ_raw`, command forwards bytes as-is.
-- On transport timeout (`icom_lan.exceptions.TimeoutError` or `asyncio.TimeoutError`),
+- On transport timeout (`rigplane.exceptions.TimeoutError` or `asyncio.TimeoutError`),
   handler returns **successful empty response** (not `RPRT -5`).
 - If backend does not implement `_send_civ_raw`, returns `ENIMPL` (`RPRT -4`).
 
@@ -329,7 +329,7 @@ Behavior details:
 ## `RadioPoller`
 
 ```python
-from icom_lan.rigctld.poller import RadioPoller
+from rigplane.rigctld.poller import RadioPoller
 ```
 
 Background asyncio task that periodically polls the radio (frequency, mode, DATA
@@ -385,7 +385,7 @@ interleaving during DATA mode transitions (USB → PKT modes).
 ## `CircuitBreaker`
 
 ```python
-from icom_lan.rigctld.circuit_breaker import CircuitBreaker, CircuitState
+from rigplane.rigctld.circuit_breaker import CircuitBreaker, CircuitState
 ```
 
 State-machine circuit breaker wrapping CI-V command execution. Prevents
@@ -466,7 +466,7 @@ Record a failed command. Increments the counter (CLOSED) or re-opens (HALF_OPEN)
 ## `StateCache`
 
 ```python
-from icom_lan.rigctld.state_cache import StateCache
+from rigplane.rigctld.state_cache import StateCache
 ```
 
 Last-known radio state with per-field monotonic timestamps. Shared between
@@ -541,7 +541,7 @@ never written).
 ### `parse_line()`
 
 ```python
-from icom_lan.rigctld.protocol import parse_line
+from rigplane.rigctld.protocol import parse_line
 
 def parse_line(line: bytes) -> RigctldCommand
 ```
@@ -578,7 +578,7 @@ Format a bare Hamlib error response, e.g. `b'RPRT -1\n'`.
 ### `RigctldCommand`
 
 ```python
-from icom_lan.rigctld.contract import RigctldCommand
+from rigplane.rigctld.contract import RigctldCommand
 ```
 
 Frozen dataclass representing a parsed client command.
@@ -593,7 +593,7 @@ Frozen dataclass representing a parsed client command.
 ### `RigctldResponse`
 
 ```python
-from icom_lan.rigctld.contract import RigctldResponse
+from rigplane.rigctld.contract import RigctldResponse
 ```
 
 Mutable dataclass representing the response to send back to the client.
@@ -612,7 +612,7 @@ Mutable dataclass representing the response to send back to the client.
 ### `AuditRecord`
 
 ```python
-from icom_lan.rigctld.audit import AuditRecord
+from rigplane.rigctld.audit import AuditRecord
 ```
 
 Immutable dataclass capturing a single command execution.
@@ -632,15 +632,15 @@ Immutable dataclass capturing a single command execution.
 ### `RigctldAuditFormatter`
 
 ```python
-from icom_lan.rigctld.audit import RigctldAuditFormatter, AUDIT_LOGGER_NAME
+from rigplane.rigctld.audit import RigctldAuditFormatter, AUDIT_LOGGER_NAME
 ```
 
 `logging.Formatter` subclass that serialises `AuditRecord` entries as a single
-JSON line. Attach it to a handler on the `icom_lan.rigctld.audit` logger:
+JSON line. Attach it to a handler on the `rigplane.rigctld.audit` logger:
 
 ```python
 import logging
-from icom_lan.rigctld.audit import AUDIT_LOGGER_NAME, RigctldAuditFormatter
+from rigplane.rigctld.audit import AUDIT_LOGGER_NAME, RigctldAuditFormatter
 
 fh = logging.FileHandler("audit.jsonl")
 fh.setFormatter(RigctldAuditFormatter())
@@ -658,7 +658,7 @@ Example output line:
 ## `HamlibError`
 
 ```python
-from icom_lan.rigctld.contract import HamlibError
+from rigplane.rigctld.contract import HamlibError
 ```
 
 `IntEnum` of standard Hamlib error codes.
@@ -694,7 +694,7 @@ from icom_lan.rigctld.contract import HamlibError
 ## `run_rigctld_server()`
 
 ```python
-from icom_lan.rigctld.server import run_rigctld_server
+from rigplane.rigctld.server import run_rigctld_server
 
 async def run_rigctld_server(radio: Radio, **kwargs) -> None
 ```

--- a/docs/api/scope.md
+++ b/docs/api/scope.md
@@ -4,13 +4,13 @@ Spectrum and waterfall data from the radio's scope display.
 
 ## Overview
 
-Icom radios with spectrum scope (IC-7610, IC-7300, IC-705, etc.) stream real-time spectrum data over the CI-V protocol as unsolicited `0x27 0x00` packets. The `icom-lan` library reassembles these multi-sequence bursts and delivers complete frames via callback.
+Icom radios with spectrum scope (IC-7610, IC-7300, IC-705, etc.) stream real-time spectrum data over the CI-V protocol as unsolicited `0x27 0x00` packets. The `rigplane` library reassembles these multi-sequence bursts and delivers complete frames via callback.
 
 ## Quick Start
 
 ```python
-from icom_lan import create_radio, LanBackendConfig
-from icom_lan.scope import ScopeFrame
+from rigplane import create_radio, LanBackendConfig
+from rigplane.scope import ScopeFrame
 
 async def main():
     config = LanBackendConfig(host="192.168.1.100", username="u", password="p")
@@ -36,7 +36,7 @@ async def main():
 ### `ScopeFrame`
 
 ```python
-from icom_lan.scope import ScopeFrame
+from rigplane.scope import ScopeFrame
 ```
 
 A complete spectrum scope frame, assembled from a burst of CI-V sequences.
@@ -59,7 +59,7 @@ A complete spectrum scope frame, assembled from a burst of CI-V sequences.
 ### `ScopeAssembler`
 
 ```python
-from icom_lan.scope import ScopeAssembler
+from rigplane.scope import ScopeAssembler
 ```
 
 Low-level assembler that reconstructs `ScopeFrame` objects from raw CI-V `0x27 0x00` payloads. Maintains independent state for main and sub receivers.
@@ -134,13 +134,13 @@ Enable scope and capture `count` complete frames. Returns list oldest-first.
 ## Rendering (optional, requires Pillow)
 
 ```bash
-pip install icom-lan[scope]
+pip install rigplane[scope]
 ```
 
 ### `render_spectrum()`
 
 ```python
-from icom_lan.scope_render import render_spectrum
+from rigplane.scope_render import render_spectrum
 
 img = render_spectrum(frame, width=800, height=200, theme="classic")
 img.save("spectrum.png")
@@ -151,7 +151,7 @@ Renders a single ScopeFrame as a spectrum plot (amplitude vs frequency) with gri
 ### `render_waterfall()`
 
 ```python
-from icom_lan.scope_render import render_waterfall
+from rigplane.scope_render import render_waterfall
 
 img = render_waterfall(frames, width=800, height=400, theme="classic")
 ```
@@ -161,7 +161,7 @@ Renders multiple frames as a waterfall display. Newest frame at top, color encod
 ### `render_scope_image()`
 
 ```python
-from icom_lan.scope_render import render_scope_image
+from rigplane.scope_render import render_scope_image
 
 img = render_scope_image(frames, output="scope.png", theme="classic")
 ```

--- a/docs/api/sync.md
+++ b/docs/api/sync.md
@@ -2,12 +2,12 @@
 
 Blocking wrapper around the async `IcomRadio` for use without `async/await`.
 
-::: icom_lan.runtime.sync.IcomRadio
+::: rigplane.runtime.sync.IcomRadio
 
 ## Usage
 
 ```python
-from icom_lan.sync import IcomRadio
+from rigplane.sync import IcomRadio
 
 with IcomRadio("192.168.1.100", username="u", password="p") as radio:
     freq = radio.get_frequency()

--- a/docs/api/transport.md
+++ b/docs/api/transport.md
@@ -5,7 +5,7 @@ Low-level async UDP transport for the Icom LAN protocol. Most users should use [
 ## Class: `IcomTransport`
 
 ```python
-from icom_lan import IcomTransport
+from rigplane import IcomTransport
 ```
 
 Handles:
@@ -104,7 +104,7 @@ Start the background retransmit request task (100ms interval).
 ## Enum: `ConnectionState`
 
 ```python
-from icom_lan import ConnectionState
+from rigplane import ConnectionState
 ```
 
 | Value | Description |

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -4,14 +4,14 @@ Core data types used throughout the library.
 
 ## StateCache
 
-::: icom_lan.core._state_cache.StateCache
+::: rigplane.core._state_cache.StateCache
 
 ## Enums
 
 ### `PacketType`
 
 ```python
-from icom_lan import PacketType
+from rigplane import PacketType
 ```
 
 UDP packet type codes from the Icom LAN protocol header (offset 0x04, 2 bytes LE).
@@ -29,7 +29,7 @@ UDP packet type codes from the Icom LAN protocol header (offset 0x04, 2 bytes LE
 ### `Mode`
 
 ```python
-from icom_lan import Mode
+from rigplane import Mode
 ```
 
 Icom CI-V operating modes. Values match the CI-V mode byte.
@@ -54,7 +54,7 @@ Icom CI-V operating modes. Values match the CI-V mode byte.
 ### `PacketHeader`
 
 ```python
-from icom_lan import PacketHeader
+from rigplane import PacketHeader
 ```
 
 Fixed 16-byte header present in every Icom LAN UDP packet.
@@ -70,7 +70,7 @@ Fixed 16-byte header present in every Icom LAN UDP packet.
 ### `CivFrame`
 
 ```python
-from icom_lan import CivFrame
+from rigplane import CivFrame
 ```
 
 Parsed CI-V frame.
@@ -88,7 +88,7 @@ Parsed CI-V frame.
 ### `AudioCapabilities`
 
 ```python
-from icom_lan import AudioCapabilities
+from rigplane import AudioCapabilities
 ```
 
 Stable audio capability structure returned by `get_audio_capabilities()` (and by
@@ -116,7 +116,7 @@ def bcd_encode(freq_hz: int) -> bytes
 Encode a frequency (Hz) to Icom's 5-byte BCD format (little-endian BCD).
 
 ```python
->>> from icom_lan import bcd_encode
+>>> from rigplane import bcd_encode
 >>> bcd_encode(14074000).hex()
 '0040071400'
 ```
@@ -130,7 +130,7 @@ def bcd_decode(data: bytes) -> int
 Decode 5-byte BCD to frequency in Hz.
 
 ```python
->>> from icom_lan import bcd_decode
+>>> from rigplane import bcd_decode
 >>> bcd_decode(bytes.fromhex('0040071400'))
 14074000
 ```
@@ -138,10 +138,10 @@ Decode 5-byte BCD to frequency in Hz.
 ### `get_audio_capabilities()`
 
 ```python
-from icom_lan import get_audio_capabilities
+from rigplane import get_audio_capabilities
 ```
 
-Return the static icom-lan audio capability matrix and deterministic defaults.
+Return the static rigplane audio capability matrix and deterministic defaults.
 
 ---
 
@@ -150,7 +150,7 @@ Return the static icom-lan audio capability matrix and deterministic defaults.
 ### `HEADER_SIZE`
 
 ```python
-from icom_lan import HEADER_SIZE  # 16 (0x10)
+from rigplane import HEADER_SIZE  # 16 (0x10)
 ```
 
 Size of the fixed packet header in bytes.

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -56,7 +56,7 @@ Version, model, capability summary, and connection metadata.
 
 ```json
 {
-  "server": "icom-lan",
+  "server": "rigplane",
   "version": "0.18.0",
   "proto": 1,
   "radio": "IC-7300",

--- a/docs/architecture/open-core-policy.md
+++ b/docs/architecture/open-core-policy.md
@@ -1,6 +1,6 @@
 # Open-core policy
 
-This document codifies the hard constraints that govern **icom-lan** as the
+This document codifies the hard constraints that govern **rigplane** as the
 open-core half of a planned commercial product. These rules are not advisory:
 they shape what may and may not land in this repository.
 
@@ -12,28 +12,28 @@ open an issue and change this document first.
 
 ## 1. Project shape
 
-- **icom-lan** — open-core, MIT-licensed Python library + Web UI for Icom
+- **rigplane** — open-core, MIT-licensed Python library + Web UI for Icom
   transceivers over LAN/USB. Target users: hams, hobbyists, headless servers,
   Raspberry Pi setups, anyone who wants a free, scriptable, embeddable radio
   control plane.
-- **icom-lan-pro** — proprietary commercial layer, planned to ship roughly
+- **rigplane-pro** — proprietary commercial layer, planned to ship roughly
   2–3 months out. Architecturally a Tauri 2 single-signed installer that
-  spawns a Python sidecar (the icom-lan server) as a child process on
+  spawns a Python sidecar (the rigplane server) as a child process on
   `127.0.0.1:8470`, plus a native integrations layer (USB HID for RC-28,
   OS-level virtual audio routing, global hotkeys, license gating in
   Tauri-Rust). Pro injects UI extensions into the open-core frontend through
   `frontend/src/lib/local-extensions/`.
-- **One binary, two tiers.** The free experience is icom-lan rendered without
+- **One binary, two tiers.** The free experience is rigplane rendered without
   Pro extensions. Paid unlocks Pro features through the same shell.
 
-This document is about icom-lan. It exists so that the two halves can coexist
+This document is about rigplane. It exists so that the two halves can coexist
 without the open-core erosion that historically follows commercial spin-offs.
 
 ---
 
 ## 2. No telemetry, ever
 
-icom-lan does not phone home. No exceptions, no opt-in tracking, no anonymous
+rigplane does not phone home. No exceptions, no opt-in tracking, no anonymous
 usage statistics, no product analytics, no crash reporting beacon.
 
 **Forbidden in open-core dependencies and runtime:**
@@ -71,13 +71,13 @@ A diagnostic report mechanism in open-core must satisfy **all** of these:
 
 - **No automatic, background, recurring, first-run, or silent collection or
   submission.** Logs may be written locally on a rotating file basis (see
-  `SafeRotatingFileHandler` in `icom_lan.diagnostics`), but submission to a
+  `SafeRotatingFileHandler` in `rigplane.diagnostics`), but submission to a
   remote endpoint is never automatic.
 - **The user must explicitly start the workflow every time.** No "always send
   reports" toggle, no install-time consent that grants ongoing permission, no
   background queue. Each report = one user gesture (CLI command, Web UI
   button, Pro Tauri click).
-- **CLI defaults never upload.** `icom-lan diagnose` (no flags) builds and
+- **CLI defaults never upload.** `rigplane diagnose` (no flags) builds and
   saves locally. `--upload` is opt-in. With a TTY, the final consent prompt
   defaults to "save locally" (`[y/N]` for upload), so accidentally hitting
   Enter cannot transmit anything.
@@ -109,7 +109,7 @@ is the broader §2 rule: no telemetry, no exceptions.
 
 ## 3. Headless mode is sacred
 
-icom-lan must run on a headless Linux box — including a Raspberry Pi
+rigplane must run on a headless Linux box — including a Raspberry Pi
 acting as a remote radio gateway — without a display server, browser, or
 audio output device.
 
@@ -124,7 +124,7 @@ audio output device.
 - New CLI presets, daemons, and entry points must be tested against a
   no-display environment before they are accepted.
 
-Headless is the deployment mode that distinguishes icom-lan from the dozens
+Headless is the deployment mode that distinguishes rigplane from the dozens
 of GUI-only Icom utilities. Breaking it would be breaking the product.
 
 ---
@@ -166,8 +166,8 @@ browser, mobile app) might want — stays open.
 
 ## 5. Radio Protocol and capability protocols are the primary boundary
 
-The Pro layer consumes icom-lan through one stable surface: the
-`Radio` protocol in `src/icom_lan/radio_protocol.py` plus the capability
+The Pro layer consumes rigplane through one stable surface: the
+`Radio` protocol in `src/rigplane/radio_protocol.py` plus the capability
 protocols (`LevelsCapable`, `MetersCapable`, `ScopeCapable`,
 `AudioCapable`, etc.).
 
@@ -215,7 +215,7 @@ money, and silent breakage is not an option.
 
 ## 7. The frontend renders in four environments
 
-The icom-lan frontend ships into more than just a developer's Chrome tab.
+The rigplane frontend ships into more than just a developer's Chrome tab.
 It must render correctly in:
 
 1. **Browsers** — Chrome, Safari, Firefox.
@@ -252,10 +252,10 @@ Linux.
 
 Per the architecture review in
 `research/2026-04-27-architecture/05-recommendations.md`, the option of
-splitting icom-lan into separate `icom-lan-lib` and `icom-lan-app` packages
+splitting rigplane into separate `rigplane-lib` and `rigplane-app` packages
 (Form B) remains deferred.
 
-**Today.** Pro uses icom-lan as a separate Python server process via
+**Today.** Pro uses rigplane as a separate Python server process via
 HTTP/WebSocket on `127.0.0.1:8470`, plus a narrow library import surface
 (`audio.backend`, `audio.dsp`, `dsp.*`) for the small handful of helpers
 that don't make sense as RPC. That surface is narrow enough that the
@@ -263,10 +263,10 @@ single-package form (Form F) remains sufficient.
 
 **Triggers that activate Form B.** Either of:
 
-- Pro embeds icom-lan in-process for the radio loop (skipping the
+- Pro embeds rigplane in-process for the radio loop (skipping the
   server-process indirection), and the lib/app boundary becomes load-bearing
   for cold-start and packaging size.
-- A second downstream Python consumer of icom-lan emerges (a third-party
+- A second downstream Python consumer of rigplane emerges (a third-party
   application, a research tool, a different commercial product) that needs
   the library without the Web UI / rigctld application code.
 

--- a/docs/guide/audio-recipes.md
+++ b/docs/guide/audio-recipes.md
@@ -1,6 +1,6 @@
 # Audio Recipes (copy/paste)
 
-Practical scenarios for the current `icom-lan` audio API.
+Practical scenarios for the current `rigplane` audio API.
 All examples use **PCM 16-bit mono 48 kHz** (`AudioCodec.PCM_1CH_16BIT`) to avoid external codec dependencies.
 
 ## Prerequisites
@@ -13,8 +13,8 @@ export ICOM_PASS=YOUR_PASS
 
 ```bash
 # Audio dependencies (opuslib, sounddevice, numpy) ship with the core
-# install since v0.19 — `pip install icom-lan` is enough.
-pip install icom-lan
+# install since v0.19 — `pip install rigplane` is enough.
+pip install rigplane
 ```
 
 ---
@@ -27,7 +27,7 @@ Saves the incoming audio stream from the radio to `rx.wav`.
 import asyncio
 import wave
 
-from icom_lan import create_radio, LanBackendConfig, AudioCodec
+from rigplane import create_radio, LanBackendConfig, AudioCodec
 
 SAMPLE_RATE = 48000
 CHANNELS = 1
@@ -74,7 +74,7 @@ Reads `tx.wav` (16-bit mono 48 kHz PCM) and transmits it.
 import asyncio
 import wave
 
-from icom_lan import create_radio, LanBackendConfig, AudioCodec
+from rigplane import create_radio, LanBackendConfig, AudioCodec
 
 SAMPLE_RATE = 48000
 CHANNELS = 1
@@ -131,7 +131,7 @@ import asyncio
 import math
 import struct
 
-from icom_lan import create_radio, LanBackendConfig, AudioCodec
+from rigplane import create_radio, LanBackendConfig, AudioCodec
 
 SAMPLE_RATE = 48000
 CHANNELS = 1
@@ -200,7 +200,7 @@ Route the same RX audio to multiple consumers simultaneously.
 
 ```python
 import asyncio
-from icom_lan import create_radio, LanBackendConfig
+from rigplane import create_radio, LanBackendConfig
 
 async def main() -> None:
     config = LanBackendConfig(
@@ -245,11 +245,11 @@ Run Web UI + audio bridge + rigctld in a single command:
 
 ```bash
 # Install (audio-bridge deps ship with the core install since v0.19)
-pip install icom-lan
+pip install rigplane
 brew install blackhole-2ch  # macOS
 
 # Start everything
-icom-lan --host 192.168.1.100 --user USER --pass PASS \
+rigplane --host 192.168.1.100 --user USER --pass PASS \
     web --bridge "BlackHole 2ch"
 
 # WSJT-X settings:
@@ -273,7 +273,7 @@ The audio bridge runs the TX path (reading from the virtual device and sending t
    ```
    You can use `max_workers=1` or `2`; the bridge only runs one TX read at a time.
 
-2. **Deployment:** For heavy scenarios, run the bridge in a **separate process** (e.g. a dedicated `icom-lan web --bridge ...` instance or a small script that only runs the bridge). That isolates CPU and I/O and avoids contention with web/rigctld in the same process.
+2. **Deployment:** For heavy scenarios, run the bridge in a **separate process** (e.g. a dedicated `rigplane web --bridge ...` instance or a small script that only runs the bridge). That isolates CPU and I/O and avoids contention with web/rigctld in the same process.
 
 3. **Scale:** Prefer **one bridge (and ideally one radio connection) per process** when you need stable low-latency audio; limit the number of simultaneous bridge clients if they share the same executor or process.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-The `icom-lan` CLI provides quick access to radio control from the terminal.
+The `rigplane` CLI provides quick access to radio control from the terminal.
 
 ## Global Options
 
@@ -24,7 +24,7 @@ All commands accept these options:
 | `--version` | — | — | Print version and exit |
 
 !!! tip "Zero-config startup"
-    If you have a single radio on the network, just run `icom-lan web` — it auto-discovers the radio via LAN broadcast. No `--host` needed.
+    If you have a single radio on the network, just run `rigplane web` — it auto-discovers the radio via LAN broadcast. No `--host` needed.
 
     For permanent setups, set environment variables in your shell profile:
 
@@ -37,7 +37,7 @@ All commands accept these options:
 
 ## Auto-discovery
 
-When `--host` is omitted (LAN backend), icom-lan sends a UDP broadcast to find radios:
+When `--host` is omitted (LAN backend), rigplane sends a UDP broadcast to find radios:
 
 - **1 radio found** → uses it automatically, prints the IP
 - **Multiple radios** → lists them, asks you to specify `--host`
@@ -63,51 +63,51 @@ Use `--preset` with `web` or `serve` commands for common scenarios:
 | `headless` | rigctld only (no web UI) |
 
 ```bash
-icom-lan web --preset digimode          # Full digital mode setup
-icom-lan web --preset hamradio          # General ham radio setup
+rigplane web --preset digimode          # Full digital mode setup
+rigplane web --preset hamradio          # General ham radio setup
 ```
 
 User-provided flags override preset values: `--preset digimode --bridge "MyDevice"` uses your device name.
 
 ## Backend Selection
 
-icom-lan supports three backends: **LAN** (default), **serial** (USB CI-V), and
+rigplane supports three backends: **LAN** (default), **serial** (USB CI-V), and
 **yaesu-cat** (text CAT over serial).
 
 ### LAN backend (default)
 
 ```bash
 # Auto-discover radio on LAN
-icom-lan status
+rigplane status
 
 # Explicit IP
-icom-lan --host 192.168.55.40 status
-icom-lan --backend lan status
+rigplane --host 192.168.55.40 status
+rigplane --backend lan status
 ```
 
 ### Serial backend
 
 ```bash
 # Auto-discover serial port
-icom-lan --backend serial status
+rigplane --backend serial status
 
 # Explicit port (--backend serial is inferred)
-icom-lan --serial-port /dev/tty.usbmodem-IC7610 status
+rigplane --serial-port /dev/tty.usbmodem-IC7610 status
 ```
 
 Set via environment variable to avoid repeating:
 
 ```bash
 export ICOM_SERIAL_DEVICE=/dev/tty.usbmodem-IC7610
-icom-lan status    # auto-infers --backend serial
+rigplane status    # auto-infers --backend serial
 ```
 
 ### Yaesu CAT backend
 
 ```bash
 # Connects via Yaesu CAT serial protocol (for example FTX-1 / FT-710 profiles)
-icom-lan --backend yaesu-cat --serial-port /dev/tty.usbserial-FTX1 status
-icom-lan --backend yaesu-cat --serial-port /dev/tty.usbserial-FTX1 freq
+rigplane --backend yaesu-cat --serial-port /dev/tty.usbserial-FTX1 status
+rigplane --backend yaesu-cat --serial-port /dev/tty.usbserial-FTX1 freq
 ```
 
 ### Serial baud defaults by backend
@@ -123,11 +123,11 @@ The serial backend uses USB audio devices exported by the radio. By default, dev
 
 ```bash
 # List all available audio devices
-icom-lan --list-audio-devices
-icom-lan --list-audio-devices --json
+rigplane --list-audio-devices
+rigplane --list-audio-devices --json
 
 # Specify explicit devices
-icom-lan --backend serial --serial-port /dev/tty.usbmodem-IC7610 \
+rigplane --backend serial --serial-port /dev/tty.usbmodem-IC7610 \
     --rx-device "IC-7610 USB Audio" \
     --tx-device "IC-7610 USB Audio" \
     audio rx --out rx.wav --seconds 10
@@ -138,10 +138,10 @@ icom-lan --backend serial --serial-port /dev/tty.usbmodem-IC7610 \
 The `discover` command scans both LAN (UDP broadcast) and USB serial ports concurrently:
 
 ```bash
-icom-lan discover                      # LAN + serial (default)
-icom-lan discover --lan-only           # UDP broadcast only
-icom-lan discover --serial-only        # USB serial ports only
-icom-lan discover --timeout 5          # Longer LAN listen window
+rigplane discover                      # LAN + serial (default)
+rigplane discover --lan-only           # UDP broadcast only
+rigplane discover --serial-only        # USB serial ports only
+rigplane discover --timeout 5          # Longer LAN listen window
 ```
 
 ## Commands
@@ -151,8 +151,8 @@ icom-lan discover --timeout 5          # Longer LAN listen window
 Show radio status (frequency, mode, S-meter, power).
 
 ```bash
-icom-lan status
-icom-lan status --json
+rigplane status
+rigplane status --json
 ```
 
 ```
@@ -180,12 +180,12 @@ Get or set the operating frequency.
 
 ```bash
 # Get current frequency
-icom-lan freq
+rigplane freq
 
 # Set frequency (multiple formats)
-icom-lan freq 14074000      # Hz
-icom-lan freq 14074k        # kHz
-icom-lan freq 14.074m       # MHz
+rigplane freq 14074000      # Hz
+rigplane freq 14074k        # kHz
+rigplane freq 14.074m       # MHz
 ```
 
 ### `mode`
@@ -194,12 +194,12 @@ Get or set the operating mode.
 
 ```bash
 # Get current mode
-icom-lan mode
+rigplane mode
 
 # Set mode
-icom-lan mode USB
-icom-lan mode CW
-icom-lan mode LSB
+rigplane mode USB
+rigplane mode CW
+rigplane mode LSB
 ```
 
 Available modes: `LSB`, `USB`, `AM`, `CW`, `RTTY`, `FM`, `WFM`, `CW_R`, `RTTY_R`, `DV`
@@ -210,10 +210,10 @@ Get or set the RF power level (0–255).
 
 ```bash
 # Get current power
-icom-lan power
+rigplane power
 
 # Set power level
-icom-lan power 128
+rigplane power 128
 ```
 
 !!! note "Power Scale"
@@ -224,8 +224,8 @@ icom-lan power 128
 Read all available meters.
 
 ```bash
-icom-lan meter
-icom-lan meter --json
+rigplane meter
+rigplane meter --json
 ```
 
 ```
@@ -240,13 +240,13 @@ ALC      n/a
 
 ### `audio caps`
 
-Show icom-lan audio capability metadata and deterministic defaults.
+Show rigplane audio capability metadata and deterministic defaults.
 
 ```bash
-icom-lan audio caps
-icom-lan audio caps --json
-icom-lan audio caps --stats
-icom-lan audio caps --json --stats
+rigplane audio caps
+rigplane audio caps --json
+rigplane audio caps --stats
+rigplane audio caps --json --stats
 ```
 
 Text output includes:
@@ -285,9 +285,9 @@ JSON output example:
 Capture RX audio to a 16-bit PCM WAV file.
 
 ```bash
-icom-lan audio rx --out rx.wav --seconds 10
-icom-lan audio rx --out rx.wav --seconds 10 --sample-rate 48000 --channels 1
-icom-lan audio rx --out rx.wav --json
+rigplane audio rx --out rx.wav --seconds 10
+rigplane audio rx --out rx.wav --seconds 10 --sample-rate 48000 --channels 1
+rigplane audio rx --out rx.wav --json
 ```
 
 ### `audio tx`
@@ -295,9 +295,9 @@ icom-lan audio rx --out rx.wav --json
 Transmit a WAV file (`16-bit PCM`, matching sample rate/channels).
 
 ```bash
-icom-lan audio tx --in tx.wav
-icom-lan audio tx --in tx.wav --sample-rate 48000 --channels 1
-icom-lan audio tx --in tx.wav --json
+rigplane audio tx --in tx.wav
+rigplane audio tx --in tx.wav --sample-rate 48000 --channels 1
+rigplane audio tx --in tx.wav --json
 ```
 
 ### `audio loopback`
@@ -305,15 +305,15 @@ icom-lan audio tx --in tx.wav --json
 Run a quick RX-to-TX PCM loopback window.
 
 ```bash
-icom-lan audio loopback --seconds 10
-icom-lan audio loopback --seconds 10 --sample-rate 48000 --channels 1
-icom-lan audio loopback --json
+rigplane audio loopback --seconds 10
+rigplane audio loopback --seconds 10 --sample-rate 48000 --channels 1
+rigplane audio loopback --json
 ```
 
 ### Shared audio flags (`rx`/`tx`/`loopback`)
 
-- `--sample-rate` — PCM sample rate in Hz (must be supported by `icom-lan`)
-- `--channels` — PCM channel count (must be supported by `icom-lan`)
+- `--sample-rate` — PCM sample rate in Hz (must be supported by `rigplane`)
+- `--channels` — PCM channel count (must be supported by `rigplane`)
 - `--json` — machine-readable JSON output
 - `--stats` — print transfer counters/metrics (human-readable mode)
 
@@ -323,16 +323,16 @@ Get or set the attenuator level.
 
 ```bash
 # Get current attenuation
-icom-lan att
-icom-lan att --json
+rigplane att
+rigplane att --json
 
 # Set level in dB (0–45, 3 dB steps)
-icom-lan att 18
-icom-lan att 0
+rigplane att 18
+rigplane att 0
 
 # Toggle shortcuts
-icom-lan att on     # Sets 18 dB
-icom-lan att off    # Sets 0 dB
+rigplane att on     # Sets 18 dB
+rigplane att off    # Sets 0 dB
 ```
 
 ```
@@ -358,14 +358,14 @@ Get or set the preamplifier level.
 
 ```bash
 # Get current preamp level
-icom-lan preamp
-icom-lan preamp --json
+rigplane preamp
+rigplane preamp --json
 
 # Set level
-icom-lan preamp 0     # Off
-icom-lan preamp 1     # PREAMP 1
-icom-lan preamp 2     # PREAMP 2
-icom-lan preamp off   # Same as 0
+rigplane preamp 0     # Off
+rigplane preamp 1     # PREAMP 1
+rigplane preamp 2     # PREAMP 2
+rigplane preamp off   # Same as 0
 ```
 
 ```
@@ -387,13 +387,13 @@ Get or set antenna selection.
 
 ```bash
 # Get current antenna state
-icom-lan antenna
+rigplane antenna
 
 # Set antenna
-icom-lan antenna --ant1 on
-icom-lan antenna --ant2 on
-icom-lan antenna --rx-ant1 on
-icom-lan antenna --rx-ant2 off
+rigplane antenna --ant1 on
+rigplane antenna --ant2 on
+rigplane antenna --rx-ant1 on
+rigplane antenna --rx-ant2 off
 ```
 
 | Flag | Default | Description |
@@ -408,7 +408,7 @@ icom-lan antenna --rx-ant2 off
 Get or set the radio's internal date.
 
 ```bash
-icom-lan date
+rigplane date
 ```
 
 ### `time`
@@ -416,7 +416,7 @@ icom-lan date
 Get or set the radio's internal time.
 
 ```bash
-icom-lan time
+rigplane time
 ```
 
 ### `dualwatch`
@@ -424,7 +424,7 @@ icom-lan time
 Get or set dual watch mode.
 
 ```bash
-icom-lan dualwatch
+rigplane dualwatch
 ```
 
 ### `tuner`
@@ -432,7 +432,7 @@ icom-lan dualwatch
 Control the antenna tuner.
 
 ```bash
-icom-lan tuner
+rigplane tuner
 ```
 
 ### `levels`
@@ -440,7 +440,7 @@ icom-lan tuner
 Get or set radio levels (AF, RF, squelch, etc.).
 
 ```bash
-icom-lan levels
+rigplane levels
 ```
 
 ### `ptt`
@@ -448,8 +448,8 @@ icom-lan levels
 Toggle Push-To-Talk.
 
 ```bash
-icom-lan ptt on
-icom-lan ptt off
+rigplane ptt on
+rigplane ptt off
 ```
 
 !!! danger "Caution"
@@ -460,7 +460,7 @@ icom-lan ptt off
 Send CW text via the radio's built-in keyer.
 
 ```bash
-icom-lan cw "CQ CQ DE KN4KYD K"
+rigplane cw "CQ CQ DE KN4KYD K"
 ```
 
 The text is sent in chunks of up to 30 characters. Supports A–Z, 0–9, and standard prosigns.
@@ -470,8 +470,8 @@ The text is sent in chunks of up to 30 characters. Supports A–Z, 0–9, and st
 Remote power control.
 
 ```bash
-icom-lan power-on
-icom-lan power-off
+rigplane power-on
+rigplane power-off
 ```
 
 !!! warning
@@ -482,10 +482,10 @@ icom-lan power-off
 Discover Icom radios on LAN and USB serial ports. Results are grouped by radio identity — the same physical radio connected via both LAN and USB appears as one entry with two connection methods.
 
 ```bash
-icom-lan discover                   # LAN + serial
-icom-lan discover --lan-only        # UDP broadcast only
-icom-lan discover --serial-only     # USB serial ports only
-icom-lan discover --timeout 5       # Longer LAN listen window (default: 3s)
+rigplane discover                   # LAN + serial
+rigplane discover --lan-only        # UDP broadcast only
+rigplane discover --serial-only     # USB serial ports only
+rigplane discover --timeout 5       # Longer LAN listen window (default: 3s)
 ```
 
 ```
@@ -523,19 +523,19 @@ Start a rigctld-compatible TCP server so that logging and contesting software (W
 
 ```bash
 # Basic rigctld server on default port 4532
-icom-lan serve
+rigplane serve
 
 # Custom port, read-only, max 5 clients
-icom-lan serve --port 4533 --read-only --max-clients 5
+rigplane serve --port 4533 --read-only --max-clients 5
 
 # Write every command to an audit log
-icom-lan serve --audit-log /var/log/icom-audit.jsonl
+rigplane serve --audit-log /var/log/icom-audit.jsonl
 
 # Rate-limit to 10 commands/sec per client, verbose debug logs
-icom-lan serve --rate-limit 10 --log-level DEBUG
+rigplane serve --rate-limit 10 --log-level DEBUG
 
 # WSJT-X preset (enables DATA mode automatically on first connect)
-icom-lan serve --wsjtx-compat
+rigplane serve --wsjtx-compat
 ```
 
 | Option | Default | Description |
@@ -559,10 +559,10 @@ Transparent UDP relay that forwards all radio traffic between a remote client an
 
 ```bash
 # Forward radio at 192.168.55.40 to all VPN clients
-icom-lan proxy --radio 192.168.55.40
+rigplane proxy --radio 192.168.55.40
 
 # Listen only on VPN interface, custom base port
-icom-lan proxy --radio 192.168.55.40 --listen 10.8.0.1 --port 50010
+rigplane proxy --radio 192.168.55.40 --listen 10.8.0.1 --port 50010
 ```
 
 | Option | Default | Description |
@@ -577,29 +577,29 @@ Start the all-in-one server: Web UI + optional audio bridge + rigctld.
 
 ```bash
 # Web UI only (auto-discovers radio)
-icom-lan web
+rigplane web
 
 # Use a preset for common scenarios
-icom-lan web --preset digimode          # Bridge + rigctld + WSJT-X compat
-icom-lan web --preset hamradio          # Bridge + rigctld
+rigplane web --preset digimode          # Bridge + rigctld + WSJT-X compat
+rigplane web --preset hamradio          # Bridge + rigctld
 
 # Web UI + audio bridge + rigctld (recommended for WSJT-X)
-icom-lan web --bridge "BlackHole 2ch"
+rigplane web --bridge "BlackHole 2ch"
 
 # Web UI + WSJT-X compatibility on embedded rigctld
-icom-lan web --bridge --wsjtx-compat
+rigplane web --bridge --wsjtx-compat
 
 # Web UI + bridge (RX only, no TX from virtual device)
-icom-lan web --bridge "BlackHole 2ch" --bridge-rx-only
+rigplane web --bridge "BlackHole 2ch" --bridge-rx-only
 
 # Disable rigctld (enabled by default on :4532)
-icom-lan web --no-rigctld
+rigplane web --no-rigctld
 
 # Custom ports
-icom-lan web --port 9090 --rigctld-port 4533
+rigplane web --port 9090 --rigctld-port 4533
 
 # Require token for /api and WebSocket channels
-icom-lan web --auth-token "change-me"
+rigplane web --auth-token "change-me"
 ```
 
 | Option | Default | Description |
@@ -622,13 +622,13 @@ Route radio audio to/from a virtual audio device (BlackHole, Loopback, VB-Audio)
 
 ```bash
 # List available audio devices
-icom-lan audio bridge --list-devices
+rigplane audio bridge --list-devices
 
 # Start bridge
-icom-lan audio bridge --device "BlackHole 2ch"
+rigplane audio bridge --device "BlackHole 2ch"
 
 # RX only (no TX from virtual device)
-icom-lan audio bridge --device "BlackHole 2ch" --rx-only
+rigplane audio bridge --device "BlackHole 2ch" --rx-only
 ```
 
 !!! tip "macOS Setup"
@@ -640,7 +640,7 @@ icom-lan audio bridge --device "BlackHole 2ch" --rx-only
 
 !!! note "Dependencies"
     Audio-bridge dependencies (`opuslib`, `sounddevice`, `numpy`) ship with
-    the core install since v0.19 — `pip install icom-lan` is sufficient.
+    the core install since v0.19 — `pip install rigplane` is sufficient.
     On macOS with Homebrew, you may also need:
     ```bash
     export DYLD_LIBRARY_PATH=/opt/homebrew/lib
@@ -650,30 +650,30 @@ icom-lan audio bridge --device "BlackHole 2ch" --rx-only
 
 Capture spectrum and waterfall data from the radio's scope display and render as PNG.
 
-Requires optional dependency: `pip install icom-lan[scope]`
+Requires optional dependency: `pip install rigplane[scope]`
 
 ```bash
 # Combined spectrum + waterfall (50 frames, ~3 seconds)
-icom-lan scope
+rigplane scope
 
 # Spectrum only (1 frame, fast)
-icom-lan scope --spectrum-only
+rigplane scope --spectrum-only
 
 # Custom output and frame count
-icom-lan scope --output waterfall.png --frames 100
+rigplane scope --output waterfall.png --frames 100
 
 # Grayscale theme
-icom-lan scope --theme grayscale
+rigplane scope --theme grayscale
 
 # Wider image
-icom-lan scope --width 1200
+rigplane scope --width 1200
 
 # Raw JSON data (no Pillow needed)
-icom-lan scope --json
-icom-lan scope --spectrum-only --json
+rigplane scope --json
+rigplane scope --spectrum-only --json
 
 # Custom capture timeout
-icom-lan scope --capture-timeout 20
+rigplane scope --capture-timeout 20
 ```
 
 | Option | Default | Description |
@@ -692,14 +692,14 @@ For daemon-like commands (`web`, `serve`), you can opt in to writing a PID file 
 
 ```bash
 # Enable PID file for web/serve (e.g. in systemd or a wrapper script)
-export ICOM_PID_FILE=/var/run/icom-lan.pid
-icom-lan web
+export ICOM_PID_FILE=/var/run/rigplane.pid
+rigplane web
 
 # Graceful shutdown
-kill $(cat /var/run/icom-lan.pid)
+kill $(cat /var/run/rigplane.pid)
 
-# Check if icom-lan is running
-test -f /var/run/icom-lan.pid && ps -p $(cat /var/run/icom-lan.pid)
+# Check if rigplane is running
+test -f /var/run/rigplane.pid && ps -p $(cat /var/run/rigplane.pid)
 ```
 
 If `ICOM_PID_FILE` is unset or empty, no PID file is written. This avoids conflicts when running multiple instances or in tests.
@@ -709,7 +709,7 @@ If `ICOM_PID_FILE` is unset or empty, no PID file is written. This avoids confli
 `web` and `serve` are long-running commands, so the CLI enables file logging by default
 to preserve diagnostics across reconnects/restarts.
 
-- Default file path: `logs/icom-lan.log`
+- Default file path: `logs/rigplane.log`
 - Handler type: Python `RotatingFileHandler`
 - Rotation defaults: `50_000_000` bytes per file, `5` backups
 
@@ -717,24 +717,24 @@ You can tune this behavior with environment variables:
 
 | Variable | Default | Meaning |
 |---|---:|---|
-| `ICOM_LOG_FILE` | `logs/icom-lan.log` (for `web`/`serve`) | Log file path. Set to `off`, `none`, or `-` to disable file logging entirely. |
+| `ICOM_LOG_FILE` | `logs/rigplane.log` (for `web`/`serve`) | Log file path. Set to `off`, `none`, or `-` to disable file logging entirely. |
 | `ICOM_LOG_MAX_BYTES` | `50000000` | Rotate when file reaches this size (bytes). |
 | `ICOM_LOG_BACKUP_COUNT` | `5` | Number of rotated files to keep. Set `0` to disable rotation. |
 | `ICOM_DEBUG` | unset | Enables debug-level logging and also enables file logging if `ICOM_LOG_FILE` is not disabled. |
 
 ```bash
 # Custom log location (systemd/container-friendly)
-export ICOM_LOG_FILE=/var/log/icom-lan/daemon.log
-icom-lan web
+export ICOM_LOG_FILE=/var/log/rigplane/daemon.log
+rigplane web
 
 # Smaller files with more backups
 export ICOM_LOG_MAX_BYTES=10000000
 export ICOM_LOG_BACKUP_COUNT=10
-icom-lan serve
+rigplane serve
 
 # Explicitly disable file logs (stdout/stderr only)
 export ICOM_LOG_FILE=off
-icom-lan web
+rigplane web
 ```
 
 ## Flag Reference
@@ -754,13 +754,13 @@ These flags apply to **every** command and must come before the subcommand name.
 
 ```bash
 # Print installed version
-icom-lan --version
+rigplane --version
 
 # Connect to a radio on a non-default port
-icom-lan --control-port 50002 status
+rigplane --control-port 50002 status
 
 # Specify radio model explicitly
-icom-lan --model IC-7300 --backend serial --serial-port /dev/cu.usbserial-XXX status
+rigplane --model IC-7300 --backend serial --serial-port /dev/cu.usbserial-XXX status
 ```
 
 ### `serve` flags
@@ -778,25 +778,25 @@ icom-lan --model IC-7300 --backend serial --serial-port /dev/cu.usbserial-XXX st
 
 ```bash
 # Log every command to a JSONL audit trail
-icom-lan serve --audit-log /var/log/icom-audit.jsonl
+rigplane serve --audit-log /var/log/icom-audit.jsonl
 
 # Tighten cache for faster state sync
-icom-lan serve --cache-ttl 0.05
+rigplane serve --cache-ttl 0.05
 
 # Verbose debug logging
-icom-lan serve --log-level DEBUG
+rigplane serve --log-level DEBUG
 
 # Limit to 3 simultaneous clients
-icom-lan serve --max-clients 3
+rigplane serve --max-clients 3
 
 # Drop commands faster than 10/sec per client
-icom-lan serve --rate-limit 10
+rigplane serve --rate-limit 10
 
 # Prevent accidental frequency/mode changes
-icom-lan serve --read-only
+rigplane serve --read-only
 
 # Enable WSJT-X compatibility preset
-icom-lan serve --wsjtx-compat
+rigplane serve --wsjtx-compat
 ```
 
 ### `proxy` flags
@@ -808,10 +808,10 @@ icom-lan serve --wsjtx-compat
 
 ```bash
 # Forward traffic to radio at 192.168.1.100 (listen on all interfaces)
-icom-lan proxy --radio 192.168.1.100
+rigplane proxy --radio 192.168.1.100
 
 # Bind only on the VPN interface
-icom-lan proxy --radio 192.168.1.100 --listen 10.8.0.1
+rigplane proxy --radio 192.168.1.100 --listen 10.8.0.1
 ```
 
 ### `web` flags
@@ -835,16 +835,16 @@ icom-lan proxy --radio 192.168.1.100 --listen 10.8.0.1
 
 ```bash
 # Bidirectional bridge: RX from BlackHole 2ch, TX through BlackHole 16ch
-icom-lan web --bridge "BlackHole 2ch" --bridge-tx-device "BlackHole 16ch"
+rigplane web --bridge "BlackHole 2ch" --bridge-tx-device "BlackHole 16ch"
 
 # Serve a custom-built web UI from a local directory
-icom-lan web --static-dir /opt/icom-ui/dist
+rigplane web --static-dir /opt/icom-ui/dist
 
 # Connect to a DX cluster and show spot overlays on the waterfall
-icom-lan web --dx-cluster dxc.nc7j.com:7373 --callsign KN4KYD
+rigplane web --dx-cluster dxc.nc7j.com:7373 --callsign KN4KYD
 
 # Protect API + WS endpoints with a bearer token
-icom-lan web --auth-token "change-me"
+rigplane web --auth-token "change-me"
 ```
 
 ## Exit Codes
@@ -858,15 +858,15 @@ icom-lan web --auth-token "change-me"
 
 ```bash
 # Monitor frequency in a loop
-watch -n 1 icom-lan freq --json
+watch -n 1 rigplane freq --json
 
 # Quick band change
-icom-lan freq 7.074m && icom-lan mode USB
+rigplane freq 7.074m && rigplane mode USB
 
 # Check RF chain setup
-icom-lan att && icom-lan preamp
+rigplane att && rigplane preamp
 
 # Script-friendly JSON output
-FREQ=$(icom-lan freq --json | jq -r '.frequency_hz')
+FREQ=$(rigplane freq --json | jq -r '.frequency_hz')
 echo "Currently on $FREQ Hz"
 ```

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -21,7 +21,7 @@ Frequency is always in **Hz** (integer). The radio internally uses BCD encoding 
 ## Mode
 
 ```python
-from icom_lan import Mode
+from rigplane import Mode
 
 # Get current mode
 mode_name, filt = await radio.get_mode()
@@ -87,7 +87,7 @@ alc = await radio.get_alc_meter()
     `get_swr()` and `get_alc_meter()` will timeout if the radio is not transmitting. Wrap them in try/except:
 
     ```python
-    from icom_lan.exceptions import TimeoutError
+    from rigplane.exceptions import TimeoutError
 
     try:
         swr = await radio.get_swr()
@@ -151,7 +151,7 @@ These commands use **Command29 framing** for dual-receiver radios (IC-7610).
 By default, they target the MAIN receiver.
 
 ```python
-from icom_lan import RECEIVER_MAIN, RECEIVER_SUB
+from rigplane import RECEIVER_MAIN, RECEIVER_SUB
 
 # --- Attenuator ---
 # Get attenuation level in dB

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -2,7 +2,7 @@
 
 ## Backend Selection
 
-icom-lan supports two backends selected via `--backend`:
+rigplane supports two backends selected via `--backend`:
 
 | Backend | Description |
 |---------|-------------|
@@ -35,11 +35,11 @@ icom-lan supports two backends selected via `--backend`:
 ```bash
 # Serial backend quick start
 export ICOM_SERIAL_DEVICE=/dev/tty.usbmodem-IC7610
-icom-lan --backend serial status
-icom-lan --backend serial freq 14.074m
+rigplane --backend serial status
+rigplane --backend serial freq 14.074m
 
 # List available USB audio devices
-icom-lan --list-audio-devices
+rigplane --list-audio-devices
 ```
 
 ## Connection Parameters (LAN, reference)
@@ -58,7 +58,7 @@ Each Icom radio model has a default CI-V address. You can also configure a custo
 | IC-R8600 | `0x96` |
 
 ```python
-from icom_lan import create_radio, LanBackendConfig
+from rigplane import create_radio, LanBackendConfig
 
 # IC-7610 (default radio_addr 0x98)
 config = LanBackendConfig(host="192.168.1.100", username="u", password="p")
@@ -136,7 +136,7 @@ ICOM_PASS=mypass
 The default 5-second timeout works well for local networks. Adjust if needed:
 
 ```python
-from icom_lan import create_radio, LanBackendConfig
+from rigplane import create_radio, LanBackendConfig
 
 # Fast local network
 config = LanBackendConfig(host="192.168.1.100", username="u", password="p", timeout=2.0)
@@ -163,12 +163,12 @@ The library uses Python's standard `logging` module. Enable debug output to trou
 ```python
 import logging
 
-# See all icom-lan internal messages
+# See all rigplane internal messages
 logging.basicConfig(level=logging.DEBUG)
 
 # Or target specific modules
-logging.getLogger("icom_lan.transport").setLevel(logging.DEBUG)
-logging.getLogger("icom_lan.radio").setLevel(logging.DEBUG)
+logging.getLogger("rigplane.transport").setLevel(logging.DEBUG)
+logging.getLogger("rigplane.radio").setLevel(logging.DEBUG)
 ```
 
 Log levels:

--- a/docs/guide/connection.md
+++ b/docs/guide/connection.md
@@ -124,7 +124,7 @@ await radio.disconnect()
 ## Connection States
 
 ```python
-from icom_lan import ConnectionState
+from rigplane import ConnectionState
 
 # Available states
 ConnectionState.DISCONNECTED  # Not connected
@@ -152,8 +152,8 @@ is skipped for that attempt.
 ## Error Handling
 
 ```python
-from icom_lan import create_radio, LanBackendConfig
-from icom_lan.exceptions import (
+from rigplane import create_radio, LanBackendConfig
+from rigplane.exceptions import (
     ConnectionError,
     AuthenticationError,
     TimeoutError,

--- a/docs/guide/diagnostic-reports.md
+++ b/docs/guide/diagnostic-reports.md
@@ -1,6 +1,6 @@
 # Diagnostic Reports
 
-When something goes wrong with `icom-lan` — a CAT timeout, a stuck audio
+When something goes wrong with `rigplane` — a CAT timeout, a stuck audio
 bridge, a Web UI panel that won't render, a frequency that won't tune —
 the fastest way to get help is a diagnostic report. One command (or one
 button click) bundles your logs, radio state, runtime config, and
@@ -10,7 +10,7 @@ This guide explains when to use the feature, what's in the bundle, what's
 deliberately left out, and exactly what happens when you hit "Send".
 
 !!! note "Privacy first"
-    `icom-lan` does not phone home. There is no automatic telemetry, no
+    `rigplane` does not phone home. There is no automatic telemetry, no
     background crash reporter, no "anonymous usage statistics" toggle.
     Every diagnostic upload is the result of a single, explicit user
     gesture — see [Privacy](#privacy) below for the hard rules.
@@ -37,7 +37,7 @@ There are three ways to produce a report. Pick whichever is convenient.
 ### Interactive (TTY)
 
 ```bash
-icom-lan diagnose --upload
+rigplane diagnose --upload
 ```
 
 The CLI walks you through a description prompt, optional issue URL,
@@ -64,11 +64,11 @@ alternative to "Send".
 ### Save locally (no upload)
 
 ```bash
-icom-lan diagnose --output ~/icom-lan-report.zip
+rigplane diagnose --output ~/rigplane-report.zip
 ```
 
-Without `--upload`, `icom-lan diagnose` builds the bundle, writes it to
-the path you specify (or `~/icom-lan-report-<timestamp>.zip` by
+Without `--upload`, `rigplane diagnose` builds the bundle, writes it to
+the path you specify (or `~/rigplane-report-<timestamp>.zip` by
 default), prints the path, and exits. No network. Inspect the ZIP, edit
 it if needed, attach it manually to a GitHub issue or email.
 
@@ -81,15 +81,15 @@ own subdirectory of the ZIP. The full schema lives in the design spec
 
 | Category       | Contents                                                                  | Redaction applied                                            |
 | -------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `system`       | OS, arch, Python version, `icom-lan` version, install method              | Absolute home paths rewritten to `<HOME>/...`                |
+| `system`       | OS, arch, Python version, `rigplane` version, install method              | Absolute home paths rewritten to `<HOME>/...`                |
 | `invocation`   | Filtered `sys.argv`, environment allowlist                                | `password=`, `pwd=`, `Bearer …`, API tokens → `***`          |
 | `radio`        | Model, firmware version, backend, capability matrix, audio codec          | Public IPs masked (RFC 1918 ranges kept — they're useful)    |
 | `audio`        | Codec, channels, sample rate, device names, bridge state                  | macOS device names containing usernames are masked           |
-| `logs`         | Rolling diagnostic logs from `~/.cache/icom-lan/logs/` (up to ~15 MiB)    | Path / IP / credential regex pass on copies                  |
+| `logs`         | Rolling diagnostic logs from `~/.cache/rigplane/logs/` (up to ~15 MiB)    | Path / IP / credential regex pass on copies                  |
 | `state`        | Current freq, mode, meters, last N CI-V exchanges (ring buffer)           | Optional callsign masking                                    |
 | `errors`       | Recent in-process tracebacks (ring buffer)                                | Paths scrubbed                                               |
 | `dependencies` | `pip freeze`-equivalent enumeration via `importlib.metadata`              | None — all-public package names + versions                   |
-| `config`       | Summary of `~/.icom-lan/*.toml` files                                     | `password` keys dropped entirely; other creds → `***`        |
+| `config`       | Summary of `~/.rigplane/*.toml` files                                     | `password` keys dropped entirely; other creds → `***`        |
 | `extensions/*` | Pro contributors (Tauri logs, Rust crash dumps, RC-28, DSP) when present  | Same redaction utilities; signed under the active license    |
 
 The manifest (`manifest.json`) lists which contributors ran, which
@@ -107,7 +107,7 @@ following:
   toggle, no install-time consent that grants ongoing permission, no
   background queue. One report = one deliberate action (CLI command,
   Web UI consent click, Pro Tauri "Send" button).
-- **CLI default never uploads.** `icom-lan diagnose` (no flags) builds
+- **CLI default never uploads.** `rigplane diagnose` (no flags) builds
   the bundle and saves it locally. `--upload` is opt-in.
 - **TTY consent prompt defaults to "save locally".** With `--upload` on
   a terminal, the final prompt is `[y/N]` for upload — pressing Enter
@@ -124,7 +124,7 @@ following:
   checkbox.
 - **Contact fields are opt-in only.** Email and callsign are never
   auto-populated from environment variables, system identity,
-  `~/.icom-lan/*.toml`, or any prior report — only typed at submission
+  `~/.rigplane/*.toml`, or any prior report — only typed at submission
   time.
 - **The bundle is always available locally.** The "Save locally"
   button (Web UI) and the default `--output` path (CLI) are always
@@ -168,7 +168,7 @@ variable:
 
 ```bash
 export ICOM_LAN_REPORT_ENDPOINT=https://reports.example.com/v1/diagnostics/upload
-icom-lan diagnose --upload
+rigplane diagnose --upload
 ```
 
 The override is visible in every preview pane (CLI and Web UI), so you
@@ -197,15 +197,15 @@ automatically. The `support_url` becomes a 404 after retention expires
 
 ## Local-only mode
 
-`icom-lan diagnose` (without `--upload`) is fundamentally a local
+`rigplane diagnose` (without `--upload`) is fundamentally a local
 bundle generator:
 
 ```bash
-icom-lan diagnose
-# → /home/you/icom-lan-report-2026-05-03T19-04-12.zip
+rigplane diagnose
+# → /home/you/rigplane-report-2026-05-03T19-04-12.zip
 ```
 
-The default output path is `~/icom-lan-report-<timestamp>.zip`;
+The default output path is `~/rigplane-report-<timestamp>.zip`;
 override with `--output PATH`. No network is ever touched in this mode.
 
 This is the right choice when:
@@ -216,17 +216,17 @@ This is the right choice when:
   the public triage endpoint.
 - You're saving a snapshot for later comparison.
 
-You can `unzip -l icom-lan-report-*.zip` to inspect the file list, or
+You can `unzip -l rigplane-report-*.zip` to inspect the file list, or
 extract and `cat manifest.json | jq` to see which contributors ran.
 
 ## Pro vs open-core
 
-Open-core (`icom-lan`) uploads are anonymous: no authentication, IP
+Open-core (`rigplane`) uploads are anonymous: no authentication, IP
 rate-limited (5/hour, 10/day per IP), 90-day retention, no AI triage.
 The bundle covers everything in §4.4 of the spec — system, radio,
 audio, logs, state, errors, dependencies, config.
 
-`icom-lan-pro` adds its own contributors (Tauri logs, Rust crash
+`rigplane-pro` adds its own contributors (Tauri logs, Rust crash
 dumps, RC-28 controller state, DSP state contributors) under
 `extensions/` in the same bundle, and signs the upload with the active
 license. Customer-tier service applies: longer retention, higher rate
@@ -238,20 +238,20 @@ through `setuptools` entry points.
 
 ### Cache directory permissions
 
-`icom-lan` keeps a rotating diagnostic log at:
+`rigplane` keeps a rotating diagnostic log at:
 
-- Linux: `~/.cache/icom-lan/logs/`
-- macOS: `~/Library/Caches/icom-lan/logs/`
-- Windows: `%LOCALAPPDATA%\icom-lan\Cache\logs\`
+- Linux: `~/.cache/rigplane/logs/`
+- macOS: `~/Library/Caches/rigplane/logs/`
+- Windows: `%LOCALAPPDATA%\rigplane\Cache\logs\`
 
 If this directory cannot be created (read-only home, sandboxed runtime,
 permission-denied) the diagnostic logger silently disables itself —
-`icom-lan` keeps running and continues to log to stdout/stderr, but the
+`rigplane` keeps running and continues to log to stdout/stderr, but the
 `logs` contributor in the bundle will be empty or absent. To fix:
 
 ```bash
-mkdir -p ~/.cache/icom-lan/logs
-chmod 700 ~/.cache/icom-lan/logs
+mkdir -p ~/.cache/rigplane/logs
+chmod 700 ~/.cache/rigplane/logs
 ```
 
 You can also set `ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING=1` to disable
@@ -264,10 +264,10 @@ per IP**. If you hit the limit you'll see:
 
 ```
 Upload rejected: rate_limited (retry after 1842 seconds).
-Bundle saved locally at /home/you/icom-lan-report-….zip
+Bundle saved locally at /home/you/rigplane-report-….zip
 ```
 
-Wait for the retry window, or activate an `icom-lan-pro` license for
+Wait for the retry window, or activate an `rigplane-pro` license for
 authenticated uploads with higher limits. The bundle is always saved
 locally on rate-limit, so you don't lose the report.
 
@@ -280,11 +280,11 @@ extension contributor can push you over. Mitigations:
 
 ```bash
 # Drop the logs category — keeps state, radio, errors, dependencies
-icom-lan diagnose --upload --exclude logs
+rigplane diagnose --upload --exclude logs
 
 # Or split: send state-only first, then logs separately
-icom-lan diagnose --output state.zip --exclude logs
-icom-lan diagnose --output logs.zip --include logs
+rigplane diagnose --output state.zip --exclude logs
+rigplane diagnose --output logs.zip --include logs
 ```
 
 ### Forbidden content rejected (422)
@@ -299,20 +299,20 @@ Upload rejected: forbidden_content (matched pattern: aws_secret_access_key).
 
 Two things to check:
 
-- Inspect your local config — `~/.icom-lan/*.toml` and any
-  `.env`-style file in the directory you ran `icom-lan` from. If raw
+- Inspect your local config — `~/.rigplane/*.toml` and any
+  `.env`-style file in the directory you ran `rigplane` from. If raw
   credentials live there in plaintext, redact or delete them.
 - The redaction utilities live at
-  `src/icom_lan/diagnostics/redaction.py` — if a legitimate value is
+  `src/rigplane/diagnostics/redaction.py` — if a legitimate value is
   being false-positive matched, please file an issue with the
   pattern (not the value).
 
 ## CLI reference
 
 ```
-icom-lan diagnose
+rigplane diagnose
   [--upload]                    # send after preview (default: save only)
-  [--output PATH]               # default: ~/icom-lan-report-<timestamp>.zip
+  [--output PATH]               # default: ~/rigplane-report-<timestamp>.zip
   [--include CATEGORY ...]      # repeatable; default: all
   [--exclude CATEGORY ...]      # repeatable
   [--description TEXT]          # bypass interactive prompt
@@ -327,7 +327,7 @@ icom-lan diagnose
 | Flag             | Default                                 | Notes                                                              |
 | ---------------- | --------------------------------------- | ------------------------------------------------------------------ |
 | `--upload`       | absent → save locally                   | Required to transmit. Combined with `--no-confirm` for headless.   |
-| `--output`       | `~/icom-lan-report-<timestamp>.zip`     | The bundle is always written to this path, upload or no upload.    |
+| `--output`       | `~/rigplane-report-<timestamp>.zip`     | The bundle is always written to this path, upload or no upload.    |
 | `--include`      | all categories                          | Repeatable. Mutually narrows: `--include radio --include logs`.    |
 | `--exclude`      | none                                    | Repeatable. Removes a category from the default-all set.           |
 | `--description`  | interactive prompt                      | Free text — explain what you were doing when the bug occurred.     |
@@ -342,7 +342,7 @@ icom-lan diagnose
     For CI / cron, the only fully-automated upload form is:
 
     ```bash
-    icom-lan diagnose --upload --no-confirm \
+    rigplane diagnose --upload --no-confirm \
       --description "nightly canary failed at $(date -Is)" \
       --issue-ref https://github.com/example/repo/issues/42
     ```
@@ -358,7 +358,7 @@ icom-lan diagnose
   — the full spec, including manifest schema, contributor protocol,
   and Pro extension boundary.
 - [Diagnostic bundle contract](../contracts/diagnostic-bundle-v1.md) —
-  the public `icom-lan-bundle-v1` contract documenting the receiver's
+  the public `rigplane-bundle-v1` contract documenting the receiver's
   HTTP API for self-hosted backends.
-- [Troubleshooting](troubleshooting.md) — general `icom-lan`
+- [Troubleshooting](troubleshooting.md) — general `rigplane`
   troubleshooting playbook.

--- a/docs/guide/ic705-usb-setup.md
+++ b/docs/guide/ic705-usb-setup.md
@@ -21,7 +21,7 @@ This guide shows how to control the IC-705 via **USB serial CI-V + USB audio dev
 !!! danger "Critical Setup Step"
     On the IC-705, navigate to **Menu → Set → Connectors → CI-V → CI-V USB Port** and set it to **`Link to [CI-V]`**, **NOT** `[REMOTE]`.
 
-    - `Link to [CI-V]` — serial CI-V commands work (required for icom-lan serial backend)
+    - `Link to [CI-V]` — serial CI-V commands work (required for rigplane serial backend)
     - `[REMOTE]` — RS-BA1 mode, serial CI-V is blocked
 
     This is the same critical setting as IC-7610; confirmed by wfview reference and IC-7610 hardware validation.
@@ -46,12 +46,12 @@ This guide shows how to control the IC-705 via **USB serial CI-V + USB audio dev
 
 ## macOS Setup
 
-### 1. Install icom-lan
+### 1. Install rigplane
 
 ```bash
 # Core install — includes serial CI-V (pyserial), USB audio RX/TX,
 # audio-device listing (sounddevice + numpy + opuslib).
-pip install icom-lan
+pip install rigplane
 ```
 
 !!! note
@@ -77,10 +77,10 @@ ls -l /dev/cu.usbserial-*
 
 The IC-705 typically appears as `/dev/cu.usbserial-*` where the suffix may include "IC705" or the radio's serial number.
 
-You can also use `icom-lan discover --serial-only` to find USB-connected radios automatically:
+You can also use `rigplane discover --serial-only` to find USB-connected radios automatically:
 
 ```bash
-icom-lan discover --serial-only
+rigplane discover --serial-only
 ```
 
 ```
@@ -92,11 +92,11 @@ IC-705:
 
 ```bash
 # List available audio devices
-icom-lan --list-audio-devices
+rigplane --list-audio-devices
 ```
 
 Audio-device listing requires `sounddevice`, which ships with the core
-install since v0.19 (`pip install icom-lan`).
+install since v0.19 (`pip install rigplane`).
 
 **Example output:**
 
@@ -140,11 +140,11 @@ install since v0.19 (`pip install icom-lan`).
 
 ```bash
 # Connect via USB serial (no audio)
-icom-lan --backend serial --device /dev/cu.usbserial-IC705123 \
+rigplane --backend serial --device /dev/cu.usbserial-IC705123 \
   --model IC-705 --baudrate 115200 repl
 
 # Connect with USB audio enabled
-icom-lan --backend serial --device /dev/cu.usbserial-IC705123 \
+rigplane --backend serial --device /dev/cu.usbserial-IC705123 \
   --model IC-705 --baudrate 115200 \
   --rx-audio-device "IC-705 RX" \
   --tx-audio-device "IC-705 TX" \
@@ -168,8 +168,8 @@ icom-lan --backend serial --device /dev/cu.usbserial-IC705123 \
 
 ```python
 import asyncio
-from icom_lan.backends.factory import create_radio
-from icom_lan.backends.config import SerialBackendConfig
+from rigplane.backends.factory import create_radio
+from rigplane.backends.config import SerialBackendConfig
 
 async def main():
     # Create IC-705 serial backend
@@ -205,8 +205,8 @@ asyncio.run(main())
 ### Python: Sync API
 
 ```python
-from icom_lan.backends.factory import create_radio
-from icom_lan.backends.config import SerialBackendConfig
+from rigplane.backends.factory import create_radio
+from rigplane.backends.config import SerialBackendConfig
 
 # Create IC-705 serial backend
 config = SerialBackendConfig(
@@ -232,7 +232,7 @@ with radio:
 
 ```bash
 # Start web server with IC-705 serial backend
-icom-lan --backend serial --device /dev/cu.usbserial-IC705123 \
+rigplane --backend serial --device /dev/cu.usbserial-IC705123 \
   --model IC-705 --baudrate 115200 \
   --rx-audio-device "IC-705 RX" \
   --tx-audio-device "IC-705 TX" \
@@ -253,7 +253,7 @@ The web UI provides:
 
 ```bash
 # Start rigctld server with IC-705 serial backend
-icom-lan --backend serial --device /dev/cu.usbserial-IC705123 \
+rigplane --backend serial --device /dev/cu.usbserial-IC705123 \
   --model IC-705 --baudrate 115200 \
   rigctld --port 4532
 
@@ -295,9 +295,9 @@ ls -l /dev/cu.*
 **Symptoms:** CI-V control works but no audio in browser/WSJT-X
 
 **Solutions:**
-- Make sure you're on icom-lan v0.19+ (audio deps ship with the core install; for older versions run `pip install 'icom-lan[bridge]'`)
+- Make sure you're on rigplane v0.19+ (audio deps ship with the core install; for older versions run `pip install 'rigplane[bridge]'`)
 - Verify `USB Audio RX/TX = Enabled` in radio settings
-- Check audio device names with `icom-lan --list-audio-devices`
+- Check audio device names with `rigplane --list-audio-devices`
 - macOS may require microphone/audio permissions for the terminal app
 
 ### Scope/Waterfall Disabled

--- a/docs/guide/ic7300-usb-setup.md
+++ b/docs/guide/ic7300-usb-setup.md
@@ -21,7 +21,7 @@ This guide shows how to control the IC-7300 via **USB serial CI-V + USB audio de
 !!! danger "Critical Setup Step"
     On the IC-7300, navigate to **Menu → Set → Connectors → CI-V → CI-V USB Port** and set it to **`Link to [CI-V]`**, **NOT** `[REMOTE]`.
 
-    - `Link to [CI-V]` — serial CI-V commands work (required for icom-lan serial backend)
+    - `Link to [CI-V]` — serial CI-V commands work (required for rigplane serial backend)
     - `[REMOTE]` — RS-BA1 mode, serial CI-V is blocked
 
     This is the same critical setting as IC-7610 and IC-705.
@@ -46,10 +46,10 @@ This guide shows how to control the IC-7300 via **USB serial CI-V + USB audio de
 
 ## macOS Setup
 
-### 1. Install icom-lan
+### 1. Install rigplane
 
 ```bash
-pip install icom-lan[serial]
+pip install rigplane[serial]
 ```
 
 ### 2. Connect USB and Verify Devices
@@ -64,7 +64,7 @@ ls /dev/cu.usbserial-* | head -5
 Check for audio devices exported by the radio:
 
 ```bash
-python -c "from icom_lan.usb_audio_resolve import list_usb_audio_devices; import json; print(json.dumps(list_usb_audio_devices(), indent=2))"
+python -c "from rigplane.usb_audio_resolve import list_usb_audio_devices; import json; print(json.dumps(list_usb_audio_devices(), indent=2))"
 ```
 
 You should see input and output devices for the IC-7300:
@@ -75,7 +75,7 @@ You should see input and output devices for the IC-7300:
 
 ```python
 import asyncio
-from icom_lan import IcomRadio
+from rigplane import IcomRadio
 
 async def main():
     # Create serial radio for IC-7300
@@ -105,19 +105,19 @@ asyncio.run(main())
 
 ```bash
 # Check connection
-icom-lan --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A602RVAV status
+rigplane --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A602RVAV status
 
 # Set frequency
-icom-lan --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A602RVAV freq 7074000
+rigplane --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A602RVAV freq 7074000
 
 # Monitor metrics
-icom-lan --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A602RVAV meters
+rigplane --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A602RVAV meters
 ```
 
 ### 5. Web UI
 
 ```bash
-icom-lan web --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A602RVAV
+rigplane web --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A602RVAV
 # Open http://localhost:8000
 ```
 
@@ -137,7 +137,7 @@ icom-lan web --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A6
 
 ## Audio Subsystem
 
-IC-7300 exports USB audio devices that icom-lan can use:
+IC-7300 exports USB audio devices that rigplane can use:
 
 ```python
 # Receive audio from radio
@@ -159,7 +159,7 @@ async with radio:
 
 ### WSJT-X Integration
 
-Use macOS BlackHole (or Loopback) to bridge icom-lan audio to WSJT-X:
+Use macOS BlackHole (or Loopback) to bridge rigplane audio to WSJT-X:
 
 1. **Install BlackHole 2ch**: https://github.com/ExistentialAudio/BlackHole
 2. **Create aggregate device**:
@@ -167,7 +167,7 @@ Use macOS BlackHole (or Loopback) to bridge icom-lan audio to WSJT-X:
    - Add "IC-7300" input + "BlackHole 2ch" output
 3. **Start audio bridge**:
    ```bash
-   icom-lan audio bridge --serial-port ic-7300-usb-in --loopback "BlackHole 2ch"
+   rigplane audio bridge --serial-port ic-7300-usb-in --loopback "BlackHole 2ch"
    ```
 4. **WSJT-X settings**:
    - Input Device: "IC-7300 Bridge"
@@ -199,7 +199,7 @@ WARNING: audio subsystem not detected; TX/RX disabled
 
 **Solution**: Verify **USB Audio TX/RX** are enabled in radio settings. Check with:
 ```bash
-python -c "from icom_lan.usb_audio_resolve import list_usb_audio_devices; import json; print(json.dumps(list_usb_audio_devices(), indent=2))"
+python -c "from rigplane.usb_audio_resolve import list_usb_audio_devices; import json; print(json.dumps(list_usb_audio_devices(), indent=2))"
 ```
 
 ### CI-V Commands Timing Out

--- a/docs/guide/ic7610-usb-setup.md
+++ b/docs/guide/ic7610-usb-setup.md
@@ -20,7 +20,7 @@ This guide shows how to control the IC-7610 via **USB serial CI-V + USB audio de
 !!! danger "Critical Setup Step"
     On the IC-7610, navigate to **Menu → Set → Connectors → CI-V → CI-V USB Port** and set it to **`Link to [CI-V]`**, **NOT** `[REMOTE]`.
     
-    - `Link to [CI-V]` — serial CI-V commands work (required for icom-lan serial backend)
+    - `Link to [CI-V]` — serial CI-V commands work (required for rigplane serial backend)
     - `[REMOTE]` — RS-BA1 mode, serial CI-V is blocked
     
     This finding was confirmed with live hardware validation in issue #146.
@@ -42,12 +42,12 @@ This guide shows how to control the IC-7610 via **USB serial CI-V + USB audio de
 
 ## macOS Setup
 
-### 1. Install icom-lan
+### 1. Install rigplane
 
 ```bash
 # Core install — includes serial CI-V (pyserial), USB audio RX/TX,
 # audio-device listing (sounddevice + numpy + opuslib).
-pip install icom-lan
+pip install rigplane
 ```
 
 !!! note
@@ -73,10 +73,10 @@ ls -l /dev/cu.usbserial-*
 
 The IC-7610 typically appears as `/dev/cu.usbserial-XXXXXX` where `XXXXXX` is the radio's serial number.
 
-You can also use `icom-lan discover --serial-only` to find USB-connected radios automatically:
+You can also use `rigplane discover --serial-only` to find USB-connected radios automatically:
 
 ```bash
-icom-lan discover --serial-only
+rigplane discover --serial-only
 ```
 
 ```
@@ -88,11 +88,11 @@ IC-7610:
 
 ```bash
 # List available audio devices
-icom-lan --list-audio-devices
+rigplane --list-audio-devices
 ```
 
 Audio-device listing requires `sounddevice`, which ships with the core
-install since v0.19 (`pip install icom-lan`).
+install since v0.19 (`pip install rigplane`).
 
 Example output:
 
@@ -108,7 +108,7 @@ The IC-7610 USB audio device is typically named `IC-7610 USB Audio` or similar.
 
 !!! tip "JSON Output"
     ```bash
-    icom-lan --list-audio-devices --json
+    rigplane --list-audio-devices --json
     ```
     Returns structured JSON for scripting.
 
@@ -134,9 +134,9 @@ export ICOM_SERIAL_DEVICE=/dev/cu.usbserial-111120
 export ICOM_SERIAL_BAUDRATE=115200
 
 # Test basic control
-icom-lan --backend serial status
-icom-lan --backend serial freq
-icom-lan --backend serial mode
+rigplane --backend serial status
+rigplane --backend serial freq
+rigplane --backend serial mode
 ```
 
 Expected output:
@@ -152,7 +152,7 @@ Power:        50
 
 ```bash
 # Capture 10 seconds of RX audio to WAV
-icom-lan --backend serial \
+rigplane --backend serial \
     --rx-device "IC-7610 USB Audio" \
     audio rx --out test_rx.wav --seconds 10
 
@@ -165,36 +165,36 @@ icom-lan --backend serial \
 
 ```bash
 # Status check
-icom-lan --backend serial status
+rigplane --backend serial status
 
 # Set frequency
-icom-lan --backend serial freq 7.074m
+rigplane --backend serial freq 7.074m
 
 # Set mode
-icom-lan --backend serial mode USB
+rigplane --backend serial mode USB
 
 # PTT on/off
-icom-lan --backend serial ptt on
-icom-lan --backend serial ptt off
+rigplane --backend serial ptt on
+rigplane --backend serial ptt off
 
 # CW keying
-icom-lan --backend serial cw "CQ CQ DE KN4KYD K"
+rigplane --backend serial cw "CQ CQ DE KN4KYD K"
 
 # Attenuator (uses Command29 for IC-7610)
-icom-lan --backend serial att 18
-icom-lan --backend serial att 0
+rigplane --backend serial att 18
+rigplane --backend serial att 0
 
 # Preamp
-icom-lan --backend serial preamp 1
-icom-lan --backend serial preamp 0
+rigplane --backend serial preamp 1
+rigplane --backend serial preamp 0
 ```
 
 ### Python API
 
 ```python
 import asyncio
-from icom_lan.backends.factory import create_radio
-from icom_lan.backends.config import SerialBackendConfig
+from rigplane.backends.factory import create_radio
+from rigplane.backends.config import SerialBackendConfig
 
 async def main():
     config = SerialBackendConfig(
@@ -220,7 +220,7 @@ async def main():
         print(f"S-meter: {s}")
         
         # Audio (if audio_capable)
-        from icom_lan.radio_protocol import AudioCapable
+        from rigplane.radio_protocol import AudioCapable
         if isinstance(radio, AudioCapable):
             def on_audio(packet):
                 print(f"RX audio: {len(packet.data)} bytes")
@@ -236,7 +236,7 @@ asyncio.run(main())
 
 ```bash
 # Start web UI on serial backend
-icom-lan --backend serial \
+rigplane --backend serial \
     --rx-device "IC-7610 USB Audio" \
     --tx-device "IC-7610 USB Audio" \
     web
@@ -254,7 +254,7 @@ The web UI will show:
 
 ```bash
 # Start rigctld server on serial backend
-icom-lan --backend serial serve
+rigplane --backend serial serve
 
 # Then configure WSJT-X:
 # Radio: Hamlib NET rigctl
@@ -318,7 +318,7 @@ ls -l /dev/cu.usbserial-*
    - Menu → Set → Connectors → USB Audio → **Enabled**
 2. List available devices:
    ```bash
-   icom-lan --list-audio-devices
+   rigplane --list-audio-devices
    ```
 3. Use exact device name from the list (case-sensitive)
 4. If still not visible, disconnect/reconnect USB cable
@@ -371,10 +371,10 @@ usb-audio-resolve: /dev/cu.usbserial-201410 → prefix 0x2014 → RX device [2],
 
 If you see `"topology resolution not supported"` (Linux), specify device indices explicitly:
 ```bash
-icom-lan --backend serial --rx-device 2 --tx-device 3 status
+rigplane --backend serial --rx-device 2 --tx-device 3 status
 ```
 
-Use `icom-lan --list-audio-devices` to find the correct indices.
+Use `rigplane --list-audio-devices` to find the correct indices.
 
 ### Audio TX not working
 
@@ -397,7 +397,7 @@ export ICOM_USB_RX_DEVICE="IC-7610 USB Audio"
 export ICOM_USB_TX_DEVICE="IC-7610 USB Audio"
 
 # Then simply:
-icom-lan --backend serial status
+rigplane --backend serial status
 ```
 
 ## Migration from LAN to Serial
@@ -407,11 +407,11 @@ If you're currently using the LAN backend and want to switch to serial:
 1. **No code changes needed** — use `create_radio(config)` factory with typed config:
    ```python
    # Before (LAN)
-   from icom_lan.backends.config import LanBackendConfig
+   from rigplane.backends.config import LanBackendConfig
    config = LanBackendConfig(host="192.168.1.100", ...)
    
    # After (Serial)
-   from icom_lan.backends.config import SerialBackendConfig
+   from rigplane.backends.config import SerialBackendConfig
    config = SerialBackendConfig(device="/dev/cu.usbserial-111120", ...)
    
    # Same factory call
@@ -421,10 +421,10 @@ If you're currently using the LAN backend and want to switch to serial:
 2. **CLI**: add `--backend serial` flag:
    ```bash
    # Before (LAN, default)
-   icom-lan status
+   rigplane status
    
    # After (Serial)
-   icom-lan --backend serial status
+   rigplane --backend serial status
    ```
 
 3. **Capability check**: scope/waterfall requires ≥115200 baud (see table above)

--- a/docs/guide/ic9700-usb-setup.md
+++ b/docs/guide/ic9700-usb-setup.md
@@ -35,7 +35,7 @@ The IC-9700 is the only supported radio with **dual independent receivers**:
 !!! danger "Critical Setup Step"
     On the IC-9700, navigate to **Menu → Set → Connectors → CI-V → CI-V USB Port** and set it to **`Link to [CI-V]`**, **NOT** `[REMOTE]`.
 
-    - `Link to [CI-V]` — serial CI-V commands work (required for icom-lan serial backend)
+    - `Link to [CI-V]` — serial CI-V commands work (required for rigplane serial backend)
     - `[REMOTE]` — RS-BA1 mode, serial CI-V is blocked
 
 ### LAN Backend (Ethernet)
@@ -71,10 +71,10 @@ The IC-9700 supports LAN operation:
 
 ## macOS Setup: Serial Backend
 
-### 1. Install icom-lan
+### 1. Install rigplane
 
 ```bash
-pip install icom-lan[serial]
+pip install rigplane[serial]
 ```
 
 ### 2. Connect USB and Verify Devices
@@ -89,7 +89,7 @@ ls /dev/cu.usbserial-* | head -5
 Verify audio devices:
 
 ```bash
-python -c "from icom_lan.usb_audio_resolve import list_usb_audio_devices; import json; print(json.dumps(list_usb_audio_devices(), indent=2))"
+python -c "from rigplane.usb_audio_resolve import list_usb_audio_devices; import json; print(json.dumps(list_usb_audio_devices(), indent=2))"
 ```
 
 You should see IC-9700 input (RX) and output (TX) audio devices.
@@ -98,7 +98,7 @@ You should see IC-9700 input (RX) and output (TX) audio devices.
 
 ```python
 import asyncio
-from icom_lan import IcomRadio
+from rigplane import IcomRadio
 
 async def main():
     # Create serial radio for IC-9700
@@ -135,23 +135,23 @@ asyncio.run(main())
 
 ```bash
 # Check connection
-icom-lan --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV status
+rigplane --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV status
 
 # MAIN receiver (default)
-icom-lan --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV freq 144100000
+rigplane --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV freq 144100000
 
 # SUB receiver
-icom-lan --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV \
+rigplane --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV \
     --receiver 1 freq 144200000
 
 # Monitor both
-icom-lan --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV meters
+rigplane --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV meters
 ```
 
 ### 5. Web UI (Serial)
 
 ```bash
-icom-lan web --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV
+rigplane web --backend serial --model IC-9700 --serial-port /dev/cu.usbserial-A602RVBV
 # Open http://localhost:8000
 # Use MAIN/SUB selector in web UI
 ```
@@ -164,7 +164,7 @@ The IC-9700 supports direct LAN connection (Ethernet):
 
 ```bash
 # Discover IC-9700 on your network
-icom-lan discover --timeout 5
+rigplane discover --timeout 5
 
 # Output:
 # Found: IC-9700 at 192.168.1.100
@@ -174,7 +174,7 @@ icom-lan discover --timeout 5
 
 ```python
 import asyncio
-from icom_lan import IcomRadio
+from rigplane import IcomRadio
 
 async def main():
     # Create LAN radio for IC-9700
@@ -198,8 +198,8 @@ asyncio.run(main())
 ### 3. CLI Usage (LAN)
 
 ```bash
-icom-lan --backend lan --host 192.168.1.100 status
-icom-lan --backend lan --host 192.168.1.100 freq 144100000
+rigplane --backend lan --host 192.168.1.100 status
+rigplane --backend lan --host 192.168.1.100 freq 144100000
 ```
 
 ## Dual-Receiver Operations
@@ -295,7 +295,7 @@ ConnectionError: failed to connect to 192.168.1.100
 ```
 
 **Solution**:
-1. Verify IP address with `icom-lan discover`
+1. Verify IP address with `rigplane discover`
 2. Check network connectivity: `ping 192.168.1.100`
 3. Verify radio network settings (username/password)
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -9,14 +9,14 @@
 ## Install from PyPI
 
 ```bash
-pip install icom-lan
+pip install rigplane
 ```
 
 ## Install from Source
 
 ```bash
-git clone https://github.com/morozsm/icom-lan.git
-cd icom-lan
+git clone https://github.com/rigplane/rigplane-core.git
+cd rigplane
 pip install -e .
 ```
 
@@ -25,22 +25,22 @@ pip install -e .
 For running tests and contributing:
 
 ```bash
-git clone https://github.com/morozsm/icom-lan.git
-cd icom-lan
+git clone https://github.com/rigplane/rigplane-core.git
+cd rigplane
 pip install -e ".[dev]"
 ```
 
 ## Optional Dependencies
 
 ```bash
-pip install icom-lan[scope]    # Scope PNG rendering (pillow)
-pip install icom-lan[tls]      # HTTPS with auto-generated certs (cryptography)
-pip install icom-lan[webrtc]   # WebRTC audio transport (aiortc)
+pip install rigplane[scope]    # Scope PNG rendering (pillow)
+pip install rigplane[tls]      # HTTPS with auto-generated certs (cryptography)
+pip install rigplane[webrtc]   # WebRTC audio transport (aiortc)
 ```
 
 !!! note "Audio bridge included by default (since v0.19)"
     `opuslib`, `sounddevice`, and `numpy` are now part of the core install.
-    `pip install icom-lan` is enough for the Web UI, audio bridge, and Opus
+    `pip install rigplane` is enough for the Web UI, audio bridge, and Opus
     codec support — no extras needed.
 
     The legacy `[audio]` and `[bridge]` extras are preserved as no-op
@@ -50,10 +50,10 @@ pip install icom-lan[webrtc]   # WebRTC audio transport (aiortc)
 
 ```bash
 # Check the CLI is available
-icom-lan --help
+rigplane --help
 
 # Or run as a module
-python -m icom_lan --help
+python -m rigplane --help
 ```
 
 ## Radio Setup
@@ -78,7 +78,7 @@ Before connecting, ensure your radio is configured for LAN control:
 The IC-7300 does **not** have LAN/WiFi connectivity. Use the **USB serial backend** instead:
 
 ```bash
-icom-lan --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-XXXXX status
+rigplane --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-XXXXX status
 ```
 
 See the [IC-7300 USB Setup guide](ic7300-usb-setup.md) for details.

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -22,7 +22,7 @@ profile = OperatingProfile(
 ## API
 
 ```python
-from icom_lan import OperatingProfile, apply_profile, PRESETS
+from rigplane import OperatingProfile, apply_profile, PRESETS
 
 async with create_radio(config) as radio:
     # Apply a profile — returns a snapshot for later restore
@@ -60,7 +60,7 @@ async with create_radio(config) as radio:
 ## Built-in Presets
 
 ```python
-from icom_lan import apply_profile, PRESETS
+from rigplane import apply_profile, PRESETS
 
 # APRS on 2m (145.500 MHz FM, DATA mode, VOX off)
 snapshot = await apply_profile(radio, PRESETS.aprs_vhf)
@@ -122,7 +122,7 @@ snapshot = await apply_profile(radio, contest_20m)
 For non-async code, use the synchronous `IcomRadio` wrapper:
 
 ```python
-from icom_lan.sync import IcomRadio
+from rigplane.sync import IcomRadio
 
 radio = IcomRadio(config)
 snapshot = radio.prepare_ic705_data_profile(frequency_hz=145_500_000)
@@ -135,7 +135,7 @@ radio.restore_ic705_data_profile(snapshot)
 The original IC-705 specific helper still works and now delegates to the generic system:
 
 ```python
-from icom_lan import prepare_ic705_data_profile, restore_ic705_data_profile
+from rigplane import prepare_ic705_data_profile, restore_ic705_data_profile
 
 snapshot = await prepare_ic705_data_profile(
     radio,

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -16,7 +16,7 @@ export ICOM_PASS=mypass           # Network password
 
 ```bash
 # Check radio status
-icom-lan status
+rigplane status
 ```
 
 Expected output:
@@ -30,13 +30,13 @@ Power:        50
 
 ```bash
 # Change frequency
-icom-lan freq 14.074m
+rigplane freq 14.074m
 
 # Change mode
-icom-lan mode USB
+rigplane mode USB
 
 # Read meters as JSON
-icom-lan meter --json
+rigplane meter --json
 ```
 
 ## 3. Python API
@@ -45,7 +45,7 @@ Use **`create_radio`** with a backend config to get a **`Radio`** instance (work
 
 ```python
 import asyncio
-from icom_lan import create_radio, LanBackendConfig
+from rigplane import create_radio, LanBackendConfig
 
 async def main():
     config = LanBackendConfig(
@@ -74,7 +74,7 @@ For LAN-only scripts you can still use **`IcomRadio(host, username=..., password
 Don't know your radio's IP — or want to find USB-connected radios too? Use unified discovery:
 
 ```bash
-icom-lan discover
+rigplane discover
 ```
 
 ```
@@ -90,9 +90,9 @@ IC-7610:
 The command scans both LAN (UDP broadcast) and USB serial ports in parallel. Use filters for targeted scans:
 
 ```bash
-icom-lan discover --lan-only      # UDP broadcast only
-icom-lan discover --serial-only   # USB serial ports only
-icom-lan discover --timeout 5     # Longer LAN listen window
+rigplane discover --lan-only      # UDP broadcast only
+rigplane discover --serial-only   # USB serial ports only
+rigplane discover --timeout 5     # Longer LAN listen window
 ```
 
 ## What's Next?

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -1,6 +1,6 @@
 # Supported Radios
 
-Radio support in icom-lan is defined by **TOML rig profiles** in `rigs/`.
+Radio support in rigplane is defined by **TOML rig profiles** in `rigs/`.
 Adding a new radio = adding a new `.toml` file — see [Adding a New Radio](rig-profiles.md).
 
 ## Tested
@@ -158,7 +158,7 @@ These radios use the same Icom LAN protocol and should work out of the box. Comm
 Instead of remembering CI-V addresses, use the built-in presets:
 
 ```python
-from icom_lan import create_radio, LanBackendConfig, get_civ_addr
+from rigplane import create_radio, LanBackendConfig, get_civ_addr
 
 # Look up by model name and pass to config
 addr = get_civ_addr("IC-705")
@@ -198,7 +198,7 @@ work. If you test with a new model:
 
 1. Connect with the model's default CI-V address
 2. Verify basic operations (frequency, mode, meters)
-3. [Open an issue](https://github.com/morozsm/icom-lan/issues) or PR with your rig file
+3. [Open an issue](https://github.com/rigplane/rigplane-core/issues) or PR with your rig file
 
 ### Finding Your Radio's CI-V Address
 

--- a/docs/guide/rig-profiles.md
+++ b/docs/guide/rig-profiles.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-icom-lan uses **TOML rig files** to define radio capabilities, protocol type, CI-V commands,
+rigplane uses **TOML rig files** to define radio capabilities, protocol type, CI-V commands,
 and hardware parameters. Adding a new radio means adding a new `.toml` file — no Python
 changes required for most radios.
 
@@ -201,7 +201,7 @@ See the full schema for: `[attenuator]`, `[preamp]`, `[agc]`, `[spectrum]`,
 # Basic load + validation
 uv run python -c "
 from pathlib import Path
-from icom_lan.rig_loader import load_rig
+from rigplane.rig_loader import load_rig
 cfg = load_rig(Path('rigs/ic9700.toml'))
 print(cfg.model, cfg.protocol_type, cfg.receiver_count)
 print('capabilities:', cfg.capabilities)

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -24,7 +24,7 @@ ping 192.168.1.100
 nc -u -z 192.168.1.100 50001
 
 # Try discovery
-icom-lan discover
+rigplane discover
 ```
 
 ### "Authentication failed"
@@ -52,7 +52,7 @@ icom-lan discover
 
 ```python
 import logging
-from icom_lan import create_radio, LanBackendConfig
+from rigplane import create_radio, LanBackendConfig
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -239,7 +239,7 @@ Look for:
 ## Getting Help
 
 1. Enable debug logging (see above)
-2. [Open an issue](https://github.com/morozsm/icom-lan/issues) with:
+2. [Open an issue](https://github.com/rigplane/rigplane-core/issues) with:
     - Your radio model
     - Python version
     - OS
@@ -275,9 +275,9 @@ line. This helps distinguish which logical channel is failing.
 
 These are Icom's factory defaults and match the vast majority of deployments.
 If the radio's menu has been changed, or the client was started with a custom
-`--control-port` / `ICOM_PORT` (see `src/icom_lan/cli.py`), the actual ports may
+`--control-port` / `ICOM_PORT` (see `src/rigplane/cli.py`), the actual ports may
 differ — CI-V and audio ports can also be reassigned by the radio's status
-report (see `src/icom_lan/_control_phase.py`). In that case, substitute your
+report (see `src/rigplane/_control_phase.py`). In that case, substitute your
 session's ports in the filters below.
 
 **How to interpret quickly:**
@@ -296,10 +296,10 @@ session's ports in the filters below.
 
 ```bash
 # Keep only UDP diagnostics from the daemon log
-rg "UDP error|UDP connection lost" logs/icom-lan.log
+rg "UDP error|UDP connection lost" logs/rigplane.log
 
 # Focus on CI-V channel failures only (replace 50002 if your session uses a custom CI-V port)
-rg "peer=.*:50002" logs/icom-lan.log
+rg "peer=.*:50002" logs/rigplane.log
 ```
 
 If only one peer/port is noisy, troubleshoot that path first (audio, CI-V, or
@@ -408,7 +408,7 @@ ls -l /dev/ttyUSB*
 4. Retry connection
 
 !!! danger "Critical Hardware Finding"
-    This was confirmed with live IC-7610 hardware validation (issue #146, 2026-03-06). `[REMOTE]` mode blocks serial CI-V commands. Use `Link to [CI-V]` for icom-lan serial backend.
+    This was confirmed with live IC-7610 hardware validation (issue #146, 2026-03-06). `[REMOTE]` mode blocks serial CI-V commands. Use `Link to [CI-V]` for rigplane serial backend.
 
 ### "Audio device 'IC-7610 USB Audio' not found"
 
@@ -422,15 +422,15 @@ ls -l /dev/ttyUSB*
 **Solutions:**
 ```bash
 # List available audio devices
-icom-lan --list-audio-devices
-icom-lan --list-audio-devices --json
+rigplane --list-audio-devices
+rigplane --list-audio-devices --json
 
 # Check radio settings:
 # Menu → Set → Connectors → USB Audio → USB Audio (RX/TX) → Enabled
 
 # Audio dependencies ship with the core install (since v0.19); the legacy
 # `[bridge]` extra still resolves but is now a no-op alias.
-pip install icom-lan
+pip install rigplane
 ```
 
 ### "Scope over serial requires baudrate >= 115200"
@@ -445,7 +445,7 @@ pip install icom-lan
 2. **Override** (use with caution for debugging only):
    ```bash
    export ICOM_SERIAL_SCOPE_ALLOW_LOW_BAUD=1
-   icom-lan --backend serial --serial-baud 19200 scope
+   rigplane --backend serial --serial-baud 19200 scope
    ```
    Python API:
    ```python
@@ -465,7 +465,7 @@ pip install icom-lan
 ```bash
 # Increase serial CI-V pacing interval (default 50 ms)
 export ICOM_SERIAL_CIV_MIN_INTERVAL_MS=80
-icom-lan --backend serial status
+rigplane --backend serial status
 
 # Or use higher baud rate (radio setting)
 # Menu → Set → Connectors → CI-V → CI-V USB Baud Rate → 115200
@@ -486,10 +486,10 @@ icom-lan --backend serial status
 # Menu → Set → Connectors → USB Audio → USB Audio TX → Enabled
 
 # Verify TX device name matches RX
-icom-lan --list-audio-devices
+rigplane --list-audio-devices
 
 # Explicitly set TX device
-icom-lan --backend serial --tx-device "IC-7610 USB Audio" audio tx --in test.wav
+rigplane --backend serial --tx-device "IC-7610 USB Audio" audio tx --in test.wav
 
 # Ensure PTT is active during TX (library handles this automatically for audio tx)
 ```

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -1,6 +1,6 @@
 # Web UI
 
-icom-lan ships with a built-in browser UI for live control, scope/waterfall, meters,
+rigplane ships with a built-in browser UI for live control, scope/waterfall, meters,
 and RX/TX audio.
 
 This page documents the **current implementation** (Svelte frontend + asyncio backend),
@@ -10,13 +10,13 @@ public interfaces, and operational workflows.
 
 ```bash
 # Default: bind all interfaces on port 8080
-icom-lan web
+rigplane web
 
 # Explicit host/port
-icom-lan web --host 0.0.0.0 --port 9090
+rigplane web --host 0.0.0.0 --port 9090
 
 # Require API/WebSocket auth token
-icom-lan web --auth-token "change-me"
+rigplane web --auth-token "change-me"
 ```
 
 Open `http://<server-ip>:8080` (or your custom port).
@@ -74,7 +74,7 @@ These are primarily used by automation, deployment scripts, and operator tooling
 
 !!! note "Audio bridge control path"
     Runtime bridge activation is typically done from CLI flags
-    (`icom-lan web --bridge ...` / `--bridge-rx-only`).
+    (`rigplane web --bridge ...` / `--bridge-rx-only`).
 
 ## WebSocket Channels
 
@@ -162,7 +162,7 @@ Control command:
 {"type":"cmd","id":"73","name":"set_band","params":{"band":5}}
 ```
 
-Backend flow (`src/icom_lan/web/radio_poller.py`):
+Backend flow (`src/rigplane/web/radio_poller.py`):
 
 1. Read Band Stack Register via CI-V `0x1A 0x01 <band> 0x01` (register 1).
 2. If response is valid, apply recalled frequency and mode/filter.
@@ -226,7 +226,7 @@ behavior is implemented in the layout and wiring modules listed above.
 
 ### Backend CI-V poll cadence (state freshness)
 
-`src/icom_lan/web/radio_poller.py` interleaves meter and state queries:
+`src/rigplane/web/radio_poller.py` interleaves meter and state queries:
 
 - even cycles -> meter query
 - odd cycles -> one state query
@@ -312,7 +312,7 @@ using `resolveSkinId(...)` and `getLayoutMode()`:
    - `min(window.innerWidth, window.innerHeight) < 640`, or
    - touch device and `min(window.innerWidth, window.innerHeight) < 500`.
 2. If `isMobile` is true -> mobile skin.
-3. Otherwise, layout preference from localStorage key `icom-lan-layout` is used:
+3. Otherwise, layout preference from localStorage key `rigplane-layout` is used:
    - `lcd` -> amber LCD skin
    - `standard` -> desktop v2 skin
    - `auto` -> desktop v2 when any scope is available, amber LCD when no scope is available.
@@ -353,13 +353,13 @@ Mobile PTT button behavior:
 ### Run with DX cluster overlays
 
 ```bash
-icom-lan web --dx-cluster dxc.nc7j.com:7373 --callsign YOURCALL
+rigplane web --dx-cluster dxc.nc7j.com:7373 --callsign YOURCALL
 ```
 
 ### Run with custom UI assets
 
 ```bash
-icom-lan web --static-dir /opt/icom-ui/dist
+rigplane web --static-dir /opt/icom-ui/dist
 ```
 
 ### Quick health checks
@@ -471,7 +471,7 @@ const sub = state.sub ?? null;
   all-zero scope frames trigger automatic re-enable attempts.
 - **UI version assumptions:** mobile v2 interactions (sheet/panel swipe, touch-first PTT flow)
   require `?ui=v2` or previously stored v2 selection; default is v1.
-- **Layout mode expectations:** v2 layout preference (`icom-lan-layout`) is capability-aware;
+- **Layout mode expectations:** v2 layout preference (`rigplane-layout`) is capability-aware;
   `auto` resolves to desktop only when any scope exists, otherwise LCD is selected.
 - **System action error surfacing:** connect/disconnect/power actions in v2 call
   `runtime.system.*` and surface backend HTTP errors directly in the UI.

--- a/docs/guide/wsjtx-setup.md
+++ b/docs/guide/wsjtx-setup.md
@@ -1,7 +1,7 @@
 # WSJT-X / JTDX / JS8Call Setup Guide
 
 This guide covers configuring WSJT-X (and compatible apps like JTDX, JS8Call)
-to work with `icom-lan serve` as a Hamlib NET rigctld replacement.
+to work with `rigplane serve` as a Hamlib NET rigctld replacement.
 
 ## Quick Start
 
@@ -10,8 +10,8 @@ to work with `icom-lan serve` as a Hamlib NET rigctld replacement.
 **Recommended: all-in-one** (Web UI + audio bridge + rigctld):
 
 ```bash
-# Install icom-lan (audio-bridge deps ship with the core install since v0.19)
-pip install icom-lan
+# Install rigplane (audio-bridge deps ship with the core install since v0.19)
+pip install rigplane
 
 # Install BlackHole virtual audio devices (macOS)
 # Two devices required: one for RX, one for TX (single device creates feedback loop)
@@ -21,7 +21,7 @@ brew install blackhole-16ch
 # IMPORTANT: Reboot after installing BlackHole to activate the audio drivers!
 
 # Start all-in-one server with separate RX/TX devices
-icom-lan --host <RADIO_IP> --user <USER> --pass <PASS> web \
+rigplane --host <RADIO_IP> --user <USER> --pass <PASS> web \
   --bridge "BlackHole 2ch" --bridge-tx-device "BlackHole 16ch"
 ```
 
@@ -33,7 +33,7 @@ This starts:
 **Alternative: rigctld only** (no Web UI or audio bridge):
 
 ```bash
-icom-lan --host <RADIO_IP> --user <USER> --pass <PASS> serve --wsjtx-compat
+rigplane --host <RADIO_IP> --user <USER> --pass <PASS> serve --wsjtx-compat
 ```
 
 ### 2. Configure WSJT-X
@@ -67,8 +67,8 @@ In **Settings → Audio**:
 > input, creating a feedback loop. Two separate devices isolate the paths.
 
 The audio bridge routes:
-- **Radio RX → icom-lan → BlackHole 2ch → WSJT-X Input** (decode FT8/FT4)
-- **WSJT-X Output → BlackHole 16ch → icom-lan → Radio TX** (transmit FT8/FT4)
+- **Radio RX → rigplane → BlackHole 2ch → WSJT-X Input** (decode FT8/FT4)
+- **WSJT-X Output → BlackHole 16ch → rigplane → Radio TX** (transmit FT8/FT4)
 
 ### Radio Settings (for TX audio)
 
@@ -121,7 +121,7 @@ When WSJT-X connects to a radio in plain USB (DATA off), it sends
 
 Some CAT client stacks (including WSJT-X and wfview's rigctld) introduce
 a ~15–20 second delay before the first PTT after this transition.
-**This is not an icom-lan bug** — the same behavior occurs with wfview's
+**This is not an rigplane bug** — the same behavior occurs with wfview's
 built-in rigctld emulation.
 
 **Workarounds:**

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# icom-lan
+# rigplane
 
 **Python library for controlling Icom, Yaesu, and other transceivers over LAN (UDP) or USB serial.**
 
@@ -70,7 +70,7 @@ Direct connection to your radio — no wfview, hamlib, or RS-BA1 required.
 - :white_check_mark: **Audio streaming** — RX/TX with jitter buffer and full-duplex support
 - :white_check_mark: **Audio FFT Scope** — real-time FFT on USB/LAN audio for radios without hardware spectrum
 - :white_check_mark: **Network discovery** — find radios on your LAN automatically
-- :white_check_mark: **CLI tool** — `icom-lan status`, `icom-lan freq 14.074m`
+- :white_check_mark: **CLI tool** — `rigplane status`, `rigplane freq 14.074m`
 - :white_check_mark: **Built-in Web UI** — spectrum, waterfall, controls, meters, audio in browser; LCD layout for non-scope radios
 - :white_check_mark: **Async + Sync API** — async by default, blocking wrapper available
 - :white_check_mark: **Auto-reconnect** — watchdog + exponential backoff (opt-in)
@@ -98,7 +98,7 @@ See [Supported Radios](guide/radios.md) for full details. Any Icom radio with LA
 
 ```python
 import asyncio
-from icom_lan import create_radio, LanBackendConfig
+from rigplane import create_radio, LanBackendConfig
 
 async def main():
     config = LanBackendConfig(host="192.168.1.100", username="user", password="pass")
@@ -111,7 +111,7 @@ asyncio.run(main())
 
 ## License
 
-MIT — see [LICENSE](https://github.com/morozsm/icom-lan/blob/main/LICENSE).
+MIT — see [LICENSE](https://github.com/rigplane/rigplane-core/blob/main/LICENSE).
 
 Protocol knowledge derived from the [wfview](https://wfview.org/) project's reverse engineering work. This is an independent clean-room implementation.
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -4,7 +4,7 @@
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│                        icom-lan                          │
+│                        rigplane                          │
 │                                                          │
 │  ┌─────────┐   ┌──────────┐   ┌────────────┐            │
 │  │   CLI   │   │  Web UI  │   │  Rigctld   │            │
@@ -69,11 +69,11 @@
 
 ## Multi-Backend Architecture
 
-icom-lan now uses a **shared-core backend-neutral architecture**. Consumers (CLI/Web/rigctld) program against the `Radio` protocol, while thin backend adapters handle transport-specific details.
+rigplane now uses a **shared-core backend-neutral architecture**. Consumers (CLI/Web/rigctld) program against the `Radio` protocol, while thin backend adapters handle transport-specific details.
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                              icom-lan                                    │
+│                              rigplane                                    │
 │                                                                          │
 │  ┌───────────┐       ┌─────────────┐       ┌────────────┐              │
 │  │    CLI    │       │   Web UI    │       │  Rigctld   │              │
@@ -187,7 +187,7 @@ USB Audio CODEC entries in IORegistry  →  filter by same hub prefix   │
 
 ## Rig Profiles (Data-Driven Radio Config)
 
-icom-lan uses **TOML rig profiles** to define per-radio capabilities, CI-V wire bytes,
+rigplane uses **TOML rig profiles** to define per-radio capabilities, CI-V wire bytes,
 and hardware parameters. This makes adding new radio support a data task — not a code
 change.
 
@@ -387,8 +387,8 @@ Used by the web UI to find available radios without manual IP entry.
 **`web/tls.py`** — TLS support for `server.py`. Certificate loading and HTTPS server setup.
 
 **Boundary rule (web layer):**
-- `src/icom_lan/web/` must depend on `radio_protocol` protocols (`Radio` + capability protocols), not on concrete `IcomRadio`.
-- Direct import of `icom_lan.radio.IcomRadio` in `web/` is forbidden and enforced by lint/CI.
+- `src/rigplane/web/` must depend on `radio_protocol` protocols (`Radio` + capability protocols), not on concrete `IcomRadio`.
+- Direct import of `rigplane.radio.IcomRadio` in `web/` is forbidden and enforced by lint/CI.
 
 ### `rigctld/` — Hamlib NET rigctld Server
 
@@ -402,7 +402,7 @@ timeout, configurable max-client cap, and per-client rate limiting.
 
 **`rigctld/handler.py`** — Command dispatcher bridging parsed rigctld commands to `IcomRadio`.
 Implements get/set operations for frequency, mode, PTT, VFO, RF/AF levels, split VFO, and
-RIT. Uses `StateCache` for reads to avoid CI-V round-trips; translates icom-lan exceptions
+RIT. Uses `StateCache` for reads to avoid CI-V round-trips; translates rigplane exceptions
 to Hamlib error codes.
 
 **`rigctld/protocol.py`** — Stateless wire-protocol layer. Pure functions for parsing
@@ -423,7 +423,7 @@ timeouts from blocking connected clients.
 
 **`rigctld/audit.py`** — Structured per-command audit logging. Defines `AuditRecord` dataclass
 and `RigctldAuditFormatter`, emitting JSON-formatted records to a dedicated logger
-(`icom_lan.rigctld.audit`) for external log aggregation.
+(`rigplane.rigctld.audit`) for external log aggregation.
 
 **`rigctld/contract.py`** — Shared type definitions for the rigctld subpackage. Contains the
 Hamlib error code enum, hamlib mode-string mappings (USB, LSB, CW, …), and configuration
@@ -467,10 +467,10 @@ Low-level serialization and identification of the fixed 16-byte header present i
 
 ### `exceptions.py` — Exception Hierarchy
 
-All library exceptions derive from `IcomLanError`, allowing callers to catch either the base class or a specific subtype. Audio exceptions form a distinct sub-tree.
+All library exceptions derive from `RigplaneError`, allowing callers to catch either the base class or a specific subtype. Audio exceptions form a distinct sub-tree.
 
 ```
-IcomLanError
+RigplaneError
 ├── ConnectionError      — connection failed or lost
 ├── AuthenticationError  — login rejected by radio
 ├── CommandError         — CI-V NAK or unexpected response
@@ -595,7 +595,7 @@ Reassembles multi-sequence CI-V `0x27/0x00` bursts into complete `ScopeFrame` ob
 
 ### `scope_render.py` — Scope Image Rendering
 
-Renders `ScopeFrame` data to PNG images using Pillow (optional `icom-lan[scope]`). Provides spectrum (amplitude vs. frequency line chart) and waterfall (time × frequency heatmap) views with configurable color themes.
+Renders `ScopeFrame` data to PNG images using Pillow (optional `rigplane[scope]`). Provides spectrum (amplitude vs. frequency line chart) and waterfall (time × frequency heatmap) views with configurable color themes.
 
 - **`render_spectrum(frame, width, height, theme)`** → PIL Image: frequency-labeled X axis, amplitude Y axis, filled line graph
 - **`render_waterfall(frames, width, height, theme)`** → PIL Image: newest row at top; uses direct pixel access (`img.load()`) for ~10× speedup over `draw.point`
@@ -749,30 +749,30 @@ while separating concerns. `IcomRadio` inherits from `ControlPhaseMixin`,
 ## Dependencies
 
 ```
-icom-lan (runtime, core install — since v0.19)
+rigplane (runtime, core install — since v0.19)
 ├── pyserial, pyserial-asyncio (CI-V serial transport)
 ├── sounddevice (PortAudio bindings — virtual-audio bridge, USB audio devices)
 ├── numpy (PCM frame processing, DSP)
 └── opuslib (Opus codec for decode/encode)
 
-icom-lan[dev]
+rigplane[dev]
 ├── pytest, pytest-asyncio, pytest-cov, pytest-timeout
 ├── ruff, mypy
 
-icom-lan[scope]
+rigplane[scope]
 └── Pillow (for scope image rendering)
 
-icom-lan[dsp]
+rigplane[dsp]
 └── scipy (advanced DSP — anti-aliasing FIR filter design, etc.)
 
-icom-lan[webrtc]
+rigplane[webrtc]
 └── aiortc (WebRTC audio transport)
 
-icom-lan[tls]
+rigplane[tls]
 └── cryptography (auto-generated HTTPS certs)
 
-icom-lan[audio]   # no-op alias preserved for backwards compat (#1090)
-icom-lan[bridge]  # no-op alias preserved for backwards compat (#1090)
+rigplane[audio]   # no-op alias preserved for backwards compat (#1090)
+rigplane[bridge]  # no-op alias preserved for backwards compat (#1090)
 ```
 
 ## High-Level Flows
@@ -929,7 +929,7 @@ sequenceDiagram
 
 ```mermaid
 classDiagram
-    class IcomLanError
+    class RigplaneError
     class ConnectionError
     class AuthenticationError
     class CommandError
@@ -938,11 +938,11 @@ classDiagram
     class AudioCodecBackendError
     class AudioFormatError
     class AudioTranscodeError
-    IcomLanError <|-- ConnectionError
-    IcomLanError <|-- AuthenticationError
-    IcomLanError <|-- CommandError
-    IcomLanError <|-- TimeoutError
-    IcomLanError <|-- AudioError
+    RigplaneError <|-- ConnectionError
+    RigplaneError <|-- AuthenticationError
+    RigplaneError <|-- CommandError
+    RigplaneError <|-- TimeoutError
+    RigplaneError <|-- AudioError
     AudioError <|-- AudioCodecBackendError
     AudioError <|-- AudioFormatError
     AudioError <|-- AudioTranscodeError
@@ -981,7 +981,7 @@ flowchart LR
 ```mermaid
 flowchart LR
     subgraph Remote["Remote operator (via VPN)"]
-        Client[wfview / icom-lan\nclient]
+        Client[wfview / rigplane\nclient]
     end
     subgraph Proxy["Proxy machine (on radio LAN)"]
         C["_RelayProtocol\ncontrol :50001"]

--- a/docs/internals/cli-design.md
+++ b/docs/internals/cli-design.md
@@ -2,7 +2,7 @@
 
 ## Current implementation
 
-The CLI is implemented in a single module, `src/icom_lan/cli.py`, using the **stdlib `argparse`** only (~1860 lines). There are no runtime dependencies for the CLI beyond the library itself.
+The CLI is implemented in a single module, `src/rigplane/cli.py`, using the **stdlib `argparse`** only (~1860 lines). There are no runtime dependencies for the CLI beyond the library itself.
 
 - **Parser:** One root parser and subparsers for commands (`status`, `freq`, `mode`, `audio`, `web`, `serve`, etc.). Global options (`--host`, `--user`, `--pass`, `--backend`, `--serial-port`, …) are defined once and shared.
 - **Dispatch:** After parsing, `_run()` builds a backend config, calls `create_radio(config)`, then runs the selected command with `async with radio:` and a long `if/elif` chain.
@@ -25,7 +25,7 @@ The CLI is implemented in a single module, `src/icom_lan/cli.py`, using the **st
   - Type hints for options/arguments and automatic validation.
   - Optional **Pydantic** integration for settings (e.g. env vars, config file).
   - Cleaner subcommand structure via decorators.
-- **Cost:** New runtime dependency (`typer` → `click`). The CLI would either require `pip install icom-lan[cli]` with typer, or the dependency would be added to the default install (common for apps with a rich CLI).
+- **Cost:** New runtime dependency (`typer` → `click`). The CLI would either require `pip install rigplane[cli]` with typer, or the dependency would be added to the default install (common for apps with a rich CLI).
 - **Recommendation:** Treat this as an **optional follow-up**, not a prerequisite for the Radio/capability refactor. First complete the refactor to `Radio` + capability protocols with the current argparse CLI; then, if desired, plan a separate change to introduce Typer (e.g. split subcommands into modules, use Pydantic for config) without changing user-facing behavior.
 
 ### Option C: Click without Typer

--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -5,14 +5,14 @@ Contributions are welcome! Here's how to get started.
 ## Development Setup
 
 ```bash
-git clone https://github.com/morozsm/icom-lan.git
-cd icom-lan
+git clone https://github.com/rigplane/rigplane-core.git
+cd rigplane
 uv sync --all-extras
 ```
 
 ### Frontend static files (one-time after clone)
 
-`src/icom_lan/web/static/` is a symlink to `frontend/dist/`, which is gitignored.
+`src/rigplane/web/static/` is a symlink to `frontend/dist/`, which is gitignored.
 Web-server tests that serve static files will fail on a clean clone until you build once:
 
 ```bash
@@ -46,7 +46,7 @@ The repository has three Actions workflows, tiered to keep billable minutes low:
 
 | Workflow | When it runs | What it does |
 |---|---|---|
-| **Tests (quick)** | push/PR to `main` **only** when one of these paths changes: `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, `.github/workflows/**` | Single Python 3.11 job: `ruff`, `import-linter`, `pytest` (no hardware integration). The frontend block (`npm ci`, type-check, vitest, build, mypy on `src/icom_lan/web`) only runs when files under `frontend/**` or `src/icom_lan/web/**` actually changed. ~2–5 min. Doc-only edits and CLAUDE.md changes don't trigger CI at all — use `gh workflow run "Tests (quick)"` if you need a manual run. |
+| **Tests (quick)** | push/PR to `main` **only** when one of these paths changes: `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, `.github/workflows/**` | Single Python 3.11 job: `ruff`, `import-linter`, `pytest` (no hardware integration). The frontend block (`npm ci`, type-check, vitest, build, mypy on `src/rigplane/web`) only runs when files under `frontend/**` or `src/rigplane/web/**` actually changed. ~2–5 min. Doc-only edits and CLAUDE.md changes don't trigger CI at all — use `gh workflow run "Tests (quick)"` if you need a manual run. |
 | **Tests (full matrix)** | cron Mon/Wed/Fri 03:00 UTC, manual `workflow_dispatch`, **or** any push whose commit message contains `[full-ci]` | Full 3.11/3.12/3.13 matrix with frontend, mypy, import-linter and the whole pytest suite. |
 | **Publish to PyPI** | on a published GitHub Release | Runs the full validation matrix first; the build/publish jobs only start if validation is green. |
 
@@ -162,7 +162,7 @@ Always include the issue number in the scope (e.g., `#123`) for feature, fix, an
 
 ## Reporting Bugs
 
-[Open an issue](https://github.com/morozsm/icom-lan/issues/new) with:
+[Open an issue](https://github.com/rigplane/rigplane-core/issues/new) with:
 
 - Radio model and firmware version
 - Python version and OS

--- a/docs/internals/rfc-audio-v1-mini.md
+++ b/docs/internals/rfc-audio-v1-mini.md
@@ -47,9 +47,9 @@ This makes API naming ambiguous, CLI scope unclear, and recovery/testing behavio
 
 ### D3. Internal transcoder layer
 - Add internal PCM<->Opus transcoder abstraction.
-- Use `opuslib` when available (`pip install icom-lan[audio]`).
+- Use `opuslib` when available (`pip install rigplane[audio]`).
 - If missing, high-level PCM APIs raise actionable error:
-  `Audio codec backend unavailable; install icom-lan[audio]`.
+  `Audio codec backend unavailable; install rigplane[audio]`.
 
 ### D4. Capabilities model + deterministic defaults
 Add `AudioCaps` model and API:
@@ -60,7 +60,7 @@ Add `AudioCaps` model and API:
   - default codec/rate/channels
 
 CLI:
-- `icom-lan audio caps [--json]`
+- `rigplane audio caps [--json]`
 
 Default selection (deterministic):
 1. Prefer Opus mono 48k
@@ -86,7 +86,7 @@ Optional auto-recover after reconnect:
 - single active stream invariant (no duplicate RX/TX tasks)
 
 ### D7. CLI scope
-Add `icom-lan audio` command group:
+Add `rigplane audio` command group:
 - `audio rx --out rx.wav --seconds 10`
 - `audio tx --in tx.wav`
 - `audio loopback --seconds 10`

--- a/docs/plans/issue-drafts/00-epic-final.md
+++ b/docs/plans/issue-drafts/00-epic-final.md
@@ -1,19 +1,19 @@
 ## Mission
 
-Restructure `src/icom_lan/` from a flat-with-some-subdirs layout into a strictly-layered internal module structure with explicit dependency contracts, without breaking the public API or any existing tests. This is **internal refactoring only** — no new PyPI packages, no `pyproject.toml` extras changes, no frontend changes, no new features. The end state enables faster onboarding for AI agents and human contributors (clear layer map), safer refactoring (compile-time-equivalent checks via dependency linting), a cleaner mental model in `ARCHITECTURE.md`, and a foundation that makes a possible future move to namespace packages cheap.
+Restructure `src/rigplane/` from a flat-with-some-subdirs layout into a strictly-layered internal module structure with explicit dependency contracts, without breaking the public API or any existing tests. This is **internal refactoring only** — no new PyPI packages, no `pyproject.toml` extras changes, no frontend changes, no new features. The end state enables faster onboarding for AI agents and human contributors (clear layer map), safer refactoring (compile-time-equivalent checks via dependency linting), a cleaner mental model in `ARCHITECTURE.md`, and a foundation that makes a possible future move to namespace packages cheap.
 
 ## Source documents
 
-- **Orchestrator brief** (out of repo): `/Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md`
-- **Phase 1 discovery doc**: [`docs/plans/2026-04-29-modularization-discovery.md`](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-discovery.md)
-- **Phase 2 plan doc**: [`docs/plans/2026-04-29-modularization-plan.md`](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md)
+- **Orchestrator brief** (out of repo): `/Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md`
+- **Phase 1 discovery doc**: [`docs/plans/2026-04-29-modularization-discovery.md`](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-discovery.md)
+- **Phase 2 plan doc**: [`docs/plans/2026-04-29-modularization-plan.md`](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md)
 
 ## Locked decisions (Phase 1, maintainer-approved)
 
 - **Silent re-export shims** with grep-able header (template in plan §5.1; verbatim `# Re-export shim for backwards compatibility.` comment block, no `DeprecationWarning`).
 - **`import-linter`** is the boundary tool, integrated in **Step 13** (after the bulk-move steps, before final import cleanup).
 - **Shims for the 43 private-path leaks** (15 test files reach into `_connection_state`, `_civ_rx`, `_poller_types`, etc.) are produced by this effort; a tracked followup migrates the tests off those private paths post-modularization.
-- **`icom-lan-pro` three-tier validation**: end-of-Phase-2 paper check (plan §9, complete) → Phase 4 smoke-imports per `audio/`/`dsp/` PR → Phase 5 full downstream test suite as the definition-of-done marker.
+- **`rigplane-pro` three-tier validation**: end-of-Phase-2 paper check (plan §9, complete) → Phase 4 smoke-imports per `audio/`/`dsp/` PR → Phase 5 full downstream test suite as the definition-of-done marker.
 
 ## Sub-issues checklist
 
@@ -42,13 +42,13 @@ These are post-modularization cleanup; they MUST NOT start until this epic is cl
 
 The work is complete when **all** of the following are true:
 
-1. `src/icom_lan/` has the layer structure agreed in Phase 2.
+1. `src/rigplane/` has the layer structure agreed in Phase 2.
 2. Every layer has an `__init__.py` with explicit `__all__`.
 3. Every layer has a `LAYER.md` charter.
 4. `import-linter` is in pre-commit and CI, with a config matching the plan.
 5. All ~5210+ existing tests pass on `main`.
 6. No public import path that worked before this effort returns `ImportError` now.
 7. `ARCHITECTURE.md` and `CLAUDE.md` are updated.
-8. `icom-lan-pro` (downstream) builds and tests cleanly against the new `icom-lan` (verified by maintainer).
+8. `rigplane-pro` (downstream) builds and tests cleanly against the new `rigplane` (verified by maintainer).
 9. The epic issue is closed with a summary comment.
 10. The maintainer agrees that this brief's mission has been achieved.

--- a/docs/plans/issue-drafts/00-epic.md
+++ b/docs/plans/issue-drafts/00-epic.md
@@ -1,19 +1,19 @@
 ## Mission
 
-Restructure `src/icom_lan/` from a flat-with-some-subdirs layout into a strictly-layered internal module structure with explicit dependency contracts, without breaking the public API or any existing tests. This is **internal refactoring only** — no new PyPI packages, no `pyproject.toml` extras changes, no frontend changes, no new features. The end state enables faster onboarding for AI agents and human contributors (clear layer map), safer refactoring (compile-time-equivalent checks via dependency linting), a cleaner mental model in `ARCHITECTURE.md`, and a foundation that makes a possible future move to namespace packages cheap.
+Restructure `src/rigplane/` from a flat-with-some-subdirs layout into a strictly-layered internal module structure with explicit dependency contracts, without breaking the public API or any existing tests. This is **internal refactoring only** — no new PyPI packages, no `pyproject.toml` extras changes, no frontend changes, no new features. The end state enables faster onboarding for AI agents and human contributors (clear layer map), safer refactoring (compile-time-equivalent checks via dependency linting), a cleaner mental model in `ARCHITECTURE.md`, and a foundation that makes a possible future move to namespace packages cheap.
 
 ## Source documents
 
-- **Orchestrator brief** (out of repo): `/Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md`
-- **Phase 1 discovery doc**: [`docs/plans/2026-04-29-modularization-discovery.md`](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-discovery.md)
-- **Phase 2 plan doc**: [`docs/plans/2026-04-29-modularization-plan.md`](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md)
+- **Orchestrator brief** (out of repo): `/Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md`
+- **Phase 1 discovery doc**: [`docs/plans/2026-04-29-modularization-discovery.md`](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-discovery.md)
+- **Phase 2 plan doc**: [`docs/plans/2026-04-29-modularization-plan.md`](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md)
 
 ## Locked decisions (Phase 1, maintainer-approved)
 
 - **Silent re-export shims** with grep-able header (template in plan §5.1; verbatim `# Re-export shim for backwards compatibility.` comment block, no `DeprecationWarning`).
 - **`import-linter`** is the boundary tool, integrated in **Step 13** (after the bulk-move steps, before final import cleanup).
 - **Shims for the 43 private-path leaks** (15 test files reach into `_connection_state`, `_civ_rx`, `_poller_types`, etc.) are produced by this effort; a tracked followup migrates the tests off those private paths post-modularization.
-- **`icom-lan-pro` three-tier validation**: end-of-Phase-2 paper check (plan §9, complete) → Phase 4 smoke-imports per `audio/`/`dsp/` PR → Phase 5 full downstream test suite as the definition-of-done marker.
+- **`rigplane-pro` three-tier validation**: end-of-Phase-2 paper check (plan §9, complete) → Phase 4 smoke-imports per `audio/`/`dsp/` PR → Phase 5 full downstream test suite as the definition-of-done marker.
 
 ## Sub-issues checklist
 
@@ -42,13 +42,13 @@ Restructure `src/icom_lan/` from a flat-with-some-subdirs layout into a strictly
 
 The work is complete when **all** of the following are true:
 
-1. `src/icom_lan/` has the layer structure agreed in Phase 2.
+1. `src/rigplane/` has the layer structure agreed in Phase 2.
 2. Every layer has an `__init__.py` with explicit `__all__`.
 3. Every layer has a `LAYER.md` charter.
 4. `import-linter` is in pre-commit and CI, with a config matching the plan.
 5. All ~5210+ existing tests pass on `main`.
 6. No public import path that worked before this effort returns `ImportError` now.
 7. `ARCHITECTURE.md` and `CLAUDE.md` are updated.
-8. `icom-lan-pro` (downstream) builds and tests cleanly against the new `icom-lan` (verified by maintainer).
+8. `rigplane-pro` (downstream) builds and tests cleanly against the new `rigplane` (verified by maintainer).
 9. The epic issue is closed with a summary comment.
 10. The maintainer agrees that this brief's mission has been achieved.

--- a/docs/plans/issue-drafts/01-skeleton.md
+++ b/docs/plans/issue-drafts/01-skeleton.md
@@ -2,7 +2,7 @@
 
 Step 1 of the internal-modularization migration: create the empty package skeleton (`core/`, `profiles/`, `runtime/`, `scope/`, `cli/`) and commit `tests/contracts/test_lazy_imports.py` — the public-API contract test that gates every subsequent step. No source files move in this step.
 
-Plan section: [§4.1 Step 1 — Skeleton + lazy-resolution contract test](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-1--skeleton--lazy-resolution-contract-test).
+Plan section: [§4.1 Step 1 — Skeleton + lazy-resolution contract test](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-1--skeleton--lazy-resolution-contract-test).
 
 ## Pre-conditions
 
@@ -12,13 +12,13 @@ This is the first step.
 
 Create only:
 
-1. `src/icom_lan/core/__init__.py` — stub with module docstring pointing at the future `LAYER.md`.
-2. `src/icom_lan/profiles/__init__.py` — stub with docstring.
-3. `src/icom_lan/runtime/__init__.py` — stub with docstring.
-4. `src/icom_lan/scope/__init__.py` — stub with docstring.
-5. `src/icom_lan/cli/__init__.py` — stub with docstring.
+1. `src/rigplane/core/__init__.py` — stub with module docstring pointing at the future `LAYER.md`.
+2. `src/rigplane/profiles/__init__.py` — stub with docstring.
+3. `src/rigplane/runtime/__init__.py` — stub with docstring.
+4. `src/rigplane/scope/__init__.py` — stub with docstring.
+5. `src/rigplane/cli/__init__.py` — stub with docstring.
 6. `tests/contracts/__init__.py` — empty package marker.
-7. `tests/contracts/test_lazy_imports.py` — contract test with three functions (`test_tier1_names_resolve`, `test_tier2_lazy_names_resolve`, `test_audio_lazy_names_resolve`) per plan §6.1. The Tier 1 / Tier 2 / audio name lists are transcribed verbatim as Python literals from `docs/plans/discovery-artifacts/init-snapshot.md`. **Do NOT reflect on `icom_lan._LAZY_MAP` at runtime** — the lists are the source of truth.
+7. `tests/contracts/test_lazy_imports.py` — contract test with three functions (`test_tier1_names_resolve`, `test_tier2_lazy_names_resolve`, `test_audio_lazy_names_resolve`) per plan §6.1. The Tier 1 / Tier 2 / audio name lists are transcribed verbatim as Python literals from `docs/plans/discovery-artifacts/init-snapshot.md`. **Do NOT reflect on `rigplane._LAZY_MAP` at runtime** — the lists are the source of truth.
 
 The 5 new `__init__.py` stubs must be importable but contribute no public symbols (no `__all__`, no re-exports). Their job in this step is only to physically create the directories so that subsequent steps can move files into them.
 
@@ -36,15 +36,15 @@ The 5 new `__init__.py` stubs must be importable but contribute no public symbol
 - `uv run ruff check src/ tests/` clean.
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes with all 3 tests green against the **current pre-migration** layout.
-- Smoke check: `uv run python -c "import icom_lan.core, icom_lan.profiles, icom_lan.runtime, icom_lan.scope, icom_lan.cli; print('skeleton OK')"` succeeds (the empty packages import).
-- Smoke check (public API stable): `uv run python -c "from icom_lan import Radio, IcomRadio, Mode; print('public API OK')"` succeeds.
+- Smoke check: `uv run python -c "import rigplane.core, rigplane.profiles, rigplane.runtime, rigplane.scope, rigplane.cli; print('skeleton OK')"` succeeds (the empty packages import).
+- Smoke check (public API stable): `uv run python -c "from rigplane import Radio, IcomRadio, Mode; print('public API OK')"` succeeds.
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections
@@ -77,4 +77,4 @@ stop and ask via PR comment. Do not guess.
 - Verify the 5 stub `__init__.py` files contain no `__all__`, no re-exports, no side effects beyond a docstring.
 - Verify `tests/contracts/test_lazy_imports.py` uses **hardcoded** Python literal lists, NOT runtime reflection on `_LAZY_MAP`.
 - Verify the Tier 1, Tier 2, and audio name lists exactly match `docs/plans/discovery-artifacts/init-snapshot.md`.
-- LAZY_MAP target tuples must be UNCHANGED (this step does not touch `icom_lan/__init__.py` or `icom_lan/audio/__init__.py`).
+- LAZY_MAP target tuples must be UNCHANGED (this step does not touch `rigplane/__init__.py` or `rigplane/audio/__init__.py`).

--- a/docs/plans/issue-drafts/02-core-foundationals.md
+++ b/docs/plans/issue-drafts/02-core-foundationals.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 2 of the internal-modularization migration: move the 9 foundational `core` files (types, exceptions, auth, transport, civ, protocol, capabilities, env_config, `_optional_deps`) into `src/icom_lan/core/`, leaving silent re-export shims at the old top-level paths.
+Step 2 of the internal-modularization migration: move the 9 foundational `core` files (types, exceptions, auth, transport, civ, protocol, capabilities, env_config, `_optional_deps`) into `src/rigplane/core/`, leaving silent re-export shims at the old top-level paths.
 
-Plan section: [§4.1 Step 2 — `core` foundationals](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-2--core-foundationals).
+Plan section: [§4.1 Step 2 — `core` foundationals](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-2--core-foundationals).
 
 ## Pre-conditions
 
@@ -10,25 +10,25 @@ Blocked by #1284 (Step 1: skeleton).
 
 ## Scope
 
-Move these 9 files from `src/icom_lan/` into `src/icom_lan/core/`:
+Move these 9 files from `src/rigplane/` into `src/rigplane/core/`:
 
-1. `src/icom_lan/types.py` → `src/icom_lan/core/types.py`
-2. `src/icom_lan/exceptions.py` → `src/icom_lan/core/exceptions.py`
-3. `src/icom_lan/auth.py` → `src/icom_lan/core/auth.py`
-4. `src/icom_lan/transport.py` → `src/icom_lan/core/transport.py`
-5. `src/icom_lan/civ.py` → `src/icom_lan/core/civ.py`
-6. `src/icom_lan/protocol.py` → `src/icom_lan/core/protocol.py`
-7. `src/icom_lan/capabilities.py` → `src/icom_lan/core/capabilities.py`
-8. `src/icom_lan/env_config.py` → `src/icom_lan/core/env_config.py`
-9. `src/icom_lan/_optional_deps.py` → `src/icom_lan/core/_optional_deps.py`
+1. `src/rigplane/types.py` → `src/rigplane/core/types.py`
+2. `src/rigplane/exceptions.py` → `src/rigplane/core/exceptions.py`
+3. `src/rigplane/auth.py` → `src/rigplane/core/auth.py`
+4. `src/rigplane/transport.py` → `src/rigplane/core/transport.py`
+5. `src/rigplane/civ.py` → `src/rigplane/core/civ.py`
+6. `src/rigplane/protocol.py` → `src/rigplane/core/protocol.py`
+7. `src/rigplane/capabilities.py` → `src/rigplane/core/capabilities.py`
+8. `src/rigplane/env_config.py` → `src/rigplane/core/env_config.py`
+9. `src/rigplane/_optional_deps.py` → `src/rigplane/core/_optional_deps.py`
 
 Add **9 re-export shim files** at the old top-level paths, each using the exact template from plan §5.1:
 
 ```python
 # Re-export shim for backwards compatibility.
-# Canonical location: icom_lan.core.<module>
+# Canonical location: rigplane.core.<module>
 # Do not add new symbols here — add them at the canonical location.
-from icom_lan.core.<module> import *  # noqa: F401, F403
+from rigplane.core.<module> import *  # noqa: F401, F403
 ```
 
 If `transport.py` (~500+ LOC) pushes the moved-LOC budget over 500, **split this step into 2a (5 small files) and 2b (transport + civ + protocol)** and file the second sub-issue at execution time per plan §4.1.
@@ -48,20 +48,20 @@ If `transport.py` (~500+ LOC) pushes the moved-LOC budget over 500, **split this
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan import Radio, IcomRadio, Mode, AudioCodec, BreakInMode"`
-  - `uv run python -c "from icom_lan.transport import UdpTransport, parse_packet, HEADER_SIZE"`
-  - `uv run python -c "from icom_lan.civ import build_civ_message"`
-  - `uv run python -c "from icom_lan.exceptions import IcomLanError"`
-  - `uv run python -c "from icom_lan.auth import Authenticator"`
-  - `uv run python -c "from icom_lan.core import types as _t, transport as _tr; print('core OK')"`
-- `_optional_deps` has zero `from icom_lan` imports (verifies foundation-tier purity per plan §6 R7).
+  - `uv run python -c "from rigplane import Radio, IcomRadio, Mode, AudioCodec, BreakInMode"`
+  - `uv run python -c "from rigplane.transport import UdpTransport, parse_packet, HEADER_SIZE"`
+  - `uv run python -c "from rigplane.civ import build_civ_message"`
+  - `uv run python -c "from rigplane.exceptions import RigplaneError"`
+  - `uv run python -c "from rigplane.auth import Authenticator"`
+  - `uv run python -c "from rigplane.core import types as _t, transport as _tr; print('core OK')"`
+- `_optional_deps` has zero `from rigplane` imports (verifies foundation-tier purity per plan §6 R7).
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections
@@ -93,5 +93,5 @@ stop and ask via PR comment. Do not guess.
 
 - Verify the shim header (the plan §5.1 template, verbatim) is present in every shim file.
 - LAZY_MAP target tuples must be UNCHANGED (Step 13 will canonicalise them).
-- Verify `_optional_deps.py` (now at `icom_lan/core/_optional_deps.py`) still imports nothing from `icom_lan`.
+- Verify `_optional_deps.py` (now at `rigplane/core/_optional_deps.py`) still imports nothing from `rigplane`.
 - Verify atomic-commit policy (plan §5.3): one commit moves files, one commit adds shims (and optionally a third updates internal imports).

--- a/docs/plans/issue-drafts/03-core-contracts.md
+++ b/docs/plans/issue-drafts/03-core-contracts.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 3 of the internal-modularization migration: move the `core` contract trio (`radio_protocol`, `radio_state`, `_state_cache`) plus transport-adjacent primitives (`_queue_pressure`, `_bounded_queue`) into `src/icom_lan/core/`, leaving silent re-export shims at the old top-level paths.
+Step 3 of the internal-modularization migration: move the `core` contract trio (`radio_protocol`, `radio_state`, `_state_cache`) plus transport-adjacent primitives (`_queue_pressure`, `_bounded_queue`) into `src/rigplane/core/`, leaving silent re-export shims at the old top-level paths.
 
-Plan section: [§4.1 Step 3 — `core` contract trio + transport primitives](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-3--core-contract-trio--transport-primitives).
+Plan section: [§4.1 Step 3 — `core` contract trio + transport primitives](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-3--core-contract-trio--transport-primitives).
 
 ## Pre-conditions
 
@@ -10,13 +10,13 @@ Blocked by #1285 (Step 2: core foundationals).
 
 ## Scope
 
-Move these 5 files from `src/icom_lan/` into `src/icom_lan/core/`:
+Move these 5 files from `src/rigplane/` into `src/rigplane/core/`:
 
-1. `src/icom_lan/radio_protocol.py` → `src/icom_lan/core/radio_protocol.py`
-2. `src/icom_lan/radio_state.py` → `src/icom_lan/core/radio_state.py`
-3. `src/icom_lan/_state_cache.py` → `src/icom_lan/core/_state_cache.py`
-4. `src/icom_lan/_queue_pressure.py` → `src/icom_lan/core/_queue_pressure.py`
-5. `src/icom_lan/_bounded_queue.py` → `src/icom_lan/core/_bounded_queue.py`
+1. `src/rigplane/radio_protocol.py` → `src/rigplane/core/radio_protocol.py`
+2. `src/rigplane/radio_state.py` → `src/rigplane/core/radio_state.py`
+3. `src/rigplane/_state_cache.py` → `src/rigplane/core/_state_cache.py`
+4. `src/rigplane/_queue_pressure.py` → `src/rigplane/core/_queue_pressure.py`
+5. `src/rigplane/_bounded_queue.py` → `src/rigplane/core/_bounded_queue.py`
 
 Add **5 re-export shim files** at the old top-level paths using the plan §5.1 template.
 
@@ -37,19 +37,19 @@ The TYPE_CHECKING-only imports in `radio_protocol.py` (`audio_bus`, `scope`) are
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan import Radio"` (Tier 1).
-  - `uv run python -c "from icom_lan.radio_protocol import Radio"`
-  - `uv run python -c "from icom_lan.radio_state import RadioState, VfoSlotState"`
-  - `uv run python -c "from icom_lan._state_cache import StateCache"`
-  - `uv run python -c "from icom_lan._queue_pressure import *"` (shim re-exports)
-  - `uv run python -c "from icom_lan._bounded_queue import *"` (shim re-exports)
+  - `uv run python -c "from rigplane import Radio"` (Tier 1).
+  - `uv run python -c "from rigplane.radio_protocol import Radio"`
+  - `uv run python -c "from rigplane.radio_state import RadioState, VfoSlotState"`
+  - `uv run python -c "from rigplane._state_cache import StateCache"`
+  - `uv run python -c "from rigplane._queue_pressure import *"` (shim re-exports)
+  - `uv run python -c "from rigplane._bounded_queue import *"` (shim re-exports)
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections

--- a/docs/plans/issue-drafts/04-commands.md
+++ b/docs/plans/issue-drafts/04-commands.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 4 of the internal-modularization migration: move the 3 top-level `commands` files (`commander`, `command_map`, `command_spec`) into `src/icom_lan/commands/`, leaving silent re-export shims at the old top-level paths. The `commands/` subpackage already exists; this step expands it.
+Step 4 of the internal-modularization migration: move the 3 top-level `commands` files (`commander`, `command_map`, `command_spec`) into `src/rigplane/commands/`, leaving silent re-export shims at the old top-level paths. The `commands/` subpackage already exists; this step expands it.
 
-Plan section: [§4.1 Step 4 — `commands` top-level](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-4--commands-top-level).
+Plan section: [§4.1 Step 4 — `commands` top-level](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-4--commands-top-level).
 
 ## Pre-conditions
 
@@ -10,13 +10,13 @@ Blocked by #1286 (Step 3: core contract trio).
 
 ## Scope
 
-Move these 3 files from `src/icom_lan/` into `src/icom_lan/commands/`:
+Move these 3 files from `src/rigplane/` into `src/rigplane/commands/`:
 
-1. `src/icom_lan/commander.py` → `src/icom_lan/commands/commander.py`
-2. `src/icom_lan/command_map.py` → `src/icom_lan/commands/command_map.py`
-3. `src/icom_lan/command_spec.py` → `src/icom_lan/commands/command_spec.py`
+1. `src/rigplane/commander.py` → `src/rigplane/commands/commander.py`
+2. `src/rigplane/command_map.py` → `src/rigplane/commands/command_map.py`
+3. `src/rigplane/command_spec.py` → `src/rigplane/commands/command_spec.py`
 
-Add **3 re-export shim files** at the old top-level paths using the plan §5.1 template. The Tier 2 lazy names `IcomCommander` and `Priority` must continue to resolve through `from icom_lan import IcomCommander, Priority`.
+Add **3 re-export shim files** at the old top-level paths using the plan §5.1 template. The Tier 2 lazy names `IcomCommander` and `Priority` must continue to resolve through `from rigplane import IcomCommander, Priority`.
 
 If the existing `commands/__init__.py` needs name-collision resolution with the moved files, that's in scope; otherwise leave it untouched (LAZY_MAP cleanup is Step 13).
 
@@ -35,18 +35,18 @@ If the existing `commands/__init__.py` needs name-collision resolution with the 
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan import IcomCommander, Priority"` (Tier 2 lazy).
-  - `uv run python -c "from icom_lan.commander import IcomCommander, Priority"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.command_map import CommandMap"`
-  - `uv run python -c "from icom_lan.command_spec import CommandSpec"`
-  - `uv run python -c "from icom_lan.commands import CommandMap, CommandSpec"` (subpackage re-export, if currently exposed).
+  - `uv run python -c "from rigplane import IcomCommander, Priority"` (Tier 2 lazy).
+  - `uv run python -c "from rigplane.commander import IcomCommander, Priority"` (legacy path via shim).
+  - `uv run python -c "from rigplane.command_map import CommandMap"`
+  - `uv run python -c "from rigplane.command_spec import CommandSpec"`
+  - `uv run python -c "from rigplane.commands import CommandMap, CommandSpec"` (subpackage re-export, if currently exposed).
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections

--- a/docs/plans/issue-drafts/05-profiles.md
+++ b/docs/plans/issue-drafts/05-profiles.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 5 of the internal-modularization migration: move `profiles.py` and `rig_loader.py` into `src/icom_lan/profiles/`, leaving silent re-export shims at the old top-level paths.
+Step 5 of the internal-modularization migration: move `profiles.py` and `rig_loader.py` into `src/rigplane/profiles/`, leaving silent re-export shims at the old top-level paths.
 
-Plan section: [§4.1 Step 5 — `profiles`](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-5--profiles).
+Plan section: [§4.1 Step 5 — `profiles`](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-5--profiles).
 
 ## Pre-conditions
 
@@ -10,14 +10,14 @@ Blocked by #1287 (Step 4: commands top-level).
 
 ## Scope
 
-Move these 2 files from `src/icom_lan/` into `src/icom_lan/profiles/`:
+Move these 2 files from `src/rigplane/` into `src/rigplane/profiles/`:
 
-1. `src/icom_lan/profiles.py` → `src/icom_lan/profiles/profiles.py` (or keep as `profiles/__init__.py` body — sub-agent's call, but if going that route, the existing `profiles/__init__.py` stub from Step 1 is overwritten and the result must still pass the contract tests).
-2. `src/icom_lan/rig_loader.py` → `src/icom_lan/profiles/rig_loader.py`
+1. `src/rigplane/profiles.py` → `src/rigplane/profiles/profiles.py` (or keep as `profiles/__init__.py` body — sub-agent's call, but if going that route, the existing `profiles/__init__.py` stub from Step 1 is overwritten and the result must still pass the contract tests).
+2. `src/rigplane/rig_loader.py` → `src/rigplane/profiles/rig_loader.py`
 
-Add **2 re-export shim files** at the old top-level paths (`src/icom_lan/profiles.py`, `src/icom_lan/rig_loader.py`) using the plan §5.1 template.
+Add **2 re-export shim files** at the old top-level paths (`src/rigplane/profiles.py`, `src/rigplane/rig_loader.py`) using the plan §5.1 template.
 
-**CRITICAL pre-mitigation (plan §6.2 / R3):** the function-local cycle-breaker at `src/icom_lan/profiles.py:266` (`from .rig_loader import …` inside a function body) MUST be preserved verbatim. Do NOT hoist it to module level. Same for the top-level `rig_loader → profiles` import. These two imports together form the runtime cycle-breaker; both must stay exactly where they are.
+**CRITICAL pre-mitigation (plan §6.2 / R3):** the function-local cycle-breaker at `src/rigplane/profiles.py:266` (`from .rig_loader import …` inside a function body) MUST be preserved verbatim. Do NOT hoist it to module level. Same for the top-level `rig_loader → profiles` import. These two imports together form the runtime cycle-breaker; both must stay exactly where they are.
 
 ## Out of scope
 
@@ -34,16 +34,16 @@ Add **2 re-export shim files** at the old top-level paths (`src/icom_lan/profile
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan.profiles import RadioProfile, load_profile_toml"`
-  - `uv run python -c "from icom_lan.rig_loader import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan import Radio; r = Radio  # ensure top-level still imports"`
+  - `uv run python -c "from rigplane.profiles import RadioProfile, load_profile_toml"`
+  - `uv run python -c "from rigplane.rig_loader import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane import Radio; r = Radio  # ensure top-level still imports"`
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections

--- a/docs/plans/issue-drafts/06-scope.md
+++ b/docs/plans/issue-drafts/06-scope.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 6 of the internal-modularization migration: move `scope.py` and `scope_render.py` into `src/icom_lan/scope/`, leaving silent re-export shims at the old top-level paths. This is a tiny step — small surface, no known risks.
+Step 6 of the internal-modularization migration: move `scope.py` and `scope_render.py` into `src/rigplane/scope/`, leaving silent re-export shims at the old top-level paths. This is a tiny step — small surface, no known risks.
 
-Plan section: [§4.1 Step 6 — `scope`](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-6--scope).
+Plan section: [§4.1 Step 6 — `scope`](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-6--scope).
 
 ## Pre-conditions
 
@@ -10,12 +10,12 @@ Blocked by #1288 (Step 5: profiles).
 
 ## Scope
 
-Move these 2 files from `src/icom_lan/` into `src/icom_lan/scope/`:
+Move these 2 files from `src/rigplane/` into `src/rigplane/scope/`:
 
-1. `src/icom_lan/scope.py` → `src/icom_lan/scope/scope.py` (or fold into `scope/__init__.py` body — sub-agent's call).
-2. `src/icom_lan/scope_render.py` → `src/icom_lan/scope/scope_render.py`
+1. `src/rigplane/scope.py` → `src/rigplane/scope/scope.py` (or fold into `scope/__init__.py` body — sub-agent's call).
+2. `src/rigplane/scope_render.py` → `src/rigplane/scope/scope_render.py`
 
-Add **2 re-export shim files** at the old top-level paths (`src/icom_lan/scope.py`, `src/icom_lan/scope_render.py`) using the plan §5.1 template.
+Add **2 re-export shim files** at the old top-level paths (`src/rigplane/scope.py`, `src/rigplane/scope_render.py`) using the plan §5.1 template.
 
 ## Out of scope
 
@@ -32,16 +32,16 @@ Add **2 re-export shim files** at the old top-level paths (`src/icom_lan/scope.p
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan.scope import ScopeFrame, assemble_scope_frame"`
-  - `uv run python -c "from icom_lan.scope_render import render_scope_image"` (legacy path via shim).
-  - `uv run python -c "from icom_lan import ScopeFixedEdge"` (Tier 1 still resolves).
+  - `uv run python -c "from rigplane.scope import ScopeFrame, assemble_scope_frame"`
+  - `uv run python -c "from rigplane.scope_render import render_scope_image"` (legacy path via shim).
+  - `uv run python -c "from rigplane import ScopeFixedEdge"` (Tier 1 still resolves).
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections

--- a/docs/plans/issue-drafts/07-audio.md
+++ b/docs/plans/issue-drafts/07-audio.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 7 of the internal-modularization migration: move 9 top-level `audio_*` and `_audio_*` files into `src/icom_lan/audio/` as submodules. **`audio.backend` and `audio.dsp` paths are NOT moved** — they are the icom-lan-pro stable contract and remain exactly where they are. This step likely splits into 7a/7b at execution time per plan size budget; the maintainer decides.
+Step 7 of the internal-modularization migration: move 9 top-level `audio_*` and `_audio_*` files into `src/rigplane/audio/` as submodules. **`audio.backend` and `audio.dsp` paths are NOT moved** — they are the rigplane-pro stable contract and remain exactly where they are. This step likely splits into 7a/7b at execution time per plan size budget; the maintainer decides.
 
-Plan section: [§4.1 Step 7 — `audio` top-level (likely split 7a/7b)](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-7--audio-top-level-likely-split-7a7b).
+Plan section: [§4.1 Step 7 — `audio` top-level (likely split 7a/7b)](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-7--audio-top-level-likely-split-7a7b).
 
 ## Pre-conditions
 
@@ -10,21 +10,21 @@ Blocked by #1289 (Step 6: scope).
 
 ## Scope
 
-Move these 9 files from `src/icom_lan/` into `src/icom_lan/audio/`:
+Move these 9 files from `src/rigplane/` into `src/rigplane/audio/`:
 
-1. `src/icom_lan/audio_analyzer.py` → `src/icom_lan/audio/analyzer.py`
-2. `src/icom_lan/audio_bridge.py` → `src/icom_lan/audio/bridge.py`
-3. `src/icom_lan/audio_bus.py` → `src/icom_lan/audio/bus.py`
-4. `src/icom_lan/audio_fft_scope.py` → `src/icom_lan/audio/fft_scope.py`
-5. `src/icom_lan/_audio_codecs.py` → `src/icom_lan/audio/_codecs.py`
-6. `src/icom_lan/_audio_transcoder.py` → `src/icom_lan/audio/_transcoder.py`
-7. `src/icom_lan/_bridge_metrics.py` → `src/icom_lan/audio/_bridge_metrics.py`
-8. `src/icom_lan/_bridge_state.py` → `src/icom_lan/audio/_bridge_state.py`
-9. `src/icom_lan/usb_audio_resolve.py` → `src/icom_lan/audio/_usb_resolve.py`
+1. `src/rigplane/audio_analyzer.py` → `src/rigplane/audio/analyzer.py`
+2. `src/rigplane/audio_bridge.py` → `src/rigplane/audio/bridge.py`
+3. `src/rigplane/audio_bus.py` → `src/rigplane/audio/bus.py`
+4. `src/rigplane/audio_fft_scope.py` → `src/rigplane/audio/fft_scope.py`
+5. `src/rigplane/_audio_codecs.py` → `src/rigplane/audio/_codecs.py`
+6. `src/rigplane/_audio_transcoder.py` → `src/rigplane/audio/_transcoder.py`
+7. `src/rigplane/_bridge_metrics.py` → `src/rigplane/audio/_bridge_metrics.py`
+8. `src/rigplane/_bridge_state.py` → `src/rigplane/audio/_bridge_state.py`
+9. `src/rigplane/usb_audio_resolve.py` → `src/rigplane/audio/_usb_resolve.py`
 
 Add **9 re-export shim files** at the old top-level paths using the plan §5.1 template.
 
-**`src/icom_lan/audio/backend/` and `src/icom_lan/audio/dsp/` subdirectories are untouched.** The `audio_*` LAZY_MAP entries inside `icom_lan/audio/__init__.py` keep pointing at the old top-level paths until Step 13.
+**`src/rigplane/audio/backend/` and `src/rigplane/audio/dsp/` subdirectories are untouched.** The `audio_*` LAZY_MAP entries inside `rigplane/audio/__init__.py` keep pointing at the old top-level paths until Step 13.
 
 ## Out of scope
 
@@ -41,24 +41,24 @@ Add **9 re-export shim files** at the old top-level paths using the plan §5.1 t
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan.audio_bridge import AudioBridge"` (legacy via shim).
-  - `uv run python -c "from icom_lan.audio_bus import AudioBus"` (legacy via shim).
-  - `uv run python -c "from icom_lan.audio_analyzer import AudioAnalyzer"` (legacy via shim).
-  - `uv run python -c "from icom_lan.audio_fft_scope import AudioFftScope"` (legacy via shim).
-  - `uv run python -c "from icom_lan.audio import AudioBus, AudioBridge"` (canonical).
-- **icom-lan-pro contract paths (Tier 2 of three-tier validation per plan §9):**
-  - `uv run python -c "from icom_lan.audio import backend, dsp"`
-  - `uv run python -c "from icom_lan.audio.backend import *"`
-  - `uv run python -c "from icom_lan.audio.dsp import *"`
-  - `uv run python -c "from icom_lan.dsp import pipeline, exceptions"`
-  - `uv run python -c "from icom_lan.dsp.nodes import base"`
+  - `uv run python -c "from rigplane.audio_bridge import AudioBridge"` (legacy via shim).
+  - `uv run python -c "from rigplane.audio_bus import AudioBus"` (legacy via shim).
+  - `uv run python -c "from rigplane.audio_analyzer import AudioAnalyzer"` (legacy via shim).
+  - `uv run python -c "from rigplane.audio_fft_scope import AudioFftScope"` (legacy via shim).
+  - `uv run python -c "from rigplane.audio import AudioBus, AudioBridge"` (canonical).
+- **rigplane-pro contract paths (Tier 2 of three-tier validation per plan §9):**
+  - `uv run python -c "from rigplane.audio import backend, dsp"`
+  - `uv run python -c "from rigplane.audio.backend import *"`
+  - `uv run python -c "from rigplane.audio.dsp import *"`
+  - `uv run python -c "from rigplane.dsp import pipeline, exceptions"`
+  - `uv run python -c "from rigplane.dsp.nodes import base"`
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections
@@ -90,6 +90,6 @@ stop and ask via PR comment. Do not guess.
 
 - Verify the shim header (plan §5.1 template, verbatim) is present in every shim file.
 - LAZY_MAP target tuples must be UNCHANGED.
-- **Confirm `audio/backend/` and `audio/dsp/` subdirectories are untouched.** Step 7 must not move, rename, or edit any file inside those two paths — they are the icom-lan-pro stable contract.
-- **Confirm icom-lan-pro smoke imports succeed (Tier 2 validation).** All five paths from plan §9 (`icom_lan.audio.backend`, `icom_lan.audio.dsp`, `icom_lan.dsp.pipeline`, `icom_lan.dsp.exceptions`, `icom_lan.dsp.nodes.base`) must import cleanly after the PR.
+- **Confirm `audio/backend/` and `audio/dsp/` subdirectories are untouched.** Step 7 must not move, rename, or edit any file inside those two paths — they are the rigplane-pro stable contract.
+- **Confirm rigplane-pro smoke imports succeed (Tier 2 validation).** All five paths from plan §9 (`rigplane.audio.backend`, `rigplane.audio.dsp`, `rigplane.dsp.pipeline`, `rigplane.dsp.exceptions`, `rigplane.dsp.nodes.base`) must import cleanly after the PR.
 - Confirm `audio_fft_scope`'s `audio → scope` edge (legitimate per plan §1.3) still resolves through the new layer.

--- a/docs/plans/issue-drafts/08-runtime-radio.md
+++ b/docs/plans/issue-drafts/08-runtime-radio.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 8 of the internal-modularization migration: move the `runtime` part-1 files (`radio.py` — the centerpiece — plus 6 supporting files) into `src/icom_lan/runtime/`. Likely splits 8a/8b at execution time per plan size budget.
+Step 8 of the internal-modularization migration: move the `runtime` part-1 files (`radio.py` — the centerpiece — plus 6 supporting files) into `src/rigplane/runtime/`. Likely splits 8a/8b at execution time per plan size budget.
 
-Plan section: [§4.1 Step 8 — `runtime` part 1 (radio + state)](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-8--runtime-part-1-radio--state).
+Plan section: [§4.1 Step 8 — `runtime` part 1 (radio + state)](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-8--runtime-part-1-radio--state).
 
 ## Pre-conditions
 
@@ -10,17 +10,17 @@ Blocked by #1290 (Step 7: audio top-level).
 
 ## Scope
 
-Move these 7 files from `src/icom_lan/` into `src/icom_lan/runtime/`:
+Move these 7 files from `src/rigplane/` into `src/rigplane/runtime/`:
 
-1. `src/icom_lan/radio.py` → `src/icom_lan/runtime/radio.py`
-2. `src/icom_lan/radio_state_snapshot.py` → `src/icom_lan/runtime/radio_state_snapshot.py`
-3. `src/icom_lan/radio_initial_state.py` → `src/icom_lan/runtime/radio_initial_state.py`
-4. `src/icom_lan/radio_reconnect.py` → `src/icom_lan/runtime/radio_reconnect.py`
-5. `src/icom_lan/radios.py` → `src/icom_lan/runtime/radios.py`
-6. `src/icom_lan/ic705.py` → `src/icom_lan/runtime/ic705.py`
-7. `src/icom_lan/_state_queries.py` → `src/icom_lan/runtime/_state_queries.py`
+1. `src/rigplane/radio.py` → `src/rigplane/runtime/radio.py`
+2. `src/rigplane/radio_state_snapshot.py` → `src/rigplane/runtime/radio_state_snapshot.py`
+3. `src/rigplane/radio_initial_state.py` → `src/rigplane/runtime/radio_initial_state.py`
+4. `src/rigplane/radio_reconnect.py` → `src/rigplane/runtime/radio_reconnect.py`
+5. `src/rigplane/radios.py` → `src/rigplane/runtime/radios.py`
+6. `src/rigplane/ic705.py` → `src/rigplane/runtime/ic705.py`
+7. `src/rigplane/_state_queries.py` → `src/rigplane/runtime/_state_queries.py`
 
-Add **7 re-export shim files** at the old top-level paths using the plan §5.1 template. The shim at `src/icom_lan/radio.py` is critical — many tests reach into the radio module via the legacy path.
+Add **7 re-export shim files** at the old top-level paths using the plan §5.1 template. The shim at `src/rigplane/radio.py` is critical — many tests reach into the radio module via the legacy path.
 
 ## Out of scope
 
@@ -37,21 +37,21 @@ Add **7 re-export shim files** at the old top-level paths using the plan §5.1 t
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan import IcomRadio, Radio"` (Tier 1).
-  - `uv run python -c "from icom_lan.radio import IcomRadio"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.radios import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.ic705 import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.radio_state_snapshot import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.radio_initial_state import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.radio_reconnect import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan._state_queries import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane import IcomRadio, Radio"` (Tier 1).
+  - `uv run python -c "from rigplane.radio import IcomRadio"` (legacy path via shim).
+  - `uv run python -c "from rigplane.radios import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.ic705 import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.radio_state_snapshot import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.radio_initial_state import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.radio_reconnect import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane._state_queries import *"` (legacy path via shim).
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections
@@ -83,6 +83,6 @@ stop and ask via PR comment. Do not guess.
 
 - Verify the shim header (plan §5.1 template, verbatim) is present in every shim file.
 - LAZY_MAP target tuples must be UNCHANGED.
-- Confirm `radio.py`'s heavy import surface is preserved unchanged — many tests import from `icom_lan.radio` directly via the shim. The `radio.py` shim is the most-imported one in the suite; verify by `grep -rn 'from icom_lan.radio import' tests/ | wc -l` returning a number consistent with the existing test count.
+- Confirm `radio.py`'s heavy import surface is preserved unchanged — many tests import from `rigplane.radio` directly via the shim. The `radio.py` shim is the most-imported one in the suite; verify by `grep -rn 'from rigplane.radio import' tests/ | wc -l` returning a number consistent with the existing test count.
 - Verify `_state_queries` shim is present (it is the one private-name file moving in this step that some test files may reach into directly).
 - The 22-occurrence `_connection_state` leak, the 8-occurrence `_civ_rx` leak, and the 4-occurrence `_poller_types` leak (per discovery §6) are NOT addressed by this step — those files move in Step 10. Reviewer of Step 10 must verify those shims; reviewer of Step 8 should NOT see those names move.

--- a/docs/plans/issue-drafts/09-runtime-mixins.md
+++ b/docs/plans/issue-drafts/09-runtime-mixins.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 9 of the internal-modularization migration: move the 5 `_*_runtime_mixin` / `_runtime_*` files into `src/icom_lan/runtime/`, leaving silent re-export shims at the old top-level paths. Mixins are internal-only; tests reach them via private paths covered by the shims.
+Step 9 of the internal-modularization migration: move the 5 `_*_runtime_mixin` / `_runtime_*` files into `src/rigplane/runtime/`, leaving silent re-export shims at the old top-level paths. Mixins are internal-only; tests reach them via private paths covered by the shims.
 
-Plan section: [§4.1 Step 9 — `runtime` part 2 (mixins)](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-9--runtime-part-2-mixins).
+Plan section: [§4.1 Step 9 — `runtime` part 2 (mixins)](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-9--runtime-part-2-mixins).
 
 ## Pre-conditions
 
@@ -10,13 +10,13 @@ Blocked by #1291 (Step 8: runtime part 1).
 
 ## Scope
 
-Move these 5 files from `src/icom_lan/` into `src/icom_lan/runtime/`:
+Move these 5 files from `src/rigplane/` into `src/rigplane/runtime/`:
 
-1. `src/icom_lan/_audio_runtime_mixin.py` → `src/icom_lan/runtime/_audio_runtime_mixin.py`
-2. `src/icom_lan/_dual_rx_runtime.py` → `src/icom_lan/runtime/_dual_rx_runtime.py`
-3. `src/icom_lan/_scope_runtime.py` → `src/icom_lan/runtime/_scope_runtime.py`
-4. `src/icom_lan/_shared_state_runtime.py` → `src/icom_lan/runtime/_shared_state_runtime.py`
-5. `src/icom_lan/_runtime_protocols.py` → `src/icom_lan/runtime/_runtime_protocols.py`
+1. `src/rigplane/_audio_runtime_mixin.py` → `src/rigplane/runtime/_audio_runtime_mixin.py`
+2. `src/rigplane/_dual_rx_runtime.py` → `src/rigplane/runtime/_dual_rx_runtime.py`
+3. `src/rigplane/_scope_runtime.py` → `src/rigplane/runtime/_scope_runtime.py`
+4. `src/rigplane/_shared_state_runtime.py` → `src/rigplane/runtime/_shared_state_runtime.py`
+5. `src/rigplane/_runtime_protocols.py` → `src/rigplane/runtime/_runtime_protocols.py`
 
 Add **5 re-export shim files** at the old top-level paths using the plan §5.1 template.
 
@@ -35,19 +35,19 @@ Add **5 re-export shim files** at the old top-level paths using the plan §5.1 t
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan._audio_runtime_mixin import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan._dual_rx_runtime import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan._scope_runtime import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan._shared_state_runtime import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan._runtime_protocols import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan import IcomRadio; r = IcomRadio  # mixin composition still resolves"`
+  - `uv run python -c "from rigplane._audio_runtime_mixin import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane._dual_rx_runtime import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane._scope_runtime import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane._shared_state_runtime import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane._runtime_protocols import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane import IcomRadio; r = IcomRadio  # mixin composition still resolves"`
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections

--- a/docs/plans/issue-drafts/10-runtime-pollers.md
+++ b/docs/plans/issue-drafts/10-runtime-pollers.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 10 of the internal-modularization migration: move 11 runtime helpers (pollers, control-phase, sync wrapper, plus several specialty modules) into `src/icom_lan/runtime/`. Likely splits 10a/10b at execution time per plan size budget. This step covers the **highest concentration of tests reaching into private paths** (per discovery §6: `_connection_state` 22 occurrences, `_civ_rx` 8, `_poller_types` 4) — every shim is load-bearing.
+Step 10 of the internal-modularization migration: move 11 runtime helpers (pollers, control-phase, sync wrapper, plus several specialty modules) into `src/rigplane/runtime/`. Likely splits 10a/10b at execution time per plan size budget. This step covers the **highest concentration of tests reaching into private paths** (per discovery §6: `_connection_state` 22 occurrences, `_civ_rx` 8, `_poller_types` 4) — every shim is load-bearing.
 
-Plan section: [§4.1 Step 10 — `runtime` part 3 (pollers + control + sync + helpers)](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-10--runtime-part-3-pollers--control--sync--helpers).
+Plan section: [§4.1 Step 10 — `runtime` part 3 (pollers + control + sync + helpers)](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-10--runtime-part-3-pollers--control--sync--helpers).
 
 ## Pre-conditions
 
@@ -10,19 +10,19 @@ Blocked by #1292 (Step 9: runtime mixins).
 
 ## Scope
 
-Move these 11 files from `src/icom_lan/` into `src/icom_lan/runtime/`:
+Move these 11 files from `src/rigplane/` into `src/rigplane/runtime/`:
 
-1. `src/icom_lan/_civ_rx.py` → `src/icom_lan/runtime/_civ_rx.py`
-2. `src/icom_lan/_connection_state.py` → `src/icom_lan/runtime/_connection_state.py`
-3. `src/icom_lan/_control_phase.py` → `src/icom_lan/runtime/_control_phase.py`
-4. `src/icom_lan/_poller_types.py` → `src/icom_lan/runtime/_poller_types.py`
-5. `src/icom_lan/_audio_recovery.py` → `src/icom_lan/runtime/_audio_recovery.py`
-6. `src/icom_lan/sync.py` → `src/icom_lan/runtime/sync.py`
-7. `src/icom_lan/profiles_runtime.py` → `src/icom_lan/runtime/profiles_runtime.py`
-8. `src/icom_lan/meter_cal.py` → `src/icom_lan/runtime/meter_cal.py`
-9. `src/icom_lan/cw_auto_tuner.py` → `src/icom_lan/runtime/cw_auto_tuner.py`
-10. `src/icom_lan/startup_checks.py` → `src/icom_lan/runtime/startup_checks.py`
-11. `src/icom_lan/proxy.py` → `src/icom_lan/runtime/proxy.py`
+1. `src/rigplane/_civ_rx.py` → `src/rigplane/runtime/_civ_rx.py`
+2. `src/rigplane/_connection_state.py` → `src/rigplane/runtime/_connection_state.py`
+3. `src/rigplane/_control_phase.py` → `src/rigplane/runtime/_control_phase.py`
+4. `src/rigplane/_poller_types.py` → `src/rigplane/runtime/_poller_types.py`
+5. `src/rigplane/_audio_recovery.py` → `src/rigplane/runtime/_audio_recovery.py`
+6. `src/rigplane/sync.py` → `src/rigplane/runtime/sync.py`
+7. `src/rigplane/profiles_runtime.py` → `src/rigplane/runtime/profiles_runtime.py`
+8. `src/rigplane/meter_cal.py` → `src/rigplane/runtime/meter_cal.py`
+9. `src/rigplane/cw_auto_tuner.py` → `src/rigplane/runtime/cw_auto_tuner.py`
+10. `src/rigplane/startup_checks.py` → `src/rigplane/runtime/startup_checks.py`
+11. `src/rigplane/proxy.py` → `src/rigplane/runtime/proxy.py`
 
 Add **11 re-export shim files** at the old top-level paths using the plan §5.1 template.
 
@@ -41,24 +41,24 @@ Add **11 re-export shim files** at the old top-level paths using the plan §5.1 
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan._connection_state import *"` (legacy path via shim — heaviest test consumer).
-  - `uv run python -c "from icom_lan._civ_rx import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan._poller_types import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan._control_phase import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan._audio_recovery import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.sync import SyncIcomRadio"`
-  - `uv run python -c "from icom_lan.profiles_runtime import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.meter_cal import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.cw_auto_tuner import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.startup_checks import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.proxy import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane._connection_state import *"` (legacy path via shim — heaviest test consumer).
+  - `uv run python -c "from rigplane._civ_rx import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane._poller_types import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane._control_phase import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane._audio_recovery import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.sync import SyncIcomRadio"`
+  - `uv run python -c "from rigplane.profiles_runtime import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.meter_cal import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.cw_auto_tuner import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.startup_checks import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.proxy import *"` (legacy path via shim).
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections

--- a/docs/plans/issue-drafts/11-discovery-to-backends.md
+++ b/docs/plans/issue-drafts/11-discovery-to-backends.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 11 of the internal-modularization migration: move `discovery.py` (the multi-protocol radio discovery utility) into `src/icom_lan/backends/discovery.py`. The `backends/__init__.py` re-exports the public entrypoint so consumers calling the discovery helper through the backends package keep working.
+Step 11 of the internal-modularization migration: move `discovery.py` (the multi-protocol radio discovery utility) into `src/rigplane/backends/discovery.py`. The `backends/__init__.py` re-exports the public entrypoint so consumers calling the discovery helper through the backends package keep working.
 
-Plan section: [§4.1 Step 11 — `discovery → backends/`](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-11--discovery--backends).
+Plan section: [§4.1 Step 11 — `discovery → backends/`](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-11--discovery--backends).
 
 ## Pre-conditions
 
@@ -12,9 +12,9 @@ Blocked by #1293 (Step 10: runtime part 3).
 
 Move 1 file:
 
-1. `src/icom_lan/discovery.py` → `src/icom_lan/backends/discovery.py`
+1. `src/rigplane/discovery.py` → `src/rigplane/backends/discovery.py`
 
-Add **1 re-export shim file** at `src/icom_lan/discovery.py` using the plan §5.1 template. Verify (and if necessary update) `src/icom_lan/backends/__init__.py` so that the public entrypoint (`discover_backends` or whatever it is named) is exposed via `from icom_lan.backends import …`.
+Add **1 re-export shim file** at `src/rigplane/discovery.py` using the plan §5.1 template. Verify (and if necessary update) `src/rigplane/backends/__init__.py` so that the public entrypoint (`discover_backends` or whatever it is named) is exposed via `from rigplane.backends import …`.
 
 ## Out of scope
 
@@ -31,15 +31,15 @@ Add **1 re-export shim file** at `src/icom_lan/discovery.py` using the plan §5.
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan.discovery import *"` (legacy path via shim).
-  - `uv run python -c "from icom_lan.backends.discovery import *"` (canonical).
+  - `uv run python -c "from rigplane.discovery import *"` (legacy path via shim).
+  - `uv run python -c "from rigplane.backends.discovery import *"` (canonical).
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections

--- a/docs/plans/issue-drafts/12-cli.md
+++ b/docs/plans/issue-drafts/12-cli.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 12 of the internal-modularization migration: move `cli.py` into `src/icom_lan/cli/`. The `__main__.py` placement decision is in this step's PR — recommendation per plan §4.1: keep `__main__.py` at top level for `python -m icom_lan` discoverability, with one delegating line `from icom_lan.cli import main; main()`.
+Step 12 of the internal-modularization migration: move `cli.py` into `src/rigplane/cli/`. The `__main__.py` placement decision is in this step's PR — recommendation per plan §4.1: keep `__main__.py` at top level for `python -m rigplane` discoverability, with one delegating line `from rigplane.cli import main; main()`.
 
-Plan section: [§4.1 Step 12 — `cli`](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-12--cli).
+Plan section: [§4.1 Step 12 — `cli`](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-12--cli).
 
 ## Pre-conditions
 
@@ -12,10 +12,10 @@ Blocked by #1294 (Step 11: discovery to backends).
 
 Move 1 file (and decide the `__main__.py` question):
 
-1. `src/icom_lan/cli.py` → `src/icom_lan/cli/cli.py` (or fold into `cli/__init__.py` body — sub-agent's call).
-2. Decision noted in the PR description: does `__main__.py` move into `cli/`, or stay top-level? Recommendation: keep top-level; if it stays, `src/icom_lan/__main__.py` is updated (1-line change) to call `from icom_lan.cli import main; main()`.
+1. `src/rigplane/cli.py` → `src/rigplane/cli/cli.py` (or fold into `cli/__init__.py` body — sub-agent's call).
+2. Decision noted in the PR description: does `__main__.py` move into `cli/`, or stay top-level? Recommendation: keep top-level; if it stays, `src/rigplane/__main__.py` is updated (1-line change) to call `from rigplane.cli import main; main()`.
 
-Add **1 re-export shim file** at `src/icom_lan/cli.py` using the plan §5.1 template (so the legacy `from icom_lan.cli import …` import continues to work — note: if the file becomes a package, the shim approach changes; sub-agent decides between (a) `cli.py` shim file alongside the new `cli/` package or (b) since you can't have both a `cli.py` and a `cli/` package with the same name, fold `cli.py`'s body into `cli/__init__.py` directly and skip the shim).
+Add **1 re-export shim file** at `src/rigplane/cli.py` using the plan §5.1 template (so the legacy `from rigplane.cli import …` import continues to work — note: if the file becomes a package, the shim approach changes; sub-agent decides between (a) `cli.py` shim file alongside the new `cli/` package or (b) since you can't have both a `cli.py` and a `cli/` package with the same name, fold `cli.py`'s body into `cli/__init__.py` directly and skip the shim).
 
 ## Out of scope
 
@@ -32,16 +32,16 @@ Add **1 re-export shim file** at `src/icom_lan/cli.py` using the plan §5.1 temp
 - `uv run mypy src/` clean.
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green).
 - Public-import + entrypoint smoke check (each must succeed):
-  - `uv run python -c "from icom_lan.cli import main"` (canonical).
-  - `uv run python -m icom_lan --help` (`__main__.py` entrypoint resolves; CLI prints help and exits 0).
-  - `uv run icom-lan --help` (console-script entrypoint per `pyproject.toml`).
+  - `uv run python -c "from rigplane.cli import main"` (canonical).
+  - `uv run python -m rigplane --help` (`__main__.py` entrypoint resolves; CLI prints help and exits 0).
+  - `uv run rigplane --help` (console-script entrypoint per `pyproject.toml`).
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections
@@ -74,4 +74,4 @@ stop and ask via PR comment. Do not guess.
 - Verify the shim header (plan §5.1 template, verbatim) is present in any shim file added.
 - LAZY_MAP target tuples must be UNCHANGED.
 - Verify the `__main__.py` decision is documented clearly in the PR description.
-- Verify the `icom-lan` console script (defined in `pyproject.toml`) still resolves — the entry point may need its target updated, BUT only if the path actually moved; do not edit `pyproject.toml` opportunistically.
+- Verify the `rigplane` console script (defined in `pyproject.toml`) still resolves — the entry point may need its target updated, BUT only if the path actually moved; do not edit `pyproject.toml` opportunistically.

--- a/docs/plans/issue-drafts/13-import-linter.md
+++ b/docs/plans/issue-drafts/13-import-linter.md
@@ -1,8 +1,8 @@
 ## Context
 
-Step 13 of the internal-modularization migration: introduce `import-linter` for boundary enforcement and rewrite `_LAZY_MAP` target tuples in `icom_lan/__init__.py` and `icom_lan/audio/__init__.py` to point at the canonical post-migration paths. **No source-code moves** in this step — it is the closing tooling step.
+Step 13 of the internal-modularization migration: introduce `import-linter` for boundary enforcement and rewrite `_LAZY_MAP` target tuples in `rigplane/__init__.py` and `rigplane/audio/__init__.py` to point at the canonical post-migration paths. **No source-code moves** in this step — it is the closing tooling step.
 
-Plan sections: [§4.1 Step 13 — `import-linter` integration + `LAZY_MAP` cleanup](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-13--import-linter-integration--lazy_map-cleanup) and [§8 Tooling integration plan](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#8-tooling-integration-plan).
+Plan sections: [§4.1 Step 13 — `import-linter` integration + `LAZY_MAP` cleanup](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#step-13--import-linter-integration--lazy_map-cleanup) and [§8 Tooling integration plan](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-plan.md#8-tooling-integration-plan).
 
 ## Pre-conditions
 
@@ -14,8 +14,8 @@ Blocked by #1295 (Step 12: cli).
 2. **Commit `.importlinter`** at repo root with the contract from plan §8.3 (one `[importlinter:contract:layers]` block + three `[importlinter:contract:independence-*]` blocks for sibling-purity belt-and-braces). The four named `ignore_imports` entries from plan §3.3 are present verbatim.
 3. **Wire `lint-imports` into CI** — add a job/step that runs `uv run lint-imports`. Pre-commit hook is deferred to a follow-up issue per plan §8.1.
 4. **Rewrite `_LAZY_MAP` target tuples** in:
-   - `src/icom_lan/__init__.py`
-   - `src/icom_lan/audio/__init__.py`
+   - `src/rigplane/__init__.py`
+   - `src/rigplane/audio/__init__.py`
    …so that every Tier 2 lazy entry points at the **canonical** (post-migration) module path, not the legacy top-level path. Tier 1 eager imports are likewise updated to canonical paths if any still reference the old locations.
 5. **No file moves.** No new shims. No source edits beyond the LAZY_MAP rewrite and the `pyproject.toml` / `.importlinter` / CI-config additions.
 
@@ -36,18 +36,18 @@ Blocked by #1295 (Step 12: cli).
 - `uv run pytest tests/contracts/test_lazy_imports.py -v` passes (3 tests green) — every Tier 1 + Tier 2 + audio name still resolves after LAZY_MAP rewrite.
 - **`uv run lint-imports` passes** — the layered contract holds, and only the 4 named `ignore_imports` exceptions from plan §3.3 are declared.
 - Public-import smoke check (each must succeed):
-  - `uv run python -c "from icom_lan import Radio, IcomRadio, Mode, IcomCommander, Priority"` (Tier 1 + Tier 2 lazy via canonical paths).
-  - `uv run python -c "from icom_lan.audio import AudioBus, AudioBridge"` (audio LAZY_MAP via canonical paths).
-  - `uv run python -c "from icom_lan.audio import backend, dsp"` (icom-lan-pro contract).
-  - `uv run python -c "from icom_lan.dsp import pipeline, exceptions"` (icom-lan-pro contract).
-  - `uv run python -c "from icom_lan.dsp.nodes import base"` (icom-lan-pro contract).
+  - `uv run python -c "from rigplane import Radio, IcomRadio, Mode, IcomCommander, Priority"` (Tier 1 + Tier 2 lazy via canonical paths).
+  - `uv run python -c "from rigplane.audio import AudioBus, AudioBridge"` (audio LAZY_MAP via canonical paths).
+  - `uv run python -c "from rigplane.audio import backend, dsp"` (rigplane-pro contract).
+  - `uv run python -c "from rigplane.dsp import pipeline, exceptions"` (rigplane-pro contract).
+  - `uv run python -c "from rigplane.dsp.nodes import base"` (rigplane-pro contract).
 
 ## Implementation prompt for the sub-agent
 
 ```
-You are implementing one step of the icom-lan internal modularization
+You are implementing one step of the rigplane internal modularization
 work. Read these references first:
-- /Users/moroz/Projects/icom-lan-research/2026-04-29-internal-modularization-orchestrator.md
+- /Users/moroz/Projects/rigplane-research/2026-04-29-internal-modularization-orchestrator.md
 - docs/plans/2026-04-29-modularization-plan.md
 - The full text of this issue, especially the Scope and Acceptance
   Criteria sections
@@ -79,10 +79,10 @@ stop and ask via PR comment. Do not guess.
 
 - **Confirm the import-linter contract matches plan §8.3 exactly** — one `[importlinter:contract:layers]` block + three `[importlinter:contract:independence-*]` blocks.
 - **Confirm `ignore_imports` lists exactly the 4 named exceptions from plan §3.3, verbatim:**
-  - `icom_lan.radio_protocol -> icom_lan.audio_bus`
-  - `icom_lan.radio_protocol -> icom_lan.scope`
-  - `icom_lan.web.web_startup -> icom_lan.backends.yaesu_cat.poller`
-  - `icom_lan.web.web_startup -> icom_lan.backends.yaesu_cat.radio`
+  - `rigplane.radio_protocol -> rigplane.audio_bus`
+  - `rigplane.radio_protocol -> rigplane.scope`
+  - `rigplane.web.web_startup -> rigplane.backends.yaesu_cat.poller`
+  - `rigplane.web.web_startup -> rigplane.backends.yaesu_cat.radio`
 - **LAZY_MAP target tuples must now be CANONICAL** (post-migration paths). This is the one step where the LAZY_MAP changes; verify each entry points at the new home and the contract test still passes.
 - Confirm `import-linter` is added under `[dependency-groups] dev` (not `[project] dependencies`) — runtime install footprint must be unchanged.
 - Confirm CI runs `uv run lint-imports`, not `uvx --with-editable . --from import-linter lint-imports` (per plan §8.1).

--- a/docs/plans/issue-drafts/14-followup-tests.md
+++ b/docs/plans/issue-drafts/14-followup-tests.md
@@ -1,24 +1,24 @@
 ## Context
 
-The internal-modularization effort (epic + 13 step issues) ships **silent re-export shims** at the old top-level paths so that the 43 private-internal-symbol imports across 15 test files keep working. That decision is correct for the migration itself (it isolates the move from the test rewrite), but it leaves technical debt: tests in this repo continue to import from `icom_lan._<private>` paths long after the canonical homes are settled.
+The internal-modularization effort (epic + 13 step issues) ships **silent re-export shims** at the old top-level paths so that the 43 private-internal-symbol imports across 15 test files keep working. That decision is correct for the migration itself (it isolates the move from the test rewrite), but it leaves technical debt: tests in this repo continue to import from `rigplane._<private>` paths long after the canonical homes are settled.
 
 **This issue is post-modularization cleanup.** It MUST NOT start until the modularization epic (#1283) is closed.
 
 References:
-- Discovery doc §6 — [`docs/plans/2026-04-29-modularization-discovery.md` §6 Internal-symbol leaks](https://github.com/morozsm/icom-lan/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-discovery.md#internal-symbol-leaks-private-paths-used-by-external-code).
+- Discovery doc §6 — [`docs/plans/2026-04-29-modularization-discovery.md` §6 Internal-symbol leaks](https://github.com/rigplane/rigplane-core/blob/refactor/modularization-discovery/docs/plans/2026-04-29-modularization-discovery.md#internal-symbol-leaks-private-paths-used-by-external-code).
 - Plan doc §0 (locked decision 3) and §6 R2.
 
 ## Scope
 
-Rewrite test imports across the 15 affected files so that they go through the **canonical** post-migration paths (e.g. `from icom_lan.runtime._connection_state import …`) instead of the legacy top-level shims (e.g. `from icom_lan._connection_state import …`).
+Rewrite test imports across the 15 affected files so that they go through the **canonical** post-migration paths (e.g. `from rigplane.runtime._connection_state import …`) instead of the legacy top-level shims (e.g. `from rigplane._connection_state import …`).
 
 **Worst offenders** (per discovery §6):
 
 | Old path | Files | Total occurrences |
 |---|---:|---:|
-| `icom_lan._connection_state` | 5 (incl. `tests/test_radio_coverage.py` with 13 function-local re-imports) | 22 |
-| `icom_lan._civ_rx` | 4 | 8 |
-| `icom_lan._poller_types` | 1 | 4 |
+| `rigplane._connection_state` | 5 (incl. `tests/test_radio_coverage.py` with 13 function-local re-imports) | 22 |
+| `rigplane._civ_rx` | 4 | 8 |
+| `rigplane._poller_types` | 1 | 4 |
 | (others — full list in discovery §6) | balance | 9 |
 
 **Total surface: 15 test files, 43 import sites.**
@@ -27,11 +27,11 @@ Rewrite test imports across the 15 affected files so that they go through the **
 
 - Removing the silent re-export shims at the old top-level paths. Those stay as the backwards-compatibility surface for any out-of-tree consumer that may also have reached into private paths. Removal is a separate decision — file a fresh issue if appropriate after this work lands.
 - Adding new tests, refactoring tested behaviour, or relocating test files. This is import-rewrite-only.
-- Touching `icom-lan-pro` (downstream uses zero private paths per discovery §6).
+- Touching `rigplane-pro` (downstream uses zero private paths per discovery §6).
 
 ## Why this is post-modularization
 
-- Some private symbols may need a new public-facing entry point (e.g. a helper that tests import via `_connection_state` may need to be exposed through `icom_lan.runtime` or kept private with the test using the canonical underscored path). That decision belongs to a fresh look at the test surface, not to the migration.
+- Some private symbols may need a new public-facing entry point (e.g. a helper that tests import via `_connection_state` may need to be exposed through `rigplane.runtime` or kept private with the test using the canonical underscored path). That decision belongs to a fresh look at the test surface, not to the migration.
 - The migration epic's acceptance criterion is "all tests pass unchanged via shims" — touching the tests during the migration would conflate two failure modes (import-rewrite errors vs migration-shim errors) and slow down debugging on the bulk-move steps.
 - The shims have no runtime cost; deferring is cheap.
 

--- a/docs/plans/issue-drafts/15-followup-web-startup.md
+++ b/docs/plans/issue-drafts/15-followup-web-startup.md
@@ -1,12 +1,12 @@
 ## Context
 
-`src/icom_lan/web/web_startup.py` currently directly instantiates `backends.yaesu_cat.poller` and `backends.yaesu_cat.radio` rather than going through the canonical `backends.factory.create_radio(BackendConfig)` entry point. This violates the layered architecture's `web → backends` rule (web should depend on `backends.factory`'s public surface, not on `backends.yaesu_cat`'s internal modules).
+`src/rigplane/web/web_startup.py` currently directly instantiates `backends.yaesu_cat.poller` and `backends.yaesu_cat.radio` rather than going through the canonical `backends.factory.create_radio(BackendConfig)` entry point. This violates the layered architecture's `web → backends` rule (web should depend on `backends.factory`'s public surface, not on `backends.yaesu_cat`'s internal modules).
 
 The modularization epic encodes this as a **transitional `web → backends` edge** with two named `ignore_imports` exceptions in the import-linter contract (plan §3.3 + §8.3):
 
 ```ini
-icom_lan.web.web_startup -> icom_lan.backends.yaesu_cat.poller   ; transitional, see followup
-icom_lan.web.web_startup -> icom_lan.backends.yaesu_cat.radio    ; transitional, see followup
+rigplane.web.web_startup -> rigplane.backends.yaesu_cat.poller   ; transitional, see followup
+rigplane.web.web_startup -> rigplane.backends.yaesu_cat.radio    ; transitional, see followup
 ```
 
 This issue lands the refactor that lets those two ignores be removed.
@@ -19,7 +19,7 @@ References:
 
 ## Scope
 
-1. **Refactor `src/icom_lan/web/web_startup.py`** so that any `from icom_lan.backends.yaesu_cat import poller, radio` (or equivalent direct-instantiation pattern) is replaced with a call into `icom_lan.backends.factory.create_radio(BackendConfig)` using the appropriate `YaesuCatBackendConfig`.
+1. **Refactor `src/rigplane/web/web_startup.py`** so that any `from rigplane.backends.yaesu_cat import poller, radio` (or equivalent direct-instantiation pattern) is replaced with a call into `rigplane.backends.factory.create_radio(BackendConfig)` using the appropriate `YaesuCatBackendConfig`.
 2. **Remove the two `ignore_imports` entries** from `.importlinter` once the refactor lands and `uv run lint-imports` passes clean.
 3. Verify the existing web-server tests still cover the codepath (do not add new tests; if a coverage gap is found, file a separate issue).
 
@@ -31,12 +31,12 @@ References:
 
 ## Why this is post-modularization
 
-- `web_startup.py` lives under `src/icom_lan/web/` which is **untouched** by every step of the modularization epic (Step 1–13 leave `web/` alone). The transitional edge exists because the discovery turned up the violation; resolving it requires touching `web/`, which is out of scope.
+- `web_startup.py` lives under `src/rigplane/web/` which is **untouched** by every step of the modularization epic (Step 1–13 leave `web/` alone). The transitional edge exists because the discovery turned up the violation; resolving it requires touching `web/`, which is out of scope.
 - The factory-based path is more testable (`BackendConfig` is the canonical seam) — but redoing it during the modularization would mix two unrelated changes in the same PR.
 
 ## Acceptance (when this work finally happens)
 
-- `web_startup.py` no longer imports from `icom_lan.backends.yaesu_cat.*`; it calls `backends.factory.create_radio(YaesuCatBackendConfig(...))` instead.
+- `web_startup.py` no longer imports from `rigplane.backends.yaesu_cat.*`; it calls `backends.factory.create_radio(YaesuCatBackendConfig(...))` instead.
 - `.importlinter` has the two transitional `ignore_imports` entries removed.
 - `uv run lint-imports` passes clean.
 - `uv run pytest tests/ -q --tb=short --ignore=tests/integration` passes (test count unchanged).

--- a/docs/radio-protocol.md
+++ b/docs/radio-protocol.md
@@ -22,7 +22,7 @@ The Radio Protocol defines a vendor-neutral interface for controlling amateur ra
 Every backend **must** implement this. It covers the essentials that any transceiver supports.
 
 ```python
-from icom_lan.radio_protocol import Radio
+from rigplane.radio_protocol import Radio
 
 class MyRadio:
     """Implements Radio protocol."""
@@ -119,7 +119,7 @@ Returned by `radio.capabilities`:
 For radios that support audio streaming — either over LAN (Icom) or via USB audio device (serial-connected radios, Digirig).
 
 ```python
-from icom_lan.radio_protocol import AudioCapable
+from rigplane.radio_protocol import AudioCapable
 
 if isinstance(radio, AudioCapable):
     # Direct callback API
@@ -156,7 +156,7 @@ async for packet in web_sub:
 For radios with spectrum/panadapter output.
 
 ```python
-from icom_lan.radio_protocol import ScopeCapable
+from rigplane.radio_protocol import ScopeCapable
 
 if isinstance(radio, ScopeCapable):
     await radio.enable_scope(span=100_000)
@@ -168,7 +168,7 @@ if isinstance(radio, ScopeCapable):
 For radios with two independent receivers (e.g. IC-7610 Main/Sub).
 
 ```python
-from icom_lan.radio_protocol import DualReceiverCapable
+from rigplane.radio_protocol import DualReceiverCapable
 
 if isinstance(radio, DualReceiverCapable):
     await radio.vfo_exchange()   # swap Main ↔ Sub
@@ -182,8 +182,8 @@ if isinstance(radio, DualReceiverCapable):
 3. The Web UI, rigctld, and CLI will work automatically
 
 ```python
-from icom_lan.radio_protocol import Radio
-from icom_lan.radio_state import RadioState, ReceiverState
+from rigplane.radio_protocol import Radio
+from rigplane.radio_state import RadioState, ReceiverState
 
 class YaesuRadio:
     """Yaesu CAT protocol backend."""
@@ -271,7 +271,7 @@ assert isinstance(YaesuRadio("/dev/ttyUSB0"), Radio)
 If you're currently using `IcomRadio` directly, **no changes are required**:
 
 ```python
-from icom_lan import IcomRadio
+from rigplane import IcomRadio
 
 # This still works (LAN backend, backward compatible)
 async with IcomRadio("192.168.1.100", username="user", password="pass") as radio:
@@ -287,8 +287,8 @@ without modification.
 For new code or when adding serial backend support, use the **typed config factory**:
 
 ```python
-from icom_lan.backends.factory import create_radio
-from icom_lan.backends.config import LanBackendConfig, SerialBackendConfig
+from rigplane.backends.factory import create_radio
+from rigplane.backends.config import LanBackendConfig, SerialBackendConfig
 
 # LAN backend via factory (explicit)
 lan_config = LanBackendConfig(
@@ -316,14 +316,14 @@ Default behavior is **unchanged** (LAN):
 
 ```bash
 # Default: LAN backend (same as before)
-icom-lan status
-icom-lan freq 14.074m
+rigplane status
+rigplane freq 14.074m
 
 # Explicit LAN backend
-icom-lan --backend lan status
+rigplane --backend lan status
 
 # New: Serial backend
-icom-lan --backend serial --serial-port /dev/cu.usbserial-111120 status
+rigplane --backend serial --serial-port /dev/cu.usbserial-111120 status
 ```
 
 ### Web UI and rigctld
@@ -332,16 +332,16 @@ Web UI and rigctld now support backend selection via CLI flags. Default is LAN f
 
 ```bash
 # Web UI: LAN backend (default)
-icom-lan web
+rigplane web
 
 # Web UI: Serial backend
-icom-lan --backend serial --serial-port /dev/cu.usbserial-111120 web
+rigplane --backend serial --serial-port /dev/cu.usbserial-111120 web
 
 # rigctld: LAN backend (default)
-icom-lan serve
+rigplane serve
 
 # rigctld: Serial backend
-icom-lan --backend serial --serial-port /dev/cu.usbserial-111120 serve
+rigplane --backend serial --serial-port /dev/cu.usbserial-111120 serve
 ```
 
 ### Consumer Code (Web/rigctld/CLI)
@@ -360,7 +360,7 @@ goes through `create_radio(...)`.
 Use runtime capability detection for optional features:
 
 ```python
-from icom_lan.radio_protocol import AudioCapable, ScopeCapable
+from rigplane.radio_protocol import AudioCapable, ScopeCapable
 
 radio = create_radio(config)  # LAN or serial
 

--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -1,7 +1,7 @@
 # Rig TOML Schema Specification
 
 This document describes the format of `.toml` rig configuration files used by
-`icom-lan` to define radio profiles in a data-driven way.
+`rigplane` to define radio profiles in a data-driven way.
 
 Adding a new radio = writing one TOML file, zero Python changes.
 

--- a/rigs/_schema_v2.md
+++ b/rigs/_schema_v2.md
@@ -1,6 +1,6 @@
 # Rig Configuration Schema v2
 
-Declarative rig profiles for icom-lan. Goal: **zero radio-dependent logic in code**.
+Declarative rig profiles for rigplane. Goal: **zero radio-dependent logic in code**.
 Adding a new radio = writing one TOML file.
 
 ## Architecture: 4 Layers
@@ -246,8 +246,8 @@ declares how per-receiver and per-slot operations are routed on the wire.
 
 ### Fields
 
-Parsed by `src/icom_lan/rig_loader.py:575-605` into
-`RadioProfile` (`src/icom_lan/profiles.py:150-198`). Landed in #710.
+Parsed by `src/rigplane/rig_loader.py:575-605` into
+`RadioProfile` (`src/rigplane/profiles.py:150-198`). Landed in #710.
 
 | Field | Type | Example | When required |
 |-------|------|---------|---------------|
@@ -294,7 +294,7 @@ accepted:
 - Otherwise: `swap` → `swap_ab`, `equal` → `equal_ab`.
 
 Loading a rig that uses them emits a `DeprecationWarning` once per file
-(`src/icom_lan/rig_loader.py:600-606`). Migrate to the explicit keys.
+(`src/rigplane/rig_loader.py:600-606`). Migrate to the explicit keys.
 
 ---
 

--- a/src/rigplane/audio/LAYER.md
+++ b/src/rigplane/audio/LAYER.md
@@ -6,7 +6,7 @@ End-to-end audio subsystem: `AudioBackend` Protocol + PortAudio/Fake
 implementations, codecs (PCM / Opus / μ-law), transcoder, audio bridge,
 audio bus, FFT scope (panadapter), reconnect-time recovery, and platform
 USB audio resolution. The `audio.backend` and `audio.dsp` submodule paths
-are part of the icom-lan-pro contract and **must remain stable**.
+are part of the rigplane-pro contract and **must remain stable**.
 
 ## Public API
 
@@ -42,7 +42,7 @@ frames from PCM. No `runtime`, no `commands`, no transport caller.
 
 ## Forbidden patterns
 
-- `from icom_lan.runtime` / `from icom_lan.commands` — audio is a leaf
+- `from rigplane.runtime` / `from rigplane.commands` — audio is a leaf
   that runtime composes; the inverse direction is forbidden.
 - Eager imports of `numpy`, `sounddevice`, `opuslib`, or `pyaudio` at
   module top level. Use `core._optional_deps._require_*()` and gate at
@@ -70,7 +70,7 @@ frames from PCM. No `runtime`, no `commands`, no transport caller.
 ## See also
 
 - `docs/plans/2026-04-29-modularization-plan.md` §1.2 ("audio.backend
-  and audio.dsp paths are the icom-lan-pro contract"), §2.2, §3.
+  and audio.dsp paths are the rigplane-pro contract"), §2.2, §3.
 - `docs/api/public-api-surface.md` — Tier 2 surface for AudioBackend.
 - `audio/backend.py` — the stable Protocol definition.
 - `tests/test_audio_*.py` — coverage; `FakeAudioBackend` lives in

--- a/src/rigplane/backends/LAYER.md
+++ b/src/rigplane/backends/LAYER.md
@@ -31,12 +31,12 @@ their own Protocol-implementing class) and feed it the right transport
 + commander stack.
 
 `backends.yaesu_cat.radio` carries one named exception in
-`.importlinter`'s `ignore_imports` (`→ icom_lan.rigctld.routing`,
+`.importlinter`'s `ignore_imports` (`→ rigplane.rigctld.routing`,
 `TYPE_CHECKING` only, added by epic #1322's RigctldRoutable work).
 
 ## Forbidden patterns
 
-- `from icom_lan.web` / `from icom_lan.rigctld` / `from icom_lan.cli`.
+- `from rigplane.web` / `from rigplane.rigctld` / `from rigplane.cli`.
   Backends are below those layers; the inverse is the legal flow.
 - Direct instantiation of backend classes from upper layers. Always go
   through `create_radio` so the discriminator + capability assembly is

--- a/src/rigplane/cli/LAYER.md
+++ b/src/rigplane/cli/LAYER.md
@@ -2,7 +2,7 @@
 
 ## Charter
 
-Command-line entrypoints (`icom-lan` / `python -m icom_lan`). Wires CLI
+Command-line entrypoints (`rigplane` / `python -m rigplane`). Wires CLI
 arguments to the `backends.factory.create_radio` assembly path and the
 `runtime.IcomRadio` API surface; provides one-shot status/control
 subcommands plus `audio` and `discover` helpers. The CLI is a consumer:
@@ -18,9 +18,9 @@ no business logic lives here.
 - `check_ports_available` — pre-flight UDP port probe used by
   `web`/`rigctld` integration.
 
-The `icom-lan` console script (`pyproject.toml` `[project.scripts]`)
-points at `icom_lan.cli:main`. The `python -m icom_lan` entry uses
-`icom_lan/__main__.py` which delegates to the same `main`.
+The `rigplane` console script (`pyproject.toml` `[project.scripts]`)
+points at `rigplane.cli:main`. The `python -m rigplane` entry uses
+`rigplane/__main__.py` which delegates to the same `main`.
 
 ## Allowed dependencies
 
@@ -36,7 +36,7 @@ on `cli`.
   `runtime` or `backends`.
 - Direct backend instantiation. Use `_build_backend_config(args)` →
   `create_radio(config)` (issue #147; LightRAG memory note: tests must
-  patch `icom_lan.cli.create_radio`, not `icom_lan.cli.IcomRadio`).
+  patch `rigplane.cli.create_radio`, not `rigplane.cli.IcomRadio`).
 - Hardware-specific branches. Probe via the Capability Protocols on
   the resolved radio and surface graceful fallbacks.
 
@@ -44,7 +44,7 @@ on `cli`.
 
 - **Add a subcommand** → declare argparse subparser in `cli/__init__.py`,
   implement the async handler, register in the dispatch dict; cover
-  with `tests/test_cli*.py`. Mock `icom_lan.cli.create_radio` to
+  with `tests/test_cli*.py`. Mock `rigplane.cli.create_radio` to
   isolate from hardware.
 - **Add a new backend flag** → extend `_build_backend_config(args)`;
   the `--backend lan|serial` discriminator + per-backend flags are the

--- a/src/rigplane/commands/LAYER.md
+++ b/src/rigplane/commands/LAYER.md
@@ -24,7 +24,7 @@ single import target. Highlights:
 - **Routing** — `CommandMap`, `CommandSpec` (rig-specific overrides).
 
 `__all__` enumerates ~250 names. Other layers import through this front
-door (`from icom_lan.commands import set_freq`) — direct sub-module
+door (`from rigplane.commands import set_freq`) — direct sub-module
 imports are an internal detail.
 
 ## Allowed dependencies
@@ -35,7 +35,7 @@ transport happens in the `runtime` layer that wires it up.
 
 ## Forbidden patterns
 
-- `from icom_lan.runtime` — would make builders depend on the commander
+- `from rigplane.runtime` — would make builders depend on the commander
   caller; instead, the runtime calls `commands.*`.
 - Module-level state (no caches, no registries that mutate at import).
   `CommandMap` is a runtime container constructed by `profiles`.

--- a/src/rigplane/core/LAYER.md
+++ b/src/rigplane/core/LAYER.md
@@ -5,14 +5,14 @@
 Foundational layer with no internal dependencies. Holds the wire-protocol
 primitives (CI-V framing, transport, auth), base types/exceptions, the
 optional-dependency probes, and the abstract Radio Protocol surface that
-downstream consumers (incl. `icom-lan-pro`) treat as the stable contract.
+downstream consumers (incl. `rigplane-pro`) treat as the stable contract.
 Anyone may import from `core`; `core` may import from no other layer.
 
 ## Public API
 
 `core/__init__.py` keeps `__all__` empty by design — layers reach into
-canonical sub-module paths and the top-level `icom_lan` lazy-loader
-(`icom_lan/__init__.py`) re-exports the Tier 1 / Tier 2 surface. Notable
+canonical sub-module paths and the top-level `rigplane` lazy-loader
+(`rigplane/__init__.py`) re-exports the Tier 1 / Tier 2 surface. Notable
 canonical entries:
 
 - `core.types` — `Mode`, `AudioCodec`, `BreakInMode`, `RadioState`,
@@ -34,14 +34,14 @@ test `tests/contracts/test_lazy_imports.py` plus `import-linter`'s layered
 contract police this.
 
 `radio_protocol` carries four named exceptions in `.importlinter`'s
-`ignore_imports`: `→ icom_lan.audio_bus` and `→ icom_lan.scope` (both
+`ignore_imports`: `→ rigplane.audio_bus` and `→ rigplane.scope` (both
 `TYPE_CHECKING`-only string annotations — see `radio_protocol.py:58`),
-plus `→ icom_lan.runtime._poller_types` and `→ icom_lan.rigctld.routing`
+plus `→ rigplane.runtime._poller_types` and `→ rigplane.rigctld.routing`
 (also `TYPE_CHECKING`, added by epic #1322).
 
 ## Forbidden patterns
 
-- Any `from icom_lan.<other layer>` import outside a `TYPE_CHECKING`
+- Any `from rigplane.<other layer>` import outside a `TYPE_CHECKING`
   block. New runtime imports here would create cycles instantly.
 - Side-effecting module-level code (no logger config, no env reads, no
   network/IO at import time).
@@ -53,12 +53,12 @@ plus `→ icom_lan.runtime._poller_types` and `→ icom_lan.rigctld.routing`
 - **Add a capability protocol** → extend `core/radio_protocol.py`, list
   the symbol in `tests/test_public_api_surface.py`, add to
   `tests/contracts/test_lazy_imports.py` if Tier 1, register in
-  `icom_lan/__init__.py` `_LAZY_MAP` if Tier 2 (see #1322 commits).
+  `rigplane/__init__.py` `_LAZY_MAP` if Tier 2 (see #1322 commits).
 - **Add an exception** → add to `core/exceptions.py`, ensure it inherits
-  from the existing `IcomLanError` hierarchy, expose via the top-level
+  from the existing `RigplaneError` hierarchy, expose via the top-level
   shim if it's part of the public Tier 1 surface.
 - **Add a transport primitive** → add to `core/transport.py` or a new
-  sub-module; verify zero `from icom_lan` imports remain.
+  sub-module; verify zero `from rigplane` imports remain.
 - **Touch `core/_optional_deps.py`** → run `uv run pytest
   tests/test_optional_deps.py`; the helper API is shared by every layer
   and breakage cascades.

--- a/src/rigplane/dsp/LAYER.md
+++ b/src/rigplane/dsp/LAYER.md
@@ -22,7 +22,7 @@ Audio-specific stages (NoiseGate / Limiter / RmsNormalizer) live in
 `GainNode`, `NRScipyNode`, …); `dsp/resample.py` exposes the
 inter-node resampler used to bridge nodes that disagree on sample rate.
 
-The `icom-lan-pro` consumer reaches `dsp.pipeline`, `dsp.nodes.base`,
+The `rigplane-pro` consumer reaches `dsp.pipeline`, `dsp.nodes.base`,
 and `dsp.exceptions` directly via canonical paths — these are part of
 the Tier 2 stable contract (plan §9).
 
@@ -35,7 +35,7 @@ The `independence-low` contract in `.importlinter` enforces that
 
 ## Forbidden patterns
 
-- `from icom_lan.audio` / `from icom_lan.runtime` — `audio` depends on
+- `from rigplane.audio` / `from rigplane.runtime` — `audio` depends on
   `dsp`, not the reverse. Audio-policy nodes live in `audio/dsp.py`.
 - Module-level numpy/scipy imports. Gate via `_require_numpy()` /
   `_require_scipy()` at construction time; `DSPBackendUnavailable` is
@@ -56,7 +56,7 @@ The `independence-low` contract in `.importlinter` enforces that
 ## See also
 
 - `docs/plans/2026-04-29-modularization-plan.md` §1.2 ("`dsp` is
-  independent of the rest"), §3 (matrix), §9 (icom-lan-pro contract).
+  independent of the rest"), §3 (matrix), §9 (rigplane-pro contract).
 - `audio/dsp.py` — audio-policy stages built on top.
 - `tests/test_dsp_*.py` — node + pipeline + tap coverage.
 - `.importlinter` `independence-low` contract.

--- a/src/rigplane/profiles/LAYER.md
+++ b/src/rigplane/profiles/LAYER.md
@@ -39,7 +39,7 @@ types. **Do not hoist it to module top-level** (plan §6.2 no-touch list).
 
 ## Forbidden patterns
 
-- `from icom_lan.runtime`, `from icom_lan.audio`, `from icom_lan.web` —
+- `from rigplane.runtime`, `from rigplane.audio`, `from rigplane.web` —
   profiles are read-only data; consumers depend on profiles, not the
   reverse.
 - Any I/O outside the lazy `_ensure_loaded()` path. Profile lookup must

--- a/src/rigplane/rigctld/LAYER.md
+++ b/src/rigplane/rigctld/LAYER.md
@@ -14,7 +14,7 @@ works without modification.
 - `RigctldServer` — async TCP server; `serve_forever()` enters the
   accept loop. Module-level import is wrapped in `try/except
   ImportError` so optional-dep absence (e.g. headless install without
-  the rigctld extras) does not break `import icom_lan`.
+  the rigctld extras) does not break `import rigplane`.
 
 Internal layout:
 
@@ -41,9 +41,9 @@ introduction (#1324, #688bda03).
 
 ## Forbidden patterns
 
-- `from icom_lan.web` — independence contract.
-- `from icom_lan.audio` / `from icom_lan.scope` / `from icom_lan.dsp`
-  / `from icom_lan.profiles` — outside the matrix.
+- `from rigplane.web` — independence contract.
+- `from rigplane.audio` / `from rigplane.scope` / `from rigplane.dsp`
+  / `from rigplane.profiles` — outside the matrix.
 - Backend-id discriminator branches. Use `isinstance(radio,
   RigctldRoutable)` (#1324). Legacy `set_vfo` overload fallbacks live
   in `rigctld/handler.py` strictly for third-party backends that don't

--- a/src/rigplane/runtime/LAYER.md
+++ b/src/rigplane/runtime/LAYER.md
@@ -12,7 +12,7 @@ turns wire-level primitives into the user-visible Radio object.
 ## Public API
 
 `runtime/__init__.py` keeps `__all__` empty by design (plan §2.2). The
-top-level `icom_lan` lazy-loader and the legacy top-level shims surface
+top-level `rigplane` lazy-loader and the legacy top-level shims surface
 the canonical types to consumers; layer-internal callers reach the
 sub-modules directly:
 
@@ -43,12 +43,12 @@ construct audio backends and the scope assembler at runtime
 
 ## Forbidden patterns
 
-- `from icom_lan.backends` — backends compose runtime, not the reverse.
+- `from rigplane.backends` — backends compose runtime, not the reverse.
   The backend factory is the assembly seam; `IcomRadio` does not know
   which factory built it.
-- `from icom_lan.web` / `from icom_lan.rigctld` / `from icom_lan.cli` —
+- `from rigplane.web` / `from rigplane.rigctld` / `from rigplane.cli` —
   these are upper-tier consumers.
-- `from icom_lan.dsp` directly — DSP processing flows through `audio`,
+- `from rigplane.dsp` directly — DSP processing flows through `audio`,
   which composes `dsp` internally.
 - New cross-layer imports without checking the matrix; `import-linter`
   will catch them at CI but do not commit them.

--- a/src/rigplane/scope/LAYER.md
+++ b/src/rigplane/scope/LAYER.md
@@ -29,9 +29,9 @@ by the `independence-low` contract in `.importlinter`.
 
 ## Forbidden patterns
 
-- `from icom_lan.audio` / `from icom_lan.runtime` / `from
-  icom_lan.commands`. Sibling/upper-tier imports break the layer.
-- `from icom_lan.dsp` — the bottom-tier independence contract bans it.
+- `from rigplane.audio` / `from rigplane.runtime` / `from
+  rigplane.commands`. Sibling/upper-tier imports break the layer.
+- `from rigplane.dsp` — the bottom-tier independence contract bans it.
   PCM-derived spectra live in `audio/fft_scope.py`, which uses `scope`,
   not the reverse.
 - Maintaining radio I/O state. The assembler is fed bytes; it does not

--- a/src/rigplane/web/LAYER.md
+++ b/src/rigplane/web/LAYER.md
@@ -2,7 +2,7 @@
 
 ## Charter
 
-WebSocket + HTTP server for the icom-lan Web UI. Hosts the built-in
+WebSocket + HTTP server for the rigplane Web UI. Hosts the built-in
 browser app — real-time spectrum/waterfall, radio control, audio
 streaming — accessible from any browser on the LAN. No external web
 framework: pure stdlib HTTP + RFC 6455 WebSocket, by design (Tier-1
@@ -42,7 +42,7 @@ than backend-id branching (#1298, #1323-#1326). The transitional
 
 ## Forbidden patterns
 
-- `from icom_lan.rigctld` — independence contract.
+- `from rigplane.rigctld` — independence contract.
 - Direct transport calls. Web talks to `runtime.IcomRadio`, never to
   `core.transport` directly. CLAUDE.md rule.
 - Direct backend-id checks (`if radio.backend_id == "yaesu_cat":`).


### PR DESCRIPTION
## Summary

Wave 2 **PR-2E**: rewrite documentation prose for the icom-lan → rigplane rebrand.

- v2.0.0 migration callout banner added to README.md → points at rigplane.dev/migrate
- Product description in README.md and ARCHITECTURE.md updated to acknowledge multi-vendor support (Icom CI-V, Yaesu CAT, Kenwood-style CAT) instead of "Icom-only"
- CLAUDE.md version banner bumped to v2.0.0
- Every `from icom_lan ...` and `::: icom_lan...` mkdocstrings ref in `docs/api/` flipped to canonical `rigplane.*` paths — `mkdocs build --strict` passes (the pre-rebrand `mkdocstrings: icom_lan.audio.lan_stream.AudioStream could not be found` failure is resolved)
- 11 in-tree `src/rigplane/*/LAYER.md` charter files rewritten

Vendor tokens (`IcomRadio`, `IcomBackend`, `Icom IC-7610`, `Icom CI-V`, trademark notice) preserved as vendor identifiers. Only product/package brand strings (`icom-lan`, `icom_lan`, `IcomLanError`, `icom-lan-pro`, `morozsm/icom-lan`, `morozsm.github.io/icom-lan`) were rewritten — fixed longest-prefix-first order in the codemod.

## Scope (77 files)

- 5 top-level: `README.md`, `ARCHITECTURE.md`, `ROADMAP.md`, `CLAUDE.md`, `.claude/commands/release.md`
- 11 layer charters: `src/rigplane/*/LAYER.md`
- 60 mkdocs pages: 12 `docs/api/`, 18 `docs/guide/`, 4 `docs/internals/`, `docs/index.md`, `docs/PROJECT.md`, `docs/SECURITY.md`, `docs/radio-protocol.md`, 17 `docs/plans/issue-drafts/`, 2 `rigs/_schema*.md`
- 1 `docs/architecture/open-core-policy.md`

## Out of scope (preserved per spec)

| Path | Why |
|---|---|
| `docs/CHANGELOG.md` | Historical — past releases shipped as `icom-lan` |
| `docs/contracts/diagnostic-bundle-v1.md` | Wire-contract v1 spec; PR-2G introduces v2 |
| `docs/plans/{archive,discovery-artifacts}/` | Historical / regenerable |
| `docs/plans/2026-0[1-4]*`, `2026-05-0[1-3]*` | Pre-rebrand plans |
| `frontend/**` | PR-2D scope |
| `mkdocs.yml` | Already done in PR-2F (folded into #1423) |
| `src/icom_lan/__init__.py` | Shim docstring legitimately discusses old name |

## Note for follow-up

`mkdocs.yml:2` still reads `site_description: Python library for controlling Icom transceivers over LAN` — left untouched per scope, but stale (project also supports Yaesu CAT and Kenwood). Quick flip in a future cleanup PR.

## Test plan

- [x] `uv run mkdocs build --strict` — passes
- [x] Grep audit returns only allow-listed files + intentional README v2.0.0 migration banner refs
- [x] No code touched — pytest/mypy/ruff not run (mkdocs build is the relevant gate)

## Stats

```
77 files changed, 925 insertions(+), 918 deletions(-)
```

4 commits, branch `feat/rebrand/wave2-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)