### PR TITLE
rebrand(wave2): diagnostic-bundle schema v2 (rigplane-bundle-v2) (PR-2G')

### DIFF
--- a/docs/contracts/diagnostic-bundle-v2.md
+++ b/docs/contracts/diagnostic-bundle-v2.md
@@ -1,0 +1,272 @@
+# Diagnostic Bundle Contract — `rigplane-bundle-v2`
+
+**Schema name:** `rigplane-bundle-v2`
+**Status:** stable, public, open-source contract.
+**Last updated:** 2026-05-04
+
+## Purpose
+
+This contract documents the public, anonymous-tier shape of diagnostic-bundle
+uploads from open-core rigplane to a maintainer-operated triage service. It is
+the spec that `rigplane.diagnostics.upload_bundle` builds against and that any
+third-party server that wants to receive rigplane reports must implement.
+
+## Differences from `icom-lan-bundle-v1`
+
+This is the v2 revision of the contract previously published as
+[`icom-lan-bundle-v1`](diagnostic-bundle-v1.md). The wire shape is otherwise
+identical; only the rebrand-affected strings change.
+
+| Field                               | v1 value              | v2 value             |
+| ----------------------------------- | --------------------- | -------------------- |
+| `metadata.schema_version`           | `icom-lan-bundle-v1`  | `rigplane-bundle-v2` |
+| `metadata.app.name`                 | `icom-lan`            | `rigplane`           |
+| `system/system.json` version key    | `icom_lan_version`    | `rigplane_version`   |
+| Endpoint override env var           | `ICOM_LAN_REPORT_ENDPOINT` | `RIGPLANE_REPORT_ENDPOINT` |
+
+A conforming v2 server **must** keep accepting v1 bundles for at least one
+deprecation window (12 months from v2 publication) so rigplane v1.x clients
+keep working unchanged. v2 clients **must** emit v2 strings end-to-end.
+
+The default maintainer-operated endpoint URL is unchanged; both schemas POST
+to the same path.
+
+## Boundary
+
+This document is open-source and authoritative for the **anonymous tier** of
+bundle submissions — open-core users with no licence context.
+
+The rigplane-pro distribution adds an authenticated tier (signed uploads tied
+to a customer support id, longer retention, customer-tier triage) on top of
+the same endpoint. Those Pro-only extensions are governed by a private
+contract and are deliberately out of scope here. Pro builds may set additional
+headers; their behaviour is documented in a private contract.
+
+## Endpoint
+
+```
+POST https://reports.msmsoft.net/v1/diagnostics/upload
+```
+
+The endpoint is overridable via the `RIGPLANE_REPORT_ENDPOINT` environment
+variable. This is intended for two use-cases:
+
+1. **Self-hosting** — point clients at a third-party backend that implements
+   this contract (see [Self-hosting](#self-hosting) below).
+2. **Testing** — integration tests and local development against a stub
+   server.
+
+When the override is unset, the default maintainer-operated endpoint is used.
+
+## Request
+
+`Content-Type: multipart/form-data`
+
+| Field      | Type            | Required | Notes                                          |
+| ---------- | --------------- | -------- | ---------------------------------------------- |
+| `bundle`   | file            | yes      | ZIP archive, maximum 25 MiB after compression. |
+| `metadata` | string (JSON)   | yes      | Bundle metadata, schema below.                 |
+
+The anonymous tier sends no authentication headers.
+
+### Metadata schema
+
+`metadata` is a JSON string with `schema_version: "rigplane-bundle-v2"`:
+
+```json
+{
+  "schema_version": "rigplane-bundle-v2",
+  "submission_id": "uuid-v4-generated-by-client",
+  "app": {
+    "name": "rigplane",
+    "version": "2.0.0",
+    "build_id": "2026-05-04.1"
+  },
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64",
+    "python_version": "3.11.14"
+  },
+  "user_description": "optional free text",
+  "issue_ref": "https://github.com/rigplane/rigplane-core/issues/1234",
+  "contact": {
+    "email": "ham@example.com",
+    "callsign": "DL9EAC"
+  }
+}
+```
+
+`app.name` is `"rigplane"` for open-core uploads.
+
+**Required fields** — server returns `metadata_invalid` (HTTP 400) if absent:
+
+- `schema_version`
+- `submission_id`
+- `generated_at_unix` — bundle assembly time as Unix epoch seconds.
+- `app.name`
+- `app.version`
+- `platform.os`
+- `platform.arch`
+
+**Optional fields** — omitted (not `null`) when data is unavailable. The
+server must accept absence without error:
+
+- `app.build_id` — git describe / build pipeline identifier; absent for pip
+  installs without git context.
+- `platform.python_version` — best-effort, derived from `sys.version_info`.
+- `user_description`, `issue_ref` — user-supplied at submission time.
+- `contact.email`, `contact.callsign` — opt-in user-supplied (see
+  [Privacy invariants](#privacy-invariants)).
+- Any field added in future schema versions.
+
+Unknown JSON fields must be ignored. Clients should never send `null` for an
+unavailable field; they must omit the key entirely.
+
+## Request rules
+
+- **Idempotency** — `submission_id` provides idempotency: if the same
+  `submission_id` arrives within 24 hours, the server returns the existing
+  `report_id` with HTTP 200.
+- **Content scanning** — the server runs a forbidden-pattern regex pass on
+  the uncompressed text content of the bundle. Detected patterns (see
+  [Forbidden content patterns](#forbidden-content-patterns)) cause the bundle
+  to be rejected with `forbidden_content` and not stored.
+- **Bundle size cap** — `bundle` size > 25 MiB → `bundle_too_large`.
+- **Anonymous rate limit** — 5 reports per source IP per hour, 10 per IP per
+  day. Exceeding either limit → `rate_limited` with `retry_after_seconds`.
+- **Retention** — anonymous bundles are retained for 90 days, then storage
+  objects are purged.
+
+## Success response
+
+```json
+{
+  "report_id": "rpt_01JZ7F8A0M5W6X3DKQNHFVHRE0",
+  "received_at_unix": 1777670400,
+  "support_url": "https://reports.msmsoft.net/r/rpt_01JZ7F8A0M5W6X3DKQNHFVHRE0",
+  "auth_class": "anonymous"
+}
+```
+
+| Field              | Type     | Notes                                                       |
+| ------------------ | -------- | ----------------------------------------------------------- |
+| `report_id`        | string   | ULID. Customer-safe identifier returned to the client.      |
+| `received_at_unix` | integer  | Server-side receive timestamp (UTC, Unix seconds).          |
+| `support_url`      | string   | Customer-safe link the user can paste into a GitHub issue.  |
+| `auth_class`       | string   | `"anonymous"` for open-core uploads.                        |
+
+`auth_class` is `"anonymous"` for every bundle submitted by open-core
+rigplane. The `support_url` is a customer-safe link and never exposes
+internal identifiers, source IP, or contact fields.
+
+## Stable error responses
+
+All non-2xx responses follow a single envelope:
+
+```json
+{
+  "error": {
+    "code": "metadata_invalid",
+    "message": "field 'app.version' is required",
+    "field": "app.version",
+    "retry_after_seconds": null
+  }
+}
+```
+
+The relevant `error.code` values for the diagnostic-bundle endpoint:
+
+| HTTP | Code                  | Extra fields            | Client action                                              |
+| ---- | --------------------- | ----------------------- | ---------------------------------------------------------- |
+| 400  | `metadata_invalid`    | `field`                 | Reject; client should regenerate the bundle.               |
+| 413  | `bundle_too_large`    | —                       | Reject; client must trim or split the bundle.              |
+| 422  | `forbidden_content`   | `pattern`               | Reject; bundle contained patterns barred by privacy rules. |
+| 429  | `rate_limited`        | `retry_after_seconds`   | Show retry later; honour `retry_after_seconds`.            |
+| 5xx  | `service_unavailable` | —                       | Surface a retry path; do not retry aggressively.           |
+
+`error.message` is safe to display, but clients may choose local copy.
+`retry_after_seconds` is `null` when not applicable.
+
+## Privacy invariants
+
+These invariants are binding for the anonymous tier and form the basis of the
+maintainer-operated server's privacy posture.
+
+- `contact.email` and `contact.callsign` are **opt-in user-provided** fields.
+  They are stored only when supplied by the user via an explicit "Send report"
+  consent form on the client. They must **never** be auto-populated from
+  system state, environment variables, or local config.
+- Source IP is collected only for rate-limit enforcement. It is hashed and
+  dropped (set to `NULL` in storage) after 24 hours.
+- Anonymous bundles must not be cross-correlated with license records by IP,
+  machine fingerprint, or any other field.
+- Public GitHub issues opened by the AI triage agent must reference reports
+  by `report_id` / `support_url` only — never by source IP, contact fields,
+  or any other identifying material.
+
+## Forbidden content patterns
+
+The server rejects bundles whose uncompressed text content contains any of:
+
+- `AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID` and similar cloud-credential
+  variable names.
+- `Authorization: Bearer` headers in captured logs or HTTP transcripts.
+- Raw activation codes or licence-code-shaped strings.
+- PEM-encoded private keys (`-----BEGIN ... PRIVATE KEY-----`).
+- `password=`, `passwd=`, and similar credential assignments in plain text.
+
+Clients should perform the same redaction pass locally before submission so
+that legitimate bundles are not rejected; the server check is a defence in
+depth, not a primary filter.
+
+## Versioning
+
+- `schema_version` is `"rigplane-bundle-v2"` for this contract revision.
+- Unknown JSON fields must be ignored by the server. Clients may begin
+  emitting new optional fields without coordination.
+- **Non-breaking changes** — adding a new optional metadata field, adding a
+  new optional response field. These do not bump the schema version.
+- **Breaking changes** — removing or renaming a required field, changing a
+  field's type or semantics, removing a stable error code. These mint a new
+  `schema_version` (e.g. `rigplane-bundle-v3`) and the server must continue
+  to accept the previous schema for a documented deprecation window.
+- **Backwards compatibility** — a v2 server must keep accepting
+  `icom-lan-bundle-v1` bundles for at least one 12-month deprecation window
+  from v2 publication, so rigplane v1.x clients (the legacy `icom-lan` brand)
+  continue to work unchanged.
+
+Clients must include `schema_version` in every submission so the server can
+route to the correct validator.
+
+## Self-hosting
+
+The default endpoint is operated by the rigplane maintainer. To redirect
+uploads to a self-hosted backend that implements this contract, set:
+
+```sh
+export RIGPLANE_REPORT_ENDPOINT=https://reports.example.org/v1/diagnostics/upload
+```
+
+A conforming self-hosted backend must:
+
+1. Accept `multipart/form-data` with `bundle` and `metadata` fields.
+2. Validate `metadata` against the schema in this document and return
+   `metadata_invalid` (HTTP 400) on missing required fields.
+3. Enforce the 25 MiB bundle cap and return `bundle_too_large` (HTTP 413).
+4. Honour `submission_id` idempotency for at least 24 hours.
+5. Return the success-response envelope documented above with
+   `auth_class: "anonymous"`.
+6. Use the stable error envelope and codes in
+   [Stable error responses](#stable-error-responses).
+7. Continue to accept `icom-lan-bundle-v1` bundles per the deprecation
+   window (see [Versioning](#versioning)).
+
+A self-hosted backend may apply its own rate-limit and retention policy, but
+SHOULD honour the anonymous-tier defaults to avoid surprising users.
+
+## See also
+
+- Open-core spec: `docs/plans/2026-05-03-diagnostic-data-collection-design.md` §5.3
+- rigplane upload client: `src/rigplane/diagnostics/upload.py`
+- Open-core policy: `docs/architecture/open-core-policy.md` §2 carve-out
+- Predecessor contract: [`diagnostic-bundle-v1.md`](diagnostic-bundle-v1.md)

--- a/src/rigplane/diagnostics/_manifest.py
+++ b/src/rigplane/diagnostics/_manifest.py
@@ -1,4 +1,17 @@
-"""manifest.json builder per icom-lan-bundle-v1 schema (spec §5.2)."""
+"""manifest.json builder per ``rigplane-bundle-v2`` schema (spec §5.2).
+
+The bundle producer supports two on-the-wire schema strings:
+
+- ``rigplane-bundle-v2`` — canonical for rigplane v2.0.0+ (default).
+- ``icom-lan-bundle-v1`` — legacy format from the icom-lan brand. Tower
+  accepts it for the 12-month deprecation window documented in
+  ``docs/contracts/diagnostic-bundle-v2.md``. Kept available for
+  backwards-compatibility tests and unit fixtures.
+
+Pick the schema by passing ``schema_version=SCHEMA_VERSION_V1`` (or v2) to
+:class:`_Manifest` / :func:`rigplane.diagnostics.build_bundle`. ``app.name``
+is derived from the schema choice and need not be set independently.
+"""
 
 from __future__ import annotations
 
@@ -9,12 +22,33 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 from rigplane.diagnostics.contributor import BundleContext, DiagnosticContributor
 
-SCHEMA_VERSION = "icom-lan-bundle-v1"
-APP_NAME = "icom-lan"
+# Wire-contract schema strings. v1 is the historical icom-lan format kept
+# for testing + backwards-compat verification; v2 is the canonical format
+# for rigplane v2.0.0+.
+SCHEMA_VERSION_V1: Final = "icom-lan-bundle-v1"
+SCHEMA_VERSION_V2: Final = "rigplane-bundle-v2"
+SCHEMA_VERSION: Final = SCHEMA_VERSION_V2  # current default
+
+# Application name embedded in bundle metadata. Derived from the schema
+# choice; v1 emits "icom-lan", v2 emits "rigplane".
+APP_NAME_V1: Final = "icom-lan"
+APP_NAME_V2: Final = "rigplane"
+APP_NAME: Final = APP_NAME_V2  # current default
+
+# All accepted schema_version strings (used to validate caller input).
+_SUPPORTED_SCHEMAS: Final = frozenset({SCHEMA_VERSION_V1, SCHEMA_VERSION_V2})
+
+# Map schema_version → app.name. Keeps the two fields locked together so a
+# caller can never produce a v2 manifest with app.name == "icom-lan".
+_APP_NAME_FOR_SCHEMA: Final = {
+    SCHEMA_VERSION_V1: APP_NAME_V1,
+    SCHEMA_VERSION_V2: APP_NAME_V2,
+}
+
 _PYPI_NAME = "rigplane"
 _VERSION_FALLBACK = "0.0.0+unknown"
 _GIT_TIMEOUT_S = 2.0
@@ -74,8 +108,17 @@ class _Warning:
 
 
 class _Manifest:
-    def __init__(self, ctx: BundleContext) -> None:
+    def __init__(
+        self, ctx: BundleContext, *, schema_version: str = SCHEMA_VERSION
+    ) -> None:
+        if schema_version not in _SUPPORTED_SCHEMAS:
+            raise ValueError(
+                f"unsupported schema_version: {schema_version!r}; "
+                f"expected one of {sorted(_SUPPORTED_SCHEMAS)}"
+            )
         self._ctx = ctx
+        self._schema_version = schema_version
+        self._app_name = _APP_NAME_FOR_SCHEMA[schema_version]
         self._contributors: list[_ContributorRecord] = []
         self._warnings: list[_Warning] = []
 
@@ -97,13 +140,13 @@ class _Manifest:
 
     def to_dict(self) -> dict[str, Any]:
         ctx = self._ctx
-        app: dict[str, Any] = {"name": APP_NAME, "version": _read_version()}
+        app: dict[str, Any] = {"name": self._app_name, "version": _read_version()}
         build_id = _read_build_id()
         if build_id:
             app["build_id"] = build_id
 
         manifest: dict[str, Any] = {
-            "schema_version": SCHEMA_VERSION,
+            "schema_version": self._schema_version,
             "submission_id": ctx.submission_id,
             "generated_at_unix": ctx.generated_at_unix,
             "app": app,

--- a/src/rigplane/diagnostics/bundle.py
+++ b/src/rigplane/diagnostics/bundle.py
@@ -10,25 +10,35 @@ import zipfile
 from pathlib import Path
 
 from rigplane.diagnostics._discovery import discover
-from rigplane.diagnostics._manifest import _Manifest
+from rigplane.diagnostics._manifest import SCHEMA_VERSION, _Manifest
 from rigplane.diagnostics.contributor import BundleContext
 
 logger = logging.getLogger(__name__)
 
 
-def build_bundle(ctx: BundleContext, output_path: Path) -> Path:
+def build_bundle(
+    ctx: BundleContext,
+    output_path: Path,
+    *,
+    schema_version: str = SCHEMA_VERSION,
+) -> Path:
     """Collect contributions, assemble manifest, write a zip at ``output_path``.
 
     Per-contributor failures are isolated: a raising ``contribute()`` is logged
     to ``manifest.warnings`` and the bundle is still produced. Returns the
     absolute path of the created zip.
+
+    ``schema_version`` selects the wire contract. Defaults to the current
+    canonical format (``rigplane-bundle-v2``); pass
+    :data:`rigplane.diagnostics._manifest.SCHEMA_VERSION_V1` to emit the
+    legacy ``icom-lan-bundle-v1`` format for backwards-compatibility tests.
     """
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with tempfile.TemporaryDirectory() as staging:
         staging_dir = Path(staging)
-        manifest = _Manifest(ctx)
+        manifest = _Manifest(ctx, schema_version=schema_version)
 
         for contributor in discover():
             contributor_dir = staging_dir / contributor.name

--- a/src/rigplane/diagnostics/contributors/system.py
+++ b/src/rigplane/diagnostics/contributors/system.py
@@ -62,7 +62,7 @@ class SystemContributor:
             "arch": platform.machine() or "unknown",
             "python_version": platform.python_version(),
             "python_implementation": platform.python_implementation(),
-            "icom_lan_version": redact_paths(_get_version()),
+            "rigplane_version": redact_paths(_get_version()),
             "install_method": redact_paths(_detect_install_method()),
         }
         text = json.dumps(payload, indent=2, sort_keys=True)

--- a/tests/test_cli_diagnose.py
+++ b/tests/test_cli_diagnose.py
@@ -50,10 +50,10 @@ def _write_fake_bundle(path: Path, manifest: dict[str, Any] | None = None) -> Pa
         manifest
         if manifest is not None
         else {
-            "schema_version": "icom-lan-bundle-v1",
+            "schema_version": "rigplane-bundle-v2",
             "submission_id": "test-submission",
             "generated_at_unix": 1_700_000_000,
-            "app": {"name": "icom-lan", "version": "0.0.0"},
+            "app": {"name": "rigplane", "version": "0.0.0"},
         }
     )
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
@@ -209,7 +209,7 @@ class TestUploadNonTty:
         # Metadata payload (1st positional after bundle path) is the manifest.
         bundle_arg, metadata_arg = fake_upload.await_args.args
         assert bundle_arg == fake_build_bundle["output"]
-        assert metadata_arg["schema_version"] == "icom-lan-bundle-v1"
+        assert metadata_arg["schema_version"] == "rigplane-bundle-v2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_diagnostics_bundle.py
+++ b/tests/test_diagnostics_bundle.py
@@ -15,6 +15,10 @@ from rigplane.diagnostics import (
     register,
 )
 from rigplane.diagnostics import _discovery
+from rigplane.diagnostics._manifest import (
+    SCHEMA_VERSION_V1,
+    SCHEMA_VERSION_V2,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -217,7 +221,8 @@ def test_optional_fields_omitted_when_absent(tmp_path: Path) -> None:
     assert "user_description" not in manifest
     assert "issue_ref" not in manifest
     assert "contact" not in manifest
-    assert manifest["schema_version"] == "icom-lan-bundle-v1"
+    assert manifest["schema_version"] == "rigplane-bundle-v2"
+    assert manifest["app"]["name"] == "rigplane"
 
 
 def test_optional_fields_present_when_set(tmp_path: Path) -> None:
@@ -287,4 +292,76 @@ def test_partial_failure_cleans_up_partial_output(tmp_path: Path) -> None:
         names = zf.namelist()
     assert not any(n.startswith("flaky/") for n in names), (
         f"partial files leaked: {names}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema version selection (v1 / v2)
+# ---------------------------------------------------------------------------
+
+
+def test_default_schema_is_v2(tmp_path: Path) -> None:
+    """rigplane v2.0.0+ emits rigplane-bundle-v2 by default."""
+    register(_OkContributor)
+    output_path = tmp_path / "report.zip"
+    result = build_bundle(_make_ctx(), output_path)
+
+    manifest = _read_manifest(result)
+    assert manifest["schema_version"] == "rigplane-bundle-v2"
+    assert manifest["app"]["name"] == "rigplane"
+
+
+def test_explicit_v2_schema(tmp_path: Path) -> None:
+    """Passing schema_version=SCHEMA_VERSION_V2 yields the v2 wire shape."""
+    register(_OkContributor)
+    output_path = tmp_path / "report.zip"
+    result = build_bundle(_make_ctx(), output_path, schema_version=SCHEMA_VERSION_V2)
+
+    manifest = _read_manifest(result)
+    assert manifest["schema_version"] == "rigplane-bundle-v2"
+    assert manifest["app"]["name"] == "rigplane"
+
+
+def test_explicit_v1_schema_for_backwards_compat(tmp_path: Path) -> None:
+    """Legacy icom-lan-bundle-v1 emission is preserved as an opt-in.
+
+    Tower accepts both schemas during the deprecation window documented in
+    docs/contracts/diagnostic-bundle-v2.md; this test exists so the v1 code
+    path remains exercised.
+    """
+    register(_OkContributor)
+    output_path = tmp_path / "report.zip"
+    result = build_bundle(_make_ctx(), output_path, schema_version=SCHEMA_VERSION_V1)
+
+    manifest = _read_manifest(result)
+    assert manifest["schema_version"] == "icom-lan-bundle-v1"
+    assert manifest["app"]["name"] == "icom-lan"
+
+
+def test_unknown_schema_raises_value_error(tmp_path: Path) -> None:
+    """Unsupported schema_version values are rejected with ValueError."""
+    register(_OkContributor)
+    output_path = tmp_path / "report.zip"
+    with pytest.raises(ValueError, match="unsupported schema_version"):
+        build_bundle(_make_ctx(), output_path, schema_version="rigplane-bundle-v999")
+
+
+def test_app_name_is_locked_to_schema(tmp_path: Path) -> None:
+    """schema_version drives app.name — caller cannot mismatch the two."""
+    register(_OkContributor)
+
+    out_v1 = tmp_path / "v1.zip"
+    build_bundle(_make_ctx(), out_v1, schema_version=SCHEMA_VERSION_V1)
+    out_v2 = tmp_path / "v2.zip"
+    build_bundle(_make_ctx(), out_v2, schema_version=SCHEMA_VERSION_V2)
+
+    m1 = _read_manifest(out_v1)
+    m2 = _read_manifest(out_v2)
+    assert (m1["schema_version"], m1["app"]["name"]) == (
+        "icom-lan-bundle-v1",
+        "icom-lan",
+    )
+    assert (m2["schema_version"], m2["app"]["name"]) == (
+        "rigplane-bundle-v2",
+        "rigplane",
     )

--- a/tests/test_diagnostics_contributors_batch1.py
+++ b/tests/test_diagnostics_contributors_batch1.py
@@ -74,10 +74,12 @@ def test_system_writes_required_keys(tmp_path: Path) -> None:
         "arch",
         "python_version",
         "python_implementation",
-        "icom_lan_version",
+        "rigplane_version",
         "install_method",
     ):
         assert key in payload, f"missing key: {key}"
+    # The legacy v1 key was renamed; ensure the old name is gone.
+    assert "icom_lan_version" not in payload
     assert payload["os"] in {"darwin", "linux", "windows"} or isinstance(
         payload["os"], str
     )

--- a/tests/test_diagnostics_e2e.py
+++ b/tests/test_diagnostics_e2e.py
@@ -105,7 +105,7 @@ def bundle_file(tmp_path: Path) -> Path:
 def _metadata_for(submission_id: str | None = None) -> dict[str, Any]:
     """Mock-required metadata: schema_version + submission_id + generated_at_unix."""
     return {
-        "schema_version": "icom-lan-bundle-v1",
+        "schema_version": "rigplane-bundle-v2",
         "submission_id": submission_id or str(uuid.uuid4()),
         "generated_at_unix": int(time.time()),
     }
@@ -324,7 +324,7 @@ async def test_cli_diagnose_upload_against_mock_no_confirm(
     assert len(receiver.received) == 1
     rec = receiver.received[0]
     # CLI manifest must include the required fields.
-    assert rec["metadata"]["schema_version"] == "icom-lan-bundle-v1"
+    assert rec["metadata"]["schema_version"] == "rigplane-bundle-v2"
     assert "submission_id" in rec["metadata"]
 
 
@@ -479,7 +479,7 @@ async def test_web_diagnose_full_flow(
         # Mock confirmed receipt.
         assert len(receiver.received) == 1
         meta = receiver.received[0]["metadata"]
-        assert meta["schema_version"] == "icom-lan-bundle-v1"
+        assert meta["schema_version"] == "rigplane-bundle-v2"
         assert "submission_id" in meta
     finally:
         await srv._diagnostics.stop()

--- a/tests/test_diagnostics_privacy_invariants.py
+++ b/tests/test_diagnostics_privacy_invariants.py
@@ -271,10 +271,10 @@ def test_manifest_required_fields_no_nulls(tmp_path: Path) -> None:
     manifest = _read_manifest(result)
 
     # Required top-level fields, all non-empty.
-    assert manifest["schema_version"] == "icom-lan-bundle-v1"
+    assert manifest["schema_version"] == "rigplane-bundle-v2"
     assert manifest["submission_id"]
     assert manifest["generated_at_unix"]
-    assert manifest["app"]["name"] == "icom-lan"
+    assert manifest["app"]["name"] == "rigplane"
     assert manifest["app"]["version"]
     assert manifest["platform"]["os"]
     assert manifest["platform"]["arch"]

--- a/tests/test_web_diagnostics.py
+++ b/tests/test_web_diagnostics.py
@@ -225,7 +225,7 @@ async def test_preview_returns_csrf_and_manifest(
         # Distinct random strings.
         assert result["preview_id"] != result["csrf_token"]
         assert isinstance(result["manifest"], dict)
-        assert result["manifest"]["schema_version"] == "icom-lan-bundle-v1"
+        assert result["manifest"]["schema_version"] == "rigplane-bundle-v2"
         # Bundle is non-empty (manifest.json + contributor file).
         assert isinstance(result["files"], list) and len(result["files"]) >= 2
         assert all(


### PR DESCRIPTION
## Summary

Wave 2 **PR-2G'** of the icom-lan → rigplane rebrand. Introduces `rigplane-bundle-v2` as the canonical wire format for diagnostic-bundle uploads and switches the open-core producer to emit it by default. Legacy `icom-lan-bundle-v1` emission is preserved as an opt-in for backwards-compatibility tests.

CI grep gate from spec task 2.13 is split into a separate **PR-2H** so this PR stays focused on the schema-v2 producer changes.

## Changes

- **New contract doc** `docs/contracts/diagnostic-bundle-v2.md` (272 lines). Wire shape identical to v1 except for the rebrand-affected strings:
  - `schema_version`: `icom-lan-bundle-v1` → `rigplane-bundle-v2`
  - `metadata.app.name`: `icom-lan` → `rigplane`
  - `system.json` version key: `icom_lan_version` → `rigplane_version`
  - Endpoint env var: `ICOM_LAN_REPORT_ENDPOINT` → `RIGPLANE_REPORT_ENDPOINT`
  
  Tower keeps accepting v1 bundles for a 12-month deprecation window — server-side dual-parse change is Wave 5 (rigplane-tower repo).

- **`_Manifest` and `build_bundle()` gain `schema_version` keyword** (default `SCHEMA_VERSION_V2`). Schema choice drives `app.name` internally — a v2 manifest can never have `app.name="icom-lan"`. Unsupported values raise `ValueError`.

- **`system.json` now emits `rigplane_version`** (was `icom_lan_version`). Clean break for v2 (option A from spec).

## Test plan

- [x] `uv run pytest tests/ -q --ignore=tests/integration` — **5682 passed** (+5 new)
- [x] `uv run ruff check / format --check src/ tests/` — clean
- [x] `uv run mypy src/` — 0 issues
- [x] `uv run lint-imports` — 4 contracts kept
- [x] Bundle e2e: default has `schema_version="rigplane-bundle-v2"` + `app.name="rigplane"`
- [x] Backwards-compat: v1 emission has `schema_version="icom-lan-bundle-v1"` + `app.name="icom-lan"`
- [ ] `mkdocs --strict` — fails on **pre-existing** stale `icom_lan.*` mkdocstrings in `docs/api/*.md` (verified on `main@90437349` independently). **PR-2E (#1426) fixes this**; merging PR-2E first will resolve.

## Stats

```
10 files changed, 426 insertions(+), 22 deletions(-)
```
3 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)