### PR TITLE
rebrand(wave2): final grep CI gate + residual leak fixes (PR-2H)

### DIFF
--- a/.github/scripts/check-rebrand-allowlist.sh
+++ b/.github/scripts/check-rebrand-allowlist.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Wave 2 final grep gate: fail CI if any new icom-lan / icom_lan / IcomLanError
+# reference appears outside the allow-list of preserved-by-design files.
+#
+# Why this exists: the v2.0.0 rebrand from icom-lan -> rigplane (epic
+# docs/roadmap/2026-05-04-rigplane-rebrand-epic.md) intentionally PRESERVES a
+# small set of brand references — backwards-compat shims, wire contracts (v1
+# diagnostic-bundle, LAN discovery magic, local-extensions deprecation
+# alias), platformdirs / localStorage migration logic, and a vendor-protocol
+# diagram label parallel to IcomSerial / YaesuCAT. Everything else must be
+# rebranded. This gate codifies that distinction.
+#
+# To add a new exception: append the path to ALLOWLIST below with a comment
+# explaining WHY the reference is intentional. Anything NOT on the list that
+# matches the pattern fails CI.
+#
+# Usage: run from the repository root with no arguments.
+
+set -euo pipefail
+
+ALLOWLIST=(
+    # Shim package (PR-2B) — re-exports rigplane with DeprecationWarning.
+    'src/icom_lan/'
+    # PR-2C: persistent-state migration logic.
+    'src/rigplane/_platformdirs_migration.py'
+    'frontend/src/lib/migrate-legacy-storage.ts'
+    'frontend/src/lib/__tests__/migrate-legacy-storage.test.ts'
+    # Wire contracts (handled per spec — schema v2 in PR-2G; LAN discovery
+    # magic stays for backwards-compat with v1 clients until Wave 4).
+    'src/rigplane/diagnostics/_manifest.py'
+    'src/rigplane/diagnostics/bundle.py'
+    'src/rigplane/web/discovery.py'
+    'docs/contracts/diagnostic-bundle-v1.md'
+    'docs/contracts/diagnostic-bundle-v2.md'
+    # Local-extensions deprecation alias (cross-repo Pro contract).
+    'frontend/src/lib/local-extensions/host-api.ts'
+    'frontend/src/lib/local-extensions/__tests__/host-api.test.ts'
+    'frontend/src/lib/api/diagnostics.ts'
+    'frontend/src/lib/api/__tests__/diagnostics.test.ts'
+    # Vendor-protocol diagram label (parallel to IcomSerial / YaesuCAT —
+    # NOT a product brand reference; describes the transport family).
+    'src/rigplane/core/radio_protocol.py'
+    'docs/radio-protocol.md'
+    # Intentional historical / migration references.
+    'README.md'
+    'docs/CHANGELOG.md'
+    'tests/golden/wsjtx_dual_rx_session.txt'
+    # pyproject.toml — preserved console-script alias `icom-lan` (line 43),
+    # hatch packages list keeping `src/icom_lan` shim, ruff per-file-ignores
+    # for the shim, and mypy override for the shim module.
+    'pyproject.toml'
+    # Pre-rebrand and historical plans.
+    'docs/plans/discovery-artifacts/'
+    'docs/plans/archive/'
+    'docs/plans/2026-03-'
+    'docs/plans/2026-04-'
+    'docs/plans/2026-05-01-'
+    'docs/plans/2026-05-02-'
+    'docs/plans/2026-05-03-'
+    # Tests of preserved / migration code.
+    'tests/test_icom_lan_shim.py'
+    'tests/test_platformdirs_migration.py'
+    'tests/test_diagnostics_bundle.py'                # asserts SCHEMA_VERSION_V1 backwards-compat
+    'tests/test_diagnostics_contributors_batch1.py'   # asserts v1 system.json key absence
+    'tests/test_discovery_responder.py'               # tests wire magic
+    'tests/test_backend_factory.py'                   # cosmetic test fn name (PR-2A)
+    'tests/test_diagnostics_logging.py'               # cosmetic test fn name
+    # This script itself: contains literal pattern in its grep regex and
+    # docstring.
+    '.github/scripts/check-rebrand-allowlist.sh'
+    # Workflow definition for the gate: references the pattern in its
+    # job description.
+    '.github/workflows/rebrand-gate.yml'
+)
+
+# Collect all files matching brand pattern.
+MATCHES=$(git grep -lEi 'icom[-_]?lan|IcomLanError' || true)
+
+LEAKS=""
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    SKIP=false
+    for allowed in "${ALLOWLIST[@]}"; do
+        case "$file" in
+            "$allowed"*)
+                SKIP=true
+                break
+                ;;
+        esac
+    done
+    if [ "$SKIP" = false ]; then
+        LEAKS="${LEAKS}${file}"$'\n'
+    fi
+done <<EOF
+$MATCHES
+EOF
+
+if [ -n "$(printf '%s' "$LEAKS" | tr -d '[:space:]')" ]; then
+    {
+        echo "::error::Wave 2 rebrand leak — files contain icom-lan / icom_lan / IcomLanError but are not in the allow-list:"
+        printf '%s' "$LEAKS"
+        echo ""
+        echo "Either:"
+        echo "  1. Rename the brand reference (preferred)."
+        echo "  2. If the reference is intentional (wire contract / migration / historical), add the"
+        echo "     path to the ALLOWLIST in .github/scripts/check-rebrand-allowlist.sh with a comment"
+        echo "     explaining why."
+    } >&2
+    exit 1
+fi
+
+echo "Wave 2 rebrand grep gate: clean."

--- a/.github/workflows/rebrand-gate.yml
+++ b/.github/workflows/rebrand-gate.yml
@@ -1,0 +1,31 @@
+name: Rebrand grep gate
+
+# Wave 2 final gate: fail any push or PR that introduces an `icom-lan` /
+# `icom_lan` / `IcomLanError` reference outside the preserved-by-design
+# allow-list. See .github/scripts/check-rebrand-allowlist.sh for the
+# rationale and the allow-list.
+#
+# Runs on EVERY push and PR (no path filter) so doc-only / rig-only / script-
+# only changes still trigger it. The job is sub-second (single git grep +
+# bash filter), so this is cheap.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: rebrand-gate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  grep-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wave 2 rebrand grep gate
+        run: .github/scripts/check-rebrand-allowlist.sh

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ mockups/
 
 # Scripts (internal dev tools)
 scripts/
+# But CI scripts under .github/ are tracked.
+!.github/scripts/
 
 # Local RAG / AI tooling
 .rag-update.sh

--- a/docs/architecture/open-core-policy.md
+++ b/docs/architecture/open-core-policy.md
@@ -84,7 +84,7 @@ A diagnostic report mechanism in open-core must satisfy **all** of these:
 - **Headless / non-TTY mode never prompts and never auto-uploads.** Scripted
   use must explicitly pass `--upload` to send.
 - **Destination endpoint is visible before upload.** The full URL (including
-  any `ICOM_LAN_REPORT_ENDPOINT` override) appears in the preview shown to
+  any `RIGPLANE_REPORT_ENDPOINT` override) appears in the preview shown to
   the user.
 - **Bundle is always available locally.** The user can always choose "save
   locally" instead of uploading; the ZIP file is the same.

--- a/docs/guide/diagnostic-reports.md
+++ b/docs/guide/diagnostic-reports.md
@@ -163,11 +163,11 @@ uploads are unauthenticated, IP rate-limited, and retained for **90
 days** before automatic deletion.
 
 You can redirect to a different host (self-hosting, audit, or a private
-support contract) with the `ICOM_LAN_REPORT_ENDPOINT` environment
+support contract) with the `RIGPLANE_REPORT_ENDPOINT` environment
 variable:
 
 ```bash
-export ICOM_LAN_REPORT_ENDPOINT=https://reports.example.com/v1/diagnostics/upload
+export RIGPLANE_REPORT_ENDPOINT=https://reports.example.com/v1/diagnostics/upload
 rigplane diagnose --upload
 ```
 
@@ -254,7 +254,7 @@ mkdir -p ~/.cache/rigplane/logs
 chmod 700 ~/.cache/rigplane/logs
 ```
 
-You can also set `ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING=1` to disable
+You can also set `RIGPLANE_DISABLE_DIAGNOSTIC_LOGGING=1` to disable
 the file logger explicitly (used by the test suite).
 
 ### Rate-limited (429)
@@ -334,7 +334,7 @@ rigplane diagnose
 | `--issue-ref`    | interactive prompt                      | Optional GitHub URL or issue number for context.                   |
 | `--email`        | not collected                           | Opt-in. If set, the maintainer can reach you about the report.     |
 | `--callsign`     | not collected                           | Opt-in. Helps if your radio behaviour is callsign-specific.        |
-| `--endpoint`     | `$ICOM_LAN_REPORT_ENDPOINT` or default  | Override the upload destination (self-hosting / audit / dev).      |
+| `--endpoint`     | `$RIGPLANE_REPORT_ENDPOINT` or default  | Override the upload destination (self-hosting / audit / dev).      |
 | `--no-confirm`   | absent (interactive)                    | Skip the consent prompt. Required for headless `--upload`.         |
 | `--bundle-id`    | new UUID v4                             | Reuse a previous submission ID for retry / dedup on the receiver.  |
 

--- a/frontend/src/lib/__tests__/migrate-legacy-storage.test.ts
+++ b/frontend/src/lib/__tests__/migrate-legacy-storage.test.ts
@@ -64,6 +64,18 @@ describe('migrateLegacyStorage', () => {
     expect(localStorageMock.getItem('icom-lan:vfo-theme')).toBeNull();
   });
 
+  it('migrates dot-namespaced tuning-step keys to their rigplane counterparts', () => {
+    localStorageMock.setItem('icom-lan.tuning-step-hz', '5000');
+    localStorageMock.setItem('icom-lan.tuning-step-auto', 'false');
+
+    migrateLegacyStorage();
+
+    expect(localStorageMock.getItem('rigplane.tuning-step-hz')).toBe('5000');
+    expect(localStorageMock.getItem('rigplane.tuning-step-auto')).toBe('false');
+    expect(localStorageMock.getItem('icom-lan.tuning-step-hz')).toBeNull();
+    expect(localStorageMock.getItem('icom-lan.tuning-step-auto')).toBeNull();
+  });
+
   it('migrates the dock-layout key with the v1 suffix preserved', () => {
     const payload = JSON.stringify({ version: 1, extensions: {} });
     localStorageMock.setItem('icom-lan:local-extension-dock-layout:v1', payload);

--- a/frontend/src/lib/local-extensions/__tests__/dock-layout.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/dock-layout.test.ts
@@ -53,7 +53,7 @@ describe('local extension dock layout', () => {
     });
   });
 
-  it('persists validated layout under the icom-lan key', () => {
+  it('persists validated layout under the rigplane storage key', () => {
     const backing = new Map<string, string>();
     const storage = memoryStorage(backing);
     const state = setLocalExtensionDockMode(loadLocalExtensionDockLayout(storage), 'meter', 'dock-bottom');

--- a/frontend/src/lib/migrate-legacy-storage.ts
+++ b/frontend/src/lib/migrate-legacy-storage.ts
@@ -43,6 +43,10 @@ const LEGACY_TO_NEW: Record<string, string> = {
   'icom-lan:vfo-theme': 'rigplane:vfo-theme',
   'icom-lan:lcd-contrast': 'rigplane:lcd-contrast',
   'icom-lan:local-extension-dock-layout:v1': 'rigplane:local-extension-dock-layout:v1',
+  // Dot-namespaced (tuning store) — produced by `frontend/src/lib/stores/tuning.svelte.ts`
+  // up to v1.x. Renamed to `rigplane.tuning-step-*` in v2.
+  'icom-lan.tuning-step-hz': 'rigplane.tuning-step-hz',
+  'icom-lan.tuning-step-auto': 'rigplane.tuning-step-auto',
 };
 
 const MIGRATION_SENTINEL_KEY = 'rigplane:storage-migrated-from-icom-lan';

--- a/frontend/src/lib/stores/tuning.svelte.ts
+++ b/frontend/src/lib/stores/tuning.svelte.ts
@@ -5,8 +5,8 @@ import { radio } from './radio.svelte';
 /** Available tuning steps in Hz */
 export const TUNING_STEPS = [10, 50, 100, 250, 500, 1_000, 5_000, 10_000, 25_000, 100_000] as const;
 
-const STORAGE_STEP_KEY = 'icom-lan.tuning-step-hz';
-const STORAGE_AUTO_KEY = 'icom-lan.tuning-step-auto';
+const STORAGE_STEP_KEY = 'rigplane.tuning-step-hz';
+const STORAGE_AUTO_KEY = 'rigplane.tuning-step-auto';
 
 /** Mode-based default steps */
 const MODE_DEFAULTS: Record<string, number> = {

--- a/frontend/tests/e2e/v2-ui-interactive.impl.ts
+++ b/frontend/tests/e2e/v2-ui-interactive.impl.ts
@@ -3,7 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const PAGE_URL = process.env.ICOM_LAN_V2_URL ?? 'http://192.168.55.152:8080?ui=v2';
+const PAGE_URL = process.env.RIGPLANE_V2_URL ?? 'http://192.168.55.152:8080?ui=v2';
 const PAGE_ORIGIN = new URL(PAGE_URL).origin;
 const STATE_URL = `${PAGE_ORIGIN}/api/v1/state`;
 const CAPABILITIES_URL = `${PAGE_ORIGIN}/api/v1/capabilities`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ icom-lan = "icom_lan._cli_shim:main"
 [project.optional-dependencies]
 # `audio` and `bridge` extras are kept as no-op aliases for backwards
 # compatibility — `opuslib`, `sounddevice`, and `numpy` are now part of
-# the core dependencies (#1090). New users should run `pip install icom-lan`.
+# the core dependencies (#1090). New users should run `pip install rigplane`.
 audio = []
 bridge = []
 scope = [

--- a/rigs/examples/sdrplay_rspdx.toml
+++ b/rigs/examples/sdrplay_rspdx.toml
@@ -10,7 +10,7 @@
 # abstract commands to SDRplay API calls.
 #
 # Integration approach: SoapySDR abstraction layer, or direct API.
-# For icom-lan: would need a separate backend module (sdrplay_backend.py)
+# For rigplane: would need a separate backend module (sdrplay_backend.py)
 # that implements the same Radio Protocol interface.
 
 # ═══ Layer 0: PROTOCOL ═══════════════════════════════════════════

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -442,7 +442,7 @@ routes = [
 #
 # Legend:
 #   # NOT_IMPLEMENTED — command known from CI-V ref but not yet
-#                       handled by the icom-lan backend
+#                       handled by the rigplane backend
 
 [commands]
 


### PR DESCRIPTION
## Summary

Closes **Wave 2** of the icom-lan → rigplane rebrand. Three concerns:

1. **PR-2C gap fix** — `frontend/src/lib/stores/tuning.svelte.ts` wrote dot-namespaced keys (`icom-lan.tuning-step-hz`, `icom-lan.tuning-step-auto`) which PR-2C's migration map (colon + hyphen patterns only) didn't catch. Renamed keys to `rigplane.tuning-step-*`, extended `LEGACY_TO_NEW`, added regression test.
2. **Residual brand-ref leaks** — 5 leaks the earlier Wave 2 PRs missed (see below).
3. **CI grep gate** — fails build if any new `icom-lan` / `icom_lan` / `IcomLanError` reference appears outside the explicit allow-list. Prevents future regressions.

This is task 2.13 from `docs/roadmap/2026-05-04-rigplane-rebrand-epic.md`.

## Leak fixes (commit 2)

| File | Fix |
|---|---|
| `docs/architecture/open-core-policy.md` | `ICOM_LAN_REPORT_ENDPOINT` → `RIGPLANE_REPORT_ENDPOINT` |
| `docs/guide/diagnostic-reports.md` | 4 occurrences of stale `ICOM_LAN_*` env vars renamed |
| `rigs/ic7610.toml` | "icom-lan backend" → "rigplane backend" |
| `rigs/examples/sdrplay_rspdx.toml` | "For icom-lan:" → "For rigplane:" |
| `frontend/tests/e2e/v2-ui-interactive.impl.ts` | `ICOM_LAN_V2_URL` → `RIGPLANE_V2_URL` env var |
| `frontend/src/lib/local-extensions/__tests__/dock-layout.test.ts` | stale test title (key already migrated in PR-2C) |
| `pyproject.toml` | stale `pip install icom-lan` comment line |

## CI grep gate (commit 3)

- Script: `.github/scripts/check-rebrand-allowlist.sh` (~110 lines, sub-second runtime)
- Workflow: `.github/workflows/rebrand-gate.yml` — **dedicated workflow with no path filter** (intentional — `quick.yml`'s path filter would silently skip the gate for docs-only or rigs-only PRs, exactly the regressions most likely to slip in)
- `.gitignore` updated with `!.github/scripts/` negation (the generic `scripts/` rule was hiding it)

### Allow-list rationale

The gate fails on any brand reference outside paths that legitimately contain `icom-lan` strings by design: shim package, wire contracts, migration logic, vendor-protocol diagram label, historical plans, tests of preserved code. Each entry has an inline comment.

## Audit table — every brand-ref file on main classified

| Category | Count |
|---|---|
| PRESERVED (preserved-by-design references — wire contracts, shim, migration, historical) | 26 |
| LEAK-FIXED in this PR | 7 |
| Total brand-ref files on main | 33 |

Full table in subagent report; abbreviated for readability.

## Test plan

- [x] `.github/scripts/check-rebrand-allowlist.sh` — clean (exit 0)
- [x] `uv run pytest tests/ -q --ignore=tests/integration` → **5682 passed**
- [x] `uv run ruff check src/ tests/` → All checks passed
- [x] `uv run ruff format --check src/ tests/` → 442 files already formatted
- [x] `uv run mypy src/` → 0 issues, 230 files
- [x] `uv run lint-imports` → 4 contracts kept, 0 broken
- [x] `npx vitest run` → **1727 passed** in 95 files
- [x] `npm run build` → succeeds (4055 modules, 2.68s)

## Notable

- **No wire contracts changed** — v1 diagnostic bundle, LAN discovery magic, local-extensions deprecation alias, shim re-exports — all intact.
- The `IcomLAN` ASCII-diagram label (parallel to `IcomSerial` / `YaesuCAT`) in `docs/radio-protocol.md` + `src/rigplane/core/radio_protocol.py` stays as-is — it's a transport-family identifier, not product brand.
- Adding new allow-list exceptions: append path + comment to `ALLOWLIST` in `.github/scripts/check-rebrand-allowlist.sh`.

## Stats

```
13 files changed, 173 insertions(+), 12 deletions(-)
```
3 commits, branch `feat/rebrand/wave2-grep-gate`.

## After merge: Wave 2 ✅ closed

Next: Wave 3 (open-core release — tag v2.0.0, PyPI publish, icom-lan tombstone repo, sunset notice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)