### PR TITLE
chore(release): bump to 2.0.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] — 2026-05-06
+
+### Fixed
+- LAN TX audio bridge: fix audio not flowing in transmit direction (#1434, ba364e54)
+
 ## [2.0.0] — 2026-05-05
 
 **Headline:** project renamed from `icom-lan` to **`rigplane`**. The old name was always misleading — the project shipped multi-vendor support (Icom CI-V, Yaesu CAT, Discovery TX-500, Xiegu X6200) over LAN, USB, and serial. Carrying "icom-lan" through a paid Pro tier also created a trademark risk on a vendor name we don't own. New brand at https://rigplane.dev.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.0.0"
+version = "2.0.1"
 description = "Python library for controlling Icom transceivers over LAN (UDP) — no wfview/hamlib required"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch release for the LAN TX audio bridge fix (#1434).

## Changes
- pyproject.toml: 2.0.0 → 2.0.1
- docs/CHANGELOG.md: [Unreleased] populated → [2.0.1] - 2026-05-06

## Test plan
- [ ] CI green (existing test suite covers the LAN TX path)
- [ ] After merge: tag v2.0.1 → publish.yml triggers → PyPI rigplane-2.0.1 released