### PR TITLE
fix(frontend): close pre-existing Wave 2 rebrand leak in e2e

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@playwright/test';
 
-const liveTarget = process.env.RIGPLANE_V2_URL ?? process.env.ICOM_LAN_V2_URL;
+const liveTarget = process.env.RIGPLANE_V2_URL;
 
 export default defineConfig({
   testDir: '../tests/e2e',

--- a/frontend/tests/e2e/v2-ui-interactive.impl.ts
+++ b/frontend/tests/e2e/v2-ui-interactive.impl.ts
@@ -3,7 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const PAGE_URL = process.env.RIGPLANE_V2_URL ?? process.env.ICOM_LAN_V2_URL;
+const PAGE_URL = process.env.RIGPLANE_V2_URL;
 const PAGE_ORIGIN = PAGE_URL ? new URL(PAGE_URL).origin : 'http://127.0.0.1:8080';
 const STATE_URL = `${PAGE_ORIGIN}/api/v1/state`;
 const CAPABILITIES_URL = `${PAGE_ORIGIN}/api/v1/capabilities`;


### PR DESCRIPTION
## Summary

Two frontend e2e files (`playwright.config.ts` + `v2-ui-interactive.impl.ts`) have been failing the Wave 2 rebrand grep-gate on every PR since commit `ba364e54`. That commit (\"Fix LAN TX audio bridge\") introduced `ICOM_LAN_V2_URL` as a backwards-compat env-var fallback — after the grep gate was already in place — without adding the paths to the allowlist.

## What changed

- **`frontend/playwright.config.ts`** — removed `?? process.env.ICOM_LAN_V2_URL` fallback; `RIGPLANE_V2_URL` is the canonical env var
- **`frontend/tests/e2e/v2-ui-interactive.impl.ts`** — same one-line removal

No allowlist entries needed: `ICOM_LAN_V2_URL` is not referenced in CI workflows, documentation, or scripts — it was a developer convenience that predates the rebrand and has no reason to persist.

## Why not allowlist?

The fallback is not a wire contract, migration path, or shim test — it's a developer-local env var alias. Dropping it is cleaner than allowlisting it. Anyone who previously set `ICOM_LAN_V2_URL` can rename it to `RIGPLANE_V2_URL`.

## Test plan

- [x] `bash .github/scripts/check-rebrand-allowlist.sh` — exits 0
- [x] `npx vitest run` — 1727 tests passed (95 files)
- [x] `npx playwright test --list` — config parses, 1 test listed
- [x] `npm run check` — 0 errors, 14 pre-existing warnings