### PR TITLE
fix(audio): route WSJT-X LAN TX as PCM DATA2

### DIFF
--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -144,17 +144,18 @@ limit is undocumented but observed empirically and matches the wfview source:
 // wfview: audio.data.mid(len, 1364)
 ```
 
-`push_tx()` (and the high-level `push_audio_tx_pcm()`) automatically chunk oversized payloads:
+`push_tx()` automatically chunks oversized payloads:
 
 ```
-push_audio_tx_pcm(pcm_frame)  # 1920-byte 20ms PCM frame @ 48kHz/16-bit
+push_tx(pcm_frame)  # 1920-byte 20ms PCM frame @ 48kHz/16-bit
   → chunk 0: bytes [0 : 1364]    → 1364-byte UDP payload  ✓
   → chunk 1: bytes [1364 : 1920] →  556-byte UDP payload  ✓
 ```
 
 The two chunk sizes — 1364 and 556 bytes — correspond to the fixed audio payload sizes
-documented in wfview for the IC-7610. Callers do not need to pre-chunk frames; any frame size
-is accepted.
+documented in wfview for the IC-7610. Low-level callers do not need to pre-chunk payloads.
+The high-level `push_audio_tx_pcm()` API still requires one complete PCM frame at the
+configured sample rate, channel count, and frame duration.
 
 ## Usage
 
@@ -204,9 +205,14 @@ async with create_radio(config) as radio:
 config = LanBackendConfig(host="192.168.1.100", username="u", password="p")
 async with create_radio(config) as radio:
     await radio.start_audio_tx_opus()
-    await radio.push_audio_tx_opus(opus_frame)
+    await radio.push_audio_tx_opus(audio_payload)
     await radio.stop_audio_tx_opus()
 ```
+
+The low-level method names are historical. For direct Icom LAN sessions,
+rigplane currently negotiates TX as `PCM_1CH_16BIT`, so the TX payload sent to
+the radio is raw PCM16LE. Opus TX payloads are only valid for endpoints that
+negotiate an Opus TX codec, such as wfview-compatible server paths.
 
 ### TX Audio (high-level PCM)
 
@@ -294,5 +300,6 @@ For RX PCM, migrate callback-side decoding to the built-in API:
 
 For TX PCM, migrate manual Opus encoding to the built-in API:
 
-- Before: encode PCM to Opus yourself, then `push_audio_tx_opus()`.
+- Before: manually prepare the low-level negotiated-codec payload and call
+  `push_audio_tx_opus()`.
 - Now: `start_audio_tx_pcm()` and `push_audio_tx_pcm()` with fixed-size PCM frames.

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -47,7 +47,7 @@ async with create_radio(config) as radio:
 | `vfo` | `str \| None` | `None` | Select VFO: `"A"` or `"B"` |
 | `data_mode` | `bool \| None` | `None` | `True` = enable DATA mode, `False` = disable |
 | `data_off_mod_input` | `int \| None` | `None` | DATA-OFF modulation input source index |
-| `data1_mod_input` | `int \| None` | `None` | DATA-1 modulation input source index |
+| `data1_mod_input` | `int \| None` | `None` | DATA-1 modulation input source index. Captured for compatibility; apply/restore do not rewrite it because DATA1 is user-owned. |
 | `squelch_level` | `int \| None` | `None` | Squelch level (0 = open) |
 | `equalize_vfo` | `bool` | `False` | Copy active VFO to both VFOs |
 | `scope_enabled` | `bool \| None` | `None` | `True` = enable spectrum scope |

--- a/docs/guide/wsjtx-setup.md
+++ b/docs/guide/wsjtx-setup.md
@@ -97,6 +97,18 @@ When a CAT client connects for the first time:
 - This eliminates a known first-TX latency when WSJT-X switches
   from plain SSB to packet mode (PKTUSB).
 
+When `--wsjtx-compat` is used with a direct Icom LAN radio connection on a
+radio profile with multiple DATA sub-modes such as the IC-7610, rigplane treats
+WSJT-X packet-mode requests as LAN audio operation:
+
+- `PKTUSB`, `PKTLSB`, and `PKTRTTY` are mapped to DATA2 instead of DATA1.
+- DATA2 modulation input is set to LAN.
+- DATA1 modulation input is not changed.
+
+For USB/serial radio connections, including cases where rigplane bridges local
+USB audio devices for remote use, the compatibility mapping remains the legacy
+DATA1 behavior.
+
 ### When to use it
 
 - **Use** `--wsjtx-compat` if you run WSJT-X, JTDX, or JS8Call
@@ -106,8 +118,10 @@ When a CAT client connects for the first time:
 
 ### What it changes on the radio
 
-Only the DATA mode flag (CI-V `0x1A 0x06`). It does **not** change
-frequency, power, filter, or any other setting.
+In USB/serial CAT operation, only the DATA mode flag (CI-V `0x1A 0x06`) is
+changed. In direct Icom LAN operation on multi-DATA radios, rigplane may also
+set the selected LAN DATA sub-mode's modulation input to LAN. DATA1 is treated
+as user-owned and is not rewritten by prewarm, profile apply, or state restore.
 
 ## Known Behavior
 

--- a/docs/plans/2026-05-07-audio-route-resolver-design.md
+++ b/docs/plans/2026-05-07-audio-route-resolver-design.md
@@ -1,0 +1,120 @@
+# Audio Route Resolver Design
+
+**Date:** 2026-05-07
+**Status:** design
+**Scope:** rigplane-core route contract, with rigplane-pro integration notes
+
+## Problem
+
+`--bridge` is an implementation mechanism, not enough information to decide how
+CAT packet modes should be mapped on the radio.
+
+Two valid setups both use a bridge but need different radio policies:
+
+- Direct Icom LAN radio: TX audio is streamed to the radio over the Icom LAN
+  audio session. WSJT-X packet modes should use DATA2 with DATA2 MOD input LAN
+  on multi-DATA radios such as the IC-7610.
+- USB/serial radio with local or remote audio bridge: TX audio reaches the radio
+  through the radio's USB audio device or another local input. WSJT-X packet
+  modes should keep the legacy DATA1 behavior, usually with DATA1 MOD input USB.
+
+The route decision must therefore come from the actual radio transport and audio
+capabilities, not from whether a local loopback bridge is enabled.
+
+## Design Principle
+
+`bridge` means "local audio loopback mechanism".
+
+`audio route` means "source of truth for radio audio and DATA-mode policy".
+
+DATA2/LAN is only valid when TX audio really enters the radio over direct Icom
+LAN audio. DATA1 remains user-owned unless a future explicit USB route policy
+chooses to manage DATA1 MOD input.
+
+## Core Route Model
+
+Add a small route model in core:
+
+```python
+@dataclass(frozen=True)
+class AudioRoute:
+    radio_transport: Literal["lan", "serial", "remote"]
+    tx_audio_source: Literal["lan", "usb", "acc", "unavailable"]
+    rx_audio_source: Literal["lan", "usb", "acc", "unavailable"]
+    data_mode_policy: Literal["data2_lan", "data1_usb", "legacy"]
+    bridge_required: bool
+```
+
+Initial policy mapping:
+
+| Condition | Route | DATA policy |
+| --- | --- | --- |
+| direct Icom LAN backend, native LAN audio, multi-DATA radio | `tx_audio_source="lan"` | `data2_lan` |
+| direct Icom LAN backend, single-DATA radio | `tx_audio_source="lan"` | `legacy` |
+| Icom serial/USB backend with local USB audio bridge | `tx_audio_source="usb"` | `data1_usb` or legacy DATA1 |
+| remote/pro server | declared by server capabilities | route decided from server declaration |
+| no usable audio route | `tx_audio_source="unavailable"` | no automatic DATA source changes |
+
+## Core Responsibilities
+
+Core should:
+
+- expose backend identity and audio capabilities in a machine-readable form;
+- resolve `AudioRoute` from the active radio/backend/profile;
+- derive `RigctldConfig.wsjtx_data_mode` and `wsjtx_data_mod_input` from
+  `AudioRoute.data_mode_policy`;
+- keep `push_audio_tx_pcm()` aligned with the negotiated TX codec, not method
+  names such as `push_audio_tx_opus`;
+- avoid automatic DATA1 MOD writes in prewarm, profile apply, and state restore.
+
+Core should not:
+
+- treat `--bridge` as proof of LAN audio;
+- infer USB vs LAN from a virtual audio device name;
+- make proprietary product decisions about always-on bridge UX.
+
+## Pro Responsibilities
+
+Pro should start with `audio_route=auto` by default:
+
+1. connect to the radio or remote server;
+2. read backend/capability information;
+3. resolve the audio route;
+4. start the required LAN session, USB bridge, virtual device, or remote bridge;
+5. configure embedded rigctld from the route policy;
+6. show a user-facing route status such as:
+   - `Audio: LAN direct`
+   - `Audio: USB via local bridge`
+   - `Audio: USB via remote server`
+   - `Audio unavailable: <reason>`
+
+Pro should preserve explicit override controls for support and debugging, but
+the default commercial experience should not require the user to know whether to
+pass `--bridge`.
+
+## Testing Strategy
+
+Core tests should cover:
+
+- direct LAN route resolves to DATA2/LAN on multi-DATA profiles;
+- direct LAN route falls back on single-DATA profiles;
+- serial/USB route with bridge does not select DATA2/LAN;
+- rigctld packet mode mapping follows route-derived config;
+- profile apply and restore never rewrite DATA1 MOD automatically;
+- codec contract sends PCM as raw PCM when negotiated TX codec is PCM.
+
+Pro tests should cover:
+
+- startup auto-routes direct LAN, serial/USB, and remote server scenarios;
+- bridge lifecycle follows the resolved route, not user-visible flags;
+- diagnostics and UI expose the selected route and failure reason;
+- explicit overrides can force or disable bridge behavior for support cases.
+
+## Migration Plan
+
+1. Keep the current backend-based guard as a short-term safety patch.
+2. Add `AudioRoute` and a resolver in core.
+3. Replace direct `backend_id` checks in CLI/rigctld wiring with route-derived
+   policy.
+4. Expose route information through diagnostics/status APIs.
+5. Update pro to default to auto route and consume the core resolver/status.

--- a/docs/plans/issue-drafts/2026-05-07-core-audio-pipeline-test-harness.md
+++ b/docs/plans/issue-drafts/2026-05-07-core-audio-pipeline-test-harness.md
@@ -1,0 +1,98 @@
+# Core Issue Draft: Build automated audio pipeline harness for WSJT-X/LAN/USB routing
+
+## Context
+
+Debugging the IC-7610 TX audio bridge required repeated manual steps across
+machines: start rigplane, start WSJT-X, press Tune, listen locally, watch the
+radio waterfall, inspect logs, and infer whether the failure was PortAudio,
+bridge capture, codec negotiation, rigctld packet mode, DATA source selection,
+or LAN audio TX payload format.
+
+That workflow is too slow and too fragile for future audio work. We need an
+automated harness that exercises the whole pipeline with synthetic audio and
+observable sinks.
+
+Related route-policy issue: rigplane/rigplane-core#1446.
+
+## Goal
+
+Create a layered audio pipeline test harness that can run without a human
+pressing WSJT-X Tune, while still allowing optional hardware-assisted validation
+against real radios.
+
+## Proposed Test Layers
+
+### Layer 1: Pure in-process pipeline
+
+- Synthetic PCM source, e.g. 1 kHz tone frames.
+- Fake bridge input/output devices.
+- Fake radio audio sink that records pushed TX payloads.
+- Assertions:
+  - non-zero peak/RMS reaches bridge TX capture path;
+  - expected frame count and continuity;
+  - PCM TX stays raw PCM when negotiated codec is `PCM_1CH_16BIT`;
+  - Opus encode is used only when negotiated TX codec is Opus;
+  - no silence is introduced by downmix/resampling/chunking.
+
+### Layer 2: rigctld + bridge integration
+
+- Run embedded rigctld against fake radio/backend.
+- Replay WSJT-X-like rigctl commands: `M PKTUSB`, `T 1`, `T 0`.
+- Feed synthetic audio during the TX window.
+- Assertions:
+  - PTT transitions occur;
+  - packet mode maps to the route-derived DATA policy;
+  - DATA1 MOD is not touched automatically;
+  - TX audio payload continues for the whole TX window.
+
+### Layer 3: OS audio backend smoke
+
+- Use PortAudio/sounddevice with a deterministic local virtual device when
+  available, or a fake backend in CI.
+- Feed synthetic tone into the configured TX device.
+- Capture through the same backend path used by `AudioBridge`.
+- Assertions:
+  - device selection uses the requested RX/TX devices;
+  - capture is non-zero under the same process/env as rigplane;
+  - no regression to all-zero capture when RX output is also open.
+
+### Layer 4: hardware-assisted validation
+
+- Optional test profile for real IC-7610 LAN at a configured host.
+- No WSJT-X UI dependency: drive rigctld commands and synthetic audio directly.
+- Capture logs and radio-side ACK/state where possible.
+- Assertions:
+  - route policy selects DATA2/LAN for direct LAN multi-DATA radio;
+  - raw PCM TX produces continuous radio TX audio symptoms;
+  - no broad intermittent burst pattern from Opus-as-PCM mismatch.
+
+## Requirements
+
+- Tests must run through `uv`.
+- CI-safe layers must not require radio hardware, microphone permissions, or
+  BlackHole/VB-Cable.
+- Hardware/OS layers must be opt-in through environment variables and skip with
+  clear reasons.
+- The harness must produce compact diagnostics: route, codec, frame count, RMS,
+  peak, drops, selected devices, and rigctld DATA policy.
+- The harness must not depend on the WSJT-X GUI. WSJT-X behavior should be
+  represented by rigctl command replay and synthetic audio generation.
+
+## Acceptance Criteria
+
+- A developer can run one command to validate the in-process TX audio pipeline.
+- A developer can run one command to validate rigctld packet-mode + TX audio
+  bridge behavior without a radio.
+- Optional OS/hardware tests are documented and skipped unless explicitly
+  enabled.
+- The previous IC-7610 failure modes would have been caught by automated tests:
+  - PCM negotiated but Opus bytes sent;
+  - DATA1 selected for direct LAN WSJT-X bridge;
+  - DATA1 MOD rewritten by profile apply/restore;
+  - PortAudio bridge TX capture reads all-zero frames.
+
+## Notes
+
+This is open-core scope because it validates generic audio routing, codec
+contract, rigctld behavior, and backend-independent diagnostics. Pro can consume
+the same harness for packaged desktop smoke tests.

--- a/docs/plans/issue-drafts/2026-05-07-core-audio-route-resolver.md
+++ b/docs/plans/issue-drafts/2026-05-07-core-audio-route-resolver.md
@@ -1,0 +1,34 @@
+# Core Issue Draft: Design and implement AudioRoute resolver for WSJT-X DATA policy
+
+## Context
+
+During IC-7610 LAN TX bridge debugging we found that `--bridge` is not a reliable signal for choosing radio DATA policy. A bridge can be used both for direct Icom LAN audio workflows and for USB/serial audio workflows. Those require different packet-mode behavior:
+
+- Direct Icom LAN TX audio: WSJT-X `PKTUSB`/`PKTLSB`/`PKTRTTY` should map to DATA2/LAN on multi-DATA radios such as IC-7610.
+- USB/serial audio route, even with a local bridge: packet mode should remain legacy DATA1/USB behavior.
+
+Canonical design doc: `docs/plans/2026-05-07-audio-route-resolver-design.md`.
+
+## Requirements
+
+- Add a core `AudioRoute` model/resolver that derives radio audio route from backend/profile/capabilities, not from `--bridge`.
+- Route policies must distinguish at least:
+  - direct Icom LAN audio -> `data2_lan` when the profile supports multiple DATA modes;
+  - direct Icom LAN single-DATA profile -> legacy fallback;
+  - Icom serial/USB audio bridge -> DATA1/USB or legacy DATA1, never DATA2/LAN;
+  - unavailable/unknown route -> no automatic DATA source changes.
+- Replace direct CLI/backend guard logic with route-derived `RigctldConfig` wiring.
+- Keep DATA1 MOD user-owned by default: no automatic DATA1 MOD writes from prewarm, profile apply, or state restore.
+- Keep TX codec behavior aligned with negotiated TX codec: direct Icom LAN PCM TX must send raw PCM, not Opus bytes.
+
+## Acceptance Criteria
+
+- Unit tests cover route resolution for direct LAN, serial/USB bridge, single-DATA fallback, and unavailable route.
+- Rigctld tests prove packet-mode mapping follows route-derived policy.
+- CLI/web startup tests prove route policy is not inferred from `--bridge` alone.
+- Docs explain `bridge` vs `audio route` and DATA1/DATA2 ownership.
+- Existing WSJT-X compatibility behavior is preserved for non-LAN routes.
+
+## Notes
+
+This is open-core scope: protocol correctness, backend capability modeling, route-derived rigctld policy, and public docs. Product auto-start behavior belongs in rigplane-pro.

--- a/src/rigplane/audio/lan_stream.py
+++ b/src/rigplane/audio/lan_stream.py
@@ -593,7 +593,7 @@ class AudioStream:
         self._tx_packets_sent = 0
         logger.info("Audio TX started")
 
-    async def push_tx(self, opus_data: bytes) -> None:
+    async def push_tx(self, audio_data: bytes) -> None:
         """Send an audio frame to the radio.
 
         Large payloads (e.g. raw PCM) are automatically chunked to fit the
@@ -601,7 +601,7 @@ class AudioStream:
         matching the wfview chunking behaviour.
 
         Args:
-            opus_data: Audio data (Opus-encoded or raw PCM).
+            audio_data: Payload encoded with the negotiated TX audio codec.
 
         Raises:
             RuntimeError: If not in transmitting state.
@@ -609,7 +609,7 @@ class AudioStream:
         if self._state != AudioState.TRANSMITTING:
             raise RuntimeError(f"Cannot push TX in state {self._state}")
 
-        data = opus_data
+        data = audio_data
         offset = 0
         while offset < len(data):
             chunk = data[offset : offset + MAX_AUDIO_PAYLOAD]
@@ -670,17 +670,17 @@ def parse_audio_packet(data: bytes) -> AudioPacket | None:
 
 
 def build_audio_packet(
-    opus_data: bytes,
+    audio_data: bytes,
     *,
     sender_id: int,
     receiver_id: int,
     send_seq: int,
     ident: int = TX_IDENT,
 ) -> bytes:
-    """Build a raw UDP audio packet from Opus data.
+    """Build a raw UDP audio packet from negotiated-codec audio data.
 
     Args:
-        opus_data: Opus-encoded audio frame.
+        audio_data: Audio payload encoded with the negotiated stream codec.
         sender_id: Our connection ID.
         receiver_id: Radio's connection ID.
         send_seq: Audio-level sequence number.
@@ -689,7 +689,7 @@ def build_audio_packet(
     Returns:
         Complete UDP packet bytes ready to send.
     """
-    total_len = AUDIO_HEADER_SIZE + len(opus_data)
+    total_len = AUDIO_HEADER_SIZE + len(audio_data)
     pkt = bytearray(total_len)
 
     struct.pack_into("<I", pkt, 0x00, total_len)  # len (LE)
@@ -700,7 +700,7 @@ def build_audio_packet(
     struct.pack_into("<H", pkt, 0x10, ident)  # ident (LE)
     struct.pack_into(">H", pkt, 0x12, send_seq)  # sendseq (BE)
     # 0x14: unused (stays 0)
-    struct.pack_into(">H", pkt, 0x16, len(opus_data))  # datalen (BE)
+    struct.pack_into(">H", pkt, 0x16, len(audio_data))  # datalen (BE)
 
-    pkt[AUDIO_HEADER_SIZE:] = opus_data
+    pkt[AUDIO_HEADER_SIZE:] = audio_data
     return bytes(pkt)

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -2499,6 +2499,11 @@ def _detect_loopback_hint() -> str | None:
     return None
 
 
+def _uses_direct_lan_audio(radio: Radio) -> bool:
+    """Return True when the active radio backend streams TX audio over Icom LAN."""
+    return getattr(radio, "backend_id", None) == "rigplane"
+
+
 def _print_startup_banner(
     *,
     radio: Radio,
@@ -2727,10 +2732,20 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
         from rigplane.rigctld.server import RigctldServer
 
         rigctld_port = getattr(args, "web_rigctld_port", 4532)
+        wsjtx_compat = getattr(args, "wsjtx_compat", False)
+        wsjtx_data_mode = None
+        wsjtx_data_mod_input = None
+        if wsjtx_compat and _uses_direct_lan_audio(radio):
+            profile = getattr(radio, "profile", None)
+            if getattr(profile, "data_mode_count", 1) >= 2:
+                wsjtx_data_mode = 2
+                wsjtx_data_mod_input = 5  # IC-7610 DATA2 MOD input: LAN
         rigctld_config = RigctldConfig(
             host="0.0.0.0",
             port=rigctld_port,
-            wsjtx_compat=getattr(args, "wsjtx_compat", False),
+            wsjtx_compat=wsjtx_compat,
+            wsjtx_data_mode=wsjtx_data_mode,
+            wsjtx_data_mod_input=wsjtx_data_mod_input,
         )
         candidate = RigctldServer(radio, rigctld_config)
         try:

--- a/src/rigplane/commands/config.py
+++ b/src/rigplane/commands/config.py
@@ -180,8 +180,8 @@ def set_data1_mod_input(
     from_addr: int = CONTROLLER_ADDR,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    if not 0 <= source <= 4:
-        raise ValueError(f"DATA1 mod input must be 0-4, got {source}")
+    if not 0 <= source <= 5:
+        raise ValueError(f"DATA1 mod input must be 0-5, got {source}")
     return _build_ctl_mem_set(
         _CTL_MEM_DATA1_MOD_INPUT,
         source,
@@ -211,8 +211,8 @@ def set_data2_mod_input(
     from_addr: int = CONTROLLER_ADDR,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    if not 0 <= source <= 4:
-        raise ValueError(f"DATA2 mod input must be 0-4, got {source}")
+    if not 0 <= source <= 5:
+        raise ValueError(f"DATA2 mod input must be 0-5, got {source}")
     return _build_ctl_mem_set(
         _CTL_MEM_DATA2_MOD_INPUT,
         source,
@@ -242,8 +242,8 @@ def set_data3_mod_input(
     from_addr: int = CONTROLLER_ADDR,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    if not 0 <= source <= 4:
-        raise ValueError(f"DATA3 mod input must be 0-4, got {source}")
+    if not 0 <= source <= 5:
+        raise ValueError(f"DATA3 mod input must be 0-5, got {source}")
     return _build_ctl_mem_set(
         _CTL_MEM_DATA3_MOD_INPUT,
         source,

--- a/src/rigplane/rigctld/contract.py
+++ b/src/rigplane/rigctld/contract.py
@@ -381,4 +381,6 @@ class RigctldConfig:
     max_line_length: int = 1024  # max bytes per command line (OOM guard)
     poll_interval: float = 0.2  # seconds between autonomous poll cycles
     wsjtx_compat: bool = False  # pre-warm DATA mode for WSJT-X-style CAT/PTT flow
+    wsjtx_data_mode: int | None = None  # explicit DATA sub-mode for packet modes
+    wsjtx_data_mod_input: int | None = None  # optional DATAx modulation source
     command_rate_limit: float | None = None  # max cmds/sec per client, None=unlimited

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -199,6 +199,12 @@ def _err(code: HamlibError) -> RigctldResponse:
     return RigctldResponse(error=code)
 
 
+def _profile_data_mode_count(radio: Any) -> int:
+    profile = getattr(radio, "profile", None)
+    count = getattr(profile, "data_mode_count", 1)
+    return count if isinstance(count, int) and count > 0 else 1
+
+
 def _mode_to_hamlib_str(mode: object) -> str:
     """Normalize backend mode values to a hamlib-compatible string."""
     if isinstance(mode, Mode):
@@ -353,6 +359,32 @@ class RigctldHandler:
         self._routing = create_routing(
             radio, self._cache, getattr(config, "max_power_w", 100.0)
         )
+
+    def _packet_data_mode_value(self) -> int | bool:
+        value = self._config.wsjtx_data_mode
+        if value is None:
+            return True
+        if value > _profile_data_mode_count(self._radio):
+            return True
+        return value
+
+    async def _apply_packet_data_mode(self, *, receiver: int = 0) -> int | bool:
+        data_mode = self._packet_data_mode_value()
+        source = self._config.wsjtx_data_mod_input
+        if source is not None and type(data_mode) is int:
+            setter = getattr(self._radio, f"set_data{data_mode}_mod_input", None)
+            if setter is not None:
+                await setter(source)
+            else:
+                logger.debug(
+                    "rigctld: radio has no set_data%d_mod_input, skipping",
+                    data_mode,
+                )
+        if receiver == 0:
+            await self._radio.set_data_mode(data_mode)
+        else:
+            await self._radio.set_data_mode(data_mode, receiver=receiver)
+        return data_mode
 
     def _radio_state(self) -> RadioState | None:
         state = getattr(self._radio, "radio_state", None)
@@ -621,9 +653,7 @@ class RigctldHandler:
                 base_mode_str, filter_width=filter_width, receiver=1
             )
             if requested_mode in packet_modes:
-                set_data_mode = getattr(self._radio, "set_data_mode", None)
-                if set_data_mode is not None:
-                    await set_data_mode(True, receiver=1)
+                await self._apply_packet_data_mode(receiver=1)
             return _ok()
 
         await self._radio.set_mode(base_mode_str, filter_width=filter_width)
@@ -631,7 +661,7 @@ class RigctldHandler:
         # Only set DATA mode explicitly for packet modes.
         # For non-packet modes, avoid hidden side-effects (do not force DATA off).
         if requested_mode in packet_modes:
-            await self._radio.set_data_mode(True)
+            data_mode = await self._apply_packet_data_mode()
 
             # Read-back sync: keep next get_mode deterministic for CAT clients.
             # Some radios acknowledge set-data quickly but reflect packet mode
@@ -656,6 +686,7 @@ class RigctldHandler:
             self._pending.mode = base_mode_str
             self._pending.filter_width = filter_width
             self._pending.data_mode = True
+            logger.debug("set_mode(%s): DATA%s selected", requested_mode, data_mode)
             if not synced:
                 logger.debug(
                     "set_mode(%s): packet read-back not fully synced yet; cached optimistic state",

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -35,6 +35,37 @@ logger = logging.getLogger(__name__)
 __all__ = ["RigctldServer", "run_rigctld_server"]
 
 
+def _profile_data_mode_count(radio: "Radio") -> int:
+    profile = getattr(radio, "profile", None)
+    count = getattr(profile, "data_mode_count", 1)
+    return count if isinstance(count, int) and count > 0 else 1
+
+
+def _wsjtx_data_mode_value(radio: "Radio", config: RigctldConfig) -> int | bool:
+    if config.wsjtx_data_mode is not None:
+        return config.wsjtx_data_mode
+    return True
+
+
+async def _apply_wsjtx_data_mod_input(
+    radio: "Radio",
+    *,
+    data_mode: int | bool,
+    source: int | None,
+) -> None:
+    if source is None or type(data_mode) is not int:
+        return
+    setter_name = f"set_data{data_mode}_mod_input"
+    setter = getattr(radio, setter_name, None)
+    if setter is None:
+        logger.debug(
+            "WSJT-X compat: radio has no %s, skipping DATA mod input",
+            setter_name,
+        )
+        return
+    await setter(source)
+
+
 def _mode_to_name(mode: object) -> str:
     """Normalize backend mode values to an uppercase mode name."""
     name = getattr(mode, "name", None)
@@ -283,12 +314,31 @@ class RigctldServer:
         try:
             mode_name, _ = await get_mode()
             data_on = await self._radio.get_data_mode()
-            if not data_on and mode_name in {"USB", "LSB", "RTTY"}:
-                await self._radio.set_data_mode(True)
+            # A plain DATA flag does not tell us whether the rig is in DATA1,
+            # DATA2, or DATA3.  When the embedded LAN bridge requests an
+            # explicit WSJT-X DATA sub-mode, apply it even if DATA is already
+            # on; otherwise keep the legacy prewarm behavior and only enable
+            # DATA1 when the rig is still in plain USB/LSB/RTTY.
+            explicit_data_mode = self._config.wsjtx_data_mode is not None
+            if mode_name in {"USB", "LSB", "RTTY"} and (
+                explicit_data_mode or not data_on
+            ):
+                data_mode = _wsjtx_data_mode_value(self._radio, self._config)
+                if type(data_mode) is int and data_mode > _profile_data_mode_count(
+                    self._radio
+                ):
+                    data_mode = True
+                await _apply_wsjtx_data_mod_input(
+                    self._radio,
+                    data_mode=data_mode,
+                    source=self._config.wsjtx_data_mod_input,
+                )
+                await self._radio.set_data_mode(data_mode)
                 if poller is not None:
                     poller.hold_for(1.5)
                 logger.info(
-                    "WSJT-X compat prewarm: DATA mode enabled (base mode=%s)",
+                    "WSJT-X compat prewarm: DATA%s enabled (base mode=%s)",
+                    data_mode,
                     mode_name,
                 )
         except Exception as exc:

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -18,9 +18,13 @@ if TYPE_CHECKING:
 else:
     _MixinBase = object
 
-from rigplane.audio._transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
+from rigplane.audio._transcoder import (
+    PcmAudioFormat,
+    PcmOpusTranscoder,
+    create_pcm_opus_transcoder,
+)
 from rigplane.audio import AudioStats, AudioStream
-from rigplane.core.exceptions import ConnectionError
+from rigplane.core.exceptions import AudioFormatError, ConnectionError
 from rigplane.core.transport import IcomTransport
 from rigplane.core.types import AudioCodec
 
@@ -38,6 +42,7 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     _pcm_rx_user_callback: Callable[[bytes | None], None] | None
     _opus_rx_user_callback: Callable[[AudioPacket | None], None] | None
     _audio_codec: AudioCodec
+    _audio_tx_codec: AudioCodec
     _audio_sample_rate: int
 
     # ------------------------------------------------------------------
@@ -181,8 +186,10 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     ) -> None:
         """Start transmitting PCM audio to the radio.
 
-        This high-level API validates PCM format settings, initializes
-        the Opus transcoder backend, and starts the underlying Opus TX stream.
+        This high-level API validates PCM format settings and starts the
+        underlying LAN audio TX stream.  Despite the legacy low-level method
+        name, Icom LAN TX is negotiated as PCM_1CH_16BIT in conninfo, so PCM
+        frames must be sent as raw s16le bytes rather than Opus frames.
 
         Args:
             sample_rate: PCM sample rate in Hz (Opus-supported values only).
@@ -192,7 +199,7 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         Raises:
             ConnectionError: If not connected or audio port unavailable.
             TypeError: If numeric args are not ints.
-            AudioCodecBackendError: If Opus backend is unavailable.
+            AudioCodecBackendError: If TX codec is Opus and backend is unavailable.
             AudioFormatError: If PCM format is unsupported.
         """
         for name, value in (
@@ -205,12 +212,24 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
 
         self._check_connected()
 
-        # Validate codec/backend and PCM format before stream startup.
-        self._get_pcm_transcoder(
-            sample_rate=sample_rate,
-            channels=channels,
-            frame_ms=frame_ms,
-        )
+        tx_codec = getattr(self, "_audio_tx_codec", AudioCodec.PCM_1CH_16BIT)
+        if tx_codec == AudioCodec.OPUS_1CH:
+            self._get_pcm_transcoder(
+                sample_rate=sample_rate,
+                channels=channels,
+                frame_ms=frame_ms,
+            )
+        else:
+            # Validate PCM format before stream startup.  Direct Icom LAN TX
+            # does not require libopus because conninfo negotiates
+            # PCM_1CH_16BIT.
+            PcmOpusTranscoder._validate_format(  # noqa: SLF001
+                PcmAudioFormat(
+                    sample_rate=sample_rate,
+                    channels=channels,
+                    frame_ms=frame_ms,
+                )
+            )
         await self.start_audio_tx_opus()
         self._pcm_tx_fmt = (sample_rate, channels, frame_ms)
 
@@ -375,13 +394,39 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         frame_ms: int = 20,
     ) -> None:
         """Internal helper for future high-level TX PCM APIs."""
-        transcoder = self._get_pcm_transcoder(
+        fmt = PcmAudioFormat(
             sample_rate=sample_rate,
             channels=channels,
             frame_ms=frame_ms,
         )
-        opus_data = transcoder.pcm_to_opus(pcm_data)
-        await self.push_audio_tx_opus(opus_data)
+        PcmOpusTranscoder._validate_format(fmt)  # noqa: SLF001
+        if not isinstance(pcm_data, (bytes, bytearray, memoryview)):
+            raise AudioFormatError("PCM input must be bytes-like.")
+        frame = bytes(pcm_data)
+        if len(frame) != fmt.frame_bytes:
+            raise AudioFormatError(
+                f"PCM frame size mismatch: expected {fmt.frame_bytes} bytes "
+                f"({fmt.frame_ms}ms at {fmt.sample_rate}Hz, "
+                f"{fmt.channels}ch s16le), got {len(frame)}."
+            )
+
+        tx_codec = getattr(self, "_audio_tx_codec", AudioCodec.PCM_1CH_16BIT)
+        if tx_codec == AudioCodec.PCM_1CH_16BIT:
+            # push_audio_tx_opus is the historical low-level packet push.  The
+            # payload must match the negotiated Icom TX codec; direct Icom LAN
+            # conninfo forces PCM_1CH_16BIT for TX, so send the PCM frame
+            # unchanged.
+            await self.push_audio_tx_opus(frame)
+            return
+        if tx_codec == AudioCodec.OPUS_1CH:
+            transcoder = self._get_pcm_transcoder(
+                sample_rate=sample_rate,
+                channels=channels,
+                frame_ms=frame_ms,
+            )
+            await self.push_audio_tx_opus(transcoder.pcm_to_opus(frame))
+            return
+        raise AudioFormatError(f"PCM TX is not supported for TX codec {tx_codec!r}.")
 
     @property
     def audio_codec(self) -> AudioCodec:

--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -549,7 +549,8 @@ class ControlPhaseRuntime:
         # issue #794.  We force ``PCM_1CH_16BIT`` so stereo RX works without
         # any user-visible tradeoff — the radio uses its own separately
         # configured TX modulation source regardless of this byte.
-        tx_codec = int(AudioCodec.PCM_1CH_16BIT)
+        h._audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+        tx_codec = int(h._audio_tx_codec)
         conninfo = build_conninfo_packet(
             sender_id=h._ctrl_transport.my_id,
             receiver_id=h._ctrl_transport.remote_id,

--- a/src/rigplane/runtime/profiles_runtime.py
+++ b/src/rigplane/runtime/profiles_runtime.py
@@ -193,10 +193,9 @@ async def apply_profile(radio: Any, profile: OperatingProfile) -> dict[str, obje
             logger.debug("apply_profile: radio has no set_data_off_mod_input, skipping")
 
     if profile.data1_mod_input is not None:
-        if hasattr(radio, "set_data1_mod_input"):
-            await radio.set_data1_mod_input(profile.data1_mod_input)
-        else:
-            logger.debug("apply_profile: radio has no set_data1_mod_input, skipping")
+        logger.debug(
+            "apply_profile: data1_mod_input is user-owned; automatic restore skipped"
+        )
 
     if profile.equalize_vfo:
         # Inline the dispatch previously hidden behind the deprecated

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -671,6 +671,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             raise ValueError("radio_addr must be a single byte (0..255).")
         self._timeout = timeout
         self._audio_codec = AudioCodec(audio_codec)
+        self._audio_tx_codec = AudioCodec.PCM_1CH_16BIT
         self._audio_sample_rate = audio_sample_rate
         self._ctrl_transport = IcomTransport()
         self._civ_transport: IcomTransport | None = None

--- a/src/rigplane/runtime/radio_state_snapshot.py
+++ b/src/rigplane/runtime/radio_state_snapshot.py
@@ -157,7 +157,6 @@ async def restore_state(radio: IcomRadio, state: dict[str, object]) -> None:
         except Exception:
             logger.debug("restore_state: set_data_off_mod_input failed", exc_info=True)
     if "data1_mod_input" in state:
-        try:
-            await radio.set_data1_mod_input(int(cast(int, state["data1_mod_input"])))
-        except Exception:
-            logger.debug("restore_state: set_data1_mod_input failed", exc_info=True)
+        logger.debug(
+            "restore_state: data1_mod_input is user-owned; automatic restore skipped"
+        )

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -771,8 +771,7 @@ class AudioHandler:
                     try:
                         # Decode Opus → PCM16
                         pcm_data = self._transcoder.opus_to_pcm(opus_data)
-                        # Send PCM via push_audio_tx_opus (method accepts any codec)
-                        await self._radio.push_audio_tx_opus(pcm_data)  # type: ignore[attr-defined]
+                        await self._radio.push_audio_tx_pcm(pcm_data)  # type: ignore[attr-defined]
                         tx_data_desc = f"{len(pcm_data)} bytes pcm"
                     except Exception as e:
                         logger.warning(

--- a/tests/test_audio_transcoder.py
+++ b/tests/test_audio_transcoder.py
@@ -15,6 +15,7 @@ from rigplane.exceptions import (
     AudioTranscodeError,
 )
 from rigplane.radio import IcomRadio
+from rigplane.types import AudioCodec
 from _audio_stream_fake import FakeAudioStream
 
 
@@ -124,8 +125,20 @@ class TestPcmOpusTranscoder:
 
 class TestRadioPcmHooks:
     @pytest.mark.asyncio
-    async def test_push_audio_tx_pcm_internal_uses_transcoder(self) -> None:
+    async def test_push_audio_tx_pcm_internal_sends_raw_pcm(self) -> None:
         radio = IcomRadio("192.168.1.100")
+        radio.push_audio_tx_opus = AsyncMock()  # type: ignore[method-assign]
+
+        pcm = b"\x01\x02" * 960
+        await radio._push_audio_tx_pcm_internal(pcm)
+        radio.push_audio_tx_opus.assert_awaited_once_with(pcm)
+
+    @pytest.mark.asyncio
+    async def test_push_audio_tx_pcm_internal_encodes_when_tx_codec_is_opus(
+        self,
+    ) -> None:
+        radio = IcomRadio("192.168.1.100")
+        radio._audio_tx_codec = AudioCodec.OPUS_1CH
         radio.push_audio_tx_opus = AsyncMock()  # type: ignore[method-assign]
 
         class _DummyTranscoder:
@@ -235,7 +248,7 @@ class TestRadioPcmRxApi:
 
 class TestRadioPcmTxApi:
     @pytest.mark.asyncio
-    async def test_start_audio_tx_pcm_starts_opus_and_tracks_format(self) -> None:
+    async def test_start_audio_tx_pcm_starts_stream_and_tracks_format(self) -> None:
         radio = IcomRadio("192.168.1.100")
         radio._connected = True
         radio._civ_transport = MagicMock()
@@ -250,22 +263,16 @@ class TestRadioPcmTxApi:
         assert radio._pcm_tx_fmt == (48000, 1, 20)
 
     @pytest.mark.asyncio
-    async def test_push_audio_tx_pcm_encodes_and_sends(self) -> None:
+    async def test_push_audio_tx_pcm_sends_raw_pcm(self) -> None:
         radio = IcomRadio("192.168.1.100")
         radio._connected = True
         radio._civ_transport = MagicMock()
         radio._pcm_tx_fmt = (48000, 1, 20)
         radio.push_audio_tx_opus = AsyncMock()  # type: ignore[method-assign]
 
-        class _DummyTranscoder:
-            def pcm_to_opus(self, pcm: bytes | bytearray | memoryview) -> bytes:
-                return b"opus:" + bytes(pcm)[:2]
-
-        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
-        radio._pcm_transcoder_fmt = (48000, 1, 20)
-
-        await radio.push_audio_tx_pcm(b"\x01\x02" * 960)
-        radio.push_audio_tx_opus.assert_awaited_once_with(b"opus:\x01\x02")
+        pcm = b"\x01\x02" * 960
+        await radio.push_audio_tx_pcm(pcm)
+        radio.push_audio_tx_opus.assert_awaited_once_with(pcm)
 
     @pytest.mark.asyncio
     async def test_push_audio_tx_pcm_not_started(self) -> None:
@@ -296,7 +303,7 @@ class TestRadioPcmTxApi:
             await radio.start_audio_tx_pcm(sample_rate=44100)
 
     @pytest.mark.asyncio
-    async def test_start_audio_tx_pcm_backend_error_is_actionable(self) -> None:
+    async def test_start_audio_tx_pcm_does_not_require_opus_backend(self) -> None:
         radio = IcomRadio("192.168.1.100")
         radio._connected = True
         radio._civ_transport = MagicMock()
@@ -308,9 +315,8 @@ class TestRadioPcmTxApi:
             )
         )
 
-        with pytest.raises(AudioCodecBackendError, match="install rigplane\\[audio\\]"):
-            await radio.start_audio_tx_pcm()
-        assert fake_stream.start_tx_count == 0
+        await radio.start_audio_tx_pcm()
+        assert fake_stream.start_tx_count == 1
 
     @pytest.mark.asyncio
     async def test_push_audio_tx_pcm_frame_size_error(self) -> None:
@@ -318,16 +324,6 @@ class TestRadioPcmTxApi:
         radio._connected = True
         radio._civ_transport = MagicMock()
         radio._pcm_tx_fmt = (48000, 1, 20)
-
-        class _DummyTranscoder:
-            def pcm_to_opus(self, pcm: bytes | bytearray | memoryview) -> bytes:
-                _ = pcm
-                raise AudioFormatError(
-                    "PCM frame size mismatch: expected 1920 bytes, got 1919."
-                )
-
-        radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
-        radio._pcm_transcoder_fmt = (48000, 1, 20)
 
         with pytest.raises(AudioFormatError, match="expected 1920 bytes"):
             await radio.push_audio_tx_pcm(b"\x00" * 1919)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -769,6 +769,170 @@ class TestWebRigctldDefault:
         assert "rigctld:" in out
         assert "4532" in out
 
+    async def test_cli_web_direct_lan_wsjtx_configures_data2_lan(self, capsys):
+        """Direct Icom LAN backend maps WSJT-X packet mode to DATA2/LAN."""
+        import asyncio
+
+        from rigplane.cli import _cmd_web
+
+        radio = AsyncMock()
+        radio.model = "IC-7610"
+        radio.backend_id = "rigplane"
+        radio.profile = MagicMock(data_mode_count=3)
+        captured = []
+
+        class FakeRigctldServer:
+            def __init__(self, _radio, cfg):
+                self.cfg = cfg
+                captured.append(cfg)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+        class FakeWebServer:
+            def __init__(self, _radio, _cfg):
+                pass
+
+            async def start_audio_bridge(self, **_kwargs):
+                pass
+
+            async def serve_forever(self):
+                raise asyncio.CancelledError
+
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web", "--wsjtx-compat"])
+        args.web_bridge = None
+
+        with (
+            patch("rigplane.web.server.WebServer", FakeWebServer),
+            patch("rigplane.rigctld.server.RigctldServer", FakeRigctldServer),
+            patch("rigplane.cli._detect_loopback_hint", return_value=None),
+        ):
+            rc = await _cmd_web(radio, args)
+
+        assert rc == 0
+        assert len(captured) == 1
+        assert captured[0].wsjtx_compat is True
+        assert captured[0].wsjtx_data_mode == 2
+        assert captured[0].wsjtx_data_mod_input == 5
+        capsys.readouterr()
+
+    async def test_cli_web_serial_bridge_wsjtx_keeps_legacy_data1(self, capsys):
+        """USB/serial backend keeps DATA1 even when local bridge is enabled."""
+        import asyncio
+
+        from rigplane.cli import _cmd_web
+
+        radio = AsyncMock()
+        radio.model = "IC-7610"
+        radio.backend_id = "icom_serial"
+        radio.profile = MagicMock(data_mode_count=3)
+        captured = []
+
+        class FakeRigctldServer:
+            def __init__(self, _radio, cfg):
+                self.cfg = cfg
+                captured.append(cfg)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+        class FakeWebServer:
+            def __init__(self, _radio, _cfg):
+                pass
+
+            async def start_audio_bridge(self, **_kwargs):
+                pass
+
+            async def serve_forever(self):
+                raise asyncio.CancelledError
+
+        p = _build_parser()
+        args = p.parse_args(
+            [
+                "--backend",
+                "serial",
+                "--serial-port",
+                "/dev/tty.usbmodem",
+                "web",
+                "--bridge",
+                "BlackHole 16ch",
+                "--wsjtx-compat",
+            ]
+        )
+
+        with (
+            patch("rigplane.web.server.WebServer", FakeWebServer),
+            patch("rigplane.rigctld.server.RigctldServer", FakeRigctldServer),
+        ):
+            rc = await _cmd_web(radio, args)
+
+        assert rc == 0
+        assert len(captured) == 1
+        assert captured[0].wsjtx_compat is True
+        assert captured[0].wsjtx_data_mode is None
+        assert captured[0].wsjtx_data_mod_input is None
+        capsys.readouterr()
+
+    async def test_cli_web_direct_lan_single_data_profile_keeps_legacy_data1(
+        self, capsys
+    ):
+        """Single-DATA radios cannot be steered to DATA2."""
+        import asyncio
+
+        from rigplane.cli import _cmd_web
+
+        radio = AsyncMock()
+        radio.model = "IC-705"
+        radio.backend_id = "rigplane"
+        radio.profile = MagicMock(data_mode_count=1)
+        captured = []
+
+        class FakeRigctldServer:
+            def __init__(self, _radio, cfg):
+                self.cfg = cfg
+                captured.append(cfg)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+        class FakeWebServer:
+            def __init__(self, _radio, _cfg):
+                pass
+
+            async def start_audio_bridge(self, **_kwargs):
+                pass
+
+            async def serve_forever(self):
+                raise asyncio.CancelledError
+
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web", "--wsjtx-compat"])
+        args.web_bridge = None
+
+        with (
+            patch("rigplane.web.server.WebServer", FakeWebServer),
+            patch("rigplane.rigctld.server.RigctldServer", FakeRigctldServer),
+            patch("rigplane.cli._detect_loopback_hint", return_value=None),
+        ):
+            rc = await _cmd_web(radio, args)
+
+        assert rc == 0
+        assert len(captured) == 1
+        assert captured[0].wsjtx_compat is True
+        assert captured[0].wsjtx_data_mode is None
+        assert captured[0].wsjtx_data_mod_input is None
+        capsys.readouterr()
+
     async def test_cli_web_no_rigctld_opt_out(self, capsys):
         """`--no-rigctld` disables rigctld; banner omits the rigctld line."""
         import asyncio

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2094,17 +2094,17 @@ class TestSystemConfigCommands:
         frame = get_data1_mod_input()
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x92\xfd"
 
-    def test_set_data1_mod_input_usb(self) -> None:
+    def test_set_data1_mod_input_lan(self) -> None:
         from rigplane.commands import set_data1_mod_input
 
-        frame = set_data1_mod_input(2)  # USB
-        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x92\x02\xfd"
+        frame = set_data1_mod_input(5)  # LAN
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x92\x05\xfd"
 
     def test_set_data1_mod_input_rejects_out_of_range(self) -> None:
         from rigplane.commands import set_data1_mod_input
 
-        with pytest.raises(ValueError, match="0-4"):
-            set_data1_mod_input(5)
+        with pytest.raises(ValueError, match="0-5"):
+            set_data1_mod_input(6)
 
     def test_get_data2_mod_input_frame(self) -> None:
         from rigplane.commands import get_data2_mod_input
@@ -2112,11 +2112,23 @@ class TestSystemConfigCommands:
         frame = get_data2_mod_input()
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x93\xfd"
 
+    def test_set_data2_mod_input_lan(self) -> None:
+        from rigplane.commands import set_data2_mod_input
+
+        frame = set_data2_mod_input(5)
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x93\x05\xfd"
+
     def test_get_data3_mod_input_frame(self) -> None:
         from rigplane.commands import get_data3_mod_input
 
         frame = get_data3_mod_input()
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x94\xfd"
+
+    def test_set_data3_mod_input_lan(self) -> None:
+        from rigplane.commands import set_data3_mod_input
+
+        frame = set_data3_mod_input(5)
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x94\x05\xfd"
 
     def test_set_data3_mod_input_lan_usb(self) -> None:
         from rigplane.commands import set_data3_mod_input

--- a/tests/test_data_mode.py
+++ b/tests/test_data_mode.py
@@ -50,7 +50,7 @@ def get_cmd(long_cmd: str, *args: str) -> RigctldCommand:
 
 class TestGetDataModeCommand:
     def test_frame_bytes(self) -> None:
-        frame = get_data_mode()
+        frame = get_data_mode(to_addr=0x98)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\xfd"
 
     def test_custom_addresses(self) -> None:
@@ -60,23 +60,23 @@ class TestGetDataModeCommand:
 
 class TestSetDataModeCommand:
     def test_on(self) -> None:
-        frame = set_data_mode(True)
+        frame = set_data_mode(True, to_addr=0x98)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\x01\xfd"
 
     def test_off(self) -> None:
-        frame = set_data_mode(False)
+        frame = set_data_mode(False, to_addr=0x98)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\x00\xfd"
 
     def test_data2(self) -> None:
-        frame = set_data_mode(2)
+        frame = set_data_mode(2, to_addr=0x98)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\x02\xfd"
 
     def test_data3(self) -> None:
-        frame = set_data_mode(3)
+        frame = set_data_mode(3, to_addr=0x98)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\x03\xfd"
 
     def test_data3_sub_receiver_uses_cmd29(self) -> None:
-        frame = set_data_mode(3, receiver=1)
+        frame = set_data_mode(3, to_addr=0x98, receiver=1)
         assert frame == b"\xfe\xfe\x98\xe0\x29\x01\x1a\x06\x03\xfd"
 
 

--- a/tests/test_ic705.py
+++ b/tests/test_ic705.py
@@ -34,7 +34,7 @@ async def test_prepare_ic705_data_profile_applies_expected_sequence() -> None:
     radio.set_mode.assert_awaited_once_with("FM")
     radio.set_data_mode.assert_awaited_once_with(True)
     radio.set_data_off_mod_input.assert_awaited_once_with(3)
-    radio.set_data1_mod_input.assert_awaited_once_with(4)
+    radio.set_data1_mod_input.assert_not_awaited()
     # #1113: apply_profile dispatches to canonical ``equalize_main_sub`` /
     # ``equalize_vfo_ab`` instead of the deprecated ``vfo_equalize`` alias.
     # The bare AsyncMock has no real ``profile`` attribute, so the dispatch

--- a/tests/test_profiles_runtime.py
+++ b/tests/test_profiles_runtime.py
@@ -162,7 +162,7 @@ class TestApplyProfileFull:
             ),
         )
         radio.set_data_off_mod_input.assert_awaited_with(3)
-        radio.set_data1_mod_input.assert_awaited_with(5)
+        radio.set_data1_mod_input.assert_not_awaited()
 
     @pytest.mark.asyncio()
     async def test_applies_squelch(self, radio: AsyncMock) -> None:
@@ -243,7 +243,7 @@ class TestApplyProfileFull:
         radio.set_mode.assert_awaited()
         radio.set_data_mode.assert_awaited()
         radio.set_data_off_mod_input.assert_awaited()
-        radio.set_data1_mod_input.assert_awaited()
+        radio.set_data1_mod_input.assert_not_awaited()
         # #1113: dispatches to canonical ``equalize_vfo_ab(0)`` (bare
         # AsyncMock has no real profile attribute → single-RX fallback).
         radio.equalize_vfo_ab.assert_awaited_with(0)
@@ -483,7 +483,7 @@ class TestIC705BackwardCompat:
             data1_mod_input=5,
         )
         radio.set_data_off_mod_input.assert_awaited_with(3)
-        radio.set_data1_mod_input.assert_awaited_with(5)
+        radio.set_data1_mod_input.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -780,7 +780,7 @@ async def test_restore_state_calls_set_methods(
     assert set_vox_called
     assert set_data_mode_called
     assert set_data_off_called
-    assert set_data1_called
+    assert not set_data1_called
 
 
 async def test_restore_state_ignores_set_failure(

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -69,7 +69,7 @@ class _ContractModeRadio:
         self.filter_width = filter_width
         self.data_mode = data_mode
         self.set_mode_calls: list[tuple[str, int | None, int]] = []
-        self.set_data_mode_calls: list[bool] = []
+        self.set_data_mode_calls: list[int | bool] = []
 
     async def get_mode(self, receiver: int = 0) -> tuple[str, int | None]:
         assert receiver == 0
@@ -88,9 +88,9 @@ class _ContractModeRadio:
     async def get_data_mode(self) -> bool:
         return self.data_mode
 
-    async def set_data_mode(self, on: bool) -> None:
+    async def set_data_mode(self, on: int | bool) -> None:
         self.set_data_mode_calls.append(on)
-        self.data_mode = on
+        self.data_mode = bool(on)
 
 
 # ---------------------------------------------------------------------------
@@ -315,6 +315,73 @@ async def test_set_mode_uses_core_contract_string_values() -> None:
     assert resp.ok
     assert radio.set_mode_calls == [("USB", 2, 0)]
     assert radio.set_data_mode_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_set_mode_packet_uses_configured_wsjtx_data_mode() -> None:
+    radio = AsyncMock()
+    radio.set_mode = AsyncMock()
+    radio.set_data_mode = AsyncMock()
+    radio.set_data2_mod_input = AsyncMock()
+    radio.get_mode_info = AsyncMock(return_value=(Mode.USB, 1))
+    radio.get_data_mode = AsyncMock(return_value=True)
+    radio.profile = type("Profile", (), {"data_mode_count": 3})()
+    h = RigctldHandler(
+        radio,
+        RigctldConfig(wsjtx_data_mode=2, wsjtx_data_mod_input=5),
+    )
+
+    resp = await h.execute(set_cmd("set_mode", "PKTUSB", "2400"))
+
+    assert resp.ok
+    radio.set_mode.assert_awaited_once_with("USB", filter_width=2)
+    radio.set_data2_mod_input.assert_awaited_once_with(5)
+    radio.set_data_mode.assert_awaited_once_with(2)
+
+
+@pytest.mark.asyncio
+async def test_set_mode_packet_configured_data2_falls_back_on_single_data_profile() -> (
+    None
+):
+    radio = AsyncMock()
+    radio.set_mode = AsyncMock()
+    radio.set_data_mode = AsyncMock()
+    radio.set_data2_mod_input = AsyncMock()
+    radio.get_mode_info = AsyncMock(return_value=(Mode.USB, 1))
+    radio.get_data_mode = AsyncMock(return_value=True)
+    radio.profile = type("Profile", (), {"data_mode_count": 1})()
+    h = RigctldHandler(
+        radio,
+        RigctldConfig(wsjtx_data_mode=2, wsjtx_data_mod_input=5),
+    )
+
+    resp = await h.execute(set_cmd("set_mode", "PKTUSB", "2400"))
+
+    assert resp.ok
+    radio.set_data2_mod_input.assert_not_called()
+    radio.set_data_mode.assert_awaited_once_with(True)
+
+
+@pytest.mark.asyncio
+async def test_set_mode_packet_without_wsjtx_data_config_does_not_touch_data_mod_input() -> (
+    None
+):
+    radio = AsyncMock()
+    radio.set_mode = AsyncMock()
+    radio.set_data_mode = AsyncMock()
+    radio.set_data1_mod_input = AsyncMock()
+    radio.set_data2_mod_input = AsyncMock()
+    radio.get_mode_info = AsyncMock(return_value=(Mode.USB, 1))
+    radio.get_data_mode = AsyncMock(return_value=True)
+    radio.profile = type("Profile", (), {"data_mode_count": 3})()
+    h = RigctldHandler(radio, RigctldConfig())
+
+    resp = await h.execute(set_cmd("set_mode", "PKTUSB", "2400"))
+
+    assert resp.ok
+    radio.set_data1_mod_input.assert_not_called()
+    radio.set_data2_mod_input.assert_not_called()
+    radio.set_data_mode.assert_awaited_once_with(True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -866,6 +866,29 @@ class TestWsjtxCompatPrewarm:
 
         mock_radio.set_data_mode.assert_not_called()
 
+    async def test_prewarm_configured_data2_falls_back_on_single_data_profile(
+        self, mock_radio: MagicMock
+    ) -> None:
+        cfg = RigctldConfig(
+            wsjtx_compat=True,
+            wsjtx_data_mode=2,
+            wsjtx_data_mod_input=5,
+        )
+        srv = RigctldServer(
+            mock_radio, cfg, _protocol=MagicMock(), _handler=MagicMock()
+        )
+
+        mock_radio.profile = MagicMock(data_mode_count=1)
+        mock_radio.get_mode_info = AsyncMock(return_value=(Mode.USB, 2))
+        mock_radio.get_data_mode = AsyncMock(return_value=True)
+        mock_radio.set_data_mode = AsyncMock(return_value=None)
+        mock_radio.set_data2_mod_input = AsyncMock(return_value=None)
+
+        await srv._wsjtx_compat_prewarm()
+
+        mock_radio.set_data2_mod_input.assert_not_called()
+        mock_radio.set_data_mode.assert_awaited_once_with(True)
+
     async def test_prewarm_skips_for_non_ssb_modes(self, mock_radio: MagicMock) -> None:
         cfg = RigctldConfig(wsjtx_compat=True)
         srv = RigctldServer(

--- a/tests/test_rigctld_server_coverage.py
+++ b/tests/test_rigctld_server_coverage.py
@@ -512,3 +512,39 @@ async def test_wsjtx_compat_prewarm_triggers_on_first_client(
         await _close(writer)
     finally:
         await srv.stop()
+
+
+async def test_wsjtx_compat_prewarm_applies_configured_data2_lan(
+    mock_radio: MagicMock,
+) -> None:
+    """LAN bridge mode should steer WSJT-X packet mode to DATA2/LAN."""
+    from rigplane.types import Mode
+
+    cfg = RigctldConfig(
+        host="127.0.0.1",
+        port=0,
+        client_timeout=0.5,
+        wsjtx_compat=True,
+        wsjtx_data_mode=2,
+        wsjtx_data_mod_input=5,
+    )
+    proto = _make_proto()
+    handler = _make_handler()
+
+    mock_radio.profile = MagicMock(data_mode_count=3)
+    mock_radio.get_mode_info = AsyncMock(return_value=(Mode.USB, 1))
+    mock_radio.get_data_mode = AsyncMock(return_value=True)
+    mock_radio.set_data_mode = AsyncMock(return_value=None)
+    mock_radio.set_data2_mod_input = AsyncMock(return_value=None)
+
+    srv = RigctldServer(mock_radio, cfg, _protocol=proto, _handler=handler)
+    await srv.start()
+    try:
+        _reader, writer = await _connect(srv)
+        await asyncio.sleep(0.1)
+        mock_radio.set_data2_mod_input.assert_awaited_once_with(5)
+        mock_radio.set_data_mode.assert_awaited_once_with(2)
+        mock_radio.set_data1_mod_input.assert_not_called()
+        await _close(writer)
+    finally:
+        await srv.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.0.0"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- Fix direct Icom LAN TX audio by sending raw PCM when conninfo negotiates `PCM_1CH_16BIT` instead of pushing Opus bytes into the radio's PCM TX stream.
- Add explicit TX codec tracking and route WSJT-X packet modes to DATA2/LAN only for direct Icom LAN multi-DATA radios.
- Keep DATA1 user-owned: prewarm, profile apply, and state restore no longer rewrite DATA1 MOD input.
- Document the bridge-vs-audio-route design and add issue drafts for the follow-up AudioRoute resolver and audio pipeline harness.

Closes #1430.

## Validation

- Hardware: IC-7610 LAN + WSJT-X Tune reproduced the broad intermittent burst failure before the PCM fix; after raw PCM TX, continuous TX audio reached the radio.
- `uv run pytest tests/test_cli.py tests/test_audio_transcoder.py tests/test_audio_bridge.py tests/test_audio_bridge_stereo.py tests/test_rigctld_handler.py tests/test_rigctld_server.py tests/test_rigctld_server_coverage.py tests/test_data_mode.py tests/test_radio_coverage.py tests/test_profiles_runtime.py tests/test_ic705.py tests/test_commands.py -q`
  - `1098 passed`

## Follow-up

- #1446 tracks replacing the short-term backend guard with a first-class `AudioRoute` resolver.
- #1447 tracks the automated audio pipeline harness so future audio regressions do not require manual WSJT-X Tune testing.
