### PR TITLE
feat(audio): resolve WSJT-X DATA policy from audio route

### DIFF
--- a/docs/guide/wsjtx-setup.md
+++ b/docs/guide/wsjtx-setup.md
@@ -70,6 +70,11 @@ The audio bridge routes:
 - **Radio RX → rigplane → BlackHole 2ch → WSJT-X Input** (decode FT8/FT4)
 - **WSJT-X Output → BlackHole 16ch → rigplane → Radio TX** (transmit FT8/FT4)
 
+`--bridge` only describes the local audio loopback between WSJT-X and
+rigplane. Radio DATA policy is derived from the resolved audio route:
+direct Icom LAN audio uses the LAN audio route, while USB/serial audio
+remains a USB route even when a local loopback bridge is enabled.
+
 ### Radio Settings (for TX audio)
 
 On the IC-7610 front panel, set:

--- a/src/rigplane/audio/LAYER.md
+++ b/src/rigplane/audio/LAYER.md
@@ -5,8 +5,10 @@
 End-to-end audio subsystem: `AudioBackend` Protocol + PortAudio/Fake
 implementations, codecs (PCM / Opus / μ-law), transcoder, audio bridge,
 audio bus, FFT scope (panadapter), reconnect-time recovery, and platform
-USB audio resolution. The `audio.backend` and `audio.dsp` submodule paths
-are part of the rigplane-pro contract and **must remain stable**.
+USB audio resolution. `audio.route` resolves the radio audio route used by
+WSJT-X DATA policy; it must not treat the local loopback bridge as proof of
+LAN audio. The `audio.backend` and `audio.dsp` submodule paths are part of
+the rigplane-pro contract and **must remain stable**.
 
 ## Public API
 
@@ -30,6 +32,8 @@ types used by transport/radio/sync at import time) and a PEP 562
 - **Lazy — USB**: `UsbAudioDriver`, `UsbAudioDevice`,
   `list_usb_audio_devices`, `select_usb_audio_devices`,
   plus driver-lifecycle/selection exceptions.
+- **Direct submodule**: `audio.route` exposes the route resolver and
+  route-derived rigctld WSJT-X DATA policy.
 
 The `AudioBackend` Protocol is Tier 2 (best-effort; lazily exposed via
 PEP 562) — see #1275.

--- a/src/rigplane/audio/route.py
+++ b/src/rigplane/audio/route.py
@@ -1,0 +1,119 @@
+"""Audio route resolution for radio DATA-mode policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rigplane.radio_protocol import Radio
+
+__all__ = [
+    "AudioRoute",
+    "DataModePolicy",
+    "RadioTransport",
+    "RxAudioSource",
+    "TxAudioSource",
+    "resolve_audio_route",
+    "rigctld_wsjtx_policy",
+]
+
+
+class RadioTransport(StrEnum):
+    """Control transport family used by the active radio backend."""
+
+    LAN = "lan"
+    SERIAL = "serial"
+    REMOTE = "remote"
+    UNKNOWN = "unknown"
+
+
+class TxAudioSource(StrEnum):
+    """How TX audio enters the radio hardware."""
+
+    LAN = "lan"
+    USB = "usb"
+    ACC = "acc"
+    UNAVAILABLE = "unavailable"
+
+
+class RxAudioSource(StrEnum):
+    """How RX audio leaves the radio hardware."""
+
+    LAN = "lan"
+    USB = "usb"
+    ACC = "acc"
+    UNAVAILABLE = "unavailable"
+
+
+class DataModePolicy(StrEnum):
+    """WSJT-X packet-mode DATA policy implied by an audio route."""
+
+    DATA2_LAN = "data2_lan"
+    DATA1_USB = "data1_usb"
+    LEGACY = "legacy"
+
+
+@dataclass(frozen=True)
+class AudioRoute:
+    """Resolved radio audio route and the DATA policy derived from it."""
+
+    radio_transport: RadioTransport
+    tx_audio_source: TxAudioSource
+    rx_audio_source: RxAudioSource
+    data_mode_policy: DataModePolicy
+    bridge_required: bool
+
+
+def _profile_data_mode_count(radio: "Radio") -> int:
+    profile = getattr(radio, "profile", None)
+    count = getattr(profile, "data_mode_count", 1)
+    return count if isinstance(count, int) and count > 0 else 1
+
+
+def resolve_audio_route(radio: "Radio") -> AudioRoute:
+    """Resolve the active radio audio route without looking at CLI bridge flags."""
+
+    backend_id = getattr(radio, "backend_id", None)
+    if backend_id == "rigplane":
+        data_policy = (
+            DataModePolicy.DATA2_LAN
+            if _profile_data_mode_count(radio) >= 2
+            else DataModePolicy.LEGACY
+        )
+        return AudioRoute(
+            radio_transport=RadioTransport.LAN,
+            tx_audio_source=TxAudioSource.LAN,
+            rx_audio_source=RxAudioSource.LAN,
+            data_mode_policy=data_policy,
+            bridge_required=False,
+        )
+
+    if (
+        backend_id in {"icom_serial", "yaesu_cat"}
+        or getattr(radio, "has_usb_audio", False) is True
+    ):
+        return AudioRoute(
+            radio_transport=RadioTransport.SERIAL,
+            tx_audio_source=TxAudioSource.USB,
+            rx_audio_source=RxAudioSource.USB,
+            data_mode_policy=DataModePolicy.DATA1_USB,
+            bridge_required=True,
+        )
+
+    return AudioRoute(
+        radio_transport=RadioTransport.UNKNOWN,
+        tx_audio_source=TxAudioSource.UNAVAILABLE,
+        rx_audio_source=RxAudioSource.UNAVAILABLE,
+        data_mode_policy=DataModePolicy.LEGACY,
+        bridge_required=False,
+    )
+
+
+def rigctld_wsjtx_policy(route: AudioRoute) -> tuple[int | None, int | None]:
+    """Return ``RigctldConfig`` WSJT-X DATA fields for a resolved route."""
+
+    if route.data_mode_policy == DataModePolicy.DATA2_LAN:
+        return 2, 5
+    return None, None

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 from rigplane import __version__  # noqa: E402
 from rigplane.audio import AudioStats  # noqa: E402
+from rigplane.audio.route import resolve_audio_route, rigctld_wsjtx_policy  # noqa: E402
 from rigplane.backends.config import (  # noqa: E402
     LanBackendConfig,
     SerialBackendConfig,
@@ -2499,11 +2500,6 @@ def _detect_loopback_hint() -> str | None:
     return None
 
 
-def _uses_direct_lan_audio(radio: Radio) -> bool:
-    """Return True when the active radio backend streams TX audio over Icom LAN."""
-    return getattr(radio, "backend_id", None) == "rigplane"
-
-
 def _print_startup_banner(
     *,
     radio: Radio,
@@ -2735,11 +2731,9 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
         wsjtx_compat = getattr(args, "wsjtx_compat", False)
         wsjtx_data_mode = None
         wsjtx_data_mod_input = None
-        if wsjtx_compat and _uses_direct_lan_audio(radio):
-            profile = getattr(radio, "profile", None)
-            if getattr(profile, "data_mode_count", 1) >= 2:
-                wsjtx_data_mode = 2
-                wsjtx_data_mod_input = 5  # IC-7610 DATA2 MOD input: LAN
+        if wsjtx_compat:
+            audio_route = resolve_audio_route(radio)
+            wsjtx_data_mode, wsjtx_data_mod_input = rigctld_wsjtx_policy(audio_route)
         rigctld_config = RigctldConfig(
             host="0.0.0.0",
             port=rigctld_port,

--- a/tests/test_audio_route.py
+++ b/tests/test_audio_route.py
@@ -1,0 +1,79 @@
+"""AudioRoute resolver tests for WSJT-X DATA policy."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+
+def _radio(*, backend_id: str, data_mode_count: int = 1) -> AsyncMock:
+    radio = AsyncMock()
+    radio.backend_id = backend_id
+    radio.profile = SimpleNamespace(data_mode_count=data_mode_count)
+    return radio
+
+
+def test_direct_lan_multi_data_resolves_data2_lan_policy() -> None:
+    from rigplane.audio.route import (
+        DataModePolicy,
+        RadioTransport,
+        TxAudioSource,
+        resolve_audio_route,
+        rigctld_wsjtx_policy,
+    )
+
+    route = resolve_audio_route(_radio(backend_id="rigplane", data_mode_count=3))
+
+    assert route.radio_transport == RadioTransport.LAN
+    assert route.tx_audio_source == TxAudioSource.LAN
+    assert route.data_mode_policy == DataModePolicy.DATA2_LAN
+    assert route.bridge_required is False
+    assert rigctld_wsjtx_policy(route) == (2, 5)
+
+
+def test_direct_lan_single_data_falls_back_to_legacy_policy() -> None:
+    from rigplane.audio.route import (
+        DataModePolicy,
+        TxAudioSource,
+        resolve_audio_route,
+        rigctld_wsjtx_policy,
+    )
+
+    route = resolve_audio_route(_radio(backend_id="rigplane", data_mode_count=1))
+
+    assert route.tx_audio_source == TxAudioSource.LAN
+    assert route.data_mode_policy == DataModePolicy.LEGACY
+    assert rigctld_wsjtx_policy(route) == (None, None)
+
+
+def test_serial_usb_route_never_selects_data2_lan() -> None:
+    from rigplane.audio.route import (
+        DataModePolicy,
+        RadioTransport,
+        TxAudioSource,
+        resolve_audio_route,
+        rigctld_wsjtx_policy,
+    )
+
+    route = resolve_audio_route(_radio(backend_id="icom_serial", data_mode_count=3))
+
+    assert route.radio_transport == RadioTransport.SERIAL
+    assert route.tx_audio_source == TxAudioSource.USB
+    assert route.data_mode_policy == DataModePolicy.DATA1_USB
+    assert route.bridge_required is True
+    assert rigctld_wsjtx_policy(route) == (None, None)
+
+
+def test_unknown_route_does_not_change_data_source() -> None:
+    from rigplane.audio.route import (
+        DataModePolicy,
+        TxAudioSource,
+        resolve_audio_route,
+        rigctld_wsjtx_policy,
+    )
+
+    route = resolve_audio_route(_radio(backend_id="unknown", data_mode_count=3))
+
+    assert route.tx_audio_source == TxAudioSource.UNAVAILABLE
+    assert route.data_mode_policy == DataModePolicy.LEGACY
+    assert rigctld_wsjtx_policy(route) == (None, None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -933,6 +933,74 @@ class TestWebRigctldDefault:
         assert captured[0].wsjtx_data_mod_input is None
         capsys.readouterr()
 
+    async def test_cli_web_wsjtx_uses_audio_route_policy_not_backend_guard(
+        self, capsys
+    ):
+        """Rigctld WSJT-X policy comes from AudioRoute, not raw backend_id."""
+        import asyncio
+
+        from rigplane.audio.route import (
+            AudioRoute,
+            DataModePolicy,
+            RadioTransport,
+            RxAudioSource,
+            TxAudioSource,
+        )
+        from rigplane.cli import _cmd_web
+
+        radio = AsyncMock()
+        radio.model = "IC-7610"
+        radio.backend_id = "rigplane"
+        radio.profile = MagicMock(data_mode_count=3)
+        captured = []
+
+        class FakeRigctldServer:
+            def __init__(self, _radio, cfg):
+                captured.append(cfg)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+        class FakeWebServer:
+            def __init__(self, _radio, _cfg):
+                pass
+
+            async def start_audio_bridge(self, **_kwargs):
+                pass
+
+            async def serve_forever(self):
+                raise asyncio.CancelledError
+
+        unavailable_route = AudioRoute(
+            radio_transport=RadioTransport.UNKNOWN,
+            tx_audio_source=TxAudioSource.UNAVAILABLE,
+            rx_audio_source=RxAudioSource.UNAVAILABLE,
+            data_mode_policy=DataModePolicy.LEGACY,
+            bridge_required=False,
+        )
+
+        p = _build_parser()
+        args = p.parse_args(["--host", "1.2.3.4", "web", "--wsjtx-compat"])
+        args.web_bridge = None
+
+        with (
+            patch("rigplane.web.server.WebServer", FakeWebServer),
+            patch("rigplane.rigctld.server.RigctldServer", FakeRigctldServer),
+            patch("rigplane.cli._detect_loopback_hint", return_value=None),
+            patch("rigplane.cli.resolve_audio_route", return_value=unavailable_route),
+        ):
+            rc = await _cmd_web(radio, args)
+
+        assert rc == 0
+        assert len(captured) == 1
+        assert captured[0].wsjtx_compat is True
+        assert captured[0].wsjtx_data_mode is None
+        assert captured[0].wsjtx_data_mod_input is None
+        capsys.readouterr()
+
     async def test_cli_web_no_rigctld_opt_out(self, capsys):
         """`--no-rigctld` disables rigctld; banner omits the rigctld line."""
         import asyncio

--- a/tests/test_rigctld_server_coverage.py
+++ b/tests/test_rigctld_server_coverage.py
@@ -517,7 +517,7 @@ async def test_wsjtx_compat_prewarm_triggers_on_first_client(
 async def test_wsjtx_compat_prewarm_applies_configured_data2_lan(
     mock_radio: MagicMock,
 ) -> None:
-    """LAN bridge mode should steer WSJT-X packet mode to DATA2/LAN."""
+    """Route-derived config should steer WSJT-X packet mode to DATA2/LAN."""
     from rigplane.types import Mode
 
     cfg = RigctldConfig(


### PR DESCRIPTION
## Summary

- add `rigplane.audio.route` with `AudioRoute`, source enums, and route-derived WSJT-X DATA policy
- wire `web --wsjtx-compat` rigctld config through the resolved audio route instead of a raw `backend_id == "rigplane"` guard
- document the bridge-vs-route distinction and cover direct LAN, serial/USB, single-DATA, and unavailable routes

## Regression coverage

- TDD red: `tests/test_audio_route.py` failed because `rigplane.audio.route` did not exist
- TDD red: CLI route-policy test failed until `_cmd_web` consumed `resolve_audio_route()`
- Direct LAN multi-DATA still maps to DATA2/LAN
- Serial/USB bridge and unavailable routes do not select DATA2/LAN
- DATA1 MOD remains untouched by this route policy

## Validation

- `uv run pytest tests/test_audio_route.py tests/test_cli.py::TestWebRigctldDefault::test_cli_web_wsjtx_uses_audio_route_policy_not_backend_guard tests/test_cli.py::TestWebRigctldDefault::test_cli_web_direct_lan_wsjtx_configures_data2_lan tests/test_cli.py::TestWebRigctldDefault::test_cli_web_serial_bridge_wsjtx_keeps_legacy_data1 tests/test_cli.py::TestWebRigctldDefault::test_cli_web_direct_lan_single_data_profile_keeps_legacy_data1 tests/test_rigctld_server_coverage.py::test_wsjtx_compat_prewarm_applies_configured_data2_lan -q`
- `uv run pytest tests/test_audio_route.py tests/test_cli.py tests/test_rigctld_handler.py tests/test_rigctld_server.py tests/test_rigctld_server_coverage.py tests/test_data_mode.py tests/test_profiles_runtime.py tests/test_audio_transcoder.py tests/test_audio_bridge.py -q`
- `uv run ruff check src/rigplane/audio/route.py src/rigplane/cli/__init__.py tests/test_audio_route.py tests/test_cli.py tests/test_rigctld_server_coverage.py`
- `git diff --check`
- `uv run pytest tests/ -q --tb=short`

Closes #1446
