### PR TITLE
test(audio): add in-process TX pipeline harness

### DIFF
--- a/tests/_audio_pipeline_helpers.py
+++ b/tests/_audio_pipeline_helpers.py
@@ -1,0 +1,84 @@
+"""Reusable helpers for CI-safe audio pipeline harness tests."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from rigplane.audio.lan_stream import AudioPacket, parse_audio_packet
+
+
+def sine_pcm16_mono(
+    frequency_hz: float,
+    *,
+    samples: int,
+    sample_rate: int = 48_000,
+    amplitude: int = 12_000,
+) -> bytes:
+    """Generate deterministic mono s16le sine PCM."""
+
+    pcm = bytearray()
+    for index in range(samples):
+        phase = 2.0 * math.pi * frequency_hz * (index / sample_rate)
+        value = int(amplitude * math.sin(phase))
+        pcm += value.to_bytes(2, "little", signed=True)
+    return bytes(pcm)
+
+
+def pcm_rms(pcm: bytes) -> float:
+    """Return RMS for mono s16le PCM bytes."""
+
+    if not pcm:
+        return 0.0
+    if len(pcm) % 2:
+        raise ValueError("PCM byte length must be even for s16le samples.")
+    count = len(pcm) // 2
+    total = 0.0
+    for offset in range(0, len(pcm), 2):
+        sample = int.from_bytes(pcm[offset : offset + 2], "little", signed=True)
+        total += float(sample) * float(sample)
+    return math.sqrt(total / count)
+
+
+@dataclass(frozen=True)
+class PcmDiagnostics:
+    """Compact PCM diagnostics emitted by pipeline harness tests."""
+
+    byte_count: int
+    frame_count: int
+    peak: int
+    rms: float
+
+    @classmethod
+    def from_pcm(cls, pcm: bytes, *, frame_bytes: int = 1920) -> "PcmDiagnostics":
+        peak = 0
+        for offset in range(0, len(pcm), 2):
+            sample = int.from_bytes(pcm[offset : offset + 2], "little", signed=True)
+            peak = max(peak, abs(sample))
+        return cls(
+            byte_count=len(pcm),
+            frame_count=len(pcm) // frame_bytes,
+            peak=peak,
+            rms=pcm_rms(pcm),
+        )
+
+
+def collect_tx_audio_packets(await_args_list: list[Any]) -> list[AudioPacket]:
+    """Parse raw packets recorded by a mocked audio transport."""
+
+    packets: list[AudioPacket] = []
+    for call in await_args_list:
+        raw = call.args[0]
+        packet = parse_audio_packet(raw)
+        if packet is not None:
+            packets.append(packet)
+    return packets
+
+
+def assert_contiguous_sequences(packets: list[AudioPacket]) -> None:
+    """Assert audio-level send_seq values increment by one with wraparound."""
+
+    sequences = [packet.send_seq for packet in packets]
+    expected = list(range(len(packets)))
+    assert sequences == expected

--- a/tests/test_audio_pipeline_harness.py
+++ b/tests/test_audio_pipeline_harness.py
@@ -1,0 +1,141 @@
+"""In-process audio pipeline harness for WSJT-X/LAN TX regressions."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.audio.lan_stream import AudioStream, MAX_AUDIO_PAYLOAD, TX_IDENT
+from rigplane.audio_bridge import AudioBridge, FRAME_BYTES, SAMPLES_PER_FRAME
+from rigplane.radio import IcomRadio
+from rigplane.runtime._connection_state import RadioConnectionState
+from rigplane.types import AudioCodec
+
+from _audio_pipeline_helpers import (
+    PcmDiagnostics,
+    assert_contiguous_sequences,
+    collect_tx_audio_packets,
+    pcm_rms,
+    sine_pcm16_mono,
+)
+
+
+class _RecordingAudioTransport:
+    my_id = 0xAABBCCDD
+    remote_id = 0x11223344
+
+    def __init__(self) -> None:
+        self.send_tracked = AsyncMock()
+
+    async def receive_packet(self, *, timeout: float = 1.0) -> bytes:
+        await asyncio.sleep(0)
+        raise TimeoutError
+
+
+async def test_bridge_tx_pipeline_sends_raw_pcm_when_tx_codec_is_pcm() -> None:
+    transport = _RecordingAudioTransport()
+    radio = IcomRadio("192.0.2.10", username="u", password="p", timeout=0.05)
+    radio._connected = True
+    radio._civ_transport = object()
+    radio._conn_state = RadioConnectionState.CONNECTED
+    radio._audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+    radio._audio_stream = AudioStream(transport)  # type: ignore[arg-type]
+
+    backend = FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="BlackHole Test",
+                input_channels=2,
+                output_channels=2,
+            )
+        ]
+    )
+    bridge = AudioBridge(
+        radio,
+        device_name="BlackHole Test",
+        tx_enabled=True,
+        backend=backend,
+    )
+
+    frame_count = 4
+    tone_frame = sine_pcm16_mono(1000.0, samples=SAMPLES_PER_FRAME)
+    assert len(tone_frame) == FRAME_BYTES
+    expected_pcm = tone_frame * frame_count
+
+    await bridge.start()
+    try:
+        for _ in range(frame_count):
+            backend.rx_streams[0].inject_frame(tone_frame)
+            await asyncio.sleep(0.01)
+    finally:
+        await bridge.stop()
+        radio._connected = False
+
+    packets = collect_tx_audio_packets(transport.send_tracked.await_args_list)
+    payload = b"".join(packet.data for packet in packets)
+    diagnostics = PcmDiagnostics.from_pcm(payload)
+
+    assert payload == expected_pcm
+    assert diagnostics.frame_count == frame_count
+    assert diagnostics.rms == pcm_rms(expected_pcm)
+    assert diagnostics.rms > 0.0
+    assert [len(packet.data) for packet in packets] == [
+        size
+        for _ in range(frame_count)
+        for size in (MAX_AUDIO_PAYLOAD, FRAME_BYTES - MAX_AUDIO_PAYLOAD)
+    ]
+    assert {packet.ident for packet in packets} == {TX_IDENT}
+    assert_contiguous_sequences(packets)
+
+
+async def test_bridge_tx_pipeline_encodes_pcm_only_when_tx_codec_is_opus() -> None:
+    transport = _RecordingAudioTransport()
+    radio = IcomRadio("192.0.2.10", username="u", password="p", timeout=0.05)
+    radio._connected = True
+    radio._civ_transport = object()
+    radio._conn_state = RadioConnectionState.CONNECTED
+    radio._audio_tx_codec = AudioCodec.OPUS_1CH
+    radio._audio_stream = AudioStream(transport)  # type: ignore[arg-type]
+
+    class _FakeTranscoder:
+        def pcm_to_opus(self, frame: bytes) -> bytes:
+            return b"OPUS" + frame[:24]
+
+    radio._get_pcm_transcoder = MagicMock(return_value=_FakeTranscoder())  # type: ignore[method-assign]
+
+    backend = FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="BlackHole Test",
+                input_channels=2,
+                output_channels=2,
+            )
+        ]
+    )
+    bridge = AudioBridge(
+        radio,
+        device_name="BlackHole Test",
+        tx_enabled=True,
+        backend=backend,
+    )
+
+    tone_frame = sine_pcm16_mono(1000.0, samples=SAMPLES_PER_FRAME)
+
+    await bridge.start()
+    try:
+        backend.rx_streams[0].inject_frame(tone_frame)
+        await asyncio.sleep(0.01)
+    finally:
+        await bridge.stop()
+        radio._connected = False
+
+    packets = collect_tx_audio_packets(transport.send_tracked.await_args_list)
+    payload = b"".join(packet.data for packet in packets)
+
+    assert payload == b"OPUS" + tone_frame[:24]
+    assert payload != tone_frame
+    assert [len(packet.data) for packet in packets] == [28]
+    assert_contiguous_sequences(packets)


### PR DESCRIPTION
## Summary

- add reusable CI-safe audio pipeline test helpers for synthetic PCM, RMS diagnostics, TX packet collection, and sequence assertions
- add an in-process TX pipeline harness that composes `AudioBridge`, `FakeAudioBackend`, real `IcomRadio` TX runtime, and real `AudioStream` packet chunking
- validate direct LAN PCM TX sends raw PCM unchanged and that Opus encoding only happens when the negotiated TX codec is Opus

## Regression coverage

- Catches PCM-negotiated-but-Opus-bytes-sent by reassembling raw TX audio packets and comparing the payload to the original PCM bytes
- Asserts raw PCM frame chunking remains `1364 + 556` bytes per 20 ms frame
- Asserts non-zero RMS and contiguous audio send sequences
- Asserts Opus path does not accidentally send raw PCM when TX codec is Opus

## Validation

- TDD red: `uv run pytest tests/test_audio_pipeline_harness.py -q` initially failed because `_audio_pipeline_helpers` did not exist
- `uv run pytest tests/test_audio_pipeline_harness.py tests/test_audio_bridge.py tests/test_audio_bridge_stereo.py tests/test_audio_transcoder.py tests/test_audio.py tests/test_pcm_e2e.py tests/test_audio_route.py -q`
- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`
- `uv run pytest tests/ -q --tb=short`

Closes #1450
Refs #1447
