### PR TITLE
feat(cli): add managed station runtime mode

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -600,12 +600,16 @@ rigplane web --port 9090 --rigctld-port 4533
 
 # Require token for /api and WebSocket channels
 rigplane web --auth-token "change-me"
+
+# Managed local runtime for a supervising desktop app
+RIGPLANE_AUTH_TOKEN="$(openssl rand -hex 24)" rigplane station --port 0
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--host` | `0.0.0.0` | Web server bind address |
 | `--port` | `8080` | Web server port |
+| `--managed` | off | Use managed local defaults: loopback bind, auth required, embedded rigctld disabled unless requested |
 | `--static-dir PATH` | — | Serve static files from a custom directory (default: built-in assets) |
 | `--bridge DEVICE` | — | Start audio bridge with named virtual device |
 | `--bridge-tx-device DEVICE` | — | Separate TX-only device for bidirectional bridge (e.g. `BlackHole 16ch`) |
@@ -615,6 +619,23 @@ rigplane web --auth-token "change-me"
 | `--dx-cluster HOST:PORT` | — | Connect to DX cluster server for real-time spot overlays (opt-in) |
 | `--callsign CALL` | — | Your callsign for DX cluster login (required with `--dx-cluster`) |
 | `--auth-token TOKEN` | — | Require `Authorization: Bearer <TOKEN>` for `/api/*` and WS channels |
+
+### `station`
+
+Start the managed local station runtime. This is a convenience command for
+supervisors such as desktop shells: it runs the web/API server on loopback,
+requires API/WebSocket auth, and does not expose embedded rigctld unless
+`--rigctld` is explicit.
+
+```bash
+export RIGPLANE_AUTH_TOKEN="$(openssl rand -hex 24)"
+rigplane station --port 0
+```
+
+`station` shares the radio connection flags from the top-level CLI, including
+`--host`, `--user`, `--pass-file`, `--backend`, `--serial-port`, and model/CI-V
+options. Prefer `RIGPLANE_AUTH_TOKEN` over `--auth-token` so the local API token
+does not appear in process listings.
 
 ### `audio bridge`
 

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -279,8 +279,40 @@ def _resolve_password(args: argparse.Namespace) -> str:
     return _get_env("ICOM_PASS", "")
 
 
+class _RigplaneArgumentParser(argparse.ArgumentParser):
+    def parse_args(
+        self,
+        args: list[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> argparse.Namespace:
+        parsed = super().parse_args(args, namespace)
+        _apply_managed_runtime_defaults(parsed)
+        return parsed
+
+
+def _apply_managed_runtime_defaults(args: argparse.Namespace) -> None:
+    if getattr(args, "command", None) == "station":
+        args.managed_runtime = True
+
+    if not getattr(args, "managed_runtime", False):
+        if (
+            getattr(args, "command", None) == "web"
+            and getattr(args, "web_rigctld", None) is None
+        ):
+            args.web_rigctld = True
+        return
+
+    if getattr(args, "command", None) not in {"web", "station"}:
+        return
+
+    if getattr(args, "web_host", "0.0.0.0") == "0.0.0.0":
+        args.web_host = "127.0.0.1"
+    if getattr(args, "web_rigctld", None) is None:
+        args.web_rigctld = False
+
+
 def _build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(
+    p = _RigplaneArgumentParser(
         prog="rigplane",
         description="Control Icom transceivers over LAN",
         epilog=(
@@ -827,6 +859,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Server listen address (default: 0.0.0.0)",
     )
     web_p.add_argument(
+        "--managed",
+        dest="managed_runtime",
+        action="store_true",
+        default=False,
+        help="Run with managed local runtime defaults for a supervising desktop app",
+    )
+    web_p.add_argument(
         "--port",
         dest="web_port",
         type=int,
@@ -908,8 +947,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "--no-rigctld",
         dest="web_rigctld",
         action="store_false",
-        default=True,
+        default=None,
         help="Disable the rigctld-compatible TCP server (enabled by default)",
+    )
+    web_p.add_argument(
+        "--rigctld",
+        dest="web_rigctld",
+        action="store_true",
+        help="Enable the embedded rigctld server when managed mode would disable it",
     )
     web_p.add_argument(
         "--rigctld-port",
@@ -958,6 +1003,74 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_false",
         default=True,
         help="Disable UDP discovery responder (enabled by default on port 8470)",
+    )
+
+    station_p = sub.add_parser(
+        "station",
+        help="Start managed local station runtime (loopback web server)",
+    )
+    station_p.add_argument(
+        "--host",
+        dest="web_host",
+        default="0.0.0.0",
+        help="Server listen address (managed default: 127.0.0.1)",
+    )
+    station_p.add_argument(
+        "--port",
+        dest="web_port",
+        type=int,
+        default=8080,
+        help="Server HTTP/WS port (default: 8080; use 0 for dynamic)",
+    )
+    station_p.add_argument(
+        "--static-dir",
+        dest="web_static_dir",
+        default=None,
+        metavar="PATH",
+        help="Directory to serve static files from (default: built-in)",
+    )
+    station_p.add_argument(
+        "--rigctld",
+        dest="web_rigctld",
+        action="store_true",
+        default=None,
+        help="Enable the embedded rigctld-compatible TCP server",
+    )
+    station_p.add_argument(
+        "--rigctld-port",
+        dest="web_rigctld_port",
+        type=int,
+        default=4532,
+        help="rigctld TCP port (default: 4532)",
+    )
+    station_p.add_argument(
+        "--auth-token",
+        dest="auth_token",
+        default="",
+        metavar="TOKEN",
+        help="Bearer token for API authentication (prefer RIGPLANE_AUTH_TOKEN)",
+    )
+    station_p.add_argument(
+        "--no-discovery",
+        dest="web_discovery",
+        action="store_false",
+        default=True,
+        help="Disable UDP discovery responder (enabled by default on port 8470)",
+    )
+    station_p.set_defaults(
+        managed_runtime=True,
+        web_bridge=None,
+        web_bridge_tx_device=None,
+        web_bridge_rx_only=False,
+        web_bridge_label=None,
+        web_bridge_max_retries=5,
+        web_bridge_retry_delay=1.0,
+        dx_cluster=None,
+        callsign=None,
+        wsjtx_compat=False,
+        tls=False,
+        tls_cert="",
+        tls_key="",
     )
 
     # proxy
@@ -1285,7 +1398,7 @@ async def _run(args: argparse.Namespace) -> int:
         return 1
     radio = create_radio(config)
 
-    if args.command == "web":
+    if args.command in ("web", "station"):
         # Only the web port is required. rigctld is best-effort: if its port
         # is busy we log a warning and continue (handled in _cmd_web).
         try:
@@ -1407,7 +1520,7 @@ async def _run(args: argparse.Namespace) -> int:
                     )
                     return 1
                 return await _cmd_levels(radio, args)
-            elif args.command == "web":
+            elif args.command in ("web", "station"):
                 return await _cmd_web(radio, args)
             elif args.command == "scope":
                 return await _cmd_scope(radio, args)
@@ -2623,7 +2736,16 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
             return 1
         config_kwargs["dx_callsign"] = callsign
 
+    managed_runtime = getattr(args, "managed_runtime", False)
     auth_token = getattr(args, "auth_token", "")
+    if managed_runtime and not auth_token:
+        auth_token = os.environ.get("RIGPLANE_AUTH_TOKEN", "").strip()
+    if managed_runtime and not auth_token:
+        print(
+            "Error: managed mode requires auth. Set RIGPLANE_AUTH_TOKEN or pass --auth-token.",
+            file=sys.stderr,
+        )
+        return 1
     if auth_token:
         config_kwargs["auth_token"] = auth_token
 
@@ -2922,11 +3044,15 @@ def main() -> None:
     # Default to a rotating file log for long-running daemon commands so we
     # have a forensic trail for bug reports (EPIPE storms, reconnect loops,
     # etc.) that are easy to lose from stdout alone.
-    is_daemon = getattr(args, "command", None) in ("web", "serve")
+    is_daemon = getattr(args, "command", None) in ("web", "serve", "station")
 
     # File handler (if log_file specified, debug mode, or daemon command)
     if (debug_mode or is_daemon) and not log_file and not log_file_disabled:
-        log_file = "logs/rigplane.log"
+        log_file = (
+            "logs/rigplane-managed.log"
+            if getattr(args, "managed_runtime", False)
+            else "logs/rigplane.log"
+        )
 
     if log_file:
         log_path = Path(log_file).expanduser().resolve()
@@ -2988,7 +3114,7 @@ def main() -> None:
         # Set ICOM_PID_FILE to a path to enable; no default path to avoid multi-instance conflicts.
         pid_path = os.environ.get("ICOM_PID_FILE", "").strip()
         pid_file: Path | None = None
-        if pid_path and args.command in ("web", "serve"):
+        if pid_path and args.command in ("web", "serve", "station"):
             pid_file = Path(pid_path)
             try:
                 pid_file.write_text(str(os.getpid()))

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -15,6 +15,7 @@ import pytest
 from _caps import FULL_ICOM_CAPS
 from rigplane.backends.config import SerialBackendConfig
 from rigplane.cli import (
+    _build_parser,
     _cmd_att,
     _cmd_audio_loopback,
     _cmd_audio_rx,
@@ -783,6 +784,79 @@ def _web_cmd_args(*, web_bridge: str | None) -> argparse.Namespace:
         dx_cluster=None,
         callsign=None,
     )
+
+
+def test_web_managed_parser_defaults_to_loopback_and_auth_required() -> None:
+    parser = _build_parser()
+
+    args = parser.parse_args(["web", "--managed"])
+
+    assert args.command == "web"
+    assert args.managed_runtime is True
+    assert args.web_host == "127.0.0.1"
+    assert args.web_rigctld is False
+    assert args.auth_token == ""
+
+
+def test_station_parser_is_managed_web_runtime() -> None:
+    parser = _build_parser()
+
+    args = parser.parse_args(["station", "--port", "0"])
+
+    assert args.command == "station"
+    assert args.managed_runtime is True
+    assert args.web_host == "127.0.0.1"
+    assert args.web_port == 0
+    assert args.web_rigctld is False
+
+
+@pytest.mark.asyncio
+async def test_cmd_web_managed_requires_auth_token(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = AsyncMock()
+    args = _web_cmd_args(web_bridge=None)
+    args.managed_runtime = True
+    args.auth_token = ""
+    monkeypatch.delenv("RIGPLANE_AUTH_TOKEN", raising=False)
+
+    rc = await _cmd_web(radio, args)
+
+    assert rc == 1
+    assert "managed mode requires auth" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_cmd_web_managed_uses_env_auth_and_no_embedded_rigctld(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = AsyncMock()
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("RIGPLANE_AUTH_TOKEN", "env-token")
+
+    class FakeWebServer:
+        def __init__(self, _radio, cfg):
+            captured["cfg"] = cfg
+
+        async def serve_forever(self):
+            raise asyncio.CancelledError
+
+    args = _web_cmd_args(web_bridge=None)
+    args.managed_runtime = True
+    args.auth_token = ""
+    args.web_rigctld = False
+
+    with (
+        patch("rigplane.web.server.WebServer", FakeWebServer),
+        patch("rigplane.rigctld.server.RigctldServer") as rigctld_cls,
+    ):
+        assert await _cmd_web(radio, args) == 0
+
+    cfg = captured["cfg"]
+    assert cfg.auth_token == "env-token"
+    assert cfg.host == "127.0.0.1"
+    rigctld_cls.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1439
Refs #1438

## Summary
- add `rigplane station` as a managed local station runtime command
- add `rigplane web --managed` for the same managed defaults on the existing web command
- default managed runtime to loopback bind, required auth, no embedded rigctld unless `--rigctld` is explicit, and a managed log path
- allow managed auth via `RIGPLANE_AUTH_TOKEN` so supervisors do not need to put the token in argv
- document managed station startup in the CLI guide

## Validation
- uv run pytest tests/test_cli_coverage.py tests/test_cli.py tests/test_dx_cluster.py tests/test_yaesu_cli_factory.py -q --tb=short
- uv run ruff check src/rigplane/cli/__init__.py tests/test_cli_coverage.py docs/guide/cli.md
- uv run ruff format --check src/rigplane/cli/__init__.py tests/test_cli_coverage.py
- uv run pytest tests -q --tb=short

Full local pytest result: 5885 passed, 110 skipped, 3 deselected, 9 xfailed, 1 xpassed.