### PR TITLE
feat(web): add runtime health endpoints

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -22,7 +22,10 @@ ws://host:8080/api/v1/ws?token=<token>
 
 | Method | Path | Purpose |
 |-------|------|---------|
+| `GET` | `/healthz` | Process/API liveness, no API token required |
+| `GET` | `/readyz` | Station readiness, returns `503` until radio is ready |
 | `GET` | `/api/v1/info` | Runtime model/capability summary |
+| `GET` | `/api/v1/runtime` | Process, bind, radio, rigctld, bridge, and diagnostic runtime status |
 | `GET` | `/api/v1/state` | Canonical current state snapshot |
 | `GET` | `/api/v1/capabilities` | Full profile-backed capabilities |
 | `GET` | `/api/v1/dx/spots` | Buffered DX spots |
@@ -47,6 +50,66 @@ ws://host:8080/api/v1/ws?token=<token>
 | `DELETE` | `/api/v1/bridge` | Stop audio bridge |
 | `POST` | `/api/v1/band-plan/config` | Change active region and reload band plans |
 | `POST` | `/api/v1/eibi/fetch` | Fetch/refresh EiBi dataset |
+
+---
+
+## `GET /healthz`
+
+Process liveness probe for local supervisors. This endpoint is intentionally
+outside `/api/*`, so it does not require bearer auth.
+
+```json
+{
+  "status": "ok",
+  "pid": 12345,
+  "version": "2.0.3"
+}
+```
+
+## `GET /readyz`
+
+Station readiness probe. Returns HTTP `200` when the attached radio is ready
+and HTTP `503` while the process is alive but the station is not ready.
+
+```json
+{
+  "status": "ready",
+  "radioReady": true
+}
+```
+
+## `GET /api/v1/runtime`
+
+Machine-readable runtime status for managed local supervisors and diagnostics.
+When auth is configured, this endpoint requires the same bearer token as other
+`/api/*` routes.
+
+```json
+{
+  "pid": 12345,
+  "uptimeSeconds": 12.3,
+  "version": "2.0.3",
+  "bind": { "host": "127.0.0.1", "port": 8080 },
+  "logPath": "/Users/me/Library/Logs/rigplane.log",
+  "authRequired": true,
+  "backend": "rigplane",
+  "radio": {
+    "model": "IC-7610",
+    "connected": true,
+    "controlConnected": true,
+    "radioReady": true
+  },
+  "rigctld": {
+    "enabled": true,
+    "address": "127.0.0.1:4532"
+  },
+  "bridge": {
+    "enabled": false,
+    "running": false
+  },
+  "lastError": null
+}
+```
 
 ---
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -609,7 +609,7 @@ RIGPLANE_AUTH_TOKEN="$(openssl rand -hex 24)" rigplane station --port 0
 |--------|---------|-------------|
 | `--host` | `0.0.0.0` | Web server bind address |
 | `--port` | `8080` | Web server port |
-| `--managed` | off | Use managed local defaults: loopback bind, auth required, embedded rigctld disabled unless requested |
+| `--managed` | off | Use managed local defaults: loopback bind, auth required, embedded rigctld on loopback |
 | `--static-dir PATH` | — | Serve static files from a custom directory (default: built-in assets) |
 | `--bridge DEVICE` | — | Start audio bridge with named virtual device |
 | `--bridge-tx-device DEVICE` | — | Separate TX-only device for bidirectional bridge (e.g. `BlackHole 16ch`) |
@@ -624,8 +624,8 @@ RIGPLANE_AUTH_TOKEN="$(openssl rand -hex 24)" rigplane station --port 0
 
 Start the managed local station runtime. This is a convenience command for
 supervisors such as desktop shells: it runs the web/API server on loopback,
-requires API/WebSocket auth, and does not expose embedded rigctld unless
-`--rigctld` is explicit.
+requires API/WebSocket auth, and enables embedded rigctld on loopback for local
+clients such as RigPlane Pro.
 
 ```bash
 export RIGPLANE_AUTH_TOKEN="$(openssl rand -hex 24)"

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -308,7 +308,7 @@ def _apply_managed_runtime_defaults(args: argparse.Namespace) -> None:
     if getattr(args, "web_host", "0.0.0.0") == "0.0.0.0":
         args.web_host = "127.0.0.1"
     if getattr(args, "web_rigctld", None) is None:
-        args.web_rigctld = False
+        args.web_rigctld = True
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -2775,6 +2775,13 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
     config_kwargs["radio_model"] = getattr(radio, "model", "IC-7610")
     config = WebConfig(**config_kwargs)
     server = WebServer(radio, config)
+    runtime_log_path = getattr(args, "runtime_log_path", None)
+    if isinstance(runtime_log_path, str) and runtime_log_path:
+        server._runtime_log_path = runtime_log_path
+    else:
+        log_file = os.environ.get("ICOM_LOG_FILE", "").strip()
+        if log_file and log_file.lower() not in ("off", "none", "-"):
+            server._runtime_log_path = str(Path(log_file).expanduser().resolve())
 
     # Start audio bridge.
     #
@@ -2856,8 +2863,9 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
         if wsjtx_compat:
             audio_route = resolve_audio_route(radio)
             wsjtx_data_mode, wsjtx_data_mod_input = rigctld_wsjtx_policy(audio_route)
+        rigctld_host = "127.0.0.1" if managed_runtime else "0.0.0.0"
         rigctld_config = RigctldConfig(
-            host="0.0.0.0",
+            host=rigctld_host,
             port=rigctld_port,
             wsjtx_compat=wsjtx_compat,
             wsjtx_data_mode=wsjtx_data_mode,
@@ -2873,14 +2881,17 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
             # ENETUNREACH, etc.) indicate a misconfigured environment and
             # must surface so the operator can fix it.
             if exc.errno == errno.EADDRINUSE:
+                server._runtime_last_error = f"rigctld bind failed: {exc}"
                 logger.warning(
-                    "rigctld disabled: failed to bind port %d: %s "
+                    "rigctld disabled: failed to bind %s:%d: %s "
                     "(another rigctld may already be running; pass --no-rigctld to silence)",
+                    rigctld_host,
                     rigctld_port,
                     exc,
                 )
                 rigctld_server = None
             else:
+                server._runtime_last_error = f"rigctld bind failed: {exc}"
                 logger.error(
                     "rigctld failed to start on port %d: %s (errno=%s)",
                     rigctld_port,
@@ -2890,7 +2901,8 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
                 raise
         else:
             rigctld_server = candidate
-            rigctld_addr = f"0.0.0.0:{rigctld_port}"
+            rigctld_addr = f"{rigctld_host}:{rigctld_port}"
+            server._runtime_rigctld_addr = rigctld_addr
 
     scheme = "https" if config_kwargs.get("tls") else "http"
     web_url = f"{scheme}://{args.web_host}:{args.web_port}/"
@@ -3057,6 +3069,7 @@ def main() -> None:
     if log_file:
         log_path = Path(log_file).expanduser().resolve()
         log_path.parent.mkdir(parents=True, exist_ok=True)
+        setattr(args, "runtime_log_path", str(log_path))
         max_bytes = _env_int("ICOM_LOG_MAX_BYTES", 50_000_000)
         backup_count = _env_int("ICOM_LOG_BACKUP_COUNT", 5)
         file_handler: logging.Handler = RotatingFileHandler(

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -25,7 +25,9 @@ import hmac
 import json
 import logging
 import mimetypes
+import os
 import pathlib
+import time
 import urllib.parse
 from dataclasses import dataclass, field
 from collections.abc import Coroutine
@@ -324,6 +326,10 @@ class WebServer:
         self._radio = radio
         self._config = config or WebConfig()
         self._server: asyncio.Server | None = None
+        self._runtime_started_at = time.monotonic()
+        self._runtime_log_path: str | None = None
+        self._runtime_rigctld_addr: str | None = None
+        self._runtime_last_error: str | None = None
         self._client_tasks: set[asyncio.Task[None]] = set()
         self._scope_handlers: set["ScopeHandler"] = set()
         self._audio_scope_handlers: set["ScopeHandler"] = set()
@@ -1296,6 +1302,106 @@ class WebServer:
                     "controlConnected": control_connected,
                     "wsClients": len(self._client_tasks),
                 },
+            },
+            separators=(",", ":"),
+        ).encode()
+        await _send_json(writer, body, headers)
+
+    async def _serve_health(
+        self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
+    ) -> None:
+        body = json.dumps(
+            {
+                "status": "ok",
+                "pid": os.getpid(),
+                "version": __version__,
+            },
+            separators=(",", ":"),
+        ).encode()
+        await _send_json(writer, body, headers)
+
+    async def _serve_ready(
+        self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
+    ) -> None:
+        ready = self._radio_ready()
+        body = json.dumps(
+            {
+                "status": "ready" if ready else "not_ready",
+                "radioReady": ready,
+            },
+            separators=(",", ":"),
+        ).encode()
+        if ready:
+            await _send_json(writer, body, headers)
+        else:
+            await _send_response(
+                writer,
+                503,
+                "Service Unavailable",
+                body,
+                {"Content-Type": "application/json"},
+            )
+
+    def _runtime_bind_payload(self) -> dict[str, Any]:
+        if self._server is not None and self._server.sockets:
+            host, port = self._server.sockets[0].getsockname()[:2]
+            return {"host": str(host), "port": int(port)}
+        return {"host": self._config.host, "port": int(self._config.port)}
+
+    def _runtime_bridge_payload(self) -> dict[str, Any]:
+        bridge = self._audio_bridge
+        if bridge is None:
+            return {"enabled": False, "running": False}
+        stats = getattr(bridge, "stats", None)
+        if callable(stats):
+            stats = stats()
+        if not isinstance(stats, dict):
+            stats = {}
+        return {
+            "enabled": True,
+            "running": bool(getattr(bridge, "running", False)),
+            "stats": stats,
+        }
+
+    async def _serve_runtime(
+        self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
+    ) -> None:
+        radio = self._radio
+        raw_connected = (
+            getattr(radio, "connected", False) if radio is not None else False
+        )
+        connected = raw_connected if isinstance(raw_connected, bool) else False
+        raw_control_connected = (
+            getattr(radio, "control_connected", False) if radio is not None else False
+        )
+        control_connected = (
+            raw_control_connected if isinstance(raw_control_connected, bool) else False
+        )
+        body = json.dumps(
+            {
+                "pid": os.getpid(),
+                "uptimeSeconds": round(time.monotonic() - self._runtime_started_at, 1),
+                "version": __version__,
+                "bind": self._runtime_bind_payload(),
+                "logPath": self._runtime_log_path,
+                "authRequired": bool(self._config.auth_token),
+                "backend": getattr(radio, "backend_id", None)
+                if radio is not None
+                else None,
+                "radio": {
+                    "model": getattr(radio, "model", self._config.radio_model)
+                    if radio is not None
+                    else self._config.radio_model,
+                    "connected": connected,
+                    "controlConnected": control_connected,
+                    "radioReady": self._radio_ready(),
+                },
+                "rigctld": {
+                    "enabled": self._runtime_rigctld_addr is not None,
+                    "address": self._runtime_rigctld_addr,
+                },
+                "bridge": self._runtime_bridge_payload(),
+                "lastError": self._runtime_last_error,
             },
             separators=(",", ":"),
         ).encode()

--- a/src/rigplane/web/web_routing.py
+++ b/src/rigplane/web/web_routing.py
@@ -67,6 +67,20 @@ async def dispatch_http_request(
             )
             return
 
+    if path == "/healthz":
+        if method not in ("GET", "HEAD"):
+            await _send_response(writer, 405, "Method Not Allowed", b"", {})
+            return
+        await server._serve_health(writer, headers)
+        return
+
+    if path == "/readyz":
+        if method not in ("GET", "HEAD"):
+            await _send_response(writer, 405, "Method Not Allowed", b"", {})
+            return
+        await server._serve_ready(writer, headers)
+        return
+
     # Routes that accept POST/DELETE
     if path == "/api/v1/bridge":
         if method not in ("GET", "HEAD", "POST", "DELETE"):
@@ -222,6 +236,8 @@ async def dispatch_http_request(
 
     if path == "/api/v1/info":
         await server._serve_info(writer, headers)
+    elif path == "/api/v1/runtime":
+        await server._serve_runtime(writer, headers)
     elif path == "/api/v1/state":
         await server._serve_state(writer, headers)
     elif path == "/api/v1/capabilities":

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -794,7 +794,7 @@ def test_web_managed_parser_defaults_to_loopback_and_auth_required() -> None:
     assert args.command == "web"
     assert args.managed_runtime is True
     assert args.web_host == "127.0.0.1"
-    assert args.web_rigctld is False
+    assert args.web_rigctld is True
     assert args.auth_token == ""
 
 
@@ -807,7 +807,7 @@ def test_station_parser_is_managed_web_runtime() -> None:
     assert args.managed_runtime is True
     assert args.web_host == "127.0.0.1"
     assert args.web_port == 0
-    assert args.web_rigctld is False
+    assert args.web_rigctld is True
 
 
 @pytest.mark.asyncio
@@ -828,7 +828,7 @@ async def test_cmd_web_managed_requires_auth_token(
 
 
 @pytest.mark.asyncio
-async def test_cmd_web_managed_uses_env_auth_and_no_embedded_rigctld(
+async def test_cmd_web_managed_uses_env_auth_and_loopback_embedded_rigctld(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     radio = AsyncMock()
@@ -838,25 +838,40 @@ async def test_cmd_web_managed_uses_env_auth_and_no_embedded_rigctld(
     class FakeWebServer:
         def __init__(self, _radio, cfg):
             captured["cfg"] = cfg
+            self._runtime_log_path = None
 
         async def serve_forever(self):
+            captured["runtime_log_path"] = self._runtime_log_path
             raise asyncio.CancelledError
+
+    class FakeRigctldServer:
+        def __init__(self, _radio, cfg):
+            captured["rigctld_cfg"] = cfg
+
+        async def start(self):
+            return None
+
+        async def stop(self):
+            return None
 
     args = _web_cmd_args(web_bridge=None)
     args.managed_runtime = True
     args.auth_token = ""
-    args.web_rigctld = False
+    args.web_rigctld = True
+    args.runtime_log_path = "/tmp/rigplane-managed.log"
 
     with (
         patch("rigplane.web.server.WebServer", FakeWebServer),
-        patch("rigplane.rigctld.server.RigctldServer") as rigctld_cls,
+        patch("rigplane.rigctld.server.RigctldServer", FakeRigctldServer),
     ):
         assert await _cmd_web(radio, args) == 0
 
     cfg = captured["cfg"]
     assert cfg.auth_token == "env-token"
     assert cfg.host == "127.0.0.1"
-    rigctld_cls.assert_not_called()
+    assert captured["runtime_log_path"] == "/tmp/rigplane-managed.log"
+    rigctld_cfg = captured["rigctld_cfg"]
+    assert rigctld_cfg.host == "127.0.0.1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import pathlib
 import time
 from types import SimpleNamespace
@@ -64,6 +65,13 @@ def _reader_with(data: bytes) -> asyncio.StreamReader:
     reader.feed_data(data)
     reader.feed_eof()
     return reader
+
+
+def _response_json(writer: _FakeWriter) -> tuple[int, dict]:
+    text = writer.buffer.decode("ascii", errors="replace")
+    status = int(text.split(" ", 2)[1])
+    body_start = text.index("\r\n\r\n") + 4
+    return status, json.loads(text[body_start:] or "{}")
 
 
 def _scope_radio(*, ready: bool = True, connected: bool = True) -> MagicMock:
@@ -261,6 +269,91 @@ async def test_handle_http_routes_and_405_404() -> None:
     assert srv2._serve_capabilities.await_count == 1
     assert srv2._serve_static.await_count == 2
     send_resp2.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_healthz_reports_process_liveness() -> None:
+    srv = WebServer(None, WebConfig(host="127.0.0.1", port=0))
+    writer = _FakeWriter()
+
+    await srv._handle_http(writer, "GET", "/healthz")  # noqa: SLF001
+
+    status, data = _response_json(writer)
+    assert status == 200
+    assert data["status"] == "ok"
+    assert data["version"]
+    assert isinstance(data["pid"], int)
+
+
+@pytest.mark.asyncio
+async def test_readyz_reflects_station_readiness() -> None:
+    ready_radio = SimpleNamespace(radio_ready=True, connected=True, capabilities=set())
+    ready_srv = WebServer(ready_radio, WebConfig(host="127.0.0.1", port=0))
+    ready_writer = _FakeWriter()
+
+    await ready_srv._handle_http(ready_writer, "GET", "/readyz")  # noqa: SLF001
+
+    status, data = _response_json(ready_writer)
+    assert status == 200
+    assert data == {"status": "ready", "radioReady": True}
+
+    not_ready_srv = WebServer(None, WebConfig(host="127.0.0.1", port=0))
+    not_ready_writer = _FakeWriter()
+
+    await not_ready_srv._handle_http(not_ready_writer, "GET", "/readyz")  # noqa: SLF001
+
+    status, data = _response_json(not_ready_writer)
+    assert status == 503
+    assert data == {"status": "not_ready", "radioReady": False}
+
+
+@pytest.mark.asyncio
+async def test_runtime_endpoint_reports_process_bind_radio_and_bridge_status() -> None:
+    radio = SimpleNamespace(
+        model="IC-7610",
+        backend_id="rigplane",
+        connected=True,
+        control_connected=True,
+        radio_ready=True,
+        capabilities=set(),
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0, auth_token="token"))
+    srv._server = _FakeAsyncServer()  # noqa: SLF001
+    srv._audio_bridge = SimpleNamespace(  # noqa: SLF001
+        running=True,
+        stats={"rx_frames": 3, "tx_frames": 4},
+    )
+    srv._runtime_log_path = "/tmp/rigplane.log"  # noqa: SLF001
+    srv._runtime_rigctld_addr = "127.0.0.1:4532"  # noqa: SLF001
+    writer = _FakeWriter()
+
+    await srv._handle_http(  # noqa: SLF001
+        writer,
+        "GET",
+        "/api/v1/runtime",
+        headers={"authorization": "Bearer token"},
+    )
+
+    status, data = _response_json(writer)
+    assert status == 200
+    assert data["pid"] > 0
+    assert data["uptimeSeconds"] >= 0
+    assert data["version"]
+    assert data["bind"] == {"host": "127.0.0.1", "port": 4242}
+    assert data["logPath"] == "/tmp/rigplane.log"
+    assert data["authRequired"] is True
+    assert data["backend"] == "rigplane"
+    assert data["radio"] == {
+        "model": "IC-7610",
+        "connected": True,
+        "controlConnected": True,
+        "radioReady": True,
+    }
+    assert data["rigctld"] == {"enabled": True, "address": "127.0.0.1:4532"}
+    assert data["bridge"]["running"] is True
+    assert data["bridge"]["stats"] == {"rx_frames": 3, "tx_frames": 4}
+    assert data["lastError"] is None
+    srv._server = None  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1440
Refs #1438

## Summary
- add unauthenticated `GET /healthz` process liveness and `GET /readyz` station readiness probes
- add authenticated `GET /api/v1/runtime` with PID, uptime, version, bind, log path, backend, radio, rigctld, bridge, and last error fields
- propagate runtime log path and rigctld address into `WebServer` runtime status
- correct managed runtime defaults so `rigplane station` / `web --managed` keep embedded rigctld enabled on `127.0.0.1` for local Pro clients
- document runtime endpoints and managed rigctld behavior

## Validation
- uv run pytest tests/test_web_server_coverage.py tests/test_web_server.py tests/test_web_runtime_helpers.py tests/test_web_auth_compare_digest.py tests/test_cli_coverage.py tests/test_cli.py -q --tb=short
- uv run ruff check src/rigplane/web/server.py src/rigplane/web/web_routing.py src/rigplane/cli/__init__.py tests/test_web_server_coverage.py tests/test_cli_coverage.py docs/api/web.md docs/guide/cli.md
- uv run ruff format --check src/rigplane/web/server.py src/rigplane/web/web_routing.py src/rigplane/cli/__init__.py tests/test_web_server_coverage.py tests/test_cli_coverage.py
- uv run pytest tests -q --tb=short

Full local pytest result: 5888 passed, 110 skipped, 3 deselected, 9 xfailed, 1 xpassed.