### PR TITLE
feat(web): emit managed runtime startup event

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -111,6 +111,21 @@ When auth is configured, this endpoint requires the same bearer token as other
 }
 ```
 
+Managed runtimes also emit a single machine-readable startup event to stdout
+after the web listener has bound successfully. Supervisors should use this JSON
+line as the startup contract instead of parsing the human-readable banner:
+
+```json
+{
+  "type": "rigplane.runtime.started",
+  "pid": 12345,
+  "baseUrl": "http://127.0.0.1:58421",
+  "healthUrl": "http://127.0.0.1:58421/healthz",
+  "runtimeUrl": "http://127.0.0.1:58421/api/v1/runtime",
+  "logPath": "/Users/me/Library/Logs/rigplane.log"
+}
+```
+
 ---
 
 ## `GET /api/v1/info`

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -637,6 +637,15 @@ rigplane station --port 0
 options. Prefer `RIGPLANE_AUTH_TOKEN` over `--auth-token` so the local API token
 does not appear in process listings.
 
+After the web listener binds, `station` writes one JSON startup event to stdout:
+
+```json
+{"type":"rigplane.runtime.started","pid":12345,"baseUrl":"http://127.0.0.1:58421","healthUrl":"http://127.0.0.1:58421/healthz","runtimeUrl":"http://127.0.0.1:58421/api/v1/runtime","logPath":"/Users/me/Library/Logs/rigplane.log"}
+```
+
+Use this event for supervisor discovery when `--port 0` asks the OS to allocate
+the actual port.
+
 ### `audio bridge`
 
 Route radio audio to/from a virtual audio device (BlackHole, Loopback, VB-Audio).

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -2748,6 +2748,8 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
         return 1
     if auth_token:
         config_kwargs["auth_token"] = auth_token
+    if managed_runtime:
+        config_kwargs["emit_startup_event"] = True
 
     tls_cert = getattr(args, "tls_cert", "")
     tls_key = getattr(args, "tls_key", "")

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -27,11 +27,12 @@ import logging
 import mimetypes
 import os
 import pathlib
+import sys
 import time
 import urllib.parse
 from dataclasses import dataclass, field
 from collections.abc import Coroutine
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TextIO
 
 from .. import __version__
 from .._bounded_queue import BoundedQueue
@@ -253,6 +254,7 @@ class WebConfig:
     discovery: bool = True  # enable UDP discovery responder
     discovery_port: int = 8470  # UDP port for discovery
     read_only: bool = False  # reject PTT and other transmit commands
+    emit_startup_event: bool = False  # emit JSON runtime startup event to stdout
 
 
 class ConnectionManager:
@@ -1047,6 +1049,8 @@ class WebServer:
 
         await self.start()
         assert self._server is not None
+        if self._config.emit_startup_event:
+            self.emit_startup_event()
 
         loop = asyncio.get_running_loop()
         stop_event = asyncio.Event()
@@ -1347,6 +1351,30 @@ class WebServer:
             host, port = self._server.sockets[0].getsockname()[:2]
             return {"host": str(host), "port": int(port)}
         return {"host": self._config.host, "port": int(self._config.port)}
+
+    def _runtime_base_url(self) -> str:
+        bind = self._runtime_bind_payload()
+        scheme = "https" if self._config.tls else "http"
+        return f"{scheme}://{bind['host']}:{bind['port']}"
+
+    def startup_event_payload(self) -> dict[str, Any]:
+        base_url = self._runtime_base_url()
+        return {
+            "type": "rigplane.runtime.started",
+            "pid": os.getpid(),
+            "baseUrl": base_url,
+            "healthUrl": f"{base_url}/healthz",
+            "runtimeUrl": f"{base_url}/api/v1/runtime",
+            "logPath": self._runtime_log_path,
+        }
+
+    def emit_startup_event(self, stream: TextIO | None = None) -> None:
+        target = stream if stream is not None else sys.stdout
+        print(
+            json.dumps(self.startup_event_payload(), separators=(",", ":")),
+            file=target,
+            flush=True,
+        )
 
     def _runtime_bridge_payload(self) -> dict[str, Any]:
         bridge = self._audio_bridge

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -869,9 +869,34 @@ async def test_cmd_web_managed_uses_env_auth_and_loopback_embedded_rigctld(
     cfg = captured["cfg"]
     assert cfg.auth_token == "env-token"
     assert cfg.host == "127.0.0.1"
+    assert cfg.emit_startup_event is True
     assert captured["runtime_log_path"] == "/tmp/rigplane-managed.log"
     rigctld_cfg = captured["rigctld_cfg"]
     assert rigctld_cfg.host == "127.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_cmd_web_plain_runtime_does_not_emit_startup_event() -> None:
+    radio = AsyncMock()
+    captured: dict[str, object] = {}
+
+    class FakeWebServer:
+        def __init__(self, _radio, cfg):
+            captured["cfg"] = cfg
+            self._runtime_log_path = None
+
+        async def serve_forever(self):
+            raise asyncio.CancelledError
+
+    args = _web_cmd_args(web_bridge=None)
+    args.managed_runtime = False
+    args.auth_token = ""
+    args.runtime_log_path = None
+
+    with patch("rigplane.web.server.WebServer", FakeWebServer):
+        assert await _cmd_web(radio, args) == 0
+
+    assert captured["cfg"].emit_startup_event is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 import pathlib
 import time
@@ -354,6 +355,30 @@ async def test_runtime_endpoint_reports_process_bind_radio_and_bridge_status() -
     assert data["bridge"]["stats"] == {"rx_frames": 3, "tx_frames": 4}
     assert data["lastError"] is None
     srv._server = None  # noqa: SLF001
+
+
+def test_startup_event_reports_actual_runtime_urls_and_log_path() -> None:
+    srv = WebServer(
+        None,
+        WebConfig(
+            host="127.0.0.1",
+            port=0,
+            emit_startup_event=True,
+        ),
+    )
+    srv._server = _FakeAsyncServer()  # noqa: SLF001
+    srv._runtime_log_path = "/tmp/rigplane-managed.log"  # noqa: SLF001
+    out = io.StringIO()
+
+    srv.emit_startup_event(out)
+
+    payload = json.loads(out.getvalue())
+    assert payload["type"] == "rigplane.runtime.started"
+    assert payload["pid"] > 0
+    assert payload["baseUrl"] == "http://127.0.0.1:4242"
+    assert payload["healthUrl"] == "http://127.0.0.1:4242/healthz"
+    assert payload["runtimeUrl"] == "http://127.0.0.1:4242/api/v1/runtime"
+    assert payload["logPath"] == "/tmp/rigplane-managed.log"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- emit a single JSON startup event for managed/station runtimes after the web listener binds
- report actual dynamic-port URLs from the bound socket plus PID and log path
- keep ordinary web mode on human banner output only
- document the supervisor startup contract

Closes #1441
Refs #1438

## Validation
- uv run pytest tests/test_web_server_coverage.py::test_startup_event_reports_actual_runtime_urls_and_log_path tests/test_cli_coverage.py::test_cmd_web_managed_uses_env_auth_and_loopback_embedded_rigctld tests/test_cli_coverage.py::test_cmd_web_plain_runtime_does_not_emit_startup_event -q --tb=short
- uv run pytest tests/test_web_server_coverage.py tests/test_cli_coverage.py -q --tb=short
- uv run ruff check src/rigplane/web/server.py src/rigplane/cli/__init__.py tests/test_web_server_coverage.py tests/test_cli_coverage.py
- uv run ruff format --check src/rigplane/web/server.py src/rigplane/cli/__init__.py tests/test_web_server_coverage.py tests/test_cli_coverage.py
- uv run pytest tests/test_web_server.py tests/test_web_server_coverage.py tests/test_cli.py tests/test_cli_coverage.py -q --tb=short
- uv run pytest tests -q --tb=short