### PR TITLE
feat(cli): read managed auth token from file

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -4,7 +4,8 @@ Built-in HTTP + WebSocket interface used by the browser UI and automation client
 
 ## Auth Model
 
-If web server is started with `--auth-token`, all `/api/*` HTTP routes require:
+If web server is started with `--auth-token`, `--auth-token-file`, or
+`RIGPLANE_AUTH_TOKEN` in managed mode, all `/api/*` HTTP routes require:
 
 ```
 Authorization: Bearer <token>

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -600,9 +600,11 @@ rigplane web --port 9090 --rigctld-port 4533
 
 # Require token for /api and WebSocket channels
 rigplane web --auth-token "change-me"
+rigplane web --auth-token-file ./runtime-token
 
 # Managed local runtime for a supervising desktop app
 RIGPLANE_AUTH_TOKEN="$(openssl rand -hex 24)" rigplane station --port 0
+rigplane station --port 0 --auth-token-file ./runtime-token
 ```
 
 | Option | Default | Description |
@@ -619,6 +621,7 @@ RIGPLANE_AUTH_TOKEN="$(openssl rand -hex 24)" rigplane station --port 0
 | `--dx-cluster HOST:PORT` | — | Connect to DX cluster server for real-time spot overlays (opt-in) |
 | `--callsign CALL` | — | Your callsign for DX cluster login (required with `--dx-cluster`) |
 | `--auth-token TOKEN` | — | Require `Authorization: Bearer <TOKEN>` for `/api/*` and WS channels |
+| `--auth-token-file PATH` | — | Read API/WS bearer token from a file |
 
 ### `station`
 
@@ -634,8 +637,10 @@ rigplane station --port 0
 
 `station` shares the radio connection flags from the top-level CLI, including
 `--host`, `--user`, `--pass-file`, `--backend`, `--serial-port`, and model/CI-V
-options. Prefer `RIGPLANE_AUTH_TOKEN` over `--auth-token` so the local API token
-does not appear in process listings.
+options. Prefer `--auth-token-file` or `RIGPLANE_AUTH_TOKEN` over `--auth-token`
+so the local API token does not appear in process listings. Explicit
+`--auth-token` wins over `--auth-token-file`; the file wins over
+`RIGPLANE_AUTH_TOKEN`.
 
 After the web listener binds, `station` writes one JSON startup event to stdout:
 
@@ -854,6 +859,7 @@ rigplane proxy --radio 192.168.1.100 --listen 10.8.0.1
 | `--dx-cluster HOST:PORT` | `web` | *(none)* | Connect to a DX cluster server for real-time spot overlays |
 | `--callsign CALL` | `web` | *(none)* | Your callsign for DX cluster login (required with `--dx-cluster`) |
 | `--auth-token TOKEN` | `web` | *(none)* | Require Bearer auth for API/WS endpoints |
+| `--auth-token-file PATH` | `web`, `station` | *(none)* | Read Bearer auth token from a file |
 | `--tls` | `web` | off | Enable HTTPS with auto-generated self-signed certificate |
 | `--tls-cert PATH` | `web` | *(none)* | Path to TLS certificate PEM file |
 | `--tls-key PATH` | `web` | *(none)* | Path to TLS private key PEM file |

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -977,6 +977,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Bearer token for API authentication (empty = no auth)",
     )
     web_p.add_argument(
+        "--auth-token-file",
+        dest="auth_token_file",
+        default="",
+        metavar="PATH",
+        help="Read Bearer token for API authentication from PATH",
+    )
+    web_p.add_argument(
         "--tls-cert",
         dest="tls_cert",
         default="",
@@ -1049,6 +1056,13 @@ def _build_parser() -> argparse.ArgumentParser:
         default="",
         metavar="TOKEN",
         help="Bearer token for API authentication (prefer RIGPLANE_AUTH_TOKEN)",
+    )
+    station_p.add_argument(
+        "--auth-token-file",
+        dest="auth_token_file",
+        default="",
+        metavar="PATH",
+        help="Read Bearer token for API authentication from PATH (preferred for supervisors)",
     )
     station_p.add_argument(
         "--no-discovery",
@@ -1569,6 +1583,10 @@ def _audio_frame_bytes(
     sample_rate: int, channels: int, frame_ms: int = _AUDIO_FRAME_MS
 ) -> int:
     return sample_rate * channels * _PCM_SAMPLE_WIDTH_BYTES * frame_ms // 1000
+
+
+def _read_auth_token_file(path: str) -> str:
+    return Path(path).expanduser().read_text(encoding="utf-8").strip()
 
 
 def _validate_audio_format_args(sample_rate: int, channels: int) -> str | None:
@@ -2738,11 +2756,21 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
 
     managed_runtime = getattr(args, "managed_runtime", False)
     auth_token = getattr(args, "auth_token", "")
+    auth_token_file = getattr(args, "auth_token_file", "")
+    if not auth_token and auth_token_file:
+        try:
+            auth_token = _read_auth_token_file(auth_token_file)
+        except OSError as exc:
+            print(
+                f"Error: failed to read --auth-token-file: {exc}",
+                file=sys.stderr,
+            )
+            return 1
     if managed_runtime and not auth_token:
         auth_token = os.environ.get("RIGPLANE_AUTH_TOKEN", "").strip()
     if managed_runtime and not auth_token:
         print(
-            "Error: managed mode requires auth. Set RIGPLANE_AUTH_TOKEN or pass --auth-token.",
+            "Error: managed mode requires auth. Set RIGPLANE_AUTH_TOKEN or pass --auth-token-file.",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -789,13 +789,14 @@ def _web_cmd_args(*, web_bridge: str | None) -> argparse.Namespace:
 def test_web_managed_parser_defaults_to_loopback_and_auth_required() -> None:
     parser = _build_parser()
 
-    args = parser.parse_args(["web", "--managed"])
+    args = parser.parse_args(["web", "--managed", "--auth-token-file", "token.txt"])
 
     assert args.command == "web"
     assert args.managed_runtime is True
     assert args.web_host == "127.0.0.1"
     assert args.web_rigctld is True
     assert args.auth_token == ""
+    assert args.auth_token_file == "token.txt"
 
 
 def test_station_parser_is_managed_web_runtime() -> None:
@@ -824,7 +825,88 @@ async def test_cmd_web_managed_requires_auth_token(
     rc = await _cmd_web(radio, args)
 
     assert rc == 1
-    assert "managed mode requires auth" in capsys.readouterr().err
+    assert (
+        "Set RIGPLANE_AUTH_TOKEN or pass --auth-token-file" in capsys.readouterr().err
+    )
+
+
+@pytest.mark.asyncio
+async def test_cmd_web_managed_uses_auth_token_file(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = AsyncMock()
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("RIGPLANE_AUTH_TOKEN", "env-token")
+    token_file = tmp_path / "token.txt"
+    token_file.write_text(" file-token \n", encoding="utf-8")
+
+    class FakeWebServer:
+        def __init__(self, _radio, cfg):
+            captured["cfg"] = cfg
+            self._runtime_log_path = None
+
+        async def serve_forever(self):
+            raise asyncio.CancelledError
+
+    args = _web_cmd_args(web_bridge=None)
+    args.managed_runtime = True
+    args.auth_token = ""
+    args.auth_token_file = str(token_file)
+
+    with patch("rigplane.web.server.WebServer", FakeWebServer):
+        assert await _cmd_web(radio, args) == 0
+
+    assert captured["cfg"].auth_token == "file-token"
+
+
+@pytest.mark.asyncio
+async def test_cmd_web_auth_token_precedence_over_file_and_env(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = AsyncMock()
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("RIGPLANE_AUTH_TOKEN", "env-token")
+    token_file = tmp_path / "token.txt"
+    token_file.write_text("file-token\n", encoding="utf-8")
+
+    class FakeWebServer:
+        def __init__(self, _radio, cfg):
+            captured["cfg"] = cfg
+            self._runtime_log_path = None
+
+        async def serve_forever(self):
+            raise asyncio.CancelledError
+
+    args = _web_cmd_args(web_bridge=None)
+    args.managed_runtime = True
+    args.auth_token = "argv-token"
+    args.auth_token_file = str(token_file)
+
+    with patch("rigplane.web.server.WebServer", FakeWebServer):
+        assert await _cmd_web(radio, args) == 0
+
+    assert captured["cfg"].auth_token == "argv-token"
+
+
+@pytest.mark.asyncio
+async def test_cmd_web_auth_token_file_failure_surfaces(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path,
+) -> None:
+    radio = AsyncMock()
+    missing = tmp_path / "missing-token.txt"
+
+    args = _web_cmd_args(web_bridge=None)
+    args.managed_runtime = True
+    args.auth_token = ""
+    args.auth_token_file = str(missing)
+
+    rc = await _cmd_web(radio, args)
+
+    assert rc == 1
+    assert "failed to read --auth-token-file" in capsys.readouterr().err
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add --auth-token-file for web and station runtimes
- resolve auth token precedence as argv token > token file > RIGPLANE_AUTH_TOKEN
- keep managed mode auth-required while recommending file/env sources over argv
- document token-file usage for Web API and station supervisors

Closes #1442
Refs #1438

## Validation
- uv run pytest tests/test_cli_coverage.py::test_web_managed_parser_defaults_to_loopback_and_auth_required tests/test_cli_coverage.py::test_cmd_web_managed_requires_auth_token tests/test_cli_coverage.py::test_cmd_web_managed_uses_auth_token_file tests/test_cli_coverage.py::test_cmd_web_auth_token_precedence_over_file_and_env tests/test_cli_coverage.py::test_cmd_web_auth_token_file_failure_surfaces -q --tb=short
- uv run ruff check src/rigplane/cli/__init__.py tests/test_cli_coverage.py
- uv run ruff format --check src/rigplane/cli/__init__.py tests/test_cli_coverage.py
- uv run pytest tests/test_cli_coverage.py tests/test_cli.py tests/test_web_auth_compare_digest.py tests/test_web_server.py -q --tb=short
- uv run pytest tests -q --tb=short