### PR TITLE
docs(web): define stable supervisor API contract

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -2,6 +2,24 @@
 
 Built-in HTTP + WebSocket interface used by the browser UI and automation clients.
 
+## Stability Contract
+
+The managed-supervisor contract is versioned separately from the browser UI.
+The current contract version is `1`.
+
+Stable routes are source-compatible within the same major `/api/v1` namespace:
+
+- existing required response fields remain present;
+- new optional fields may be added without a version bump;
+- new enum/string values may be added when clients can ignore unknown values;
+- removing fields, changing field type, or changing route semantics requires a
+  new versioned route or an explicit migration note.
+
+Stable contract metadata is maintained in `rigplane.web.api_contract` and
+covered by tests. Pro and other supervisors should depend on the stable routes
+below, not on browser static assets, private handler classes, or routes marked
+diagnostic/experimental.
+
 ## Auth Model
 
 If web server is started with `--auth-token`, `--auth-token-file`, or
@@ -19,18 +37,28 @@ ws://host:8080/api/v1/ws?token=<token>
 
 ## HTTP Endpoints
 
-### Read Endpoints
+### Stable Supervisor Endpoints
+
+These routes are part of the Pro/supervisor compatibility surface:
 
 | Method | Path | Purpose |
 |-------|------|---------|
 | `GET` | `/healthz` | Process/API liveness, no API token required |
 | `GET` | `/readyz` | Station readiness, returns `503` until radio is ready |
-| `GET` | `/api/v1/info` | Runtime model/capability summary |
 | `GET` | `/api/v1/runtime` | Process, bind, radio, rigctld, bridge, and diagnostic runtime status |
+| `GET` | `/api/v1/info` | Runtime model/capability summary |
 | `GET` | `/api/v1/state` | Canonical current state snapshot |
 | `GET` | `/api/v1/capabilities` | Full profile-backed capabilities |
-| `GET` | `/api/v1/dx/spots` | Buffered DX spots |
+| `GET` | `/api/v1/audio/analysis` | Audio analysis snapshot when analyzer is active |
 | `GET` | `/api/v1/bridge` | Audio bridge status |
+| `POST` | `/api/v1/bridge` | Start audio bridge |
+| `DELETE` | `/api/v1/bridge` | Stop audio bridge |
+
+### Other Web UI Endpoints
+
+| Method | Path | Purpose |
+|-------|------|---------|
+| `GET` | `/api/v1/dx/spots` | Buffered DX spots |
 | `GET` | `/api/v1/band-plan/config` | Active band-plan region |
 | `GET` | `/api/v1/band-plan/layers` | Band-plan layers metadata |
 | `GET` | `/api/v1/band-plan/segments?start=<hz>&end=<hz>&layers=<csv>` | Band-plan overlay segments |
@@ -47,10 +75,29 @@ ws://host:8080/api/v1/ws?token=<token>
 | `POST` | `/api/v1/radio/connect` | Connect/reconnect radio control path |
 | `POST` | `/api/v1/radio/disconnect` | Disconnect radio control path |
 | `POST` | `/api/v1/radio/power` | Power on/off via CI-V power control |
-| `POST` | `/api/v1/bridge` | Start audio bridge |
-| `DELETE` | `/api/v1/bridge` | Stop audio bridge |
 | `POST` | `/api/v1/band-plan/config` | Change active region and reload band plans |
 | `POST` | `/api/v1/eibi/fetch` | Fetch/refresh EiBi dataset |
+
+### WebSocket Routes
+
+Stable supervisor routes:
+
+| Path | Purpose | Availability |
+|------|---------|--------------|
+| `/api/v1/ws` | Control events and commands | always |
+| `/api/v1/scope` | Hardware or audio FFT spectrum stream | when scope or audio FFT is available |
+| `/api/v1/audio` | Audio control and media frames | when radio/audio backend supports audio |
+| `/api/v1/audio-scope` | Audio FFT spectrum stream | when audio FFT is available |
+
+WebSocket auth accepts the same bearer header as HTTP. Query token auth is also
+accepted for browser/WebSocket clients that cannot set headers.
+
+### Internal And Diagnostic Surface
+
+Browser static files, `src/rigplane/web/static*`, handler class names, queue
+shapes, diagnostic upload routes, EiBi/Band Plan helpers, and DX cluster helper
+routes are not the Pro supervisor contract unless they are promoted into
+`rigplane.web.api_contract`.
 
 ---
 

--- a/src/rigplane/web/api_contract.py
+++ b/src/rigplane/web/api_contract.py
@@ -1,0 +1,159 @@
+"""Stable Web API surface for managed supervisors and Pro clients."""
+
+from __future__ import annotations
+
+from typing import Final, TypedDict
+
+WEB_API_CONTRACT_VERSION: Final[int] = 1
+
+
+class HttpEndpoint(TypedDict):
+    method: str
+    path: str
+    purpose: str
+    auth: str
+
+
+class WebSocketRoute(TypedDict):
+    path: str
+    purpose: str
+    auth: str
+    availability: str
+
+
+class ResponseFieldContract(TypedDict):
+    required: tuple[str, ...]
+
+
+STABLE_HTTP_ENDPOINTS: Final[tuple[HttpEndpoint, ...]] = (
+    {
+        "method": "GET",
+        "path": "/healthz",
+        "purpose": "process liveness",
+        "auth": "none",
+    },
+    {
+        "method": "GET",
+        "path": "/readyz",
+        "purpose": "station readiness",
+        "auth": "none",
+    },
+    {
+        "method": "GET",
+        "path": "/api/v1/runtime",
+        "purpose": "managed runtime status",
+        "auth": "bearer",
+    },
+    {
+        "method": "GET",
+        "path": "/api/v1/info",
+        "purpose": "runtime model and capability summary",
+        "auth": "bearer",
+    },
+    {
+        "method": "GET",
+        "path": "/api/v1/state",
+        "purpose": "canonical station state snapshot",
+        "auth": "bearer",
+    },
+    {
+        "method": "GET",
+        "path": "/api/v1/capabilities",
+        "purpose": "profile-backed capability matrix",
+        "auth": "bearer",
+    },
+    {
+        "method": "GET",
+        "path": "/api/v1/audio/analysis",
+        "purpose": "audio analyzer snapshot when active",
+        "auth": "bearer",
+    },
+    {
+        "method": "GET",
+        "path": "/api/v1/bridge",
+        "purpose": "audio bridge status",
+        "auth": "bearer",
+    },
+    {
+        "method": "POST",
+        "path": "/api/v1/bridge",
+        "purpose": "start audio bridge",
+        "auth": "bearer",
+    },
+    {
+        "method": "DELETE",
+        "path": "/api/v1/bridge",
+        "purpose": "stop audio bridge",
+        "auth": "bearer",
+    },
+)
+
+STABLE_WEBSOCKET_ROUTES: Final[tuple[WebSocketRoute, ...]] = (
+    {
+        "path": "/api/v1/ws",
+        "purpose": "control events and commands",
+        "auth": "bearer-or-query-token",
+        "availability": "always",
+    },
+    {
+        "path": "/api/v1/scope",
+        "purpose": "hardware or audio FFT spectrum stream",
+        "auth": "bearer-or-query-token",
+        "availability": "when scope or audio FFT is available",
+    },
+    {
+        "path": "/api/v1/audio",
+        "purpose": "audio control and media frames",
+        "auth": "bearer-or-query-token",
+        "availability": "when radio/audio backend supports audio",
+    },
+    {
+        "path": "/api/v1/audio-scope",
+        "purpose": "audio FFT spectrum stream",
+        "auth": "bearer-or-query-token",
+        "availability": "when audio FFT is available",
+    },
+)
+
+RESPONSE_FIELD_CONTRACTS: Final[dict[str, ResponseFieldContract]] = {
+    "/healthz": {"required": ("status", "pid", "version")},
+    "/readyz": {"required": ("status", "radioReady")},
+    "/api/v1/runtime": {
+        "required": (
+            "pid",
+            "uptimeSeconds",
+            "version",
+            "bind",
+            "logPath",
+            "authRequired",
+            "backend",
+            "radio",
+            "rigctld",
+            "bridge",
+            "lastError",
+        )
+    },
+    "/api/v1/info": {
+        "required": (
+            "server",
+            "version",
+            "proto",
+            "radio",
+            "model",
+            "capabilities",
+            "connection",
+        )
+    },
+    "/api/v1/state": {"required": ("revision", "updatedAt")},
+    "/api/v1/capabilities": {
+        "required": (
+            "model",
+            "capabilities",
+            "receivers",
+            "modes",
+            "filters",
+            "audioConfig",
+            "webrtc",
+        )
+    },
+}

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -1,0 +1,95 @@
+"""Stable Web API contract tests for managed supervisors and Pro clients."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rigplane.web.api_contract import (
+    RESPONSE_FIELD_CONTRACTS,
+    STABLE_HTTP_ENDPOINTS,
+    STABLE_WEBSOCKET_ROUTES,
+    WEB_API_CONTRACT_VERSION,
+)
+from rigplane.web.server import WebConfig, WebServer
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+
+def _json_response(writer: _Writer) -> tuple[int, dict]:
+    text = writer.buffer.decode("ascii", errors="replace")
+    status = int(text.split(" ", 2)[1])
+    body_start = text.index("\r\n\r\n") + 4
+    return status, json.loads(text[body_start:] or "{}")
+
+
+def test_pro_web_api_contract_lists_stable_surface() -> None:
+    assert WEB_API_CONTRACT_VERSION == 1
+
+    http = {(route["method"], route["path"]) for route in STABLE_HTTP_ENDPOINTS}
+    assert ("GET", "/healthz") in http
+    assert ("GET", "/readyz") in http
+    assert ("GET", "/api/v1/runtime") in http
+    assert ("GET", "/api/v1/info") in http
+    assert ("GET", "/api/v1/state") in http
+    assert ("GET", "/api/v1/capabilities") in http
+    assert ("GET", "/api/v1/audio/analysis") in http
+    assert ("GET", "/api/v1/bridge") in http
+    assert ("POST", "/api/v1/bridge") in http
+    assert ("DELETE", "/api/v1/bridge") in http
+
+    ws = {route["path"] for route in STABLE_WEBSOCKET_ROUTES}
+    assert "/api/v1/ws" in ws
+    assert "/api/v1/scope" in ws
+    assert "/api/v1/audio" in ws
+    assert "/api/v1/audio-scope" in ws
+
+    assert RESPONSE_FIELD_CONTRACTS["/api/v1/info"]["required"] == (
+        "server",
+        "version",
+        "proto",
+        "radio",
+        "model",
+        "capabilities",
+        "connection",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stable_http_payloads_satisfy_required_field_contract() -> None:
+    srv = WebServer(None, WebConfig(host="127.0.0.1", port=0, auth_token="token"))
+    srv._server = type(  # noqa: SLF001
+        "_Server",
+        (),
+        {
+            "sockets": [
+                type("_Socket", (), {"getsockname": lambda self: ("127.0.0.1", 0)})()
+            ]
+        },
+    )()
+    headers = {"authorization": "Bearer token"}
+
+    for path, expected_status in (
+        ("/healthz", 200),
+        ("/readyz", 503),
+        ("/api/v1/runtime", 200),
+        ("/api/v1/info", 200),
+        ("/api/v1/state", 200),
+        ("/api/v1/capabilities", 200),
+    ):
+        writer = _Writer()
+        await srv._handle_http(writer, "GET", path, headers=headers)  # noqa: SLF001
+        status, payload = _json_response(writer)
+        assert status == expected_status
+        required = RESPONSE_FIELD_CONTRACTS[path]["required"]
+        assert set(required).issubset(payload)


### PR DESCRIPTION
## Summary
- add a versioned stable Web API contract module for managed supervisors/Pro clients
- cover stable HTTP response required fields and WebSocket route inventory with tests
- document compatibility expectations, stable supervisor endpoints, and internal/non-contract web surface

Closes #1443
Refs #1438

## Validation
- uv run pytest tests/test_web_api_contract.py -q --tb=short
- uv run ruff check src/rigplane/web/api_contract.py tests/test_web_api_contract.py
- uv run ruff format --check src/rigplane/web/api_contract.py tests/test_web_api_contract.py
- uv run pytest tests/test_web_api_contract.py tests/test_web_server_coverage.py tests/test_web_server.py tests/test_websocket_coverage.py -q --tb=short
- uv run pytest tests -q --tb=short