### PR TITLE
feat(discovery): emit setup wizard discovery JSON

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -142,6 +142,7 @@ rigplane discover                      # LAN + serial (default)
 rigplane discover --lan-only           # UDP broadcast only
 rigplane discover --serial-only        # USB serial ports only
 rigplane discover --timeout 5          # Longer LAN listen window
+rigplane --json discover               # Stable setup-wizard JSON
 ```
 
 ## Commands
@@ -486,6 +487,7 @@ rigplane discover                   # LAN + serial
 rigplane discover --lan-only        # UDP broadcast only
 rigplane discover --serial-only     # USB serial ports only
 rigplane discover --timeout 5       # Longer LAN listen window (default: 3s)
+rigplane --json discover            # Stable setup-wizard JSON
 ```
 
 ```
@@ -516,6 +518,21 @@ IC-705:
 | `--lan-only` | off | Only scan via UDP broadcast |
 | `--serial-only` | off | Only scan USB serial ports |
 | `--timeout SECONDS` | `3.0` | LAN broadcast listen timeout |
+
+With global `--json`, `discover` emits `schema: rigplane.discovery.v1` for
+first-run setup wizards. Each radio has stable `connections` entries for LAN
+and USB serial candidates. LAN entries include `host`, `remoteId`, and
+`requiresCredentials: true`; serial entries include `port`, `protocol`,
+`profileId`, `baudrate`, CI-V/CAT `address`, OS `description`, and `hwid` when
+available. Credentials are never included in discovery output.
+
+The JSON payload also reports current platform limitations:
+
+| Field | Meaning |
+|-------|---------|
+| `macosUsbAudio` | CoreAudio device selection is supported, but users may still need to grant microphone/input permission |
+| `windowsUsbAudio` | USB audio topology may require explicit/manual device selection |
+| `linuxUsbAudio` | PipeWire/PulseAudio device naming varies by distribution/session |
 
 ### `serve`
 

--- a/src/rigplane/backends/discovery.py
+++ b/src/rigplane/backends/discovery.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 __all__ = [
+    "build_setup_discovery_payload",
     "CivProbeResult",
     "RadioDiscoveryResult",
     "SerialPortCandidate",
@@ -57,6 +58,8 @@ class RadioDiscoveryResult:
         profile_id: Rig profile identifier, e.g. ``"icom_ic7610"`` or ``"yaesu_ftx1"``.
         baudrate: Baud rate at which the radio was detected.
         address: CI-V address (``int``) for Icom radios; CAT model ID string for others.
+        description: Human-readable OS serial port description, if available.
+        hwid: OS hardware ID string, if available.
     """
 
     port: str
@@ -65,6 +68,8 @@ class RadioDiscoveryResult:
     profile_id: str
     baudrate: int
     address: int | str
+    description: str | None = None
+    hwid: str | None = None
 
 
 @dataclass
@@ -529,6 +534,8 @@ async def discover_serial_radios(
                     profile_id=profile_id,
                     baudrate=civ.baud,
                     address=civ.address,
+                    description=port.description,
+                    hwid=port.hwid,
                 )
             )
             continue
@@ -539,12 +546,16 @@ async def discover_serial_radios(
             _transport_factory=_yaesu_transport_factory,
         )
         if yaesu:
+            yaesu.description = port.description
+            yaesu.hwid = port.hwid
             results.append(yaesu)
             continue
 
         # --- Kenwood CAT probe ---
         kenwood = await probe_serial_kenwood_cat(port.device)
         if kenwood:
+            kenwood.description = port.description
+            kenwood.hwid = port.hwid
             results.append(kenwood)
 
     return results
@@ -603,6 +614,65 @@ def dedupe_radios(
         cast_list.append(serial)
 
     return list(radios.values())
+
+
+def build_setup_discovery_payload(
+    grouped_radios: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build stable discovery JSON for setup wizards and managed supervisors."""
+    radios: list[dict[str, Any]] = []
+    for index, radio in enumerate(grouped_radios, start=1):
+        connections: list[dict[str, Any]] = []
+        for lan in radio.get("lan", []):
+            host = str(lan.get("host", ""))
+            remote_id = lan.get("remote_id")
+            connection: dict[str, Any] = {
+                "type": "lan",
+                "backend": "lan",
+                "label": f"LAN {host}" if host else "LAN",
+                "host": host,
+                "remoteId": remote_id,
+                "requiresCredentials": True,
+            }
+            connections.append(connection)
+
+        for serial in radio.get("serial", []):
+            port = str(serial.get("port", ""))
+            baudrate = serial.get("baudrate", serial.get("baud"))
+            protocol = serial.get("protocol", "civ")
+            backend = "yaesu-cat" if protocol == "yaesu_cat" else "serial"
+            connection = {
+                "type": "serial",
+                "backend": backend,
+                "label": f"USB serial {port}" if port else "USB serial",
+                "port": port,
+                "protocol": protocol,
+                "profileId": serial.get("profile_id"),
+                "baudrate": baudrate,
+                "address": serial.get("address"),
+                "description": serial.get("description"),
+                "hwid": serial.get("hwid"),
+                "requiresCredentials": False,
+            }
+            connections.append(connection)
+
+        radios.append(
+            {
+                "id": f"radio-{index}",
+                "model": radio.get("model", "Unknown"),
+                "connections": connections,
+            }
+        )
+
+    return {
+        "schema": "rigplane.discovery.v1",
+        "radios": radios,
+        "limitations": {
+            "macosUsbAudio": "coreaudio-device-selection",
+            "windowsUsbAudio": "manual-device-selection",
+            "linuxUsbAudio": "pipewire-or-pulseaudio-device-selection",
+        },
+    }
 
 
 def _is_candidate(port: object) -> bool:

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -2959,6 +2959,7 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
 async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
     """Discover Icom radios on LAN and/or serial ports."""
     from rigplane.discovery import (
+        build_setup_discovery_payload,
         dedupe_radios,
         discover_lan_radios,
         discover_serial_radios,
@@ -2982,7 +2983,11 @@ async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
     if not lan_only:
         tasks.append(discover_serial_radios())
 
-    if not serial_only and not lan_only:
+    json_output = getattr(args, "json", False)
+
+    if json_output:
+        pass
+    elif not serial_only and not lan_only:
         print(f"Scanning for Icom radios ({timeout:.0f}s LAN + serial)...")
     elif serial_only:
         print("Scanning serial ports for Icom radios...")
@@ -3020,6 +3025,10 @@ async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
         scan_failed = True
 
     grouped = dedupe_radios(lan_radios, serial_radios)
+
+    if json_output:
+        print(json.dumps(build_setup_discovery_payload(grouped)))
+        return 1 if scan_failed else 0
 
     if not grouped:
         print("No radios found.")

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -31,6 +31,7 @@ from rigplane.cli import (
     _validate_audio_format_args,
     main,
 )
+from rigplane.discovery import RadioDiscoveryResult
 from rigplane.radio_protocol import (
     AdvancedControlCapable,
     AudioCapable,
@@ -1115,6 +1116,43 @@ async def test_cmd_discover_found_and_not_found(
         rc_none = await _cmd_discover(None, None)
     assert rc_none == 0
     assert "No radios found." in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_cmd_discover_json_outputs_setup_payload(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = SimpleNamespace(serial_only=False, lan_only=False, timeout=0.1, json=True)
+    with (
+        patch(
+            "rigplane.discovery.discover_lan_radios",
+            AsyncMock(return_value=[{"host": "192.168.55.40", "remote_id": 42}]),
+        ),
+        patch(
+            "rigplane.discovery.discover_serial_radios",
+            AsyncMock(
+                return_value=[
+                    RadioDiscoveryResult(
+                        port="/dev/cu.usbmodem7610",
+                        protocol="civ",
+                        model="IC-7610",
+                        profile_id="icom_ic7610",
+                        baudrate=115200,
+                        address=0x98,
+                        description="IC-7610 USB",
+                        hwid="USB VID:PID=10C4:EA60",
+                    )
+                ]
+            ),
+        ),
+    ):
+        rc = await _cmd_discover(None, args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "rigplane.discovery.v1"
+    assert payload["radios"][0]["connections"][0]["type"] == "lan"
+    assert payload["radios"][1]["connections"][0]["type"] == "serial"
 
 
 def test_main_branches(monkeypatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -15,6 +15,7 @@ from rigplane.discovery import (
     SerialPortCandidate,
     _is_candidate,
     _parse_probe_response,
+    build_setup_discovery_payload,
     _parse_yaesu_id_response,
     dedupe_radios,
     discover_serial_radios,
@@ -441,6 +442,53 @@ class TestDedupeRadios:
         assert "serial" in result[0]
 
 
+def test_build_setup_discovery_payload_is_stable_and_credential_free() -> None:
+    grouped = [
+        {
+            "model": "IC-7610",
+            "lan": [
+                {
+                    "host": "192.168.55.40",
+                    "remote_id": 0x12345678,
+                    "user": "must-not-leak",
+                    "password": "must-not-leak",
+                }
+            ],
+            "serial": [
+                {
+                    "port": "/dev/cu.usbmodem7610",
+                    "protocol": "civ",
+                    "model": "IC-7610",
+                    "profile_id": "icom_ic7610",
+                    "baudrate": 115200,
+                    "address": 0x98,
+                    "description": "IC-7610 USB",
+                    "hwid": "USB VID:PID=10C4:EA60",
+                }
+            ],
+        }
+    ]
+
+    payload = build_setup_discovery_payload(grouped)
+
+    assert payload["schema"] == "rigplane.discovery.v1"
+    radio = payload["radios"][0]
+    assert radio["model"] == "IC-7610"
+    assert radio["connections"][0] == {
+        "type": "lan",
+        "backend": "lan",
+        "label": "LAN 192.168.55.40",
+        "host": "192.168.55.40",
+        "remoteId": 0x12345678,
+        "requiresCredentials": True,
+    }
+    assert radio["connections"][1]["type"] == "serial"
+    assert radio["connections"][1]["description"] == "IC-7610 USB"
+    assert radio["connections"][1]["hwid"] == "USB VID:PID=10C4:EA60"
+    assert "password" not in str(payload).lower()
+    assert payload["limitations"]["windowsUsbAudio"] == "manual-device-selection"
+
+
 # ---------------------------------------------------------------------------
 # Fake Yaesu CAT transport helpers
 # ---------------------------------------------------------------------------
@@ -672,6 +720,8 @@ class TestDiscoverSerialRadios:
         assert r.model == "IC-7610"
         assert r.profile_id == "icom_ic7610"
         assert r.address == 0x98
+        assert r.description == "USB Serial"
+        assert r.hwid == "USB VID:PID=10C4:EA60"
 
     @pytest.mark.asyncio
     async def test_yaesu_radio_detected(self) -> None:


### PR DESCRIPTION
## Summary
- add stable `rigplane.discovery.v1` JSON payload for `rigplane --json discover`
- include LAN and USB serial connection metadata for setup wizards without credentials
- preserve serial OS description/hwid in discovery results
- document JSON schema and current platform USB/audio topology limitations

Closes #1444
Refs #1438

## Validation
- `uv run pytest tests/test_discovery.py::test_build_setup_discovery_payload_is_stable_and_credential_free tests/test_discovery.py::TestDiscoverSerialRadios::test_civ_radio_detected tests/test_cli_coverage.py::test_cmd_discover_json_outputs_setup_payload -q --tb=short`
- `uv run ruff check src/rigplane/backends/discovery.py src/rigplane/cli/__init__.py tests/test_discovery.py tests/test_cli_coverage.py`
- `uv run ruff format --check src/rigplane/backends/discovery.py src/rigplane/cli/__init__.py tests/test_discovery.py tests/test_cli_coverage.py`
- `uv run pytest tests/test_discovery.py tests/test_cli_coverage.py tests/test_cli.py -q --tb=short`
- `uv run pytest tests -q --tb=short`
