### PR TITLE
Validate USB audio discovery metadata smoke coverage

### DIFF
--- a/docs/operations/managed-runtime-packaging.md
+++ b/docs/operations/managed-runtime-packaging.md
@@ -38,7 +38,10 @@ paths are green:
 
 The core `rigplane --json discover` payload uses `schema: rigplane.discovery.v1`
 and includes platform limitation hints for setup wizards. Discovery output must
-not include credentials.
+not include credentials. When USB audio topology resolution is available, serial
+connections may include a `usbAudio` object with PortAudio device indices,
+the resolved serial port, and platform location metadata. This is descriptive
+setup metadata only; it must not include account, radio, or service credentials.
 
 ## Validation Commands
 
@@ -53,6 +56,37 @@ Hardware or OS-assisted validation remains opt-in:
 ```bash
 RIGPLANE_OS_AUDIO_SMOKE=1 uv run pytest tests/test_audio_pipeline_os_smoke.py -q --tb=short
 RIGPLANE_HARDWARE_AUDIO=1 uv run pytest tests/hardware/test_ic7610_audio_pipeline.py -q --tb=short
+```
+
+For Windows local validation, install the managed-runtime bridge dependencies
+and run mocked core coverage first:
+
+```bash
+uv run pytest tests/test_discovery.py tests/test_cli_coverage.py tests/test_audio_pipeline_os_smoke.py -q --tb=short
+```
+
+Then run the opt-in PortAudio smoke with explicit device selectors. Typical
+Windows names include `Microphone (USB Audio CODEC)`, `Speakers (USB Audio
+CODEC)`, and `CABLE Output (VB-Audio Virtual Cable)`; use an integer device id
+when a substring matches more than one device:
+
+```powershell
+$env:RIGPLANE_OS_AUDIO_SMOKE="1"
+$env:RIGPLANE_OS_AUDIO_TX_DEVICE="Microphone (USB Audio CODEC)"
+$env:RIGPLANE_OS_AUDIO_RX_DEVICE="Speakers (USB Audio CODEC)"
+uv run pytest tests/test_audio_pipeline_os_smoke.py -q --tb=short
+```
+
+For Linux local validation, run the same mocked core coverage, then select
+ALSA/PipeWire/PulseAudio device names reported by PortAudio. Common names
+include `USB Audio CODEC: Audio (hw:2,0)`, `pipewire`, and `pulse`; use integer
+ids for ambiguous loopback devices:
+
+```bash
+RIGPLANE_OS_AUDIO_SMOKE=1 \
+RIGPLANE_OS_AUDIO_TX_DEVICE='USB Audio CODEC: Audio (hw:2,0)' \
+RIGPLANE_OS_AUDIO_RX_DEVICE='pipewire' \
+uv run pytest tests/test_audio_pipeline_os_smoke.py -q --tb=short
 ```
 
 ## Follow-up issues

--- a/src/rigplane/backends/discovery.py
+++ b/src/rigplane/backends/discovery.py
@@ -6,7 +6,9 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
+
+from rigplane.usb_audio_resolve import AudioDeviceMapping, resolve_audio_for_serial_port
 
 __all__ = [
     "build_setup_discovery_payload",
@@ -60,6 +62,9 @@ class RadioDiscoveryResult:
         address: CI-V address (``int``) for Icom radios; CAT model ID string for others.
         description: Human-readable OS serial port description, if available.
         hwid: OS hardware ID string, if available.
+        usb_audio: Optional USB audio resolution metadata. Keys match
+            :class:`rigplane.usb_audio_resolve.AudioDeviceMapping` field names
+            when topology resolution is available.
     """
 
     port: str
@@ -70,6 +75,7 @@ class RadioDiscoveryResult:
     address: int | str
     description: str | None = None
     hwid: str | None = None
+    usb_audio: dict[str, Any] | None = None
 
 
 @dataclass
@@ -267,7 +273,7 @@ def _default_yaesu_transport_factory() -> _YaesuTransportFactory:
     """Return YaesuCatTransport class, or raise ImportError with hint."""
     from .yaesu_cat.transport import YaesuCatTransport
 
-    return YaesuCatTransport
+    return cast(_YaesuTransportFactory, YaesuCatTransport)
 
 
 async def probe_serial_yaesu_cat(
@@ -536,6 +542,7 @@ async def discover_serial_radios(
                     address=civ.address,
                     description=port.description,
                     hwid=port.hwid,
+                    usb_audio=_resolve_usb_audio_metadata(civ.port),
                 )
             )
             continue
@@ -548,6 +555,7 @@ async def discover_serial_radios(
         if yaesu:
             yaesu.description = port.description
             yaesu.hwid = port.hwid
+            yaesu.usb_audio = _resolve_usb_audio_metadata(yaesu.port)
             results.append(yaesu)
             continue
 
@@ -556,9 +564,28 @@ async def discover_serial_radios(
         if kenwood:
             kenwood.description = port.description
             kenwood.hwid = port.hwid
+            kenwood.usb_audio = _resolve_usb_audio_metadata(kenwood.port)
             results.append(kenwood)
 
     return results
+
+
+def _resolve_usb_audio_metadata(port: str) -> dict[str, object] | None:
+    """Return optional USB audio mapping metadata without failing discovery."""
+    mapping: AudioDeviceMapping | None
+    try:
+        mapping = resolve_audio_for_serial_port(port)
+    except Exception as exc:
+        logger.debug("discover_serial_radios: USB audio resolve failed: %s", exc)
+        return None
+    if mapping is None:
+        return None
+    return {
+        "rx_device_index": mapping.rx_device_index,
+        "tx_device_index": mapping.tx_device_index,
+        "serial_port": mapping.serial_port,
+        "location_prefix": mapping.location_prefix,
+    }
 
 
 def dedupe_radios(
@@ -654,6 +681,9 @@ def build_setup_discovery_payload(
                 "hwid": serial.get("hwid"),
                 "requiresCredentials": False,
             }
+            usb_audio = _normalize_usb_audio_metadata(serial.get("usb_audio"))
+            if usb_audio is not None:
+                connection["usbAudio"] = usb_audio
             connections.append(connection)
 
         radios.append(
@@ -673,6 +703,26 @@ def build_setup_discovery_payload(
             "linuxUsbAudio": "pipewire-or-pulseaudio-device-selection",
         },
     }
+
+
+def _normalize_usb_audio_metadata(value: object) -> dict[str, object] | None:
+    """Convert internal USB audio metadata into stable discovery JSON."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        return None
+
+    result: dict[str, object] = {}
+    field_map = {
+        "rx_device_index": "rxDeviceIndex",
+        "tx_device_index": "txDeviceIndex",
+        "serial_port": "serialPort",
+        "location_prefix": "locationPrefix",
+    }
+    for source, target in field_map.items():
+        if source in value:
+            result[target] = value[source]
+    return result or None
 
 
 def _is_candidate(port: object) -> bool:

--- a/tests/test_audio_pipeline_os_smoke.py
+++ b/tests/test_audio_pipeline_os_smoke.py
@@ -30,6 +30,22 @@ class _SelectedDevices:
     tx: AudioDeviceInfo
 
 
+class _FakeNumpy:
+    pass
+
+
+def _portaudio_backend_for(raw_devices: list[dict[str, object]]) -> PortAudioBackend:
+    class FakeSd:
+        class default:
+            device = [0, 1]
+
+        @staticmethod
+        def query_devices() -> list[dict[str, object]]:
+            return raw_devices
+
+    return PortAudioBackend(dependency_loader=lambda: (FakeSd(), _FakeNumpy()))
+
+
 def _format_device(device: AudioDeviceInfo) -> str:
     flags = []
     if device.is_default_input:
@@ -47,6 +63,82 @@ def _format_devices(devices: list[AudioDeviceInfo]) -> str:
     if not devices:
         return "no PortAudio devices reported"
     return "; ".join(_format_device(device) for device in devices)
+
+
+def test_mocked_portaudio_enumeration_preserves_windows_usb_audio_names() -> None:
+    backend = _portaudio_backend_for(
+        [
+            {
+                "index": 12,
+                "name": "Microphone (USB Audio CODEC)",
+                "max_input_channels": 2,
+                "max_output_channels": 0,
+                "default_samplerate": 48000.0,
+            },
+            {
+                "index": 13,
+                "name": "Speakers (USB Audio CODEC)",
+                "max_input_channels": 0,
+                "max_output_channels": 2,
+                "default_samplerate": 48000.0,
+            },
+            {
+                "index": 14,
+                "name": "CABLE Output (VB-Audio Virtual Cable)",
+                "max_input_channels": 2,
+                "max_output_channels": 0,
+                "default_samplerate": 48000.0,
+            },
+        ]
+    )
+
+    devices = backend.list_devices()
+
+    assert [(int(d.id), d.name) for d in devices] == [
+        (12, "Microphone (USB Audio CODEC)"),
+        (13, "Speakers (USB Audio CODEC)"),
+        (14, "CABLE Output (VB-Audio Virtual Cable)"),
+    ]
+    assert devices[0].input_channels == 2
+    assert devices[1].output_channels == 2
+
+
+def test_mocked_portaudio_enumeration_preserves_linux_usb_audio_names() -> None:
+    backend = _portaudio_backend_for(
+        [
+            {
+                "index": 4,
+                "name": "USB Audio CODEC: Audio (hw:2,0)",
+                "max_input_channels": 2,
+                "max_output_channels": 2,
+                "default_samplerate": 48000.0,
+            },
+            {
+                "index": 5,
+                "name": "pipewire",
+                "max_input_channels": 64,
+                "max_output_channels": 64,
+                "default_samplerate": 48000.0,
+            },
+            {
+                "index": 6,
+                "name": "pulse",
+                "max_input_channels": 32,
+                "max_output_channels": 32,
+                "default_samplerate": 48000.0,
+            },
+        ]
+    )
+
+    devices = backend.list_devices()
+
+    assert [(int(d.id), d.name) for d in devices] == [
+        (4, "USB Audio CODEC: Audio (hw:2,0)"),
+        (5, "pipewire"),
+        (6, "pulse"),
+    ]
+    assert devices[0].duplex is True
+    assert devices[1].default_samplerate == 48_000
 
 
 def _select_device(

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1155,6 +1155,48 @@ async def test_cmd_discover_json_outputs_setup_payload(
     assert payload["radios"][1]["connections"][0]["type"] == "serial"
 
 
+@pytest.mark.asyncio
+async def test_cmd_discover_json_preserves_usb_audio_resolution_metadata(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = SimpleNamespace(serial_only=True, lan_only=False, timeout=0.1, json=True)
+    with (
+        patch("rigplane.discovery.discover_lan_radios", AsyncMock(return_value=[])),
+        patch(
+            "rigplane.discovery.discover_serial_radios",
+            AsyncMock(
+                return_value=[
+                    RadioDiscoveryResult(
+                        port="/dev/cu.usbserial-111120",
+                        protocol="civ",
+                        model="IC-7610",
+                        profile_id="icom_ic7610",
+                        baudrate=115200,
+                        address=0x98,
+                        description="Silicon Labs CP210x USB to UART Bridge",
+                        hwid="USB VID:PID=10C4:EA60",
+                        usb_audio={
+                            "rx_device_index": 6,
+                            "tx_device_index": 5,
+                            "serial_port": "/dev/cu.usbserial-111120",
+                            "location_prefix": 0x0111,
+                        },
+                    )
+                ]
+            ),
+        ),
+    ):
+        rc = await _cmd_discover(None, args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    connection = payload["radios"][0]["connections"][0]
+    assert connection["requiresCredentials"] is False
+    assert connection["usbAudio"]["rxDeviceIndex"] == 6
+    assert connection["usbAudio"]["serialPort"] == "/dev/cu.usbserial-111120"
+    assert "password" not in str(payload).lower()
+
+
 def test_main_branches(monkeypatch, capsys: pytest.CaptureFixture[str]) -> None:
     class DummyParser:
         def __init__(self, args):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -23,6 +23,7 @@ from rigplane.discovery import (
     probe_serial_civ,
     probe_serial_yaesu_cat,
 )
+from rigplane.usb_audio_resolve import AudioDeviceMapping
 
 
 @contextmanager
@@ -489,6 +490,47 @@ def test_build_setup_discovery_payload_is_stable_and_credential_free() -> None:
     assert payload["limitations"]["windowsUsbAudio"] == "manual-device-selection"
 
 
+def test_setup_payload_preserves_usb_audio_metadata_without_credentials() -> None:
+    grouped = [
+        {
+            "model": "IC-7610",
+            "lan": [],
+            "serial": [
+                {
+                    "port": "/dev/cu.usbserial-111120",
+                    "protocol": "civ",
+                    "model": "IC-7610",
+                    "profile_id": "icom_ic7610",
+                    "baudrate": 115200,
+                    "address": 0x98,
+                    "description": "Silicon Labs CP210x USB to UART Bridge",
+                    "hwid": "USB VID:PID=10C4:EA60 LOCATION=1-1.2",
+                    "usb_audio": {
+                        "rx_device_index": 6,
+                        "tx_device_index": 5,
+                        "serial_port": "/dev/cu.usbserial-111120",
+                        "location_prefix": 0x0111,
+                    },
+                    "user": "must-not-leak",
+                    "password": "must-not-leak",
+                }
+            ],
+        }
+    ]
+
+    payload = build_setup_discovery_payload(grouped)
+
+    connection = payload["radios"][0]["connections"][0]
+    assert connection["requiresCredentials"] is False
+    assert connection["usbAudio"] == {
+        "rxDeviceIndex": 6,
+        "txDeviceIndex": 5,
+        "serialPort": "/dev/cu.usbserial-111120",
+        "locationPrefix": 0x0111,
+    }
+    assert "password" not in str(payload).lower()
+
+
 # ---------------------------------------------------------------------------
 # Fake Yaesu CAT transport helpers
 # ---------------------------------------------------------------------------
@@ -722,6 +764,37 @@ class TestDiscoverSerialRadios:
         assert r.address == 0x98
         assert r.description == "USB Serial"
         assert r.hwid == "USB VID:PID=10C4:EA60"
+
+    @pytest.mark.asyncio
+    async def test_civ_radio_preserves_usb_audio_resolution_metadata(self) -> None:
+        reader = _FakeReader([_IC7610_RESPONSE])
+        writer = _FakeWriter()
+
+        port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=10C4:EA60")
+        mapping = AudioDeviceMapping(
+            rx_device_index=6,
+            tx_device_index=5,
+            serial_port="/dev/ttyUSB0",
+            location_prefix=None,
+        )
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+            patch(
+                "rigplane.discovery.resolve_audio_for_serial_port",
+                return_value=mapping,
+            ),
+        ):
+            results = await discover_serial_radios(
+                _open_serial=_make_open(reader, writer),
+            )
+
+        assert results[0].usb_audio == {
+            "rx_device_index": 6,
+            "tx_device_index": 5,
+            "serial_port": "/dev/ttyUSB0",
+            "location_prefix": None,
+        }
 
     @pytest.mark.asyncio
     async def test_yaesu_radio_detected(self) -> None:

--- a/tests/test_managed_runtime_packaging_doc.py
+++ b/tests/test_managed_runtime_packaging_doc.py
@@ -23,6 +23,10 @@ def test_managed_runtime_packaging_requirements_doc_tracks_v1_gates() -> None:
         "PipeWire",
         "PulseAudio",
         "minimum viable paid-v1 support",
+        "RIGPLANE_OS_AUDIO_TX_DEVICE",
+        "RIGPLANE_OS_AUDIO_RX_DEVICE",
+        "USB Audio CODEC: Audio (hw:2,0)",
+        "Microphone (USB Audio CODEC)",
         "Follow-up issues",
     ]
     for term in required_terms:


### PR DESCRIPTION
## Summary

Closes #1464.

- add optional USB audio resolver metadata to serial discovery results and the setup JSON payload
- cover Windows/Linux PortAudio naming patterns with mocked enumeration tests
- document opt-in Windows/Linux audio smoke commands and lock the docs contract

## Verification

- RED: `uv run pytest tests/test_discovery.py::test_build_setup_discovery_payload_preserves_usb_audio_metadata_without_credentials -q --tb=short` failed with missing `usbAudio`
- RED: `uv run pytest tests/test_cli_coverage.py::test_cmd_discover_json_preserves_usb_audio_resolution_metadata -q --tb=short` failed before `RadioDiscoveryResult.usb_audio` existed
- RED: `uv run pytest tests/test_managed_runtime_packaging_doc.py -q --tb=short` failed before Windows/Linux smoke env vars were documented
- `uv run pytest tests/test_discovery.py tests/test_cli_coverage.py tests/test_audio_pipeline_os_smoke.py tests/test_managed_runtime_packaging_doc.py -q --tb=short`
- `uv run mypy src/rigplane/backends/discovery.py`
- `uv run ruff check src/rigplane/backends/discovery.py tests/test_discovery.py tests/test_cli_coverage.py tests/test_audio_pipeline_os_smoke.py tests/test_managed_runtime_packaging_doc.py`
- `uv run ruff format --check src/rigplane/backends/discovery.py tests/test_discovery.py tests/test_cli_coverage.py tests/test_audio_pipeline_os_smoke.py tests/test_managed_runtime_packaging_doc.py`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`

## Manual / hardware gap

Real Windows/Linux audio hardware smoke remains opt-in via `RIGPLANE_OS_AUDIO_SMOKE=1` and explicit TX/RX device selectors.
