### PR TITLE
Implement audio codec policy contracts

### DIFF
--- a/docs/guide/audio-recipes.md
+++ b/docs/guide/audio-recipes.md
@@ -1,7 +1,46 @@
 # Audio Recipes (copy/paste)
 
 Practical scenarios for the current `rigplane` audio API.
-All examples use **PCM 16-bit mono 48 kHz** (`AudioCodec.PCM_1CH_16BIT`) to avoid external codec dependencies.
+Most generic examples below use **PCM 16-bit mono 48 kHz**
+(`AudioCodec.PCM_1CH_16BIT`) to avoid external codec dependencies. Radio
+profiles may choose a different radio-native LAN contract when a model has a
+better-known default.
+
+## Radio-native vs browser/client audio contracts
+
+Direct Icom LAN audio is PCM-first in `rigplane`. The radio-native contract is
+the codec, sample rate, and channel count written into the Icom conninfo packet
+and accepted by the radio. For direct radio LAN connections this should normally
+be PCM or u-law; Opus is not assumed to be a native Icom radio codec. Opus can
+still be useful as a server-to-browser or server-to-client transport when a web
+consumer benefits from lower bandwidth, but that is a consumer contract layered
+after the radio stream has been decoded to PCM for taps, DSP, and bridges.
+
+The runtime tracks three related decisions:
+
+| Contract | Meaning |
+| --- | --- |
+| Requested radio-native | Values selected before conninfo from explicit overrides, the radio profile, or global defaults. |
+| Effective radio-native | Values actually used after conninfo. If the radio rejects a request, this can record a fallback such as stereo RX downgraded to mono. |
+| Web RX emission | Browser/client codec selected from profile policy, for example PCM from the radio emitted as browser Opus. This does not change the radio-native stream. |
+
+Use diagnostics when debugging audio negotiation. The `audio/audio.json` file in
+a diagnostic report includes `radio_native.requested`,
+`radio_native.effective`, and `web_rx` when those values are available or
+configured.
+
+`ICOM_AUDIO_SAMPLE_RATE` remains an operator override. Set it only when you
+need to force the direct LAN conninfo sample rate for testing or hardware
+compatibility:
+
+```bash
+export ICOM_AUDIO_SAMPLE_RATE=16000
+uv run rigplane --host 192.168.55.40 --user USER --pass-file .rigplane-pass web
+```
+
+Explicit API or CLI/env overrides take precedence over profile defaults. If no
+override is supplied, model profiles choose the best known radio-native default;
+for example the IC-7610 direct LAN profile requests PCM at 16 kHz.
 
 ## Prerequisites
 

--- a/docs/guide/diagnostic-reports.md
+++ b/docs/guide/diagnostic-reports.md
@@ -84,7 +84,7 @@ own subdirectory of the ZIP. The full schema lives in the design spec
 | `system`       | OS, arch, Python version, `rigplane` version, install method              | Absolute home paths rewritten to `<HOME>/...`                |
 | `invocation`   | Filtered `sys.argv`, environment allowlist                                | `password=`, `pwd=`, `Bearer …`, API tokens → `***`          |
 | `radio`        | Model, firmware version, backend, capability matrix, audio codec          | Public IPs masked (RFC 1918 ranges kept — they're useful)    |
-| `audio`        | Codec, channels, sample rate, device names, bridge state                  | macOS device names containing usernames are masked           |
+| `audio`        | Legacy codec/rate/channel summary, requested and effective radio-native audio contracts, configured Web RX emission policy, device names, bridge state | macOS device names containing usernames are masked           |
 | `logs`         | Rolling diagnostic logs from `~/.cache/rigplane/logs/` (up to ~15 MiB)    | Path / IP / credential regex pass on copies                  |
 | `state`        | Current freq, mode, meters, last N CI-V exchanges (ring buffer)           | Optional callsign masking                                    |
 | `errors`       | Recent in-process tracebacks (ring buffer)                                | Paths scrubbed                                               |
@@ -95,6 +95,27 @@ own subdirectory of the ZIP. The full schema lives in the design spec
 The manifest (`manifest.json`) lists which contributors ran, which
 files each produced, and which redaction passes were applied to the
 bundle.
+
+### Audio contract fields
+
+For LAN audio issues, inspect `audio/audio.json` first. The file keeps the
+legacy top-level `codec`, `sample_rate_hz`, and `channels` fields for older
+tools, and may also include:
+
+- `radio_native.requested` — RX/TX codec, sample rate, channel count, and
+  source metadata selected before the Icom conninfo exchange.
+- `radio_native.effective` — RX/TX values in use after conninfo. If the radio
+  rejected a requested value, `fallback_reason` explains the downgrade.
+- `web_rx` — configured browser/client emission policy. When the diagnostic
+  bundle is created outside the WebSocket runtime, this reports profile policy
+  such as `auto` plus the derived emission codec; it does not claim that a
+  browser client was actively connected.
+
+Source metadata uses stable strings such as `explicit`, `profile-default`,
+`profile-codec-default`, `global-default`, and `fallback`. For example, an
+IC-7610 can request radio-native `PCM_2CH_16BIT` at `16000` Hz from its profile
+while the Web UI emits Opus as a browser transport. That means only the browser
+leg is Opus; the direct radio LAN stream remains PCM.
 
 ## Privacy
 

--- a/docs/plans/2026-05-08-audio-codec-policy.md
+++ b/docs/plans/2026-05-08-audio-codec-policy.md
@@ -1,0 +1,263 @@
+# Audio Codec Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce an explicit audio route and codec policy so direct radio LAN streams, local bridges, DSP/taps, and web/app clients each receive the correct codec, sample rate, and channel contract.
+
+**Architecture:** Direct Icom LAN operation is PCM-first. Opus is not a radio-native codec for direct Icom LAN radios such as IC-7610; it may be used later as a server-to-client transport optimization over constrained links. The policy flow is: `RadioProfile audio policy -> effective LAN stream request -> radio-native stream contract -> consumer-specific output contract`.
+
+**Tech Stack:** Python backend, TOML radio profiles, Icom LAN conninfo, existing `AudioCodec`, `AudioBus`, `AudioBroadcaster`, `AudioBridge`, `PcmOpusTranscoder`, frontend WebAudio/WebCodecs RX player.
+
+---
+
+## Context
+
+Issue: `rigplane-core#1467`, "IC-7610 receive audio distortion".
+
+The issue reports two IC-7610 RX symptoms:
+
+- Default sample-rate mismatch: rigplane requests and labels `48000`, while the customer's IC-7610 appears to emit usable stereo PCM16 only up to `16000`.
+- Browser PCM playback artifact: raw PCM frames scheduled through `AudioBufferSourceNode.start(when)` produce periodic clicks; sending Opus to the browser avoids that client playback path.
+
+Recent WSJT-X bridge work fixed the TX bridge path by making LAN TX PCM explicit and by routing WSJT-X LAN operation through DATA2/LAN. This plan keeps that lesson: codec/rate/channel decisions must come from route and profile policy, not from local guesses inside a web handler.
+
+## Findings
+
+### Icom direct LAN is PCM-first
+
+Current code defines Icom LAN audio codec bytes in `AudioCodec`:
+
+- `PCM_1CH_16BIT = 0x04`
+- `PCM_2CH_16BIT = 0x10`
+- `OPUS_1CH = 0x40`
+- `OPUS_2CH = 0x41`
+
+The enum docstring states that Opus codecs are available only when the radio reports `connection_type == "WFVIEW"`. The wfview reference code also forces Opus back to LPCM16 when the connection type is not `WFVIEW`.
+
+Decision: direct radio LAN policy must not prefer Opus. Opus is only a potential server-to-client transport codec.
+
+### Current negotiation is mostly a request, not a measured result
+
+`build_conninfo_packet()` writes requested `rxcodec`, `txcodec`, `rxsample`, and `txsample` into the conninfo packet. The radio accepts or rejects the session, but the backend does not receive a separate "actual sample rate" value.
+
+Consequence: if a radio silently caps or mangles an unsupported sample rate, `radio.audio_sample_rate` can remain the requested value even when the wire payload rate differs.
+
+### Current defaults mix global and model-specific concerns
+
+`get_audio_capabilities()` builds a global default codec/rate:
+
+- codec default: `PCM_2CH_16BIT`
+- sample-rate default: `ICOM_AUDIO_SAMPLE_RATE`, currently `48000`
+
+Profiles can already pin `codec_preference`, but they cannot express sample-rate policy, per-codec rate caps, or browser transport preferences.
+
+### Consumer contracts are conflated
+
+`AudioBus` distributes radio-native payloads. `AudioBroadcaster` currently maps radio codecs directly to web codecs. For PCM/uLaw radios it emits PCM16 to the browser; for Opus-native streams it emits Opus. This conflates:
+
+- radio-native stream format;
+- DSP/tap/bridge PCM contract;
+- browser/web-app transport contract.
+
+Decision: keep `AudioBus`, `AudioBridge`, DSP, FFT, and analyzers PCM/native where appropriate. Any PCM-to-Opus conversion for browsers must happen as a consumer-specific web emission policy after PCM taps/DSP.
+
+## Target Contracts
+
+### RadioProfile audio policy
+
+Profiles should be able to describe radio audio behavior without hardcoding model names in handlers.
+
+Proposed profile fields:
+
+```toml
+[audio]
+codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT", "ULAW_2CH", "ULAW_1CH"]
+tx_codec = "PCM_1CH_16BIT"
+default_sample_rate_hz = 16000
+supported_sample_rates_hz = [8000, 16000]
+sample_rate_by_codec = { PCM_2CH_16BIT = 16000, PCM_1CH_16BIT = 16000 }
+browser_rx_transport = "auto"
+browser_rx_transcode_to_opus = true
+```
+
+`browser_rx_transcode_to_opus = true` means "browser delivery may use Opus". It does not mean "request Opus from the radio".
+
+### Effective LAN stream request
+
+The backend should resolve a concrete request before conninfo:
+
+```python
+AudioStreamRequest(
+    rx_codec=AudioCodec.PCM_2CH_16BIT,
+    tx_codec=AudioCodec.PCM_1CH_16BIT,
+    rx_sample_rate_hz=16000,
+    tx_sample_rate_hz=16000,
+    source="profile-default",
+)
+```
+
+Rules:
+
+- Explicit CLI/env/API sample-rate override wins.
+- Explicit codec override wins if compatible.
+- Profile default wins over global default.
+- If the requested stereo codec is rejected during conninfo, existing stereo-to-mono fallback remains valid, but it must update the effective contract.
+
+### Radio-native stream contract
+
+After conninfo succeeds, expose the effective radio-native contract:
+
+```python
+AudioStreamContract(
+    rx_codec=AudioCodec.PCM_2CH_16BIT,
+    tx_codec=AudioCodec.PCM_1CH_16BIT,
+    rx_sample_rate_hz=16000,
+    tx_sample_rate_hz=16000,
+    rx_channels=2,
+    tx_channels=1,
+)
+```
+
+This contract should be the source for `radio.audio_codec`, `radio.audio_sample_rate`, bridge sample-rate defaults, broadcaster headers, and diagnostics.
+
+### Consumer-specific output contract
+
+Web/browser delivery may choose a different transport codec:
+
+```python
+AudioConsumerContract(
+    consumer="web-rx",
+    input_codec=AudioCodec.PCM_2CH_16BIT,
+    input_sample_rate_hz=16000,
+    output_codec="opus",
+    output_sample_rate_hz=16000,
+    output_channels=2,
+    frame_ms=20,
+)
+```
+
+Bridge/DSP/taps stay PCM/native:
+
+```python
+AudioConsumerContract(
+    consumer="bridge-rx",
+    input_codec=AudioCodec.PCM_2CH_16BIT,
+    output_codec="pcm16",
+    output_sample_rate_hz=16000,
+    output_channels=1,
+)
+```
+
+## Non-Goals
+
+- Do not request Opus from direct Icom LAN radios by default.
+- Do not move Opus transcode into `AudioBus`.
+- Do not make `AudioBridge` consume browser/web transport frames.
+- Do not accept the reference patch as-is inside `web/handlers/audio.py`.
+- Do not change DATA1/DATA2 policy as part of this issue.
+
+## Implementation Tasks
+
+### Task 1: Add profile audio policy model and tests
+
+**Files:**
+- Modify: `src/rigplane/profiles/__init__.py`
+- Modify: `src/rigplane/profiles/rig_loader.py`
+- Modify: `rigs/ic7610.toml`
+- Test: `tests/test_rig_loader.py`
+
+- [ ] Add profile fields for `tx_codec`, `default_sample_rate_hz`, `supported_sample_rates_hz`, `sample_rate_by_codec`, `browser_rx_transport`, and `browser_rx_transcode_to_opus`.
+- [ ] Validate codec names against `AudioCodec`.
+- [ ] Validate sample rates as positive integers from the supported Icom/Opus set: `8000`, `12000`, `16000`, `24000`, `48000`.
+- [ ] Add IC-7610 profile defaults: stereo PCM16 RX, mono PCM16 TX, `16000` Hz default, browser Opus transcode allowed.
+- [ ] Add regression tests proving existing profiles without new fields still load.
+
+### Task 2: Resolve effective audio stream request before conninfo
+
+**Files:**
+- Create or modify: `src/rigplane/audio/route.py`
+- Modify: `src/rigplane/runtime/radio.py`
+- Modify: `src/rigplane/backends/config.py`
+- Test: `tests/test_audio_route.py`
+- Test: `tests/test_radio_connect.py`
+
+- [ ] Introduce a small resolver that accepts profile policy plus explicit constructor/config values.
+- [ ] Track whether sample-rate and codec were explicit or defaulted.
+- [ ] Ensure explicit user overrides win over profile defaults.
+- [ ] Ensure IC-7610 LAN default resolves to `PCM_2CH_16BIT` RX, `PCM_1CH_16BIT` TX, `16000` Hz.
+- [ ] Ensure non-IC-7610 defaults remain behavior-compatible until their profiles are audited.
+
+### Task 3: Expose radio-native audio stream contract
+
+**Files:**
+- Modify: `src/rigplane/runtime/radio.py`
+- Modify: `src/rigplane/runtime/_control_phase.py`
+- Modify: `src/rigplane/core/radio_protocol.py`
+- Test: `tests/test_audio_codec.py`
+- Test: `tests/test_radio_connect.py`
+
+- [ ] Replace ad hoc `_audio_codec`, `_audio_tx_codec`, and `_audio_sample_rate` reads with a resolved contract where practical.
+- [ ] Keep existing public properties for compatibility.
+- [ ] Update stereo-to-mono fallback so the contract reflects the final accepted RX codec.
+- [ ] Add tests for conninfo bytes: `rxcodec`, `txcodec`, `rxsample`, `txsample`.
+
+### Task 4: Split web emission contract from radio-native contract
+
+**Files:**
+- Modify: `src/rigplane/web/handlers/audio.py`
+- Test: `tests/test_web_server.py`
+- Test: `tests/test_web_audio_streaming_profile.py`
+
+- [ ] Add an internal web RX emission policy object.
+- [ ] Keep PCM taps and DSP before browser transcode.
+- [ ] If web policy selects Opus, buffer PCM into legal Opus frame sizes and emit `AUDIO_CODEC_OPUS`.
+- [ ] If Opus encoder is unavailable, log once and fall back to PCM16 with correct sample-rate/channels.
+- [ ] Add tests proving bridge/taps still receive PCM while browser receives Opus.
+
+### Task 5: Add diagnostics and operator visibility
+
+**Files:**
+- Modify: `src/rigplane/diagnostics/contributors/audio.py`
+- Modify: `docs/guide/audio-recipes.md`
+- Test: `tests/test_diagnostics_contributors_batch2.py`
+
+- [ ] Report requested radio-native codec/rate/channels.
+- [ ] Report effective radio-native codec/rate/channels.
+- [ ] Report web emission codec/rate/channels.
+- [ ] Include whether each value came from explicit user config, profile default, or fallback.
+
+### Task 6: Profile audit follow-up
+
+**Files:**
+- Modify later: `rigs/ic705.toml`
+- Modify later: `rigs/ic7300.toml`
+- Modify later: `rigs/ic9700.toml`
+- Modify later: `rigs/ftx1.toml`
+
+- [ ] Audit each supported radio against official docs, wfview profiles, and available hardware data.
+- [ ] Fill profile audio policy where known.
+- [ ] Leave unknown values absent rather than inventing them.
+- [ ] Add a fallback probing or downgrade strategy only where protocol evidence supports it.
+
+## Test Matrix
+
+Required before closing `#1467`:
+
+- `uv run pytest tests/test_rig_loader.py tests/test_audio_route.py tests/test_audio_codec.py tests/test_radio_connect.py -q`
+- `uv run pytest tests/test_web_server.py tests/test_web_audio_streaming_profile.py -q`
+- `uv run pytest tests/test_audio_bridge.py tests/test_audio_bridge_stereo.py tests/integration/test_rigctld_audio_pipeline.py -q`
+- Frontend RX tests if browser code changes: `npm run test -- --run frontend/src/lib/audio/__tests__/rx-player.test.ts`
+
+Hardware validation:
+
+- IC-7610 LAN with no `ICOM_AUDIO_SAMPLE_RATE`: verify conninfo requests `16000` Hz.
+- IC-7610 LAN with explicit `ICOM_AUDIO_SAMPLE_RATE=48000`: verify override is respected and diagnostics show explicit source.
+- Browser RX: verify no chipmunk playback and no periodic click pattern.
+- WSJT-X bridge: verify RX decode still works and LAN TX still uses PCM/DATA2 path.
+
+## Open Questions
+
+- Should web Opus transcode be default-on for IC-7610 immediately, or hidden behind an `auto` policy that can be disabled from CLI/env?
+- Should profile `supported_sample_rates_hz` represent documented support, empirically safe support, or both as separate fields?
+- Do we want server-to-client Opus as a general low-bandwidth mode for pro/remote deployments, separate from this IC-7610 browser bug?
+

--- a/docs/plans/2026-05-08-audio-profile-policy-audit.md
+++ b/docs/plans/2026-05-08-audio-profile-policy-audit.md
@@ -1,0 +1,114 @@
+# Audio Profile Policy Audit
+
+Issue: #1475
+Date: 2026-05-08
+
+## Scope
+
+This audit reviews radio profile audio policy candidates for:
+
+- `rigs/ic7610.toml`
+- `rigs/ic705.toml`
+- `rigs/ic7300.toml`
+- `rigs/ic9700.toml`
+- `rigs/ftx1.toml`
+- `rigs/examples/*.toml`
+
+No runtime code or rig profile values were changed. Unknown per-radio audio
+limits are intentionally left absent rather than inferred from generic defaults.
+
+## Evidence Sources
+
+| Source | Evidence |
+| --- | --- |
+| `src/rigplane/core/types.py:54` | `AudioCodec` conninfo values; local docstring says Opus is only available when the radio reports `connection_type == "WFVIEW"`. |
+| `src/rigplane/core/types.py:179` | Current generic supported sample-rate set is `8000`, `16000`, `24000`, `48000`; this is not per-radio evidence. |
+| `src/rigplane/core/types.py:191` | Current global codec preference is stereo PCM16, mono PCM16, stereo uLaw, mono uLaw, 8-bit PCM, then Opus. |
+| `src/rigplane/runtime/_control_phase.py:198` | Existing stereo-to-mono retry on immediate conninfo rejection. |
+| `src/rigplane/runtime/_control_phase.py:540` | Runtime forces Icom LAN `txcodec` to `PCM_1CH_16BIT`; comment cites stock firmware rejection of stereo TX and wfview's mono-only TX UI. |
+| `src/rigplane/profiles/rig_loader.py:741` | Profile loader currently supports only `[audio].codec_preference`. |
+| `references/wfview/include/audioconverter.h:118` | wfview maps codec bytes to audio formats and channel counts. |
+| `references/wfview/src/settingswidget.cpp:106` | wfview RX UI exposes LPCM/uLaw/Opus/ADPCM choices; TX UI exposes only mono codecs. |
+| `references/wfview/src/settingswidget.ui:732` | wfview sample-rate UI exposes `48000`, `24000`, `16000`, `8000`; this is generic UI evidence, not a per-radio support matrix. |
+| `references/wfview/src/radio/icomudphandler.cpp:384` | wfview forces Opus back to LPCM16 when connection type is not `WFVIEW`. |
+| `references/wfview/include/packettypes.h:322` | wfview conninfo send packet contains `rxcodec`, `txcodec`, `rxsample`, and `txsample`. |
+| `references/icom-official/IC-7610_CI-V_Reference.pdf` via `pdftotext` | Documents LAN AF/IF output, LAN MOD level, and Network Audio Port, but did not expose a codec/sample-rate support matrix in this audit. |
+| `references/IC-7300_CI-V_Reference.pdf` via `pdftotext` | Documents LAN AF/IF output and Audio Port entries, but this repo's `rigs/ic7300.toml` is `has_lan = false`; no direct LAN audio profile should be inferred for IC-7300. |
+| `references/Yaesu-official/FTX-1_CAT_OM_ENG_2508-C.pdf` via `pdftotext` | Documents CAT control and fixed passband values; no direct LAN audio codec/sample-rate policy evidence was found. |
+
+## Cross-Cutting Conclusions
+
+Direct Icom LAN should be PCM-first. Opus is not an evidence-backed
+radio-native default for direct Icom LAN because wfview explicitly downgrades
+Opus when the connection type is not `WFVIEW`.
+
+The only profile audio field currently implemented is `codec_preference`.
+Adding `tx_codec`, `default_sample_rate_hz`, `supported_sample_rates_hz`,
+`sample_rate_by_codec`, `browser_rx_transport`, or
+`browser_rx_transcode_to_opus` is follow-up implementation work, not part of
+this audit.
+
+`supported_sample_rates_hz = [8000, 16000, 24000, 48000]` is a generic
+rigplane/wfview capability set, not proof that every supported radio accepts
+every rate over its direct radio audio path.
+
+Browser Opus should be modeled as a server-to-client/web transport policy.
+It must not cause direct Icom LAN conninfo to request Opus from the radio.
+
+## Per-Radio Recommendations
+
+| Profile | Evidence-backed current state | `codec_preference` | `tx_codec` | `default_sample_rate_hz` | `supported_sample_rates_hz` | `sample_rate_by_codec` | `browser_rx_transport` / `browser_rx_transcode_to_opus` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| IC-7610 | `rigs/ic7610.toml` has LAN, 2 receivers, hardware-testing provenance, and IC-7610-only LAN dual-RX audio routing. wfview has LAN+Ethernet and 2 receivers. Runtime already supports stereo RX with mono TX. | Recommend `["PCM_2CH_16BIT", "PCM_1CH_16BIT", "ULAW_2CH", "ULAW_1CH"]` if a profile-level field is added for IC-7610. Evidence: profile dual-RX LAN routing plus current global PCM-first order. Do not include Opus. | Recommend `PCM_1CH_16BIT`. Evidence: runtime forced mono TX and wfview mono-only TX UI. | Unknown for profile data. A 16000 Hz candidate belongs in #1467/#1470 hardware validation, not in the profile without captured measurement. | Unknown per-radio. Do not copy the generic `[8000, 16000, 24000, 48000]` set into the profile without official or hardware evidence. | Unknown; leave absent. | Recommend web policy outside radio-native profile: `auto` transport, Opus transcode allowed only after PCM capture/DSP. Do not request Opus from radio. |
+| IC-705 | `rigs/ic705.toml` has LAN+WiFi, 1 receiver, and current mono-first `codec_preference`. wfview has LAN+WiFi and 1 receiver. No official IC-705 audio codec/rate matrix was present locally. | Keep current `["PCM_1CH_16BIT", "ULAW_1CH"]`. Evidence: existing profile pin plus single-RX caution. Do not add stereo or Opus by default. | Recommend `PCM_1CH_16BIT` for direct Icom LAN when `tx_codec` exists. Evidence: same Icom LAN TX mono constraint. | Unknown; leave absent. | Unknown per-radio; leave absent. | Unknown; leave absent. | Same web-only policy as above; do not encode as radio-native Opus. |
+| IC-7300 | `rigs/ic7300.toml` has `has_lan = false` and current mono-first `codec_preference`. wfview IC-7300 also has `HasLAN=false`. | Keep current `["PCM_1CH_16BIT", "ULAW_1CH"]` for compatibility with existing audio abstractions. Do not add direct LAN-specific defaults to this non-LAN profile. | Unknown/not applicable for direct radio LAN in this profile. If reused through Icom LAN in future, use the generic mono TX rule only after profile identity is resolved. | Unknown/not applicable; leave absent. | Unknown/not applicable; leave absent. | Unknown/not applicable; leave absent. | Browser transport is not a radio profile fact here. |
+| IC-9700 | `rigs/ic9700.toml` has LAN, 2 receivers, and current mono-first `codec_preference` because stereo negotiation has not been hardware validated. wfview has LAN+Ethernet and 2 receivers. | Keep current `["PCM_1CH_16BIT", "ULAW_1CH"]` until hardware or official docs prove stereo RX is accepted. Do not infer stereo from `receiver_count = 2`. | Recommend `PCM_1CH_16BIT` for direct Icom LAN when `tx_codec` exists. Evidence: same Icom LAN TX mono constraint. | Unknown; leave absent. | Unknown per-radio; leave absent. | Unknown; leave absent. | Same web-only policy as above; do not encode as radio-native Opus. |
+| FTX-1 | `rigs/ftx1.toml` is Yaesu CAT, `has_lan = false`; wfview FTX-1 also has `HasLAN=false`. Official CAT manual does not document a direct LAN audio codec policy. | Unknown/not applicable; leave absent. | Unknown/not applicable; leave absent. | Unknown. The official CAT manual's `16000 Hz (Fixed)` hit is passband/mode context, not evidence for a rigplane audio stream sample rate. | Unknown; leave absent. | Unknown; leave absent. | Browser transport should be decided by backend/web policy, not a direct Icom LAN radio profile field. |
+| `rigs/examples/ftx1.toml` | Example profile says Yaesu and no LAN/ethernet/wifi; protocol comment says CI-V-compatible via wfview, but this is an example, not a direct radio LAN profile. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent unless the example is rewritten as a web/server demonstration. |
+| `rigs/examples/lab599_tx500.toml` | Example profile is Kenwood CAT, no LAN/ethernet/wifi. | Unknown/not applicable; leave absent. | Unknown/not applicable; leave absent. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent. |
+| `rigs/examples/sdrplay_rspdx.toml` | Example profile is native SDRplay USB API with software demodulated audio and a sample-rate control for SDR/IQ, not Icom LAN audio. | Unknown/not applicable to Icom LAN; leave absent. | Unknown/not applicable; leave absent. | Unknown for radio audio policy; leave absent. | Existing sample-rate control is SDR control data, not this policy field. | Unknown; leave absent. | Browser transport belongs to web/SDR output policy if implemented. |
+| `rigs/examples/xiegu_x6200.toml` | Example profile is CI-V-compatible Xiegu with WiFi but no LAN/ethernet. No direct Icom LAN audio evidence found. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent. | Unknown; leave absent. |
+
+## Values That Should Not Be Guessed
+
+- Do not set per-radio `default_sample_rate_hz` from the generic rigplane or
+  wfview sample-rate list.
+- Do not set per-radio `supported_sample_rates_hz` without official docs,
+  wfview model-specific evidence, or hardware capture.
+- Do not set `sample_rate_by_codec` without measured or documented
+  codec-specific behavior.
+- Do not infer IC-9700 stereo RX support from `receiver_count = 2`.
+- Do not infer IC-7300 direct LAN audio policy while the current profile and
+  wfview both mark it as no LAN.
+- Do not treat FTX-1 CAT passband widths as an audio stream sample-rate policy.
+- Do not put Opus in direct Icom LAN `codec_preference` unless the connection is
+  explicitly `WFVIEW` or a future server/client path is being described outside
+  the radio-native profile.
+- Do not encode browser playback workarounds as radio-native codec requests.
+
+## Suggested Follow-Up Issues
+
+1. Add profile audio policy fields and loader validation.
+   Acceptance should cover `tx_codec`, `default_sample_rate_hz`,
+   `supported_sample_rates_hz`, `sample_rate_by_codec`,
+   `browser_rx_transport`, and `browser_rx_transcode_to_opus`, with unknown
+   values omitted.
+
+2. Capture IC-7610 LAN audio sample-rate evidence.
+   Use hardware or packet/audio captures to decide whether `16000` Hz should be
+   an IC-7610 profile default, a fallback candidate, or only an operator
+   workaround.
+
+3. Validate IC-9700 direct LAN stereo RX.
+   Current profile is correctly mono-first until hardware or official evidence
+   proves stereo RX conninfo is accepted.
+
+4. Split browser RX transport policy from radio-native policy.
+   Browser Opus can be allowed as server-to-client transcode after PCM-native
+   radio capture, DSP, taps, and bridge consumers are handled.
+
+5. Clarify IC-7300 vs IC-7300MK2 profile identity.
+   Local official CI-V references include LAN AF/IF and Audio Port entries,
+   while `rigs/ic7300.toml` and wfview IC-7300 both say no LAN. Any MK2 LAN
+   behavior should be represented as a separate profile or documented variant,
+   not silently folded into IC-7300.

--- a/rigs/_schema_v2.md
+++ b/rigs/_schema_v2.md
@@ -37,6 +37,24 @@ type = "civ"                 # Protocol type (see below)
 variant = "standard"         # Protocol variant/extensions
 ```
 
+### Audio Policy
+
+```toml
+[audio]
+codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT"]  # RX codec names from AudioCodec
+tx_codec = "PCM_1CH_16BIT"                             # TX codec name from AudioCodec
+default_sample_rate_hz = 16000
+supported_sample_rates_hz = [8000, 12000, 16000, 24000, 48000]
+sample_rate_by_codec = { PCM_2CH_16BIT = 16000, PCM_1CH_16BIT = 16000 }
+browser_rx_transport = "auto"                          # auto | pcm | opus
+browser_rx_transcode_to_opus = true                    # Browser consumer policy only
+```
+
+Codec names must match `AudioCodec`. Sample rates must be positive supported
+audio rates from `8000`, `12000`, `16000`, `24000`, or `48000`. For direct Icom
+LAN profiles, Opus must not be used as the radio-native default; browser Opus is
+only a consumer/web transport policy.
+
 ### Protocol Types
 
 | Type | Format | Radios | Notes |

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -15,6 +15,16 @@ receiver_count = 2
 has_lan = true
 has_wifi = false
 
+[audio]
+# Direct IC-7610 LAN is PCM-first. Opus is only allowed as a browser
+# consumer transport after the server receives radio-native PCM.
+codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT", "ULAW_2CH", "ULAW_1CH"]
+tx_codec = "PCM_1CH_16BIT"
+default_sample_rate_hz = 16000
+sample_rate_by_codec = { PCM_2CH_16BIT = 16000, PCM_1CH_16BIT = 16000 }
+browser_rx_transport = "auto"
+browser_rx_transcode_to_opus = true
+
 [spectrum]
 seq_max = 15
 amp_max = 200

--- a/src/rigplane/audio/route.py
+++ b/src/rigplane/audio/route.py
@@ -1,23 +1,43 @@
-"""Audio route resolution for radio DATA-mode policy."""
+"""Audio route and LAN stream request resolution."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from rigplane.types import AudioCodec, get_audio_capabilities
 
 if TYPE_CHECKING:
     from rigplane.radio_protocol import Radio
 
 __all__ = [
+    "AudioConfigSource",
     "AudioRoute",
+    "AudioStreamContract",
+    "AudioStreamRequest",
     "DataModePolicy",
     "RadioTransport",
     "RxAudioSource",
     "TxAudioSource",
+    "audio_stream_contract_from_request",
+    "resolve_lan_audio_stream_request",
     "resolve_audio_route",
     "rigctld_wsjtx_policy",
 ]
+
+_AUDIO_CAPABILITIES = get_audio_capabilities()
+_DEFAULT_RX_CODEC = _AUDIO_CAPABILITIES.default_codec
+_CHANNELS_BY_CODEC: dict[AudioCodec, int] = {
+    AudioCodec.ULAW_1CH: 1,
+    AudioCodec.PCM_1CH_8BIT: 1,
+    AudioCodec.PCM_1CH_16BIT: 1,
+    AudioCodec.PCM_2CH_8BIT: 2,
+    AudioCodec.PCM_2CH_16BIT: 2,
+    AudioCodec.ULAW_2CH: 2,
+    AudioCodec.OPUS_1CH: 1,
+    AudioCodec.OPUS_2CH: 2,
+}
 
 
 class RadioTransport(StrEnum):
@@ -55,6 +75,16 @@ class DataModePolicy(StrEnum):
     LEGACY = "legacy"
 
 
+class AudioConfigSource(StrEnum):
+    """Where an effective LAN audio request value came from."""
+
+    EXPLICIT = "explicit"
+    PROFILE_DEFAULT = "profile-default"
+    PROFILE_CODEC_DEFAULT = "profile-codec-default"
+    GLOBAL_DEFAULT = "global-default"
+    FALLBACK = "fallback"
+
+
 @dataclass(frozen=True)
 class AudioRoute:
     """Resolved radio audio route and the DATA policy derived from it."""
@@ -66,10 +96,162 @@ class AudioRoute:
     bridge_required: bool
 
 
+@dataclass(frozen=True, slots=True)
+class AudioStreamRequest:
+    """Concrete Icom LAN audio values to write into conninfo."""
+
+    rx_codec: AudioCodec
+    tx_codec: AudioCodec
+    rx_sample_rate_hz: int
+    tx_sample_rate_hz: int
+    rx_channels: int
+    tx_channels: int
+    rx_codec_source: AudioConfigSource
+    tx_codec_source: AudioConfigSource
+    rx_sample_rate_source: AudioConfigSource
+    tx_sample_rate_source: AudioConfigSource
+
+
+@dataclass(frozen=True, slots=True)
+class AudioStreamContract:
+    """Accepted/effective radio-native Icom LAN audio values."""
+
+    rx_codec: AudioCodec
+    tx_codec: AudioCodec
+    rx_sample_rate_hz: int
+    tx_sample_rate_hz: int
+    rx_channels: int
+    tx_channels: int
+    rx_codec_source: AudioConfigSource
+    tx_codec_source: AudioConfigSource
+    rx_sample_rate_source: AudioConfigSource
+    tx_sample_rate_source: AudioConfigSource
+    fallback_reason: str | None = None
+
+
+def audio_stream_contract_from_request(
+    request: AudioStreamRequest,
+) -> AudioStreamContract:
+    """Create the initial effective contract from a pre-conninfo request."""
+
+    return AudioStreamContract(
+        rx_codec=request.rx_codec,
+        tx_codec=request.tx_codec,
+        rx_sample_rate_hz=request.rx_sample_rate_hz,
+        tx_sample_rate_hz=request.tx_sample_rate_hz,
+        rx_channels=request.rx_channels,
+        tx_channels=request.tx_channels,
+        rx_codec_source=request.rx_codec_source,
+        tx_codec_source=request.tx_codec_source,
+        rx_sample_rate_source=request.rx_sample_rate_source,
+        tx_sample_rate_source=request.tx_sample_rate_source,
+    )
+
+
 def _profile_data_mode_count(radio: "Radio") -> int:
     profile = getattr(radio, "profile", None)
     count = getattr(profile, "data_mode_count", 1)
     return count if isinstance(count, int) and count > 0 else 1
+
+
+def _profile_codec(name: str | None) -> AudioCodec | None:
+    if not name:
+        return None
+    try:
+        return AudioCodec[name]
+    except KeyError:
+        return None
+
+
+def _profile_rx_codec(profile: Any) -> AudioCodec | None:
+    preference = getattr(profile, "codec_preference", None)
+    if not preference:
+        return None
+    supported = _AUDIO_CAPABILITIES.supported_codecs
+    for name in preference:
+        codec = _profile_codec(name)
+        if codec in supported:
+            return codec
+    return None
+
+
+def _sample_rate_for_codec(
+    profile: Any,
+    codec: AudioCodec,
+) -> tuple[int | None, AudioConfigSource | None]:
+    by_codec = getattr(profile, "sample_rate_by_codec", None) or {}
+    if codec.name in by_codec:
+        return int(by_codec[codec.name]), AudioConfigSource.PROFILE_CODEC_DEFAULT
+    default_rate = getattr(profile, "default_sample_rate_hz", None)
+    if default_rate is not None:
+        return int(default_rate), AudioConfigSource.PROFILE_DEFAULT
+    return None, None
+
+
+def resolve_lan_audio_stream_request(
+    *,
+    profile: Any,
+    requested_rx_codec: AudioCodec | int,
+    requested_sample_rate_hz: int,
+    rx_codec_explicit: bool = False,
+    sample_rate_explicit: bool = False,
+) -> AudioStreamRequest:
+    """Resolve concrete direct Icom LAN audio values before conninfo.
+
+    The resolver is intentionally small: profile policy may replace only caller
+    defaults, while explicit constructor/CLI/env choices remain authoritative.
+    """
+
+    requested_codec = AudioCodec(requested_rx_codec)
+    if rx_codec_explicit:
+        rx_codec = requested_codec
+        rx_codec_source = AudioConfigSource.EXPLICIT
+    else:
+        profile_rx_codec = _profile_rx_codec(profile)
+        if profile_rx_codec is not None:
+            rx_codec = profile_rx_codec
+            rx_codec_source = AudioConfigSource.PROFILE_DEFAULT
+        else:
+            rx_codec = requested_codec
+            rx_codec_source = (
+                AudioConfigSource.GLOBAL_DEFAULT
+                if requested_codec == _DEFAULT_RX_CODEC
+                else AudioConfigSource.EXPLICIT
+            )
+
+    profile_tx_codec = _profile_codec(getattr(profile, "tx_codec", None))
+    if profile_tx_codec is not None:
+        tx_codec = profile_tx_codec
+        tx_codec_source = AudioConfigSource.PROFILE_DEFAULT
+    else:
+        tx_codec = AudioCodec.PCM_1CH_16BIT
+        tx_codec_source = AudioConfigSource.GLOBAL_DEFAULT
+
+    if sample_rate_explicit:
+        rx_sample_rate_hz = requested_sample_rate_hz
+        tx_sample_rate_hz = requested_sample_rate_hz
+        rx_sample_rate_source = AudioConfigSource.EXPLICIT
+        tx_sample_rate_source = AudioConfigSource.EXPLICIT
+    else:
+        rx_rate, rx_rate_source = _sample_rate_for_codec(profile, rx_codec)
+        tx_rate, tx_rate_source = _sample_rate_for_codec(profile, tx_codec)
+        rx_sample_rate_hz = rx_rate or requested_sample_rate_hz
+        tx_sample_rate_hz = tx_rate or rx_sample_rate_hz
+        rx_sample_rate_source = rx_rate_source or AudioConfigSource.GLOBAL_DEFAULT
+        tx_sample_rate_source = tx_rate_source or rx_sample_rate_source
+
+    return AudioStreamRequest(
+        rx_codec=rx_codec,
+        tx_codec=tx_codec,
+        rx_sample_rate_hz=rx_sample_rate_hz,
+        tx_sample_rate_hz=tx_sample_rate_hz,
+        rx_channels=_CHANNELS_BY_CODEC[rx_codec],
+        tx_channels=_CHANNELS_BY_CODEC[tx_codec],
+        rx_codec_source=rx_codec_source,
+        tx_codec_source=tx_codec_source,
+        rx_sample_rate_source=rx_sample_rate_source,
+        tx_sample_rate_source=tx_sample_rate_source,
+    )
 
 
 def resolve_audio_route(radio: "Radio") -> AudioRoute:

--- a/src/rigplane/backends/config.py
+++ b/src/rigplane/backends/config.py
@@ -26,6 +26,8 @@ class LanBackendConfig:
     timeout: float = 5.0
     audio_codec: AudioCodec | int = _DEFAULT_AUDIO_CODEC
     audio_sample_rate: int = _DEFAULT_AUDIO_SAMPLE_RATE
+    audio_codec_explicit: bool = False
+    audio_sample_rate_explicit: bool = False
     auto_reconnect: bool = False
     reconnect_delay: float = 2.0
     reconnect_max_delay: float = 60.0

--- a/src/rigplane/backends/factory.py
+++ b/src/rigplane/backends/factory.py
@@ -35,6 +35,8 @@ def create_radio(config: BackendConfig) -> Radio:
             timeout=config.timeout,
             audio_codec=config.audio_codec,
             audio_sample_rate=config.audio_sample_rate,
+            audio_codec_explicit=config.audio_codec_explicit,
+            audio_sample_rate_explicit=config.audio_sample_rate_explicit,
             auto_reconnect=config.auto_reconnect,
             reconnect_delay=config.reconnect_delay,
             reconnect_max_delay=config.reconnect_max_delay,

--- a/src/rigplane/diagnostics/contributors/audio.py
+++ b/src/rigplane/diagnostics/contributors/audio.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 import re
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from rigplane.core.radio_protocol import AudioCapable
+from rigplane.types import AudioCodec
 from rigplane.diagnostics.redaction import redact_paths
 
 if TYPE_CHECKING:
@@ -19,6 +21,109 @@ def _safe_attr(obj: Any, name: str, default: Any = None) -> Any:
         return getattr(obj, name, default)
     except Exception:
         return default
+
+
+def _diag_value(value: Any) -> Any:
+    if isinstance(value, AudioCodec):
+        return value.name
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _audio_leg(contract: Any, direction: str) -> dict[str, Any]:
+    return {
+        "codec": _diag_value(_safe_attr(contract, f"{direction}_codec")),
+        "sample_rate_hz": _safe_attr(contract, f"{direction}_sample_rate_hz"),
+        "channels": _safe_attr(contract, f"{direction}_channels"),
+        "codec_source": _diag_value(_safe_attr(contract, f"{direction}_codec_source")),
+        "sample_rate_source": _diag_value(
+            _safe_attr(contract, f"{direction}_sample_rate_source")
+        ),
+    }
+
+
+def _radio_native_contracts(radio: Any) -> dict[str, Any]:
+    contracts: dict[str, Any] = {}
+    request = _safe_attr(radio, "audio_stream_request")
+    if request is not None:
+        contracts["requested"] = {
+            "rx": _audio_leg(request, "rx"),
+            "tx": _audio_leg(request, "tx"),
+        }
+    effective = _safe_attr(radio, "audio_stream_contract")
+    if effective is not None:
+        contracts["effective"] = {
+            "rx": _audio_leg(effective, "rx"),
+            "tx": _audio_leg(effective, "tx"),
+        }
+        fallback_reason = _safe_attr(effective, "fallback_reason")
+        if fallback_reason:
+            contracts["effective"]["fallback_reason"] = fallback_reason
+    return contracts
+
+
+def _codec_name(value: Any) -> str:
+    if isinstance(value, AudioCodec):
+        return value.name
+    if isinstance(value, str):
+        return value
+    return str(value or "unknown")
+
+
+def _resolve_web_rx_codec(
+    *,
+    radio_codec: Any,
+    transport: str | None,
+    transcode_to_opus: bool | None,
+) -> str:
+    radio_codec_name = _codec_name(radio_codec)
+    if radio_codec_name.startswith("OPUS_"):
+        return "OPUS"
+    if transport == "pcm":
+        return "PCM16"
+    if transport == "opus" and transcode_to_opus is not False:
+        return "OPUS"
+    if transport == "auto" and transcode_to_opus is True:
+        return "OPUS"
+    return "PCM16"
+
+
+def _web_rx_policy(radio: Any) -> dict[str, Any] | None:
+    contract = _safe_attr(radio, "audio_stream_contract")
+    profile = _safe_attr(radio, "profile")
+    transport = _safe_attr(profile, "browser_rx_transport") if profile else None
+    transcode_to_opus = (
+        _safe_attr(profile, "browser_rx_transcode_to_opus") if profile else None
+    )
+    if contract is None and transport is None and transcode_to_opus is None:
+        return None
+
+    codec = _resolve_web_rx_codec(
+        radio_codec=_safe_attr(contract, "rx_codec", _safe_attr(radio, "audio_codec")),
+        transport=transport,
+        transcode_to_opus=transcode_to_opus,
+    )
+    sample_rate_hz = _safe_attr(
+        contract, "rx_sample_rate_hz", _safe_attr(radio, "audio_sample_rate")
+    )
+    channels = _safe_attr(contract, "rx_channels", _safe_attr(radio, "audio_channels"))
+    policy_source = (
+        "profile-default"
+        if transport is not None or transcode_to_opus is not None
+        else "global-default"
+    )
+    return {
+        "state": "configured-policy",
+        "transport": transport or "auto",
+        "transcode_to_opus": transcode_to_opus,
+        "codec": codec,
+        "sample_rate_hz": sample_rate_hz,
+        "channels": channels,
+        "codec_source": policy_source,
+        "sample_rate_source": "radio-native-effective",
+        "channels_source": "radio-native-effective",
+    }
 
 
 # macOS device labels embed the local account name in parens, e.g.
@@ -61,12 +166,18 @@ class AudioContributor:
         else:
             payload = {
                 "available": True,
-                "codec": str(_safe_attr(radio, "audio_codec") or "unknown"),
+                "codec": _codec_name(_safe_attr(radio, "audio_codec")),
                 "sample_rate_hz": _safe_attr(radio, "audio_sample_rate"),
                 "channels": _safe_attr(radio, "audio_channels"),
                 "rx_device": _redact_device_name(_safe_attr(radio, "audio_rx_device")),
                 "tx_device": _redact_device_name(_safe_attr(radio, "audio_tx_device")),
                 "bridge_active": bool(_safe_attr(radio, "audio_bridge_active", False)),
             }
+            radio_native = _radio_native_contracts(radio)
+            if radio_native:
+                payload["radio_native"] = radio_native
+            web_rx = _web_rx_policy(radio)
+            if web_rx is not None:
+                payload["web_rx"] = web_rx
         text = json.dumps(payload, indent=2, sort_keys=True)
         (output_dir / "audio.json").write_text(text + "\n", encoding="utf-8")

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -184,6 +184,12 @@ class RadioProfile:
     # profile (unless the caller passes an explicit non-default value). Values
     # are ``AudioCodec`` enum names (e.g. ``"PCM_1CH_16BIT"``).
     codec_preference: tuple[str, ...] | None = None
+    tx_codec: str | None = None
+    default_sample_rate_hz: int | None = None
+    supported_sample_rates_hz: tuple[int, ...] | None = None
+    sample_rate_by_codec: dict[str, int] | None = None
+    browser_rx_transport: str | None = None
+    browser_rx_transcode_to_opus: bool | None = None
 
     @property
     def vfo_swap_code(self) -> int | None:

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -40,6 +40,8 @@ VALID_CONTROL_STYLES = {
 }
 VALID_RULE_KINDS = {"mutex", "disables", "requires", "value_limit"}
 VALID_KEYBOARD_MODIFIERS = {"SHIFT", "CTRL", "ALT", "META"}
+VALID_AUDIO_SAMPLE_RATES_HZ = {8000, 12000, 16000, 24000, 48000}
+VALID_BROWSER_RX_TRANSPORTS = {"auto", "pcm", "opus"}
 DEFAULT_KEYBOARD_PROFILE_NAME = "_keyboard-default.toml"
 
 _REQUIRED_SECTIONS = ("radio", "capabilities", "modes", "filters", "vfo")
@@ -106,6 +108,12 @@ class RigConfig:
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None
     codec_preference: tuple[str, ...] | None = None
+    tx_codec: str | None = None
+    default_sample_rate_hz: int | None = None
+    supported_sample_rates_hz: tuple[int, ...] | None = None
+    sample_rate_by_codec: dict[str, int] | None = None
+    browser_rx_transport: str | None = None
+    browser_rx_transcode_to_opus: bool | None = None
 
     def to_profile(self) -> RadioProfile:
         """Build a ``RadioProfile`` from this config."""
@@ -177,6 +185,12 @@ class RigConfig:
             scope_ref_max_db=self.scope_ref_max_db,
             scope_ref_step_db=self.scope_ref_step_db,
             codec_preference=self.codec_preference,
+            tx_codec=self.tx_codec,
+            default_sample_rate_hz=self.default_sample_rate_hz,
+            supported_sample_rates_hz=self.supported_sample_rates_hz,
+            sample_rate_by_codec=self.sample_rate_by_codec,
+            browser_rx_transport=self.browser_rx_transport,
+            browser_rx_transcode_to_opus=self.browser_rx_transcode_to_opus,
         )
 
     def to_command_map(self) -> CommandMap:
@@ -440,6 +454,39 @@ def _merge_keyboard_config(
         help_title=help_title,
         bindings=tuple(merged_bindings.values()),
     )
+
+
+def _valid_audio_codec_names() -> set[str]:
+    from rigplane.types import AudioCodec
+
+    return {codec.name for codec in AudioCodec}
+
+
+def _validate_audio_codec_name(
+    filename: str,
+    field_name: str,
+    value: Any,
+    valid_names: set[str],
+) -> str:
+    if not isinstance(value, str):
+        raise RigLoadError(f"{filename}: [audio].{field_name} must be a string")
+    if value not in valid_names:
+        raise RigLoadError(
+            f"{filename}: [audio].{field_name} has unknown codec {value!r}. "
+            f"Valid names: {sorted(valid_names)}"
+        )
+    return value
+
+
+def _validate_audio_sample_rate(filename: str, field_name: str, value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise RigLoadError(f"{filename}: [audio].{field_name} must be an integer")
+    if value <= 0 or value not in VALID_AUDIO_SAMPLE_RATES_HZ:
+        raise RigLoadError(
+            f"{filename}: [audio].{field_name} must be one of "
+            f"{sorted(VALID_AUDIO_SAMPLE_RATES_HZ)}, got {value!r}"
+        )
+    return value
 
 
 def load_rig(path: Path) -> RigConfig:
@@ -738,12 +785,19 @@ def load_rig(path: Path) -> RigConfig:
         filename=filename,
     )
 
-    # Parse optional [audio] codec_preference (#797).
+    # Parse optional [audio] codec and sample-rate policy (#797, #1470).
     codec_preference: tuple[str, ...] | None = None
+    tx_codec: str | None = None
+    default_sample_rate_hz: int | None = None
+    supported_sample_rates_hz: tuple[int, ...] | None = None
+    sample_rate_by_codec: dict[str, int] | None = None
+    browser_rx_transport: str | None = None
+    browser_rx_transcode_to_opus: bool | None = None
     audio_section = data.get("audio")
     if audio_section is not None:
         if not isinstance(audio_section, dict):
             raise RigLoadError(f"{filename}: [audio] must be a table")
+        valid_codec_names = _valid_audio_codec_names()
         codec_raw = audio_section.get("codec_preference")
         if codec_raw is not None:
             if not isinstance(codec_raw, list) or not all(
@@ -756,17 +810,71 @@ def load_rig(path: Path) -> RigConfig:
                 raise RigLoadError(
                     f"{filename}: [audio].codec_preference must not be empty"
                 )
-            # Validate entries against AudioCodec enum to fail fast on typos.
-            from rigplane.types import AudioCodec
-
-            valid_names = {c.name for c in AudioCodec}
-            unknown = [c for c in codec_raw if c not in valid_names]
+            unknown = [c for c in codec_raw if c not in valid_codec_names]
             if unknown:
                 raise RigLoadError(
                     f"{filename}: [audio].codec_preference has unknown codec(s): "
-                    f"{unknown}. Valid names: {sorted(valid_names)}"
+                    f"{unknown}. Valid names: {sorted(valid_codec_names)}"
                 )
             codec_preference = tuple(codec_raw)
+        if "tx_codec" in audio_section:
+            tx_codec = _validate_audio_codec_name(
+                filename, "tx_codec", audio_section["tx_codec"], valid_codec_names
+            )
+        if "default_sample_rate_hz" in audio_section:
+            default_sample_rate_hz = _validate_audio_sample_rate(
+                filename,
+                "default_sample_rate_hz",
+                audio_section["default_sample_rate_hz"],
+            )
+        if "supported_sample_rates_hz" in audio_section:
+            supported_raw = audio_section["supported_sample_rates_hz"]
+            if not isinstance(supported_raw, list) or not supported_raw:
+                raise RigLoadError(
+                    f"{filename}: [audio].supported_sample_rates_hz must be a non-empty list"
+                )
+            supported_sample_rates_hz = tuple(
+                _validate_audio_sample_rate(filename, "supported_sample_rates_hz", rate)
+                for rate in supported_raw
+            )
+        if "sample_rate_by_codec" in audio_section:
+            by_codec_raw = audio_section["sample_rate_by_codec"]
+            if not isinstance(by_codec_raw, dict) or not by_codec_raw:
+                raise RigLoadError(
+                    f"{filename}: [audio].sample_rate_by_codec must be a non-empty table"
+                )
+            sample_rate_by_codec = {}
+            for codec_name, sample_rate in by_codec_raw.items():
+                codec_key = _validate_audio_codec_name(
+                    filename,
+                    "sample_rate_by_codec",
+                    codec_name,
+                    valid_codec_names,
+                )
+                sample_rate_by_codec[codec_key] = _validate_audio_sample_rate(
+                    filename,
+                    f"sample_rate_by_codec.{codec_key}",
+                    sample_rate,
+                )
+        if "browser_rx_transport" in audio_section:
+            browser_rx_transport_raw = audio_section["browser_rx_transport"]
+            if not isinstance(browser_rx_transport_raw, str):
+                raise RigLoadError(
+                    f"{filename}: [audio].browser_rx_transport must be a string"
+                )
+            if browser_rx_transport_raw not in VALID_BROWSER_RX_TRANSPORTS:
+                raise RigLoadError(
+                    f"{filename}: [audio].browser_rx_transport must be one of "
+                    f"{sorted(VALID_BROWSER_RX_TRANSPORTS)}, got {browser_rx_transport_raw!r}"
+                )
+            browser_rx_transport = browser_rx_transport_raw
+        if "browser_rx_transcode_to_opus" in audio_section:
+            transcode_raw = audio_section["browser_rx_transcode_to_opus"]
+            if not isinstance(transcode_raw, bool):
+                raise RigLoadError(
+                    f"{filename}: [audio].browser_rx_transcode_to_opus must be a boolean"
+                )
+            browser_rx_transcode_to_opus = transcode_raw
 
     return RigConfig(
         id=radio["id"],
@@ -818,6 +926,12 @@ def load_rig(path: Path) -> RigConfig:
         scope_ref_max_db=scope_ref_max_db,
         scope_ref_step_db=scope_ref_step_db,
         codec_preference=codec_preference,
+        tx_codec=tx_codec,
+        default_sample_rate_hz=default_sample_rate_hz,
+        supported_sample_rates_hz=supported_sample_rates_hz,
+        sample_rate_by_codec=sample_rate_by_codec,
+        browser_rx_transport=browser_rx_transport,
+        browser_rx_transcode_to_opus=browser_rx_transcode_to_opus,
     )
 
 

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from typing import Callable
 
     from rigplane.audio import AudioPacket
+    from rigplane.audio.route import AudioStreamContract, AudioStreamRequest
 
     from .radio import CoreRadio as _MixinBase  # type: ignore[attr-defined]
 else:
@@ -44,6 +45,8 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     _audio_codec: AudioCodec
     _audio_tx_codec: AudioCodec
     _audio_sample_rate: int
+    _audio_stream_request: AudioStreamRequest
+    _audio_stream_contract: AudioStreamContract
 
     # ------------------------------------------------------------------
     # Audio streaming
@@ -437,6 +440,16 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     def audio_sample_rate(self) -> int:
         """Configured audio sample rate in Hz."""
         return self._audio_sample_rate
+
+    @property
+    def audio_stream_request(self) -> "AudioStreamRequest":
+        """Requested radio-native audio values before conninfo fallback."""
+        return self._audio_stream_request
+
+    @property
+    def audio_stream_contract(self) -> "AudioStreamContract":
+        """Effective radio-native audio values accepted for this connection."""
+        return self._audio_stream_contract
 
     async def _ensure_audio_transport(self) -> None:
         """Connect the audio transport if not already connected."""

--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -7,6 +7,7 @@ import logging
 import socket as _socket
 import struct
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from rigplane.core.auth import (
@@ -20,6 +21,7 @@ from rigplane.core.exceptions import AuthenticationError, ConnectionError, Timeo
 from .startup_checks import wait_for_radio_startup_ready
 from rigplane.core.transport import ConnectionState, IcomTransport
 from rigplane.core.types import AudioCodec
+from rigplane.audio.route import AudioConfigSource
 
 if TYPE_CHECKING:
     from ._runtime_protocols import ControlPhaseHost
@@ -210,6 +212,13 @@ class ControlPhaseRuntime:
                             h._audio_codec.name,
                         )
                         h._audio_codec = AudioCodec.PCM_1CH_16BIT
+                        h._audio_stream_contract = replace(
+                            h._audio_stream_contract,
+                            rx_codec=AudioCodec.PCM_1CH_16BIT,
+                            rx_channels=1,
+                            rx_codec_source=AudioConfigSource.FALLBACK,
+                            fallback_reason="conninfo-stereo-rx-rejected",
+                        )
                         h._last_status_error = 0
                         await self._send_conninfo(
                             guid, _civ_local_port, _audio_local_port
@@ -539,18 +548,7 @@ class ControlPhaseRuntime:
         audio_local_port: int = 0,
     ) -> None:
         h = self._host
-        # TX codec must always be mono for IC-7610 (and all Icom LAN radios
-        # we target): the mic path through the transceiver is 1-channel, and
-        # the stock firmware rejects conninfo with ``error=0xFFFFFFFF`` when
-        # ``txcodec`` is a 2ch value (0x08 / 0x10 / 0x20 / 0x41).  wfview
-        # enforces the same constraint in its UI by only offering mono TX
-        # codecs (``settingswidget.cpp:118-124``).  Our Python client used to
-        # mirror the RX codec into TX, which broke stereo RX on LAN.  See
-        # issue #794.  We force ``PCM_1CH_16BIT`` so stereo RX works without
-        # any user-visible tradeoff — the radio uses its own separately
-        # configured TX modulation source regardless of this byte.
-        h._audio_tx_codec = AudioCodec.PCM_1CH_16BIT
-        tx_codec = int(h._audio_tx_codec)
+        contract = h._audio_stream_contract
         conninfo = build_conninfo_packet(
             sender_id=h._ctrl_transport.my_id,
             receiver_id=h._ctrl_transport.remote_id,
@@ -561,10 +559,10 @@ class ControlPhaseRuntime:
             mac_address=b"\x00" * 6,
             auth_seq=h._auth_seq,
             guid=guid,
-            rx_codec=int(h._audio_codec),
-            tx_codec=tx_codec,
-            rx_sample_rate=h._audio_sample_rate,
-            tx_sample_rate=h._audio_sample_rate,
+            rx_codec=int(contract.rx_codec),
+            tx_codec=int(contract.tx_codec),
+            rx_sample_rate=contract.rx_sample_rate_hz,
+            tx_sample_rate=contract.tx_sample_rate_hz,
             civ_local_port=civ_local_port,
             audio_local_port=audio_local_port,
         )

--- a/src/rigplane/runtime/_runtime_protocols.py
+++ b/src/rigplane/runtime/_runtime_protocols.py
@@ -133,7 +133,12 @@ class ControlPhaseHost(Protocol):
     _tok_request: int
     _auth_seq: int
     _audio_codec: Any
+    _audio_tx_codec: Any
     _audio_sample_rate: int
+    _audio_rx_sample_rate: int
+    _audio_tx_sample_rate: int
+    _audio_stream_request: Any
+    _audio_stream_contract: Any
 
     # Status / error tracking
     _last_status_error: int

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -30,6 +30,12 @@ from . import radio_state_snapshot as _state_snapshot
 from rigplane.runtime._audio_recovery import AudioRecoveryRuntime, AudioRecoveryState
 from rigplane.runtime._audio_runtime_mixin import AudioRuntimeMixin
 from rigplane.audio._transcoder import PcmOpusTranscoder
+from rigplane.audio.route import (
+    AudioStreamContract,
+    AudioStreamRequest,
+    audio_stream_contract_from_request,
+    resolve_lan_audio_stream_request,
+)
 from rigplane.core._bounded_queue import BoundedQueue
 from rigplane.runtime._civ_rx import CivRuntime
 from rigplane.runtime._dual_rx_runtime import DualRxRuntimeMixin
@@ -311,30 +317,6 @@ _DEFAULT_CACHE_TTL: dict[str, float] = {"freq": 10.0, "mode": 10.0, "rf_power": 
 # cumulative and only the 30s watchdog resets it via ``soft_reconnect``.
 # Require >=3 accumulated errors before reporting ``connected = False``.
 _UDP_ERROR_THRESHOLD: int = 3
-
-
-def _resolve_profile_codec(
-    profile: RadioProfile, explicit: "AudioCodec | int"
-) -> "AudioCodec":
-    """Pick the effective RX codec for a radio under ``profile`` (#797).
-
-    The caller passes the ``audio_codec`` argument value (which defaults to the
-    global stereo-first default). If the caller accepted the global default AND
-    the profile pins a per-rig ``codec_preference``, honor the profile. An
-    explicit non-default value always wins.
-    """
-    resolved = AudioCodec(explicit)
-    if resolved != _DEFAULT_AUDIO_CODEC or not profile.codec_preference:
-        return resolved
-    supported = _AUDIO_CAPABILITIES.supported_codecs
-    for name in profile.codec_preference:
-        try:
-            candidate = AudioCodec[name]
-        except KeyError:
-            continue
-        if candidate in supported:
-            return candidate
-    return resolved
 
 
 class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
@@ -652,7 +634,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         radio_addr: int | None = None,
         timeout: float = 5.0,
         audio_codec: AudioCodec | int = _DEFAULT_AUDIO_CODEC,
-        audio_sample_rate: int = _DEFAULT_AUDIO_SAMPLE_RATE,
+        audio_sample_rate: int | None = None,
+        audio_codec_explicit: bool | None = None,
+        audio_sample_rate_explicit: bool | None = None,
         auto_reconnect: bool = False,
         reconnect_delay: float = 2.0,
         reconnect_max_delay: float = 60.0,
@@ -672,7 +656,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._timeout = timeout
         self._audio_codec = AudioCodec(audio_codec)
         self._audio_tx_codec = AudioCodec.PCM_1CH_16BIT
-        self._audio_sample_rate = audio_sample_rate
+        requested_sample_rate = (
+            _DEFAULT_AUDIO_SAMPLE_RATE
+            if audio_sample_rate is None
+            else audio_sample_rate
+        )
+        self._audio_sample_rate = requested_sample_rate
+        self._audio_rx_sample_rate = requested_sample_rate
+        self._audio_tx_sample_rate = requested_sample_rate
+        self._audio_stream_request: AudioStreamRequest | None = None
+        self._audio_stream_contract: AudioStreamContract | None = None
         self._ctrl_transport = IcomTransport()
         self._civ_transport: IcomTransport | None = None
         self._audio_transport: IcomTransport | None = None
@@ -765,7 +758,33 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         # Apply per-profile codec preference override (#797) — only if caller
         # accepted the global default. An explicit non-default value always wins.
-        self._audio_codec = _resolve_profile_codec(self._profile, audio_codec)
+        # Limitation kept for compatibility with the historical constructor:
+        # passing the global default codec value is indistinguishable from
+        # omitting it, so profile codec preference may still apply in that case.
+        codec_is_explicit = (
+            audio_codec_explicit is True
+            or AudioCodec(audio_codec) != _DEFAULT_AUDIO_CODEC
+        )
+        sample_rate_is_explicit = (
+            audio_sample_rate_explicit is True
+            or (audio_sample_rate_explicit is None and audio_sample_rate is not None)
+            or "ICOM_AUDIO_SAMPLE_RATE" in os.environ
+        )
+        self._audio_stream_request = resolve_lan_audio_stream_request(
+            profile=self._profile,
+            requested_rx_codec=audio_codec,
+            requested_sample_rate_hz=requested_sample_rate,
+            rx_codec_explicit=codec_is_explicit,
+            sample_rate_explicit=sample_rate_is_explicit,
+        )
+        self._audio_stream_contract = audio_stream_contract_from_request(
+            self._audio_stream_request
+        )
+        self._audio_codec = self._audio_stream_contract.rx_codec
+        self._audio_tx_codec = self._audio_stream_contract.tx_codec
+        self._audio_rx_sample_rate = self._audio_stream_contract.rx_sample_rate_hz
+        self._audio_tx_sample_rate = self._audio_stream_contract.tx_sample_rate_hz
+        self._audio_sample_rate = self._audio_rx_sample_rate
         self._radio_addr = self._profile.civ_addr if radio_addr is None else radio_addr
         # GET commands use a shorter timeout than the general connection timeout.
         # wfview-style: send once, short deadline, fall back to cache.

--- a/src/rigplane/runtime/sync.py
+++ b/src/rigplane/runtime/sync.py
@@ -45,7 +45,8 @@ class IcomRadio:
         audio_codec: Audio codec (default: stereo PCM 2ch 16-bit on dual-RX
             radios, auto-negotiated down to mono on single-RX firmware — see
             ``_DEFAULT_CODEC_PREFERENCE`` in ``types.py``).
-        audio_sample_rate: Audio sample rate in Hz.
+        audio_sample_rate: Audio sample rate in Hz. Omit to use the radio
+            profile's LAN audio policy.
     """
 
     def __init__(
@@ -57,7 +58,7 @@ class IcomRadio:
         radio_addr: int = 0x98,
         timeout: float = 5.0,
         audio_codec: AudioCodec | int = _DEFAULT_AUDIO_CODEC,
-        audio_sample_rate: int = 48000,
+        audio_sample_rate: int | None = None,
     ) -> None:
         self._loop = asyncio.new_event_loop()
         self._radio = _AsyncIcomRadio(

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -56,9 +56,9 @@ class _AudioBus(Protocol):
 class AudioBroadcaster:
     """Single-instance RX audio broadcaster shared by all AudioHandler clients.
 
-    Uses :class:`~rigplane.audio_bus.AudioBus` to subscribe to the radio's
-    opus RX stream.  Multiple consumers (WebSocket clients, audio bridge,
-    recorders) can all share the same stream through the bus.
+    Uses :class:`~rigplane.audio_bus.AudioBus` to subscribe to the radio-native
+    RX stream.  Browser WebSocket clients may receive a consumer-specific
+    transport codec, while PCM taps continue to see decoded radio audio.
     """
 
     HIGH_WATERMARK: int = 10
@@ -75,6 +75,9 @@ class AudioBroadcaster:
         self._radio_codec: AudioCodec | None = None
         self._sample_rate: int = 48000
         self._channels: int = 1
+        self._browser_opus_transcoder: PcmOpusTranscoder | None = None
+        self._browser_opus_transcoder_key: tuple[int, int, int] | None = None
+        self._browser_opus_warned: bool = False
         self._lock = asyncio.Lock()
         # Optional DSP pipeline (inserted between codec decode and tap/distribute).
         # NOTE: the DSP pipeline and the tap registry both operate on decoded
@@ -180,7 +183,7 @@ class AudioBroadcaster:
             return
         if self._dsp_pipeline is None:
             return
-        if self._web_codec != AUDIO_CODEC_OPUS:
+        if self._radio_codec not in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
             return
         logger.warning(
             "audio-broadcaster: DSP pipeline is configured but the radio's "
@@ -247,22 +250,10 @@ class AudioBroadcaster:
         refresh. Behavior-preserving extraction of the block previously
         inlined in ``_start_relay``.
         """
-        # Negotiate web codec from radio's actual audio codec
+        # Resolve browser transport from the radio-native codec plus profile
+        # consumer policy; this must not feed back into the radio conninfo codec.
         _codec = getattr(self._radio, "audio_codec", None)
         if isinstance(_codec, AudioCodec):
-            # Map radio codec → web transport codec.
-            # For ulaw codecs, we transcode to PCM16 in _relay_loop.
-            # NOTE: PCM_1CH_8BIT / PCM_2CH_8BIT intentionally NOT mapped
-            # (see #765); unknown codec falls through to PCM16 default.
-            _CODEC_MAP = {
-                AudioCodec.OPUS_1CH: AUDIO_CODEC_OPUS,
-                AudioCodec.OPUS_2CH: AUDIO_CODEC_OPUS,
-                AudioCodec.PCM_1CH_16BIT: AUDIO_CODEC_PCM16,
-                AudioCodec.PCM_2CH_16BIT: AUDIO_CODEC_PCM16,
-                AudioCodec.ULAW_1CH: AUDIO_CODEC_PCM16,
-                AudioCodec.ULAW_2CH: AUDIO_CODEC_PCM16,
-            }
-            self._web_codec = _CODEC_MAP.get(_codec, AUDIO_CODEC_PCM16)
             self._radio_codec = _codec
             self._channels = (
                 2
@@ -274,6 +265,7 @@ class AudioBroadcaster:
                 )
                 else 1
             )
+            self._web_codec = self._resolve_web_rx_codec(_codec)
             logger.info(
                 "audio-broadcaster: radio codec=%s (0x%02x) → web_codec=0x%02x",
                 _codec.name,
@@ -297,6 +289,64 @@ class AudioBroadcaster:
         # Re-check DSP-on-Opus after the codec may have just flipped.
         # Issue #762.
         self._maybe_warn_dsp_opus_gate()
+
+    def _resolve_web_rx_codec(self, radio_codec: AudioCodec) -> int:
+        """Resolve browser RX transport codec from profile consumer policy."""
+        if radio_codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
+            return AUDIO_CODEC_OPUS
+
+        default_codec = {
+            AudioCodec.PCM_1CH_16BIT: AUDIO_CODEC_PCM16,
+            AudioCodec.PCM_2CH_16BIT: AUDIO_CODEC_PCM16,
+            AudioCodec.ULAW_1CH: AUDIO_CODEC_PCM16,
+            AudioCodec.ULAW_2CH: AUDIO_CODEC_PCM16,
+        }.get(radio_codec, AUDIO_CODEC_PCM16)
+
+        profile = getattr(self._radio, "profile", None)
+        transport = getattr(profile, "browser_rx_transport", None)
+        transcode_to_opus = getattr(profile, "browser_rx_transcode_to_opus", None)
+        if transport == "pcm":
+            return AUDIO_CODEC_PCM16
+        if transport == "opus":
+            return AUDIO_CODEC_OPUS if transcode_to_opus is not False else default_codec
+        if transport == "auto" and transcode_to_opus is True:
+            return AUDIO_CODEC_OPUS
+        return default_codec
+
+    def _encode_browser_rx_frame(
+        self,
+        pcm_data: bytes,
+        frame_ms: int,
+    ) -> tuple[int, bytes]:
+        """Apply browser-only RX transport encoding after PCM consumers run."""
+        if self._web_codec != AUDIO_CODEC_OPUS:
+            return self._web_codec, pcm_data
+        if self._radio_codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
+            return AUDIO_CODEC_OPUS, pcm_data
+
+        key = (self._sample_rate, self._channels, frame_ms)
+        try:
+            if (
+                self._browser_opus_transcoder is None
+                or self._browser_opus_transcoder_key != key
+            ):
+                self._browser_opus_transcoder = create_pcm_opus_transcoder(
+                    sample_rate=self._sample_rate,
+                    channels=self._channels,
+                    frame_ms=frame_ms,
+                )
+                self._browser_opus_transcoder_key = key
+            return AUDIO_CODEC_OPUS, self._browser_opus_transcoder.pcm_to_opus(pcm_data)
+        except Exception as exc:
+            if not self._browser_opus_warned:
+                logger.warning(
+                    "audio: browser Opus transcode unavailable, emitting PCM16: %s",
+                    exc,
+                )
+                self._browser_opus_warned = True
+            self._browser_opus_transcoder = None
+            self._browser_opus_transcoder_key = None
+            return AUDIO_CODEC_PCM16, pcm_data
 
     async def _apply_phones_mix_off(self) -> None:
         """Force Phones L/R Mix = OFF so the LAN stream is separated stereo.
@@ -383,9 +433,9 @@ class AudioBroadcaster:
                 # quality loss on the wire; see issue #762 for the design
                 # note and ``_maybe_warn_dsp_opus_gate`` for the one-shot
                 # warning that surfaces this asymmetry to the operator.
-                if (
-                    self._dsp_pipeline is not None
-                    and self._web_codec == AUDIO_CODEC_PCM16
+                if self._dsp_pipeline is not None and self._radio_codec not in (
+                    AudioCodec.OPUS_1CH,
+                    AudioCodec.OPUS_2CH,
                 ):
                     try:
                         audio_data = self._dsp_pipeline.process_bytes(
@@ -397,7 +447,10 @@ class AudioBroadcaster:
                 # Fan out PCM data to all registered taps (FFT scope, analyzers, etc.).
                 # Opus-native radios do not feed taps — consumers get silence.
                 # Same rationale as the DSP gate above.  Issue #762.
-                if self._tap_registry.active and self._web_codec == AUDIO_CODEC_PCM16:
+                if self._tap_registry.active and self._radio_codec not in (
+                    AudioCodec.OPUS_1CH,
+                    AudioCodec.OPUS_2CH,
+                ):
                     self._tap_registry.feed(audio_data)
 
                 # frame_ms is derived from the actual payload size (issue #765).
@@ -410,14 +463,18 @@ class AudioBroadcaster:
                 _bytes_per_sample = 2
                 _denom = max(1, self._sample_rate * self._channels * _bytes_per_sample)
                 _frame_ms = max(1, min((len(audio_data) * 1000) // _denom, 255))
+                _frame_codec, _frame_audio_data = self._encode_browser_rx_frame(
+                    audio_data,
+                    _frame_ms,
+                )
                 frame = encode_audio_frame(
                     MSG_TYPE_AUDIO_RX,
-                    self._web_codec,
+                    _frame_codec,
                     self._seq,
                     self._sample_rate // 100,
                     self._channels,
                     _frame_ms,
-                    audio_data,
+                    _frame_audio_data,
                 )
                 self._seq = (self._seq + 1) & 0xFFFF
                 dead_ids: list[int] = []
@@ -463,12 +520,12 @@ class AudioBroadcaster:
 class AudioHandler:
     """Handler for the /api/v1/audio WebSocket channel.
 
-    Streams RX audio from the radio to the browser as binary Opus frames,
+    Streams RX audio from the radio to the browser as binary audio frames,
     and accepts TX audio frames from the browser to push to the radio.
 
     Control flow:
         Client sends JSON text: ``audio_start`` / ``audio_stop``
-        Server sends binary Opus frames continuously while RX is active.
+        Server sends binary audio frames continuously while RX is active.
         Client sends binary Opus frames while TX is active (after PTT on).
 
     Args:

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from rigplane.audio.route import AudioConfigSource
 from rigplane.types import AudioCapabilities, AudioCodec, get_audio_capabilities
 from rigplane.radio import IcomRadio
 
@@ -33,6 +34,21 @@ class TestRadioAudioConfig:
     def test_default_codec(self) -> None:
         r = IcomRadio("192.168.1.100")
         assert r.audio_codec == AudioCodec.PCM_2CH_16BIT
+        assert r.audio_sample_rate == 16000
+        assert r.audio_stream_request.rx_codec == AudioCodec.PCM_2CH_16BIT
+        assert r.audio_stream_request.tx_codec == AudioCodec.PCM_1CH_16BIT
+        assert r.audio_stream_request.rx_sample_rate_hz == 16000
+        assert r.audio_stream_request.tx_sample_rate_hz == 16000
+        assert r.audio_stream_contract.rx_codec == r.audio_stream_request.rx_codec
+        assert r.audio_stream_contract.tx_codec == r.audio_stream_request.tx_codec
+        assert (
+            r.audio_stream_contract.rx_sample_rate_hz
+            == r.audio_stream_request.rx_sample_rate_hz
+        )
+
+    def test_non_ic7610_keeps_global_sample_rate_default(self) -> None:
+        r = IcomRadio("192.168.1.100", model="IC-7300")
+        assert r.audio_codec == AudioCodec.PCM_1CH_16BIT
         assert r.audio_sample_rate == 48000
 
     def test_custom_codec(self) -> None:
@@ -43,6 +59,26 @@ class TestRadioAudioConfig:
         )
         assert r.audio_codec == AudioCodec.OPUS_1CH
         assert r.audio_sample_rate == 16000
+        assert r.audio_stream_contract.rx_codec == AudioCodec.OPUS_1CH
+        assert r.audio_stream_contract.tx_codec == AudioCodec.PCM_1CH_16BIT
+        assert (
+            r.audio_stream_contract.rx_sample_rate_source == AudioConfigSource.EXPLICIT
+        )
+        assert (
+            r.audio_stream_contract.tx_sample_rate_source == AudioConfigSource.EXPLICIT
+        )
+
+    def test_import_time_env_sample_rate_beats_profile_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import rigplane.runtime.radio as radio_module
+
+        monkeypatch.setenv("ICOM_AUDIO_SAMPLE_RATE", "24000")
+        monkeypatch.setattr(radio_module, "_DEFAULT_AUDIO_SAMPLE_RATE", 24000)
+
+        r = IcomRadio("192.168.1.100")
+
+        assert r.audio_sample_rate == 24000
 
     def test_codec_from_int(self) -> None:
         r = IcomRadio("192.168.1.100", audio_codec=0x40)

--- a/tests/test_audio_route.py
+++ b/tests/test_audio_route.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+from rigplane.profiles import get_radio_profile
+from rigplane.types import AudioCodec
+
 
 def _radio(*, backend_id: str, data_mode_count: int = 1) -> AsyncMock:
     radio = AsyncMock()
@@ -77,3 +80,62 @@ def test_unknown_route_does_not_change_data_source() -> None:
     assert route.tx_audio_source == TxAudioSource.UNAVAILABLE
     assert route.data_mode_policy == DataModePolicy.LEGACY
     assert rigctld_wsjtx_policy(route) == (None, None)
+
+
+def test_ic7610_lan_stream_request_uses_profile_audio_policy() -> None:
+    from rigplane.audio.route import AudioConfigSource, resolve_lan_audio_stream_request
+
+    request = resolve_lan_audio_stream_request(
+        profile=get_radio_profile("IC-7610"),
+        requested_rx_codec=AudioCodec.PCM_2CH_16BIT,
+        requested_sample_rate_hz=48000,
+    )
+
+    assert request.rx_codec == AudioCodec.PCM_2CH_16BIT
+    assert request.tx_codec == AudioCodec.PCM_1CH_16BIT
+    assert request.rx_sample_rate_hz == 16000
+    assert request.tx_sample_rate_hz == 16000
+    assert request.rx_channels == 2
+    assert request.tx_channels == 1
+    assert request.rx_codec_source == AudioConfigSource.PROFILE_DEFAULT
+    assert request.tx_codec_source == AudioConfigSource.PROFILE_DEFAULT
+    assert request.rx_sample_rate_source == AudioConfigSource.PROFILE_CODEC_DEFAULT
+    assert request.tx_sample_rate_source == AudioConfigSource.PROFILE_CODEC_DEFAULT
+
+
+def test_lan_stream_request_honors_explicit_overrides() -> None:
+    from rigplane.audio.route import AudioConfigSource, resolve_lan_audio_stream_request
+
+    request = resolve_lan_audio_stream_request(
+        profile=get_radio_profile("IC-7610"),
+        requested_rx_codec=AudioCodec.OPUS_1CH,
+        requested_sample_rate_hz=48000,
+        rx_codec_explicit=True,
+        sample_rate_explicit=True,
+    )
+
+    assert request.rx_codec == AudioCodec.OPUS_1CH
+    assert request.tx_codec == AudioCodec.PCM_1CH_16BIT
+    assert request.rx_sample_rate_hz == 48000
+    assert request.tx_sample_rate_hz == 48000
+    assert request.rx_channels == 1
+    assert request.rx_codec_source == AudioConfigSource.EXPLICIT
+    assert request.rx_sample_rate_source == AudioConfigSource.EXPLICIT
+    assert request.tx_sample_rate_source == AudioConfigSource.EXPLICIT
+
+
+def test_lan_stream_request_preserves_non_audited_profile_defaults() -> None:
+    from rigplane.audio.route import AudioConfigSource, resolve_lan_audio_stream_request
+
+    request = resolve_lan_audio_stream_request(
+        profile=get_radio_profile("IC-7300"),
+        requested_rx_codec=AudioCodec.PCM_2CH_16BIT,
+        requested_sample_rate_hz=48000,
+    )
+
+    assert request.rx_codec == AudioCodec.PCM_1CH_16BIT
+    assert request.tx_codec == AudioCodec.PCM_1CH_16BIT
+    assert request.rx_sample_rate_hz == 48000
+    assert request.tx_sample_rate_hz == 48000
+    assert request.rx_codec_source == AudioConfigSource.PROFILE_DEFAULT
+    assert request.rx_sample_rate_source == AudioConfigSource.GLOBAL_DEFAULT

--- a/tests/test_diagnostics_contributors_batch2.py
+++ b/tests/test_diagnostics_contributors_batch2.py
@@ -16,16 +16,19 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from rigplane.audio.route import AudioConfigSource
 from rigplane.diagnostics import _discovery
 from rigplane.diagnostics.contributor import BundleContext
 from rigplane.diagnostics.contributors import (
     AudioContributor,
     RadioContributor,
 )
+from rigplane.types import AudioCodec
 
 
 @pytest.fixture(autouse=True)
@@ -291,6 +294,95 @@ def test_audio_emits_codec_and_sample_rate(tmp_path: Path) -> None:
     assert payload["available"] is True
     assert payload["codec"] == "PCM_1CH_16BIT"
     assert payload["sample_rate_hz"] == 48000
+
+
+def test_audio_emits_requested_and_effective_radio_native_contracts(
+    tmp_path: Path,
+) -> None:
+    class FakeAudioRadio(_AudioCapableStub):
+        audio_stream_request = SimpleNamespace(
+            rx_codec=AudioCodec.PCM_2CH_16BIT,
+            tx_codec=AudioCodec.PCM_1CH_16BIT,
+            rx_sample_rate_hz=16000,
+            tx_sample_rate_hz=16000,
+            rx_channels=2,
+            tx_channels=1,
+            rx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+            tx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+            rx_sample_rate_source=AudioConfigSource.PROFILE_CODEC_DEFAULT,
+            tx_sample_rate_source=AudioConfigSource.PROFILE_CODEC_DEFAULT,
+        )
+        audio_stream_contract = SimpleNamespace(
+            rx_codec=AudioCodec.PCM_1CH_16BIT,
+            tx_codec=AudioCodec.PCM_1CH_16BIT,
+            rx_sample_rate_hz=16000,
+            tx_sample_rate_hz=16000,
+            rx_channels=1,
+            tx_channels=1,
+            rx_codec_source=AudioConfigSource.FALLBACK,
+            tx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+            rx_sample_rate_source=AudioConfigSource.PROFILE_CODEC_DEFAULT,
+            tx_sample_rate_source=AudioConfigSource.PROFILE_CODEC_DEFAULT,
+            fallback_reason="conninfo-stereo-rx-rejected",
+        )
+
+    AudioContributor().contribute(_make_ctx(radio=FakeAudioRadio()), tmp_path)
+    payload = json.loads((tmp_path / "audio.json").read_text())
+
+    requested = payload["radio_native"]["requested"]
+    assert requested["rx"] == {
+        "codec": "PCM_2CH_16BIT",
+        "sample_rate_hz": 16000,
+        "channels": 2,
+        "codec_source": "profile-default",
+        "sample_rate_source": "profile-codec-default",
+    }
+    assert requested["tx"]["codec"] == "PCM_1CH_16BIT"
+    assert requested["tx"]["channels"] == 1
+
+    effective = payload["radio_native"]["effective"]
+    assert effective["rx"]["codec"] == "PCM_1CH_16BIT"
+    assert effective["rx"]["codec_source"] == "fallback"
+    assert effective["fallback_reason"] == "conninfo-stereo-rx-rejected"
+
+
+def test_audio_emits_configured_web_rx_policy_without_runtime_client_state(
+    tmp_path: Path,
+) -> None:
+    class FakeAudioRadio(_AudioCapableStub):
+        profile = SimpleNamespace(
+            browser_rx_transport="auto",
+            browser_rx_transcode_to_opus=True,
+        )
+        audio_stream_contract = SimpleNamespace(
+            rx_codec="PCM_2CH_16BIT",
+            tx_codec="PCM_1CH_16BIT",
+            rx_sample_rate_hz=16000,
+            tx_sample_rate_hz=16000,
+            rx_channels=2,
+            tx_channels=1,
+            rx_codec_source="profile-default",
+            tx_codec_source="profile-default",
+            rx_sample_rate_source="profile-codec-default",
+            tx_sample_rate_source="profile-codec-default",
+            fallback_reason=None,
+        )
+
+    AudioContributor().contribute(_make_ctx(radio=FakeAudioRadio()), tmp_path)
+    payload = json.loads((tmp_path / "audio.json").read_text())
+
+    web_rx = payload["web_rx"]
+    assert web_rx == {
+        "state": "configured-policy",
+        "transport": "auto",
+        "transcode_to_opus": True,
+        "codec": "OPUS",
+        "sample_rate_hz": 16000,
+        "channels": 2,
+        "codec_source": "profile-default",
+        "sample_rate_source": "radio-native-effective",
+        "channels_source": "radio-native-effective",
+    }
 
 
 def test_audio_redacts_device_name_with_username(tmp_path: Path) -> None:

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -16,6 +16,7 @@ from rigplane.radio import (
     STATUS_SIZE,
     TOKEN_ACK_SIZE,
 )
+from rigplane.audio.route import AudioConfigSource
 from rigplane.transport import ConnectionState
 from rigplane.types import AudioCodec
 
@@ -216,6 +217,34 @@ class TestSendConninfo:
         assert packet[0x73] == int(AudioCodec.PCM_1CH_16BIT), (
             f"txcodec must be mono 0x04 even for stereo RX, got 0x{packet[0x73]:02X}"
         )
+        rx_sample = struct.unpack_from(">I", packet, 0x74)[0]
+        tx_sample = struct.unpack_from(">I", packet, 0x78)[0]
+        assert rx_sample == 16000
+        assert tx_sample == 16000
+
+    @pytest.mark.asyncio
+    async def test_conninfo_honors_explicit_sample_rate_override(self) -> None:
+        from rigplane.types import AudioCodec
+
+        radio = IcomRadio(
+            "192.168.1.100",
+            username="u",
+            password="p",
+            audio_codec=AudioCodec.PCM_2CH_16BIT,
+            audio_sample_rate=48000,
+        )
+        mt = ConnectMockTransport()
+        radio._ctrl_transport = mt
+        radio._token = 0x12345678
+        radio._tok_request = 0xABCD
+
+        await radio._control_phase._send_conninfo(b"\x00" * 16)
+
+        packet = mt.sent_packets[0]
+        assert packet[0x72] == int(AudioCodec.PCM_2CH_16BIT)
+        assert packet[0x73] == int(AudioCodec.PCM_1CH_16BIT)
+        assert struct.unpack_from(">I", packet, 0x74)[0] == 48000
+        assert struct.unpack_from(">I", packet, 0x78)[0] == 48000
 
 
 class TestReceiveCivPort:
@@ -562,7 +591,17 @@ class TestConnectSessionRejection:
             AudioCodec.PCM_2CH_16BIT,
             AudioCodec.PCM_1CH_16BIT,
         ], "Second conninfo must be sent with mono codec, before any later mutation"
+        assert radio.audio_stream_request.rx_codec == AudioCodec.PCM_2CH_16BIT
+        assert radio.audio_stream_contract.rx_codec == AudioCodec.PCM_1CH_16BIT
+        assert radio.audio_stream_contract.tx_codec == AudioCodec.PCM_1CH_16BIT
+        assert radio.audio_stream_contract.rx_sample_rate_hz == 16000
+        assert radio.audio_stream_contract.tx_sample_rate_hz == 16000
+        assert radio.audio_stream_contract.rx_codec_source == AudioConfigSource.FALLBACK
+        assert (
+            radio.audio_stream_contract.fallback_reason == "conninfo-stereo-rx-rejected"
+        )
         assert radio._audio_codec == AudioCodec.PCM_1CH_16BIT
+        assert radio.audio_codec == AudioCodec.PCM_1CH_16BIT
         assert radio._civ_port == 50001
 
     @pytest.mark.asyncio

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -581,11 +581,21 @@ class TestCodecPreference:
             profile = rig.to_profile()
             assert profile.codec_preference == ("PCM_1CH_16BIT", "ULAW_1CH")
 
-    def test_ic7610_has_no_override(self):
-        """IC-7610 stays on the global stereo-first default (no override)."""
+    def test_ic7610_declares_stereo_pcm_first_override(self):
+        """IC-7610 explicitly pins the direct-LAN PCM-first RX preference."""
         rig = load_rig(TEMPLATE_PATH)
-        assert rig.codec_preference is None
-        assert rig.to_profile().codec_preference is None
+        assert rig.codec_preference == (
+            "PCM_2CH_16BIT",
+            "PCM_1CH_16BIT",
+            "ULAW_2CH",
+            "ULAW_1CH",
+        )
+        assert rig.to_profile().codec_preference == (
+            "PCM_2CH_16BIT",
+            "PCM_1CH_16BIT",
+            "ULAW_2CH",
+            "ULAW_1CH",
+        )
 
     def test_codec_preference_parses_list_of_strings(self, tmp_path):
         toml = _MINIMAL_TOML + '\n[audio]\ncodec_preference = ["PCM_1CH_16BIT"]\n'
@@ -622,3 +632,113 @@ class TestCodecPreference:
         p = _write_toml(tmp_path, toml)
         with pytest.raises(RigLoadError, match=r"\[audio\] must be a table"):
             load_rig(p)
+
+
+class TestAudioPolicy:
+    """Per-profile [audio] codec and sample-rate policy (#1470)."""
+
+    def test_ic7610_declares_pcm_first_lan_policy(self):
+        rig = load_rig(TEMPLATE_PATH)
+
+        assert rig.codec_preference == (
+            "PCM_2CH_16BIT",
+            "PCM_1CH_16BIT",
+            "ULAW_2CH",
+            "ULAW_1CH",
+        )
+        assert rig.tx_codec == "PCM_1CH_16BIT"
+        assert rig.default_sample_rate_hz == 16000
+        assert rig.supported_sample_rates_hz is None
+        assert rig.sample_rate_by_codec == {
+            "PCM_2CH_16BIT": 16000,
+            "PCM_1CH_16BIT": 16000,
+        }
+        assert rig.browser_rx_transport == "auto"
+        assert rig.browser_rx_transcode_to_opus is True
+
+        profile = rig.to_profile()
+        assert profile.codec_preference == (
+            "PCM_2CH_16BIT",
+            "PCM_1CH_16BIT",
+            "ULAW_2CH",
+            "ULAW_1CH",
+        )
+        assert profile.tx_codec == "PCM_1CH_16BIT"
+        assert profile.default_sample_rate_hz == 16000
+        assert profile.supported_sample_rates_hz is None
+        assert profile.sample_rate_by_codec == {
+            "PCM_2CH_16BIT": 16000,
+            "PCM_1CH_16BIT": 16000,
+        }
+        assert profile.browser_rx_transport == "auto"
+        assert profile.browser_rx_transcode_to_opus is True
+
+    def test_full_audio_policy_parses(self, tmp_path):
+        toml = (
+            _MINIMAL_TOML
+            + """
+
+[audio]
+codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT"]
+tx_codec = "PCM_1CH_16BIT"
+default_sample_rate_hz = 16000
+supported_sample_rates_hz = [8000, 16000, 48000]
+sample_rate_by_codec = { PCM_2CH_16BIT = 16000, PCM_1CH_16BIT = 16000 }
+browser_rx_transport = "auto"
+browser_rx_transcode_to_opus = true
+"""
+        )
+        rig = load_rig(_write_toml(tmp_path, toml))
+
+        assert rig.codec_preference == ("PCM_2CH_16BIT", "PCM_1CH_16BIT")
+        assert rig.tx_codec == "PCM_1CH_16BIT"
+        assert rig.default_sample_rate_hz == 16000
+        assert rig.supported_sample_rates_hz == (8000, 16000, 48000)
+        assert rig.sample_rate_by_codec == {
+            "PCM_2CH_16BIT": 16000,
+            "PCM_1CH_16BIT": 16000,
+        }
+        assert rig.browser_rx_transport == "auto"
+        assert rig.browser_rx_transcode_to_opus is True
+
+    def test_existing_profiles_without_new_policy_load_unchanged(self, tmp_path):
+        rig = load_rig(_write_toml(tmp_path, _MINIMAL_TOML))
+        profile = rig.to_profile()
+
+        assert rig.codec_preference is None
+        assert rig.tx_codec is None
+        assert rig.default_sample_rate_hz is None
+        assert rig.supported_sample_rates_hz is None
+        assert rig.sample_rate_by_codec is None
+        assert rig.browser_rx_transport is None
+        assert rig.browser_rx_transcode_to_opus is None
+        assert profile.tx_codec is None
+        assert profile.default_sample_rate_hz is None
+
+    def test_unknown_tx_codec_rejected(self, tmp_path):
+        toml = _MINIMAL_TOML + '\n[audio]\ntx_codec = "BOGUS_CODEC"\n'
+        with pytest.raises(RigLoadError, match=r"\[audio\].tx_codec.*unknown codec"):
+            load_rig(_write_toml(tmp_path, toml))
+
+    def test_unsupported_default_sample_rate_rejected(self, tmp_path):
+        toml = _MINIMAL_TOML + "\n[audio]\ndefault_sample_rate_hz = 44100\n"
+        with pytest.raises(RigLoadError, match="default_sample_rate_hz"):
+            load_rig(_write_toml(tmp_path, toml))
+
+    def test_negative_sample_rate_rejected(self, tmp_path):
+        toml = _MINIMAL_TOML + "\n[audio]\nsupported_sample_rates_hz = [16000, -1]\n"
+        with pytest.raises(RigLoadError, match="supported_sample_rates_hz"):
+            load_rig(_write_toml(tmp_path, toml))
+
+    def test_unknown_sample_rate_codec_key_rejected(self, tmp_path):
+        toml = (
+            _MINIMAL_TOML
+            + "\n[audio]\nsample_rate_by_codec = { BOGUS_CODEC = 16000 }\n"
+        )
+        with pytest.raises(RigLoadError, match="sample_rate_by_codec.*unknown codec"):
+            load_rig(_write_toml(tmp_path, toml))
+
+    def test_invalid_browser_transport_rejected(self, tmp_path):
+        toml = _MINIMAL_TOML + '\n[audio]\nbrowser_rx_transport = "rtmp"\n'
+        with pytest.raises(RigLoadError, match="browser_rx_transport"):
+            load_rig(_write_toml(tmp_path, toml))

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -13,6 +13,11 @@ class TestSyncInit:
         assert r._loop is not None
         r._loop.close()
 
+    def test_default_sample_rate_uses_profile_policy(self) -> None:
+        r = IcomRadio("192.168.1.100")
+        assert r.audio_sample_rate == 16000
+        r._loop.close()
+
     def test_custom_params(self) -> None:
         r = IcomRadio(
             "192.168.1.100",

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1389,6 +1389,120 @@ class TestAudioHandlerCodecDetection:
         frame = await self._start_rx_and_capture(MagicMock(), 48000)
         assert frame[1] == AUDIO_CODEC_PCM16
 
+    async def test_ic7610_pcm_native_can_emit_browser_opus_by_profile_policy(
+        self,
+    ) -> None:
+        from rigplane.audio_bus import AudioBus
+        from rigplane.radio_protocol import AudioCapable
+        from rigplane.types import AudioCodec
+        from rigplane.web.handlers import AudioBroadcaster, AudioHandler
+        from rigplane.web.protocol import AUDIO_CODEC_OPUS, AUDIO_HEADER_SIZE
+        from rigplane.web.websocket import WebSocketConnection
+
+        mock_ws = MagicMock(spec=WebSocketConnection)
+        mock_radio = MagicMock(spec=AudioCapable)
+        mock_radio.capabilities = {"audio"}
+        mock_radio.audio_codec = AudioCodec.PCM_2CH_16BIT
+        mock_radio.audio_sample_rate = 16000
+        mock_radio.profile = SimpleNamespace(
+            browser_rx_transport="auto",
+            browser_rx_transcode_to_opus=True,
+        )
+        mock_radio.start_audio_rx_opus = AsyncMock()
+        mock_radio.stop_audio_rx_opus = AsyncMock()
+        bus = AudioBus(mock_radio)
+        mock_radio.audio_bus = bus
+
+        pcm_payload = b"\x01\x02" * 640  # 20 ms, 16 kHz, stereo, s16le
+        tap_frames: list[bytes] = []
+
+        class _FakeTranscoder:
+            def pcm_to_opus(self, pcm: bytes) -> bytes:
+                assert pcm == pcm_payload
+                return b"opus-web-frame"
+
+        broadcaster = AudioBroadcaster(mock_radio)
+        broadcaster.set_pcm_tap(tap_frames.append)
+        handler = AudioHandler(mock_ws, mock_radio, broadcaster)
+
+        with patch(
+            "rigplane.web.handlers.audio.create_pcm_opus_transcoder",
+            return_value=_FakeTranscoder(),
+        ) as transcoder_factory:
+            await handler._start_rx()
+            mock_pkt = MagicMock()
+            mock_pkt.data = pcm_payload
+            bus._on_opus_packet(mock_pkt)
+            await asyncio.sleep(0.1)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_OPUS
+        assert frame[AUDIO_HEADER_SIZE:] == b"opus-web-frame"
+        assert tap_frames == [pcm_payload]
+        transcoder_factory.assert_called_once_with(
+            sample_rate=16000,
+            channels=2,
+            frame_ms=20,
+        )
+
+    async def test_browser_opus_policy_falls_back_to_pcm16_when_encoder_unavailable(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from rigplane.audio_bus import AudioBus
+        from rigplane.radio_protocol import AudioCapable
+        from rigplane.types import AudioCodec
+        from rigplane.web.handlers import AudioBroadcaster, AudioHandler
+        from rigplane.web.protocol import AUDIO_CODEC_PCM16, AUDIO_HEADER_SIZE
+        from rigplane.web.websocket import WebSocketConnection
+
+        mock_ws = MagicMock(spec=WebSocketConnection)
+        mock_radio = MagicMock(spec=AudioCapable)
+        mock_radio.capabilities = {"audio"}
+        mock_radio.audio_codec = AudioCodec.PCM_2CH_16BIT
+        mock_radio.audio_sample_rate = 16000
+        mock_radio.profile = SimpleNamespace(
+            browser_rx_transport="auto",
+            browser_rx_transcode_to_opus=True,
+        )
+        mock_radio.start_audio_rx_opus = AsyncMock()
+        mock_radio.stop_audio_rx_opus = AsyncMock()
+        bus = AudioBus(mock_radio)
+        mock_radio.audio_bus = bus
+
+        pcm_payload = b"\x01\x02" * 640
+        tap_frames: list[bytes] = []
+        broadcaster = AudioBroadcaster(mock_radio)
+        broadcaster.set_pcm_tap(tap_frames.append)
+        handler = AudioHandler(mock_ws, mock_radio, broadcaster)
+
+        with (
+            caplog.at_level("WARNING"),
+            patch(
+                "rigplane.web.handlers.audio.create_pcm_opus_transcoder",
+                side_effect=RuntimeError("opus disabled"),
+            ),
+        ):
+            await handler._start_rx()
+            for _ in range(2):
+                mock_pkt = MagicMock()
+                mock_pkt.data = pcm_payload
+                bus._on_opus_packet(mock_pkt)
+            await asyncio.sleep(0.1)
+
+        frames = [handler._frame_queue.get_nowait() for _ in range(2)]
+        assert [frame[1] for frame in frames] == [AUDIO_CODEC_PCM16, AUDIO_CODEC_PCM16]
+        assert [frame[AUDIO_HEADER_SIZE:] for frame in frames] == [
+            pcm_payload,
+            pcm_payload,
+        ]
+        assert tap_frames == [pcm_payload, pcm_payload]
+        warnings = [
+            record
+            for record in caplog.records
+            if "browser Opus transcode unavailable" in record.message
+        ]
+        assert len(warnings) == 1
+
 
 class TestBroadcasterFrameMsInvariant:
     """Wire-header ``frame_ms`` must match the actual payload size (issue #765).


### PR DESCRIPTION
## Summary

- add RadioProfile audio policy fields and IC-7610 PCM-first LAN defaults
- resolve requested direct-Icom-LAN audio stream values before conninfo
- expose requested vs accepted/effective radio-native audio contracts
- split browser RX emission codec from radio-native/AudioBus/bridge PCM contracts
- add diagnostics and operator docs for requested/effective/web audio contracts

Fixes/implements the implementation scope for #1469:
- #1470
- #1471
- #1472
- #1473
- #1474
- #1475

Related customer bug/evidence: #1467.

## Verification

- uv run pytest tests/test_diagnostics_contributors_batch2.py tests/test_audio_codec.py tests/test_audio_route.py tests/test_radio_connect.py tests/test_backend_factory.py tests/test_sync.py tests/test_rig_loader.py tests/test_radio.py tests/test_icom7610_serial_radio.py tests/test_web_server.py::TestAudioHandlerCodecDetection tests/test_web_server.py::TestBroadcasterFrameMsInvariant tests/test_web_server.py::TestBroadcasterCodecInvalidation tests/test_web_server.py::TestDspOpusGateWarning tests/test_web_audio_streaming_profile.py tests/test_audio_bridge.py tests/test_audio_bridge_stereo.py tests/integration/test_rigctld_audio_pipeline.py -q
  - 483 passed, 1 deselected
- uv run ruff check focused changed files
  - passed
- git diff --check
  - passed

## Hardware validation

Prepared opt-in hardware test exists at tests/hardware/test_ic7610_audio_pipeline.py and covers IC-7610 LAN + rigctld DATA2/LAN + synthetic PCM TX bridge path.

Current live check from the dev Mac:
- ping 192.168.55.40: OK
- nc 192.168.55.40:50001: connection refused
- nc 192.168.55.40:50002: connection refused

So real-radio validation is currently blocked by the radio LAN control/audio ports being closed/refused. Once the radio LAN server is available and credentials are provided via env/pass file, run:

============================= test session starts ==============================
platform darwin -- Python 3.13.9, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/moroz/Projects/icom-lan
configfile: pyproject.toml
plugins: xdist-3.8.0, timeout-2.4.0, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 1 item

tests/hardware/test_ic7610_audio_pipeline.py E

==================================== ERRORS ====================================
_______ ERROR at setup of test_ic7610_lan_rigctld_data2_pcm_tx_pipeline ________
tests/hardware/test_ic7610_audio_pipeline.py:151: in hardware_radio
    config = _hardware_config()
             ^^^^^^^^^^^^^^^^^^
tests/hardware/test_ic7610_audio_pipeline.py:100: in _hardware_config
    password = _password_from_env()
               ^^^^^^^^^^^^^^^^^^^^
tests/hardware/test_ic7610_audio_pipeline.py:87: in _password_from_env
    return Path(pass_file).read_text(encoding="utf-8").strip()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.local/share/uv/python/cpython-3.13.9-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.local/share/uv/python/cpython-3.13.9-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.local/share/uv/python/cpython-3.13.9-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   FileNotFoundError: [Errno 2] No such file or directory: '/path/to/passfile'
=========================== short test summary info ============================
ERROR tests/hardware/test_ic7610_audio_pipeline.py::test_ic7610_lan_rigctld_data2_pcm_tx_pipeline
=============================== 1 error in 0.05s ===============================

Only run this with a safe transmitter/load setup.