### PR TITLE
Add Icom LAN audio policies for IC-705 and IC-9700

### DIFF
--- a/docs/plans/2026-05-08-audio-profile-policy-audit.md
+++ b/docs/plans/2026-05-08-audio-profile-policy-audit.md
@@ -14,8 +14,22 @@ This audit reviews radio profile audio policy candidates for:
 - `rigs/ftx1.toml`
 - `rigs/examples/*.toml`
 
-No runtime code or rig profile values were changed. Unknown per-radio audio
-limits are intentionally left absent rather than inferred from generic defaults.
+The original audit did not change runtime code or rig profile values. Unknown
+per-radio audio limits are intentionally left absent rather than inferred from
+generic defaults.
+
+## Implementation Follow-Up
+
+Issue #1477 populated the evidence-backed subset of this audit for IC-705 and
+IC-9700. Both profiles now declare mono PCM TX and browser-only Opus transport
+policy, matching the Icom LAN rule that direct radio-native conninfo stays
+PCM/uLaw while web clients may receive a server-side transcode after PCM capture.
+
+Per-radio sample-rate fields remain intentionally unset for IC-705 and IC-9700.
+The local wfview UI exposes a generic sample-rate set, but neither the local
+official references nor the wfview rig files provide a per-radio support matrix.
+Those rates must be added only after official documentation, packet captures, or
+hardware validation prove the specific radio behavior.
 
 ## Evidence Sources
 

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -29,6 +29,9 @@ data_len_max = 475
 # mono fallback as belt-and-braces.
 [audio]
 codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
+tx_codec = "PCM_1CH_16BIT"
+browser_rx_transport = "auto"
+browser_rx_transcode_to_opus = true
 
 # ── Capabilities ─────────────────────────────────────────────────
 

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -26,6 +26,9 @@ data_len_max = 475
 # provides a secondary safety net.
 [audio]
 codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
+tx_codec = "PCM_1CH_16BIT"
+browser_rx_transport = "auto"
+browser_rx_transcode_to_opus = true
 
 # ── Capabilities ─────────────────────────────────────────────────
 # Feature tags determine which UI panels and controls are rendered.

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -302,6 +302,10 @@ class AudioBroadcaster:
             AudioCodec.ULAW_2CH: AUDIO_CODEC_PCM16,
         }.get(radio_codec, AUDIO_CODEC_PCM16)
 
+        backend_id = getattr(self._radio, "backend_id", None)
+        if isinstance(backend_id, str) and backend_id != "rigplane":
+            return default_codec
+
         profile = getattr(self._radio, "profile", None)
         transport = getattr(profile, "browser_rx_transport", None)
         transcode_to_opus = getattr(profile, "browser_rx_transcode_to_opus", None)

--- a/tests/test_audio_route.py
+++ b/tests/test_audio_route.py
@@ -103,6 +103,28 @@ def test_ic7610_lan_stream_request_uses_profile_audio_policy() -> None:
     assert request.tx_sample_rate_source == AudioConfigSource.PROFILE_CODEC_DEFAULT
 
 
+def test_ic705_and_ic9700_lan_stream_requests_use_profile_tx_codec_only() -> None:
+    from rigplane.audio.route import AudioConfigSource, resolve_lan_audio_stream_request
+
+    for model in ("IC-705", "IC-9700"):
+        request = resolve_lan_audio_stream_request(
+            profile=get_radio_profile(model),
+            requested_rx_codec=AudioCodec.PCM_2CH_16BIT,
+            requested_sample_rate_hz=48000,
+        )
+
+        assert request.rx_codec == AudioCodec.PCM_1CH_16BIT
+        assert request.tx_codec == AudioCodec.PCM_1CH_16BIT
+        assert request.rx_sample_rate_hz == 48000
+        assert request.tx_sample_rate_hz == 48000
+        assert request.rx_channels == 1
+        assert request.tx_channels == 1
+        assert request.rx_codec_source == AudioConfigSource.PROFILE_DEFAULT
+        assert request.tx_codec_source == AudioConfigSource.PROFILE_DEFAULT
+        assert request.rx_sample_rate_source == AudioConfigSource.GLOBAL_DEFAULT
+        assert request.tx_sample_rate_source == AudioConfigSource.GLOBAL_DEFAULT
+
+
 def test_lan_stream_request_honors_explicit_overrides() -> None:
     from rigplane.audio.route import AudioConfigSource, resolve_lan_audio_stream_request
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -673,6 +673,25 @@ class TestAudioPolicy:
         assert profile.browser_rx_transport == "auto"
         assert profile.browser_rx_transcode_to_opus is True
 
+    def test_ic705_and_ic9700_declare_evidence_backed_mono_lan_policy(self):
+        for name in ("ic705.toml", "ic9700.toml"):
+            rig = load_rig(RIGS_DIR / name)
+
+            assert rig.codec_preference == ("PCM_1CH_16BIT", "ULAW_1CH")
+            assert rig.tx_codec == "PCM_1CH_16BIT"
+            assert rig.default_sample_rate_hz is None
+            assert rig.supported_sample_rates_hz is None
+            assert rig.sample_rate_by_codec is None
+            assert rig.browser_rx_transport == "auto"
+            assert rig.browser_rx_transcode_to_opus is True
+
+            profile = rig.to_profile()
+            assert profile.tx_codec == "PCM_1CH_16BIT"
+            assert profile.default_sample_rate_hz is None
+            assert profile.sample_rate_by_codec is None
+            assert profile.browser_rx_transport == "auto"
+            assert profile.browser_rx_transcode_to_opus is True
+
     def test_full_audio_policy_parses(self, tmp_path):
         toml = (
             _MINIMAL_TOML

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1445,6 +1445,44 @@ class TestAudioHandlerCodecDetection:
             frame_ms=20,
         )
 
+    async def test_serial_backend_ignores_direct_lan_browser_opus_profile_policy(
+        self,
+    ) -> None:
+        from rigplane.audio_bus import AudioBus
+        from rigplane.radio_protocol import AudioCapable
+        from rigplane.types import AudioCodec
+        from rigplane.web.handlers import AudioBroadcaster, AudioHandler
+        from rigplane.web.protocol import AUDIO_CODEC_PCM16, AUDIO_HEADER_SIZE
+        from rigplane.web.websocket import WebSocketConnection
+
+        mock_ws = MagicMock(spec=WebSocketConnection)
+        mock_radio = MagicMock(spec=AudioCapable)
+        mock_radio.backend_id = "icom_serial"
+        mock_radio.capabilities = {"audio"}
+        mock_radio.audio_codec = AudioCodec.PCM_2CH_16BIT
+        mock_radio.audio_sample_rate = 48000
+        mock_radio.profile = SimpleNamespace(
+            browser_rx_transport="auto",
+            browser_rx_transcode_to_opus=True,
+        )
+        mock_radio.start_audio_rx_opus = AsyncMock()
+        mock_radio.stop_audio_rx_opus = AsyncMock()
+        bus = AudioBus(mock_radio)
+        mock_radio.audio_bus = bus
+
+        broadcaster = AudioBroadcaster(mock_radio)
+        handler = AudioHandler(mock_ws, mock_radio, broadcaster)
+        await handler._start_rx()
+
+        mock_pkt = MagicMock()
+        mock_pkt.data = b"\x01\x02" * 960
+        bus._on_opus_packet(mock_pkt)
+        await asyncio.sleep(0.1)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_PCM16
+        assert frame[AUDIO_HEADER_SIZE:] == mock_pkt.data
+
     async def test_browser_opus_policy_falls_back_to_pcm16_when_encoder_unavailable(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
## Summary

- Add evidence-backed IC-705 and IC-9700 audio policy fields: mono PCM TX plus browser-only Opus transport policy.
- Keep per-radio sample-rate fields unset where the references do not provide a radio-specific matrix.
- Prevent direct-LAN browser Opus policy from changing serial/USB backend browser frames.
- Record the follow-up in the audio profile policy audit doc.

Closes #1477.

## Verification

- `uv run pytest tests/test_rig_loader.py::TestAudioPolicy::test_ic705_and_ic9700_declare_evidence_backed_mono_lan_policy tests/test_audio_route.py::test_ic705_and_ic9700_lan_stream_requests_use_profile_tx_codec_only`
- `uv run pytest tests/test_rig_loader.py tests/test_audio_route.py tests/test_diagnostics_contributors_batch2.py -q`
- `uv run pytest tests/test_web_server.py::TestAudioHandlerCodecDetection tests/test_web_server.py::TestAudioFrameFormat tests/test_web_server.py::TestBroadcasterCodecInvalidation -q`
- `uv run pytest tests/test_web_server.py::TestAudioHandlerCodecDetection::test_serial_backend_ignores_direct_lan_browser_opus_profile_policy tests/test_serial_backend_smoke.py::test_web_audio_broadcaster_smoke_with_serial_backend_audio_driver -q`
- `uv run ruff check src/rigplane/web/handlers/audio.py tests/test_web_server.py tests/test_rig_loader.py tests/test_audio_route.py`
- `uv run ruff format --check src/rigplane/web/handlers/audio.py tests/test_web_server.py tests/test_rig_loader.py tests/test_audio_route.py`
- `uv run pytest -q`: 5928 passed, 107 skipped, 3 deselected, 9 xfailed, 1 xpassed

## Evidence notes

- wfview direct-radio path rejects Opus for non-WFVIEW connection types and forces LPCM16.
- wfview TX codec UI exposes mono TX codecs only.
- IC-705 and IC-9700 are LAN-capable in local wfview rig metadata, but no per-radio sample-rate matrix was found in local official references or wfview rig files.
