### PR TITLE
Add audio probe foundation and USB audio contracts

### DIFF
--- a/docs/plans/2026-05-08-audio-capability-probing.md
+++ b/docs/plans/2026-05-08-audio-capability-probing.md
@@ -1,0 +1,53 @@
+# Audio Capability Probing Design
+
+Issues: #1479, #1481, #1482, #1483
+Date: 2026-05-08
+
+## Scope
+
+This design separates radio-native LAN audio probing from consumer transport
+encoding and OS audio-device probing.
+
+Direct stock-radio LAN policy is protocol-specific. For Icom LAN, probe
+artifacts test PCM/uLaw conninfo combinations and intentionally exclude Opus:
+wfview-server compatibility is a separate transport concern and is not a
+priority for radio-native defaults.
+
+USB audio is out of scope for radio-native codec probing. USB-connected radios
+expose OS audio devices, so their hardening lives in #1480.
+
+## Boundaries
+
+- Radio-native stream policy: codec/sample-rate/channels sent to the radio or
+  accepted by the radio protocol endpoint.
+- Probe result: one attempted candidate plus its accepted/rejected/failed state.
+- Evidence artifact: machine-readable JSON containing model, profile, transport,
+  metadata, candidates, statuses, reasons, and observed payload data.
+- Profile update: a later explicit change to `rigs/*.toml` made only from passed
+  evidence. Rejected or failed candidates remain evidence but never become
+  defaults.
+
+## Foundation
+
+`rigplane.audio.probe` defines:
+
+- `AudioProbeCandidate`
+- `AudioProbeResult`
+- `AudioProbeArtifact`
+- `AudioProbeStatus`
+- `build_icom_lan_probe_matrix()`
+- `classify_icom_lan_probe_error()`
+- `profile_policy_from_probe_results()`
+
+The initial Icom LAN matrix is conservative:
+
+- RX codecs: PCM 2ch/1ch 16-bit, uLaw 2ch/1ch.
+- TX codec: mono PCM 16-bit.
+- Sample rates: 48000, 24000, 16000, 8000.
+- Opus: excluded for direct stock-radio LAN.
+
+## Follow-Up Work
+
+- #1481 adds the actual Icom LAN probe runner and CLI.
+- #1482 records hardware validation artifacts.
+- #1483 turns passed artifacts into guarded profile update proposals.

--- a/docs/plans/2026-05-08-audio-capability-probing.md
+++ b/docs/plans/2026-05-08-audio-capability-probing.md
@@ -35,8 +35,8 @@ expose OS audio devices, so their hardening lives in #1480.
 - `AudioProbeResult`
 - `AudioProbeArtifact`
 - `AudioProbeStatus`
-- `build_icom_lan_probe_matrix()`
-- `classify_icom_lan_probe_error()`
+- `build_icomlan_probe_matrix()`
+- `classify_icomlan_probe_error()`
 - `profile_policy_from_probe_results()`
 
 The initial Icom LAN matrix is conservative:

--- a/docs/plans/2026-05-08-audio-capability-probing.md
+++ b/docs/plans/2026-05-08-audio-capability-probing.md
@@ -35,8 +35,8 @@ expose OS audio devices, so their hardening lives in #1480.
 - `AudioProbeResult`
 - `AudioProbeArtifact`
 - `AudioProbeStatus`
-- `build_icomlan_probe_matrix()`
-- `classify_icomlan_probe_error()`
+- `build_stock_radio_lan_probe_matrix()`
+- `classify_stock_radio_lan_probe_error()`
 - `profile_policy_from_probe_results()`
 
 The initial Icom LAN matrix is conservative:

--- a/docs/plans/2026-05-08-usb-audio-negotiation.md
+++ b/docs/plans/2026-05-08-usb-audio-negotiation.md
@@ -1,0 +1,43 @@
+# USB Audio Negotiation Design
+
+Issue: #1480
+Date: 2026-05-08
+
+## Scope
+
+USB-connected radios do not negotiate radio-native audio codecs or bitrates.
+The radio control session is serial/CAT/CI-V, while audio is an OS audio device
+opened through the configured audio backend.
+
+This design hardens the OS audio-device layer without mixing it with LAN
+radio-native codec probing.
+
+## Effective Contract
+
+`UsbAudioDriver` now records an effective USB audio contract after RX or TX
+streams are opened:
+
+- selected RX/TX device;
+- sample rate;
+- channels;
+- frame duration;
+- sample-rate source: `default`, `explicit`, or `fallback`;
+- fallback reason when a default rate is unsupported.
+
+The contract is exposed as `usb_audio_contract` and serialized through
+diagnostics as `audio/usb_audio`.
+
+## Negotiation Rules
+
+- Automatic defaults may fall back from the requested rate through the ordered
+  candidate list: 48000, 24000, 16000, 8000.
+- Explicit calls can disable fallback with `allow_sample_rate_fallback=False`.
+  In that mode unsupported sample rates fail clearly before opening the stream.
+- Device selection remains the existing deterministic rule: explicit overrides,
+  macOS serial topology when available, then name/default ranking.
+
+## Diagnostics
+
+The audio diagnostics contributor includes the effective USB audio contract when
+the active radio exposes it. This gives support and pro tooling enough detail to
+explain which OS audio device/rate/channels were actually used.

--- a/src/rigplane/audio/probe.py
+++ b/src/rigplane/audio/probe.py
@@ -1,0 +1,189 @@
+"""Audio capability probe models and evidence helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Iterable
+
+from rigplane.types import AudioCodec
+
+_DEFAULT_ICOM_LAN_RX_CODECS: tuple[AudioCodec, ...] = (
+    AudioCodec.PCM_2CH_16BIT,
+    AudioCodec.PCM_1CH_16BIT,
+    AudioCodec.ULAW_2CH,
+    AudioCodec.ULAW_1CH,
+)
+_DEFAULT_ICOM_LAN_SAMPLE_RATES_HZ: tuple[int, ...] = (48_000, 24_000, 16_000, 8_000)
+_DIRECT_RADIO_OPUS_CODECS: frozenset[AudioCodec] = frozenset(
+    {AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH}
+)
+
+
+class AudioProbeStatus(StrEnum):
+    """Normalized result status for one probe candidate."""
+
+    PASS = "pass"
+    REJECTED = "rejected"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True, slots=True)
+class AudioProbeCandidate:
+    """One radio-native stream combination to test."""
+
+    rx_codec: AudioCodec
+    tx_codec: AudioCodec
+    sample_rate_hz: int
+    rx_channels: int
+    tx_channels: int
+    frame_ms: int = 20
+    mode: str = "rx-only"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "rx_codec": self.rx_codec.name,
+            "tx_codec": self.tx_codec.name,
+            "sample_rate_hz": self.sample_rate_hz,
+            "rx_channels": self.rx_channels,
+            "tx_channels": self.tx_channels,
+            "frame_ms": self.frame_ms,
+            "mode": self.mode,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AudioProbeResult:
+    """Observed result for a single probe candidate."""
+
+    candidate: AudioProbeCandidate
+    status: AudioProbeStatus
+    phase: str
+    reason: str
+    rx_payload_bytes: int | None = None
+    observed_packets: int | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "candidate": self.candidate.to_dict(),
+            "status": self.status.value,
+            "phase": self.phase,
+            "reason": self.reason,
+        }
+        if self.rx_payload_bytes is not None:
+            payload["rx_payload_bytes"] = self.rx_payload_bytes
+        if self.observed_packets is not None:
+            payload["observed_packets"] = self.observed_packets
+        if self.error:
+            payload["error"] = self.error
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class AudioProbeArtifact:
+    """Machine-readable evidence artifact emitted by audio probes."""
+
+    model: str
+    profile_id: str
+    transport: str
+    results: list[AudioProbeResult]
+    schema_version: int = 1
+    tool: str = "rigplane-audio-probe"
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "tool": self.tool,
+            "model": self.model,
+            "profile_id": self.profile_id,
+            "transport": self.transport,
+            "metadata": dict(self.metadata),
+            "results": [result.to_dict() for result in self.results],
+        }
+
+
+def _channels_for_codec(codec: AudioCodec) -> int:
+    return 2 if "_2CH" in codec.name else 1
+
+
+def build_icom_lan_probe_matrix(
+    *,
+    rx_codecs: Iterable[AudioCodec] = _DEFAULT_ICOM_LAN_RX_CODECS,
+    sample_rates_hz: Iterable[int] = _DEFAULT_ICOM_LAN_SAMPLE_RATES_HZ,
+    tx_codec: AudioCodec = AudioCodec.PCM_1CH_16BIT,
+    frame_ms: int = 20,
+) -> list[AudioProbeCandidate]:
+    """Build a conservative stock-Icom LAN probe matrix.
+
+    Opus is intentionally excluded for direct stock-radio LAN paths. wfview
+    server support is a separate transport concern, not a radio-native default.
+    """
+
+    candidates: list[AudioProbeCandidate] = []
+    if _channels_for_codec(tx_codec) != 1 or tx_codec in _DIRECT_RADIO_OPUS_CODECS:
+        return candidates
+    for rx_codec in rx_codecs:
+        if rx_codec in _DIRECT_RADIO_OPUS_CODECS:
+            continue
+        for sample_rate_hz in sample_rates_hz:
+            candidates.append(
+                AudioProbeCandidate(
+                    rx_codec=rx_codec,
+                    tx_codec=tx_codec,
+                    sample_rate_hz=int(sample_rate_hz),
+                    rx_channels=_channels_for_codec(rx_codec),
+                    tx_channels=1,
+                    frame_ms=frame_ms,
+                )
+            )
+    return candidates
+
+
+def classify_icom_lan_probe_error(exc: Exception) -> tuple[AudioProbeStatus, str]:
+    """Classify common Icom LAN session failures into probe statuses."""
+
+    text = str(exc).lower()
+    if "0xffffffff" in text or "conninfo" in text or "rejected" in text:
+        return AudioProbeStatus.REJECTED, "conninfo-rejected"
+    return AudioProbeStatus.FAILED, "runtime-error"
+
+
+def profile_policy_from_probe_results(
+    results: Iterable[AudioProbeResult],
+) -> dict[str, object]:
+    """Build a profile-policy candidate from passed probe evidence only."""
+
+    passed = [result for result in results if result.status is AudioProbeStatus.PASS]
+    codec_preference: list[str] = []
+    sample_rate_by_codec: dict[str, int] = {}
+    tx_codec: str | None = None
+    for result in passed:
+        candidate = result.candidate
+        rx_name = candidate.rx_codec.name
+        if rx_name not in codec_preference:
+            codec_preference.append(rx_name)
+        sample_rate_by_codec.setdefault(rx_name, candidate.sample_rate_hz)
+        tx_codec = tx_codec or candidate.tx_codec.name
+
+    policy: dict[str, object] = {}
+    if codec_preference:
+        policy["codec_preference"] = codec_preference
+    if tx_codec is not None:
+        policy["tx_codec"] = tx_codec
+    if sample_rate_by_codec:
+        policy["sample_rate_by_codec"] = sample_rate_by_codec
+    return policy
+
+
+__all__ = [
+    "AudioProbeArtifact",
+    "AudioProbeCandidate",
+    "AudioProbeResult",
+    "AudioProbeStatus",
+    "build_icom_lan_probe_matrix",
+    "classify_icom_lan_probe_error",
+    "profile_policy_from_probe_results",
+]

--- a/src/rigplane/audio/probe.py
+++ b/src/rigplane/audio/probe.py
@@ -109,7 +109,7 @@ def _channels_for_codec(codec: AudioCodec) -> int:
     return 2 if "_2CH" in codec.name else 1
 
 
-def build_icom_lan_probe_matrix(
+def build_icomlan_probe_matrix(
     *,
     rx_codecs: Iterable[AudioCodec] = _DEFAULT_ICOM_LAN_RX_CODECS,
     sample_rates_hz: Iterable[int] = _DEFAULT_ICOM_LAN_SAMPLE_RATES_HZ,
@@ -142,7 +142,7 @@ def build_icom_lan_probe_matrix(
     return candidates
 
 
-def classify_icom_lan_probe_error(exc: Exception) -> tuple[AudioProbeStatus, str]:
+def classify_icomlan_probe_error(exc: Exception) -> tuple[AudioProbeStatus, str]:
     """Classify common Icom LAN session failures into probe statuses."""
 
     text = str(exc).lower()
@@ -183,7 +183,7 @@ __all__ = [
     "AudioProbeCandidate",
     "AudioProbeResult",
     "AudioProbeStatus",
-    "build_icom_lan_probe_matrix",
-    "classify_icom_lan_probe_error",
+    "build_icomlan_probe_matrix",
+    "classify_icomlan_probe_error",
     "profile_policy_from_probe_results",
 ]

--- a/src/rigplane/audio/probe.py
+++ b/src/rigplane/audio/probe.py
@@ -8,13 +8,18 @@ from typing import Iterable
 
 from rigplane.types import AudioCodec
 
-_DEFAULT_ICOM_LAN_RX_CODECS: tuple[AudioCodec, ...] = (
+_DEFAULT_STOCK_RADIO_LAN_RX_CODECS: tuple[AudioCodec, ...] = (
     AudioCodec.PCM_2CH_16BIT,
     AudioCodec.PCM_1CH_16BIT,
     AudioCodec.ULAW_2CH,
     AudioCodec.ULAW_1CH,
 )
-_DEFAULT_ICOM_LAN_SAMPLE_RATES_HZ: tuple[int, ...] = (48_000, 24_000, 16_000, 8_000)
+_DEFAULT_STOCK_RADIO_LAN_SAMPLE_RATES_HZ: tuple[int, ...] = (
+    48_000,
+    24_000,
+    16_000,
+    8_000,
+)
 _DIRECT_RADIO_OPUS_CODECS: frozenset[AudioCodec] = frozenset(
     {AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH}
 )
@@ -109,10 +114,10 @@ def _channels_for_codec(codec: AudioCodec) -> int:
     return 2 if "_2CH" in codec.name else 1
 
 
-def build_icomlan_probe_matrix(
+def build_stock_radio_lan_probe_matrix(
     *,
-    rx_codecs: Iterable[AudioCodec] = _DEFAULT_ICOM_LAN_RX_CODECS,
-    sample_rates_hz: Iterable[int] = _DEFAULT_ICOM_LAN_SAMPLE_RATES_HZ,
+    rx_codecs: Iterable[AudioCodec] = _DEFAULT_STOCK_RADIO_LAN_RX_CODECS,
+    sample_rates_hz: Iterable[int] = _DEFAULT_STOCK_RADIO_LAN_SAMPLE_RATES_HZ,
     tx_codec: AudioCodec = AudioCodec.PCM_1CH_16BIT,
     frame_ms: int = 20,
 ) -> list[AudioProbeCandidate]:
@@ -142,7 +147,9 @@ def build_icomlan_probe_matrix(
     return candidates
 
 
-def classify_icomlan_probe_error(exc: Exception) -> tuple[AudioProbeStatus, str]:
+def classify_stock_radio_lan_probe_error(
+    exc: Exception,
+) -> tuple[AudioProbeStatus, str]:
     """Classify common Icom LAN session failures into probe statuses."""
 
     text = str(exc).lower()
@@ -183,7 +190,7 @@ __all__ = [
     "AudioProbeCandidate",
     "AudioProbeResult",
     "AudioProbeStatus",
-    "build_icomlan_probe_matrix",
-    "classify_icomlan_probe_error",
+    "build_stock_radio_lan_probe_matrix",
+    "classify_stock_radio_lan_probe_error",
     "profile_policy_from_probe_results",
 ]

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -50,6 +50,9 @@ class AudioDriverLifecycleError(RuntimeError):
     """Raised on invalid USB audio lifecycle operations."""
 
 
+_DEFAULT_SAMPLE_RATE_CANDIDATES: tuple[int, ...] = (48_000, 24_000, 16_000, 8_000)
+
+
 @dataclass(frozen=True, slots=True)
 class UsbAudioDevice:
     """Normalized USB audio device descriptor."""
@@ -77,6 +80,58 @@ class UsbAudioDevice:
     def duplex(self) -> bool:
         """Whether the device supports both capture and playback."""
         return self.supports_rx and self.supports_tx
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly device descriptor for diagnostics."""
+
+        return {
+            "index": self.index,
+            "name": self.name,
+            "input_channels": self.input_channels,
+            "output_channels": self.output_channels,
+            "default_samplerate": self.default_samplerate,
+            "platform_uid": self.platform_uid,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class UsbAudioStreamContract:
+    """Effective OS audio-device stream contract for one direction."""
+
+    direction: str
+    device: UsbAudioDevice
+    sample_rate_hz: int
+    channels: int
+    frame_ms: int
+    sample_rate_source: str
+    fallback_reason: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "direction": self.direction,
+            "device": self.device.to_dict(),
+            "sample_rate_hz": self.sample_rate_hz,
+            "channels": self.channels,
+            "frame_ms": self.frame_ms,
+            "sample_rate_source": self.sample_rate_source,
+        }
+        if self.fallback_reason:
+            payload["fallback_reason"] = self.fallback_reason
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class UsbAudioContract:
+    """Effective RX/TX OS audio contract for a USB-audio radio path."""
+
+    rx: UsbAudioStreamContract | None = None
+    tx: UsbAudioStreamContract | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "rx": self.rx.to_dict() if self.rx is not None else None,
+            "tx": self.tx.to_dict() if self.tx is not None else None,
+        }
 
 
 def _safe_int(value: object, default: int = 0) -> int:
@@ -316,6 +371,7 @@ class UsbAudioDriver:
 
         self._rx_stream: RxStream | None = None
         self._tx_stream: TxStream | None = None
+        self._usb_audio_contract = UsbAudioContract()
 
         self._rx_lock = asyncio.Lock()
         self._tx_lock = asyncio.Lock()
@@ -335,6 +391,12 @@ class UsbAudioDriver:
     @property
     def selected_tx_device(self) -> UsbAudioDevice | None:
         return self._selected_tx
+
+    @property
+    def usb_audio_contract(self) -> UsbAudioContract | None:
+        if self._usb_audio_contract.rx is None and self._usb_audio_contract.tx is None:
+            return None
+        return self._usb_audio_contract
 
     def _ensure_selected_devices(self) -> tuple[UsbAudioDevice, UsbAudioDevice]:
         devices = _devices_from_backend(self._backend)
@@ -408,6 +470,79 @@ class UsbAudioDriver:
         """List normalized devices from the active audio backend."""
         return _devices_from_backend(self._backend)
 
+    def _sample_rate_candidates(self, requested: int) -> tuple[int, ...]:
+        return tuple(dict.fromkeys((requested, *_DEFAULT_SAMPLE_RATE_CANDIDATES)))
+
+    def _resolve_stream_contract(
+        self,
+        *,
+        direction: str,
+        device: UsbAudioDevice,
+        requested_sample_rate: int,
+        channels: int,
+        frame_ms: int,
+        allow_sample_rate_fallback: bool,
+    ) -> UsbAudioStreamContract:
+        device_id = AudioDeviceId(device.index)
+        if self._backend.check_sample_rate(
+            device_id,
+            requested_sample_rate,
+            direction=direction,
+        ):
+            source = "default" if allow_sample_rate_fallback else "explicit"
+            return UsbAudioStreamContract(
+                direction=direction,
+                device=device,
+                sample_rate_hz=requested_sample_rate,
+                channels=channels,
+                frame_ms=frame_ms,
+                sample_rate_source=source,
+            )
+
+        if not allow_sample_rate_fallback:
+            raise AudioDriverLifecycleError(
+                f"Explicit {direction.upper()} sample rate "
+                f"{requested_sample_rate} Hz is not supported by [{device.index}] "
+                f"{device.name}."
+            )
+
+        for candidate in self._sample_rate_candidates(requested_sample_rate):
+            if candidate == requested_sample_rate:
+                continue
+            if self._backend.check_sample_rate(
+                device_id,
+                candidate,
+                direction=direction,
+            ):
+                return UsbAudioStreamContract(
+                    direction=direction,
+                    device=device,
+                    sample_rate_hz=candidate,
+                    channels=channels,
+                    frame_ms=frame_ms,
+                    sample_rate_source="fallback",
+                    fallback_reason=(
+                        f"sample-rate-{requested_sample_rate}-unsupported"
+                    ),
+                )
+
+        raise AudioDriverLifecycleError(
+            f"No supported {direction.upper()} sample rate found for [{device.index}] "
+            f"{device.name}; tried {list(self._sample_rate_candidates(requested_sample_rate))}."
+        )
+
+    def _store_stream_contract(self, contract: UsbAudioStreamContract) -> None:
+        if contract.direction == "rx":
+            self._usb_audio_contract = UsbAudioContract(
+                rx=contract,
+                tx=self._usb_audio_contract.tx,
+            )
+        else:
+            self._usb_audio_contract = UsbAudioContract(
+                rx=self._usb_audio_contract.rx,
+                tx=contract,
+            )
+
     async def start_rx(
         self,
         callback: Callable[[bytes], None] | None = None,
@@ -415,6 +550,7 @@ class UsbAudioDriver:
         sample_rate: int | None = None,
         channels: int | None = None,
         frame_ms: int | None = None,
+        allow_sample_rate_fallback: bool = True,
     ) -> None:
         """Start capture loop and deliver PCM frames to callback."""
         if callback is None:
@@ -434,13 +570,22 @@ class UsbAudioDriver:
                 raise AudioDriverLifecycleError(
                     "Invalid RX frame format: sample_rate * frame_ms must be divisible by 1000."
                 )
+            contract = self._resolve_stream_contract(
+                direction="rx",
+                device=selected_rx,
+                requested_sample_rate=sr,
+                channels=ch,
+                frame_ms=fm,
+                allow_sample_rate_fallback=allow_sample_rate_fallback,
+            )
             self._rx_stream = self._backend.open_rx(
                 AudioDeviceId(selected_rx.index),
-                sample_rate=sr,
+                sample_rate=contract.sample_rate_hz,
                 channels=ch,
                 frame_ms=fm,
             )
             await self._rx_stream.start(callback)
+            self._store_stream_contract(contract)
 
     async def stop_rx(self) -> None:
         """Stop capture loop and close RX stream."""
@@ -456,6 +601,7 @@ class UsbAudioDriver:
         sample_rate: int | None = None,
         channels: int | None = None,
         frame_ms: int | None = None,
+        allow_sample_rate_fallback: bool = True,
     ) -> None:
         """Start playback loop for outgoing PCM frames."""
         async with self._tx_lock:
@@ -470,13 +616,22 @@ class UsbAudioDriver:
                 raise AudioDriverLifecycleError(
                     "Invalid TX frame format: sample_rate * frame_ms must be divisible by 1000."
                 )
+            contract = self._resolve_stream_contract(
+                direction="tx",
+                device=selected_tx,
+                requested_sample_rate=sr,
+                channels=ch,
+                frame_ms=fm,
+                allow_sample_rate_fallback=allow_sample_rate_fallback,
+            )
             self._tx_stream = self._backend.open_tx(
                 AudioDeviceId(selected_tx.index),
-                sample_rate=sr,
+                sample_rate=contract.sample_rate_hz,
                 channels=ch,
                 frame_ms=fm,
             )
             await self._tx_stream.start()
+            self._store_stream_contract(contract)
 
     async def _push_tx_pcm(self, frame: bytes) -> None:
         """Queue one PCM frame for playback."""
@@ -500,7 +655,9 @@ __all__ = [
     "AudioDeviceSelectionError",
     "AudioDriverLifecycleError",
     "UsbAudioDevice",
+    "UsbAudioContract",
     "UsbAudioDriver",
+    "UsbAudioStreamContract",
     "list_usb_audio_devices",
     "select_usb_audio_devices",
 ]

--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -166,6 +166,12 @@ class _IcomSerialRadioBase(CoreRadio):
         """Stable backend family identifier — ``"icom_serial"`` for serial CI-V."""
         return "icom_serial"
 
+    @property
+    def usb_audio_contract(self) -> object | None:
+        """Effective OS audio contract reported by the USB audio driver."""
+
+        return getattr(self._serial_audio_driver, "usb_audio_contract", None)
+
     # ------------------------------------------------------------------
     # Connection properties
     # ------------------------------------------------------------------

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -237,6 +237,12 @@ class YaesuCatRadio:
         return self._audio_sample_rate
 
     @property
+    def usb_audio_contract(self) -> object | None:
+        """Effective OS audio contract reported by the USB audio driver."""
+
+        return getattr(self._audio_driver, "usb_audio_contract", None)
+
+    @property
     def audio_bus(self) -> "AudioBus":
         """AudioBus instance for pub/sub audio distribution."""
         if self._audio_bus is None:

--- a/src/rigplane/diagnostics/contributors/audio.py
+++ b/src/rigplane/diagnostics/contributors/audio.py
@@ -126,6 +126,29 @@ def _web_rx_policy(radio: Any) -> dict[str, Any] | None:
     }
 
 
+def _usb_audio_contract(radio: Any) -> dict[str, Any] | None:
+    contract = _safe_attr(radio, "usb_audio_contract")
+    to_dict = _safe_attr(contract, "to_dict")
+    if callable(to_dict):
+        data = to_dict()
+        if isinstance(data, dict):
+            for leg in ("rx", "tx"):
+                stream = data.get(leg)
+                if not isinstance(stream, dict):
+                    continue
+                device = stream.get("device")
+                if not isinstance(device, dict):
+                    continue
+                name = device.get("name")
+                if isinstance(name, str):
+                    device["name"] = _redact_device_name(name)
+                platform_uid = device.get("platform_uid")
+                if isinstance(platform_uid, str):
+                    device["platform_uid"] = redact_paths(platform_uid)
+            return data
+    return None
+
+
 # macOS device labels embed the local account name in parens, e.g.
 # ``"BlackHole 2ch (moroz's Mac)"`` or ``"... (Alice's MacBook Pro)"``.
 # Match the wrapping ``(... 's <Mac variant> ...)`` and replace with a
@@ -179,5 +202,8 @@ class AudioContributor:
             web_rx = _web_rx_policy(radio)
             if web_rx is not None:
                 payload["web_rx"] = web_rx
+            usb_audio = _usb_audio_contract(radio)
+            if usb_audio is not None:
+                payload["usb_audio"] = usb_audio
         text = json.dumps(payload, indent=2, sort_keys=True)
         (output_dir / "audio.json").write_text(text + "\n", encoding="utf-8")

--- a/tests/test_audio_probe.py
+++ b/tests/test_audio_probe.py
@@ -1,0 +1,111 @@
+"""Tests for audio capability probe evidence artifacts."""
+
+from __future__ import annotations
+
+from rigplane.audio.probe import (
+    AudioProbeArtifact,
+    AudioProbeCandidate,
+    AudioProbeResult,
+    AudioProbeStatus,
+    build_icom_lan_probe_matrix,
+    classify_icom_lan_probe_error,
+    profile_policy_from_probe_results,
+)
+from rigplane.types import AudioCodec
+
+
+def test_icom_lan_probe_matrix_excludes_opus_and_stereo_tx() -> None:
+    matrix = build_icom_lan_probe_matrix(
+        rx_codecs=(AudioCodec.PCM_2CH_16BIT, AudioCodec.OPUS_2CH),
+        sample_rates_hz=(48_000, 16_000),
+    )
+
+    assert matrix
+    assert {candidate.rx_codec for candidate in matrix} == {AudioCodec.PCM_2CH_16BIT}
+    assert {candidate.tx_codec for candidate in matrix} == {AudioCodec.PCM_1CH_16BIT}
+    assert {candidate.rx_channels for candidate in matrix} == {2}
+    assert {candidate.tx_channels for candidate in matrix} == {1}
+    assert {candidate.sample_rate_hz for candidate in matrix} == {48_000, 16_000}
+
+
+def test_probe_artifact_serializes_machine_readable_evidence() -> None:
+    candidate = AudioProbeCandidate(
+        rx_codec=AudioCodec.PCM_1CH_16BIT,
+        tx_codec=AudioCodec.PCM_1CH_16BIT,
+        sample_rate_hz=16_000,
+        rx_channels=1,
+        tx_channels=1,
+        frame_ms=20,
+    )
+    artifact = AudioProbeArtifact(
+        model="IC-7610",
+        profile_id="icom_ic7610",
+        transport="icom_lan",
+        results=[
+            AudioProbeResult(
+                candidate=candidate,
+                status=AudioProbeStatus.PASS,
+                phase="rx",
+                reason="rx-payload-stable",
+                rx_payload_bytes=640,
+                observed_packets=50,
+            )
+        ],
+    )
+
+    data = artifact.to_dict()
+
+    assert data["schema_version"] == 1
+    assert data["model"] == "IC-7610"
+    assert data["transport"] == "icom_lan"
+    assert data["results"][0]["candidate"]["rx_codec"] == "PCM_1CH_16BIT"
+    assert data["results"][0]["status"] == "pass"
+    assert data["results"][0]["rx_payload_bytes"] == 640
+
+
+def test_icom_lan_probe_error_classification_distinguishes_rejects() -> None:
+    assert classify_icom_lan_probe_error(RuntimeError("conninfo error=0xFFFFFFFF")) == (
+        AudioProbeStatus.REJECTED,
+        "conninfo-rejected",
+    )
+    assert classify_icom_lan_probe_error(RuntimeError("socket timeout")) == (
+        AudioProbeStatus.FAILED,
+        "runtime-error",
+    )
+
+
+def test_profile_policy_from_probe_results_uses_only_passed_evidence() -> None:
+    passed = AudioProbeResult(
+        candidate=AudioProbeCandidate(
+            rx_codec=AudioCodec.PCM_2CH_16BIT,
+            tx_codec=AudioCodec.PCM_1CH_16BIT,
+            sample_rate_hz=16_000,
+            rx_channels=2,
+            tx_channels=1,
+            frame_ms=20,
+        ),
+        status=AudioProbeStatus.PASS,
+        phase="rx",
+        reason="rx-payload-stable",
+    )
+    rejected = AudioProbeResult(
+        candidate=AudioProbeCandidate(
+            rx_codec=AudioCodec.ULAW_1CH,
+            tx_codec=AudioCodec.PCM_1CH_16BIT,
+            sample_rate_hz=48_000,
+            rx_channels=1,
+            tx_channels=1,
+            frame_ms=20,
+        ),
+        status=AudioProbeStatus.REJECTED,
+        phase="conninfo",
+        reason="conninfo-rejected",
+    )
+
+    policy = profile_policy_from_probe_results([rejected, passed])
+
+    assert policy == {
+        "codec_preference": ["PCM_2CH_16BIT"],
+        "tx_codec": "PCM_1CH_16BIT",
+        "sample_rate_by_codec": {"PCM_2CH_16BIT": 16000},
+    }

--- a/tests/test_audio_probe.py
+++ b/tests/test_audio_probe.py
@@ -7,15 +7,15 @@ from rigplane.audio.probe import (
     AudioProbeCandidate,
     AudioProbeResult,
     AudioProbeStatus,
-    build_icomlan_probe_matrix,
-    classify_icomlan_probe_error,
+    build_stock_radio_lan_probe_matrix,
+    classify_stock_radio_lan_probe_error,
     profile_policy_from_probe_results,
 )
 from rigplane.types import AudioCodec
 
 
-def test_icomlan_probe_matrix_excludes_opus_and_stereo_tx() -> None:
-    matrix = build_icomlan_probe_matrix(
+def test_stock_radio_lan_probe_matrix_excludes_opus_and_stereo_tx() -> None:
+    matrix = build_stock_radio_lan_probe_matrix(
         rx_codecs=(AudioCodec.PCM_2CH_16BIT, AudioCodec.OPUS_2CH),
         sample_rates_hz=(48_000, 16_000),
     )
@@ -40,7 +40,7 @@ def test_probe_artifact_serializes_machine_readable_evidence() -> None:
     artifact = AudioProbeArtifact(
         model="IC-7610",
         profile_id="icom_ic7610",
-        transport="icomlan",
+        transport="stock_radio_lan",
         results=[
             AudioProbeResult(
                 candidate=candidate,
@@ -57,18 +57,20 @@ def test_probe_artifact_serializes_machine_readable_evidence() -> None:
 
     assert data["schema_version"] == 1
     assert data["model"] == "IC-7610"
-    assert data["transport"] == "icomlan"
+    assert data["transport"] == "stock_radio_lan"
     assert data["results"][0]["candidate"]["rx_codec"] == "PCM_1CH_16BIT"
     assert data["results"][0]["status"] == "pass"
     assert data["results"][0]["rx_payload_bytes"] == 640
 
 
-def test_icomlan_probe_error_classification_distinguishes_rejects() -> None:
-    assert classify_icomlan_probe_error(RuntimeError("conninfo error=0xFFFFFFFF")) == (
+def test_stock_radio_lan_probe_error_classification_distinguishes_rejects() -> None:
+    assert classify_stock_radio_lan_probe_error(
+        RuntimeError("conninfo error=0xFFFFFFFF")
+    ) == (
         AudioProbeStatus.REJECTED,
         "conninfo-rejected",
     )
-    assert classify_icomlan_probe_error(RuntimeError("socket timeout")) == (
+    assert classify_stock_radio_lan_probe_error(RuntimeError("socket timeout")) == (
         AudioProbeStatus.FAILED,
         "runtime-error",
     )

--- a/tests/test_audio_probe.py
+++ b/tests/test_audio_probe.py
@@ -7,15 +7,15 @@ from rigplane.audio.probe import (
     AudioProbeCandidate,
     AudioProbeResult,
     AudioProbeStatus,
-    build_icom_lan_probe_matrix,
-    classify_icom_lan_probe_error,
+    build_icomlan_probe_matrix,
+    classify_icomlan_probe_error,
     profile_policy_from_probe_results,
 )
 from rigplane.types import AudioCodec
 
 
-def test_icom_lan_probe_matrix_excludes_opus_and_stereo_tx() -> None:
-    matrix = build_icom_lan_probe_matrix(
+def test_icomlan_probe_matrix_excludes_opus_and_stereo_tx() -> None:
+    matrix = build_icomlan_probe_matrix(
         rx_codecs=(AudioCodec.PCM_2CH_16BIT, AudioCodec.OPUS_2CH),
         sample_rates_hz=(48_000, 16_000),
     )
@@ -40,7 +40,7 @@ def test_probe_artifact_serializes_machine_readable_evidence() -> None:
     artifact = AudioProbeArtifact(
         model="IC-7610",
         profile_id="icom_ic7610",
-        transport="icom_lan",
+        transport="icomlan",
         results=[
             AudioProbeResult(
                 candidate=candidate,
@@ -57,18 +57,18 @@ def test_probe_artifact_serializes_machine_readable_evidence() -> None:
 
     assert data["schema_version"] == 1
     assert data["model"] == "IC-7610"
-    assert data["transport"] == "icom_lan"
+    assert data["transport"] == "icomlan"
     assert data["results"][0]["candidate"]["rx_codec"] == "PCM_1CH_16BIT"
     assert data["results"][0]["status"] == "pass"
     assert data["results"][0]["rx_payload_bytes"] == 640
 
 
-def test_icom_lan_probe_error_classification_distinguishes_rejects() -> None:
-    assert classify_icom_lan_probe_error(RuntimeError("conninfo error=0xFFFFFFFF")) == (
+def test_icomlan_probe_error_classification_distinguishes_rejects() -> None:
+    assert classify_icomlan_probe_error(RuntimeError("conninfo error=0xFFFFFFFF")) == (
         AudioProbeStatus.REJECTED,
         "conninfo-rejected",
     )
-    assert classify_icom_lan_probe_error(RuntimeError("socket timeout")) == (
+    assert classify_icomlan_probe_error(RuntimeError("socket timeout")) == (
         AudioProbeStatus.FAILED,
         "runtime-error",
     )

--- a/tests/test_diagnostics_contributors_batch2.py
+++ b/tests/test_diagnostics_contributors_batch2.py
@@ -385,6 +385,59 @@ def test_audio_emits_configured_web_rx_policy_without_runtime_client_state(
     }
 
 
+def test_audio_emits_usb_audio_contract(tmp_path: Path) -> None:
+    class FakeAudioRadio(_AudioCapableStub):
+        usb_audio_contract = SimpleNamespace(
+            to_dict=lambda: {
+                "rx": {
+                    "device": {"index": 1, "name": "USB Audio CODEC"},
+                    "sample_rate_hz": 16000,
+                    "sample_rate_source": "fallback",
+                    "fallback_reason": "sample-rate-48000-unsupported",
+                },
+                "tx": None,
+            }
+        )
+
+    AudioContributor().contribute(_make_ctx(radio=FakeAudioRadio()), tmp_path)
+    payload = json.loads((tmp_path / "audio.json").read_text())
+
+    usb_audio = payload["usb_audio"]
+    assert usb_audio["rx"]["sample_rate_hz"] == 16000
+    assert usb_audio["rx"]["sample_rate_source"] == "fallback"
+    assert usb_audio["rx"]["fallback_reason"] == "sample-rate-48000-unsupported"
+
+
+def test_audio_redacts_usb_audio_contract_device_labels(tmp_path: Path) -> None:
+    class FakeAudioRadio(_AudioCapableStub):
+        usb_audio_contract = SimpleNamespace(
+            to_dict=lambda: {
+                "rx": {
+                    "device": {
+                        "index": 1,
+                        "name": "BlackHole 2ch (moroz's Mac)",
+                        "platform_uid": "/Users/moroz/Audio/Device",
+                    },
+                    "sample_rate_hz": 48000,
+                },
+                "tx": None,
+            }
+        )
+
+    AudioContributor().contribute(_make_ctx(radio=FakeAudioRadio()), tmp_path)
+    text = (tmp_path / "audio.json").read_text()
+    payload = json.loads(text)
+
+    assert "moroz" not in text
+    assert (
+        payload["usb_audio"]["rx"]["device"]["name"] == "BlackHole 2ch (<USER>'s Mac)"
+    )
+    assert (
+        payload["usb_audio"]["rx"]["device"]["platform_uid"]
+        == "/Users/<USER>/Audio/Device"
+    )
+
+
 def test_audio_redacts_device_name_with_username(tmp_path: Path) -> None:
     class FakeAudioRadio(_AudioCapableStub):
         audio_rx_device = "Speakers (/Users/foo/Library/Audio)"

--- a/tests/test_usb_audio_stub.py
+++ b/tests/test_usb_audio_stub.py
@@ -199,3 +199,75 @@ async def test_usb_audio_driver_selected_devices_populated_after_start() -> None
     assert driver.selected_rx_device is not None
     assert driver.selected_rx_device.name == "USB Audio CODEC"
     await driver.stop_rx()
+
+
+@pytest.mark.asyncio
+async def test_usb_audio_driver_auto_sample_rate_falls_back_and_reports_contract() -> (
+    None
+):
+    backend = FakeAudioBackend(_fake_devices(), supported_sample_rates={16_000})
+    driver = UsbAudioDriver(backend=backend, sample_rate=48_000)
+
+    await driver.start_rx(lambda _: None)
+
+    contract = driver.usb_audio_contract
+    assert contract is not None
+    assert contract.rx.sample_rate_hz == 16_000
+    assert contract.rx.sample_rate_source == "fallback"
+    assert contract.rx.fallback_reason == "sample-rate-48000-unsupported"
+    assert contract.rx.device.name == "USB Audio CODEC"
+    assert contract.to_dict()["rx"]["sample_rate_hz"] == 16_000
+    assert contract.to_dict()["rx"]["sample_rate_source"] == "fallback"
+    await driver.stop_rx()
+
+
+@pytest.mark.asyncio
+async def test_usb_audio_driver_explicit_sample_rate_failure_is_clear() -> None:
+    backend = FakeAudioBackend(_fake_devices(), supported_sample_rates={16_000})
+    driver = UsbAudioDriver(backend=backend, sample_rate=48_000)
+
+    with pytest.raises(
+        AudioDriverLifecycleError,
+        match="Explicit RX sample rate 48000 Hz is not supported",
+    ):
+        await driver.start_rx(
+            lambda _: None,
+            sample_rate=48_000,
+            allow_sample_rate_fallback=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_usb_audio_driver_explicit_sample_rate_reports_explicit_source() -> None:
+    backend = FakeAudioBackend(_fake_devices(), supported_sample_rates={48_000})
+    driver = UsbAudioDriver(backend=backend)
+
+    await driver.start_rx(
+        lambda _: None,
+        sample_rate=48_000,
+        allow_sample_rate_fallback=False,
+    )
+
+    assert driver.usb_audio_contract is not None
+    assert driver.usb_audio_contract.rx is not None
+    assert driver.usb_audio_contract.rx.sample_rate_source == "explicit"
+    await driver.stop_rx()
+
+
+@pytest.mark.asyncio
+async def test_usb_audio_driver_reports_rx_and_tx_effective_contract() -> None:
+    backend = FakeAudioBackend(_fake_devices(), supported_sample_rates={48_000})
+    driver = UsbAudioDriver(backend=backend)
+
+    await driver.start_rx(lambda _: None)
+    await driver.start_tx()
+
+    contract = driver.usb_audio_contract
+    assert contract is not None
+    assert contract.rx.sample_rate_source == "default"
+    assert contract.tx is not None
+    assert contract.tx.sample_rate_hz == 48_000
+    assert contract.tx.direction == "tx"
+    assert contract.tx.device.name == "USB Audio CODEC"
+    await driver.stop_tx()
+    await driver.stop_rx()


### PR DESCRIPTION
## Summary

- Add `rigplane.audio.probe` evidence models for audio probe candidates/results/artifacts.
- Add conservative Icom LAN probe matrix helpers that exclude Opus for direct stock-radio LAN.
- Add no-guess profile policy extraction from passed probe results only.
- Harden USB/OS audio negotiation by probing backend sample-rate support before stream open, falling back through safe default rates, and recording an effective USB audio contract.
- Surface USB audio contracts in diagnostics with device-name/path redaction.
- Decompose remaining #1479 work into #1481, #1482, and #1483.

Closes #1480.
Refs #1479.

## Verification

- `uv run pytest tests/test_usb_audio_stub.py tests/test_audio_probe.py tests/test_diagnostics_contributors_batch2.py tests/test_serial_backend_smoke.py tests/test_yaesu_audio.py -q`
- `uv run ruff check src/rigplane/audio/usb_driver.py src/rigplane/audio/probe.py src/rigplane/diagnostics/contributors/audio.py src/rigplane/backends/_icom_serial_base.py src/rigplane/backends/yaesu_cat/radio.py tests/test_usb_audio_stub.py tests/test_audio_probe.py tests/test_diagnostics_contributors_batch2.py`
- `uv run ruff format --check src/rigplane/audio/usb_driver.py src/rigplane/audio/probe.py src/rigplane/diagnostics/contributors/audio.py src/rigplane/backends/_icom_serial_base.py src/rigplane/backends/yaesu_cat/radio.py tests/test_usb_audio_stub.py tests/test_audio_probe.py tests/test_diagnostics_contributors_batch2.py`
- `uv run pytest -q`: 5938 passed, 107 skipped, 3 deselected, 9 xfailed, 1 xpassed

## Follow-up issues

- #1481: Icom LAN audio probe runner and CLI.
- #1482: hardware matrix validation.
- #1483: guarded profile update tooling.
