### PR TITLE
fix(discovery): advertise RigPlane service

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,7 +59,7 @@ User-facing data (web-UI panel layouts, theme, auth token, memory channels, log 
 - **PyPI package**: `icom-lan` → `rigplane`. Preferred install: `pip install rigplane`. The old `icom-lan` package on PyPI is frozen at v1.1.0; future releases ship as `rigplane`.
 - **Python import path**: `icom_lan.*` → `rigplane.*`. The `icom_lan` shim re-exports from `rigplane` with `DeprecationWarning` and will be removed in a future major release.
 - **CLI binary**: `icom-lan` → `rigplane`. `icom-lan` retained as deprecated alias.
-- **Environment variables**: `ICOM_LAN_REPORT_ENDPOINT`, `ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING`, `ICOM_LAN_LOG_DIR` → `RIGPLANE_*`. The wire-protocol magic byte `b"ICOM_LAN_DISCOVER\n"` is unchanged (LAN discovery contract).
+- **Environment variables**: `ICOM_LAN_REPORT_ENDPOINT`, `ICOM_LAN_DISABLE_DIAGNOSTIC_LOGGING`, `ICOM_LAN_LOG_DIR` → `RIGPLANE_*`. LAN discovery now uses `b"RIGPLANE_DISCOVER\n"` with `b"ICOM_LAN_DISCOVER\n"` accepted as a legacy request.
 - **Diagnostic bundle schema**: default emission is now `rigplane-bundle-v2` (was `icom-lan-bundle-v1`). The maintainer-operated triage service accepts both v1 and v2 for at least 12 months.
 - **Exception class**: `IcomLanError` → `RigplaneError`. Class is re-exported from `icom_lan` shim under both names.
 
@@ -813,7 +813,7 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - **CW Auto Tuner** (#675, #677, #678) — FFT peak detection engine (`CwAutoTuner`),
   backend `cw_auto_tune` command, restored AUTO TUNE button in Web UI
 - **AudioAnalyzer** (#679) — realtime SNR estimation from PCM stream
-- **UDP Discovery Responder** — companion apps can broadcast `ICOM_LAN_DISCOVER` on
+- **UDP Discovery Responder** — companion apps can broadcast `RIGPLANE_DISCOVER` on
   UDP 8470 and receive server URL, version, and radio status via unicast;
   `--no-discovery` CLI flag to opt out
 - **Unified frontend architecture** (Epics #647–#653, #662–#665) — `FrontendRuntime`

--- a/src/rigplane/web/discovery.py
+++ b/src/rigplane/web/discovery.py
@@ -4,7 +4,7 @@ Listens for broadcast discovery requests from companion apps and responds
 with server information (version, URL, radio status) via unicast.
 
 Protocol:
-    Request:  UDP broadcast, payload ``ICOM_LAN_DISCOVER\\n`` (17 bytes ASCII)
+    Request:  UDP broadcast, payload ``RIGPLANE_DISCOVER\\n`` (ASCII)
     Response: UDP unicast, payload JSON (UTF-8, single line, ≤512 bytes)
 """
 
@@ -23,7 +23,9 @@ __all__ = ["DiscoveryResponder", "RadioInfo"]
 
 logger = logging.getLogger(__name__)
 
-_DISCOVERY_MAGIC = b"ICOM_LAN_DISCOVER\n"
+_DISCOVERY_MAGIC = b"RIGPLANE_DISCOVER\n"
+_LEGACY_DISCOVERY_MAGIC = b"ICOM_LAN_DISCOVER\n"
+_DISCOVERY_MAGICS = {_DISCOVERY_MAGIC, _LEGACY_DISCOVERY_MAGIC}
 _DEFAULT_PORT = 8470
 
 
@@ -46,7 +48,7 @@ class _DiscoveryProtocol(asyncio.DatagramProtocol):
         self.transport = transport  # type: ignore[assignment]
 
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
-        if data != _DISCOVERY_MAGIC:
+        if data not in _DISCOVERY_MAGICS:
             logger.debug("discovery: ignoring %d bytes from %s", len(data), addr[0])
             return
 
@@ -148,10 +150,10 @@ class DiscoveryResponder:
         elif radio_info and radio_info.model:
             name = radio_info.model
         else:
-            name = "icom-lan"
+            name = "RigPlane"
 
         payload: dict[str, object] = {
-            "service": "icom-lan",
+            "service": "rigplane",
             "version": __version__,
             "url": f"{scheme}://{local_ip}:{self._web_port}",
             "name": name,

--- a/tests/test_discovery_responder.py
+++ b/tests/test_discovery_responder.py
@@ -11,7 +11,8 @@ import pytest
 from rigplane import __version__
 from rigplane.web.discovery import DiscoveryResponder, RadioInfo
 
-MAGIC = b"ICOM_LAN_DISCOVER\n"
+MAGIC = b"RIGPLANE_DISCOVER\n"
+LEGACY_MAGIC = b"ICOM_LAN_DISCOVER\n"
 
 
 async def _query(port: int, payload: bytes, timeout: float = 1.0) -> bytes | None:
@@ -66,11 +67,19 @@ class TestDiscoveryResponder:
         raw = await _query(responder.port, MAGIC)
         assert raw is not None
         data = json.loads(raw)
-        assert data["service"] == "icom-lan"
+        assert data["service"] == "rigplane"
         assert data["version"] == __version__
         assert "url" in data
         assert data["url"].startswith("http://")
         assert ":8080" in data["url"]
+
+    async def test_legacy_request_returns_json(
+        self, responder: DiscoveryResponder
+    ) -> None:
+        raw = await _query(responder.port, LEGACY_MAGIC)
+        assert raw is not None
+        data = json.loads(raw)
+        assert data["service"] == "rigplane"
 
     async def test_response_fields(self, responder: DiscoveryResponder) -> None:
         raw = await _query(responder.port, MAGIC)
@@ -85,7 +94,7 @@ class TestDiscoveryResponder:
         assert result is None
 
     async def test_ignores_partial_magic(self, responder: DiscoveryResponder) -> None:
-        result = await _query(responder.port, b"ICOM_LAN_DISCOVER", timeout=0.3)
+        result = await _query(responder.port, b"RIGPLANE_DISCOVER", timeout=0.3)
         assert result is None
 
     async def test_no_radio_provider(
@@ -95,7 +104,7 @@ class TestDiscoveryResponder:
         assert raw is not None
         data = json.loads(raw)
         assert data["radio"] is None
-        assert data["name"] == "icom-lan"
+        assert data["name"] == "RigPlane"
         assert data["url"].startswith("https://")
         assert ":9090" in data["url"]
 


### PR DESCRIPTION
## Summary

- advertise the LAN discovery responder as RigPlane
- respond to the new `RIGPLANE_DISCOVER\n` probe
- keep accepting legacy `ICOM_LAN_DISCOVER\n` requests during the branding rollover
- update discovery responder tests and changelog wording

## Compatibility

The responder returns `service: "rigplane"` for both new and legacy discovery requests. Legacy clients can still find the server by sending `ICOM_LAN_DISCOVER\n`; updated clients should send `RIGPLANE_DISCOVER\n`.

## Validation

- `uv run pytest -n0 tests/test_discovery_responder.py`
