### PR TITLE
Implement LAN audio probe runner CLI

### DIFF
--- a/src/rigplane/audio/probe_runner.py
+++ b/src/rigplane/audio/probe_runner.py
@@ -1,0 +1,98 @@
+"""Safe audio capability probe runner helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+
+from rigplane.audio.probe import (
+    AudioProbeArtifact,
+    AudioProbeCandidate,
+    AudioProbeResult,
+    AudioProbeStatus,
+    classify_stock_radio_lan_probe_error,
+)
+
+AudioProbeAttempt = Callable[[AudioProbeCandidate], Awaitable[AudioProbeResult]]
+
+
+async def run_audio_probe(
+    candidates: Iterable[AudioProbeCandidate],
+    attempt: AudioProbeAttempt,
+) -> list[AudioProbeResult]:
+    """Run probe candidates sequentially and normalize attempt failures."""
+
+    results: list[AudioProbeResult] = []
+    for candidate in candidates:
+        try:
+            results.append(await attempt(candidate))
+        except Exception as exc:
+            status, reason = classify_stock_radio_lan_probe_error(exc)
+            results.append(
+                AudioProbeResult(
+                    candidate=candidate,
+                    status=status,
+                    phase="conninfo"
+                    if status is AudioProbeStatus.REJECTED
+                    else "runtime",
+                    reason=reason,
+                    error=str(exc),
+                )
+            )
+    return results
+
+
+def dry_run_probe_results(
+    candidates: Iterable[AudioProbeCandidate],
+) -> list[AudioProbeResult]:
+    """Return skipped results for operators validating the probe plan."""
+
+    return [
+        AudioProbeResult(
+            candidate=candidate,
+            status=AudioProbeStatus.SKIPPED,
+            phase="dry-run",
+            reason="dry-run",
+        )
+        for candidate in candidates
+    ]
+
+
+def summarize_probe_results(
+    results: Iterable[AudioProbeResult],
+) -> dict[str, int]:
+    """Count probe results by normalized status."""
+
+    summary = {status.value: 0 for status in AudioProbeStatus}
+    for result in results:
+        summary[result.status.value] += 1
+    return summary
+
+
+def build_probe_artifact(
+    *,
+    model: str,
+    profile_id: str,
+    transport: str,
+    results: list[AudioProbeResult],
+    metadata: Mapping[str, object] | None = None,
+) -> AudioProbeArtifact:
+    """Build a machine-readable probe artifact with a stable summary."""
+
+    merged_metadata: dict[str, object] = dict(metadata or {})
+    merged_metadata["summary"] = summarize_probe_results(results)
+    return AudioProbeArtifact(
+        model=model,
+        profile_id=profile_id,
+        transport=transport,
+        results=results,
+        metadata=merged_metadata,
+    )
+
+
+__all__ = [
+    "AudioProbeAttempt",
+    "build_probe_artifact",
+    "dry_run_probe_results",
+    "run_audio_probe",
+    "summarize_probe_results",
+]

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -24,6 +24,7 @@ __all__ = ["main", "check_ports_available"]
 
 import argparse
 import asyncio
+from dataclasses import replace
 import errno
 import json
 import logging
@@ -40,8 +41,20 @@ logger = logging.getLogger(__name__)
 
 from rigplane import __version__  # noqa: E402
 from rigplane.audio import AudioStats  # noqa: E402
+from rigplane.audio.probe import (  # noqa: E402
+    AudioProbeCandidate,
+    AudioProbeResult,
+    AudioProbeStatus,
+    build_stock_radio_lan_probe_matrix,
+)
+from rigplane.audio.probe_runner import (  # noqa: E402
+    build_probe_artifact,
+    dry_run_probe_results,
+    run_audio_probe,
+)
 from rigplane.audio.route import resolve_audio_route, rigctld_wsjtx_policy  # noqa: E402
 from rigplane.backends.config import (  # noqa: E402
+    BackendConfig,
     LanBackendConfig,
     SerialBackendConfig,
     YaesuCatBackendConfig,
@@ -585,6 +598,38 @@ def _build_parser() -> argparse.ArgumentParser:
         type=float,
         default=10.0,
         help="Loopback duration in seconds (default: 10)",
+    )
+
+    audio_probe_p = audio_sub.add_parser(
+        "probe",
+        help="Probe safe RX-only LAN audio stream candidates",
+        description=(
+            "Try radio-native LAN RX audio codec/sample-rate candidates and "
+            "emit a machine-readable evidence artifact. TX is intentionally "
+            "out of scope for this safe probe."
+        ),
+    )
+    audio_probe_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Emit the candidate matrix without connecting to the radio",
+    )
+    audio_probe_p.add_argument("--json", action="store_true", help="Output as JSON")
+    audio_probe_p.add_argument(
+        "--output",
+        help="Write the JSON artifact to this path",
+    )
+    audio_probe_p.add_argument(
+        "--duration",
+        type=float,
+        default=1.0,
+        help="RX observation duration per candidate in seconds (default: 1)",
+    )
+    audio_probe_p.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit candidates for smoke tests and staged hardware validation",
     )
 
     # bridge
@@ -1410,6 +1455,8 @@ async def _run(args: argparse.Namespace) -> int:
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+    if args.command == "audio" and args.audio_command == "probe":
+        return await _cmd_audio_probe(config, args)
     radio = create_radio(config)
 
     if args.command in ("web", "station"):
@@ -1730,6 +1777,125 @@ async def _cmd_audio_caps(
                 else AudioStats.inactive().to_dict()
             )
     return 0
+
+
+async def _cmd_audio_probe(config: BackendConfig, args: argparse.Namespace) -> int:
+    """Run a safe RX-only LAN audio capability probe."""
+
+    if not isinstance(config, LanBackendConfig):
+        print("Error: audio probe requires a LAN backend.", file=sys.stderr)
+        return 1
+    duration_s = float(getattr(args, "duration", 1.0))
+    if duration_s <= 0:
+        print("Error: --duration must be > 0.", file=sys.stderr)
+        return 1
+    limit = getattr(args, "limit", None)
+    if limit is not None and int(limit) <= 0:
+        print("Error: --limit must be > 0.", file=sys.stderr)
+        return 1
+
+    candidates = build_stock_radio_lan_probe_matrix()
+    if limit is not None:
+        candidates = candidates[: int(limit)]
+
+    if getattr(args, "dry_run", False):
+        results = dry_run_probe_results(candidates)
+    else:
+        results = await run_audio_probe(
+            candidates,
+            lambda candidate: _attempt_stock_radio_lan_audio_probe(
+                config,
+                candidate,
+                duration_s=duration_s,
+            ),
+        )
+
+    model = config.model or "unknown"
+    artifact = build_probe_artifact(
+        model=model,
+        profile_id=model,
+        transport="stock_radio_lan",
+        results=results,
+        metadata={
+            "duration_s": duration_s,
+            "candidate_count": len(candidates),
+            "dry_run": bool(getattr(args, "dry_run", False)),
+        },
+    )
+    payload = artifact.to_dict()
+    output_path = getattr(args, "output", None)
+    if output_path:
+        Path(output_path).write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        summary = payload["metadata"]["summary"]
+        print(
+            f"{len(candidates)} candidates: "
+            f"pass={summary['pass']} rejected={summary['rejected']} "
+            f"failed={summary['failed']} skipped={summary['skipped']}"
+        )
+        if output_path:
+            print(f"Wrote {output_path}")
+    sys.stdout.flush()
+    return 0
+
+
+async def _attempt_stock_radio_lan_audio_probe(
+    config: LanBackendConfig,
+    candidate: AudioProbeCandidate,
+    *,
+    duration_s: float,
+) -> AudioProbeResult:
+    """Attempt one RX-only candidate against a fresh radio session."""
+
+    probe_config = replace(
+        config,
+        audio_codec=candidate.rx_codec,
+        audio_sample_rate=candidate.sample_rate_hz,
+        audio_codec_explicit=True,
+        audio_sample_rate_explicit=True,
+        auto_recover_audio=False,
+    )
+    packets = 0
+    payload_bytes: int | None = None
+
+    def _on_packet(packet: Any) -> None:
+        nonlocal packets, payload_bytes
+        if packet is None:
+            return
+        packets += 1
+        data = getattr(packet, "data", b"") or b""
+        payload_bytes = len(data)
+
+    radio = create_radio(probe_config)
+    async with radio:
+        await radio.start_audio_rx_opus(_on_packet)
+        try:
+            await asyncio.sleep(duration_s)
+        finally:
+            await radio.stop_audio_rx_opus()
+
+    if packets > 0:
+        return AudioProbeResult(
+            candidate=candidate,
+            status=AudioProbeStatus.PASS,
+            phase="rx",
+            reason="rx-payload-stable",
+            rx_payload_bytes=payload_bytes,
+            observed_packets=packets,
+        )
+    return AudioProbeResult(
+        candidate=candidate,
+        status=AudioProbeStatus.FAILED,
+        phase="rx",
+        reason="no-rx-packets",
+        observed_packets=0,
+    )
 
 
 async def _cmd_audio_rx(radio: Radio, args: argparse.Namespace) -> int:

--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -202,7 +202,12 @@ class ControlPhaseRuntime:
                 # Stereo rejection: downgrade to mono and retry once (#797).
                 # Mono rejection: raise immediately.
                 if getattr(h, "_last_status_error", 0) == 0xFFFFFFFF:
-                    if h._audio_codec in _STEREO_CODECS:
+                    codec_source = h._audio_stream_contract.rx_codec_source
+                    allow_stereo_fallback = (
+                        h._audio_codec in _STEREO_CODECS
+                        and codec_source is not AudioConfigSource.EXPLICIT
+                    )
+                    if allow_stereo_fallback:
                         # Single-RX firmwares (IC-7300/IC-705, possibly IC-9700)
                         # may reject stereo rx_codec at conninfo. Retry once with
                         # PCM_1CH_16BIT before failing. See issue #797.

--- a/tests/test_audio_probe_runner.py
+++ b/tests/test_audio_probe_runner.py
@@ -1,0 +1,189 @@
+"""Tests for safe LAN audio probe execution helpers."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from rigplane.audio.probe import (
+    AudioProbeResult,
+    AudioProbeStatus,
+    build_stock_radio_lan_probe_matrix,
+)
+from rigplane.audio.probe_runner import (
+    build_probe_artifact,
+    dry_run_probe_results,
+    run_audio_probe,
+)
+from rigplane.backends.config import LanBackendConfig, SerialBackendConfig
+from rigplane.cli import _attempt_stock_radio_lan_audio_probe, _cmd_audio_probe
+
+
+@pytest.mark.asyncio
+async def test_run_audio_probe_executes_candidates_sequentially() -> None:
+    candidates = build_stock_radio_lan_probe_matrix()[:2]
+    seen: list[int] = []
+
+    async def attempt(candidate):
+        seen.append(candidate.sample_rate_hz)
+        return AudioProbeResult(
+            candidate=candidate,
+            status=AudioProbeStatus.PASS,
+            phase="rx",
+            reason="rx-payload-stable",
+            observed_packets=1,
+            rx_payload_bytes=640,
+        )
+
+    results = await run_audio_probe(candidates, attempt)
+
+    assert [result.status for result in results] == [
+        AudioProbeStatus.PASS,
+        AudioProbeStatus.PASS,
+    ]
+    assert seen == [candidate.sample_rate_hz for candidate in candidates]
+
+
+@pytest.mark.asyncio
+async def test_run_audio_probe_classifies_attempt_exceptions() -> None:
+    candidate = build_stock_radio_lan_probe_matrix()[0]
+
+    async def attempt(_candidate):
+        raise RuntimeError("conninfo error=0xFFFFFFFF")
+
+    result = (await run_audio_probe([candidate], attempt))[0]
+
+    assert result.status is AudioProbeStatus.REJECTED
+    assert result.phase == "conninfo"
+    assert result.reason == "conninfo-rejected"
+    assert "conninfo" in (result.error or "")
+
+
+def test_dry_run_probe_results_marks_candidates_skipped() -> None:
+    candidates = build_stock_radio_lan_probe_matrix()[:3]
+
+    results = dry_run_probe_results(candidates)
+
+    assert len(results) == 3
+    assert {result.status for result in results} == {AudioProbeStatus.SKIPPED}
+    assert {result.phase for result in results} == {"dry-run"}
+
+
+def test_build_probe_artifact_records_profile_and_summary() -> None:
+    candidate = build_stock_radio_lan_probe_matrix()[0]
+    artifact = build_probe_artifact(
+        model="IC-7610",
+        profile_id="icom_ic7610",
+        transport="stock_radio_lan",
+        results=[
+            AudioProbeResult(
+                candidate=candidate,
+                status=AudioProbeStatus.PASS,
+                phase="rx",
+                reason="rx-payload-stable",
+            )
+        ],
+        metadata={"duration_s": 0.1},
+    )
+
+    data = artifact.to_dict()
+
+    assert data["model"] == "IC-7610"
+    assert data["metadata"]["duration_s"] == 0.1
+    assert data["metadata"]["summary"] == {
+        "pass": 1,
+        "rejected": 0,
+        "failed": 0,
+        "skipped": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cmd_audio_probe_dry_run_writes_machine_readable_artifact(
+    tmp_path,
+    capsys,
+) -> None:
+    output = tmp_path / "probe.json"
+    args = SimpleNamespace(
+        dry_run=True,
+        json=True,
+        output=str(output),
+        duration=0.01,
+        limit=2,
+    )
+    config = LanBackendConfig(host="127.0.0.1", model="IC-7610")
+
+    rc = await _cmd_audio_probe(config, args)
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(stdout)
+    written = json.loads(output.read_text())
+    assert payload == written
+    assert payload["transport"] == "stock_radio_lan"
+    assert payload["model"] == "IC-7610"
+    assert len(payload["results"]) == 2
+    assert {result["status"] for result in payload["results"]} == {"skipped"}
+
+
+@pytest.mark.asyncio
+async def test_cmd_audio_probe_rejects_non_lan_backend(capsys) -> None:
+    args = SimpleNamespace(
+        dry_run=True,
+        json=False,
+        output=None,
+        duration=0.01,
+        limit=None,
+    )
+    config = SerialBackendConfig(device="/dev/ttyUSB0")
+
+    rc = await _cmd_audio_probe(config, args)
+
+    assert rc == 1
+    assert "LAN backend" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_stock_radio_lan_attempt_is_rx_only(monkeypatch) -> None:
+    candidate = build_stock_radio_lan_probe_matrix()[0]
+    calls: list[str] = []
+
+    class Packet:
+        data = b"\x00\x01" * 16
+
+    class FakeRadio:
+        async def __aenter__(self):
+            calls.append("enter")
+            return self
+
+        async def __aexit__(self, *_exc_info):
+            calls.append("exit")
+
+        async def start_audio_rx_opus(self, callback):
+            calls.append("start-rx")
+            callback(Packet())
+
+        async def stop_audio_rx_opus(self):
+            calls.append("stop-rx")
+
+        async def start_audio_tx_opus(self, *_args, **_kwargs):
+            raise AssertionError("TX must not be started by RX-only probe")
+
+        async def start_audio_tx_pcm(self, *_args, **_kwargs):
+            raise AssertionError("TX must not be started by RX-only probe")
+
+    monkeypatch.setattr("rigplane.cli.create_radio", lambda _config: FakeRadio())
+    config = LanBackendConfig(host="127.0.0.1", model="IC-7610")
+
+    result = await _attempt_stock_radio_lan_audio_probe(
+        config,
+        candidate,
+        duration_s=0,
+    )
+
+    assert result.status is AudioProbeStatus.PASS
+    assert result.observed_packets == 1
+    assert result.rx_payload_bytes == 32
+    assert calls == ["enter", "start-rx", "stop-rx", "exit"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,6 +154,30 @@ class TestBuildParser:
         assert args.audio_command == "loopback"
         assert args.seconds == 3.0
 
+    def test_audio_probe(self):
+        p = _build_parser()
+        args = p.parse_args(
+            [
+                "audio",
+                "probe",
+                "--dry-run",
+                "--json",
+                "--output",
+                "probe.json",
+                "--duration",
+                "0.25",
+                "--limit",
+                "4",
+            ]
+        )
+        assert args.command == "audio"
+        assert args.audio_command == "probe"
+        assert args.dry_run is True
+        assert args.json is True
+        assert args.output == "probe.json"
+        assert args.duration == 0.25
+        assert args.limit == 4
+
     def test_ptt_on(self):
         p = _build_parser()
         args = p.parse_args(["ptt", "on"])

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -605,6 +605,53 @@ class TestConnectSessionRejection:
         assert radio._civ_port == 50001
 
     @pytest.mark.asyncio
+    async def test_explicit_stereo_codec_rejection_does_not_fallback(self) -> None:
+        """Explicit probe-style codec requests must preserve candidate evidence."""
+        radio = IcomRadio(
+            "192.168.1.100",
+            username="u",
+            password="p",
+            audio_codec=AudioCodec.PCM_2CH_16BIT,
+            audio_codec_explicit=True,
+        )
+        mt = ConnectMockTransport()
+        radio._ctrl_transport = mt
+
+        async def _reject_status() -> int:
+            radio._last_status_error = 0xFFFFFFFF
+            return 0
+
+        send_mock = AsyncMock()
+
+        with (
+            patch.object(radio._control_phase, "_status_retry_pause", return_value=0.0),
+            patch.object(
+                radio._control_phase,
+                "_wait_for_packet",
+                new=AsyncMock(return_value=_build_login_response()),
+            ),
+            patch.object(radio._control_phase, "_send_token_ack", new=AsyncMock()),
+            patch.object(
+                radio._control_phase,
+                "_receive_guid",
+                new=AsyncMock(return_value=b"\x00" * 16),
+            ),
+            patch.object(radio._control_phase, "_send_conninfo", new=send_mock),
+            patch.object(
+                radio._control_phase,
+                "_receive_civ_port",
+                new=AsyncMock(side_effect=_reject_status),
+            ),
+        ):
+            with pytest.raises(ConnectionError, match="rejected session allocation"):
+                await radio.connect()
+
+        assert send_mock.await_count == 1
+        assert radio.audio_stream_contract.rx_codec == AudioCodec.PCM_2CH_16BIT
+        assert radio.audio_stream_contract.rx_codec_source == AudioConfigSource.EXPLICIT
+        assert mt.disconnected is True
+
+    @pytest.mark.asyncio
     async def test_stereo_codec_fallback_raises_on_second_rejection(self) -> None:
         """Stereo rx_codec rejected twice → raise, no infinite loop."""
         radio = IcomRadio(


### PR DESCRIPTION
## Summary

- add `rigplane audio probe` with safe RX-only LAN candidate probing
- add JSON/stdout and `--output` artifact generation plus dry-run and duration/limit controls
- preserve explicit codec candidate evidence by disabling stereo-to-mono conninfo fallback for explicit codec requests

## Validation

- `uv run pytest tests/test_audio_probe.py tests/test_audio_probe_runner.py tests/test_cli.py::TestBuildParser::test_audio_probe tests/test_radio_connect.py::TestConnectSessionRejection -q`
- `uv run ruff check src/rigplane/audio/probe_runner.py src/rigplane/cli/__init__.py src/rigplane/runtime/_control_phase.py tests/test_audio_probe_runner.py tests/test_cli.py tests/test_radio_connect.py`
- `.github/scripts/check-rebrand-allowlist.sh`
- `uv run pytest -q` (`5947 passed, 107 skipped, 3 deselected, 9 xfailed, 1 xpassed`)
- live IC-7610 RX-only smoke: `PCM_2CH_16BIT@48000` passed with 39 observed packets in 0.25s; artifact `/tmp/rigplane-debug/audio-probe-live-smoke.json`

Closes #1481
Refs #1479
