### PR TITLE
Add guarded profile proposal tool for audio probes

### DIFF
--- a/src/rigplane/audio/probe_profile.py
+++ b/src/rigplane/audio/probe_profile.py
@@ -1,0 +1,99 @@
+"""Guarded profile patch proposals from audio probe artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+class AudioProfileProposalError(ValueError):
+    """Raised when an artifact cannot produce a profile patch."""
+
+
+@dataclass(frozen=True, slots=True)
+class AudioProfileProposal:
+    """A proposed TOML patch plus non-fatal evidence warnings."""
+
+    toml: str
+    warnings: list[str]
+
+
+def propose_audio_profile_patch(
+    artifact: Mapping[str, Any],
+) -> AudioProfileProposal:
+    """Build a deterministic ``[audio]`` TOML patch from passed evidence only."""
+
+    passed = [
+        result
+        for result in artifact.get("results", [])
+        if isinstance(result, Mapping) and result.get("status") == "pass"
+    ]
+    if not passed:
+        raise AudioProfileProposalError("No passed probe results in artifact.")
+
+    codec_preference: list[str] = []
+    sample_rate_by_codec: dict[str, int] = {}
+    tx_codec: str | None = None
+    for result in passed:
+        candidate = result.get("candidate")
+        if not isinstance(candidate, Mapping):
+            continue
+        rx_codec = str(candidate.get("rx_codec") or "")
+        if not rx_codec:
+            continue
+        sample_rate_hz = int(candidate["sample_rate_hz"])
+        if rx_codec not in codec_preference:
+            codec_preference.append(rx_codec)
+        sample_rate_by_codec.setdefault(rx_codec, sample_rate_hz)
+        tx_codec = tx_codec or str(candidate.get("tx_codec") or "")
+
+    if not codec_preference:
+        raise AudioProfileProposalError("No passed probe results with candidate data.")
+
+    lines = [
+        "[audio]",
+        "codec_preference = ["
+        + ", ".join(f'"{codec}"' for codec in codec_preference)
+        + "]",
+    ]
+    if tx_codec:
+        lines.append(f'tx_codec = "{tx_codec}"')
+    lines.append(
+        f"default_sample_rate_hz = {sample_rate_by_codec[codec_preference[0]]}"
+    )
+    by_codec = ", ".join(
+        f"{codec} = {sample_rate_by_codec[codec]}" for codec in codec_preference
+    )
+    lines.append(f"sample_rate_by_codec = {{ {by_codec} }}")
+    lines.append("")
+
+    return AudioProfileProposal(
+        toml="\n".join(lines),
+        warnings=_artifact_warnings(artifact),
+    )
+
+
+def _artifact_warnings(artifact: Mapping[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    model = str(artifact.get("model") or "").strip().lower()
+    profile_id = str(artifact.get("profile_id") or "").strip().lower()
+    if model in {"", "unknown"} or profile_id in {"", "unknown"}:
+        warnings.append("artifact model/profile_id metadata is missing or unknown")
+    metadata = artifact.get("metadata")
+    firmware = None
+    if isinstance(metadata, Mapping):
+        firmware = (
+            metadata.get("firmware_version")
+            or metadata.get("firmware")
+            or metadata.get("version")
+        )
+    if firmware in (None, ""):
+        warnings.append("artifact firmware/version metadata is missing")
+    return warnings
+
+
+__all__ = [
+    "AudioProfileProposal",
+    "AudioProfileProposalError",
+    "propose_audio_profile_patch",
+]

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -47,6 +47,10 @@ from rigplane.audio.probe import (  # noqa: E402
     AudioProbeStatus,
     build_stock_radio_lan_probe_matrix,
 )
+from rigplane.audio.probe_profile import (  # noqa: E402
+    AudioProfileProposalError,
+    propose_audio_profile_patch,
+)
 from rigplane.audio.probe_runner import (  # noqa: E402
     build_probe_artifact,
     dry_run_probe_results,
@@ -630,6 +634,16 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Limit candidates for smoke tests and staged hardware validation",
+    )
+
+    audio_probe_profile_p = audio_sub.add_parser(
+        "probe-profile",
+        help="Propose a guarded profile [audio] patch from a probe artifact",
+    )
+    audio_probe_profile_p.add_argument(
+        "--artifact",
+        required=True,
+        help="Path to a JSON artifact emitted by `rigplane audio probe`",
     )
 
     # bridge
@@ -1444,6 +1458,8 @@ async def _run(args: argparse.Namespace) -> int:
     wants_stats = bool(getattr(args, "stats", False))
     if args.command == "audio" and args.audio_command == "caps" and not wants_stats:
         return await _cmd_audio_caps(args)
+    if args.command == "audio" and args.audio_command == "probe-profile":
+        return await _cmd_audio_probe_profile(args)
 
     # Apply preset before building config (so discovery sees preset-applied backend).
     preset = getattr(args, "preset", None)
@@ -1896,6 +1912,29 @@ async def _attempt_stock_radio_lan_audio_probe(
         reason="no-rx-packets",
         observed_packets=0,
     )
+
+
+async def _cmd_audio_probe_profile(args: argparse.Namespace) -> int:
+    """Print a guarded profile patch from a probe artifact."""
+
+    try:
+        artifact = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
+        proposal = propose_audio_profile_patch(artifact)
+    except OSError as exc:
+        print(f"Error: cannot read artifact: {exc}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Error: artifact is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+    except AudioProfileProposalError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    for warning in proposal.warnings:
+        print(f"Warning: {warning}", file=sys.stderr)
+    print(proposal.toml, end="")
+    sys.stdout.flush()
+    return 0
 
 
 async def _cmd_audio_rx(radio: Radio, args: argparse.Namespace) -> int:

--- a/tests/test_audio_probe_profile.py
+++ b/tests/test_audio_probe_profile.py
@@ -1,0 +1,147 @@
+"""Tests for guarded profile patch proposals from audio probe artifacts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rigplane.audio.probe_profile import (
+    AudioProfileProposalError,
+    propose_audio_profile_patch,
+)
+from rigplane.cli import _build_parser, _cmd_audio_probe_profile
+
+
+def _artifact(results: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "tool": "rigplane-audio-probe",
+        "model": "IC-7610",
+        "profile_id": "icom_ic7610",
+        "transport": "stock_radio_lan",
+        "metadata": {"firmware_version": "1.42"},
+        "results": results,
+    }
+
+
+def _result(
+    *,
+    status: str,
+    rx_codec: str,
+    sample_rate_hz: int,
+    tx_codec: str = "PCM_1CH_16BIT",
+) -> dict[str, object]:
+    return {
+        "status": status,
+        "phase": "rx",
+        "reason": "rx-payload-stable" if status == "pass" else "conninfo-rejected",
+        "candidate": {
+            "rx_codec": rx_codec,
+            "tx_codec": tx_codec,
+            "sample_rate_hz": sample_rate_hz,
+            "rx_channels": 2 if "_2CH" in rx_codec else 1,
+            "tx_channels": 1,
+            "frame_ms": 20,
+            "mode": "rx-only",
+        },
+    }
+
+
+def test_propose_audio_profile_patch_uses_only_passed_results() -> None:
+    proposal = propose_audio_profile_patch(
+        _artifact(
+            [
+                _result(status="rejected", rx_codec="ULAW_1CH", sample_rate_hz=48000),
+                _result(
+                    status="pass",
+                    rx_codec="PCM_2CH_16BIT",
+                    sample_rate_hz=48000,
+                ),
+                _result(
+                    status="pass",
+                    rx_codec="PCM_1CH_16BIT",
+                    sample_rate_hz=16000,
+                ),
+            ]
+        )
+    )
+
+    assert proposal.toml == "\n".join(
+        [
+            "[audio]",
+            'codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT"]',
+            'tx_codec = "PCM_1CH_16BIT"',
+            "default_sample_rate_hz = 48000",
+            "sample_rate_by_codec = { PCM_2CH_16BIT = 48000, PCM_1CH_16BIT = 16000 }",
+            "",
+        ]
+    )
+    assert proposal.warnings == []
+
+
+def test_propose_audio_profile_patch_rejects_no_pass_artifacts() -> None:
+    with pytest.raises(AudioProfileProposalError, match="No passed probe results"):
+        propose_audio_profile_patch(
+            _artifact(
+                [
+                    _result(
+                        status="rejected",
+                        rx_codec="PCM_2CH_16BIT",
+                        sample_rate_hz=48000,
+                    )
+                ]
+            )
+        )
+
+
+def test_propose_audio_profile_patch_warns_when_model_or_firmware_missing() -> None:
+    artifact = _artifact(
+        [_result(status="pass", rx_codec="PCM_2CH_16BIT", sample_rate_hz=48000)]
+    )
+    artifact["model"] = "unknown"
+    artifact["metadata"] = {}
+
+    proposal = propose_audio_profile_patch(artifact)
+
+    assert proposal.warnings == [
+        "artifact model/profile_id metadata is missing or unknown",
+        "artifact firmware/version metadata is missing",
+    ]
+
+
+def test_audio_probe_profile_parser() -> None:
+    args = _build_parser().parse_args(
+        ["audio", "probe-profile", "--artifact", "probe.json"]
+    )
+
+    assert args.command == "audio"
+    assert args.audio_command == "probe-profile"
+    assert args.artifact == "probe.json"
+
+
+@pytest.mark.asyncio
+async def test_cmd_audio_probe_profile_prints_patch(tmp_path, capsys) -> None:
+    artifact_path = tmp_path / "probe.json"
+    artifact_path.write_text(
+        json.dumps(
+            _artifact(
+                [
+                    _result(
+                        status="pass",
+                        rx_codec="PCM_2CH_16BIT",
+                        sample_rate_hz=48000,
+                    )
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+    args = _build_parser().parse_args(
+        ["audio", "probe-profile", "--artifact", str(artifact_path)]
+    )
+
+    rc = await _cmd_audio_probe_profile(args)
+
+    assert rc == 0
+    assert '[audio]\ncodec_preference = ["PCM_2CH_16BIT"]' in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- add `rigplane audio probe-profile --artifact <path>` for guarded `[audio]` TOML proposals
- derive profile defaults only from passed probe results, ignoring rejected/failed/skipped candidates
- warn when artifact model/profile or firmware/version evidence is missing
- keep the command offline so it does not require radio discovery or backend config

## Validation

- `uv run pytest tests/test_audio_probe.py tests/test_audio_probe_runner.py tests/test_audio_probe_profile.py tests/test_cli.py::TestBuildParser::test_audio_probe tests/test_radio_connect.py::TestConnectSessionRejection -q`
- `uv run ruff check src/rigplane/audio/probe_profile.py src/rigplane/audio/probe_runner.py src/rigplane/cli/__init__.py src/rigplane/runtime/_control_phase.py tests/test_audio_probe_profile.py tests/test_audio_probe_runner.py tests/test_cli.py tests/test_radio_connect.py`
- `.github/scripts/check-rebrand-allowlist.sh`
- `uv run pytest -q` (`5952 passed, 107 skipped, 3 deselected, 9 xfailed, 1 xpassed`)
- CLI smoke: `uv run rigplane audio probe-profile --artifact /tmp/rigplane-debug/audio-probe-live-smoke.json`

Closes #1483
Refs #1479
