### PR TITLE
Add cooldown and retry controls to LAN audio probe

### DIFF
--- a/src/rigplane/audio/probe_runner.py
+++ b/src/rigplane/audio/probe_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 
 from rigplane.audio.probe import (
@@ -18,27 +19,62 @@ AudioProbeAttempt = Callable[[AudioProbeCandidate], Awaitable[AudioProbeResult]]
 async def run_audio_probe(
     candidates: Iterable[AudioProbeCandidate],
     attempt: AudioProbeAttempt,
+    *,
+    candidate_cooldown_s: float = 0.0,
+    retry_rejected: int = 0,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
 ) -> list[AudioProbeResult]:
     """Run probe candidates sequentially and normalize attempt failures."""
 
     results: list[AudioProbeResult] = []
-    for candidate in candidates:
-        try:
-            results.append(await attempt(candidate))
-        except Exception as exc:
-            status, reason = classify_stock_radio_lan_probe_error(exc)
-            results.append(
-                AudioProbeResult(
-                    candidate=candidate,
-                    status=status,
-                    phase="conninfo"
-                    if status is AudioProbeStatus.REJECTED
-                    else "runtime",
-                    reason=reason,
-                    error=str(exc),
-                )
-            )
+    candidate_list = list(candidates)
+    for index, candidate in enumerate(candidate_list):
+        result = await _attempt_with_retries(
+            candidate,
+            attempt,
+            candidate_cooldown_s=candidate_cooldown_s,
+            retry_rejected=retry_rejected,
+            sleep=sleep,
+        )
+        results.append(result)
+        if candidate_cooldown_s > 0 and index < len(candidate_list) - 1:
+            await sleep(candidate_cooldown_s)
     return results
+
+
+async def _attempt_with_retries(
+    candidate: AudioProbeCandidate,
+    attempt: AudioProbeAttempt,
+    *,
+    candidate_cooldown_s: float,
+    retry_rejected: int,
+    sleep: Callable[[float], Awaitable[None]],
+) -> AudioProbeResult:
+    tries = 0
+    while True:
+        result = await _attempt_once(candidate, attempt)
+        if result.status is not AudioProbeStatus.REJECTED or tries >= retry_rejected:
+            return result
+        tries += 1
+        if candidate_cooldown_s > 0:
+            await sleep(candidate_cooldown_s)
+
+
+async def _attempt_once(
+    candidate: AudioProbeCandidate,
+    attempt: AudioProbeAttempt,
+) -> AudioProbeResult:
+    try:
+        return await attempt(candidate)
+    except Exception as exc:
+        status, reason = classify_stock_radio_lan_probe_error(exc)
+        return AudioProbeResult(
+            candidate=candidate,
+            status=status,
+            phase="conninfo" if status is AudioProbeStatus.REJECTED else "runtime",
+            reason=reason,
+            error=str(exc),
+        )
 
 
 def dry_run_probe_results(

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -635,6 +635,23 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Limit candidates for smoke tests and staged hardware validation",
     )
+    audio_probe_p.add_argument(
+        "--candidate-cooldown",
+        type=float,
+        default=0.0,
+        metavar="SEC",
+        help=(
+            "Cooldown between candidates in seconds (default: 0). "
+            "Use 35 for full IC-7610-class hardware validation."
+        ),
+    )
+    audio_probe_p.add_argument(
+        "--retry-rejected",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Retry conninfo-rejected candidates after cooldown (default: 0)",
+    )
 
     audio_probe_profile_p = audio_sub.add_parser(
         "probe-profile",
@@ -1809,6 +1826,14 @@ async def _cmd_audio_probe(config: BackendConfig, args: argparse.Namespace) -> i
     if limit is not None and int(limit) <= 0:
         print("Error: --limit must be > 0.", file=sys.stderr)
         return 1
+    candidate_cooldown_s = float(getattr(args, "candidate_cooldown", 0.0))
+    if candidate_cooldown_s < 0:
+        print("Error: --candidate-cooldown must be >= 0.", file=sys.stderr)
+        return 1
+    retry_rejected = int(getattr(args, "retry_rejected", 0))
+    if retry_rejected < 0:
+        print("Error: --retry-rejected must be >= 0.", file=sys.stderr)
+        return 1
 
     candidates = build_stock_radio_lan_probe_matrix()
     if limit is not None:
@@ -1824,6 +1849,8 @@ async def _cmd_audio_probe(config: BackendConfig, args: argparse.Namespace) -> i
                 candidate,
                 duration_s=duration_s,
             ),
+            candidate_cooldown_s=candidate_cooldown_s,
+            retry_rejected=retry_rejected,
         )
 
     model = config.model or "unknown"
@@ -1836,6 +1863,8 @@ async def _cmd_audio_probe(config: BackendConfig, args: argparse.Namespace) -> i
             "duration_s": duration_s,
             "candidate_count": len(candidates),
             "dry_run": bool(getattr(args, "dry_run", False)),
+            "candidate_cooldown_s": candidate_cooldown_s,
+            "retry_rejected": retry_rejected,
         },
     )
     payload = artifact.to_dict()

--- a/tests/test_audio_probe_runner.py
+++ b/tests/test_audio_probe_runner.py
@@ -61,6 +61,70 @@ async def test_run_audio_probe_classifies_attempt_exceptions() -> None:
     assert "conninfo" in (result.error or "")
 
 
+@pytest.mark.asyncio
+async def test_run_audio_probe_applies_cooldown_between_candidates() -> None:
+    candidates = build_stock_radio_lan_probe_matrix()[:3]
+    events: list[str] = []
+
+    async def attempt(candidate):
+        events.append(f"attempt:{candidate.sample_rate_hz}")
+        return AudioProbeResult(
+            candidate=candidate,
+            status=AudioProbeStatus.PASS,
+            phase="rx",
+            reason="rx-payload-stable",
+        )
+
+    async def sleep(seconds: float) -> None:
+        events.append(f"sleep:{seconds:g}")
+
+    await run_audio_probe(
+        candidates,
+        attempt,
+        candidate_cooldown_s=35.0,
+        sleep=sleep,
+    )
+
+    assert events == [
+        "attempt:48000",
+        "sleep:35",
+        "attempt:24000",
+        "sleep:35",
+        "attempt:16000",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_audio_probe_retries_rejected_after_cooldown() -> None:
+    candidate = build_stock_radio_lan_probe_matrix()[0]
+    events: list[str] = []
+
+    async def attempt(_candidate):
+        events.append("attempt")
+        if events.count("attempt") == 1:
+            raise RuntimeError("conninfo error=0xFFFFFFFF")
+        return AudioProbeResult(
+            candidate=candidate,
+            status=AudioProbeStatus.PASS,
+            phase="rx",
+            reason="rx-payload-stable",
+        )
+
+    async def sleep(seconds: float) -> None:
+        events.append(f"sleep:{seconds:g}")
+
+    results = await run_audio_probe(
+        [candidate],
+        attempt,
+        candidate_cooldown_s=35.0,
+        retry_rejected=1,
+        sleep=sleep,
+    )
+
+    assert results[0].status is AudioProbeStatus.PASS
+    assert events == ["attempt", "sleep:35", "attempt"]
+
+
 def test_dry_run_probe_results_marks_candidates_skipped() -> None:
     candidates = build_stock_radio_lan_probe_matrix()[:3]
 
@@ -112,6 +176,8 @@ async def test_cmd_audio_probe_dry_run_writes_machine_readable_artifact(
         output=str(output),
         duration=0.01,
         limit=2,
+        candidate_cooldown=35.0,
+        retry_rejected=1,
     )
     config = LanBackendConfig(host="127.0.0.1", model="IC-7610")
 
@@ -124,6 +190,8 @@ async def test_cmd_audio_probe_dry_run_writes_machine_readable_artifact(
     assert payload == written
     assert payload["transport"] == "stock_radio_lan"
     assert payload["model"] == "IC-7610"
+    assert payload["metadata"]["candidate_cooldown_s"] == 35.0
+    assert payload["metadata"]["retry_rejected"] == 1
     assert len(payload["results"]) == 2
     assert {result["status"] for result in payload["results"]} == {"skipped"}
 
@@ -136,6 +204,8 @@ async def test_cmd_audio_probe_rejects_non_lan_backend(capsys) -> None:
         output=None,
         duration=0.01,
         limit=None,
+        candidate_cooldown=0.0,
+        retry_rejected=0,
     )
     config = SerialBackendConfig(device="/dev/ttyUSB0")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,10 @@ class TestBuildParser:
                 "0.25",
                 "--limit",
                 "4",
+                "--candidate-cooldown",
+                "35",
+                "--retry-rejected",
+                "1",
             ]
         )
         assert args.command == "audio"
@@ -177,6 +181,8 @@ class TestBuildParser:
         assert args.output == "probe.json"
         assert args.duration == 0.25
         assert args.limit == 4
+        assert args.candidate_cooldown == 35.0
+        assert args.retry_rejected == 1
 
     def test_ptt_on(self):
         p = _build_parser()


### PR DESCRIPTION
## Summary

- add `--candidate-cooldown SEC` to `rigplane audio probe`
- add `--retry-rejected N` for retrying conninfo-rejected candidates after cooldown
- record cooldown/retry values in probe artifact metadata
- document in CLI help that full IC-7610-class hardware validation should use a 35s cooldown

## Validation

- `uv run pytest tests/test_audio_probe.py tests/test_audio_probe_runner.py tests/test_cli.py::TestBuildParser::test_audio_probe -q`
- `uv run ruff check src/rigplane/audio/probe_runner.py src/rigplane/cli/__init__.py tests/test_audio_probe_runner.py tests/test_cli.py`
- `.github/scripts/check-rebrand-allowlist.sh`
- `uv run rigplane --host 127.0.0.1 --model IC-7610 audio probe --dry-run --json --limit 1 --duration 0.01 --candidate-cooldown 35 --retry-rejected 1`
- `uv run pytest -q` (`5955 passed, 107 skipped, 3 deselected, 9 xfailed, 1 xpassed`)

Closes #1488
Refs #1482
Refs #1479
