### PR TITLE
Update IC-7610 LAN audio profile from probe evidence

### DIFF
--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -34,6 +34,41 @@ Protocol types:
 - **`kenwood_cat`** — Kenwood text-based CAT (Lab599 TX-500, TS-890S). Commands: `"FA14200000;"`, `"MD2;"`
 - **`yaesu_cat`** — Yaesu text-based CAT (FTX-1, FT-710, FT-DX101)
 
+## `[audio]` — LAN Audio Policy
+
+Optional section. Defines radio-native LAN audio defaults and browser consumer
+transport policy. These fields are used by the LAN audio stream resolver when
+the caller did not explicitly override codec or sample rate.
+
+| Field                         | Type              | Required | Description |
+|-------------------------------|-------------------|----------|-------------|
+| `codec_preference`            | string[]          | no       | Ordered RX codec preference. Values must match `AudioCodec` names. The first supported codec is used unless the caller passed an explicit codec. |
+| `tx_codec`                    | string            | no       | Radio-native TX codec name from `AudioCodec`. Direct LAN TX profiles should prefer mono PCM unless hardware evidence proves otherwise. |
+| `default_sample_rate_hz`      | int               | no       | Profile default sample rate when `sample_rate_by_codec` has no entry for the selected codec. |
+| `supported_sample_rates_hz`   | int[]             | no       | Evidence-backed sample rates accepted by the radio profile. |
+| `sample_rate_by_codec`        | table string→int  | no       | Per-codec default sample rate used by the resolver for RX and TX. Keys must be `AudioCodec` names. |
+| `browser_rx_transport`        | string            | no       | Browser consumer transport policy: `"auto"`, `"pcm"`, or `"opus"`. |
+| `browser_rx_transcode_to_opus`| bool              | no       | Whether browser RX may transcode radio-native audio to Opus. This is not a radio-native codec setting. |
+
+Example:
+
+```toml
+[audio]
+codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT", "ULAW_2CH", "ULAW_1CH"]
+tx_codec = "PCM_1CH_16BIT"
+default_sample_rate_hz = 48000
+sample_rate_by_codec = { PCM_2CH_16BIT = 48000, PCM_1CH_16BIT = 48000 }
+browser_rx_transport = "auto"
+browser_rx_transcode_to_opus = true
+```
+
+Profile defaults must be backed by radio evidence, not copied from generic
+codec lists. Prefer pass-only artifacts from `rigplane audio probe`; for radios
+with LAN session cooldown behavior, include a conservative candidate cooldown in
+the validation command. Opus must not be used as a stock radio LAN default unless
+the endpoint or protocol explicitly proves native Opus support. Browser Opus is
+only a server-to-browser transport policy after radio-native audio is received.
+
 ## `[capabilities]` — Feature Flags
 
 | Field      | Type     | Required | Description                    |

--- a/rigs/_schema_v2.md
+++ b/rigs/_schema_v2.md
@@ -43,9 +43,9 @@ variant = "standard"         # Protocol variant/extensions
 [audio]
 codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT"]  # RX codec names from AudioCodec
 tx_codec = "PCM_1CH_16BIT"                             # TX codec name from AudioCodec
-default_sample_rate_hz = 16000
+default_sample_rate_hz = 48000
 supported_sample_rates_hz = [8000, 12000, 16000, 24000, 48000]
-sample_rate_by_codec = { PCM_2CH_16BIT = 16000, PCM_1CH_16BIT = 16000 }
+sample_rate_by_codec = { PCM_2CH_16BIT = 48000, PCM_1CH_16BIT = 48000 }
 browser_rx_transport = "auto"                          # auto | pcm | opus
 browser_rx_transcode_to_opus = true                    # Browser consumer policy only
 ```
@@ -54,6 +54,13 @@ Codec names must match `AudioCodec`. Sample rates must be positive supported
 audio rates from `8000`, `12000`, `16000`, `24000`, or `48000`. For direct Icom
 LAN profiles, Opus must not be used as the radio-native default; browser Opus is
 only a consumer/web transport policy.
+
+`codec_preference`, `tx_codec`, `default_sample_rate_hz`, and
+`sample_rate_by_codec` feed the LAN audio stream resolver. Explicit runtime
+codec and sample-rate choices still win over profile defaults. Profile defaults
+must come from pass-only radio evidence, preferably a `rigplane audio probe`
+artifact captured with enough cooldown for radios that reject rapid LAN audio
+session churn.
 
 ### Protocol Types
 

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -18,10 +18,13 @@ has_wifi = false
 [audio]
 # Direct IC-7610 LAN is PCM-first. Opus is only allowed as a browser
 # consumer transport after the server receives radio-native PCM.
+# Hardware probe: 2026-05-08, firmware 1.42,
+# `rigplane audio probe --candidate-cooldown 35 --retry-rejected 1`.
+# All conservative RX candidates passed at 48000/24000/16000/8000 Hz.
 codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT", "ULAW_2CH", "ULAW_1CH"]
 tx_codec = "PCM_1CH_16BIT"
-default_sample_rate_hz = 16000
-sample_rate_by_codec = { PCM_2CH_16BIT = 16000, PCM_1CH_16BIT = 16000 }
+default_sample_rate_hz = 48000
+sample_rate_by_codec = { PCM_2CH_16BIT = 48000, PCM_1CH_16BIT = 48000, ULAW_2CH = 48000, ULAW_1CH = 48000 }
 browser_rx_transport = "auto"
 browser_rx_transcode_to_opus = true
 

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -34,11 +34,11 @@ class TestRadioAudioConfig:
     def test_default_codec(self) -> None:
         r = IcomRadio("192.168.1.100")
         assert r.audio_codec == AudioCodec.PCM_2CH_16BIT
-        assert r.audio_sample_rate == 16000
+        assert r.audio_sample_rate == 48000
         assert r.audio_stream_request.rx_codec == AudioCodec.PCM_2CH_16BIT
         assert r.audio_stream_request.tx_codec == AudioCodec.PCM_1CH_16BIT
-        assert r.audio_stream_request.rx_sample_rate_hz == 16000
-        assert r.audio_stream_request.tx_sample_rate_hz == 16000
+        assert r.audio_stream_request.rx_sample_rate_hz == 48000
+        assert r.audio_stream_request.tx_sample_rate_hz == 48000
         assert r.audio_stream_contract.rx_codec == r.audio_stream_request.rx_codec
         assert r.audio_stream_contract.tx_codec == r.audio_stream_request.tx_codec
         assert (

--- a/tests/test_audio_route.py
+++ b/tests/test_audio_route.py
@@ -93,8 +93,8 @@ def test_ic7610_lan_stream_request_uses_profile_audio_policy() -> None:
 
     assert request.rx_codec == AudioCodec.PCM_2CH_16BIT
     assert request.tx_codec == AudioCodec.PCM_1CH_16BIT
-    assert request.rx_sample_rate_hz == 16000
-    assert request.tx_sample_rate_hz == 16000
+    assert request.rx_sample_rate_hz == 48000
+    assert request.tx_sample_rate_hz == 48000
     assert request.rx_channels == 2
     assert request.tx_channels == 1
     assert request.rx_codec_source == AudioConfigSource.PROFILE_DEFAULT

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -219,8 +219,8 @@ class TestSendConninfo:
         )
         rx_sample = struct.unpack_from(">I", packet, 0x74)[0]
         tx_sample = struct.unpack_from(">I", packet, 0x78)[0]
-        assert rx_sample == 16000
-        assert tx_sample == 16000
+        assert rx_sample == 48000
+        assert tx_sample == 48000
 
     @pytest.mark.asyncio
     async def test_conninfo_honors_explicit_sample_rate_override(self) -> None:
@@ -594,8 +594,8 @@ class TestConnectSessionRejection:
         assert radio.audio_stream_request.rx_codec == AudioCodec.PCM_2CH_16BIT
         assert radio.audio_stream_contract.rx_codec == AudioCodec.PCM_1CH_16BIT
         assert radio.audio_stream_contract.tx_codec == AudioCodec.PCM_1CH_16BIT
-        assert radio.audio_stream_contract.rx_sample_rate_hz == 16000
-        assert radio.audio_stream_contract.tx_sample_rate_hz == 16000
+        assert radio.audio_stream_contract.rx_sample_rate_hz == 48000
+        assert radio.audio_stream_contract.tx_sample_rate_hz == 48000
         assert radio.audio_stream_contract.rx_codec_source == AudioConfigSource.FALLBACK
         assert (
             radio.audio_stream_contract.fallback_reason == "conninfo-stereo-rx-rejected"

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -647,11 +647,13 @@ class TestAudioPolicy:
             "ULAW_1CH",
         )
         assert rig.tx_codec == "PCM_1CH_16BIT"
-        assert rig.default_sample_rate_hz == 16000
+        assert rig.default_sample_rate_hz == 48000
         assert rig.supported_sample_rates_hz is None
         assert rig.sample_rate_by_codec == {
-            "PCM_2CH_16BIT": 16000,
-            "PCM_1CH_16BIT": 16000,
+            "PCM_2CH_16BIT": 48000,
+            "PCM_1CH_16BIT": 48000,
+            "ULAW_2CH": 48000,
+            "ULAW_1CH": 48000,
         }
         assert rig.browser_rx_transport == "auto"
         assert rig.browser_rx_transcode_to_opus is True
@@ -664,11 +666,13 @@ class TestAudioPolicy:
             "ULAW_1CH",
         )
         assert profile.tx_codec == "PCM_1CH_16BIT"
-        assert profile.default_sample_rate_hz == 16000
+        assert profile.default_sample_rate_hz == 48000
         assert profile.supported_sample_rates_hz is None
         assert profile.sample_rate_by_codec == {
-            "PCM_2CH_16BIT": 16000,
-            "PCM_1CH_16BIT": 16000,
+            "PCM_2CH_16BIT": 48000,
+            "PCM_1CH_16BIT": 48000,
+            "ULAW_2CH": 48000,
+            "ULAW_1CH": 48000,
         }
         assert profile.browser_rx_transport == "auto"
         assert profile.browser_rx_transcode_to_opus is True

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -15,7 +15,7 @@ class TestSyncInit:
 
     def test_default_sample_rate_uses_profile_policy(self) -> None:
         r = IcomRadio("192.168.1.100")
-        assert r.audio_sample_rate == 16000
+        assert r.audio_sample_rate == 48000
         r._loop.close()
 
     def test_custom_params(self) -> None:


### PR DESCRIPTION
## Summary

- update the IC-7610 LAN audio profile to prefer the hardware-probed 48 kHz radio-native matrix
- document the `[audio]` profile contract and the evidence-backed update rule
- extend runtime/profile tests so profile sample-rate policy is loaded and applied by LAN audio request resolution

## Validation

- `uv run pytest tests/test_rig_loader.py::TestAudioPolicy::test_ic7610_declares_pcm_first_lan_policy tests/test_audio_route.py::test_ic7610_lan_stream_request_uses_profile_audio_policy -q`
- `uv run pytest tests/test_audio_codec.py::TestRadioAudioConfig::test_default_codec tests/test_radio_connect.py::TestSendConninfo::test_tx_codec_is_mono_even_when_rx_codec_is_stereo tests/test_radio_connect.py::TestConnectSessionRejection::test_stereo_codec_fallback_succeeds tests/test_sync.py::TestSyncInit::test_default_sample_rate_uses_profile_policy -q`
- `uv run ruff check tests/test_rig_loader.py tests/test_audio_route.py tests/test_audio_codec.py tests/test_radio_connect.py tests/test_sync.py`
- `uv run pytest tests/test_rig_loader.py tests/test_audio_route.py tests/test_audio_codec.py tests/test_radio_connect.py tests/test_sync.py tests/test_profiles_runtime.py -q`
- `.github/scripts/check-rebrand-allowlist.sh`
- `uv run pytest -q`

Closes #1490
Refs #1482
Refs #1479
