### PR TITLE
Improve CLI launch UX and CW HTTP control

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -26,6 +26,7 @@ import argparse
 import asyncio
 from dataclasses import replace
 import errno
+import ipaddress
 import json
 import logging
 from logging.handlers import RotatingFileHandler
@@ -262,8 +263,9 @@ class _DeprecatedPassAction(argparse.Action):
         values: Any,
         option_string: str | None = None,
     ) -> None:
+        flag = option_string or "--pass"
         print(
-            "DeprecationWarning: --pass exposes the password on the process "
+            f"DeprecationWarning: {flag} exposes the password on the process "
             "command line (visible in `ps aux` and shell history). "
             "Use $ICOM_PASS or --pass-file PATH instead.",
             file=sys.stderr,
@@ -296,14 +298,143 @@ def _resolve_password(args: argparse.Namespace) -> str:
     return _get_env("ICOM_PASS", "")
 
 
+_COMMAND_NAMES = {
+    "status",
+    "freq",
+    "mode",
+    "power",
+    "meter",
+    "audio",
+    "ptt",
+    "cw",
+    "power-on",
+    "power-off",
+    "att",
+    "preamp",
+    "antenna",
+    "date",
+    "time",
+    "dualwatch",
+    "tuner",
+    "levels",
+    "discover",
+    "serve",
+    "web",
+    "station",
+    "proxy",
+    "scope",
+    "diagnose",
+}
+
+_GLOBAL_CONNECTION_OPTIONS = {
+    "--host",
+    "--control-port",
+    "--port",
+    "--user",
+    "--pass",
+    "--password",
+    "--pass-file",
+    "--timeout",
+    "--backend",
+    "--serial-port",
+    "--serial-baud",
+    "--serial-ptt-mode",
+    "--rx-device",
+    "--tx-device",
+    "--model",
+    "--radio-addr",
+}
+
+
+def _argv_tokens(args: list[str] | None) -> list[str]:
+    return list(sys.argv[1:] if args is None else args)
+
+
+def _token_matches_option(token: str, options: set[str]) -> bool:
+    name = token.split("=", 1)[0]
+    return name in options
+
+
+def _first_command_index(argv: list[str]) -> int | None:
+    for index, token in enumerate(argv):
+        if token in _COMMAND_NAMES:
+            return index
+    return None
+
+
+def _has_global_connection_options_after_command(argv: list[str]) -> bool:
+    command_index = _first_command_index(argv)
+    if command_index is None:
+        return False
+    return any(
+        _token_matches_option(token, _GLOBAL_CONNECTION_OPTIONS)
+        for token in argv[command_index + 1 :]
+    )
+
+
+def _print_common_cli_hint(argv: list[str]) -> None:
+    if "discover" in argv and "web" in argv:
+        print(
+            "\nHint: do not combine 'discover' and 'web'. "
+            "'web' can auto-discover the radio, or you can pass the radio explicitly:\n"
+            "  rigplane web\n"
+            "  rigplane web --radio-host 192.168.55.40 --radio-user USER "
+            "--radio-pass-file /path/to/password\n",
+            file=sys.stderr,
+        )
+        return
+
+    if _has_global_connection_options_after_command(argv):
+        print(
+            "\nHint: radio connection options normally go before the command:\n"
+            "  rigplane --backend lan --host 192.168.55.40 --user USER "
+            "--pass-file /path/to/password web\n\n"
+            "For the web UI, the more readable form is also supported:\n"
+            "  rigplane web --radio-host 192.168.55.40 --radio-user USER "
+            "--radio-pass-file /path/to/password\n",
+            file=sys.stderr,
+        )
+
+
+def _looks_like_explicit_radio_ip(value: str) -> bool:
+    try:
+        address = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return not (address.is_loopback or address.is_unspecified)
+
+
+def _warn_web_host_ambiguity(args: argparse.Namespace) -> None:
+    if getattr(args, "command", None) != "web":
+        return
+    if getattr(args, "host", _HOST_NOT_SET) != _HOST_NOT_SET:
+        return
+    web_host = getattr(args, "web_host", "")
+    if not web_host or not _looks_like_explicit_radio_ip(web_host):
+        return
+    print(
+        "Warning: 'rigplane web --host ...' sets the web server listen address, "
+        "not the radio IP. If you meant the radio, use "
+        "'rigplane web --radio-host ...' or 'rigplane --host ... web'.",
+        file=sys.stderr,
+    )
+
+
 class _RigplaneArgumentParser(argparse.ArgumentParser):
     def parse_args(
         self,
         args: list[str] | None = None,
         namespace: argparse.Namespace | None = None,
     ) -> argparse.Namespace:
-        parsed = super().parse_args(args, namespace)
+        argv = _argv_tokens(args)
+        try:
+            parsed = super().parse_args(args, namespace)
+        except SystemExit as exc:
+            if exc.code != 0:
+                _print_common_cli_hint(argv)
+            raise
         _apply_managed_runtime_defaults(parsed)
+        _warn_web_host_ambiguity(parsed)
         return parsed
 
 
@@ -335,7 +466,7 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=(
             "examples:\n"
             "  rigplane web                          # auto-discover radio, start web UI\n"
-            "  rigplane web --host 192.168.55.40     # explicit radio IP\n"
+            "  rigplane web --radio-host 192.168.55.40  # explicit radio IP\n"
             "  rigplane web --preset digimode        # bridge + rigctld + WSJT-X compat\n"
             "  rigplane web --bridge                 # web UI + audio bridge\n"
             "  rigplane serve                        # rigctld server only\n"
@@ -382,6 +513,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Deprecated: exposes password in `ps aux`/shell history. "
             "Prefer $ICOM_PASS or --pass-file PATH."
+        ),
+    )
+    p.add_argument(
+        "--password",
+        dest="password_cli",
+        default=None,
+        action=_DeprecatedPassAction,
+        help=(
+            "Alias for --pass. Deprecated: exposes password in process list "
+            "and shell history. Prefer $ICOM_PASS or --pass-file PATH."
         ),
     )
     p.add_argument(
@@ -927,6 +1068,56 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="NAME",
         help=f"Apply a named preset ({', '.join(_PRESETS)}). User flags override preset values.",
+    )
+    web_radio = web_p.add_argument_group("radio connection")
+    web_radio.add_argument(
+        "--radio-host",
+        dest="host",
+        default=argparse.SUPPRESS,
+        metavar="HOST",
+        help="Radio IP/hostname for the web UI backend",
+    )
+    web_radio.add_argument(
+        "--radio-user",
+        dest="user",
+        default=argparse.SUPPRESS,
+        metavar="USER",
+        help="Radio username for the web UI backend",
+    )
+    web_radio.add_argument(
+        "--radio-pass-file",
+        dest="pass_file",
+        default=argparse.SUPPRESS,
+        metavar="PATH",
+        help="Read radio password from file",
+    )
+    web_radio.add_argument(
+        "--radio-password",
+        "--password",
+        dest="password_cli",
+        default=argparse.SUPPRESS,
+        action=_DeprecatedPassAction,
+        metavar="PASSWORD",
+        help=(
+            "Radio password. Deprecated: exposes password in process list "
+            "and shell history. Prefer --radio-pass-file."
+        ),
+    )
+    web_radio.add_argument(
+        "--radio-control-port",
+        dest="control_port",
+        type=int,
+        default=argparse.SUPPRESS,
+        metavar="PORT",
+        help="Radio control port (default: $ICOM_PORT or 50001)",
+    )
+    web_radio.add_argument(
+        "--radio-backend",
+        dest="backend",
+        choices=["lan", "serial", "yaesu-cat"],
+        default=argparse.SUPPRESS,
+        metavar="TYPE",
+        help="Radio backend type for the web UI backend",
     )
     web_p.add_argument(
         "--host",

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1914,7 +1914,7 @@ class WebServer:
         headers: dict[str, str] | None = None,
         reader: asyncio.StreamReader | None = None,
     ) -> None:
-        """Handle POST /api/v1/radio/{disconnect,connect,power}."""
+        """Handle POST /api/v1/radio/{disconnect,connect,power,cw/send,cw/stop}."""
         radio = self._radio
         if radio is None:
             body = json.dumps(
@@ -2012,9 +2012,134 @@ class WebServer:
                     self._radio_state.power_on = is_on
                 self._on_radio_state_change("powerstat_changed", {"power_on": is_on})
                 resp = {"status": "ok", "power": power_state}
+            elif path == "/api/v1/radio/cw/send":
+                body_bytes = b""
+                if reader is not None:
+                    cl = int((headers or {}).get("content-length", "0"))
+                    if cl > 0:
+                        read_result = await _read_capped_body(reader, cl)
+                        if read_result is None:
+                            err = json.dumps(
+                                {"error": "request_too_large"},
+                                separators=(",", ":"),
+                            ).encode()
+                            await _send_response(
+                                writer,
+                                413,
+                                "Content Too Large",
+                                err,
+                                {"Content-Type": "application/json"},
+                            )
+                            writer.close()
+                            return
+                        body_bytes = read_result
+                if not body_bytes:
+                    err = json.dumps(
+                        {
+                            "error": "missing_body",
+                            "message": "JSON body with 'text' required",
+                        },
+                        separators=(",", ":"),
+                    ).encode()
+                    await _send_response(
+                        writer,
+                        400,
+                        "Bad Request",
+                        err,
+                        {"Content-Type": "application/json"},
+                    )
+                    return
+                payload = json.loads(body_bytes)
+                text = payload.get("text") if isinstance(payload, dict) else None
+                if not isinstance(text, str):
+                    err = json.dumps(
+                        {
+                            "error": "invalid_text",
+                            "message": "text must be a string",
+                        },
+                        separators=(",", ":"),
+                    ).encode()
+                    await _send_response(
+                        writer,
+                        400,
+                        "Bad Request",
+                        err,
+                        {"Content-Type": "application/json"},
+                    )
+                    return
+                handler = ControlHandler(
+                    None,  # type: ignore[arg-type]
+                    radio,
+                    __version__,
+                    self._config.radio_model,
+                    server=self,
+                    read_only=self._config.read_only,
+                )
+                resp = await handler._enqueue_command(  # noqa: SLF001
+                    "send_cw_text",
+                    {"text": text},
+                )
+            elif path == "/api/v1/radio/cw/stop":
+                handler = ControlHandler(
+                    None,  # type: ignore[arg-type]
+                    radio,
+                    __version__,
+                    self._config.radio_model,
+                    server=self,
+                    read_only=self._config.read_only,
+                )
+                resp = await handler._enqueue_command(  # noqa: SLF001
+                    "stop_cw_text",
+                    {},
+                )
             else:
                 await _send_response(writer, 404, "Not Found", b"", {})
                 return
+        except PermissionError as exc:
+            body = json.dumps(
+                {"error": "read_only", "message": str(exc)},
+                separators=(",", ":"),
+            ).encode()
+            await _send_response(
+                writer,
+                403,
+                "Forbidden",
+                body,
+                {"Content-Type": "application/json"},
+            )
+            return
+        except ValueError as exc:
+            body = json.dumps(
+                {"error": "invalid_request", "message": str(exc)},
+                separators=(",", ":"),
+            ).encode()
+            await _send_response(
+                writer,
+                400,
+                "Bad Request",
+                body,
+                {"Content-Type": "application/json"},
+            )
+            return
+        except RuntimeError as exc:
+            message = str(exc)
+            status, reason, code = (
+                (409, "Conflict", "unsupported_command")
+                if "does not support" in message
+                else (500, "Internal Server Error", "command_failed")
+            )
+            body = json.dumps(
+                {"error": code, "message": message},
+                separators=(",", ":"),
+            ).encode()
+            await _send_response(
+                writer,
+                status,
+                reason,
+                body,
+                {"Content-Type": "application/json"},
+            )
+            return
         except Exception as exc:
             body = json.dumps(
                 {"error": str(exc)},

--- a/src/rigplane/web/web_routing.py
+++ b/src/rigplane/web/web_routing.py
@@ -92,6 +92,8 @@ async def dispatch_http_request(
         "/api/v1/radio/disconnect",
         "/api/v1/radio/connect",
         "/api/v1/radio/power",
+        "/api/v1/radio/cw/send",
+        "/api/v1/radio/cw/stop",
     ):
         if method != "POST":
             await _send_response(writer, 405, "Method Not Allowed", b"", {})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from rigplane.cli import (
+    _HOST_NOT_SET,
     _build_backend_config,
     _build_parser,
     _parse_frequency,
@@ -283,6 +284,14 @@ class TestPasswordResolution:
         assert "--pass" in err
         assert "ICOM_PASS" in err
 
+    def test_password_alias_matches_user_expectation(self, monkeypatch):
+        monkeypatch.delenv("ICOM_PASS", raising=False)
+        p = _build_parser()
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            args = p.parse_args(["--password", "cli-secret", "status"])
+        assert _resolve_password(args) == "cli-secret"
+        assert "--password" in mock_stderr.getvalue()
+
     def test_no_warning_without_cli_pass(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ICOM_PASS", "env-secret")
         p = _build_parser()
@@ -328,6 +337,75 @@ class TestPasswordResolution:
         p = _build_parser()
         args = p.parse_args(["--timeout", "10", "status"])
         assert args.timeout == 10.0
+
+    def test_web_accepts_radio_connection_options_after_command(self, tmp_path):
+        pw_file = tmp_path / "pw.txt"
+        pw_file.write_text("secret\n", encoding="utf-8")
+
+        p = _build_parser()
+        args = p.parse_args(
+            [
+                "web",
+                "--radio-host",
+                "192.168.55.40",
+                "--radio-user",
+                "moroz",
+                "--radio-pass-file",
+                str(pw_file),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8080",
+            ]
+        )
+
+        assert args.command == "web"
+        assert args.host == "192.168.55.40"
+        assert args.user == "moroz"
+        assert args.pass_file == str(pw_file)
+        assert args.web_host == "127.0.0.1"
+        assert args.web_port == 8080
+
+    def test_web_warns_when_host_looks_like_radio_ip(self):
+        p = _build_parser()
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            args = p.parse_args(["web", "--host", "192.168.55.40"])
+
+        assert args.web_host == "192.168.55.40"
+        assert args.host == _HOST_NOT_SET
+        assert "--radio-host" in mock_stderr.getvalue()
+
+    def test_discover_web_common_mistake_gets_human_hint(self):
+        p = _build_parser()
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            with pytest.raises(SystemExit):
+                p.parse_args(
+                    [
+                        "discover",
+                        "--backend",
+                        "lan",
+                        "--host",
+                        "192.168.55.40",
+                        "--user",
+                        "moroz",
+                        "--password",
+                        "secret",
+                        "web",
+                    ]
+                )
+
+        err = mock_stderr.getvalue()
+        assert "do not combine 'discover' and 'web'" in err
+        assert "rigplane web --radio-host 192.168.55.40" in err
+
+    def test_web_help_does_not_print_error_hint(self):
+        p = _build_parser()
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            with pytest.raises(SystemExit) as exc_info:
+                p.parse_args(["web", "--radio-host", "192.168.55.40", "--help"])
+
+        assert exc_info.value.code == 0
+        assert "Hint:" not in mock_stderr.getvalue()
 
     def test_no_command_prints_help(self):
         p = _build_parser()

--- a/tests/test_web_cw_http_control.py
+++ b/tests/test_web_cw_http_control.py
@@ -1,0 +1,119 @@
+"""HTTP CW control endpoints for local app integrations."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.capabilities import CAP_CW
+from rigplane.web.server import WebConfig, WebServer
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+    def get_extra_info(self, name: str, default=None):
+        if name == "peername":
+            return ("127.0.0.1", 55555)
+        return default
+
+    @property
+    def response_status(self) -> int:
+        line = self.buffer.split(b"\r\n", 1)[0]
+        return int(line.split(b" ")[1])
+
+    @property
+    def response_body(self) -> dict:
+        body = self.buffer.split(b"\r\n\r\n", 1)[1]
+        return json.loads(body) if body else {}
+
+
+def _reader_for(payload: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(payload)
+    reader.feed_eof()
+    return reader
+
+
+def _cw_radio() -> MagicMock:
+    radio = MagicMock()
+    radio.capabilities = {CAP_CW}
+    radio.send_cw_text = AsyncMock()
+    radio.stop_cw_text = AsyncMock()
+    return radio
+
+
+@pytest.mark.asyncio
+async def test_http_cw_send_calls_radio_send_cw_text() -> None:
+    radio = _cw_radio()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    payload = json.dumps({"text": "CQ CQ DE KN4KYD"}).encode()
+    writer = _FakeWriter()
+
+    await srv._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/radio/cw/send",
+        headers={"content-length": str(len(payload))},
+        reader=_reader_for(payload),
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body == {"text": "CQ CQ DE KN4KYD"}
+    radio.send_cw_text.assert_awaited_once_with("CQ CQ DE KN4KYD")
+
+
+@pytest.mark.asyncio
+async def test_http_cw_stop_calls_radio_stop_cw_text() -> None:
+    radio = _cw_radio()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    writer = _FakeWriter()
+
+    await srv._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/radio/cw/stop",
+        headers={"content-length": "0"},
+        reader=_reader_for(b""),
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body == {}
+    radio.stop_cw_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_cw_send_respects_read_only_mode() -> None:
+    radio = _cw_radio()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0, read_only=True))
+    payload = json.dumps({"text": "CQ"}).encode()
+    writer = _FakeWriter()
+
+    await srv._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/radio/cw/send",
+        headers={"content-length": str(len(payload))},
+        reader=_reader_for(payload),
+    )
+
+    assert writer.response_status == 403
+    assert writer.response_body["error"] == "read_only"
+    radio.send_cw_text.assert_not_awaited()


### PR DESCRIPTION
## Summary
- improve CLI launch guidance and add clearer web radio aliases
- expose direct CW send/stop HTTP endpoints for local app integrations
- add focused tests for CLI parsing and CW HTTP control

## Verification
- uv run ruff check src/rigplane/cli/__init__.py src/rigplane/web/server.py src/rigplane/web/web_routing.py tests/test_cli.py tests/test_web_cw_http_control.py
- uv run pytest -q tests/test_cli.py tests/test_web_cw_http_control.py tests/test_web_post_body_cap.py tests/test_handlers_coverage.py::test_send_cw_text_calls_radio_method tests/test_handlers_coverage.py::test_stop_cw_text_calls_radio_method