### PR TITLE
fix(audio): repair IC-7610 web audio hotfixes

### DIFF
--- a/frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte
+++ b/frontend/src/components-v2/panels/vfo/DualVfoDisplay.svelte
@@ -77,10 +77,4 @@
     border-radius: 4px;
     transition: box-shadow 150ms ease;
   }
-
-  .dual-vfo-tile.is-active {
-    /* Active highlight is rendered by the inner VfoPanel.active class.
-       This selector exists so tests and external CSS can target the
-       outer tile without reaching into the panel. */
-  }
 </style>

--- a/frontend/src/lib/Button/__tests__/ControlledHarness.svelte
+++ b/frontend/src/lib/Button/__tests__/ControlledHarness.svelte
@@ -14,7 +14,11 @@
 
   let { family = 'control', initial = false }: Props = $props();
 
-  let active = $state(initial);
+  let active = $state(false);
+
+  $effect(() => {
+    active = initial;
+  });
 </script>
 
 <!-- data-testid="parent-toggle" lets the test drive parent state externally -->

--- a/frontend/src/lib/audio/__tests__/audio-manager.test.ts
+++ b/frontend/src/lib/audio/__tests__/audio-manager.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rxStart = vi.fn();
+const rxStop = vi.fn();
+const rxFlush = vi.fn();
+const rxSetJitterBounds = vi.fn();
+const txStart = vi.fn().mockResolvedValue(null);
+const txStop = vi.fn();
+
+vi.mock('../rx-player', () => ({
+  RxPlayer: class {
+    start = rxStart;
+    stop = rxStop;
+    flush = rxFlush;
+    setJitterBounds = rxSetJitterBounds;
+    setFocus = vi.fn();
+    setSplitStereo = vi.fn();
+    setChannelGainDb = vi.fn();
+    get focus() { return 'main'; }
+    get splitStereo() { return true; }
+    get mainGainDb() { return 0; }
+    get subGainDb() { return 0; }
+    set volume(_value: number) {}
+  },
+}));
+
+vi.mock('../tx-mic', () => ({
+  TxMic: class {
+    start = txStart;
+    stop = txStop;
+    static supported() { return true; }
+  },
+}));
+
+vi.mock('../../stores/connection.svelte', () => ({
+  setAudioConnected: vi.fn(),
+}));
+
+vi.mock('../../stores/audio.svelte', () => ({
+  setRxEnabled: vi.fn(),
+  setTxEnabled: vi.fn(),
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => null),
+}));
+
+class FakeWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType = '';
+  sent: unknown[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  constructor(_url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: unknown) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = 3;
+  }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+}
+
+describe('AudioManager websocket subscriptions', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5173' });
+  });
+
+  it('sends rx audio_start when startRx is called after config already opened the websocket', async () => {
+    const { audioManager } = await import('../audio-manager');
+
+    audioManager.setAudioConfig({ focus: 'main', split_stereo: true });
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    ws.sent = [];
+
+    audioManager.startRx();
+
+    expect(ws.sent).toContain(JSON.stringify({ type: 'audio_start', direction: 'rx' }));
+  });
+
+  it('sends rx audio_stop before closing an open websocket', async () => {
+    const { audioManager } = await import('../audio-manager');
+
+    audioManager.startRx();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    ws.sent = [];
+
+    audioManager.stopRx();
+
+    expect(ws.sent).toContain(JSON.stringify({ type: 'audio_stop', direction: 'rx' }));
+  });
+});

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -91,6 +91,9 @@ class AudioManager {
     }
     this.rxPlayer.start();
     this.connect();
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: 'audio_start', direction: 'rx' }));
+    }
     this.notify();
   }
 
@@ -98,6 +101,9 @@ class AudioManager {
     if (!this._rxEnabled) return;
     this._rxEnabled = false;
     setRxEnabled(false);
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: 'audio_stop', direction: 'rx' }));
+    }
     this.rxPlayer.stop();
     this.maybeDisconnect();
     this.notify();

--- a/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
+++ b/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
@@ -798,62 +798,6 @@
   }
   .bridge .speak:hover { color: var(--v2-accent-cyan, #00D4FF); }
 
-  /* vbtn */
-  .vbtn {
-    display: inline-flex; align-items: center; justify-content: center;
-    min-height: var(--btn-min-height);
-    padding: var(--btn-padding-block) var(--btn-padding-inline);
-    appearance: none;
-    background: linear-gradient(180deg, var(--ctrl-top) 0%, var(--ctrl-bot) 100%);
-    border: 1px solid var(--v2-border-dark, #18202A);
-    border-radius: var(--btn-border-radius);
-    color: var(--v2-text-subdued, #8ca0b8);
-    font-family: inherit; font-size: var(--btn-font-size);
-    font-weight: var(--btn-font-weight); letter-spacing: var(--btn-letter-spacing);
-    line-height: 1; text-transform: uppercase; white-space: nowrap; cursor: pointer;
-    box-shadow: inset 0 1px 0 var(--ctrl-hl);
-    transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
-    --glow-color: var(--v2-accent-cyan, #00D4FF);
-  }
-  .vbtn:hover { color: var(--v2-text-bright, #F0F5FA); background: var(--v2-bg-gradient-start, #0d1117); }
-  .vbtn--compact {
-    min-height: var(--btn-compact-min-height);
-    padding: var(--btn-compact-padding-block) var(--btn-compact-padding-inline);
-    font-size: var(--btn-compact-font-size);
-  }
-  .vbtn[data-color="cyan"]   { --glow-color: var(--v2-accent-cyan, #00D4FF); }
-  .vbtn[data-color="amber"]  { --glow-color: var(--v2-accent-yellow, #F2CF4A); }
-  .vbtn[data-color="orange"] { --glow-color: var(--v2-accent-orange, #FF6A00); }
-  .vbtn[data-color="red"]    { --glow-color: var(--v2-accent-red, #FF2020); }
-
-  .vbtn[data-surface="hardware"] {
-    background: linear-gradient(180deg, var(--hw-top-1) 0%, var(--hw-top-2) 14%, var(--hw-mid) 52%, var(--hw-bot) 100%);
-  }
-
-  .vbtn.active {
-    background: linear-gradient(180deg,
-      color-mix(in srgb, var(--glow-color) 22%, var(--ctrl-top)) 0%,
-      color-mix(in srgb, var(--glow-color) 12%, var(--ctrl-bot)) 100%);
-    border-color: color-mix(in srgb, var(--glow-color) 48%, transparent);
-    color: var(--v2-text-bright, #F0F5FA);
-    box-shadow:
-      0 0 0 1px color-mix(in srgb, var(--glow-color) 12%, transparent),
-      0 0 8px color-mix(in srgb, var(--glow-color) 7%, transparent),
-      inset 0 1px 0 var(--ctrl-hl);
-  }
-  .vbtn[data-indicator="dot"] { padding-left: 18px; position: relative; }
-  .vbtn[data-indicator="dot"]::before {
-    content: ""; position: absolute; left: 6px; top: 50%;
-    width: 5px; height: 5px; border-radius: 999px;
-    transform: translateY(-50%);
-    border: 1px solid color-mix(in srgb, var(--glow-color) 52%, var(--v2-border-dark, #18202A));
-    background: transparent;
-  }
-  .vbtn[data-indicator="dot"].active::before {
-    background: var(--glow-color); border-color: var(--glow-color);
-    box-shadow: 0 0 6px color-mix(in srgb, var(--glow-color) 30%, transparent);
-  }
-
   /* Stacked layout for narrow viewports */
   @media (max-width: 900px) {
     .sdr-panel { grid-template-columns: 1fr; }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
             'src/components-v2/panels/__tests__/AudioRoutingControl.test.ts',
             'src/lib/stores/radio.svelte.test.ts',
             'src/lib/runtime/__tests__/frontend-runtime.test.ts',
+            'src/lib/audio/__tests__/audio-manager.test.ts',
             'src/lib/radio/pending-focus.test.ts',
             // *.component(.svelte).test.ts mount real Svelte components and
             // depend on store mocks that vary across the suite. Under
@@ -109,6 +110,7 @@ export default defineConfig({
             'src/components-v2/panels/__tests__/AudioRoutingControl.test.ts',
             'src/lib/stores/radio.svelte.test.ts',
             'src/lib/runtime/__tests__/frontend-runtime.test.ts',
+            'src/lib/audio/__tests__/audio-manager.test.ts',
             'src/lib/radio/pending-focus.test.ts',
             'src/**/*.component.test.ts',
             'src/**/*.component.svelte.test.ts',

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -20,11 +20,12 @@ has_wifi = false
 # consumer transport after the server receives radio-native PCM.
 # Hardware probe: 2026-05-08, firmware 1.42,
 # `rigplane audio probe --candidate-cooldown 35 --retry-rejected 1`.
-# All conservative RX candidates passed at 48000/24000/16000/8000 Hz.
+# The initial probe saw packets at 48000/24000/16000/8000 Hz, but PCM
+# payload-size validation leaves valid PCM16 framing at 16000/8000 Hz.
 codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT", "ULAW_2CH", "ULAW_1CH"]
 tx_codec = "PCM_1CH_16BIT"
-default_sample_rate_hz = 48000
-sample_rate_by_codec = { PCM_2CH_16BIT = 48000, PCM_1CH_16BIT = 48000, ULAW_2CH = 48000, ULAW_1CH = 48000 }
+default_sample_rate_hz = 16000
+sample_rate_by_codec = { PCM_2CH_16BIT = 16000, PCM_1CH_16BIT = 16000, ULAW_2CH = 48000, ULAW_1CH = 48000 }
 browser_rx_transport = "auto"
 browser_rx_transcode_to_opus = true
 

--- a/src/rigplane/audio/probe.py
+++ b/src/rigplane/audio/probe.py
@@ -67,6 +67,7 @@ class AudioProbeResult:
     phase: str
     reason: str
     rx_payload_bytes: int | None = None
+    expected_rx_payload_bytes: int | None = None
     observed_packets: int | None = None
     error: str | None = None
 
@@ -79,6 +80,8 @@ class AudioProbeResult:
         }
         if self.rx_payload_bytes is not None:
             payload["rx_payload_bytes"] = self.rx_payload_bytes
+        if self.expected_rx_payload_bytes is not None:
+            payload["expected_rx_payload_bytes"] = self.expected_rx_payload_bytes
         if self.observed_packets is not None:
             payload["observed_packets"] = self.observed_packets
         if self.error:
@@ -112,6 +115,23 @@ class AudioProbeArtifact:
 
 def _channels_for_codec(codec: AudioCodec) -> int:
     return 2 if "_2CH" in codec.name else 1
+
+
+def expected_pcm16_rx_payload_bytes(candidate: AudioProbeCandidate) -> int | None:
+    """Return expected RX payload bytes for PCM16 candidates."""
+
+    if candidate.rx_codec not in {
+        AudioCodec.PCM_1CH_16BIT,
+        AudioCodec.PCM_2CH_16BIT,
+    }:
+        return None
+    return (
+        candidate.sample_rate_hz
+        * candidate.frame_ms
+        * candidate.rx_channels
+        * 2
+        // 1000
+    )
 
 
 def build_stock_radio_lan_probe_matrix(
@@ -192,5 +212,6 @@ __all__ = [
     "AudioProbeStatus",
     "build_stock_radio_lan_probe_matrix",
     "classify_stock_radio_lan_probe_error",
+    "expected_pcm16_rx_payload_bytes",
     "profile_policy_from_probe_results",
 ]

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -47,6 +47,7 @@ from rigplane.audio.probe import (  # noqa: E402
     AudioProbeResult,
     AudioProbeStatus,
     build_stock_radio_lan_probe_matrix,
+    expected_pcm16_rx_payload_bytes,
 )
 from rigplane.audio.probe_profile import (  # noqa: E402
     AudioProfileProposalError,
@@ -2117,12 +2118,27 @@ async def _attempt_stock_radio_lan_audio_probe(
             await radio.stop_audio_rx_opus()
 
     if packets > 0:
+        expected_payload_bytes = expected_pcm16_rx_payload_bytes(candidate)
+        if (
+            expected_payload_bytes is not None
+            and payload_bytes != expected_payload_bytes
+        ):
+            return AudioProbeResult(
+                candidate=candidate,
+                status=AudioProbeStatus.FAILED,
+                phase="rx",
+                reason="pcm-payload-size-mismatch",
+                rx_payload_bytes=payload_bytes,
+                expected_rx_payload_bytes=expected_payload_bytes,
+                observed_packets=packets,
+            )
         return AudioProbeResult(
             candidate=candidate,
             status=AudioProbeStatus.PASS,
             phase="rx",
             reason="rx-payload-stable",
             rx_payload_bytes=payload_bytes,
+            expected_rx_payload_bytes=expected_payload_bytes,
             observed_packets=packets,
         )
     return AudioProbeResult(

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -183,9 +183,9 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def start_audio_tx_pcm(
         self,
         *,
-        sample_rate: int = 48000,
-        channels: int = 1,
-        frame_ms: int = 20,
+        sample_rate: int | None = None,
+        channels: int | None = None,
+        frame_ms: int | None = None,
     ) -> None:
         """Start transmitting PCM audio to the radio.
 
@@ -205,6 +205,16 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
             AudioCodecBackendError: If TX codec is Opus and backend is unavailable.
             AudioFormatError: If PCM format is unsupported.
         """
+        contract = getattr(self, "_audio_stream_contract", None)
+        if sample_rate is None:
+            sample_rate = getattr(contract, "tx_sample_rate_hz", None) or getattr(
+                self, "_audio_tx_sample_rate", 48000
+            )
+        if channels is None:
+            channels = getattr(contract, "tx_channels", None) or 1
+        if frame_ms is None:
+            frame_ms = 20
+
         for name, value in (
             ("sample_rate", sample_rate),
             ("channels", channels),

--- a/src/rigplane/runtime/_runtime_protocols.py
+++ b/src/rigplane/runtime/_runtime_protocols.py
@@ -296,9 +296,9 @@ class AudioRuntimeHost(Protocol):
     async def start_audio_tx_pcm(
         self,
         *,
-        sample_rate: int,
-        channels: int,
-        frame_ms: int,
+        sample_rate: int | None = None,
+        channels: int | None = None,
+        frame_ms: int | None = None,
     ) -> None: ...
 
     async def start_audio_tx_opus(self) -> None: ...

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -637,7 +637,12 @@ class AudioHandler:
                 if self._radio and CAP_AUDIO in self._radio.capabilities:
                     self._ensure_tx_transcoder()
                     try:
-                        await self._radio.start_audio_tx_opus()  # type: ignore[attr-defined]
+                        if self._tx_codec() == AudioCodec.PCM_1CH_16BIT:
+                            await self._radio.start_audio_tx_pcm(  # type: ignore[attr-defined]
+                                sample_rate=self._tx_sample_rate()
+                            )
+                        else:
+                            await self._radio.start_audio_tx_opus()  # type: ignore[attr-defined]
                     except RuntimeError as exc:
                         if "Already transmitting" in str(exc):
                             logger.info("audio: TX already started by poller, reusing")
@@ -650,7 +655,10 @@ class AudioHandler:
                 await self._stop_rx()
             elif direction == "tx":
                 if self._radio and CAP_AUDIO in self._radio.capabilities:
-                    await self._radio.stop_audio_tx_opus()  # type: ignore[attr-defined]
+                    if self._tx_codec() == AudioCodec.PCM_1CH_16BIT:
+                        await self._radio.stop_audio_tx_pcm()  # type: ignore[attr-defined]
+                    else:
+                        await self._radio.stop_audio_tx_opus()  # type: ignore[attr-defined]
                 self._tx_active = False
                 logger.info("audio: TX stopped")
         elif msg_type == "audio_config":
@@ -768,7 +776,10 @@ class AudioHandler:
         and the radio silently dropped TX audio. Called on ``audio_start
         direction=tx``, when the rate is guaranteed available.
         """
-        sr = getattr(self._radio, "audio_sample_rate", None)
+        contract = getattr(self._radio, "audio_stream_contract", None)
+        sr = getattr(contract, "tx_sample_rate_hz", None)
+        if not isinstance(sr, int) or isinstance(sr, bool) or sr <= 0:
+            sr = getattr(self._radio, "audio_sample_rate", None)
         rate = (
             sr if isinstance(sr, int) and not isinstance(sr, bool) and sr > 0 else 48000
         )
@@ -782,6 +793,20 @@ class AudioHandler:
             logger.debug("audio: TX transcoder unavailable (opus codec missing?)")
             self._transcoder = None
             self._transcoder_rate = 0
+
+    def _tx_codec(self) -> AudioCodec | None:
+        contract = getattr(self._radio, "audio_stream_contract", None)
+        tx_codec = getattr(contract, "tx_codec", None)
+        if tx_codec is not None:
+            return tx_codec
+        return getattr(self._radio, "audio_codec", None)
+
+    def _tx_sample_rate(self) -> int:
+        contract = getattr(self._radio, "audio_stream_contract", None)
+        tx_sr = getattr(contract, "tx_sample_rate_hz", None)
+        if isinstance(tx_sr, int) and not isinstance(tx_sr, bool) and tx_sr > 0:
+            return tx_sr
+        return 48000
 
     async def _start_rx(self) -> None:
         """Subscribe to audio broadcaster for RX frames."""
@@ -826,9 +851,9 @@ class AudioHandler:
         opus_data = payload[AUDIO_HEADER_SIZE:]
         if opus_data:
             try:
-                # Check if radio uses PCM codec → decode Opus → PCM
-                audio_codec = getattr(self._radio, "audio_codec", None)
-                if audio_codec == AudioCodec.PCM_1CH_16BIT and self._transcoder:
+                # Browser TX sends Opus; radio-native PCM TX must be decoded
+                # according to the accepted TX contract, not the RX codec.
+                if self._tx_codec() == AudioCodec.PCM_1CH_16BIT and self._transcoder:
                     try:
                         # Decode Opus → PCM16
                         pcm_data = self._transcoder.opus_to_pcm(opus_data)

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -69,6 +69,7 @@ from ..capabilities import (
 from .._queue_pressure import PRESSURE_THRESHOLD
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
+from ..types import AudioCodec
 
 if TYPE_CHECKING:
     from ..radio_protocol import Radio
@@ -160,6 +161,15 @@ _DEFAULT_POLL_FIELD_TTL: float = 0.2
 _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
+
+
+def _audio_tx_codec_and_rate(radio: Any) -> tuple[AudioCodec | None, int]:
+    contract = getattr(radio, "audio_stream_contract", None)
+    tx_codec = getattr(contract, "tx_codec", None)
+    tx_sr = getattr(contract, "tx_sample_rate_hz", None)
+    if not isinstance(tx_sr, int) or isinstance(tx_sr, bool) or tx_sr <= 0:
+        tx_sr = 48000
+    return tx_codec, tx_sr
 
 
 # ------------------------------------------------------------------
@@ -855,8 +865,16 @@ class RadioPoller:
                 # Start TX audio stream before PTT (LAN audio requires this)
                 if CAP_AUDIO in self._caps:
                     try:
-                        await radio.start_audio_tx_opus()
-                        logger.info("poller: TX audio stream started")
+                        tx_codec, tx_sr = _audio_tx_codec_and_rate(radio)
+                        if tx_codec == AudioCodec.PCM_1CH_16BIT:
+                            await radio.start_audio_tx_pcm(sample_rate=tx_sr)
+                        else:
+                            await radio.start_audio_tx_opus()
+                        logger.info(
+                            "poller: TX audio stream started (tx_codec=%s, sr=%d)",
+                            tx_codec,
+                            tx_sr,
+                        )
                     except Exception as e:
                         logger.warning("poller: start TX audio failed: %s", e)
                 await radio.set_ptt(True)
@@ -866,7 +884,11 @@ class RadioPoller:
                 # Stop TX audio stream after PTT, then restart RX
                 if CAP_AUDIO in self._caps:
                     try:
-                        await radio.stop_audio_tx_opus()
+                        tx_codec, _tx_sr = _audio_tx_codec_and_rate(radio)
+                        if tx_codec == AudioCodec.PCM_1CH_16BIT:
+                            await radio.stop_audio_tx_pcm()
+                        else:
+                            await radio.stop_audio_tx_opus()
                         logger.info("poller: TX audio stream stopped")
 
                         # Restart RX audio after TX (IC-7610 doesn't support full duplex)

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -34,11 +34,11 @@ class TestRadioAudioConfig:
     def test_default_codec(self) -> None:
         r = IcomRadio("192.168.1.100")
         assert r.audio_codec == AudioCodec.PCM_2CH_16BIT
-        assert r.audio_sample_rate == 48000
+        assert r.audio_sample_rate == 16000
         assert r.audio_stream_request.rx_codec == AudioCodec.PCM_2CH_16BIT
         assert r.audio_stream_request.tx_codec == AudioCodec.PCM_1CH_16BIT
-        assert r.audio_stream_request.rx_sample_rate_hz == 48000
-        assert r.audio_stream_request.tx_sample_rate_hz == 48000
+        assert r.audio_stream_request.rx_sample_rate_hz == 16000
+        assert r.audio_stream_request.tx_sample_rate_hz == 16000
         assert r.audio_stream_contract.rx_codec == r.audio_stream_request.rx_codec
         assert r.audio_stream_contract.tx_codec == r.audio_stream_request.tx_codec
         assert (

--- a/tests/test_audio_probe.py
+++ b/tests/test_audio_probe.py
@@ -9,6 +9,7 @@ from rigplane.audio.probe import (
     AudioProbeStatus,
     build_stock_radio_lan_probe_matrix,
     classify_stock_radio_lan_probe_error,
+    expected_pcm16_rx_payload_bytes,
     profile_policy_from_probe_results,
 )
 from rigplane.types import AudioCodec
@@ -48,6 +49,7 @@ def test_probe_artifact_serializes_machine_readable_evidence() -> None:
                 phase="rx",
                 reason="rx-payload-stable",
                 rx_payload_bytes=640,
+                expected_rx_payload_bytes=640,
                 observed_packets=50,
             )
         ],
@@ -61,6 +63,49 @@ def test_probe_artifact_serializes_machine_readable_evidence() -> None:
     assert data["results"][0]["candidate"]["rx_codec"] == "PCM_1CH_16BIT"
     assert data["results"][0]["status"] == "pass"
     assert data["results"][0]["rx_payload_bytes"] == 640
+    assert data["results"][0]["expected_rx_payload_bytes"] == 640
+
+
+def test_expected_pcm16_rx_payload_bytes_uses_frame_rate_channels_and_width() -> None:
+    assert (
+        expected_pcm16_rx_payload_bytes(
+            AudioProbeCandidate(
+                rx_codec=AudioCodec.PCM_2CH_16BIT,
+                tx_codec=AudioCodec.PCM_1CH_16BIT,
+                sample_rate_hz=48_000,
+                rx_channels=2,
+                tx_channels=1,
+                frame_ms=20,
+            )
+        )
+        == 3840
+    )
+    assert (
+        expected_pcm16_rx_payload_bytes(
+            AudioProbeCandidate(
+                rx_codec=AudioCodec.PCM_1CH_16BIT,
+                tx_codec=AudioCodec.PCM_1CH_16BIT,
+                sample_rate_hz=16_000,
+                rx_channels=1,
+                tx_channels=1,
+                frame_ms=20,
+            )
+        )
+        == 640
+    )
+    assert (
+        expected_pcm16_rx_payload_bytes(
+            AudioProbeCandidate(
+                rx_codec=AudioCodec.ULAW_2CH,
+                tx_codec=AudioCodec.PCM_1CH_16BIT,
+                sample_rate_hz=48_000,
+                rx_channels=2,
+                tx_channels=1,
+                frame_ms=20,
+            )
+        )
+        is None
+    )
 
 
 def test_stock_radio_lan_probe_error_classification_distinguishes_rejects() -> None:

--- a/tests/test_audio_probe_runner.py
+++ b/tests/test_audio_probe_runner.py
@@ -217,11 +217,11 @@ async def test_cmd_audio_probe_rejects_non_lan_backend(capsys) -> None:
 
 @pytest.mark.asyncio
 async def test_stock_radio_lan_attempt_is_rx_only(monkeypatch) -> None:
-    candidate = build_stock_radio_lan_probe_matrix()[0]
+    candidate = build_stock_radio_lan_probe_matrix(sample_rates_hz=(16_000,))[0]
     calls: list[str] = []
 
     class Packet:
-        data = b"\x00\x01" * 16
+        data = b"\x00" * 1280
 
     class FakeRadio:
         async def __aenter__(self):
@@ -255,5 +255,57 @@ async def test_stock_radio_lan_attempt_is_rx_only(monkeypatch) -> None:
 
     assert result.status is AudioProbeStatus.PASS
     assert result.observed_packets == 1
-    assert result.rx_payload_bytes == 32
+    assert result.rx_payload_bytes == 1280
+    assert result.expected_rx_payload_bytes == 1280
     assert calls == ["enter", "start-rx", "stop-rx", "exit"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sample_rate_hz", "payload_bytes", "expected_payload_bytes"),
+    [
+        (48_000, 1112, 3840),
+        (24_000, 556, 1920),
+    ],
+)
+async def test_stock_radio_lan_attempt_fails_pcm_payload_size_mismatch(
+    monkeypatch,
+    sample_rate_hz,
+    payload_bytes,
+    expected_payload_bytes,
+) -> None:
+    candidate = build_stock_radio_lan_probe_matrix(
+        sample_rates_hz=(sample_rate_hz,),
+    )[0]
+
+    class Packet:
+        data = b"\x00" * payload_bytes
+
+    class FakeRadio:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc_info):
+            pass
+
+        async def start_audio_rx_opus(self, callback):
+            callback(Packet())
+
+        async def stop_audio_rx_opus(self):
+            pass
+
+    monkeypatch.setattr("rigplane.cli.create_radio", lambda _config: FakeRadio())
+    config = LanBackendConfig(host="127.0.0.1", model="IC-7610")
+
+    result = await _attempt_stock_radio_lan_audio_probe(
+        config,
+        candidate,
+        duration_s=0,
+    )
+
+    assert result.status is AudioProbeStatus.FAILED
+    assert result.phase == "rx"
+    assert result.reason == "pcm-payload-size-mismatch"
+    assert result.rx_payload_bytes == payload_bytes
+    assert result.expected_rx_payload_bytes == expected_payload_bytes
+    assert result.observed_packets == 1

--- a/tests/test_audio_route.py
+++ b/tests/test_audio_route.py
@@ -93,8 +93,8 @@ def test_ic7610_lan_stream_request_uses_profile_audio_policy() -> None:
 
     assert request.rx_codec == AudioCodec.PCM_2CH_16BIT
     assert request.tx_codec == AudioCodec.PCM_1CH_16BIT
-    assert request.rx_sample_rate_hz == 48000
-    assert request.tx_sample_rate_hz == 48000
+    assert request.rx_sample_rate_hz == 16000
+    assert request.tx_sample_rate_hz == 16000
     assert request.rx_channels == 2
     assert request.tx_channels == 1
     assert request.rx_codec_source == AudioConfigSource.PROFILE_DEFAULT

--- a/tests/test_audio_rx_tx_transition.py
+++ b/tests/test_audio_rx_tx_transition.py
@@ -18,8 +18,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from rigplane.audio.route import AudioConfigSource, AudioStreamContract
 from rigplane.profiles import resolve_radio_profile
 from rigplane.rigctld.state_cache import StateCache
+from rigplane.types import AudioCodec
 from rigplane.web.radio_poller import (
     CommandQueue,
     PttOff,
@@ -180,3 +182,30 @@ async def test_multiple_ptt_cycles(poller: RadioPoller, radio: SimpleNamespace) 
     assert radio.stop_audio_tx_opus.await_count == 3
     assert radio.start_audio_rx_opus.await_count == 3
     assert radio.set_ptt.await_count == 6  # 3 ON + 3 OFF
+
+
+@pytest.mark.asyncio
+async def test_ptt_cycle_uses_pcm_when_audio_contract_tx_codec_is_pcm(
+    poller: RadioPoller, radio: SimpleNamespace
+) -> None:
+    """PTT transitions must follow the radio-native TX codec contract."""
+    radio.audio_stream_contract = AudioStreamContract(
+        rx_codec=AudioCodec.PCM_2CH_16BIT,
+        tx_codec=AudioCodec.PCM_1CH_16BIT,
+        rx_sample_rate_hz=16000,
+        tx_sample_rate_hz=16000,
+        rx_channels=2,
+        tx_channels=1,
+        rx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+        tx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+        rx_sample_rate_source=AudioConfigSource.PROFILE_DEFAULT,
+        tx_sample_rate_source=AudioConfigSource.PROFILE_DEFAULT,
+    )
+
+    await poller._execute(PttOn())
+    await poller._execute(PttOff())
+
+    radio.start_audio_tx_pcm.assert_awaited_once_with(sample_rate=16000)
+    radio.start_audio_tx_opus.assert_not_awaited()
+    radio.stop_audio_tx_pcm.assert_awaited_once()
+    radio.stop_audio_tx_opus.assert_not_awaited()

--- a/tests/test_audio_transcoder.py
+++ b/tests/test_audio_transcoder.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from rigplane.audio.route import AudioConfigSource, AudioStreamContract
 from rigplane.audio._transcoder import PcmAudioFormat, PcmOpusTranscoder
 from rigplane.audio import AudioPacket
 from rigplane.exceptions import (
@@ -317,6 +318,34 @@ class TestRadioPcmTxApi:
 
         await radio.start_audio_tx_pcm()
         assert fake_stream.start_tx_count == 1
+
+    @pytest.mark.asyncio
+    async def test_start_audio_tx_pcm_defaults_to_contract_sample_rate(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        radio._connected = True
+        radio._civ_transport = MagicMock()
+        fake_stream = FakeAudioStream()
+        radio._audio_stream = fake_stream  # type: ignore[assignment]
+        radio._audio_stream_contract = AudioStreamContract(
+            rx_codec=AudioCodec.PCM_2CH_16BIT,
+            tx_codec=AudioCodec.PCM_1CH_16BIT,
+            rx_sample_rate_hz=16000,
+            tx_sample_rate_hz=16000,
+            rx_channels=2,
+            tx_channels=1,
+            rx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+            tx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+            rx_sample_rate_source=AudioConfigSource.PROFILE_DEFAULT,
+            tx_sample_rate_source=AudioConfigSource.PROFILE_DEFAULT,
+        )
+        radio._audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+        radio._audio_tx_sample_rate = 16000
+
+        await radio.start_audio_tx_pcm()
+
+        assert fake_stream.start_tx_count == 1
+        assert radio._pcm_tx_fmt == (16000, 1, 20)
+        radio._connected = False
 
     @pytest.mark.asyncio
     async def test_push_audio_tx_pcm_frame_size_error(self) -> None:

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -9,6 +9,7 @@ import pytest
 
 from _caps import FULL_ICOM_CAPS
 from rigplane.profiles import resolve_radio_profile
+from rigplane.audio.route import AudioConfigSource, AudioStreamContract
 from rigplane.scope import ScopeFrame
 from rigplane.types import AudioCodec
 from rigplane.web.handlers import (
@@ -1433,6 +1434,56 @@ async def test_audio_handler_tx_other_runtime_error_propagates() -> None:
     handler = AudioHandler(ws, radio, None)
     with pytest.raises(RuntimeError, match="Something else"):
         await handler._handle_control({"type": "audio_start", "direction": "tx"})
+
+
+async def test_audio_handler_uses_tx_contract_for_pcm_browser_tx() -> None:
+    from rigplane.radio_protocol import AudioCapable
+
+    contract = AudioStreamContract(
+        rx_codec=AudioCodec.PCM_2CH_16BIT,
+        tx_codec=AudioCodec.PCM_1CH_16BIT,
+        rx_sample_rate_hz=16000,
+        tx_sample_rate_hz=16000,
+        rx_channels=2,
+        tx_channels=1,
+        rx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+        tx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+        rx_sample_rate_source=AudioConfigSource.PROFILE_DEFAULT,
+        tx_sample_rate_source=AudioConfigSource.PROFILE_DEFAULT,
+    )
+
+    class _FakeAudioRadio(AudioCapable):
+        capabilities = {"audio"}
+        audio_codec = AudioCodec.PCM_2CH_16BIT
+        audio_sample_rate = 16000
+        audio_stream_contract = contract
+        push_audio_tx_opus = AsyncMock()
+        push_audio_tx_pcm = AsyncMock()
+        start_audio_rx_opus = AsyncMock()
+        stop_audio_rx_opus = AsyncMock()
+        start_audio_tx_opus = AsyncMock()
+        stop_audio_tx_opus = AsyncMock()
+        start_audio_tx_pcm = AsyncMock()
+        stop_audio_tx_pcm = AsyncMock()
+        audio_bus = None
+
+    radio = _FakeAudioRadio()
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+    handler._transcoder = SimpleNamespace(opus_to_pcm=lambda data: b"pcm-frame")
+    handler._transcoder_rate = 16000
+    handler._tx_active = True
+
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+    await handler._handle_tx_audio(b"\x00" * AUDIO_HEADER_SIZE + b"opus-frame")
+    await handler._handle_control({"type": "audio_stop", "direction": "tx"})
+
+    radio.start_audio_tx_pcm.assert_awaited_once_with(sample_rate=16000)
+    radio.start_audio_tx_opus.assert_not_awaited()
+    radio.push_audio_tx_pcm.assert_awaited_once_with(b"pcm-frame")
+    radio.push_audio_tx_opus.assert_not_awaited()
+    radio.stop_audio_tx_pcm.assert_awaited_once()
+    radio.stop_audio_tx_opus.assert_not_awaited()
 
 
 async def test_audio_handler_run_resets_tx_active_on_exit() -> None:

--- a/tests/test_pcm_e2e.py
+++ b/tests/test_pcm_e2e.py
@@ -50,7 +50,7 @@ def _make_radio() -> IcomRadio:
     )
     # Pre-install dummy transcoder so _get_pcm_transcoder succeeds.
     radio._pcm_transcoder = _DummyTranscoder()  # type: ignore[assignment]
-    radio._pcm_transcoder_fmt = (48000, 1, 20)
+    radio._pcm_transcoder_fmt = (16000, 1, 20)
     # PR #1448 added a TX-codec branch in _push_audio_tx_pcm_internal: when
     # the negotiated TX codec is PCM_1CH_16BIT (the default for direct Icom
     # LAN), the frame is sent unchanged and the transcoder is bypassed.
@@ -74,7 +74,10 @@ class TestPcmRxE2E:
         radio = _make_radio()
         received: list[bytes | None] = []
 
-        await radio.start_audio_rx_pcm(lambda frame: received.append(frame))
+        await radio.start_audio_rx_pcm(
+            lambda frame: received.append(frame),
+            sample_rate=16000,
+        )
 
         # Grab the internal Opus-level callback that was registered.
         rx_cb = radio._audio_stream.start_rx.await_args.args[0]
@@ -98,7 +101,10 @@ class TestPcmRxE2E:
         radio = _make_radio()
         received: list[bytes | None] = []
 
-        await radio.start_audio_rx_pcm(lambda frame: received.append(frame))
+        await radio.start_audio_rx_pcm(
+            lambda frame: received.append(frame),
+            sample_rate=16000,
+        )
         rx_cb = radio._audio_stream.start_rx.await_args.args[0]
 
         rx_cb(AudioPacket(ident=0x0080, send_seq=1, data=b"\xaa"))
@@ -115,7 +121,10 @@ class TestPcmRxE2E:
         radio = _make_radio()
         received: list[bytes | None] = []
 
-        await radio.start_audio_rx_pcm(lambda frame: received.append(frame))
+        await radio.start_audio_rx_pcm(
+            lambda frame: received.append(frame),
+            sample_rate=16000,
+        )
         rx_cb = radio._audio_stream.start_rx.await_args.args[0]
 
         for seq in range(100):
@@ -140,10 +149,10 @@ class TestPcmTxE2E:
 
         await radio.start_audio_tx_pcm()
         radio._audio_stream.start_tx.assert_awaited_once()
-        assert radio._pcm_tx_fmt == (48000, 1, 20)
+        assert radio._pcm_tx_fmt == (16000, 1, 20)
 
         # Push a PCM frame.
-        pcm_frame = b"\x10\x00" * 960  # 1920 bytes = 960 samples × 2 bytes
+        pcm_frame = b"\x10\x00" * 320  # 640 bytes = 320 samples × 2 bytes
         await radio.push_audio_tx_pcm(pcm_frame)
 
         # Transcoder produces "opus:" + first 4 bytes of PCM.
@@ -159,7 +168,7 @@ class TestPcmTxE2E:
         await radio.start_audio_tx_pcm()
 
         for _ in range(10):
-            await radio.push_audio_tx_pcm(b"\x00\x01" * 960)
+            await radio.push_audio_tx_pcm(b"\x00\x01" * 320)
 
         assert radio._audio_stream.push_tx.await_count == 10
         await radio.stop_audio_tx_pcm()
@@ -191,7 +200,7 @@ class TestPcmLoopbackE2E:
 
         # Start TX first, then RX.
         await radio.start_audio_tx_pcm()
-        await radio.start_audio_rx_pcm(_on_pcm)
+        await radio.start_audio_rx_pcm(_on_pcm, sample_rate=16000)
 
         rx_cb = radio._audio_stream.start_rx.await_args.args[0]
 
@@ -204,10 +213,10 @@ class TestPcmLoopbackE2E:
         # Now drive the TX pipeline N times. The dummy transcoder's RX output
         # is a tagged byte string (not real PCM), so we can't feed it back
         # verbatim — the TX path validates frame size against PcmAudioFormat
-        # (1920 bytes for 48kHz/1ch/20ms). Use a properly-sized synthetic
+        # (640 bytes for 16kHz/1ch/20ms). Use a properly-sized synthetic
         # frame; the assertion only checks that TX was invoked once per RX
         # frame.
-        tx_frame = b"\x00" * 1920
+        tx_frame = b"\x00" * 640
         for frame in rx_frames:
             if frame is not None:
                 await radio.push_audio_tx_pcm(tx_frame)
@@ -233,7 +242,10 @@ class TestPcmStartStopCycles:
             radio = _make_radio()
             received: list[bytes | None] = []
 
-            await radio.start_audio_rx_pcm(lambda frame: received.append(frame))
+            await radio.start_audio_rx_pcm(
+                lambda frame: received.append(frame),
+                sample_rate=16000,
+            )
             rx_cb = radio._audio_stream.start_rx.await_args.args[0]
             rx_cb(AudioPacket(ident=0x0080, send_seq=0, data=b"\xcc"))
             assert received == [b"pcm:\xcc"]
@@ -247,7 +259,7 @@ class TestPcmStartStopCycles:
             radio = _make_radio()
 
             await radio.start_audio_tx_pcm()
-            await radio.push_audio_tx_pcm(b"\xaa\xbb" * 960)
+            await radio.push_audio_tx_pcm(b"\xaa\xbb" * 320)
             assert radio._audio_stream.push_tx.await_count == 1
 
             await radio.stop_audio_tx_pcm()
@@ -280,9 +292,9 @@ class TestPcmEdgeCases:
         radio._audio_stream.start_rx = AsyncMock(
             side_effect=[None, RuntimeError("Already receiving")],
         )
-        await radio.start_audio_rx_pcm(lambda _: None)
+        await radio.start_audio_rx_pcm(lambda _: None, sample_rate=16000)
         with pytest.raises(RuntimeError, match="Already receiving"):
-            await radio.start_audio_rx_pcm(lambda _: None)
+            await radio.start_audio_rx_pcm(lambda _: None, sample_rate=16000)
         await radio.stop_audio_rx_pcm()
 
     @pytest.mark.asyncio

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -219,8 +219,8 @@ class TestSendConninfo:
         )
         rx_sample = struct.unpack_from(">I", packet, 0x74)[0]
         tx_sample = struct.unpack_from(">I", packet, 0x78)[0]
-        assert rx_sample == 48000
-        assert tx_sample == 48000
+        assert rx_sample == 16000
+        assert tx_sample == 16000
 
     @pytest.mark.asyncio
     async def test_conninfo_honors_explicit_sample_rate_override(self) -> None:
@@ -594,8 +594,8 @@ class TestConnectSessionRejection:
         assert radio.audio_stream_request.rx_codec == AudioCodec.PCM_2CH_16BIT
         assert radio.audio_stream_contract.rx_codec == AudioCodec.PCM_1CH_16BIT
         assert radio.audio_stream_contract.tx_codec == AudioCodec.PCM_1CH_16BIT
-        assert radio.audio_stream_contract.rx_sample_rate_hz == 48000
-        assert radio.audio_stream_contract.tx_sample_rate_hz == 48000
+        assert radio.audio_stream_contract.rx_sample_rate_hz == 16000
+        assert radio.audio_stream_contract.tx_sample_rate_hz == 16000
         assert radio.audio_stream_contract.rx_codec_source == AudioConfigSource.FALLBACK
         assert (
             radio.audio_stream_contract.fallback_reason == "conninfo-stereo-rx-rejected"

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -647,11 +647,11 @@ class TestAudioPolicy:
             "ULAW_1CH",
         )
         assert rig.tx_codec == "PCM_1CH_16BIT"
-        assert rig.default_sample_rate_hz == 48000
+        assert rig.default_sample_rate_hz == 16000
         assert rig.supported_sample_rates_hz is None
         assert rig.sample_rate_by_codec == {
-            "PCM_2CH_16BIT": 48000,
-            "PCM_1CH_16BIT": 48000,
+            "PCM_2CH_16BIT": 16000,
+            "PCM_1CH_16BIT": 16000,
             "ULAW_2CH": 48000,
             "ULAW_1CH": 48000,
         }
@@ -666,11 +666,11 @@ class TestAudioPolicy:
             "ULAW_1CH",
         )
         assert profile.tx_codec == "PCM_1CH_16BIT"
-        assert profile.default_sample_rate_hz == 48000
+        assert profile.default_sample_rate_hz == 16000
         assert profile.supported_sample_rates_hz is None
         assert profile.sample_rate_by_codec == {
-            "PCM_2CH_16BIT": 48000,
-            "PCM_1CH_16BIT": 48000,
+            "PCM_2CH_16BIT": 16000,
+            "PCM_1CH_16BIT": 16000,
             "ULAW_2CH": 48000,
             "ULAW_1CH": 48000,
         }

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -15,7 +15,7 @@ class TestSyncInit:
 
     def test_default_sample_rate_uses_profile_policy(self) -> None:
         r = IcomRadio("192.168.1.100")
-        assert r.audio_sample_rate == 48000
+        assert r.audio_sample_rate == 16000
         r._loop.close()
 
     def test_custom_params(self) -> None:


### PR DESCRIPTION
## Summary

- fix web TX startup to use the accepted radio-native TX contract instead of starting Opus against PCM-only IC-7610 LAN audio
- fix web RX LIVE toggling when the audio WebSocket is already open
- tighten `rigplane audio probe` PCM16 validation so packets with wrong payload size no longer count as passed evidence
- set the IC-7610 PCM default back to 16 kHz based on corrected payload-size interpretation
- remove existing Svelte check warnings in unrelated-but-touched frontend files

Closes #1493.
Closes #1494.
Closes #1495.

## Verification

- `uv run pytest -q` -> 5969 passed, 107 skipped, 3 deselected, 9 xfailed, 1 xpassed
- `uv run ruff check src/rigplane/audio/probe.py src/rigplane/cli/__init__.py tests/test_audio_probe.py tests/test_audio_probe_runner.py tests/test_rig_loader.py tests/test_audio_codec.py tests/test_audio_route.py tests/test_pcm_e2e.py tests/test_radio_connect.py tests/test_sync.py`
- `git diff --check`
- `npm run check` -> 0 errors, 0 warnings
- `npm run test` -> 96 files / 1729 tests passed
- `npm run build`
