### PR TITLE
ci: migrate workflow actions to Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -43,7 +43,7 @@ jobs:
         run: uv run mkdocs build --strict
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -26,10 +26,10 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -43,7 +43,7 @@ jobs:
         run: uv sync --extra dev --extra bridge
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -99,7 +99,7 @@ jobs:
 
       - name: Update tests badge
         if: matrix.python-version == '3.11' && github.ref == 'refs/heads/main' && always()
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: bce917f4007ac491e527e142564fbbae
@@ -110,7 +110,7 @@ jobs:
 
       - name: Update version badge
         if: matrix.python-version == '3.11' && github.ref == 'refs/heads/main' && always()
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: bce917f4007ac491e527e142564fbbae
@@ -121,7 +121,7 @@ jobs:
 
       - name: Update mypy badge
         if: matrix.python-version == '3.11' && github.ref == 'refs/heads/main' && always()
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: bce917f4007ac491e527e142564fbbae

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,10 @@ jobs:
         # Tracked: TODO file follow-up issue to fix fixtures + restore 3.11.
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -40,7 +40,7 @@ jobs:
         run: uv sync --extra dev --extra bridge
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -75,10 +75,10 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -89,7 +89,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -108,7 +108,7 @@ jobs:
         run: uv build
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -121,7 +121,7 @@ jobs:
       url: https://pypi.org/p/rigplane
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -32,11 +32,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Detect frontend changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             frontend:
@@ -44,7 +44,7 @@ jobs:
               - 'src/rigplane/web/**'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -67,7 +67,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.filter.outputs.frontend == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -107,7 +107,7 @@ jobs:
 
       - name: Update tests badge
         if: github.ref == 'refs/heads/main' && always()
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: bce917f4007ac491e527e142564fbbae
@@ -118,7 +118,7 @@ jobs:
 
       - name: Update version badge
         if: github.ref == 'refs/heads/main' && always()
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: bce917f4007ac491e527e142564fbbae
@@ -129,7 +129,7 @@ jobs:
 
       - name: Update mypy badge
         if: github.ref == 'refs/heads/main' && always()
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: bce917f4007ac491e527e142564fbbae

--- a/.github/workflows/rebrand-gate.yml
+++ b/.github/workflows/rebrand-gate.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 2
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Wave 2 rebrand grep gate
         run: .github/scripts/check-rebrand-allowlist.sh


### PR DESCRIPTION
## Summary
- upgrade GitHub workflow actions to Node 24-compatible releases
- include docs, quick, full, publish, and rebrand workflows
- keep project Node.js install at Node 20; this only changes action runtimes

## Validation
- python3 YAML parse for all .github/workflows/*.yml
- bash .github/scripts/check-rebrand-allowlist.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- action metadata audit confirms no node20 or unresolved action runtime remains

Fixes #1492