### PR TITLE
Expose classified radio health

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -214,17 +214,28 @@ Version, model, capability summary, and connection metadata.
 
 Canonical full state payload for web consumers (camelCase keys).
 
-- Includes `revision` + `updatedAt`.
+- Includes `revision`, `healthRevision`, and `updatedAt`.
 - Includes `connection` object (`rigConnected`, `radioReady`, `controlConnected`).
+- Includes `radioHealth`, a classified server/radio health contract.
 - For single-receiver profiles, `sub` key is omitted.
-- Supports `ETag` based on `revision` for conditional requests.
+- Supports `ETag` based on `revision` and `healthRevision` for conditional
+  requests, so radio-health-only changes are not hidden behind `304 Not Modified`.
 
 ```json
 {
   "main": { "freqHz": 14074000, "mode": "USB", "filter": 1 },
   "revision": 42,
+  "healthRevision": 7,
   "updatedAt": "2026-03-15T10:00:00+00:00",
   "radioDetail": { "status": "connected" },
+  "radioHealth": {
+    "serverReachable": true,
+    "radioLink": "connected",
+    "readiness": "ready",
+    "likelyCause": "unknown",
+    "sinceMs": 0,
+    "lastError": null
+  },
   "wsClients": { "scope": 1, "control": 1, "audio": 0 },
   "connection": {
     "rigConnected": true,
@@ -233,6 +244,16 @@ Canonical full state payload for web consumers (camelCase keys).
   }
 }
 ```
+
+`radioHealth.likelyCause` distinguishes these public states:
+
+| Value | Meaning |
+|---|---|
+| `server_unreachable` | Browser/client cannot reach the web or proxy server. The server normally cannot emit this for itself; clients derive it from HTTP/WS failures. |
+| `radio_network_lost` | Server is reachable, but the radio link is disconnected or reconnecting. |
+| `radio_not_responding` | Radio link still exists, but CI-V/control data is delayed or stalled. |
+| `radio_powered_off_likely` | Server is reachable, the radio was previously available, and repeated timeout/recovery evidence suggests the hardware is off or unreachable. |
+| `unknown` | Insufficient evidence or healthy/ready state. |
 
 ## `GET /api/v1/capabilities`
 

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -253,6 +253,9 @@ secondary telemetry (COMP/Vd/Id) is intentionally sampled less often.
 
 - Polling uses `If-None-Match` with the previous `ETag`.
 - `304 Not Modified` is treated as a successful poll with no state payload.
+- The state `ETag` includes both `revision` and `healthRevision`. A
+  radio-health-only transition therefore returns `200` with a fresh payload even
+  when frequency/mode/meter state did not change.
 - On transient HTTP errors, cached ETag is cleared to force a fresh `200` response.
 - After repeated HTTP failures, the connection store marks HTTP as disconnected until recovery.
 

--- a/docs/internals/reliability-semantics.md
+++ b/docs/internals/reliability-semantics.md
@@ -78,9 +78,32 @@ So “ready” means: connection is up, CI-V stream is up and not in recovery, a
 
 `radio_ready` is **true** only when state is **CONNECTED** and the CI-V stream is healthy and recently active. So you can be CONNECTED but not ready (e.g. CI-V data stalled or recovering).
 
+### Public radio health classification
+
+`GET /api/v1/state` exposes `radioHealth` plus `healthRevision` in addition to
+the backward-compatible `connection` booleans. `revision` still tracks ordinary
+radio-state changes. `healthRevision` tracks classified health transitions, so
+HTTP polling and frontend stores can update degraded radio status even when the
+last frequency/mode/meter snapshot did not change.
+
+The public health model separates:
+
+- **`server_unreachable`** — client-side server/proxy loss.
+- **`radio_network_lost`** — server reachable, radio link disconnected or reconnecting.
+- **`radio_not_responding`** — radio link exists, but CI-V/control data is delayed or stalled.
+- **`radio_powered_off_likely`** — prior radio availability plus repeated timeout/recovery evidence indicates the radio is probably off or unreachable.
+- **`unknown`** — healthy/ready state or insufficient evidence.
+
+Temporary CI-V gaps are classified as `readiness: "delayed"` before they become
+`readiness: "stalled"`; ordinary jitter should not be treated as likely power
+loss.
+
 ### What consumers (web, rigctld) should expect
 
-- **Web:** The Web UI and API expose `radio_ready` (and optionally `connection_state`). Consumers should treat `radio_ready === false` as “do not rely on live CI-V” (e.g. scope or tuning may be deferred or show last-known state).
+- **Web:** The Web UI and API expose `radio_ready`, `connection`, and
+  `radioHealth`. Consumers should treat `radio_ready === false` and
+  non-ready `radioHealth.readiness` as “do not rely on live CI-V” (e.g. scope or
+  tuning may be deferred or show last-known state).
 - **Rigctld:** Commands that hit the radio will get `ETIMEOUT` or connection errors if the radio is not responding; the server does not gate commands on `radio_ready`, but the circuit breaker will open after consecutive timeouts and fail commands quickly until recovery.
 
 The helper `radio_ready(radio)` in `web/runtime_helpers.py` normalizes readiness: it uses `radio.radio_ready` if it is a boolean, otherwise falls back to `radio.connected`; `None` is treated as not ready.

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -11,6 +11,7 @@
     getHttpConnected,
     getRadioPowerOn,
     getRigConnected,
+    getRadioHealth,
   } from '$lib/stores/connection.svelte';
   import { getFrequency } from '$lib/stores/radio.svelte';
   import { hasAnyScope, hasAudio, hasSpectrum } from '$lib/stores/capabilities.svelte';
@@ -63,8 +64,31 @@
   let audioState = $derived(isPoweredOff ? 'disconnected' : (isAudioConnected() ? 'connected' : 'disconnected'));
   let httpState = $derived(getHttpConnected() ? 'connected' : 'disconnected'); // server link — always real
   let rigConnected = $derived(getRigConnected());
+  let radioHealth = $derived(getRadioHealth());
   // Effective radio indicator: downgrade to 'disconnected' when rigCtld reports radio offline
-  let radioIndicatorState = $derived(radioState === 'connected' && !rigConnected ? 'degraded' : radioState);
+  let radioIndicatorState = $derived.by(() => {
+    if (radioHealth?.likelyCause === 'radio_network_lost' || radioHealth?.likelyCause === 'radio_powered_off_likely') {
+      return 'disconnected';
+    }
+    if (radioHealth?.readiness === 'delayed' || radioHealth?.readiness === 'stalled') {
+      return 'degraded';
+    }
+    return radioState === 'connected' && !rigConnected ? 'degraded' : radioState;
+  });
+  let radioHealthLabel = $derived.by(() => {
+    switch (radioHealth?.likelyCause) {
+      case 'radio_network_lost':
+        return 'radio link lost';
+      case 'radio_not_responding':
+        return radioHealth.readiness === 'delayed' ? 'radio response delayed' : 'radio not responding';
+      case 'radio_powered_off_likely':
+        return 'radio appears powered off or unreachable';
+      case 'server_unreachable':
+        return 'server unreachable';
+      default:
+        return !rigConnected && radioState === 'connected' ? 'rig offline' : '';
+    }
+  });
 
   let connectionTooltip = $derived(
     controlState === 'connected'
@@ -153,7 +177,7 @@
 {/if}
 <div class="status-bar">
   <div class="status-indicators">
-    <span class="indicator" role="status" title="Radio ↔ Server: {radioState}{!rigConnected && radioState === 'connected' ? ' (rig offline)' : ''}" style="--indicator-color: {stateColor(radioIndicatorState)}">
+    <span class="indicator" role="status" title="Radio ↔ Server: {radioState}{radioHealthLabel ? ` (${radioHealthLabel})` : ''}" style="--indicator-color: {stateColor(radioIndicatorState)}">
       <span class="indicator-dot"></span>
       <Radio size={12} color="currentColor" strokeWidth={2.5} />
     </span>

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -37,6 +37,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   isAudioConnected: vi.fn(() => false),
   getHttpConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),
+  getRadioHealth: vi.fn(() => null),
 }));
 
 vi.mock('$lib/stores/tuning.svelte', () => ({

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
@@ -32,6 +32,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   isAudioConnected: vi.fn(() => false),
   getHttpConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),
+  getRadioHealth: vi.fn(() => null),
 }));
 
 vi.mock('$lib/stores/tuning.svelte', () => ({

--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -168,6 +168,29 @@ describe('radio store', () => {
     expect(store.getRadioState()?.ptt).toBe(false);
   });
 
+  it('accepts health-only updates when healthRevision advances', async () => {
+    const connection = await import('../connection.svelte');
+    store.setRadioState(makeState({ revision: 5, healthRevision: 1 }));
+    store.setRadioState(makeState({
+      revision: 5,
+      healthRevision: 2,
+      connection: { rigConnected: true, radioReady: false, controlConnected: true },
+      radioHealth: {
+        serverReachable: true,
+        radioLink: 'connected',
+        readiness: 'delayed',
+        likelyCause: 'radio_not_responding',
+        sinceMs: 1200,
+        lastError: null,
+      },
+    }));
+
+    expect(store.getRadioState()?.healthRevision).toBe(2);
+    expect(store.getRadioState()?.radioHealth?.likelyCause).toBe('radio_not_responding');
+    expect(connection.getRadioReady()).toBe(false);
+    expect(connection.getRadioHealth()?.readiness).toBe('delayed');
+  });
+
   it('getFrequency returns active receiver frequency (MAIN)', () => {
     store.setRadioState(makeState({ active: 'MAIN' }));
     expect(store.getFrequency()).toBe(14074000);

--- a/frontend/src/lib/stores/connection.svelte.ts
+++ b/frontend/src/lib/stores/connection.svelte.ts
@@ -1,4 +1,8 @@
 // Connection health state
+import type { ServerState } from '../types/state';
+
+type RadioHealth = NonNullable<ServerState['radioHealth']>;
+
 let httpConnected = $state(false);
 let wsConnected = $state(false);
 let audioConnected = $state(false);
@@ -9,6 +13,7 @@ let radioPowerOn = $state<boolean | null>(null);
 let rigConnected = $state(false);
 let radioReady = $state(false);
 let controlConnected = $state(false);
+let radioHealth = $state<RadioHealth | null>(null);
 let lastResponseTime = $state<number | null>(null);
 
 let lastStateUpdate = $state(0);
@@ -148,4 +153,12 @@ export function setControlConnected(v: boolean): void {
 
 export function getControlConnected(): boolean {
   return controlConnected;
+}
+
+export function setRadioHealth(v: RadioHealth | null): void {
+  radioHealth = v;
+}
+
+export function getRadioHealth(): RadioHealth | null {
+  return radioHealth;
 }

--- a/frontend/src/lib/stores/connection.test.ts
+++ b/frontend/src/lib/stores/connection.test.ts
@@ -6,6 +6,8 @@ import {
   getRadioReady,
   setControlConnected,
   getControlConnected,
+  setRadioHealth,
+  getRadioHealth,
 } from './connection.svelte';
 
 describe('connection readiness fields', () => {
@@ -31,5 +33,20 @@ describe('connection readiness fields', () => {
     expect(getControlConnected()).toBe(true);
     setControlConnected(false);
     expect(getControlConnected()).toBe(false);
+  });
+
+  it('classified radio health defaults to null and can be set', () => {
+    expect(getRadioHealth()).toBeNull();
+    setRadioHealth({
+      serverReachable: true,
+      radioLink: 'connected',
+      readiness: 'stalled',
+      likelyCause: 'radio_not_responding',
+      sinceMs: 2500,
+      lastError: null,
+    });
+    expect(getRadioHealth()?.likelyCause).toBe('radio_not_responding');
+    setRadioHealth(null);
+    expect(getRadioHealth()).toBeNull();
   });
 });

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -1,5 +1,5 @@
 import type { ServerState, ReceiverState } from '../types/state';
-import { setRadioPowerOn, setRigConnected, setRadioReady, setControlConnected } from './connection.svelte';
+import { setRadioPowerOn, setRigConnected, setRadioReady, setControlConnected, setRadioHealth } from './connection.svelte';
 
 /**
  * Shared radio state — class-based $state pattern for cross-module reactivity.
@@ -13,6 +13,7 @@ class RadioStore {
 export const radio = new RadioStore();
 
 let lastRevision = -1;
+let lastHealthRevision = -1;
 const stateSubscribers = new Set<(state: ServerState | null) => void>();
 
 function notifyRadioStateSubscribers(): void {
@@ -125,6 +126,7 @@ function applyOptimistic(state: ServerState): ServerState {
 export function resetRadioState(): void {
   radio.current = null;
   lastRevision = -1;
+  lastHealthRevision = -1;
   optimisticMain.clear();
   optimisticSub.clear();
   optimisticTopLevel.clear();
@@ -135,13 +137,16 @@ export function resetRadioState(): void {
 export function setRadioState(state: ServerState): void {
   const isReset = lastRevision > 10 && state.revision < lastRevision / 2;
   const isInitial = radio.current === null;
+  const nextHealthRevision = state.healthRevision ?? 0;
+  const healthAdvanced = nextHealthRevision > lastHealthRevision;
   if (isReset) {
     console.warn(
       `Detected server restart: revision reset from ${lastRevision} to ${state.revision}`,
     );
   }
-  if (isInitial || state.revision > lastRevision || isReset) {
+  if (isInitial || state.revision > lastRevision || healthAdvanced || isReset) {
     lastRevision = state.revision;
+    lastHealthRevision = nextHealthRevision;
     radio.current = applyOptimistic(state);
     notifyRadioStateSubscribers();
     // Sync power status to connection store
@@ -153,6 +158,9 @@ export function setRadioState(state: ServerState): void {
       setRigConnected(state.connection.rigConnected);
       setRadioReady(state.connection.radioReady);
       setControlConnected(state.connection.controlConnected);
+    }
+    if (state.radioHealth !== undefined) {
+      setRadioHealth(state.radioHealth);
     }
   }
 }

--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -187,6 +187,45 @@ describe('startPolling', () => {
     stop();
   });
 
+  it('calls callback when only healthRevision advances', async () => {
+    const first = makeState(42);
+    first.healthRevision = 1;
+    const second = makeState(42);
+    second.healthRevision = 2;
+    second.connection = { rigConnected: true, radioReady: false, controlConnected: true };
+    second.radioHealth = {
+      serverReachable: true,
+      radioLink: 'connected',
+      readiness: 'delayed',
+      likelyCause: 'radio_not_responding',
+      sinceMs: 1500,
+      lastError: null,
+    };
+    let index = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      const state = index++ === 0 ? first : second;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => `"42-${state.healthRevision}"` },
+        json: () => Promise.resolve(state),
+      });
+    });
+
+    const { startPolling } = await import('../http-client');
+    const received: ServerState[] = [];
+    const stop = startPolling((s) => received.push(s), 200);
+
+    await flushMicrotasks();
+    vi.advanceTimersByTime(200);
+    await flushMicrotasks();
+
+    expect(received).toHaveLength(2);
+    expect(received[1].revision).toBe(42);
+    expect(received[1].healthRevision).toBe(2);
+    stop();
+  });
+
   it('does not crash on fetch error', async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('network gone'));
 
@@ -256,6 +295,24 @@ describe('startPolling', () => {
     await flushMicrotasks();
 
     expect(getHttpConnected()).toBe(false);
+    stop();
+  });
+
+  it('classifies repeated HTTP failures as server_unreachable', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network gone'));
+
+    const { startPolling } = await import('../http-client');
+    const { getRadioHealth } = await import('../../stores/connection.svelte');
+
+    const stop = startPolling(() => {}, 10);
+
+    for (let i = 0; i < 3; i++) {
+      await flushMicrotasks();
+      vi.advanceTimersByTime(10);
+    }
+    await flushMicrotasks();
+
+    expect(getRadioHealth()?.likelyCause).toBe('server_unreachable');
     stop();
   });
 

--- a/frontend/src/lib/transport/http-client.ts
+++ b/frontend/src/lib/transport/http-client.ts
@@ -1,7 +1,7 @@
 import type { ServerState } from '../types/state';
 import type { Capabilities } from '../types/capabilities';
 import type { InfoResponse } from '../types/protocol';
-import { markStateUpdated, setHttpConnected, setRadioStatus, setReconnecting } from '../stores/connection.svelte';
+import { markStateUpdated, setHttpConnected, setRadioHealth, setRadioStatus, setReconnecting } from '../stores/connection.svelte';
 
 const BASE = '/api/v1';
 
@@ -93,6 +93,7 @@ export function startPolling(
   let running = true;
   let inflight = false;
   let lastRevision = -1;
+  let lastHealthRevision = -1;
   let consecutiveErrors = 0;
 
   async function tick() {
@@ -110,8 +111,13 @@ export function startPolling(
         if (state?.radioDetail?.status) {
           setRadioStatus(state.radioDetail.status);
         }
-        if (state && state.revision > lastRevision) {
+        const healthRevision = state?.healthRevision ?? 0;
+        if (
+          state
+          && (state.revision > lastRevision || healthRevision > lastHealthRevision)
+        ) {
           lastRevision = state.revision;
+          lastHealthRevision = healthRevision;
           callback(state);
         }
       } catch {
@@ -121,6 +127,14 @@ export function startPolling(
         lastStateEtag = null;
         if (consecutiveErrors >= HTTP_ERROR_THRESHOLD) {
           setHttpConnected(false);
+          setRadioHealth({
+            serverReachable: false,
+            radioLink: 'unknown',
+            readiness: 'stalled',
+            likelyCause: 'server_unreachable',
+            sinceMs: 0,
+            lastError: null,
+          });
         }
       } finally {
         inflight = false;

--- a/frontend/src/lib/types/state.ts
+++ b/frontend/src/lib/types/state.ts
@@ -60,6 +60,7 @@ export interface ScopeControls {
 
 export interface ServerState {
   revision: number;
+  healthRevision?: number;
   updatedAt: string;
 
   active: 'MAIN' | 'SUB';
@@ -76,6 +77,20 @@ export interface ServerState {
     rigConnected: boolean;
     radioReady: boolean;
     controlConnected: boolean;
+  };
+
+  radioHealth?: {
+    serverReachable: boolean;
+    radioLink: 'connected' | 'reconnecting' | 'disconnected' | 'unknown';
+    readiness: 'ready' | 'delayed' | 'stalled' | 'recovering';
+    likelyCause:
+      | 'server_unreachable'
+      | 'radio_network_lost'
+      | 'radio_not_responding'
+      | 'radio_powered_off_likely'
+      | 'unknown';
+    sinceMs: number;
+    lastError: string | null;
   };
 
   radioDetail?: {

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import time
 from typing import TYPE_CHECKING, Any
 
 from ..radio_protocol import (
@@ -14,7 +15,12 @@ from ..radio_state import RadioState
 if TYPE_CHECKING:
     from ..radio_protocol import Radio
 
-__all__ = ["runtime_capabilities", "radio_ready", "build_public_state_payload"]
+__all__ = [
+    "runtime_capabilities",
+    "radio_ready",
+    "classify_radio_health",
+    "build_public_state_payload",
+]
 
 _RECEIVER_KEY_MAP = {"freq": "freqHz"}
 
@@ -78,6 +84,132 @@ def radio_ready(radio: "Radio | None") -> bool:
     return connected if isinstance(connected, bool) else False
 
 
+def _bool_attr(obj: Any, name: str, default: bool = False) -> bool:
+    raw = getattr(obj, name, default)
+    return raw if isinstance(raw, bool) else default
+
+
+def _conn_state_value(radio: Any) -> str | None:
+    conn_state = getattr(radio, "conn_state", None)
+    raw = getattr(conn_state, "value", conn_state)
+    return raw if isinstance(raw, str) else None
+
+
+def _civ_stats(radio: Any) -> dict[str, Any]:
+    stats_fn = getattr(radio, "civ_stats", None)
+    if not callable(stats_fn):
+        return {}
+    try:
+        stats = stats_fn()
+    except Exception:
+        return {}
+    return stats if isinstance(stats, dict) else {}
+
+
+def classify_radio_health(
+    radio: "Radio | None",
+    *,
+    server_reachable: bool = True,
+    now_monotonic: float | None = None,
+) -> dict[str, Any]:
+    """Classify server/radio health from runtime evidence.
+
+    The web server can only assert its own reachability when it is answering
+    the request; browser-side failures should override this to
+    ``server_unreachable``. Radio classification is intentionally conservative:
+    short CI-V gaps are ``delayed``, longer gaps are ``stalled``, and
+    ``radio_powered_off_likely`` requires prior availability plus repeated
+    timeout/recovery evidence.
+    """
+    now = time.monotonic() if now_monotonic is None else now_monotonic
+    if not server_reachable:
+        return {
+            "serverReachable": False,
+            "radioLink": "unknown",
+            "readiness": "stalled",
+            "likelyCause": "server_unreachable",
+            "sinceMs": 0,
+            "lastError": None,
+        }
+    if radio is None:
+        return {
+            "serverReachable": True,
+            "radioLink": "unknown",
+            "readiness": "stalled",
+            "likelyCause": "unknown",
+            "sinceMs": 0,
+            "lastError": None,
+        }
+
+    connected = _bool_attr(radio, "connected")
+    ready = radio_ready(radio)
+    conn_state = _conn_state_value(radio)
+    if conn_state in {"connecting", "reconnecting"}:
+        radio_link = "reconnecting"
+    elif connected or conn_state == "connected":
+        radio_link = "connected"
+    elif conn_state == "disconnected":
+        radio_link = "disconnected"
+    else:
+        radio_link = "unknown"
+
+    stats = _civ_stats(radio)
+    last_error = getattr(radio, "last_error", None)
+    last_error_value = last_error if isinstance(last_error, str) else None
+
+    if ready:
+        return {
+            "serverReachable": True,
+            "radioLink": "connected",
+            "readiness": "ready",
+            "likelyCause": "unknown",
+            "sinceMs": 0,
+            "lastError": last_error_value,
+        }
+
+    if radio_link in {"reconnecting", "disconnected"}:
+        return {
+            "serverReachable": True,
+            "radioLink": radio_link,
+            "readiness": "recovering" if radio_link == "reconnecting" else "stalled",
+            "likelyCause": "radio_network_lost",
+            "sinceMs": 0,
+            "lastError": last_error_value,
+        }
+
+    last_civ = getattr(radio, "_last_civ_data_received", None)
+    idle_s = 0.0
+    if isinstance(last_civ, (int, float)) and not isinstance(last_civ, bool):
+        idle_s = max(0.0, now - float(last_civ))
+    ready_timeout = getattr(radio, "_civ_ready_idle_timeout", 2.0)
+    if not isinstance(ready_timeout, (int, float)) or isinstance(ready_timeout, bool):
+        ready_timeout = 2.0
+    delayed_limit = max(float(ready_timeout) * 2.0, 2.0)
+    readiness = "delayed" if idle_s <= delayed_limit else "stalled"
+
+    timeouts = stats.get("timeouts", 0)
+    timeout_count = timeouts if isinstance(timeouts, int) else 0
+    had_success = _bool_attr(radio, "_has_connected_once") or last_civ is not None
+    recovering = _bool_attr(radio, "_civ_recovering")
+    powered_off_likely = (
+        had_success
+        and readiness == "stalled"
+        and (timeout_count >= 3 or recovering)
+        and idle_s >= max(delayed_limit, 10.0)
+    )
+
+    return {
+        "serverReachable": True,
+        "radioLink": radio_link,
+        "readiness": readiness,
+        "likelyCause": (
+            "radio_powered_off_likely" if powered_off_likely else "radio_not_responding"
+        ),
+        "sinceMs": int(idle_s * 1000),
+        "lastError": last_error_value,
+    }
+
+
 def _to_camel(s: str) -> str:
     parts = s.split("_")
     return parts[0] + "".join(p.capitalize() for p in parts[1:])
@@ -129,6 +261,8 @@ def build_public_state_payload(
     scope_clients: int = 0,
     control_clients: int = 0,
     audio_clients: int = 0,
+    radio_health: dict[str, Any] | None = None,
+    health_revision: int = 0,
 ) -> dict[str, Any]:
     """Build the canonical public web state payload from RadioState.
 
@@ -147,6 +281,7 @@ def build_public_state_payload(
         raw_control_connected if isinstance(raw_control_connected, bool) else False
     )
     state["revision"] = revision
+    state["health_revision"] = health_revision
     state["updated_at"] = (
         updated_at or datetime.datetime.now(datetime.timezone.utc).isoformat()
     )
@@ -167,6 +302,7 @@ def build_public_state_payload(
     state["radio_detail"] = {
         "status": radio_status,
     }
+    state["radio_health"] = radio_health or classify_radio_health(radio)
     state["ws_clients"] = {
         "scope": scope_clients,
         "control": control_clients,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -59,6 +59,7 @@ from .rtc import handle_rtc_offer, rtc_capability_info, webrtc_available  # noqa
 from .radio_poller import CommandQueue, DisableScope, EnableScope, RadioPoller  # noqa: TID251
 from .runtime_helpers import (  # noqa: TID251
     build_public_state_payload,
+    classify_radio_health,
     radio_ready,
     runtime_capabilities,
 )
@@ -380,6 +381,9 @@ class WebServer:
         self._last_state_broadcast: float = 0.0
         # Delta encoder for efficient state broadcasting
         self._delta_encoder: DeltaEncoder = DeltaEncoder(full_state_interval=100)
+        self._health_revision: int = 0
+        self._health_signature: tuple[object, ...] | None = None
+        self._health_since_monotonic: float = time.monotonic()
         # Audio bridge (virtual device integration)
         self._audio_bridge: "AudioBridge | None" = None
         # Scope health monitor
@@ -682,6 +686,7 @@ class WebServer:
     def build_public_state(self, *, updated_at: str | None = None) -> dict[str, Any]:
         """Return the canonical public state payload for web consumers."""
         revision = self._radio_poller.revision if self._radio_poller is not None else 0
+        health = self._build_radio_health()
         return build_public_state_payload(
             self._radio_state,
             radio=self._radio,
@@ -691,7 +696,31 @@ class WebServer:
             scope_clients=len(self._scope_handlers),
             control_clients=len(self._control_event_queues),
             audio_clients=len(self._audio_broadcaster._clients),
+            radio_health=health,
+            health_revision=self._health_revision,
         )
+
+    def _build_radio_health(self) -> dict[str, Any]:
+        """Build radio health and advance the health revision on transitions."""
+        now = time.monotonic()
+        health = classify_radio_health(
+            self._radio,
+            server_reachable=True,
+            now_monotonic=now,
+        )
+        signature = (
+            health.get("serverReachable"),
+            health.get("radioLink"),
+            health.get("readiness"),
+            health.get("likelyCause"),
+            health.get("lastError"),
+        )
+        if self._health_signature != signature:
+            self._health_signature = signature
+            self._health_revision += 1
+            self._health_since_monotonic = now
+        health["sinceMs"] = int(max(0.0, now - self._health_since_monotonic) * 1000)
+        return health
 
     def broadcast_notification(
         self,
@@ -1440,8 +1469,9 @@ class WebServer:
     ) -> None:
         body_dict = self.build_public_state()
         revision = int(body_dict.get("revision", 0))
+        health_revision = int(body_dict.get("healthRevision", 0))
         body = json.dumps(body_dict, separators=(",", ":")).encode()
-        await _send_json(writer, body, headers, etag=f'"{revision}"')
+        await _send_json(writer, body, headers, etag=f'"{revision}-{health_revision}"')
 
     async def _serve_audio_analysis(
         self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -6,7 +6,11 @@ from typing import Any
 import pytest
 from unittest.mock import MagicMock
 
-from rigplane.web.runtime_helpers import radio_ready, runtime_capabilities
+from rigplane.web.runtime_helpers import (
+    classify_radio_health,
+    radio_ready,
+    runtime_capabilities,
+)
 from rigplane.web.server import WebServer
 
 
@@ -137,6 +141,70 @@ def test_radio_ready_handles_missing_or_non_bool_attributes() -> None:
     radio = _FakeRadio(connected="yes", radio_ready_flag="maybe")  # type: ignore[arg-type]
     assert radio_ready(radio) is False
     assert radio_ready(None) is False
+
+
+def test_radio_health_classifies_ready_radio() -> None:
+    radio = _FakeRadio(connected=True, radio_ready_flag=True)
+    health = classify_radio_health(radio, server_reachable=True, now_monotonic=100.0)
+
+    assert health["serverReachable"] is True
+    assert health["radioLink"] == "connected"
+    assert health["readiness"] == "ready"
+    assert health["likelyCause"] == "unknown"
+
+
+def test_radio_health_classifies_network_loss_separately_from_server_loss() -> None:
+    radio = _FakeRadio(connected=False, radio_ready_flag=False)
+    radio.conn_state = "reconnecting"
+
+    health = classify_radio_health(radio, server_reachable=True, now_monotonic=100.0)
+
+    assert health["serverReachable"] is True
+    assert health["radioLink"] == "reconnecting"
+    assert health["readiness"] == "recovering"
+    assert health["likelyCause"] == "radio_network_lost"
+
+
+def test_radio_health_classifies_delayed_then_stalled_radio_response() -> None:
+    radio = _FakeRadio(connected=True, radio_ready_flag=False)
+    radio._last_civ_data_received = 98.5
+    radio._civ_ready_idle_timeout = 1.0
+
+    delayed = classify_radio_health(radio, server_reachable=True, now_monotonic=100.0)
+    assert delayed["radioLink"] == "connected"
+    assert delayed["readiness"] == "delayed"
+    assert delayed["likelyCause"] == "radio_not_responding"
+
+    radio._last_civ_data_received = 94.0
+    stalled = classify_radio_health(radio, server_reachable=True, now_monotonic=100.0)
+    assert stalled["readiness"] == "stalled"
+    assert stalled["likelyCause"] == "radio_not_responding"
+
+
+def test_radio_health_promotes_repeated_probe_failures_to_powered_off_likely() -> None:
+    radio = _FakeRadio(connected=True, radio_ready_flag=False)
+    radio._last_civ_data_received = 80.0
+    radio._civ_ready_idle_timeout = 2.0
+    radio._has_connected_once = True
+
+    def _stats() -> dict[str, int]:
+        return {"timeouts": 3, "active_waiters": 0}
+
+    radio.civ_stats = _stats
+
+    health = classify_radio_health(radio, server_reachable=True, now_monotonic=100.0)
+
+    assert health["readiness"] == "stalled"
+    assert health["likelyCause"] == "radio_powered_off_likely"
+
+
+def test_radio_health_reports_server_unreachable_without_radio_guess() -> None:
+    health = classify_radio_health(None, server_reachable=False, now_monotonic=100.0)
+
+    assert health["serverReachable"] is False
+    assert health["radioLink"] == "unknown"
+    assert health["readiness"] == "stalled"
+    assert health["likelyCause"] == "server_unreachable"
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1018,6 +1018,43 @@ class TestStateEtag:
         assert text2[body_start:] == "", "304 response must have empty body"
 
     @pytest.mark.asyncio
+    async def test_state_etag_changes_when_health_changes_without_revision(
+        self,
+    ) -> None:
+        """Health-only transitions must not be hidden behind a revision-only ETag."""
+
+        class _HealthRadio:
+            connected = True
+            control_connected = True
+            radio_ready = True
+            capabilities: set[str] = set()
+
+        radio = _HealthRadio()
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+        await srv._serve_state(writer)
+        text = writer.buffer.decode("ascii", errors="replace")
+        header_block = text[: text.index("\r\n\r\n")]
+        etag = next(
+            line.split(":", 1)[1].strip()
+            for line in header_block.splitlines()
+            if line.startswith("ETag:")
+        )
+
+        radio.radio_ready = False
+        radio._last_civ_data_received = 0.0
+        radio._civ_ready_idle_timeout = 1.0
+
+        writer2 = _FakeWriter()
+        await srv._serve_state(writer2, {"if-none-match": etag})
+        text2 = writer2.buffer.decode("ascii", errors="replace")
+        assert "200 OK" in text2.split("\r\n", 1)[0]
+        body = json.loads(text2[text2.index("\r\n\r\n") + 4 :])
+        assert body["revision"] == 0
+        assert body["healthRevision"] == 2
+        assert body["radioHealth"]["likelyCause"] == "radio_not_responding"
+
+    @pytest.mark.asyncio
     async def test_state_200_when_etag_differs(self) -> None:
         """GET /api/v1/state with stale If-None-Match returns 200 with full body."""
         srv = WebServer(None)

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- Add backend `radioHealth` and `healthRevision` to `/api/v1/state`, with separate classification for server loss, radio link/network loss, delayed/stalled CI-V response, and likely powered-off radios.
- Change `/api/v1/state` ETag to include both radio state revision and health revision, so health-only transitions return fresh state instead of 304.
- Teach the web client to accept health-only state updates, store radio health, classify repeated HTTP failures as `server_unreachable`, and surface degraded/disconnected radio status in the status bar.
- Document the API contract and UI consumer semantics.

## Verification
- `uv run --extra dev python -m pytest tests/test_web_runtime_helpers.py tests/test_web_server_coverage.py::TestStateEtag -q --tb=short`
- `cd frontend && npx vitest run src/lib/stores/__tests__/radio.test.ts src/lib/transport/__tests__/http-client.test.ts src/lib/stores/__tests__/connection.test.ts src/lib/stores/connection.test.ts`
- `cd frontend && npm run check`
- `uv run --extra dev ruff check src/rigplane/web/runtime_helpers.py src/rigplane/web/server.py tests/test_web_runtime_helpers.py tests/test_web_server_coverage.py`
- `uv run --extra dev ruff format --check src/rigplane/web/runtime_helpers.py src/rigplane/web/server.py tests/test_web_runtime_helpers.py tests/test_web_server_coverage.py`
- `uv run --extra dev python -m mkdocs build --strict`
- `cd frontend && npm run build`
- `uv run --extra dev mypy --strict src/rigplane/web`
- `cd frontend && npx vitest run`
- `uv run --extra dev python -m pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread`

Fixes #1500
Fixes #1501