### PR TITLE
Tighten classified radio health follow-ups

### DIFF
--- a/frontend/src/lib/stores/connection.svelte.ts
+++ b/frontend/src/lib/stores/connection.svelte.ts
@@ -162,3 +162,16 @@ export function setRadioHealth(v: RadioHealth | null): void {
 export function getRadioHealth(): RadioHealth | null {
   return radioHealth;
 }
+
+export function isLiveRadioAvailable(): boolean {
+  if (!radioHealth) {
+    return radioReady;
+  }
+  return (
+    radioReady
+    && radioHealth.serverReachable
+    && radioHealth.radioLink === 'connected'
+    && radioHealth.readiness === 'ready'
+    && radioHealth.likelyCause === 'unknown'
+  );
+}

--- a/frontend/src/lib/stores/connection.test.ts
+++ b/frontend/src/lib/stores/connection.test.ts
@@ -8,6 +8,7 @@ import {
   getControlConnected,
   setRadioHealth,
   getRadioHealth,
+  isLiveRadioAvailable,
 } from './connection.svelte';
 
 describe('connection readiness fields', () => {
@@ -48,5 +49,30 @@ describe('connection readiness fields', () => {
     expect(getRadioHealth()?.likelyCause).toBe('radio_not_responding');
     setRadioHealth(null);
     expect(getRadioHealth()).toBeNull();
+  });
+
+  it('marks live radio unavailable for degraded health', () => {
+    setRadioReady(true);
+    setRadioHealth({
+      serverReachable: true,
+      radioLink: 'connected',
+      readiness: 'stalled',
+      likelyCause: 'radio_not_responding',
+      sinceMs: 9000,
+      lastError: null,
+    });
+
+    expect(isLiveRadioAvailable()).toBe(false);
+
+    setRadioHealth({
+      serverReachable: true,
+      radioLink: 'connected',
+      readiness: 'ready',
+      likelyCause: 'unknown',
+      sinceMs: 0,
+      lastError: null,
+    });
+
+    expect(isLiveRadioAvailable()).toBe(true);
   });
 });

--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../stores/connection.svelte', () => ({
   setHttpConnected: vi.fn(),
   markStateUpdated: vi.fn(),
   setReconnecting: vi.fn(),
+  isLiveRadioAvailable: vi.fn(() => true),
 }));
 
 vi.mock('../../stores/radio.svelte', () => ({
@@ -17,7 +18,7 @@ vi.mock('../../stores/radio.svelte', () => ({
   setRadioState: vi.fn(),
 }));
 
-import { setWsConnected } from '../../stores/connection.svelte';
+import { isLiveRadioAvailable, setWsConnected } from '../../stores/connection.svelte';
 import { patchActiveReceiver } from '../../stores/radio.svelte';
 
 // ─── Minimal WebSocket mock ──────────────────────────────────────────────────
@@ -288,6 +289,17 @@ describe('control channel singleton', () => {
     expect(isConnected()).toBe(false);
     const result = sendCommand('ptt', { state: true });
     expect(result).toBe(false);
+  });
+
+  it('sendCommand blocks live-radio commands while radio health is degraded', async () => {
+    vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
+    vi.mocked(patchActiveReceiver).mockClear();
+    const { sendCommand } = await import('../ws-client');
+
+    const result = sendCommand('set_freq', { freq: 14074000, receiver: 0 });
+
+    expect(result).toBe(false);
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
   });
 
   it('getChannel returns the same instance for the same name', async () => {

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -1,6 +1,6 @@
 import type { WsCommand, WsIncoming } from '../types/protocol';
 import { makeCommandId } from '../types/protocol';
-import { setWsConnected, setHttpConnected, markStateUpdated, setReconnecting } from '../stores/connection.svelte';
+import { isLiveRadioAvailable, setWsConnected, setHttpConnected, markStateUpdated, setReconnecting } from '../stores/connection.svelte';
 import { getRadioState, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
@@ -320,6 +320,10 @@ export function disconnect() {
 }
 
 export function sendCommand(name: string, params: Record<string, unknown> = {}, id?: string): boolean {
+  if (!isLiveRadioAvailable()) {
+    console.warn('[cmd] blocked while radio health is degraded', name);
+    return false;
+  }
   // Auto-optimistic: apply UI patch immediately before sending
   try { _applyOptimistic(name, params); } catch (e) { console.warn('[optimistic]', e); }
   return _ctrl.send({

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -178,9 +178,24 @@ def classify_radio_health(
         }
 
     last_civ = getattr(radio, "_last_civ_data_received", None)
-    idle_s = 0.0
+    last_civ_value: float | None = None
     if isinstance(last_civ, (int, float)) and not isinstance(last_civ, bool):
-        idle_s = max(0.0, now - float(last_civ))
+        last_civ_value = float(last_civ)
+    has_civ_evidence = last_civ_value is not None
+    had_success = _bool_attr(radio, "_has_connected_once") or has_civ_evidence
+    if radio_link == "unknown" and not had_success and not stats:
+        return {
+            "serverReachable": True,
+            "radioLink": "unknown",
+            "readiness": "stalled",
+            "likelyCause": "unknown",
+            "sinceMs": 0,
+            "lastError": last_error_value,
+        }
+
+    idle_s = 0.0
+    if last_civ_value is not None:
+        idle_s = max(0.0, now - last_civ_value)
     ready_timeout = getattr(radio, "_civ_ready_idle_timeout", 2.0)
     if not isinstance(ready_timeout, (int, float)) or isinstance(ready_timeout, bool):
         ready_timeout = 2.0
@@ -189,7 +204,6 @@ def classify_radio_health(
 
     timeouts = stats.get("timeouts", 0)
     timeout_count = timeouts if isinstance(timeouts, int) else 0
-    had_success = _bool_attr(radio, "_has_connected_once") or last_civ is not None
     recovering = _bool_attr(radio, "_civ_recovering")
     powered_off_likely = (
         had_success

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -165,6 +165,17 @@ def test_radio_health_classifies_network_loss_separately_from_server_loss() -> N
     assert health["likelyCause"] == "radio_network_lost"
 
 
+def test_radio_health_keeps_unknown_when_radio_has_no_runtime_evidence() -> None:
+    radio = _FakeRadio(connected=False, radio_ready_flag=False)
+
+    health = classify_radio_health(radio, server_reachable=True, now_monotonic=100.0)
+
+    assert health["serverReachable"] is True
+    assert health["radioLink"] == "unknown"
+    assert health["readiness"] == "stalled"
+    assert health["likelyCause"] == "unknown"
+
+
 def test_radio_health_classifies_delayed_then_stalled_radio_response() -> None:
     radio = _FakeRadio(connected=True, radio_ready_flag=False)
     radio._last_civ_data_received = 98.5


### PR DESCRIPTION
## Summary
- Keep never-connected/insufficient-evidence radio runtime state classified as `unknown`, instead of prematurely reporting `radio_not_responding`.
- Add a shared `isLiveRadioAvailable()` frontend predicate backed by `radioHealth` and block `sendCommand()` before optimistic state updates while health is degraded.
- Add regression coverage for both independent review findings.

## Verification
- `uv run --extra dev python -m pytest tests/test_web_runtime_helpers.py tests/test_web_server_coverage.py::TestStateEtag -q --tb=short`
- `cd frontend && npx vitest run src/lib/stores/connection.test.ts src/lib/transport/__tests__/ws-client.test.ts`
- `cd frontend && npx vitest run src/lib/transport/__tests__/ws-client.test.ts src/lib/stores/connection.test.ts src/lib/stores/__tests__/radio.test.ts src/lib/transport/__tests__/http-client.test.ts src/lib/local-extensions/__tests__/host-api.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npm run build`
- `cd frontend && npx vitest run`
- `uv run --extra dev mypy --strict src/rigplane/web`
- `uv run --extra dev ruff check src/rigplane/web/runtime_helpers.py tests/test_web_runtime_helpers.py`
- `uv run --extra dev ruff format --check src/rigplane/web/runtime_helpers.py tests/test_web_runtime_helpers.py`

Follow-up to #1502 / #1500 / #1501.