### PR TITLE
docs(#1494): document IC-7610 tunnel MTU audio workaround

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Web TX audio on IC-7610 LAN now starts the accepted radio-native TX contract instead of starting Opus against the radio's PCM-only TX stream (#1493).
 - Web RX LIVE toggling now sends `audio_start` / `audio_stop` even when the audio WebSocket is already open, fixing the first-click silence after page load (#1495).
-- IC-7610 LAN audio defaults and probe evidence handling now validate PCM16 payload size; malformed 24/48 kHz PCM frames no longer count as passed probe evidence, and the profile defaults PCM back to 16 kHz (#1494).
+- IC-7610 LAN audio keeps 48 kHz PCM as the full-fidelity profile default; troubleshooting docs now call out VPN/tunnel MTU fragmentation issues and the `ICOM_AUDIO_SAMPLE_RATE=16000` low-bandwidth workaround (#1494).
 - Existing Svelte check warnings in touched frontend files were removed so `npm run check` is clean for the hotfix branch (#1497).
 
 ## [2.1.0] — 2026-05-08

--- a/docs/guide/audio-recipes.md
+++ b/docs/guide/audio-recipes.md
@@ -29,9 +29,9 @@ a diagnostic report includes `radio_native.requested`,
 `radio_native.effective`, and `web_rx` when those values are available or
 configured.
 
-`ICOM_AUDIO_SAMPLE_RATE` remains an operator override. Set it only when you
-need to force the direct LAN conninfo sample rate for testing or hardware
-compatibility:
+`ICOM_AUDIO_SAMPLE_RATE` remains an operator override. Set it when you need to
+force the direct LAN conninfo sample rate for testing, hardware compatibility,
+or bandwidth-constrained tunnel paths:
 
 ```bash
 export ICOM_AUDIO_SAMPLE_RATE=16000
@@ -40,7 +40,9 @@ uv run rigplane --host 192.168.55.40 --user USER --pass-file .rigplane-pass web
 
 Explicit API or CLI/env overrides take precedence over profile defaults. If no
 override is supplied, model profiles choose the best known radio-native default;
-for example the IC-7610 direct LAN profile requests PCM at 16 kHz.
+for example the IC-7610 direct LAN profile requests full-fidelity PCM at
+48 kHz. On constrained VPN/cloud paths, 16 kHz is a good low-bandwidth override
+because it fits each 20 ms stereo PCM frame in one UDP packet.
 
 ## Prerequisites
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -20,6 +20,7 @@ All commands accept these options:
 | `--serial-ptt-mode` | `ICOM_SERIAL_PTT_MODE` | `civ` | Serial PTT mode (`civ` currently supported) |
 | `--rx-device` | `ICOM_USB_RX_DEVICE` | auto | USB audio RX device name (serial/CAT profiles with audio support) |
 | `--tx-device` | `ICOM_USB_TX_DEVICE` | auto | USB audio TX device name (serial/CAT profiles with audio support) |
+| — | `ICOM_AUDIO_SAMPLE_RATE` | profile/default | LAN audio sample-rate override (`8000`, `16000`, `24000`, or `48000`) |
 | `--list-audio-devices` | — | — | List USB audio devices and exit |
 | `--version` | — | — | Print version and exit |
 

--- a/docs/guide/diagnostic-reports.md
+++ b/docs/guide/diagnostic-reports.md
@@ -113,7 +113,7 @@ tools, and may also include:
 
 Source metadata uses stable strings such as `explicit`, `profile-default`,
 `profile-codec-default`, `global-default`, and `fallback`. For example, an
-IC-7610 can request radio-native `PCM_2CH_16BIT` at `16000` Hz from its profile
+IC-7610 can request radio-native `PCM_2CH_16BIT` at `48000` Hz from its profile
 while the Web UI emits Opus as a browser transport. That means only the browser
 leg is Opus; the direct radio LAN stream remains PCM.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -349,6 +349,43 @@ may stutter briefly during reconnection.
 **Solution:** v0.8.0+ uses a 200ms jitter buffer (up from 50ms). For very high
 latency connections, this may still be insufficient — consider a local deployment.
 
+## LAN Audio Breaks Over WireGuard or Other UDP Tunnels
+
+**Symptom:** Control and CI-V commands work, but LAN audio is choppy, chipmunky,
+or loses whole chunks over a VPN/tunnel. This is most visible with high-rate
+PCM modes such as IC-7610 `PCM_2CH_16BIT` at 48 kHz.
+
+**Cause:** The radio may send one 20 ms audio frame as multiple UDP payloads.
+For IC-7610 48 kHz stereo PCM, one frame is 3840 audio bytes and is normally
+split across three payloads. If a tunnel path silently drops IP fragments, the
+receiver may see only the small trailing packets and cannot reassemble the
+original audio. This is a tunnel/path-MTU problem, not a radio capability
+failure.
+
+**Quick workaround:**
+
+```bash
+export ICOM_AUDIO_SAMPLE_RATE=16000
+uv run rigplane --host 192.168.55.40 --user USER --pass-file .rigplane-pass web
+```
+
+16 kHz stereo PCM fits a 20 ms frame in one UDP packet and is usually adequate
+for remote voice monitoring. Keep 48 kHz for full-fidelity LAN or well-tuned
+VPN paths.
+
+**MTU runbook:**
+
+1. Capture on both tunnel endpoints while audio is running:
+   `tcpdump -ni wg0 'udp and host <radio-or-peer-ip>'`.
+2. Look for IP fragments, especially first fragments with `MF` set.
+3. If first fragments disappear but small trailing fragments arrive, lower the
+   tunnel interface MTU on both ends.
+4. For WireGuard, remember to budget for outer IP/UDP/WireGuard overhead. The
+   correct value depends on the WAN path; cellular/CGNAT/cloud paths often need
+   smaller MTUs than a normal Ethernet LAN.
+5. Re-run `rigplane audio probe --candidate-cooldown 35 --retry-rejected 1`
+   after changing MTU and confirm packet counts are stable.
+
 ## TX Audio Has No Modulation on macOS (Web UI / Bridge)
 
 **Symptom:** PTT toggles ON, but transmitted audio is silent or very weak.

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -20,12 +20,14 @@ has_wifi = false
 # consumer transport after the server receives radio-native PCM.
 # Hardware probe: 2026-05-08, firmware 1.42,
 # `rigplane audio probe --candidate-cooldown 35 --retry-rejected 1`.
-# The initial probe saw packets at 48000/24000/16000/8000 Hz, but PCM
-# payload-size validation leaves valid PCM16 framing at 16000/8000 Hz.
+# Full-fidelity 48000 Hz stereo PCM is valid. It fragments one 20 ms frame
+# across multiple UDP payloads (1364 + 1364 + 1112 audio bytes); make sure
+# VPN/tunnel MTU settings preserve those fragments, or override the sample
+# rate to 16000 Hz for constrained paths.
 codec_preference = ["PCM_2CH_16BIT", "PCM_1CH_16BIT", "ULAW_2CH", "ULAW_1CH"]
 tx_codec = "PCM_1CH_16BIT"
-default_sample_rate_hz = 16000
-sample_rate_by_codec = { PCM_2CH_16BIT = 16000, PCM_1CH_16BIT = 16000, ULAW_2CH = 48000, ULAW_1CH = 48000 }
+default_sample_rate_hz = 48000
+sample_rate_by_codec = { PCM_2CH_16BIT = 48000, PCM_1CH_16BIT = 48000, ULAW_2CH = 48000, ULAW_1CH = 48000 }
 browser_rx_transport = "auto"
 browser_rx_transcode_to_opus = true
 

--- a/tests/test_audio_route.py
+++ b/tests/test_audio_route.py
@@ -93,8 +93,8 @@ def test_ic7610_lan_stream_request_uses_profile_audio_policy() -> None:
 
     assert request.rx_codec == AudioCodec.PCM_2CH_16BIT
     assert request.tx_codec == AudioCodec.PCM_1CH_16BIT
-    assert request.rx_sample_rate_hz == 16000
-    assert request.tx_sample_rate_hz == 16000
+    assert request.rx_sample_rate_hz == 48000
+    assert request.tx_sample_rate_hz == 48000
     assert request.rx_channels == 2
     assert request.tx_channels == 1
     assert request.rx_codec_source == AudioConfigSource.PROFILE_DEFAULT

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -647,11 +647,11 @@ class TestAudioPolicy:
             "ULAW_1CH",
         )
         assert rig.tx_codec == "PCM_1CH_16BIT"
-        assert rig.default_sample_rate_hz == 16000
+        assert rig.default_sample_rate_hz == 48000
         assert rig.supported_sample_rates_hz is None
         assert rig.sample_rate_by_codec == {
-            "PCM_2CH_16BIT": 16000,
-            "PCM_1CH_16BIT": 16000,
+            "PCM_2CH_16BIT": 48000,
+            "PCM_1CH_16BIT": 48000,
             "ULAW_2CH": 48000,
             "ULAW_1CH": 48000,
         }
@@ -666,11 +666,11 @@ class TestAudioPolicy:
             "ULAW_1CH",
         )
         assert profile.tx_codec == "PCM_1CH_16BIT"
-        assert profile.default_sample_rate_hz == 16000
+        assert profile.default_sample_rate_hz == 48000
         assert profile.supported_sample_rates_hz is None
         assert profile.sample_rate_by_codec == {
-            "PCM_2CH_16BIT": 16000,
-            "PCM_1CH_16BIT": 16000,
+            "PCM_2CH_16BIT": 48000,
+            "PCM_1CH_16BIT": 48000,
             "ULAW_2CH": 48000,
             "ULAW_1CH": 48000,
         }


### PR DESCRIPTION
## Summary

- keep IC-7610 LAN PCM at the full-fidelity 48 kHz profile default
- document WireGuard/UDP tunnel MTU fragmentation failure mode and the 16 kHz workaround
- update audio docs, diagnostics example, changelog, and profile-policy tests

## Verification

- `uv run pytest tests/test_rig_loader.py tests/test_audio_route.py -q --tb=short` -> 74 passed
- `uv run ruff check tests/test_rig_loader.py tests/test_audio_route.py` -> clean
- `git diff --check` -> clean

Closes #1494