### PR TITLE
docs: add multi-agent repo hygiene policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Scope
+
+- Linked issue / task:
+- Compatibility impact: API / CLI / config / wire behavior / docs / none
+
+## Verification
+
+- [ ] Relevant local tests or checks run
+- [ ] Public/open-core boundary checked
+- [ ] Release or migration impact documented if applicable
+
+## Agent Review
+
+- [ ] Independent agent review completed before merge
+- Reviewer:
+- Result: `Agent Review: PASS` / `Agent Review: BLOCKED`
+
+## Notes
+
+- Out of scope / follow-ups:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,36 @@ Default rule for agents:
 See `docs/internals/github-project-workflow.md` for the exact CLI and UI
 workflow.
 
+## Multi-agent Git hygiene
+
+This repo is developed from multiple machines and by multiple agents. Before
+editing:
+
+- run `git fetch --all --tags --prune`;
+- inspect `git status --short --branch`;
+- do not work directly on `main`;
+- use `codex/<issue-or-task>` branches for agent work;
+- use `git pull --ff-only --tags` only on clean branches with a normal upstream;
+- do not reset, clean, delete, or rebase uncertain work without explicit user
+  approval.
+
+Use the global `repo-hygiene` skill for cross-repo inventory and cleanup.
+
+## Protected main and review gate
+
+`main` is protected. Changes should land through PRs.
+
+Every non-trivial PR requires independent agent review before merge. The
+implementation agent may not be the review agent. The review must be visible in
+the PR and include either `Agent Review: PASS` or `Agent Review: BLOCKED`.
+
+## Release branches
+
+Use release branches only when a public/core release needs stabilization while
+`main` continues moving. Tags remain the source of truth for published
+artifacts. Hotfixes made on a release branch must be merged or cherry-picked
+back to `main`.
+
 ## Engineering rules
 
 - Follow `CLAUDE.md` for commands, architecture, testing, and workflow gates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,35 @@ User-facing → **Russian**. Code/commits/docs/PR → **English**.
 Commits: `feat(#N):` / `fix(#N):` / `refactor:` / `test:` / `docs:` / `chore:`
 One change per commit. Full test suite before push.
 
+### Multi-machine Git hygiene
+
+Development runs across a local laptop and a dev Mac mini, often with several
+agents. Before editing:
+
+```bash
+git fetch --all --tags --prune
+git status --short --branch
+python3 ~/.codex/skills/repo-hygiene/scripts/repo_inventory.py --roots /Users/moroz/Projects --summary
+```
+
+Rules:
+
+- never work directly on `main`;
+- use `codex/<issue-or-task>` for agent work;
+- use `git pull --ff-only --tags` only on a clean branch with a normal upstream;
+- do not reset, clean, delete, or rebase uncertain work without explicit user
+  approval;
+- report or snapshot dirty trees before sync.
+
+`main` is protected. Non-trivial PRs require independent agent review before
+merge. The implementation agent cannot self-review. The review must be visible
+in the PR and include either `Agent Review: PASS` or `Agent Review: BLOCKED`.
+
+Release branches are exceptional: use `release/<major.minor>` only when a
+public release needs stabilization while `main` moves ahead. Tags remain the
+published artifact source of truth, and release-branch hotfixes must return to
+`main`.
+
 ---
 
 ## Completion criteria


### PR DESCRIPTION
## Summary\n- Adds multi-machine Git hygiene rules for agents\n- Documents protected main, mandatory independent agent review, and release branch policy\n- Adds a PR template with an Agent Review gate\n\n## Verification\n- Documentation-only change; reviewed diff locally\n- GitHub branch protection enabled for main\n- repo-hygiene skill validated separately with quick_validate.py\n\n## Agent Review\n- Pending: independent agent review required before merge\n- Result: Agent Review: BLOCKED until reviewed