### PR TITLE
ci: add agent review gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,11 @@
 
 ## Agent Review
 
-- [ ] Independent agent review completed before merge
+- [ ] Independent agent review comment posted before merge
 - Reviewer:
 - Result: `Agent Review: PASS` / `Agent Review: BLOCKED`
+- If BLOCKED: include concrete problems, file/line references, risks, required
+  fixes, and checks to rerun.
 
 ## Notes
 

--- a/.github/workflows/agent-review-gate.yml
+++ b/.github/workflows/agent-review-gate.yml
@@ -4,12 +4,13 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   issue_comment:
-    types: [created, edited]
+    types: [created, edited, deleted]
 
 permissions:
   contents: read
   issues: read
   pull-requests: read
+  statuses: write
 
 concurrency:
   group: agent-review-gate-${{ github.event.issue.pull_request && github.event.issue.number || github.event.pull_request.number }}
@@ -17,7 +18,7 @@ concurrency:
 
 jobs:
   agent-review:
-    name: Agent Review Gate
+    name: Update Agent Review Gate status
     if: github.event_name == 'pull_request' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -29,13 +30,32 @@ jobs:
         with:
           script: |
             const number = context.payload.pull_request?.number ?? context.payload.issue?.number;
+            const {owner, repo} = context.repo;
+            const {data: pull} = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: number,
+            });
+            const {data: commit} = await github.rest.repos.getCommit({
+              owner,
+              repo,
+              ref: pull.head.sha,
+            });
+            const committedAt =
+              commit.commit.committer?.date ??
+              commit.commit.author?.date ??
+              pull.updated_at;
             core.setOutput('number', String(number));
+            core.setOutput('head_sha', pull.head.sha);
+            core.setOutput('committed_at', committedAt);
 
-      - name: Require Agent Review PASS comment
+      - name: Update required Agent Review Gate status
         uses: actions/github-script@v7
         with:
           script: |
             const pull_number = Number('${{ steps.pr.outputs.number }}');
+            const head_sha = '${{ steps.pr.outputs.head_sha }}';
+            const committed_at = new Date('${{ steps.pr.outputs.committed_at }}');
             const {owner, repo} = context.repo;
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
@@ -46,8 +66,20 @@ jobs:
             const pass = comments.some((comment) =>
               !comment.minimized &&
               typeof comment.body === 'string' &&
-              comment.body.includes('Agent Review: PASS')
+              comment.body.includes('Agent Review: PASS') &&
+              new Date(comment.updated_at ?? comment.created_at) >= committed_at
             );
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: head_sha,
+              state: pass ? 'success' : 'failure',
+              context: 'Agent Review Gate',
+              description: pass
+                ? 'Agent Review PASS comment found for the current PR head.'
+                : 'Missing Agent Review PASS comment for the current PR head.',
+              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            });
             if (!pass) {
-              core.setFailed('Missing required PR comment containing "Agent Review: PASS".');
+              core.notice('Missing required PR comment containing "Agent Review: PASS" posted or edited after the current PR head commit.');
             }

--- a/.github/workflows/agent-review-gate.yml
+++ b/.github/workflows/agent-review-gate.yml
@@ -1,0 +1,53 @@
+name: Agent Review Gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: agent-review-gate-${{ github.event.issue.pull_request && github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  agent-review:
+    name: Agent Review Gate
+    if: github.event_name == 'pull_request' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Resolve pull request number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const number = context.payload.pull_request?.number ?? context.payload.issue?.number;
+            core.setOutput('number', String(number));
+
+      - name: Require Agent Review PASS comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pull_number = Number('${{ steps.pr.outputs.number }}');
+            const {owner, repo} = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pull_number,
+              per_page: 100,
+            });
+            const pass = comments.some((comment) =>
+              !comment.minimized &&
+              typeof comment.body === 'string' &&
+              comment.body.includes('Agent Review: PASS')
+            );
+            if (!pass) {
+              core.setFailed('Missing required PR comment containing "Agent Review: PASS".');
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,21 +81,23 @@ Use the global `repo-hygiene` skill for cross-repo inventory and cleanup.
 `main` is protected. Changes should land through PRs.
 
 RigPlane's standard automation gate is `.github/workflows/agent-review-gate.yml`.
-It passes only after a normal PR comment contains `Agent Review: PASS`. Use the
-required status check `Agent Review Gate` instead of GitHub required approving
+It updates the required commit status `Agent Review Gate` on the current PR
+head SHA and passes only after a normal PR comment contains `Agent Review:
+PASS` for that head. Use this status instead of GitHub required approving
 reviews; same-user approval restrictions break automated agent flow.
 
 Every non-trivial PR requires independent agent review before merge. The
 implementation agent may not be the review agent.
 
-- `Agent Review: PASS` means the PR may merge once required checks are green and
-  the PR is not draft.
+- `Agent Review: PASS` means the PR may merge once required checks are green,
+  the PASS comment is fresh for the current head, and the PR is not draft.
 - `Agent Review: BLOCKED` must include concrete problems, file/line references
   where applicable, risk, required fixes, and checks to run.
 - The implementation agent must address BLOCKED feedback, push updates, and
   rerun or wait for checks before merge.
-- A failed `Agent Review Gate` without BLOCKED feedback usually means no PASS
-  comment exists yet; perform the review instead of skipping the PR.
+- A failed `Agent Review Gate` without BLOCKED feedback usually means no fresh
+  PASS comment exists for the current head; perform or refresh the review
+  instead of skipping the PR.
 - Cancelled checks must be rerun with `gh run rerun <run-id>` or a new push,
   then watched to completion.
 - Draft PRs must not merge. Determine why the PR is draft, finish the missing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,26 @@ Use the global `repo-hygiene` skill for cross-repo inventory and cleanup.
 
 `main` is protected. Changes should land through PRs.
 
+RigPlane's standard automation gate is `.github/workflows/agent-review-gate.yml`.
+It passes only after a normal PR comment contains `Agent Review: PASS`. Use the
+required status check `Agent Review Gate` instead of GitHub required approving
+reviews; same-user approval restrictions break automated agent flow.
+
 Every non-trivial PR requires independent agent review before merge. The
-implementation agent may not be the review agent. The review must be visible in
-the PR and include either `Agent Review: PASS` or `Agent Review: BLOCKED`.
+implementation agent may not be the review agent.
+
+- `Agent Review: PASS` means the PR may merge once required checks are green and
+  the PR is not draft.
+- `Agent Review: BLOCKED` must include concrete problems, file/line references
+  where applicable, risk, required fixes, and checks to run.
+- The implementation agent must address BLOCKED feedback, push updates, and
+  rerun or wait for checks before merge.
+- A failed `Agent Review Gate` without BLOCKED feedback usually means no PASS
+  comment exists yet; perform the review instead of skipping the PR.
+- Cancelled checks must be rerun with `gh run rerun <run-id>` or a new push,
+  then watched to completion.
+- Draft PRs must not merge. Determine why the PR is draft, finish the missing
+  work, run `gh pr ready`, then complete checks and review.
 
 ## Release branches
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,22 +122,24 @@ Rules:
 
 `main` is protected. RigPlane uses `.github/workflows/agent-review-gate.yml`
 as the standard PR automation gate. The workflow passes only after a normal PR
-comment contains `Agent Review: PASS`; use the required status check
-`Agent Review Gate` instead of GitHub required approving reviews, because
-same-user approval restrictions break automated agent flow.
+comment contains `Agent Review: PASS` for the current PR head; use the required
+commit status `Agent Review Gate` instead of GitHub required approving reviews,
+because same-user approval restrictions break automated agent flow.
 
 Non-trivial PRs require independent agent review before merge. The
 implementation agent cannot self-review. `Agent Review: PASS` means the PR may
-merge once required checks are green and the PR is not draft. `Agent Review:
-BLOCKED` must include concrete problems, file/line references where applicable,
-risk, required fixes, and checks to run. The implementation agent must fix
+merge once required checks are green, the PASS comment is fresh for the current
+head, and the PR is not draft. `Agent Review: BLOCKED` must include concrete
+problems, file/line references where applicable, risk, required fixes, and
+checks to run. The implementation agent must fix
 BLOCKED feedback, push updates, and rerun or wait for checks before merge.
 
-A failed `Agent Review Gate` without BLOCKED feedback usually means no PASS
-comment exists yet; perform the review instead of skipping the PR. Cancelled
-checks must be rerun with `gh run rerun <run-id>` or a new push, then watched to
-completion. Draft PRs must not merge: determine why the PR is draft, finish the
-missing work, run `gh pr ready`, then complete checks and review.
+A failed `Agent Review Gate` without BLOCKED feedback usually means no fresh
+PASS comment exists for the current head; perform or refresh the review instead
+of skipping the PR. Cancelled checks must be rerun with `gh run rerun <run-id>`
+or a new push, then watched to completion. Draft PRs must not merge: determine
+why the PR is draft, finish the missing work, run `gh pr ready`, then complete
+checks and review.
 
 Release branches are exceptional: use `release/<major.minor>` only when a
 public release needs stabilization while `main` moves ahead. Tags remain the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,24 @@ Rules:
   approval;
 - report or snapshot dirty trees before sync.
 
-`main` is protected. Non-trivial PRs require independent agent review before
-merge. The implementation agent cannot self-review. The review must be visible
-in the PR and include either `Agent Review: PASS` or `Agent Review: BLOCKED`.
+`main` is protected. RigPlane uses `.github/workflows/agent-review-gate.yml`
+as the standard PR automation gate. The workflow passes only after a normal PR
+comment contains `Agent Review: PASS`; use the required status check
+`Agent Review Gate` instead of GitHub required approving reviews, because
+same-user approval restrictions break automated agent flow.
+
+Non-trivial PRs require independent agent review before merge. The
+implementation agent cannot self-review. `Agent Review: PASS` means the PR may
+merge once required checks are green and the PR is not draft. `Agent Review:
+BLOCKED` must include concrete problems, file/line references where applicable,
+risk, required fixes, and checks to run. The implementation agent must fix
+BLOCKED feedback, push updates, and rerun or wait for checks before merge.
+
+A failed `Agent Review Gate` without BLOCKED feedback usually means no PASS
+comment exists yet; perform the review instead of skipping the PR. Cancelled
+checks must be rerun with `gh run rerun <run-id>` or a new push, then watched to
+completion. Draft PRs must not merge: determine why the PR is draft, finish the
+missing work, run `gh pr ready`, then complete checks and review.
 
 Release branches are exceptional: use `release/<major.minor>` only when a
 public release needs stabilization while `main` moves ahead. Tags remain the


### PR DESCRIPTION
Adds a GitHub Actions gate that requires a PR comment containing Agent Review: PASS before merge.

This keeps review automation friendly: agents can satisfy the gate with a visible PR comment, without requiring same-user GitHub approval.

Agent review: pending.