### PR TITLE
feat(#1498): advertise friendly station server status

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -46,6 +46,7 @@ These routes are part of the Pro/supervisor compatibility surface:
 | `GET` | `/healthz` | Process/API liveness, no API token required |
 | `GET` | `/readyz` | Station readiness, returns `503` until radio is ready |
 | `GET` | `/api/v1/runtime` | Process, bind, radio, rigctld, bridge, and diagnostic runtime status |
+| `GET` | `/api/v1/station` | Friendly station-server identity, readiness, and next-action status |
 | `GET` | `/api/v1/info` | Runtime model/capability summary |
 | `GET` | `/api/v1/state` | Canonical current state snapshot |
 | `GET` | `/api/v1/capabilities` | Full profile-backed capabilities |
@@ -147,6 +148,13 @@ When auth is configured, this endpoint requires the same bearer token as other
     "controlConnected": true,
     "radioReady": true
   },
+  "station": {
+    "readiness": "ready_with_radio",
+    "radioAvailable": true,
+    "backend": "rigplane",
+    "authRequired": true,
+    "message": "Station server is ready with an attached radio."
+  },
   "rigctld": {
     "enabled": true,
     "address": "127.0.0.1:4532"
@@ -158,6 +166,49 @@ When auth is configured, this endpoint requires the same bearer token as other
   "lastError": null
 }
 ```
+
+## `GET /api/v1/station`
+
+Friendly station-server status for desktop supervisors and setup tools. When
+auth is configured, this endpoint requires the same bearer token as other
+`/api/*` routes.
+
+```json
+{
+  "schema": "rigplane.station.status.v1",
+  "service": "rigplane",
+  "kind": "station_server",
+  "version": "2.0.3",
+  "displayName": "IC-7610",
+  "instanceId": null,
+  "baseUrl": "http://127.0.0.1:58421",
+  "healthUrl": "http://127.0.0.1:58421/healthz",
+  "readinessUrl": "http://127.0.0.1:58421/readyz",
+  "runtimeUrl": "http://127.0.0.1:58421/api/v1/runtime",
+  "stationUrl": "http://127.0.0.1:58421/api/v1/station",
+  "station": {
+    "readiness": "ready_with_radio",
+    "radioAvailable": true,
+    "backend": "rigplane",
+    "authRequired": true,
+    "message": "Station server is ready with an attached radio."
+  },
+  "radio": {
+    "model": "IC-7610",
+    "connected": true,
+    "controlConnected": true,
+    "radioReady": true
+  }
+}
+```
+
+Current readiness values are:
+
+- `ready_with_radio`
+- `radio_powered_off_or_unreachable`
+- `no_usb_radio_connected`
+- `lan_radio_unsupported_or_not_found`
+- `requires_configuration_or_auth`
 
 Managed runtimes also emit a single machine-readable startup event to stdout
 after the web listener has bound successfully. Supervisors should use this JSON

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -669,6 +669,14 @@ After the web listener binds, `station` writes one JSON startup event to stdout:
 Use this event for supervisor discovery when `--port 0` asks the OS to allocate
 the actual port.
 
+When UDP discovery is enabled, `rigplane station` and `rigplane web` answer
+`RIGPLANE_DISCOVER\n` broadcasts with a `rigplane.station.discovery.v1` JSON
+payload. The payload includes the base URL, `/healthz`, `/readyz`,
+`/api/v1/runtime`, `/api/v1/station`, version, display name, radio model,
+backend, auth-required flag, and a readiness value such as
+`ready_with_radio`, `no_usb_radio_connected`, or
+`radio_powered_off_or_unreachable`.
+
 ### `audio bridge`
 
 Route radio audio to/from a virtual audio device (BlackHole, Loopback, VB-Audio).

--- a/src/rigplane/web/api_contract.py
+++ b/src/rigplane/web/api_contract.py
@@ -46,6 +46,12 @@ STABLE_HTTP_ENDPOINTS: Final[tuple[HttpEndpoint, ...]] = (
     },
     {
         "method": "GET",
+        "path": "/api/v1/station",
+        "purpose": "friendly station-server status",
+        "auth": "bearer",
+    },
+    {
+        "method": "GET",
         "path": "/api/v1/info",
         "purpose": "runtime model and capability summary",
         "auth": "bearer",
@@ -128,9 +134,25 @@ RESPONSE_FIELD_CONTRACTS: Final[dict[str, ResponseFieldContract]] = {
             "authRequired",
             "backend",
             "radio",
+            "station",
             "rigctld",
             "bridge",
             "lastError",
+        )
+    },
+    "/api/v1/station": {
+        "required": (
+            "schema",
+            "service",
+            "kind",
+            "version",
+            "displayName",
+            "baseUrl",
+            "healthUrl",
+            "readinessUrl",
+            "runtimeUrl",
+            "station",
+            "radio",
         )
     },
     "/api/v1/info": {

--- a/src/rigplane/web/discovery.py
+++ b/src/rigplane/web/discovery.py
@@ -35,6 +35,12 @@ class RadioInfo:
 
     model: str
     connected: bool
+    control_connected: bool = False
+    radio_ready: bool = False
+    backend: str | None = None
+    readiness: str | None = None
+    message: str | None = None
+    auth_required: bool = False
 
 
 class _DiscoveryProtocol(asyncio.DatagramProtocol):
@@ -153,12 +159,46 @@ class DiscoveryResponder:
             name = "RigPlane"
 
         payload: dict[str, object] = {
+            "schema": "rigplane.station.discovery.v1",
             "service": "rigplane",
+            "kind": "station_server",
             "version": __version__,
             "url": f"{scheme}://{local_ip}:{self._web_port}",
+            "urls": {
+                "base": f"{scheme}://{local_ip}:{self._web_port}",
+                "health": f"{scheme}://{local_ip}:{self._web_port}/healthz",
+                "readiness": f"{scheme}://{local_ip}:{self._web_port}/readyz",
+                "runtime": (f"{scheme}://{local_ip}:{self._web_port}/api/v1/runtime"),
+                "station": (f"{scheme}://{local_ip}:{self._web_port}/api/v1/station"),
+            },
             "name": name,
+            "displayName": name,
+            "instanceId": None,
+            "station": {
+                "readiness": (
+                    radio_info.readiness
+                    if radio_info and radio_info.readiness
+                    else (
+                        "ready_with_radio"
+                        if radio_info
+                        and (radio_info.radio_ready or radio_info.connected)
+                        else "requires_configuration_or_auth"
+                    )
+                ),
+                "radioAvailable": bool(
+                    radio_info and (radio_info.radio_ready or radio_info.connected)
+                ),
+                "backend": radio_info.backend if radio_info else None,
+                "authRequired": bool(radio_info.auth_required) if radio_info else False,
+                "message": radio_info.message if radio_info else None,
+            },
             "radio": (
-                {"model": radio_info.model, "connected": radio_info.connected}
+                {
+                    "model": radio_info.model,
+                    "connected": radio_info.connected,
+                    "controlConnected": radio_info.control_connected,
+                    "radioReady": radio_info.radio_ready,
+                }
                 if radio_info
                 else None
             ),

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1386,6 +1386,85 @@ class WebServer:
         scheme = "https" if self._config.tls else "http"
         return f"{scheme}://{bind['host']}:{bind['port']}"
 
+    def _radio_runtime_payload(self) -> dict[str, Any]:
+        radio = self._radio
+        raw_connected = (
+            getattr(radio, "connected", False) if radio is not None else False
+        )
+        connected = raw_connected if isinstance(raw_connected, bool) else False
+        raw_control_connected = (
+            getattr(radio, "control_connected", False) if radio is not None else False
+        )
+        control_connected = (
+            raw_control_connected if isinstance(raw_control_connected, bool) else False
+        )
+        return {
+            "model": getattr(radio, "model", self._config.radio_model)
+            if radio is not None
+            else self._config.radio_model,
+            "connected": connected,
+            "controlConnected": control_connected,
+            "radioReady": self._radio_ready(),
+        }
+
+    def _station_readiness_payload(self) -> dict[str, Any]:
+        radio = self._radio
+        backend = getattr(radio, "backend_id", None) if radio is not None else None
+        radio_payload = self._radio_runtime_payload()
+        health = self._build_radio_health()
+        if radio_payload["radioReady"]:
+            readiness = "ready_with_radio"
+            message = "Station server is ready with an attached radio."
+        elif radio is None:
+            readiness = "requires_configuration_or_auth"
+            message = "Start the station server with a configured radio target."
+        elif backend in {"icom_serial", "yaesu_cat"}:
+            readiness = "no_usb_radio_connected"
+            message = "Connect the radio by USB and confirm serial permissions."
+        elif backend == "rigplane":
+            likely = health.get("likelyCause")
+            readiness = (
+                "radio_powered_off_or_unreachable"
+                if likely in {"radio_powered_off_likely", "radio_not_responding"}
+                else "lan_radio_unsupported_or_not_found"
+            )
+            message = "Power on the radio and confirm it is reachable on the LAN."
+        else:
+            readiness = "requires_configuration_or_auth"
+            message = "Configure a supported radio target before using this station."
+        return {
+            "readiness": readiness,
+            "radioAvailable": bool(radio_payload["radioReady"]),
+            "backend": backend,
+            "health": health,
+            "authRequired": bool(self._config.auth_token),
+            "message": message,
+        }
+
+    def _station_status_payload(self) -> dict[str, Any]:
+        base_url = self._runtime_base_url()
+        radio_payload = self._radio_runtime_payload()
+        display_name = (
+            radio_payload["model"]
+            if radio_payload["model"]
+            else self._config.radio_model
+        )
+        return {
+            "schema": "rigplane.station.status.v1",
+            "service": "rigplane",
+            "kind": "station_server",
+            "version": __version__,
+            "displayName": display_name,
+            "instanceId": None,
+            "baseUrl": base_url,
+            "healthUrl": f"{base_url}/healthz",
+            "readinessUrl": f"{base_url}/readyz",
+            "runtimeUrl": f"{base_url}/api/v1/runtime",
+            "stationUrl": f"{base_url}/api/v1/station",
+            "station": self._station_readiness_payload(),
+            "radio": radio_payload,
+        }
+
     def startup_event_payload(self) -> dict[str, Any]:
         base_url = self._runtime_base_url()
         return {
@@ -1424,16 +1503,6 @@ class WebServer:
         self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
     ) -> None:
         radio = self._radio
-        raw_connected = (
-            getattr(radio, "connected", False) if radio is not None else False
-        )
-        connected = raw_connected if isinstance(raw_connected, bool) else False
-        raw_control_connected = (
-            getattr(radio, "control_connected", False) if radio is not None else False
-        )
-        control_connected = (
-            raw_control_connected if isinstance(raw_control_connected, bool) else False
-        )
         body = json.dumps(
             {
                 "pid": os.getpid(),
@@ -1445,14 +1514,8 @@ class WebServer:
                 "backend": getattr(radio, "backend_id", None)
                 if radio is not None
                 else None,
-                "radio": {
-                    "model": getattr(radio, "model", self._config.radio_model)
-                    if radio is not None
-                    else self._config.radio_model,
-                    "connected": connected,
-                    "controlConnected": control_connected,
-                    "radioReady": self._radio_ready(),
-                },
+                "radio": self._radio_runtime_payload(),
+                "station": self._station_readiness_payload(),
                 "rigctld": {
                     "enabled": self._runtime_rigctld_addr is not None,
                     "address": self._runtime_rigctld_addr,
@@ -1460,6 +1523,15 @@ class WebServer:
                 "bridge": self._runtime_bridge_payload(),
                 "lastError": self._runtime_last_error,
             },
+            separators=(",", ":"),
+        ).encode()
+        await _send_json(writer, body, headers)
+
+    async def _serve_station_status(
+        self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
+    ) -> None:
+        body = json.dumps(
+            self._station_status_payload(),
             separators=(",", ":"),
         ).encode()
         await _send_json(writer, body, headers)

--- a/src/rigplane/web/web_routing.py
+++ b/src/rigplane/web/web_routing.py
@@ -238,6 +238,8 @@ async def dispatch_http_request(
 
     if path == "/api/v1/info":
         await server._serve_info(writer, headers)
+    elif path == "/api/v1/station":
+        await server._serve_station_status(writer, headers)
     elif path == "/api/v1/runtime":
         await server._serve_runtime(writer, headers)
     elif path == "/api/v1/state":

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -143,13 +143,23 @@ async def start_web_server(server: WebServer) -> None:
         def _radio_provider() -> RadioInfo | None:
             if radio is None:
                 return None
+            radio_payload = server._radio_runtime_payload()
+            station_payload = server._station_readiness_payload()
             return RadioInfo(
-                model=getattr(radio, "model", None) or server._config.radio_model,
-                connected=bool(getattr(radio, "connected", False)),
+                model=str(radio_payload["model"]),
+                connected=bool(radio_payload["connected"]),
+                control_connected=bool(radio_payload["controlConnected"]),
+                radio_ready=bool(radio_payload["radioReady"]),
+                backend=station_payload["backend"]
+                if isinstance(station_payload["backend"], str)
+                else None,
+                readiness=str(station_payload["readiness"]),
+                message=str(station_payload["message"]),
+                auth_required=bool(station_payload["authRequired"]),
             )
 
         server._discovery = DiscoveryResponder(
-            web_port=server._config.port,
+            web_port=server._runtime_bind_payload()["port"],
             tls=server._config.tls,
             radio_provider=_radio_provider,
             discovery_port=server._config.discovery_port,

--- a/tests/test_discovery_responder.py
+++ b/tests/test_discovery_responder.py
@@ -88,6 +88,17 @@ class TestDiscoveryResponder:
         assert data["radio"]["model"] == "IC-7610"
         assert data["radio"]["connected"] is True
         assert data["name"] == "IC-7610"
+        assert data["schema"] == "rigplane.station.discovery.v1"
+        assert data["kind"] == "station_server"
+        assert data["displayName"] == "IC-7610"
+        assert data["urls"]["base"].startswith("http://")
+        assert data["urls"]["health"].endswith("/healthz")
+        assert data["urls"]["readiness"].endswith("/readyz")
+        assert data["urls"]["runtime"].endswith("/api/v1/runtime")
+        assert data["urls"]["station"].endswith("/api/v1/station")
+        assert data["station"]["readiness"] == "ready_with_radio"
+        assert data["station"]["radioAvailable"] is True
+        assert data["station"]["authRequired"] is False
 
     async def test_ignores_garbage(self, responder: DiscoveryResponder) -> None:
         result = await _query(responder.port, b"hello world", timeout=0.3)
@@ -105,15 +116,18 @@ class TestDiscoveryResponder:
         data = json.loads(raw)
         assert data["radio"] is None
         assert data["name"] == "RigPlane"
+        assert data["displayName"] == "RigPlane"
+        assert data["station"]["readiness"] == "requires_configuration_or_auth"
+        assert data["station"]["radioAvailable"] is False
         assert data["url"].startswith("https://")
         assert ":9090" in data["url"]
 
-    async def test_response_fits_single_udp_packet(
+    async def test_response_fits_udp_datagram_budget(
         self, responder: DiscoveryResponder
     ) -> None:
         raw = await _query(responder.port, MAGIC)
         assert raw is not None
-        assert len(raw) <= 512
+        assert len(raw) <= 1200
 
     async def test_stop_idempotent(self, responder: DiscoveryResponder) -> None:
         await responder.stop()

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -40,6 +40,7 @@ def test_pro_web_api_contract_lists_stable_surface() -> None:
     assert ("GET", "/healthz") in http
     assert ("GET", "/readyz") in http
     assert ("GET", "/api/v1/runtime") in http
+    assert ("GET", "/api/v1/station") in http
     assert ("GET", "/api/v1/info") in http
     assert ("GET", "/api/v1/state") in http
     assert ("GET", "/api/v1/capabilities") in http
@@ -83,6 +84,7 @@ async def test_stable_http_payloads_satisfy_required_field_contract() -> None:
         ("/healthz", 200),
         ("/readyz", 503),
         ("/api/v1/runtime", 200),
+        ("/api/v1/station", 200),
         ("/api/v1/info", 200),
         ("/api/v1/state", 200),
         ("/api/v1/capabilities", 200),

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -257,17 +257,20 @@ async def test_handle_http_routes_and_405_404() -> None:
     srv2._serve_info = AsyncMock()
     srv2._serve_state = AsyncMock()
     srv2._serve_capabilities = AsyncMock()
+    srv2._serve_station_status = AsyncMock()
     srv2._serve_static = AsyncMock()
     with patch("rigplane.web.server._send_response", new=AsyncMock()) as send_resp2:
         await srv2._handle_http(writer2, "GET", "/api/v1/info")  # noqa: SLF001
         await srv2._handle_http(writer2, "GET", "/api/v1/state")  # noqa: SLF001
         await srv2._handle_http(writer2, "GET", "/api/v1/capabilities")  # noqa: SLF001
+        await srv2._handle_http(writer2, "GET", "/api/v1/station")  # noqa: SLF001
         await srv2._handle_http(writer2, "GET", "/")  # noqa: SLF001
         await srv2._handle_http(writer2, "GET", "/file.js")  # noqa: SLF001
         await srv2._handle_http(writer2, "GET", "relative-path")  # noqa: SLF001
     assert srv2._serve_info.await_count == 1
     assert srv2._serve_state.await_count == 1
     assert srv2._serve_capabilities.await_count == 1
+    assert srv2._serve_station_status.await_count == 1
     assert srv2._serve_static.await_count == 2
     send_resp2.assert_awaited_once()
 
@@ -350,10 +353,48 @@ async def test_runtime_endpoint_reports_process_bind_radio_and_bridge_status() -
         "controlConnected": True,
         "radioReady": True,
     }
+    assert data["station"]["readiness"] == "ready_with_radio"
+    assert data["station"]["radioAvailable"] is True
+    assert data["station"]["backend"] == "rigplane"
     assert data["rigctld"] == {"enabled": True, "address": "127.0.0.1:4532"}
     assert data["bridge"]["running"] is True
     assert data["bridge"]["stats"] == {"rx_frames": 3, "tx_frames": 4}
     assert data["lastError"] is None
+    srv._server = None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_station_endpoint_reports_selection_metadata_and_guidance() -> None:
+    serial_radio = SimpleNamespace(
+        model="IC-7300",
+        backend_id="icom_serial",
+        connected=False,
+        control_connected=False,
+        radio_ready=False,
+        capabilities=set(),
+    )
+    srv = WebServer(serial_radio, WebConfig(host="127.0.0.1", port=0))
+    srv._server = _FakeAsyncServer()  # noqa: SLF001
+    writer = _FakeWriter()
+
+    await srv._handle_http(writer, "GET", "/api/v1/station")  # noqa: SLF001
+
+    status, data = _response_json(writer)
+    assert status == 200
+    assert data["schema"] == "rigplane.station.status.v1"
+    assert data["displayName"] == "IC-7300"
+    assert data["baseUrl"] == "http://127.0.0.1:4242"
+    assert data["healthUrl"] == "http://127.0.0.1:4242/healthz"
+    assert data["runtimeUrl"] == "http://127.0.0.1:4242/api/v1/runtime"
+    assert data["station"]["readiness"] == "no_usb_radio_connected"
+    assert data["station"]["radioAvailable"] is False
+    assert "Connect the radio by USB" in data["station"]["message"]
+    assert data["radio"] == {
+        "model": "IC-7300",
+        "connected": False,
+        "controlConnected": False,
+        "radioReady": False,
+    }
     srv._server = None  # noqa: SLF001
 
 


### PR DESCRIPTION
## Summary

- Extend UDP discovery responses with a public station-server advertisement schema, endpoint URLs, readiness, auth-required, backend, and radio metadata while preserving legacy fields.
- Add the stable `GET /api/v1/station` supervisor endpoint and include station readiness in `/api/v1/runtime`.
- Document the station status/discovery contract and cover it with discovery, web server, and API contract tests.

## Boundary

Public-core candidate. This adds generic LAN station-server discovery/readiness/status primitives only; branded installers, account/licensing, hosted pairing, appliance packaging, VPN/relay, and support workflows remain outside core.

Closes #1498.

## Verification

- `uv run python -m pytest tests/test_discovery_responder.py tests/test_web_server_coverage.py tests/test_web_api_contract.py -q`
- `uv run python -m pytest tests/test_web_server.py tests/test_cli.py -q`
- `uv run ruff check .`
- `uv run ruff check src/rigplane/web tests/test_discovery_responder.py tests/test_web_server_coverage.py tests/test_web_api_contract.py`
- `uv run ruff format --check src/rigplane/web tests/test_discovery_responder.py tests/test_web_server_coverage.py tests/test_web_api_contract.py`
- `git diff --check`

Note: `uv run ruff format --check .` still reports pre-existing formatting drift in `docs/plans/discovery-artifacts/{build_orphan_report.py,classify_cycle_edges.py,discovery_graph.py}`; those files are unrelated to this PR and were not modified.