### PR TITLE
docs(seo): exclude internal docs from sitemap, add Project Overview to nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,18 @@ site_url: https://rigplane.dev/
 repo_url: https://github.com/rigplane/rigplane-core
 repo_name: rigplane/rigplane-core
 
+# Exclude internal working docs from the published site and sitemap.
+# These pages exist in the repo for contributors but are not meant for
+# end users or search indexing.
+exclude_docs: |
+  EXTENDED_PROTOCOL_RESEARCH.md
+  architecture/
+  contracts/
+  operations/
+  parity/
+  plans/
+  internals/rfc-audio-v1-mini.md
+
 theme:
   name: material
   custom_dir: docs/overrides
@@ -103,12 +115,14 @@ nav:
       - Exceptions: api/exceptions.md
       - Backends: api/backends.md
       - Icom 7610 Backend: api/backends-icom7610.md
+      - Icom 7610 Drivers: api/backends-icom7610-drivers.md
       - Rig Loader: api/rig-loader.md
       - rigctld: api/rigctld.md
       - Scope: api/scope.md
       - Web: api/web.md
   - Internals:
       - Architecture: internals/architecture.md
+      - Project Overview: PROJECT.md
       - Protocol Deep Dive: internals/protocol.md
       - Radio Protocol: radio-protocol.md
       - Reliability semantics: internals/reliability-semantics.md


### PR DESCRIPTION
Of 116 sitemap entries on rigplane.dev, about 65 were orphan pages with no internal links - research drafts, RFC drafts, architecture exploration docs, and dated planning artifacts. Google Search Console showed them all as Discovered - currently not indexed because they had no referring page.

Two end-user-relevant pages were also orphan:

- **PROJECT.md** - high-level project overview
- **api/backends-icom7610-drivers.md** - public driver documentation that belongs in the API Reference section

## Changes

- Add exclude_docs to drop EXTENDED_PROTOCOL_RESEARCH.md (research notes, status Investigation), internals/rfc-audio-v1-mini.md (draft RFC), and the top-level working folders architecture/, contracts/, operations/, parity/, plans/ (57+ planning files).
- Add PROJECT.md to the Internals nav as Project Overview.
- Add api/backends-icom7610-drivers.md to API Reference nav.

## Verification

Built locally with mkdocstrings disabled (no rigplane install in test env):

- sitemap.xml drops from 116 to 51 entries
- mkdocs build no longer reports pages exist in the docs directory, but are not included in the nav configuration

## Risk

Low. Only affects published site / sitemap. No source code, no API, no protocol.