### PR TITLE
ci(gates): migrate Agent Review and Rebrand gates to Mac mini runner

### DIFF
--- a/.github/workflows/agent-review-gate.yml
+++ b/.github/workflows/agent-review-gate.yml
@@ -20,7 +20,10 @@ jobs:
   agent-review:
     name: Update Agent Review Gate status
     if: github.event_name == 'pull_request' || github.event.issue.pull_request
-    runs-on: ubuntu-latest
+    # Self-hosted Mac mini gate-tier runner. API-only workflow via
+    # actions/github-script -- no compile/test toolchain needed. See
+    # rigplane-tower/docs/development/mac-mini-self-hosted-runners.md.
+    runs-on: [self-hosted, linux, gate]
     timeout-minutes: 2
 
     steps:

--- a/.github/workflows/rebrand-gate.yml
+++ b/.github/workflows/rebrand-gate.yml
@@ -21,7 +21,10 @@ concurrency:
 
 jobs:
   grep-gate:
-    runs-on: ubuntu-latest
+    # Self-hosted Mac mini gate-tier runner. Sub-second git-grep + bash
+    # filter, no toolchain needed. See
+    # rigplane-tower/docs/development/mac-mini-self-hosted-runners.md.
+    runs-on: [self-hosted, linux, gate]
     timeout-minutes: 2
 
     steps:


### PR DESCRIPTION
## Summary

Routes the two gate workflows in this repo (Agent Review Gate and
Rebrand grep gate) to the new Mac mini self-hosted Linux ARM64 runner
instead of `ubuntu-latest`. Comment refresh on both files pointing at
the operator doc.

## Why

This repo is public, so `ubuntu-latest` minutes are currently free, but
the migration is worth doing for two reasons:

1. **Parity.** All four `rigplane-*` repos converge on the same gate
   tier, so there is one routing token (`gate`) and one operator doc to
   reason about. PR #52 in `rigplane-tower` and the parallel migration
   PR #19 in `rigplane-www` already moved.
2. **Pickup speed.** GitHub-hosted `ubuntu-latest` jobs queue for tens of
   seconds before the runner is provisioned; the Mac mini container
   picks up in single-digit seconds for the API-only Agent Review Gate
   and sub-second for the Rebrand grep gate.

## Scope

Two workflow files, each one-line `runs-on` swap plus a comment:

- `.github/workflows/agent-review-gate.yml`: `ubuntu-latest` →
  `[self-hosted, linux, gate]`. API-only workflow.
- `.github/workflows/rebrand-gate.yml`: `ubuntu-latest` →
  `[self-hosted, linux, gate]`. Single `git grep` + bash filter.

No other workflows are touched: `quick.yml`, `full.yml`, `publish.yml`,
and `docs.yml` keep their existing runners — they need the build/test
toolchains and the Mac mini gate-tier image deliberately does not
include them. Phase 3 will introduce a separate `rigplane-ci-build-runner`
image and migrate those workloads.

## Verification

- `rp-gate-core` container is live on the Mac mini, runner
  `mm-gate-core` is online and registered against this repo with labels
  `[self-hosted, Linux, ARM64, gate, mac-mini]`.
- Container has `bash` 5.1, `git` 2.34.1, `grep` available (verified via
  `docker exec rp-gate-core which git bash grep`) — sufficient for the
  Rebrand grep gate's `actions/checkout@v6` and
  `.github/scripts/check-rebrand-allowlist.sh`.
- `uv run pytest`, `uv run ruff`, and import-linter not run — change is
  workflow YAML only, no Python imports affected.

## Layer / boundary check

CI workflows live in `.github/workflows/`, outside the `src/rigplane/`
layered packages. No layering matrix impact. No public/private boundary
move — this is internal CI plumbing.

## Open-core policy check

No telemetry, no headless-sacred violation, no Pro-vs-public hollowing.
Workflow YAML only.
