### PR TITLE
ci(quick): migrate Tests (quick) to Mac mini build-tier runner

### DIFF
--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -28,7 +28,11 @@ concurrency:
 
 jobs:
   quick:
-    runs-on: ubuntu-latest
+    # Self-hosted Mac mini build-tier runner. Python 3.11+/uv/Node 24/Rust
+    # and the Tauri/audio system libs are pre-baked in the image, so this
+    # job avoids the ubuntu-latest pickup + apt install passes. Operator
+    # doc: rigplane-tower/docs/development/mac-mini-self-hosted-runners.md.
+    runs-on: [self-hosted, linux, build]
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Summary

Routes `quick.yml` from `ubuntu-latest` to the new Phase 3 Mac mini
build-tier runner (`[self-hosted, linux, build]`). The quick gate is the
PR feedback loop, so this is the highest-leverage workflow to migrate.

## Why

The quick gate runs on every PR and exercises `ruff`, `ruff format`,
`import-linter`, Python wheel install via `uv sync`, and the full
non-integration pytest suite (`-n auto`). On `ubuntu-latest` it pays
GitHub-hosted runner pickup time (10-60 s) before any work starts. The
new Mac mini build-tier image pre-bakes Python 3.11/3.12/3.13, uv, Rust,
Node 24, libopus, portaudio, libhidapi, and the Tauri webkit deps, so
the same workload starts within a second of the workflow being queued.

## Phase 3 validation

A one-off `docker run` of `rigplane-ci-build-runner:0.1` against
`origin/main` of this repo ran the entire quick.yml workload and
reported:

```
ruff check src/ tests/      -> clean
ruff format --check         -> clean
lint-imports                -> 4 contracts kept, 0 broken
pytest tests/ -n auto       -> 5744 passed, 55 skipped, 9 xfailed,
                                1 xpassed, 7 warnings in 20.71s
```

Pytest exit code 0. The three Phase-0 ARM timing-failures (documented in
the operator handoff) are no longer present in the current suite, so no
deselects are needed.

## Pilot runner

- Container: `rp-build-core` on the Mac mini, `--restart=unless-stopped`,
  ephemeral one-job-per-restart mode.
- Image: `rigplane-ci-build-runner:0.1` (2.44 GB, ARM64).
- Runner: `mm-build-core`, labels
  `[self-hosted, Linux, ARM64, mac-mini, build]`, online and idle.

Other workflows in this repo (`full.yml`, `publish.yml`, `docs.yml`)
keep their existing runners. `full.yml` runs on the weekly cron and
`workflow_dispatch`; migrating it would mean a matrix of 3.11/3.12/3.13
which the build-tier image supports, but it can wait until the quick
tier has soaked on the new runner for a week.

## Scope

Single workflow file: `.github/workflows/quick.yml`. One-line `runs-on`
swap plus a comment refresh.

## Verification

- `uv run pytest tests/ -q --tb=short` on `rp-build-core`-equivalent
  one-off container: 5744 passed, 0 failed in 20.71 s.
- `uv run ruff check src/ tests/`: clean.
- `uv run lint-imports`: 4 contracts kept, 0 broken.
- The path filter on `quick.yml` already includes
  `.github/workflows/**`, so this PR's workflow change triggers the
  workflow itself — first real run on the new runner happens via this
  PR's `pull_request` event.

## Open-core / boundary

Workflow YAML only. No telemetry, no `src/` change, no public API, no
boundary move. Internal CI plumbing.
