### PR TITLE
ci(full): migrate Tests (full matrix) to Mac mini build-tier runner

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -19,7 +19,11 @@ jobs:
     if: >-
       github.event_name != 'push' ||
       contains(github.event.head_commit.message, '[full-ci]')
-    runs-on: ubuntu-latest
+    # Self-hosted Mac mini build-tier runner. Python 3.11/3.12/3.13, uv,
+    # Node 24, Rust, and the Tauri/audio system libs are pre-baked in the
+    # image, so the matrix avoids ubuntu-latest pickup + apt install passes.
+    # Operator doc: rigplane-tower/docs/development/mac-mini-self-hosted-runners.md.
+    runs-on: [self-hosted, linux, build]
     timeout-minutes: 25
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- Routes `Tests (full matrix)` (Python 3.11/3.12/3.13) from `ubuntu-latest` to `[self-hosted, linux, build]` — the Phase 3 Mac mini runner image already serving `quick.yml` on this repo (precedent PR #1513).
- Image pre-bakes Python 3.11/3.12/3.13 (via uv), Node 24, Rust stable, and Tauri/audio system libs, so the matrix avoids ubuntu-latest pickup + apt-install passes per job.
- One workflow file changed; no test/source changes.

## Validation plan
- After merge, trigger via `gh workflow run "Tests (full matrix)"` to confirm the matrix runs cleanly on the build-tier runner before the next Mon/Wed/Fri 03:00 UTC cron.
- Runner pool: `rp-build-core` on Mac mini (ARM64, online).

## Notes
- Operator doc: `rigplane-tower/docs/development/mac-mini-self-hosted-runners.md`.
- The build runner is shared across repos by registration; only the workflow target changes here.
