### PR TITLE
Fix audio scope aspect ratio

### DIFF
--- a/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
+++ b/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
@@ -44,8 +44,10 @@
 <style>
   .audio-spectrum-panel {
     width: 100%;
-    height: 100%;
+    aspect-ratio: 2 / 1;
+    height: auto;
     min-height: 80px;
+    max-height: 180px;
     background: var(--panel, #121922);
     border: 1px solid var(--panel-border, #1e293b);
     border-radius: var(--radius, 8px);


### PR DESCRIPTION
## Summary

Fixes #1518.

Stabilizes the audio FFT scope panel dimensions in the desktop sidebar by giving the panel a fixed 2:1 aspect ratio while leaving the canvas DPR resize path intact.

## Boundary

Public open-core web UI fix. No Pro/private logic.

## Test plan

- [x] `npm run build` in `frontend/`
- [x] Manual Pro/core smoke: audio scope no longer renders vertically stretched in the sidebar
