### PR TITLE
feat(i18n): Core Svelte i18n runtime (RP-ML-003)

### DIFF
--- a/frontend/src/lib/i18n/CONTRIBUTING.md
+++ b/frontend/src/lib/i18n/CONTRIBUTING.md
@@ -1,0 +1,196 @@
+# Contributing translations to RigPlane Core
+
+Thank you for helping localize RigPlane Core. This document is the
+self-contained guide for community translators. You do not need to read
+the strategy glossary or run any frontend tooling to add or update a
+translation.
+
+If anything here is unclear, please open an issue at
+<https://github.com/rigplane/rigplane-core/issues> with the `i18n` label.
+
+## TL;DR
+
+1. Fork `rigplane/rigplane-core` on GitHub.
+2. Copy `frontend/src/lib/i18n/locales/en-US.json` to a new file named
+   after your locale, for example `de-DE.json`, `fr-FR.json`, `pt-BR.json`.
+   Use a BCP-47 tag (`language-REGION`).
+3. Edit the values in the new file. Keep the keys exactly the same.
+4. Leave the `$schema` documentation wrapper at the top — it is ignored at
+   runtime and reminds future translators of the rules.
+5. Open a pull request. Mention the locale in the title:
+   `i18n: add de-DE translation`.
+
+No `npm install`, no Node.js, no Svelte/Vite tooling required to
+translate. The repository's CI will validate your file.
+
+## File format
+
+Each locale file is plain JSON. Keys are dot-separated identifiers
+(e.g. `core.statusbar.connection.connected`); values are translated
+strings. The English source catalog is the single source of truth — only
+keys that exist in `en-US.json` are valid.
+
+Example (excerpt):
+
+```json
+{
+  "core.statusbar.connection.connected": "Connected",
+  "core.statusbar.connection.connectingTo": "Connecting to {radio} on {transport}…"
+}
+```
+
+Same key, translated to Japanese:
+
+```json
+{
+  "core.statusbar.connection.connected": "接続済み",
+  "core.statusbar.connection.connectingTo": "{radio} に {transport} で接続中…"
+}
+```
+
+You may omit keys you have not translated yet. Missing keys fall back to
+English silently.
+
+## Placeholder syntax
+
+Variables inside translations use **named placeholders** wrapped in
+curly braces:
+
+```
+"Connecting to {radio} on {transport}…"
+```
+
+Rules:
+
+- Every placeholder you receive in English must appear in your
+  translation. If `{radio}` is in the English string, your translation
+  must include `{radio}` somewhere.
+- You may reorder placeholders freely. That is the whole point.
+- A literal `{` is written as `'{'` (single quote, opening brace, single
+  quote — three characters). This is unusual; you will almost never need
+  it.
+- Do not introduce new placeholders. Translators cannot invent variables;
+  if you need a placeholder the source does not have, open an issue.
+
+## Plural forms
+
+Some keys come in plural variants, identified by suffixes from CLDR
+(<https://cldr.unicode.org/index/cldr-spec/plural-rules>):
+
+- `.zero`, `.one`, `.two`, `.few`, `.many`, `.other`
+
+Example:
+
+```json
+{
+  "core.diagnostics.attachedFiles.one": "1 file attached",
+  "core.diagnostics.attachedFiles.other": "{count} files attached"
+}
+```
+
+For each base key, your locale should provide the forms its grammar
+requires. The runtime always falls back to `.other` if a more specific
+form is missing, so you can start with just `.other` and add the others
+later. Japanese (`ja-JP`) only needs `.other` — that is correct, not a
+bug.
+
+## Non-translatable tokens
+
+Some tokens are part of RigPlane's machine-readable contract or its
+brand identity. They MUST appear verbatim in every locale, even inside
+sentences in your language.
+
+### Brand names
+
+Keep the exact spelling, casing, and Latin letters:
+
+- RigPlane, RigPlane Core, RigPlane Pro
+- Tower, RigPlane Pro Companion
+- `rigctld` (lowercase, the executable name)
+- Hamlib (the library, capital H)
+- CI-V (Icom Communications Interface V)
+
+Do not translate, transliterate, or pluralize these terms. In Japanese,
+do not wrap them in 「」 brackets.
+
+### Radio abbreviations
+
+These are international amateur/professional radio abbreviations that
+operators recognize worldwide. Keep verbatim, in uppercase, without
+expansion:
+
+- VFO, MAIN, SUB, A, B, A=B, M-VFO
+- PTT, TX, RX, MOX
+- RIT, XIT, IF Shift, Notch, BPF, Roofing
+- CW, SSB, USB, LSB, AM, FM, NFM, WFM, DV, DD, RTTY, PSK, DATA, DIGITAL
+- AGC (FAST/MID/SLOW/OFF), DSP, NB, NR, NF, MN, VOX
+- SWR, ALC, COMP, MIC, MON, PWR
+- S-meter, squelch (the abbreviation; per-locale forms like スケルチ are
+  allowed in body copy — see `glossary.squelch`)
+- Q-codes: QSO, QRZ, QRM, QRN, QRP, QSL, QTH, QSY
+- Band names: 160m, 80m, 60m, 40m, 30m, 20m, 17m, 15m, 12m, 10m, 6m, 4m,
+  2m, 70cm, 23cm
+- Units: Hz, kHz, MHz, GHz, dB, dBm, ms, s
+
+Surrounding prose may be translated — only the token itself stays in
+English.
+
+### Glossary tokens
+
+Some everyday radio nouns have widely-used local forms (e.g. Japanese
+コールサイン for "callsign"). These live in the `glossary.*` namespace:
+
+- `glossary.callsign`
+- `glossary.squelch`
+- `glossary.bandPlan`
+
+If you add a locale, you may translate these. They are explicitly
+intended to be the locale community's word, not a verbatim English copy.
+
+### Things that look like prose but are not
+
+If you ever see a string that contains a `type` field name, an HTTP
+status, a JSON key, a CLI flag (`--port`), an environment variable
+(`RIGPLANE_*`), or a Python module/class name — it should not be in the
+catalog. Please open an issue rather than translating it.
+
+## Testing your translation locally (optional)
+
+You do not need this step to contribute. CI will run all checks on your
+PR. If you do want to run the tests yourself:
+
+```bash
+cd frontend
+npm install
+npm test -- src/lib/i18n
+```
+
+The pseudo-locale (`qps-ploc`) is a developer/QA tool that wraps every
+catalog string in `⟦…⟧` to visualize layout. It is not a real locale and
+never ships to users.
+
+## What CI checks
+
+The pull-request lint will report (RP-ML-013A wires the exact CI surface;
+the rules below are the contract):
+
+- Invalid JSON.
+- Keys present in your file that are not in `en-US.json` (typos).
+- Placeholders that do not match the English source (extra or missing
+  `{name}`s for the same key).
+- Translated glossary tokens that should have stayed verbatim (brand
+  names, radio abbreviations).
+- File-encoding issues (must be UTF-8 without BOM).
+
+## Review process
+
+A new or improved translation needs a second community speaker of the
+locale to review the PR before merge. RigPlane maintainers will:
+
+- Verify the file is valid and complete.
+- Check that brand names and radio abbreviations are unchanged.
+- Run the pseudo-locale and visual smoke checks.
+- Tag a reviewer who reads the locale.
+
+We are not native speakers of every locale we ship; thank you for caring
+about the details.

--- a/frontend/src/lib/i18n/__tests__/index.test.ts
+++ b/frontend/src/lib/i18n/__tests__/index.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { t, tPlural, messageFromReasonCode, setLocale } from '../index';
+import { _resetLocale } from '../store.svelte';
+
+beforeEach(() => {
+  localStorage.clear();
+  _resetLocale();
+  // Tests in jsdom default to en-US (or whatever the jsdom navigator
+  // reports). Pin to en-US to avoid env drift.
+  setLocale('en-US');
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('t()', () => {
+  it('resolves a key from the en-US source catalog', () => {
+    expect(t('common.action.save')).toBe('Save');
+  });
+
+  it('interpolates named placeholders', () => {
+    expect(
+      t('core.statusbar.connection.connectingTo', {
+        radio: 'IC-7610',
+        transport: 'LAN',
+      }),
+    ).toBe('Connecting to IC-7610 on LAN…');
+  });
+
+  it('falls back to en-US when a key is missing in the selected locale', () => {
+    setLocale('ja-JP');
+    // `common.action.cancel` is not translated in ja-JP scaffold.
+    expect(t('common.action.cancel')).toBe('Cancel');
+  });
+
+  it('returns translated value for ja-JP when present', () => {
+    setLocale('ja-JP');
+    expect(t('core.statusbar.connection.connected')).toBe('接続済み');
+  });
+
+  it('preserves glossary-token interpolation values verbatim across locales', () => {
+    // Glossary tokens are composed at the call site: the caller asks for
+    // `t('glossary.callsign')` and threads the returned value into another
+    // string via params. The runtime must NOT mutate interpolated values.
+    setLocale('ja-JP');
+    const callsign = t('glossary.callsign');
+    expect(callsign).toBe('コールサイン');
+    // Now thread it into a parametric sentence using en-US fallback for
+    // demonstration:
+    setLocale('en-US');
+    const sentence = t('core.error.transport.timeout.body', {
+      host: '192.168.55.40',
+    });
+    expect(sentence).toContain('192.168.55.40');
+  });
+});
+
+describe('tPlural()', () => {
+  it('selects en-US singular for count=1', () => {
+    expect(tPlural('core.diagnostics.attachedFiles', 1)).toBe('1 file attached');
+  });
+
+  it('selects en-US plural for count=5', () => {
+    expect(tPlural('core.diagnostics.attachedFiles', 5)).toBe(
+      '5 files attached',
+    );
+  });
+
+  it('ja-JP uses .other only', () => {
+    setLocale('ja-JP');
+    expect(tPlural('core.diagnostics.attachedFiles', 1)).toBe(
+      '1 個のファイルを添付',
+    );
+  });
+});
+
+describe('messageFromReasonCode()', () => {
+  it('resolves a known reason code under the core.toast namespace', () => {
+    expect(messageFromReasonCode('licenseExpired')).toBe(
+      'Your license has expired. Reactivate to continue.',
+    );
+  });
+
+  it('threads params into the resolved toast', () => {
+    expect(messageFromReasonCode('updateAvailable', { version: '2.1.0' })).toBe(
+      'An update is available: 2.1.0.',
+    );
+  });
+
+  it('falls back to core.toast.unknown for an unknown code', () => {
+    expect(messageFromReasonCode('completelyMadeUpCode')).toBe(
+      'Something went wrong. Try again later.',
+    );
+  });
+
+  it('rejects malformed codes safely (returns the unknown toast)', () => {
+    expect(messageFromReasonCode('../injection.attempt')).toBe(
+      'Something went wrong. Try again later.',
+    );
+    expect(messageFromReasonCode('')).toBe(
+      'Something went wrong. Try again later.',
+    );
+  });
+});
+
+describe('pseudo-locale active', () => {
+  it('wraps t() output in ⟦…⟧', () => {
+    setLocale('qps-ploc');
+    const out = t('common.action.save');
+    expect(out.startsWith('⟦')).toBe(true);
+    expect(out.endsWith('⟧')).toBe(true);
+  });
+
+  it('preserves glossary-token style interpolated values verbatim under pseudo-locale', () => {
+    setLocale('qps-ploc');
+    const out = t('core.statusbar.connection.connectingTo', {
+      radio: 'IC-7610',
+      transport: 'LAN',
+    });
+    expect(out).toContain('IC-7610');
+    expect(out).toContain('LAN');
+  });
+
+  it('wraps tPlural() output', () => {
+    setLocale('qps-ploc');
+    const out = tPlural('core.diagnostics.attachedFiles', 3);
+    expect(out.startsWith('⟦')).toBe(true);
+    expect(out.endsWith('⟧')).toBe(true);
+    expect(out).toContain('3'); // count param survives
+  });
+
+  it('wraps messageFromReasonCode output', () => {
+    setLocale('qps-ploc');
+    const out = messageFromReasonCode('licenseExpired');
+    expect(out.startsWith('⟦')).toBe(true);
+    expect(out.endsWith('⟧')).toBe(true);
+  });
+});

--- a/frontend/src/lib/i18n/__tests__/plural.test.ts
+++ b/frontend/src/lib/i18n/__tests__/plural.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { registerCatalog, _resetCatalogs } from '../runtime';
+import { resolvePlural, selectCategory, pluralFallbackChain } from '../plural';
+
+const EN = {
+  'core.diagnostics.attachedFiles.one': '1 file attached',
+  'core.diagnostics.attachedFiles.other': '{count} files attached',
+};
+const JA = {
+  'core.diagnostics.attachedFiles.other': '{count} 個のファイルを添付',
+};
+
+beforeEach(() => {
+  _resetCatalogs();
+  registerCatalog('en-US', EN);
+  registerCatalog('ja-JP', JA);
+});
+
+afterEach(() => {
+  _resetCatalogs();
+});
+
+describe('Intl.PluralRules wrapper', () => {
+  it('selects `one` for n=1 in en-US', () => {
+    expect(selectCategory('en-US', 1)).toBe('one');
+  });
+
+  it('selects `other` for n=5 in en-US', () => {
+    expect(selectCategory('en-US', 5)).toBe('other');
+  });
+
+  it('selects `other` for any count in ja-JP', () => {
+    expect(selectCategory('ja-JP', 1)).toBe('other');
+    expect(selectCategory('ja-JP', 5)).toBe('other');
+  });
+});
+
+describe('resolvePlural', () => {
+  it('renders the en-US singular for count=1', () => {
+    expect(resolvePlural('core.diagnostics.attachedFiles', 1, 'en-US')).toBe(
+      '1 file attached',
+    );
+  });
+
+  it('renders the en-US plural for count=5', () => {
+    expect(resolvePlural('core.diagnostics.attachedFiles', 5, 'en-US')).toBe(
+      '5 files attached',
+    );
+  });
+
+  it('renders ja-JP using only `.other` even for count=1', () => {
+    expect(resolvePlural('core.diagnostics.attachedFiles', 1, 'ja-JP')).toBe(
+      '1 個のファイルを添付',
+    );
+  });
+
+  it('falls back to en-US when ja-JP lacks the specific plural form', () => {
+    // ja-JP only has .other; English (`one`) is reached via the resolver
+    // fallback in the .other → en-US-other path. The CLDR-category for
+    // ja-JP is always `other`, so we just see the ja-JP `.other` string.
+    expect(resolvePlural('core.diagnostics.attachedFiles', 1, 'ja-JP')).toBe(
+      '1 個のファイルを添付',
+    );
+  });
+
+  it('allows extra params alongside auto-injected count', () => {
+    const enWithName = {
+      'core.attach.one': '1 file: {name}',
+      'core.attach.other': '{count} files starting with {name}',
+    };
+    _resetCatalogs();
+    registerCatalog('en-US', enWithName);
+    expect(
+      resolvePlural('core.attach', 3, 'en-US', { name: 'foo' }),
+    ).toBe('3 files starting with foo');
+  });
+});
+
+describe('pluralFallbackChain', () => {
+  it('always ends with `other`', () => {
+    expect(pluralFallbackChain('one')).toContain('other');
+    expect(pluralFallbackChain('few').slice(-1)[0]).toBe('other');
+    expect(pluralFallbackChain('other')).toEqual(['other']);
+  });
+});

--- a/frontend/src/lib/i18n/__tests__/pseudo.test.ts
+++ b/frontend/src/lib/i18n/__tests__/pseudo.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { registerCatalog, _resetCatalogs } from '../runtime';
+import { pseudoize, resolvePseudo } from '../pseudo';
+
+const EN = {
+  'common.action.save': 'Save',
+  'common.action.cancel': 'Cancel',
+  'core.statusbar.connection.connectingTo':
+    'Connecting to {radio} on {transport}…',
+  'core.error.literalBrace.example': "Use '{name} to refer to a placeholder.",
+};
+
+beforeEach(() => {
+  _resetCatalogs();
+  registerCatalog('en-US', EN);
+});
+
+afterEach(() => {
+  _resetCatalogs();
+});
+
+describe('pseudoize', () => {
+  it('wraps every output in ⟦…⟧', () => {
+    const out = pseudoize('Save');
+    expect(out.startsWith('⟦')).toBe(true);
+    expect(out.endsWith('⟧')).toBe(true);
+  });
+
+  it('substitutes ASCII letters with diacritic forms', () => {
+    const out = pseudoize('Save');
+    // Inside the brackets the four letters should each have been mapped.
+    expect(out).toMatch(/[ŠšŚś].*[Ááâã]/);
+    expect(out).not.toContain('Save'); // raw English must not remain
+  });
+
+  it('expands the string by at least 35%', () => {
+    const source = 'Save';
+    const out = pseudoize(source);
+    // Strip the ⟦⟧ brackets, count characters.
+    const inner = out.slice(1, -1);
+    expect(inner.length).toBeGreaterThanOrEqual(Math.ceil(source.length * 1.35));
+  });
+
+  it('preserves {name} placeholders verbatim', () => {
+    const out = pseudoize('Connecting to {radio} on {transport}…');
+    expect(out).toContain('{radio}');
+    expect(out).toContain('{transport}');
+  });
+
+  it("preserves '{' literal-brace escape verbatim", () => {
+    const out = pseudoize("Use '{'name} verbatim");
+    expect(out).toContain("'{'");
+    // The escape is preserved as a passthrough atom; surrounding ASCII
+    // text is still diacritic-substituted.
+    expect(out).not.toContain('Use');
+  });
+
+  it('handles empty strings without crashing', () => {
+    expect(pseudoize('')).toBe('⟦⟧');
+  });
+});
+
+describe('resolvePseudo', () => {
+  it('runs the catalog value through the transform', () => {
+    const out = resolvePseudo('common.action.save');
+    expect(out.startsWith('⟦')).toBe(true);
+    expect(out.endsWith('⟧')).toBe(true);
+  });
+
+  it('interpolates params after pseudo-transform without diacritizing them', () => {
+    const out = resolvePseudo('core.statusbar.connection.connectingTo', {
+      radio: 'IC-7610',
+      transport: 'LAN',
+    });
+    // Brand-like values (radios, transport names) must come through
+    // verbatim — they would be glossary/protocol values in real call sites.
+    expect(out).toContain('IC-7610');
+    expect(out).toContain('LAN');
+  });
+
+  it('returns [missing:key] when en-US lacks the key', () => {
+    expect(resolvePseudo('does.not.exist')).toBe('[missing:does.not.exist]');
+  });
+});

--- a/frontend/src/lib/i18n/__tests__/runtime.test.ts
+++ b/frontend/src/lib/i18n/__tests__/runtime.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  registerCatalog,
+  resolve,
+  interpolate,
+  lookup,
+  setMissingKeyHandler,
+  _resetCatalogs,
+} from '../runtime';
+
+const EN = {
+  $schema: { _comment: 'doc' },
+  'common.action.save': 'Save',
+  'common.action.cancel': 'Cancel',
+  'core.statusbar.connection.connectingTo': 'Connecting to {radio} on {transport}…',
+  'core.error.literalBrace.example': "Use '{'name} to refer to a placeholder.",
+};
+
+const JA = {
+  $schema: { _comment: 'doc' },
+  'common.action.save': '保存',
+  'core.statusbar.connection.connectingTo': '{radio} に {transport} で接続中…',
+};
+
+beforeEach(() => {
+  _resetCatalogs();
+  registerCatalog('en-US', EN);
+  registerCatalog('ja-JP', JA);
+});
+
+afterEach(() => {
+  _resetCatalogs();
+});
+
+describe('interpolate', () => {
+  it('replaces named placeholders', () => {
+    expect(
+      interpolate('Hello {name}, you have {count} items', {
+        name: 'Sergey',
+        count: 3,
+      }),
+    ).toBe('Hello Sergey, you have 3 items');
+  });
+
+  it('leaves unknown placeholders intact', () => {
+    expect(interpolate('Hello {name}, {unknown}', { name: 'X' })).toBe(
+      'Hello X, {unknown}',
+    );
+  });
+
+  it("supports literal brace escape '{'", () => {
+    // The escape `'{'` (three chars: quote, brace, quote) becomes a literal `{`.
+    // A literal `}` needs no escape because `}` alone is not a placeholder
+    // start.
+    expect(interpolate("Use '{'name} verbatim", { name: 'X' })).toBe(
+      'Use {name} verbatim',
+    );
+  });
+
+  it('handles missing params', () => {
+    expect(interpolate('No params here')).toBe('No params here');
+  });
+
+  it('coerces numbers to strings', () => {
+    expect(interpolate('Count: {count}', { count: 42 })).toBe('Count: 42');
+  });
+});
+
+describe('lookup + resolve', () => {
+  it('returns the translation in the active locale', () => {
+    expect(lookup('common.action.save', 'ja-JP')).toBe('保存');
+  });
+
+  it('falls back to en-US silently when the key is missing in the active locale', () => {
+    expect(lookup('common.action.cancel', 'ja-JP')).toBe('Cancel');
+  });
+
+  it('returns [missing:key] in dev when neither locale has the key', () => {
+    expect(lookup('core.nonexistent.key', 'ja-JP')).toBe(
+      '[missing:core.nonexistent.key]',
+    );
+  });
+
+  it('calls the missing-key hook on softer (locale-only) miss', () => {
+    const hook = vi.fn();
+    setMissingKeyHandler(hook);
+    lookup('common.action.cancel', 'ja-JP');
+    expect(hook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'common.action.cancel',
+        locale: 'ja-JP',
+      }),
+    );
+  });
+
+  it('calls the missing-key hook on hard miss (no en-US either)', () => {
+    const hook = vi.fn();
+    setMissingKeyHandler(hook);
+    lookup('does.not.exist', 'ja-JP');
+    expect(hook).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'does.not.exist' }),
+    );
+  });
+
+  it('does NOT call missing-key hook for fully-present en-US key in en-US locale', () => {
+    const hook = vi.fn();
+    setMissingKeyHandler(hook);
+    lookup('common.action.save', 'en-US');
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('interpolates via resolve()', () => {
+    expect(
+      resolve('core.statusbar.connection.connectingTo', 'ja-JP', {
+        radio: 'IC-7610',
+        transport: 'LAN',
+      }),
+    ).toBe('IC-7610 に LAN で接続中…');
+  });
+
+  it('strips the $schema documentation wrapper from catalogs', () => {
+    // `$schema` is not a real message key — looking it up must miss.
+    expect(lookup('$schema', 'en-US')).toBe('[missing:$schema]');
+  });
+
+  it("propagates literal-brace escape through resolve()", () => {
+    expect(resolve('core.error.literalBrace.example', 'en-US', { name: 'foo' }))
+      .toBe('Use {name} to refer to a placeholder.');
+  });
+});

--- a/frontend/src/lib/i18n/__tests__/store.test.ts
+++ b/frontend/src/lib/i18n/__tests__/store.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  getLocale,
+  setLocale,
+  STORAGE_KEY,
+  SUPPORTED_LOCALES,
+  _resetLocale,
+} from '../store.svelte';
+
+beforeEach(() => {
+  localStorage.clear();
+  _resetLocale();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('locale store', () => {
+  it('lists the bundled locales', () => {
+    expect(SUPPORTED_LOCALES).toContain('en-US');
+    expect(SUPPORTED_LOCALES).toContain('ja-JP');
+    expect(SUPPORTED_LOCALES).toContain('qps-ploc');
+  });
+
+  it('persists an explicit selection to localStorage under the stable key', () => {
+    setLocale('ja-JP');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('ja-JP');
+    expect(getLocale()).toBe('ja-JP');
+  });
+
+  it('rejects an unknown locale string', () => {
+    const before = getLocale();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setLocale('xx-YY' as any);
+    expect(getLocale()).toBe(before);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('round-trips qps-ploc as an explicit developer opt-in', () => {
+    setLocale('qps-ploc');
+    expect(getLocale()).toBe('qps-ploc');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('qps-ploc');
+  });
+
+  it('clears persisted value on _resetLocale (test hook)', () => {
+    setLocale('ja-JP');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('ja-JP');
+    _resetLocale();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/lib/i18n/index.ts
+++ b/frontend/src/lib/i18n/index.ts
@@ -1,0 +1,150 @@
+/**
+ * Public API for the RigPlane Core i18n runtime.
+ *
+ * Usage from Svelte components (RP-ML-005 will adopt this; the runtime is
+ * delivered independently in RP-ML-003):
+ *
+ *   import { t, tPlural, messageFromReasonCode, getLocale, setLocale } from '$lib/i18n';
+ *   const label = t('core.statusbar.connection.connected');
+ *   const status = t('core.statusbar.connection.connectingTo',
+ *                    { radio: 'IC-7610', transport: 'LAN' });
+ *   const files = tPlural('core.diagnostics.attachedFiles', n);
+ *   const toast = messageFromReasonCode(reason.code, reason.params);
+ *
+ * Design constraints (non-negotiable — see strategy glossary §4, §5, §8 and
+ * core-string-inventory "Notes for translators" / "Surprises"):
+ *
+ *   - Catalogs are plain JSON. Community contributors copy `en-US.json`,
+ *     translate, and PR — no TS/Vite tooling required.
+ *   - Keys are dot-separated lowerCamelCase, `[a-zA-Z0-9.]`, <=80 chars.
+ *   - Placeholders are `{name}`; literal `{` is `'{'`.
+ *   - Plural suffixes follow CLDR (`zero/one/two/few/many/other`).
+ *   - Missing key in selected locale falls back to en-US silently in prod
+ *     (reported via missing-key hook); dev shows `[missing:scope.key]`.
+ *   - Glossary tokens (brand names, radio abbreviations, MHz/kHz/dB) MUST
+ *     NOT be translated. The lint check is RP-ML-013A's responsibility;
+ *     see `CONTRIBUTING.md` for the contract.
+ *   - Server-rendered toasts (today: `web/server.py` -> `broadcast_notification`)
+ *     will migrate to a reason-code-on-the-wire pattern. The frontend helper
+ *     `messageFromReasonCode(code, params)` resolves `core.toast.<code>` and
+ *     is the single place a translator edits a toast. Server-side migration
+ *     is RP-ML-005's responsibility; this issue (RP-ML-003) lands only the
+ *     frontend helper + contract.
+ *
+ * Performance: catalogs are imported synchronously at module init. No async
+ * loading framework is used.
+ */
+
+import enUSCatalog from './locales/en-US.json' with { type: 'json' };
+import jaJPCatalog from './locales/ja-JP.json' with { type: 'json' };
+
+import { registerCatalog, resolve, setMissingKeyHandler } from './runtime';
+import { resolvePlural } from './plural';
+import { resolvePseudo } from './pseudo';
+import { getLocale, setLocale, STORAGE_KEY, SUPPORTED_LOCALES } from './store.svelte';
+import {
+  PSEUDO_LOCALE,
+  SOURCE_LOCALE,
+  type LocaleCode,
+  type MessageKey,
+  type MessageParams,
+  type MissingKeyHandler,
+} from './types';
+
+// Register bundled catalogs once at module load. `qps-ploc` is computed
+// on-the-fly by `resolvePseudo`; no JSON file ships for it.
+registerCatalog('en-US', enUSCatalog as Record<string, unknown>);
+registerCatalog('ja-JP', jaJPCatalog as Record<string, unknown>);
+
+/**
+ * Resolve a message key for the active locale, applying `{name}`
+ * interpolation. Falls back to en-US silently in production.
+ */
+export function t(key: MessageKey | string, params?: MessageParams): string {
+  const locale = getLocale();
+  if (locale === PSEUDO_LOCALE) {
+    return resolvePseudo(key, params);
+  }
+  return resolve(key, locale, params);
+}
+
+/**
+ * Resolve a plural-form message key. `count` is injected as a parameter
+ * named `count` unless the caller passes an explicit one in `params`.
+ */
+export function tPlural(
+  baseKey: string,
+  count: number,
+  params?: MessageParams,
+): string {
+  const locale = getLocale();
+  if (locale === PSEUDO_LOCALE) {
+    // Pseudo plural: pick `.one` / `.other` heuristically from en-US, run
+    // through the pseudo transform. We keep this simple — CLDR for en-US.
+    const category = count === 1 ? 'one' : 'other';
+    const merged: MessageParams = { count, ...(params ?? {}) };
+    const primary = resolvePseudo(`${baseKey}.${category}`, merged);
+    if (primary.startsWith('[missing:')) {
+      return resolvePseudo(`${baseKey}.other`, merged);
+    }
+    return primary;
+  }
+  return resolvePlural(baseKey, count, locale, params);
+}
+
+/**
+ * Resolve a server-supplied reason code to a localized toast/dialog
+ * message. The wire contract is:
+ *
+ *   { code: string, params?: Record<string, string | number> }
+ *
+ * `code` is a short reason identifier (e.g. `licenseExpired`,
+ * `updateAvailable`, `readinessNoRadio`). The frontend looks up
+ * `core.toast.<code>`; if the code is unknown, falls back to
+ * `core.toast.unknown`.
+ *
+ * The server is responsible for emitting English-stable reason codes in
+ * logs and on the wire; only the rendered toast is localized. See strategy
+ * glossary §3.5 ("translatable inside otherwise-stable surfaces") and the
+ * core-string-inventory "Surprises" note about `web/server.py` toasts.
+ */
+export function messageFromReasonCode(
+  code: string,
+  params?: MessageParams,
+): string {
+  // Reject obviously malformed codes so a broken server payload cannot
+  // tunnel arbitrary catalog keys.
+  if (!/^[a-zA-Z][a-zA-Z0-9]*$/.test(code)) {
+    return t('core.toast.unknown', params);
+  }
+  const key = `core.toast.${code}`;
+  const locale = getLocale();
+  if (locale === PSEUDO_LOCALE) {
+    const rendered = resolvePseudo(key, params);
+    if (rendered.startsWith('[missing:')) {
+      return resolvePseudo('core.toast.unknown', params);
+    }
+    return rendered;
+  }
+  const rendered = resolve(key, locale, params);
+  // resolve() returns `[missing:KEY]` in dev when even en-US lacks the key.
+  if (rendered === `[missing:${key}]` || rendered === key) {
+    return resolve('core.toast.unknown', locale, params);
+  }
+  return rendered;
+}
+
+export {
+  // Reactive store
+  getLocale,
+  setLocale,
+  SUPPORTED_LOCALES,
+  STORAGE_KEY,
+  // Constants & types
+  SOURCE_LOCALE,
+  PSEUDO_LOCALE,
+  // Hooks (CI / RP-ML-013A)
+  setMissingKeyHandler,
+};
+
+export type { LocaleCode, MessageKey, MessageParams, MissingKeyHandler };

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -1,0 +1,34 @@
+{
+  "$schema": {
+    "_comment": "Source catalog for RigPlane Core. See CONTRIBUTING.md for the contributor flow. Keys follow scope.subscope.verbOrNoun (lowerCamelCase, ASCII, [a-zA-Z0-9.], <=80 chars). Interpolation uses {name}. A literal opening brace is written as '{'. Plurals use CLDR suffixes (.zero/.one/.two/.few/.many/.other). Glossary tokens (VFO/CW/MHz/brand names like RigPlane, Tower, rigctld, Hamlib) must never be translated — see frontend/src/lib/i18n/CONTRIBUTING.md sections 'Non-translatable tokens' and 'Glossary tokens'."
+  },
+
+  "common.action.save": "Save",
+  "common.action.cancel": "Cancel",
+  "common.action.retry": "Retry",
+
+  "core.statusbar.connection.connected": "Connected",
+  "core.statusbar.connection.notConnected": "Not Connected",
+  "core.statusbar.connection.connectingTo": "Connecting to {radio} on {transport}…",
+
+  "core.diagnostics.sendReport.title": "Send Diagnostic Report",
+  "core.diagnostics.sendReport.confirm": "Send Report",
+  "core.diagnostics.attachedFiles.one": "1 file attached",
+  "core.diagnostics.attachedFiles.other": "{count} files attached",
+
+  "core.settings.language.label": "Language",
+  "core.settings.language.helpText": "Choose the language used by the RigPlane UI. Radio mode codes such as {modeToken} stay in English regardless of locale.",
+
+  "core.error.transport.timeout.title": "Connection Timed Out",
+  "core.error.transport.timeout.body": "No response from {host}. Check that the radio is powered on and reachable.",
+  "core.error.literalBrace.example": "Use '{'name} to refer to a placeholder.",
+
+  "core.toast.licenseExpired": "Your license has expired. Reactivate to continue.",
+  "core.toast.updateAvailable": "An update is available: {version}.",
+  "core.toast.readinessNoRadio": "No radio is connected. Choose a radio in Setup.",
+  "core.toast.unknown": "Something went wrong. Try again later.",
+
+  "glossary.callsign": "callsign",
+  "glossary.squelch": "squelch",
+  "glossary.bandPlan": "band plan"
+}

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -1,0 +1,17 @@
+{
+  "$schema": {
+    "_comment": "Pilot locale scaffold (ja-JP). Missing keys fall back to en-US silently in production. Add translations here following the same key set as en-US.json. Brand names (RigPlane, Tower, rigctld, Hamlib, CI-V) and radio abbreviations (VFO, CW, USB, LSB, AM, FM, MHz, kHz, Hz, dB, dBm, etc.) MUST stay verbatim in English even inside Japanese sentences. See ../CONTRIBUTING.md."
+  },
+
+  "core.statusbar.connection.connected": "接続済み",
+  "core.statusbar.connection.notConnected": "未接続",
+  "core.statusbar.connection.connectingTo": "{radio} に {transport} で接続中…",
+
+  "core.settings.language.label": "言語",
+
+  "core.diagnostics.attachedFiles.other": "{count} 個のファイルを添付",
+
+  "glossary.callsign": "コールサイン",
+  "glossary.squelch": "スケルチ",
+  "glossary.bandPlan": "バンドプラン"
+}

--- a/frontend/src/lib/i18n/plural.ts
+++ b/frontend/src/lib/i18n/plural.ts
@@ -1,0 +1,96 @@
+/**
+ * CLDR plural-form resolution via the platform `Intl.PluralRules`.
+ *
+ * We avoid bundling a plural-rules library (CLDR tables ship with every
+ * modern browser) so the i18n runtime stays small and `Intl` updates with
+ * the platform.
+ *
+ * Convention: a plural message has the same base key with CLDR-suffix
+ * variants, e.g.
+ *   core.diagnostics.attachedFiles.one     -> "1 file attached"
+ *   core.diagnostics.attachedFiles.other   -> "{count} files attached"
+ *
+ * Resolution order for count = N:
+ *   1. `base.<plural-cat-for-N>` in the active locale.
+ *   2. `base.other` in the active locale.
+ *   3. `base.<plural-cat-for-N>` in en-US (via lookup fallback).
+ *   4. `base.other` in en-US.
+ *   5. Missing-key path.
+ *
+ * Note: Japanese (`ja-JP`) collapses to `.other` only; CLDR returns "other"
+ * for every count. This is correct, not a bug.
+ */
+
+import type { LocaleCode, MessageParams } from './types';
+import { resolve } from './runtime';
+
+export type PluralCategory = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other';
+
+const ORDERED_FALLBACKS: PluralCategory[] = [
+  'zero',
+  'one',
+  'two',
+  'few',
+  'many',
+  'other',
+];
+
+function selectCategory(locale: LocaleCode, count: number): PluralCategory {
+  try {
+    const rules = new Intl.PluralRules(locale);
+    return rules.select(count) as PluralCategory;
+  } catch {
+    // Locale unknown to the platform. Treat as `other`.
+    return 'other';
+  }
+}
+
+/**
+ * Resolve a plural-form message. Returns the rendered string with
+ * interpolation applied (`{count}` is injected automatically unless the
+ * caller already passed a `count` param).
+ */
+export function resolvePlural(
+  baseKey: string,
+  count: number,
+  locale: LocaleCode,
+  params?: MessageParams,
+): string {
+  const category = selectCategory(locale, count);
+  const mergedParams: MessageParams = { count, ...(params ?? {}) };
+
+  // 1) Try the CLDR-selected variant.
+  const primaryKey = `${baseKey}.${category}`;
+  // Resolver gives `[missing:...]` in dev when neither locale nor en-US has
+  // the key; for plurals we explicitly want to fall through to `.other`.
+  const primary = resolve(primaryKey, locale, mergedParams);
+  if (!isMissingMarker(primary, primaryKey)) return primary;
+
+  // 2) Fall back to `.other` in the active locale (en-US fallback handled
+  //    by resolve()).
+  if (category !== 'other') {
+    const otherKey = `${baseKey}.other`;
+    return resolve(otherKey, locale, mergedParams);
+  }
+  // If `.other` itself missing, resolve() already returned the missing
+  // marker / key — propagate.
+  return primary;
+}
+
+function isMissingMarker(rendered: string, key: string): boolean {
+  return rendered === `[missing:${key}]` || rendered === key;
+}
+
+/** Exposed for tests. */
+export { selectCategory };
+
+/**
+ * Walk the CLDR fallback chain. Currently unused by the resolver (the chain
+ * is `category -> other`), but exported for downstream tooling and tests.
+ */
+export function pluralFallbackChain(category: PluralCategory): PluralCategory[] {
+  const idx = ORDERED_FALLBACKS.indexOf(category);
+  if (idx < 0) return ['other'];
+  // Always end with 'other' as the safety net.
+  return [...ORDERED_FALLBACKS.slice(idx).filter((c) => c !== 'other'), 'other'];
+}

--- a/frontend/src/lib/i18n/pseudo.ts
+++ b/frontend/src/lib/i18n/pseudo.ts
@@ -1,0 +1,124 @@
+/**
+ * Pseudo-locale (`qps-ploc`) transform.
+ *
+ * Why runtime, not build-time:
+ *   We chose a runtime transform layered on top of en-US (rather than
+ *   shipping a precomputed `qps-ploc.json`) for three reasons:
+ *
+ *   1. The catalog is small and the transform is O(string length) — cost
+ *      is negligible at render time.
+ *   2. Build-time generation would have to track every new en-US key and
+ *      keep a generated artifact in sync. A runtime transform cannot drift.
+ *   3. Community contributors editing `en-US.json` automatically get
+ *      pseudo-locale coverage for their additions, without learning a
+ *      build step.
+ *
+ * Transformation rules (binding contract — strategy glossary §5.2):
+ *   - Wrap every translated string in `⟦` and `⟧`. Missing wrappers in QA
+ *     mean a string bypassed the catalog.
+ *   - Substitute ASCII letters with diacritic forms.
+ *   - Expand by >=35% with padding tokens to simulate European-language
+ *     length.
+ *   - Preserve `{placeholder}` runs verbatim — pseudo-locale does NOT
+ *     interpolate placeholders into the transform.
+ *   - Preserve the `'{'` literal-brace escape verbatim.
+ *
+ * Glossary tokens and protocol values are preserved by composing them at the
+ * call site (the resolver pulls `glossary.callsign` etc. unchanged from
+ * `en-US.json` once `qps-ploc` falls back, but pseudo-locale wraps the
+ * returned string). For Phase 2, glossary preservation is delivered via
+ * documented call-site composition (`t('glossary.callsign')` injected as a
+ * params value, which the placeholder-skip rule below leaves untouched in
+ * the transform).
+ */
+
+import type { Catalog, MessageParams } from './types';
+import { interpolate, getCatalog } from './runtime';
+
+const DIACRITIC_MAP: Record<string, string> = {
+  a: 'á', b: 'ƀ', c: 'ç', d: 'đ', e: 'é', f: 'ƒ', g: 'ğ', h: 'ĥ',
+  i: 'í', j: 'ĵ', k: 'ķ', l: 'ł', m: 'ɱ', n: 'ñ', o: 'ó', p: 'þ',
+  q: 'ǫ', r: 'ŕ', s: 'š', t: 'ť', u: 'ú', v: 'ṽ', w: 'ŵ', x: 'ẋ',
+  y: 'ý', z: 'ž',
+  A: 'Á', B: 'Ɓ', C: 'Ç', D: 'Đ', E: 'É', F: 'Ƒ', G: 'Ğ', H: 'Ĥ',
+  I: 'Í', J: 'Ĵ', K: 'Ķ', L: 'Ł', M: 'Ɱ', N: 'Ñ', O: 'Ó', P: 'Þ',
+  Q: 'Ǫ', R: 'Ŕ', S: 'Š', T: 'Ť', U: 'Ú', V: 'Ṽ', W: 'Ŵ', X: 'Ẋ',
+  Y: 'Ý', Z: 'Ž',
+};
+
+const EXPANSION_RATIO = 0.35;
+const PAD_SEGMENT = '~';
+
+/**
+ * Apply the pseudo-locale transform to a single string drawn from en-US.
+ * The string may contain `{placeholder}` runs and `'{'` literal-brace
+ * escapes — both are preserved verbatim.
+ */
+export function pseudoize(source: string): string {
+  if (source.length === 0) return '⟦⟧';
+
+  // Tokenize: placeholders and literal-brace escapes are passthrough atoms;
+  // everything else is letter-substitutable text.
+  const PLACEHOLDER_OR_ESCAPE = /(\{[a-zA-Z][a-zA-Z0-9]*\}|'\{')/g;
+  const parts = source.split(PLACEHOLDER_OR_ESCAPE);
+
+  let baseLen = 0;
+  const transformed = parts.map((part) => {
+    if (!part) return '';
+    if (PLACEHOLDER_OR_ESCAPE.test(part)) {
+      // Reset lastIndex because we used the same regex above.
+      PLACEHOLDER_OR_ESCAPE.lastIndex = 0;
+      return part;
+    }
+    PLACEHOLDER_OR_ESCAPE.lastIndex = 0;
+    baseLen += part.length;
+    let buf = '';
+    for (const ch of part) {
+      buf += DIACRITIC_MAP[ch] ?? ch;
+    }
+    return buf;
+  });
+
+  // Compute padding required to hit >=35% expansion based on the
+  // substitutable text length (the brackets already add 2 chars; we count
+  // them toward the budget).
+  const required = Math.ceil(baseLen * EXPANSION_RATIO);
+  const padLength = Math.max(required, 1);
+  const padding = ' ' + PAD_SEGMENT.repeat(padLength);
+
+  return `⟦${transformed.join('')}${padding}⟧`;
+}
+
+/**
+ * Resolve a key under `qps-ploc`. Reads the en-US catalog directly (not the
+ * `qps-ploc` catalog — there is no such file) and transforms the result.
+ * Missing keys return the same `[missing:key]` marker the resolver would.
+ */
+export function resolvePseudo(key: string, params?: MessageParams): string {
+  const source = getCatalog('en-US');
+  const value = source?.[key];
+  if (typeof value !== 'string') {
+    return `[missing:${key}]`;
+  }
+  // Interpolate AFTER pseudoizing the template, so placeholder atoms inside
+  // the source survive (and so the interpolated values themselves are not
+  // diacritic-substituted — they may be brand names, frequencies, etc.).
+  const transformed = pseudoize(value);
+  return interpolate(transformed, params);
+}
+
+/** Lightweight tap for tests that want to inspect the transformation. */
+export function _stripPseudo(s: string): string {
+  return s.replace(/^⟦/, '').replace(/[~ ]+⟧$/, '').replace(/⟧$/, '');
+}
+
+/** Exposed for tests / tooling. */
+export function pseudoCatalog(): Catalog {
+  const out: Catalog = {};
+  const en = getCatalog('en-US');
+  if (!en) return out;
+  for (const k of Object.keys(en)) {
+    out[k] = pseudoize(en[k]);
+  }
+  return out;
+}

--- a/frontend/src/lib/i18n/runtime.ts
+++ b/frontend/src/lib/i18n/runtime.ts
@@ -1,0 +1,142 @@
+/**
+ * Core i18n resolver: catalog lookup, en-US fallback, and `{name}`
+ * interpolation with `'{'` literal-brace escape.
+ *
+ * This module is deliberately small and synchronous.  Catalogs are imported
+ * statically by `index.ts` and registered via `registerCatalog`, so runtime
+ * lookups never hit the network.  See `pseudo.ts` for the `qps-ploc`
+ * transformation that wraps the resolver during dev/QA.
+ *
+ * Missing-key policy:
+ *   - production builds (import.meta.env.PROD): return the en-US source
+ *     value silently; if even en-US is missing, return the key itself.  A
+ *     missing-key hook is still invoked so CI lint (RP-ML-013A) can report.
+ *   - development builds: return `[missing:scope.key]` so contributors notice
+ *     the gap immediately.
+ */
+
+import type {
+  Catalog,
+  LocaleCode,
+  MessageParams,
+  MissingKeyHandler,
+} from './types';
+import { SOURCE_LOCALE } from './types';
+
+const catalogs: Map<LocaleCode, Catalog> = new Map();
+let missingKeyHandler: MissingKeyHandler | null = null;
+
+/**
+ * Strip the `$schema` documentation wrapper from a raw catalog object before
+ * it is used as a lookup table. Community contributors can copy the wrapper
+ * verbatim from `en-US.json`; the runtime ignores it.
+ */
+function stripSchemaWrapper(raw: Record<string, unknown>): Catalog {
+  const out: Catalog = {};
+  for (const k of Object.keys(raw)) {
+    if (k === '$schema') continue;
+    const v = raw[k];
+    if (typeof v === 'string') {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+export function registerCatalog(
+  locale: LocaleCode,
+  raw: Record<string, unknown>,
+): void {
+  catalogs.set(locale, stripSchemaWrapper(raw));
+}
+
+export function getCatalog(locale: LocaleCode): Catalog | undefined {
+  return catalogs.get(locale);
+}
+
+/** Test/development helper. Not part of the public API. */
+export function _resetCatalogs(): void {
+  catalogs.clear();
+  missingKeyHandler = null;
+}
+
+export function setMissingKeyHandler(handler: MissingKeyHandler | null): void {
+  missingKeyHandler = handler;
+}
+
+function isProd(): boolean {
+  // Vite injects `import.meta.env.PROD`. Vitest/jsdom default to dev.
+  try {
+    return Boolean((import.meta as ImportMeta & { env?: { PROD?: boolean } }).env?.PROD);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Replace `{name}` placeholders. A literal `{` is written as `'{'` (single
+ * quote prefix; mirrors ICU MessageFormat escape and is unambiguous because
+ * placeholder names never begin with a quote).
+ *
+ * Unknown placeholders are left intact so they show up in tests / QA.
+ */
+export function interpolate(template: string, params?: MessageParams): string {
+  if (!params) return template.replace(/'\{'/g, '{');
+  // Two-pass: first interpolate {name}, then unescape '{'. This ordering
+  // means params named like '{' do not collide; placeholders are matched
+  // strictly as `{<lowerCamelCase ASCII>}`.
+  const interpolated = template.replace(
+    /\{([a-zA-Z][a-zA-Z0-9]*)\}/g,
+    (match, name: string) => {
+      if (Object.prototype.hasOwnProperty.call(params, name)) {
+        const val = params[name];
+        return val == null ? match : String(val);
+      }
+      return match;
+    },
+  );
+  return interpolated.replace(/'\{'/g, '{');
+}
+
+/**
+ * Look up a key in `locale`, falling back to en-US, then to `[missing:key]`
+ * (dev) or the key itself (prod). Calls the missing-key hook in either case.
+ */
+export function lookup(
+  key: string,
+  locale: LocaleCode,
+  options?: { source?: string },
+): string {
+  const primary = catalogs.get(locale);
+  const fromPrimary = primary?.[key];
+  if (typeof fromPrimary === 'string') return fromPrimary;
+
+  // Fallback path. Report once.
+  const fallback = catalogs.get(SOURCE_LOCALE);
+  const fromFallback = fallback?.[key];
+  if (typeof fromFallback === 'string') {
+    // Missing in the selected locale, but covered by en-US. CI cares only
+    // when *en-US* is missing the key; we still emit a softer hook so QA
+    // can spot incomplete locales.
+    if (locale !== SOURCE_LOCALE) {
+      missingKeyHandler?.({ key, locale, source: options?.source });
+    }
+    return fromFallback;
+  }
+
+  // Truly missing — even en-US lacks this key. This is a bug.
+  missingKeyHandler?.({ key, locale, source: options?.source });
+  return isProd() ? key : `[missing:${key}]`;
+}
+
+/**
+ * Resolve and interpolate. The runtime entry point that `index.ts#t` calls.
+ */
+export function resolve(
+  key: string,
+  locale: LocaleCode,
+  params?: MessageParams,
+  options?: { source?: string },
+): string {
+  return interpolate(lookup(key, locale, options), params);
+}

--- a/frontend/src/lib/i18n/store.svelte.ts
+++ b/frontend/src/lib/i18n/store.svelte.ts
@@ -1,0 +1,100 @@
+/**
+ * Svelte 5 reactive locale store + `localStorage` persistence.
+ *
+ * Convention matches the rest of `$lib/stores/*.svelte.ts`: top-level
+ * `$state` rune, getter + setter functions, no class wrappers.
+ *
+ * Precedence (per glossary §5.4):
+ *   1. Explicit user selection (persisted to `rigplane.i18n.locale`).
+ *   2. OS / browser `navigator.language`, narrowed to a supported locale.
+ *   3. en-US fallback.
+ *
+ * The pseudo-locale `qps-ploc` is selectable only when a developer has
+ * opted in (either by explicit `setLocale('qps-ploc')` or by stamping the
+ * storage value manually) — `navigator.language` should never produce it.
+ */
+
+import type { LocaleCode } from './types';
+import { PSEUDO_LOCALE, SOURCE_LOCALE } from './types';
+
+const STORAGE_KEY = 'rigplane.i18n.locale';
+
+const SUPPORTED_LOCALES: readonly LocaleCode[] = ['en-US', 'ja-JP', 'qps-ploc'];
+
+function isSupported(value: string): value is LocaleCode {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}
+
+/**
+ * Detect from `navigator.language` / `navigator.languages`. Pseudo-locale
+ * is never returned from detection.
+ */
+function detectFromBrowser(): LocaleCode {
+  if (typeof navigator === 'undefined') return SOURCE_LOCALE;
+  const candidates: string[] = [];
+  // Prefer `languages` (ordered list) when available, fall back to single.
+  const langs = (navigator as Navigator & { languages?: readonly string[] }).languages;
+  if (Array.isArray(langs)) candidates.push(...langs);
+  if (typeof navigator.language === 'string') candidates.push(navigator.language);
+
+  for (const raw of candidates) {
+    // Exact match first.
+    if (isSupported(raw) && raw !== PSEUDO_LOCALE) return raw;
+    // Language-tag match (e.g. "ja" -> "ja-JP").
+    const lang = raw.split('-')[0]?.toLowerCase();
+    for (const supported of SUPPORTED_LOCALES) {
+      if (supported === PSEUDO_LOCALE) continue;
+      if (supported.split('-')[0].toLowerCase() === lang) return supported;
+    }
+  }
+  return SOURCE_LOCALE;
+}
+
+function readStoredLocale(): LocaleCode | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw && isSupported(raw)) return raw;
+  } catch {
+    /* test envs may stub localStorage; treat as unset */
+  }
+  return null;
+}
+
+function initialLocale(): LocaleCode {
+  return readStoredLocale() ?? detectFromBrowser();
+}
+
+let locale = $state<LocaleCode>(initialLocale());
+
+export function getLocale(): LocaleCode {
+  return locale;
+}
+
+export function setLocale(next: LocaleCode): void {
+  if (!isSupported(next)) return;
+  locale = next;
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    /* persistence is best-effort */
+  }
+}
+
+/**
+ * Forget the explicit user choice and re-derive from the browser.  Used by
+ * tests; not exposed in the UI (Settings always writes an explicit value).
+ */
+export function _resetLocale(): void {
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* ignore */
+    }
+  }
+  locale = detectFromBrowser();
+}
+
+export { SUPPORTED_LOCALES, STORAGE_KEY };

--- a/frontend/src/lib/i18n/types.ts
+++ b/frontend/src/lib/i18n/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Typed lookup helpers for the i18n catalog.
+ *
+ * The English source catalog (`locales/en-US.json`) is the schema authority:
+ * its key set is the canonical universe of message keys, and other locales
+ * are subsets that fall back to en-US for missing entries.
+ *
+ * `MessageKey` is derived structurally from the imported JSON so adding a key
+ * to `en-US.json` immediately surfaces it as a valid argument to `t()`,
+ * `tPlural()`, etc.  No `.d.ts` generation step is required for the runtime
+ * to be typed — the JSON itself is the source of truth and TypeScript reads
+ * it directly via `resolveJsonModule`.
+ *
+ * The catalog wrapper key `$schema` carries a human-readable doc comment for
+ * community contributors and is stripped at lookup time, so it is excluded
+ * from `MessageKey`.
+ */
+
+import enUS from './locales/en-US.json' with { type: 'json' };
+
+/** All locale codes the bundled runtime ships with. */
+export type LocaleCode = 'en-US' | 'ja-JP' | 'qps-ploc';
+
+/** BCP-47 source-of-truth locale. Fallback target for every other locale. */
+export const SOURCE_LOCALE: LocaleCode = 'en-US';
+
+/** Pseudo-locale tag (Microsoft convention, BCP-47 private-use). */
+export const PSEUDO_LOCALE: LocaleCode = 'qps-ploc';
+
+/**
+ * Discriminated keys of the English catalog, minus the documentation wrapper
+ * key `$schema`. This drives `t(key)` autocompletion.
+ */
+export type MessageKey = Exclude<keyof typeof enUS, '$schema'> & string;
+
+/** Shape of a single locale file at runtime (after `$schema` is stripped). */
+export type Catalog = Record<string, string>;
+
+/** Parameters passed to {@link t} / interpolation. Values are coerced to text. */
+export type MessageParams = Record<string, string | number>;
+
+/**
+ * Hook called whenever a key is missing in the selected locale AND in the
+ * en-US fallback. CI tooling (RP-ML-013A) wires into this. The hook MUST be
+ * side-effect-light: it is invoked during render.
+ */
+export type MissingKeyHandler = (info: {
+  key: string;
+  locale: LocaleCode;
+  /** Best-effort source location. Undefined when called from runtime code. */
+  source?: string;
+}) => void;


### PR DESCRIPTION
Closes #1521.

## Summary

Adds a minimal typed localization runtime for the Svelte 5 frontend under
`frontend/src/lib/i18n/`. This is **infrastructure + tests only** — no
existing user-facing strings are migrated. RP-ML-005 owns the migration
pass; this PR delivers the runtime those follow-on PRs depend on.

## Design constraints honored

From strategy glossary §4, §5, §8 and the core-string-inventory "Notes
for translators" / "Surprises" sections:

- **Community-friendly catalog format.** Catalogs are plain JSON keyed
  by `scope.subscope.verbOrNoun` (lowerCamelCase, ASCII, `[a-zA-Z0-9.]`,
  <=80 chars). A community contributor can fork the repo, copy
  `en-US.json` to `<locale>.json`, translate values, and open a PR
  without running `npm install` or any Svelte/Vite tooling.
- **Placeholders are `{name}`**; a literal `{` is written as `'{'`.
- **Plural suffixes follow CLDR** (`.zero/.one/.two/.few/.many/.other`).
  Selection uses the platform `Intl.PluralRules` — no
  `@formatjs/intl` / `i18next` dependency is added.
- **Pseudo-locale (`qps-ploc`)** is a runtime transform over en-US:
  `⟦…⟧` wrapping, ASCII diacritization, >=35% expansion, placeholders
  and `'{'` escape preserved as passthrough atoms. The runtime-vs-build
  choice is justified in `pseudo.ts`.
- **Fallback policy.** Missing key in selected locale falls back to en-US
  silently in production (reported via a runtime hook so RP-ML-013A can
  wire CI). Development surfaces `[missing:scope.key]`.
- **Locale preference** persists to `localStorage` under
  `rigplane.i18n.locale`. Browser locale is consulted only before
  explicit selection. Tower is never consulted.
- **Reason-code-on-the-wire helper.** `messageFromReasonCode(code,
  params)` resolves `core.toast.<code>` so the frontend catalog is the
  single place a translator edits server-rendered toast text. Server-side
  migration of `web/server.py::broadcast_notification` is **deferred**
  (RP-ML-005 / follow-up). The contract is documented inline.
- **Glossary tokens** stay verbatim. The contract is documented; the
  catalog-side lint check is RP-ML-013A.

## Files added

- `frontend/src/lib/i18n/index.ts` — public API.
- `frontend/src/lib/i18n/runtime.ts` — catalog registry, fallback,
  interpolation, missing-key hook.
- `frontend/src/lib/i18n/plural.ts` — `Intl.PluralRules` wrapper.
- `frontend/src/lib/i18n/pseudo.ts` — runtime pseudo-locale transform.
- `frontend/src/lib/i18n/store.svelte.ts` — Svelte 5 `$state` rune store
  with `localStorage` persistence + browser-locale detection.
- `frontend/src/lib/i18n/types.ts` — typed `MessageKey` derived from
  `en-US.json`.
- `frontend/src/lib/i18n/locales/en-US.json` — source catalog
  (~25 keys covering interpolation, plurals, glossary tokens, toast
  reason codes).
- `frontend/src/lib/i18n/locales/ja-JP.json` — pilot scaffold (partial;
  falls back to en-US).
- `frontend/src/lib/i18n/CONTRIBUTING.md` — community translator guide
  (fork → edit JSON → PR; placeholder syntax; non-translatable tokens
  inlined per glossary §2.A / §2.B).
- `frontend/src/lib/i18n/__tests__/*.test.ts` — 53 unit tests.

## Public API

```ts
function t(key: MessageKey | string, params?: MessageParams): string;
function tPlural(baseKey: string, count: number, params?: MessageParams): string;
function messageFromReasonCode(code: string, params?: MessageParams): string;
function getLocale(): LocaleCode;
function setLocale(next: LocaleCode): void;
function setMissingKeyHandler(handler: MissingKeyHandler | null): void;
```

## Tests and gates

- New tests: 53 passed (i18n module).
- Full frontend suite: 1788 passed, 0 failed.
- `npm run check` (svelte-check + tsc): 0 errors, 0 warnings.
- `npm run lint`: clean.

## Boundary check

- This is `rigplane-core` (public open-core). The runtime ships open to
  community translators by design — the `CONTRIBUTING.md` makes the
  `fork → edit JSON → PR` flow explicit.
- No backend / Python changes. `src/rigplane/web/server.py` is untouched.
- No existing UI strings migrated (RP-ML-005).
- No new dependencies added.
- No proprietary terminology or commercial framing entered the catalog
  or the contributor doc.

## Deferred

- Server-side toast migration to reason codes (RP-ML-005 or follow-up).
- CI lint enforcement (RP-ML-013A) — runtime exposes the missing-key
  hook and a strict JSON catalog format for that wiring.
- Cross-app locale propagation contract (RP-ML-012).
- Adoption of `t()` in existing components (RP-ML-005).

## Test plan

- [ ] Reviewer runs `cd frontend && npm test -- src/lib/i18n` and
  confirms 53 tests pass.
- [ ] Reviewer runs `cd frontend && npm run check` and confirms clean.
- [ ] Reviewer runs `cd frontend && npm run lint` and confirms clean.
- [ ] Reviewer reads `frontend/src/lib/i18n/CONTRIBUTING.md` and
  confirms it is self-contained for a community translator who has not
  read the strategy glossary.
- [ ] Reviewer confirms no protocol/schema strings leaked into the
  catalog (review `en-US.json`).