### PR TITLE
feat(i18n): Core language preference UX (RP-ML-004)

### DIFF
--- a/frontend/src/components-v2/controls/LanguageSelector.svelte
+++ b/frontend/src/components-v2/controls/LanguageSelector.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  /**
+   * Compact language picker for the Core Settings modal (RP-ML-004).
+   *
+   * Design constraints (see issue #1522 and strategy glossary §5.4):
+   *   - Operational, not marketing: a quiet inline label + native <select>.
+   *     No flags, no marketing copy, no animation.
+   *   - The selector's own labels resolve through the i18n runtime so the
+   *     control reflects the language the user is about to leave.
+   *   - The option list is derived from `SUPPORTED_LOCALES`, not a hardcoded
+   *     array — a translator adding `frontend/src/lib/i18n/locales/<bcp47>.json`
+   *     and registering it in the runtime barrel surfaces here automatically.
+   *   - Option labels use the locale's own endonym ("English", "日本語")
+   *     because that is the universally legible cue across all locales.
+   *   - The pseudo-locale `qps-ploc` is selectable but clearly tagged as
+   *     "developer pseudo-locale" so contributors do not confuse it with a
+   *     real translation.
+   *   - Persistence, browser-locale fallback, and the unsupported-locale
+   *     guard already live in `$lib/i18n/store.svelte.ts`. This component
+   *     only reads and writes through that store.
+   */
+  import { getLocale, setLocale, SUPPORTED_LOCALES, t } from '$lib/i18n';
+  import { PSEUDO_LOCALE, type LocaleCode } from '$lib/i18n';
+
+  /**
+   * Endonym lookup. Kept small and explicit because endonyms are static
+   * cultural data — they do not change per release and never need
+   * translation. A community-contributed locale that lacks an entry here
+   * falls back to its BCP-47 code, which is the most honest signal we can
+   * surface until the contributor updates this table.
+   *
+   * Keep this list ASCII-sortable on the locale code so future contributors
+   * know where to insert a new row.
+   */
+  const ENDONYMS: Record<string, string> = {
+    'en-US': 'English',
+    'ja-JP': '日本語',
+    // qps-ploc gets its label assembled at render time so the
+    // "developer pseudo-locale" suffix follows the active locale.
+    'qps-ploc': 'qps-ploc',
+  };
+
+  function formatOptionLabel(code: LocaleCode): string {
+    if (code === PSEUDO_LOCALE) {
+      const suffix = t('core.settings.language.devLocaleSuffix');
+      return `${ENDONYMS[code]} — ${suffix}`;
+    }
+    return ENDONYMS[code] ?? code;
+  }
+
+  // Reactive view of the current locale. Reading getLocale() inside a
+  // $derived expression subscribes us to the Svelte 5 rune in the store.
+  const current = $derived<LocaleCode>(getLocale());
+
+  // Labels resolved through the runtime so they re-render on locale change.
+  const labelText = $derived(t('core.settings.language.label'));
+  const chooseText = $derived(t('core.settings.language.choose'));
+  const srHintText = $derived(t('core.settings.language.srHint'));
+
+  function handleChange(ev: Event): void {
+    const value = (ev.currentTarget as HTMLSelectElement).value as LocaleCode;
+    // The store already rejects unsupported codes; this is belt-and-braces
+    // against a future DOM contributor wiring a stray <option>.
+    if ((SUPPORTED_LOCALES as readonly string[]).includes(value)) {
+      setLocale(value);
+    }
+  }
+</script>
+
+<div class="language-selector" data-testid="language-selector">
+  <label class="lang-row">
+    <span class="lang-label">{labelText}</span>
+    <select
+      class="lang-select"
+      data-testid="language-select"
+      aria-label={chooseText}
+      title={chooseText}
+      value={current}
+      onchange={handleChange}
+    >
+      {#each SUPPORTED_LOCALES as code (code)}
+        <option value={code} data-testid="language-option-{code}">
+          {formatOptionLabel(code)}
+        </option>
+      {/each}
+    </select>
+  </label>
+  <p class="lang-hint" data-testid="language-hint">{srHintText}</p>
+</div>
+
+<style>
+  .language-selector {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 4px;
+  }
+
+  .lang-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .lang-label {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--v2-text-secondary, #aaa);
+  }
+
+  .lang-select {
+    appearance: none;
+    min-width: 200px;
+    padding: 6px 26px 6px 10px;
+    background: var(--v2-bg-input, #1a1a2e);
+    border: 1px solid var(--v2-border, #2a2a3e);
+    border-radius: 3px;
+    color: var(--v2-text-primary, #fff);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    background-image:
+      linear-gradient(45deg, transparent 50%, currentColor 50%),
+      linear-gradient(135deg, currentColor 50%, transparent 50%);
+    background-position: calc(100% - 12px) 50%, calc(100% - 8px) 50%;
+    background-size: 4px 4px;
+    background-repeat: no-repeat;
+  }
+
+  .lang-select:hover,
+  .lang-select:focus {
+    border-color: var(--v2-accent-cyan, #06b6d4);
+    outline: none;
+  }
+
+  .lang-select option {
+    background: var(--v2-bg-input, #1a1a2e);
+    color: var(--v2-text-primary, #fff);
+  }
+
+  .lang-hint {
+    margin: 0;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 10px;
+    color: var(--v2-text-dim, #888);
+    line-height: 1.4;
+  }
+</style>

--- a/frontend/src/components-v2/controls/__tests__/LanguageSelector.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/LanguageSelector.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the Core language preference UX (RP-ML-004, issue #1522).
+ *
+ * The selector is a thin shell over `$lib/i18n`:
+ *   - it reads `SUPPORTED_LOCALES` to render options,
+ *   - it reads `getLocale()` for the active selection,
+ *   - it writes `setLocale()` on change.
+ *
+ * These tests verify the component honors that contract without
+ * re-implementing browser-locale detection, persistence, or unsupported-
+ * locale fallback (the runtime owns those — covered by `store.test.ts`).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync, tick } from 'svelte';
+
+import LanguageSelector from '../LanguageSelector.svelte';
+import {
+  getLocale,
+  setLocale,
+  SUPPORTED_LOCALES,
+  STORAGE_KEY,
+} from '$lib/i18n';
+import { _resetLocale } from '$lib/i18n/store.svelte';
+import enUS from '$lib/i18n/locales/en-US.json' with { type: 'json' };
+
+function setup() {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(LanguageSelector, { target, props: {} });
+  flushSync();
+  return { target, component };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  _resetLocale();
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  localStorage.clear();
+});
+
+describe('LanguageSelector', () => {
+  it('renders one option per SUPPORTED_LOCALES entry', () => {
+    const { target, component } = setup();
+    const options = target.querySelectorAll('option');
+    // Component must not hardcode a fixed locale set — list comes from
+    // SUPPORTED_LOCALES so community translators get free coverage.
+    expect(options.length).toBe(SUPPORTED_LOCALES.length);
+    const values = Array.from(options).map((o) => (o as HTMLOptionElement).value);
+    for (const code of SUPPORTED_LOCALES) {
+      expect(values).toContain(code);
+    }
+    unmount(component);
+  });
+
+  it('uses endonyms for known locales', () => {
+    const { target, component } = setup();
+    const enOpt = target.querySelector(
+      '[data-testid="language-option-en-US"]',
+    ) as HTMLOptionElement;
+    const jaOpt = target.querySelector(
+      '[data-testid="language-option-ja-JP"]',
+    ) as HTMLOptionElement;
+    expect(enOpt?.textContent?.trim()).toBe('English');
+    expect(jaOpt?.textContent?.trim()).toBe('日本語');
+    unmount(component);
+  });
+
+  it('marks the pseudo-locale as a developer pseudo-locale', () => {
+    const { target, component } = setup();
+    const pseudoOpt = target.querySelector(
+      '[data-testid="language-option-qps-ploc"]',
+    ) as HTMLOptionElement;
+    expect(pseudoOpt).not.toBeNull();
+    // The endonym/code stays verbatim; the en-US suffix string is appended.
+    expect(pseudoOpt.textContent).toContain('qps-ploc');
+    expect(pseudoOpt.textContent).toContain('developer pseudo-locale');
+    unmount(component);
+  });
+
+  it('reflects the active locale in the <select> value', () => {
+    setLocale('ja-JP');
+    const { target, component } = setup();
+    const sel = target.querySelector(
+      '[data-testid="language-select"]',
+    ) as HTMLSelectElement;
+    expect(sel.value).toBe('ja-JP');
+    unmount(component);
+  });
+
+  it('persists the explicit selection through the store on change', async () => {
+    const { target, component } = setup();
+    const sel = target.querySelector(
+      '[data-testid="language-select"]',
+    ) as HTMLSelectElement;
+
+    sel.value = 'ja-JP';
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+    await tick();
+
+    expect(getLocale()).toBe('ja-JP');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('ja-JP');
+
+    unmount(component);
+  });
+
+  it('exposes a localized aria-label and title on the select', () => {
+    const { target, component } = setup();
+    const sel = target.querySelector(
+      '[data-testid="language-select"]',
+    ) as HTMLSelectElement;
+    // en-US active by default — string comes from the catalog so we
+    // verify it tracks the bundled English source.
+    expect(sel.getAttribute('aria-label')).toBe('Choose language');
+    expect(sel.getAttribute('title')).toBe('Choose language');
+    unmount(component);
+  });
+
+  it('renders a hint paragraph for screen readers / sighted users', () => {
+    const { target, component } = setup();
+    const hint = target.querySelector('[data-testid="language-hint"]');
+    expect(hint).not.toBeNull();
+    expect(hint!.textContent).toContain('Selecting a language');
+    unmount(component);
+  });
+
+  it('catalog source ships every key the component reads', () => {
+    // Guard: if a future PR removes a key, this test will catch it
+    // before the missing-key handler fires at runtime.
+    const required = [
+      'core.settings.language.label',
+      'core.settings.language.choose',
+      'core.settings.language.srHint',
+      'core.settings.language.devLocaleSuffix',
+    ];
+    const catalog = enUS as Record<string, unknown>;
+    for (const key of required) {
+      expect(catalog[key], `en-US missing ${key}`).toBeTypeOf('string');
+    }
+  });
+
+  it('updates the visible label when the locale flips', async () => {
+    // Mount in en-US, switch to ja-JP via the store, and confirm the label
+    // re-renders. This exercises the $derived(t(...)) subscription path.
+    const { target, component } = setup();
+
+    const label = () => target.querySelector('.lang-label')?.textContent?.trim();
+    expect(label()).toBe('Language');
+
+    setLocale('ja-JP');
+    flushSync();
+    await tick();
+
+    expect(label()).toBe('言語');
+
+    unmount(component);
+  });
+});

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -46,6 +46,7 @@
   import LcdLayout from './LcdLayout.svelte';
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
   import BandSelector from '../controls/BandSelector.svelte';
+  import LanguageSelector from '../controls/LanguageSelector.svelte';
   import DspPanel from '../panels/DspPanel.svelte';
   import AgcPanel from '../panels/AgcPanel.svelte';
   import RfFrontEnd from '../panels/RfFrontEnd.svelte';
@@ -341,6 +342,10 @@
         <button class="settings-close" onclick={() => (settingsOpen = false)}>✕</button>
       </div>
       <div class="settings-content">
+        <CollapsiblePanel title="LANGUAGE" panelId="desktop-language">
+          <LanguageSelector />
+        </CollapsiblePanel>
+
         <CollapsiblePanel title="VFO / BAND" panelId="desktop-vfo-ops">
           <div class="settings-vfo-ops-row">
             <HardwareButton

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -18,6 +18,9 @@
 
   "core.settings.language.label": "Language",
   "core.settings.language.helpText": "Choose the language used by the RigPlane UI. Radio mode codes such as {modeToken} stay in English regardless of locale.",
+  "core.settings.language.choose": "Choose language",
+  "core.settings.language.srHint": "Selecting a language updates the UI immediately and is saved on this device.",
+  "core.settings.language.devLocaleSuffix": "developer pseudo-locale",
 
   "core.error.transport.timeout.title": "Connection Timed Out",
   "core.error.transport.timeout.body": "No response from {host}. Check that the radio is powered on and reachable.",

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -8,6 +8,9 @@
   "core.statusbar.connection.connectingTo": "{radio} に {transport} で接続中…",
 
   "core.settings.language.label": "言語",
+  "core.settings.language.choose": "言語を選択",
+  "core.settings.language.srHint": "言語を選択すると UI が即座に更新され、この端末に保存されます。",
+  "core.settings.language.devLocaleSuffix": "開発者用擬似ロケール",
 
   "core.diagnostics.attachedFiles.other": "{count} 個のファイルを添付",
 


### PR DESCRIPTION
Closes #1522 (RP-ML-004 — Phase 3 wave 1).

## Summary
- Adds a quiet, operational language picker to the existing Core Settings modal (no parallel settings surface).
- Uses the `setLocale()` / `getLocale()` / `SUPPORTED_LOCALES` API from the i18n runtime shipped in RP-ML-003. Browser-locale fallback, persistence, and unsupported-locale guard already live in the store and are untouched.
- Option list is derived from `SUPPORTED_LOCALES` so a community-contributed `<bcp47>.json` catalog auto-appears once registered. Endonyms keep labels universally legible; `qps-ploc` is tagged `developer pseudo-locale` via a translatable suffix.
- Selector aria-label, title, label, and hint all resolve through the i18n runtime and re-render on locale change.

## Files changed
- `frontend/src/components-v2/controls/LanguageSelector.svelte` — new component.
- `frontend/src/components-v2/controls/__tests__/LanguageSelector.test.ts` — 9 tests, vitest + mount/unmount idiom matching the rest of the repo.
- `frontend/src/components-v2/layout/RadioLayout.svelte` — inserts `LanguageSelector` as the first `CollapsiblePanel` ("LANGUAGE") inside the existing settings modal.
- `frontend/src/lib/i18n/locales/en-US.json` — adds `core.settings.language.choose`, `.srHint`, `.devLocaleSuffix` (existing `.label` and `.helpText` keys unchanged).
- `frontend/src/lib/i18n/locales/ja-JP.json` — Japanese stubs for the three new keys.

## Tests run
- `npm test` — 102 files / 1797 tests pass.
- `npm test -- LanguageSelector` — 9 / 9 pass.
- `npm run check` — 0 errors / 0 warnings (svelte-check + tsc).
- `npm run lint` — clean.

## Acceptance criteria (issue #1522)
- [x] Language selector appears in the appropriate settings surface (desktop Settings modal opened via the StatusBar gear).
- [x] Selected locale persists locally — `setLocale()` writes `localStorage[rigplane.i18n.locale]` per the existing store.
- [x] Browser locale used only before explicit selection — runtime behavior, asserted via existing `store.test.ts` + new component flow.
- [x] Unsupported locales fall back to English — runtime guard; component cannot render unsupported options because it iterates `SUPPORTED_LOCALES`.
- [x] Accessibility labels are localized — `aria-label`, `title`, label, and hint all sourced via `t(...)`.

## Risks / deferred
- The settings modal is only mounted in the desktop (non-mobile, non-LCD) layout. Mobile/LCD shells do not currently expose a settings entry point — out of scope for this issue; RP-ML-005 / a follow-up mobile-shell issue can mirror the panel there.
- The pseudo-locale is selectable in all builds. The acceptance criteria explicitly allow this; gating to dev builds was listed as "not required for Phase 3 wave 1".
- Server-toast migration and broader string extraction stay in RP-ML-005 scope; `web/server.py` is untouched.

## Boundary check
- Public open-core repo: yes (`rigplane-core`).
- No protocol/wire strings touched.
- No glossary tokens translated (brand names, radio abbreviations stay verbatim).
- i18n runtime (`runtime.ts`, `plural.ts`, `pseudo.ts`, `store.svelte.ts`, `index.ts`, `types.ts`) untouched.

## Test plan
- [ ] Manual: open Settings modal, pick `日本語` → label flips to `言語`; reload → selection persists.
- [ ] Manual: pick `qps-ploc` → all visible Core strings render with accent/expansion transform.
- [ ] Manual: clear `localStorage` with `navigator.language=ja-JP` → app boots in Japanese; selector reflects `ja-JP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)