### PR TITLE
feat(i18n): Core locale preference contract (RP-ML-012A)

### DIFF
--- a/docs/i18n/locale-contract.md
+++ b/docs/i18n/locale-contract.md
@@ -1,0 +1,150 @@
+# Cross-app locale preference contract (RP-ML-012)
+
+Status: Phase 3 wave 2 — public-core.
+Scope: protocol-level propagation contract only. No commercial framing, no
+Tower involvement. See strategy `docs/i18n/glossary-and-policy.md` §5.4 for
+the precedence policy this contract implements (sanitized per §7 row 5.4 —
+"scope to the propagation contract; do not surface Tower or commercial
+framing").
+
+## Why this contract exists
+
+RigPlane Pro embeds the Core web UI either via a Tauri WebView, an
+external browser window, or a managed-station kiosk surface. When Pro
+holds a user-explicit locale preference (set in the Pro Settings UI),
+the embedded Core UI must honor that preference instead of falling back
+to the browser locale. Conversely, when Core is launched standalone or
+without any Pro hint, its existing per-installation explicit choice
+(`localStorage["rigplane.i18n.locale"]`) and detection logic must keep
+working unchanged.
+
+The contract intentionally avoids any network dependency. Locale
+selection is local-first and works offline. Tower is never consulted.
+
+## Envelope shape
+
+A single small JSON envelope is the unit of propagation:
+
+```json
+{
+  "locale": "ja-JP",
+  "source": "pro-shell",
+  "updatedAt": "2026-05-19T18:00:00Z",
+  "supportedLocales": ["en-US", "ja-JP", "qps-ploc"]
+}
+```
+
+Fields:
+
+- `locale` — BCP-47 tag. Must be one of `supportedLocales`. Only the
+  locales bundled with Core's runtime are accepted; anything else is
+  rejected and Core falls back to its standalone resolution.
+- `source` — one of:
+  - `"pro-shell"` — written by Pro from its own Settings UI;
+  - `"core-explicit"` — informational; for symmetry when Core writes to
+    its own contract surface (Core already uses
+    `rigplane.i18n.locale`, so this value is reserved for future use);
+  - `"browser"` — informational fallback marker;
+  - `"fallback"` — informational marker for the en-US fallback.
+- `updatedAt` — ISO-8601 UTC instant. The reader does not enforce
+  freshness today; the field exists so a future revision can ignore
+  stale envelopes (for example, a Pro reinstall that left a stale
+  `localStorage` key behind).
+- `supportedLocales` — the locales the writer believes are supported.
+  Informational; the Core reader validates `locale` against its own
+  bundled list, not the writer's list, because Core is the runtime
+  authority for what it can render.
+
+The envelope is JSON-encoded as a single value at every transport.
+
+## Transport surfaces
+
+Core accepts the contract from Pro through three surfaces. A writer
+(Pro) MAY use any subset; a reader (Core) checks them in fixed order.
+
+### Surface A — URL query parameter `?locale=<bcp47>` (required)
+
+The smallest, most testable surface. Pro launches embedded or external
+Core URLs with `?locale=<tag>`, for example:
+
+```
+http://127.0.0.1:8080/?locale=ja-JP
+```
+
+Core reads `URLSearchParams` exactly once at module init. Subsequent
+navigations do not re-read this parameter — it is a boot signal, not a
+session state. This is intentional so a user who later picks a
+different locale via the Core LanguageSelector is not stomped on every
+route change.
+
+The query parameter form carries only `locale`. The `source`,
+`updatedAt`, and `supportedLocales` fields are synthesized by the
+reader (source `"pro-shell"`, `updatedAt` = read time).
+
+### Surface B — `localStorage` key `rigplane.i18n.proLocale.v1`
+
+Pro MAY write the full envelope as JSON to:
+
+```
+localStorage["rigplane.i18n.proLocale.v1"]
+```
+
+This surface is useful when Pro and Core share the same WebView storage
+partition. The Core reader parses the envelope and validates each
+field. Malformed JSON or a missing/invalid `locale` is silently
+ignored. This surface is read once at boot, like surface A.
+
+### Surface C — `postMessage` from a Tauri host (deferred)
+
+Reserved for a future revision. The shape MUST be the same envelope
+above wrapped in `{ type: "rigplane.i18n.localePreference", payload: <envelope> }`.
+Not implemented in RP-ML-012A. Pro's RP-ML-012B is not required to
+implement this surface either; it is documented to keep the contract
+extensible.
+
+## Read precedence (Core side)
+
+When Core boots, it computes the active locale using:
+
+1. Surface A: `?locale=<bcp47>` in the current URL.
+2. Surface B: `rigplane.i18n.proLocale.v1` in `localStorage`.
+3. Explicit Core setting: existing `rigplane.i18n.locale` in
+   `localStorage` (owned by the Core LanguageSelector).
+4. Browser locale: `navigator.languages` / `navigator.language`,
+   narrowed to a supported locale.
+5. `en-US` fallback.
+
+Rungs 1 and 2 are the "Pro setting" rung from strategy §5.4. Rungs 3–5
+are the existing Core behavior; they are not changed by this contract.
+
+An external source (rungs 1 or 2) is accepted only if its `locale`
+parses as a member of Core's bundled `SUPPORTED_LOCALES`. An invalid
+tag (typo, unsupported region, removed locale) is ignored entirely and
+Core falls through to rung 3.
+
+The pseudo-locale `qps-ploc` is accepted from a Pro hint only as a
+deliberate developer opt-in. The reader does not special-case it; if a
+Pro build is configured to forward `qps-ploc`, the Core side honors it.
+
+## Standalone behavior is preserved
+
+When neither surface A nor surface B yields a valid locale, the boot
+path is a no-op against the existing store and Core behaves exactly as
+before RP-ML-012A. The contract module never writes to the explicit
+Core key `rigplane.i18n.locale`; that key remains owned by the
+LanguageSelector and is the user's stable preference across launches.
+
+## Dev-mode diagnostics
+
+In development builds (`import.meta.env.PROD === false`) the contract
+module logs the resolved source on boot via `console.info`, prefixed
+with `[i18n]`. Production builds are silent. This is to support manual
+QA of precedence without shipping a visible UI affordance.
+
+## Cross-side coordination
+
+The Pro side (RP-ML-012B / `rigplane-pro` #882) implements the writer.
+Both sides reference this document as the single source of truth for
+the envelope shape and transport surfaces. Any change to envelope
+field names or transport keys is a coordinated change across both
+repos.

--- a/frontend/src/lib/i18n/__tests__/locale-contract.test.ts
+++ b/frontend/src/lib/i18n/__tests__/locale-contract.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  applyContractOnBoot,
+  PRO_LOCALE_QUERY_PARAM,
+  PRO_LOCALE_STORAGE_KEY,
+  readLocaleFromExternalStorage,
+  readLocaleFromQuery,
+  resolveInitialLocale,
+} from '../locale-contract';
+import { getLocale, setLocale, STORAGE_KEY, _resetLocale } from '../store.svelte';
+
+beforeEach(() => {
+  localStorage.clear();
+  _resetLocale();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('readLocaleFromQuery', () => {
+  it('returns null when no locale query is present', () => {
+    expect(readLocaleFromQuery('https://core.local/')).toBeNull();
+  });
+
+  it('returns a supported locale tagged as pro-shell-query', () => {
+    const out = readLocaleFromQuery('https://core.local/?locale=ja-JP');
+    expect(out).toEqual({ locale: 'ja-JP', source: 'pro-shell-query' });
+  });
+
+  it('accepts qps-ploc as a deliberate dev opt-in', () => {
+    expect(readLocaleFromQuery('https://core.local/?locale=qps-ploc')).toEqual({
+      locale: 'qps-ploc',
+      source: 'pro-shell-query',
+    });
+  });
+
+  it('rejects an unsupported locale tag', () => {
+    expect(readLocaleFromQuery('https://core.local/?locale=de-DE')).toBeNull();
+  });
+
+  it('rejects an empty locale param', () => {
+    expect(readLocaleFromQuery('https://core.local/?locale=')).toBeNull();
+    expect(readLocaleFromQuery('https://core.local/?locale=%20%20')).toBeNull();
+  });
+
+  it('rejects nonsense values without throwing', () => {
+    expect(readLocaleFromQuery('https://core.local/?locale=../etc/passwd')).toBeNull();
+    expect(readLocaleFromQuery('https://core.local/?locale=ja_JP')).toBeNull();
+  });
+
+  it('returns null when the URL is malformed', () => {
+    expect(readLocaleFromQuery('not a url')).toBeNull();
+  });
+
+  it('reads from window.location when no url is given', () => {
+    // jsdom's window.location is mutable via history; set search and verify.
+    const originalSearch = window.location.search;
+    window.history.replaceState({}, '', `/?${PRO_LOCALE_QUERY_PARAM}=ja-JP`);
+    try {
+      expect(readLocaleFromQuery()).toEqual({
+        locale: 'ja-JP',
+        source: 'pro-shell-query',
+      });
+    } finally {
+      window.history.replaceState({}, '', `/${originalSearch}`);
+    }
+  });
+});
+
+describe('readLocaleFromExternalStorage', () => {
+  it('returns null when the storage key is unset', () => {
+    expect(readLocaleFromExternalStorage()).toBeNull();
+  });
+
+  it('parses a well-formed envelope and tags the source', () => {
+    localStorage.setItem(
+      PRO_LOCALE_STORAGE_KEY,
+      JSON.stringify({
+        locale: 'ja-JP',
+        source: 'pro-shell',
+        updatedAt: '2026-05-19T18:00:00Z',
+        supportedLocales: ['en-US', 'ja-JP', 'qps-ploc'],
+      }),
+    );
+    expect(readLocaleFromExternalStorage()).toEqual({
+      locale: 'ja-JP',
+      source: 'pro-shell-storage',
+    });
+  });
+
+  it('ignores malformed JSON without throwing', () => {
+    localStorage.setItem(PRO_LOCALE_STORAGE_KEY, 'not json');
+    expect(readLocaleFromExternalStorage()).toBeNull();
+  });
+
+  it('ignores an envelope without a locale field', () => {
+    localStorage.setItem(
+      PRO_LOCALE_STORAGE_KEY,
+      JSON.stringify({ source: 'pro-shell' }),
+    );
+    expect(readLocaleFromExternalStorage()).toBeNull();
+  });
+
+  it('ignores an envelope whose locale is not bundled', () => {
+    localStorage.setItem(
+      PRO_LOCALE_STORAGE_KEY,
+      JSON.stringify({ locale: 'pt-BR', source: 'pro-shell' }),
+    );
+    expect(readLocaleFromExternalStorage()).toBeNull();
+  });
+
+  it('ignores a numeric or null locale value', () => {
+    localStorage.setItem(
+      PRO_LOCALE_STORAGE_KEY,
+      JSON.stringify({ locale: 42 }),
+    );
+    expect(readLocaleFromExternalStorage()).toBeNull();
+    localStorage.setItem(
+      PRO_LOCALE_STORAGE_KEY,
+      JSON.stringify({ locale: null }),
+    );
+    expect(readLocaleFromExternalStorage()).toBeNull();
+  });
+});
+
+describe('resolveInitialLocale precedence', () => {
+  it('prefers the URL query over the storage envelope', () => {
+    localStorage.setItem(
+      PRO_LOCALE_STORAGE_KEY,
+      JSON.stringify({ locale: 'qps-ploc' }),
+    );
+    expect(resolveInitialLocale('https://core.local/?locale=ja-JP')).toEqual({
+      locale: 'ja-JP',
+      source: 'pro-shell-query',
+    });
+  });
+
+  it('falls back to the storage envelope when no query is present', () => {
+    localStorage.setItem(
+      PRO_LOCALE_STORAGE_KEY,
+      JSON.stringify({ locale: 'ja-JP' }),
+    );
+    expect(resolveInitialLocale('https://core.local/')).toEqual({
+      locale: 'ja-JP',
+      source: 'pro-shell-storage',
+    });
+  });
+
+  it('returns null when neither surface has a valid hint', () => {
+    expect(resolveInitialLocale('https://core.local/')).toBeNull();
+  });
+
+  it('falls through to storage when the query holds an invalid tag', () => {
+    localStorage.setItem(
+      PRO_LOCALE_STORAGE_KEY,
+      JSON.stringify({ locale: 'ja-JP' }),
+    );
+    expect(resolveInitialLocale('https://core.local/?locale=de-DE')).toEqual({
+      locale: 'ja-JP',
+      source: 'pro-shell-storage',
+    });
+  });
+});
+
+describe('applyContractOnBoot — integration with the store', () => {
+  it('Pro query overrides an existing Core explicit setting', () => {
+    // Core user previously picked en-US explicitly.
+    setLocale('en-US');
+    expect(getLocale()).toBe('en-US');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('en-US');
+
+    const out = applyContractOnBoot('https://core.local/?locale=ja-JP');
+    expect(out).toEqual({ locale: 'ja-JP', source: 'pro-shell-query' });
+    expect(getLocale()).toBe('ja-JP');
+
+    // The user's explicit Core key is NOT overwritten — standalone behavior
+    // resumes on the next launch without a Pro hint.
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('en-US');
+  });
+
+  it('Pro storage envelope overrides an existing Core explicit setting', () => {
+    setLocale('en-US');
+    localStorage.setItem(
+      PRO_LOCALE_STORAGE_KEY,
+      JSON.stringify({ locale: 'ja-JP', source: 'pro-shell' }),
+    );
+
+    const out = applyContractOnBoot('https://core.local/');
+    expect(out).toEqual({ locale: 'ja-JP', source: 'pro-shell-storage' });
+    expect(getLocale()).toBe('ja-JP');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('en-US');
+  });
+
+  it('no-op when no Pro hint exists; standalone behavior preserved', () => {
+    setLocale('ja-JP');
+    const before = getLocale();
+    expect(before).toBe('ja-JP');
+
+    const out = applyContractOnBoot('https://core.local/');
+    expect(out).toBeNull();
+    expect(getLocale()).toBe(before);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('ja-JP');
+  });
+
+  it('invalid Pro hint is ignored; Core explicit setting wins', () => {
+    setLocale('ja-JP');
+    const out = applyContractOnBoot('https://core.local/?locale=de-DE');
+    expect(out).toBeNull();
+    expect(getLocale()).toBe('ja-JP');
+  });
+
+  it('Pro hint outranks the browser-detected default', () => {
+    // No explicit Core key is set; store starts at the detected value.
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    const out = applyContractOnBoot('https://core.local/?locale=ja-JP');
+    expect(out).toEqual({ locale: 'ja-JP', source: 'pro-shell-query' });
+    expect(getLocale()).toBe('ja-JP');
+    // Still does not persist as the Core explicit setting.
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/lib/i18n/index.ts
+++ b/frontend/src/lib/i18n/index.ts
@@ -42,6 +42,7 @@ import { registerCatalog, resolve, setMissingKeyHandler } from './runtime';
 import { resolvePlural } from './plural';
 import { resolvePseudo } from './pseudo';
 import { getLocale, setLocale, STORAGE_KEY, SUPPORTED_LOCALES } from './store.svelte';
+import { applyContractOnBoot } from './locale-contract';
 import {
   PSEUDO_LOCALE,
   SOURCE_LOCALE,
@@ -55,6 +56,13 @@ import {
 // on-the-fly by `resolvePseudo`; no JSON file ships for it.
 registerCatalog('en-US', enUSCatalog as Record<string, unknown>);
 registerCatalog('ja-JP', jaJPCatalog as Record<string, unknown>);
+
+// Cross-app locale preference contract (RP-ML-012A): if Pro launched this
+// Core surface with a `?locale=` query or wrote the shared `proLocale.v1`
+// envelope to `localStorage`, apply it once at boot. No-op when there is
+// no Pro hint, so standalone Core keeps its existing precedence rules.
+// See `docs/i18n/locale-contract.md` and `./locale-contract.ts`.
+applyContractOnBoot();
 
 /**
  * Resolve a message key for the active locale, applying `{name}`

--- a/frontend/src/lib/i18n/locale-contract.ts
+++ b/frontend/src/lib/i18n/locale-contract.ts
@@ -1,0 +1,168 @@
+/**
+ * Cross-app locale preference contract — Core (reader) side.
+ *
+ * Strategy reference: glossary §5.4 (Cross-app locale precedence). The full
+ * contract — envelope shape, transport surfaces, precedence semantics — is
+ * documented in `docs/i18n/locale-contract.md`. Pro (RP-ML-012B) writes the
+ * envelope; this module reads it.
+ *
+ * Design constraints (RP-ML-012A):
+ *   - Layered on top of the existing i18n runtime/store. The resolver
+ *     (`runtime.ts`, `plural.ts`, `pseudo.ts`) is NOT modified.
+ *   - Standalone Core (no Pro hint) must behave exactly as before. This
+ *     module is a no-op in that case.
+ *   - No Tower dependency; no network. Local-first.
+ *   - Boot-only signal: query/storage are read once at module init, not on
+ *     every navigation, so a later in-UI locale change is not stomped.
+ *   - External-source apply uses `_applyExternalLocale` and deliberately
+ *     does NOT persist to the explicit Core key `rigplane.i18n.locale`.
+ *     That key remains owned by the LanguageSelector and survives Pro
+ *     reinstalls.
+ */
+
+import { _applyExternalLocale, isSupported, SUPPORTED_LOCALES } from './store.svelte';
+import type { LocaleCode } from './types';
+
+/** The five sources surfaceable from the precedence resolver. */
+export type LocaleSourceKind =
+  | 'pro-shell-query'
+  | 'pro-shell-storage'
+  | 'core-explicit'
+  | 'browser'
+  | 'fallback';
+
+/** A locale paired with its provenance. */
+export interface LocaleSource {
+  locale: LocaleCode;
+  source: LocaleSourceKind;
+}
+
+/**
+ * `localStorage` key Pro writes the JSON envelope to. Versioned so that a
+ * future shape change can coexist with old Pro installs.
+ */
+export const PRO_LOCALE_STORAGE_KEY = 'rigplane.i18n.proLocale.v1';
+
+/** URL query parameter name Pro appends to launched Core URLs. */
+export const PRO_LOCALE_QUERY_PARAM = 'locale';
+
+/**
+ * Envelope as written by Pro. The reader treats every field except
+ * `locale` as informational — `locale` is validated against Core's own
+ * bundled `SUPPORTED_LOCALES`.
+ */
+export interface LocalePreferenceEnvelope {
+  locale: string;
+  source?: 'pro-shell' | 'core-explicit' | 'browser' | 'fallback';
+  updatedAt?: string;
+  supportedLocales?: readonly string[];
+}
+
+/**
+ * Parse `?locale=<bcp47>` from a URL (or `window.location` by default).
+ * Returns null when the parameter is absent, malformed, or names a locale
+ * Core does not bundle.
+ */
+export function readLocaleFromQuery(url?: string | URL): LocaleSource | null {
+  let search: URLSearchParams;
+  try {
+    if (url !== undefined) {
+      search = new URL(typeof url === 'string' ? url : url.toString()).searchParams;
+    } else if (typeof window !== 'undefined' && window.location) {
+      search = new URLSearchParams(window.location.search);
+    } else {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  const raw = search.get(PRO_LOCALE_QUERY_PARAM);
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (!isSupported(trimmed)) return null;
+  return { locale: trimmed, source: 'pro-shell-query' };
+}
+
+/**
+ * Parse the JSON envelope at `localStorage[PRO_LOCALE_STORAGE_KEY]`.
+ * Silently returns null for missing/malformed envelopes or for a locale
+ * that does not exist in Core's bundled `SUPPORTED_LOCALES`.
+ */
+export function readLocaleFromExternalStorage(): LocaleSource | null {
+  if (typeof localStorage === 'undefined') return null;
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(PRO_LOCALE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (raw == null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const envelope = parsed as Partial<LocalePreferenceEnvelope>;
+  if (typeof envelope.locale !== 'string') return null;
+  const candidate = envelope.locale.trim();
+  if (!candidate || !isSupported(candidate)) return null;
+  return { locale: candidate, source: 'pro-shell-storage' };
+}
+
+/**
+ * Resolve the initial locale by applying the cross-app precedence rules.
+ *
+ *   1. URL `?locale=` (Pro launch hint).
+ *   2. `localStorage[PRO_LOCALE_STORAGE_KEY]` envelope (Pro shared key).
+ *   3. Explicit Core setting (existing `rigplane.i18n.locale`).
+ *   4. Browser locale (narrowed to supported).
+ *   5. en-US fallback.
+ *
+ * Rungs 3–5 are handled by the existing store; this function only reports
+ * which Pro rung (if any) is active. Callers use the returned source to
+ * decide whether to override the store via `_applyExternalLocale`.
+ *
+ * Pure: does not touch the store. Safe to call from tests.
+ */
+export function resolveInitialLocale(url?: string | URL): LocaleSource | null {
+  return readLocaleFromQuery(url) ?? readLocaleFromExternalStorage();
+}
+
+/**
+ * Apply the Pro-side hint to the i18n store, if any. Idempotent.
+ *
+ * Called once at module init from `index.ts`. Returns the resolved Pro
+ * source for diagnostics; returns null when there is no Pro hint and the
+ * store keeps its standalone-resolved value.
+ *
+ * Never persists to `rigplane.i18n.locale`. The user's stored Core
+ * preference survives the Pro override.
+ */
+export function applyContractOnBoot(url?: string | URL): LocaleSource | null {
+  const hint = resolveInitialLocale(url);
+  if (hint) {
+    _applyExternalLocale(hint.locale);
+  }
+  if (isDevMode()) {
+    // Best-effort dev diagnostic so manual QA can see which rung resolved.
+    // Silent in production builds.
+    // eslint-disable-next-line no-console
+    console.info(
+      `[i18n] locale-contract: ${hint ? `applied ${hint.locale} from ${hint.source}` : 'no Pro hint; store retained'}`,
+    );
+  }
+  return hint;
+}
+
+function isDevMode(): boolean {
+  try {
+    return !(import.meta as ImportMeta & { env?: { PROD?: boolean } }).env?.PROD;
+  } catch {
+    return false;
+  }
+}
+
+export { SUPPORTED_LOCALES };

--- a/frontend/src/lib/i18n/store.svelte.ts
+++ b/frontend/src/lib/i18n/store.svelte.ts
@@ -97,4 +97,21 @@ export function _resetLocale(): void {
   locale = detectFromBrowser();
 }
 
-export { SUPPORTED_LOCALES, STORAGE_KEY };
+/**
+ * Set the active locale WITHOUT persisting to `rigplane.i18n.locale`.
+ *
+ * Reserved for the cross-app locale preference contract
+ * (`locale-contract.ts`, RP-ML-012A). The contract module reads a Pro-side
+ * hint (URL query or shared `localStorage` envelope) on boot and applies it
+ * here so the Pro setting can override the existing Core stored value
+ * without stomping it permanently — the next standalone launch without a
+ * Pro hint will fall back to the user's stable Core preference.
+ *
+ * Not part of the public UI surface; do not call from components.
+ */
+export function _applyExternalLocale(next: LocaleCode): void {
+  if (!isSupported(next)) return;
+  locale = next;
+}
+
+export { SUPPORTED_LOCALES, STORAGE_KEY, isSupported };


### PR DESCRIPTION
Closes #1525.

## Summary

Implements the Core reader half of the cross-app locale preference contract
(strategy glossary §5.4). Pro can launch embedded or external Core URLs with
`?locale=<bcp47>` or write a shared JSON envelope to
`localStorage["rigplane.i18n.proLocale.v1"]`; Core honors that hint once at
boot without overwriting the user's explicit standalone Core preference.

Tower is not consulted. Standalone Core (no Pro hint) behaves exactly as
before. The resolver core (`runtime.ts`, `plural.ts`, `pseudo.ts`) is
untouched — the contract is layered on top via a non-persisting
`_applyExternalLocale` hook on the store.

## Files added

- `docs/i18n/locale-contract.md` — shared schema doc that the Pro side
  (RP-ML-012B / rigplane/rigplane-pro#882) references for the envelope
  shape and transport surfaces.
- `frontend/src/lib/i18n/locale-contract.ts` — query/storage readers,
  `resolveInitialLocale`, `applyContractOnBoot`. Dev-mode `console.info`
  diagnostic to support manual QA of precedence.
- `frontend/src/lib/i18n/__tests__/locale-contract.test.ts` — 23 Vitest
  cases.

## Files modified

- `frontend/src/lib/i18n/store.svelte.ts` — adds `_applyExternalLocale`
  (non-persisting setter, only callable from the contract module) and
  exports `isSupported`.
- `frontend/src/lib/i18n/index.ts` — calls `applyContractOnBoot()` once
  at module init, after catalog registration.

## Contract shape

See `docs/i18n/locale-contract.md` for the canonical spec. Envelope:

```json
{
  "locale": "ja-JP",
  "source": "pro-shell",
  "updatedAt": "2026-05-19T18:00:00Z",
  "supportedLocales": ["en-US", "ja-JP", "qps-ploc"]
}
```

Transport surfaces implemented:
- (A) URL query `?locale=<bcp47>` — boot-only read, preferred.
- (B) `localStorage["rigplane.i18n.proLocale.v1"]` — full envelope.
- (C) `postMessage` — documented as future-only, not implemented.

## Precedence — test coverage matrix

| # | Rung                                            | Test                                                                |
| - | ----------------------------------------------- | ------------------------------------------------------------------- |
| 1 | URL `?locale=` (Pro hint)                       | `readLocaleFromQuery` block + `Pro query overrides Core explicit`   |
| 2 | `proLocale.v1` localStorage envelope            | `readLocaleFromExternalStorage` block + `Pro storage overrides`     |
| 3 | Existing `rigplane.i18n.locale` (Core explicit) | `no-op when no Pro hint; standalone behavior preserved`             |
| 4 | Browser locale                                  | `Pro hint outranks the browser-detected default`                    |
| 5 | en-US fallback                                  | Covered indirectly by the existing store tests; unchanged behavior. |
|   | Invalid Pro tag is ignored                      | `rejects an unsupported locale tag` + `invalid Pro hint is ignored` |
|   | Pro override does NOT stomp `rigplane.i18n.locale` | `Pro query overrides ... not overwritten`                        |
|   | Query > storage when both present               | `prefers the URL query over the storage envelope`                   |
|   | Storage envelope malformed JSON                 | `ignores malformed JSON without throwing`                           |

23 Vitest cases total in `locale-contract.test.ts`.

## Boundary check

Strategy boundary table (`docs/i18n/glossary-and-policy.md` §7 row 5.4)
permits Core to document "the propagation contract". Sanitization
applied: no Tower mention, no commercial framing, no copy from the
glossary commercial-priority paragraphs. `locale-contract.md`
references §5.4 by section number only.

This PR does not extract any UI strings (RP-ML-005 owns that). The
LanguageSelector is unmodified (it already covers the "explicit Core
setting" rung).

## Verification

```
npm test           # 1826 passed (104 files), 23 new
npm run i18n:check # OK (2 locale files, 25 source keys; ja-JP gaps informational)
npm run check      # 0 errors / 0 warnings
npm run lint       # clean
```

## Coordination with RP-ML-012B (Pro side)

Pro writer in `rigplane/rigplane-pro#882` runs in parallel. Both sides
reference `docs/i18n/locale-contract.md` as the single source of truth
for the envelope shape and transport surfaces. The reader is permissive
on the envelope's informational fields (`source`, `updatedAt`,
`supportedLocales`) so a minor writer-side iteration on those does not
break Core. The `locale` field and storage/query key names are the
load-bearing parts of the contract — those require coordinated change
across repos.

Draft until the Pro-side PR appears so the envelope shape can be
ratified jointly.