### PR TITLE
fix(i18n): Core ja-JP linguistic validation pass (RP-ML-015)

### DIFF
--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -11,7 +11,7 @@
   "common.action.copied": "コピーしました",
 
   "core.app.backendError": "サーバーエラー: {detail}",
-  "core.app.serverUnreachable": "複数回の試行後もサーバーに接続できません。接続を確認して手動で再読み込みしてください。",
+  "core.app.serverUnreachable": "何度試してもサーバーに接続できません。接続を確認して手動で再読み込みしてください。",
   "core.app.retryIndicator": "再試行 {attempt}/{max}、次の試行まで {seconds} 秒…",
 
   "core.statusbar.connection.connected": "接続済み",
@@ -83,7 +83,7 @@
   "core.diagnostics.attachedFiles.one": "ファイル 1 件を添付",
   "core.diagnostics.attachedFiles.other": "ファイル {count} 件を添付",
   "core.diagnostics.sendReport.dialogTitle": "診断レポートを送信",
-  "core.diagnostics.sendReport.helpText": "最近のログと設定の機密情報を伏せた診断バンドルを作成します。アップロードする前に全体をプレビューできます。",
+  "core.diagnostics.sendReport.helpText": "最近のログと設定から機密情報を伏せた診断バンドルを作成します。アップロードする前に全体をプレビューできます。",
   "core.diagnostics.sendReport.fieldDescribe": "問題の内容",
   "core.diagnostics.sendReport.placeholderDescribe": "問題が発生したときに何をしていましたか?",
   "core.diagnostics.sendReport.fieldIssueUrl": "Issue の URL (任意)",
@@ -94,7 +94,7 @@
   "core.diagnostics.sendReport.placeholderCallsign": "N0CALL",
   "core.diagnostics.sendReport.generatingButton": "生成中…",
   "core.diagnostics.sendReport.generatePreviewButton": "プレビューを生成",
-  "core.diagnostics.sendReport.previewHelp": "下のバンドルを確認してください。「送信」をクリックするまで、何もこの端末から送信されません。",
+  "core.diagnostics.sendReport.previewHelp": "下のバンドルを確認してください。「送信」をクリックするまで、この端末から何も送信されません。",
   "core.diagnostics.sendReport.metaEndpoint": "エンドポイント",
   "core.diagnostics.sendReport.metaTotalSize": "合計サイズ",
   "core.diagnostics.sendReport.metaFiles": "ファイル",


### PR DESCRIPTION
## Summary

Second independent LLM pass over the ja-JP pilot from #1536. Fresh-eyes
re-review with the rubric in RP-ML-015: naturalness / register /
half-width discipline / consistency / domain terms.

**3 small edits / 158 keys**. No glossary, placeholder, or key-set
changes. Boundary preservation: N/A for Core (boundary-flagged keys
live in Pro).

## Change log

| Key | Before | After | Rationale |
|---|---|---|---|
| `core.app.serverUnreachable` | `複数回の試行後もサーバーに接続できません…` | `何度試してもサーバーに接続できません…` | More idiomatic phrasing for "after multiple attempts" |
| `core.diagnostics.sendReport.helpText` | `…ログと設定の機密情報を伏せた…` | `…ログと設定から機密情報を伏せた…` | Disambiguate parse: redact FROM logs and settings, not "logs and [settings' info]" |
| `core.diagnostics.sendReport.previewHelp` | `何もこの端末から送信されません` | `この端末から何も送信されません` | Move 何も closer to verb so negation scope reads naturally |

## Keys reviewed and deliberately left unchanged

- `core.statusbar.health.rigOffline` ("リグがオフラインです"): kept リグ
  (operator slang) — matches casual register of en "rig offline".
  Documented in #1536 spot-check #2.
- `core.statusbar.power.toggleOn/Off/labelOn/labelOff`: English ON/OFF
  inside Japanese sentence preserved per glossary §2.A (radio
  abbrev convention) and #1536 spot-check #3.
- `core.statusbar.nowPlaying.live` ("オンエア"): operator vocabulary, more
  natural for SWL/DXer audience than 生放送. Per #1536 spot-check #4.
- `core.diagnostics.attachedFiles.{one,other}` (件 counter): standard
  counter for attachments in Japanese UI. Per #1536 spot-check #5.
- `core.mobile.tx.pushToTalk` ("押して送信"): short imperative for a
  button; the abbreviation PTT surfaces elsewhere unchanged.
- `core.installPrompt.iosInstruction` (「ホーム画面に追加」): Apple
  Japan convention preserved.
- `core.error.literalBrace.example`: `'{'` escape preserved verbatim.
- Health-fragment strings (`core.statusbar.health.*`): full ます-form
  embedded in `({reason})` parens is slightly stilted but consistent
  with the file's polite-form policy; rewriting to fragment style
  would mix registers across the catalog.
- Mode names inside prose (`DATA モード`, `TX 設定`, etc.) stay English
  uppercase per §2.D.

## Gates

- `npm run i18n:check` → OK (3 locale files, 158 source keys).
- `npm test` → 1832 / 1832 passed.
- `npm run check` → 4113 files, 0 errors, 0 warnings.
- `npm run lint` → clean.

## Honest self-assessment

This is a polish pass, not a retranslation. The base translation in #1536
is already high quality; the three edits above are the changes I'm 100%
confident improve naturalness. There are stylistic alternatives for a
half-dozen other strings (e.g. spelling out オン/オフ instead of English
ON/OFF, ローテーター vs. アンテナ wording in non-existent rotator strings)
but they are judgment calls, not corrections — community refinement
post-pilot is the right place for those.

A Japanese-speaking ham operator should still do the final pass for
domain register before ja-JP is declared production-ready.

Draft PR — orchestrator will mark ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)