### PR TITLE
chore(pyproject): match landing-page multi-vendor framing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rigplane"
 version = "2.2.0"
-description = "Python library for controlling Icom transceivers over LAN (UDP) — no wfview/hamlib required"
+description = "Multi-vendor radio control library and Web UI for IP-connected ham transceivers (Icom, Yaesu, Xiegu, Lab599) — no wfview/hamlib required"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
@@ -20,9 +20,9 @@ dependencies = [
 authors = [
     { name = "Sergey Morozik", email = "morozsm@gmail.com" },
 ]
-keywords = ["rigplane", "icom", "ham-radio", "amateur-radio", "transceiver", "ci-v", "ic-7610", "ic-705"]
+keywords = ["rigplane", "ham-radio", "amateur-radio", "transceiver", "icom", "yaesu", "xiegu", "lab599", "ci-v", "cat", "rigctld", "ic-7610", "ic-7300", "ic-705", "ftx-1"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Topic :: Communications :: Ham Radio",


### PR DESCRIPTION
## What

`pyproject.toml` is what PyPI uses to render the package page, and it is what visitors see after clicking "Available on PyPI today" on rigplane.com. Two signals there currently contradict the public marketing:

1. `description = "Python library for controlling Icom transceivers over LAN (UDP) — no wfview/hamlib required"` — single-vendor framing, despite the v2.x rename and the multi-vendor support matrix in `README.md`.
2. `Development Status :: 3 - Alpha` — contradicts the "production-grade backends" language in `README.md` and on rigplane.com, and the v2.x release line.

## Diff

```
- description = "Python library for controlling Icom transceivers over LAN (UDP) — no wfview/hamlib required"
+ description = "Multi-vendor radio control library and Web UI for IP-connected ham transceivers (Icom, Yaesu, Xiegu, Lab599) — no wfview/hamlib required"

- keywords = ["rigplane", "icom", "ham-radio", "amateur-radio", "transceiver", "ci-v", "ic-7610", "ic-705"]
+ keywords = ["rigplane", "ham-radio", "amateur-radio", "transceiver", "icom", "yaesu", "xiegu", "lab599", "ci-v", "cat", "rigctld", "ic-7610", "ic-7300", "ic-705", "ftx-1"]

- "Development Status :: 3 - Alpha",
+ "Development Status :: 5 - Production/Stable",
```

## Why

Surfaced during a brand review of rigplane.com (see rigplane/rigplane-www#33). The landing page positions the open core as production-ready multi-vendor software; the PyPI page should not say otherwise.

## Verification

Targeted gates per `CLAUDE.md` (pyproject text-only change, so the smallest relevant gates are):

```bash
uv run lint-imports
uv run ruff check src/ tests/
```

Both expected to pass — this PR changes only descriptive metadata, no imports, no code.

## Related upstream PRs

- rigplane/rigplane-www#33 — landing brand-review revisions
- rigplane/rigplane-pro#911 — Pro README banner + lead sentence stale