### PR TITLE
SEO Q8: configure MkDocs site_name and per-page descriptions

### DIFF
--- a/docs/guide/audio-recipes.md
+++ b/docs/guide/audio-recipes.md
@@ -1,3 +1,7 @@
+---
+description: Copy-paste recipes for RX and TX audio with RigPlane — PCM and Opus contracts, browser playback, microphone capture, and radio-native LAN audio.
+---
+
 # Audio Recipes (copy/paste)
 
 Practical scenarios for the current `rigplane` audio API.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,3 +1,7 @@
+---
+description: Full RigPlane CLI reference — connect, scan, tune, serve the Web UI, run rigctld, and stream audio from the terminal on macOS, Linux, and Windows.
+---
+
 # CLI Reference
 
 The `rigplane` CLI provides quick access to radio control from the terminal.

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -1,3 +1,7 @@
+---
+description: CI-V commands supported by RigPlane — frequency, mode, filter, AGC, attenuator, preamp, meters, and per-radio extensions exposed in a Python API.
+---
+
 # CI-V Commands
 
 The library supports a comprehensive set of CI-V commands for controlling your Icom transceiver.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,3 +1,7 @@
+---
+description: Configure RigPlane backends, credentials, and runtime options — LAN versus USB serial, environment variables, and per-radio configuration tips.
+---
+
 # Configuration
 
 ## Backend Selection

--- a/docs/guide/connection.md
+++ b/docs/guide/connection.md
@@ -1,3 +1,7 @@
+---
+description: Understand the RigPlane connection lifecycle to an Icom radio — discovery, login, keep-alive, control and audio streams, and clean shutdown.
+---
+
 # Connection Lifecycle
 
 Understanding the connection sequence helps with debugging and advanced usage.

--- a/docs/guide/diagnostic-reports.md
+++ b/docs/guide/diagnostic-reports.md
@@ -1,3 +1,7 @@
+---
+description: Generate redacted RigPlane diagnostic reports — bundle logs, radio state, runtime config, and environment into a single ZIP for support and triage.
+---
+
 # Diagnostic Reports
 
 When something goes wrong with `rigplane` — a CAT timeout, a stuck audio

--- a/docs/guide/ic705-usb-setup.md
+++ b/docs/guide/ic705-usb-setup.md
@@ -1,3 +1,7 @@
+---
+description: Configure the Icom IC-705 for USB serial CI-V and USB audio control from macOS with RigPlane — field-friendly setup with no network required.
+---
+
 # IC-705 USB Serial Backend Setup (macOS)
 
 This guide shows how to control the IC-705 via **USB serial CI-V + USB audio devices** instead of the default LAN backend.

--- a/docs/guide/ic7300-usb-setup.md
+++ b/docs/guide/ic7300-usb-setup.md
@@ -1,3 +1,7 @@
+---
+description: Set up the Icom IC-7300 over USB serial CI-V and USB audio from macOS with RigPlane — low-latency direct control without LAN, hamlib, or RS-BA1.
+---
+
 # IC-7300 USB Serial Backend Setup (macOS)
 
 This guide shows how to control the IC-7300 via **USB serial CI-V + USB audio devices** instead of the default LAN backend.

--- a/docs/guide/ic7610-usb-setup.md
+++ b/docs/guide/ic7610-usb-setup.md
@@ -1,3 +1,7 @@
+---
+description: Step-by-step guide to control the Icom IC-7610 from macOS over USB serial CI-V and USB audio with RigPlane — no LAN, hamlib, or RS-BA1 required.
+---
+
 # IC-7610 USB Serial Backend Setup (macOS)
 
 This guide shows how to control the IC-7610 via **USB serial CI-V + USB audio devices** instead of the default LAN backend.

--- a/docs/guide/ic9700-usb-setup.md
+++ b/docs/guide/ic9700-usb-setup.md
@@ -1,3 +1,7 @@
+---
+description: Control the dual-receiver Icom IC-9700 via USB serial CI-V or LAN from macOS with RigPlane — both transport options covered end to end.
+---
+
 # IC-9700 USB Serial Backend Setup (macOS)
 
 This guide shows how to control the **IC-9700 dual-receiver transceiver** via USB serial CI-V + USB audio devices or LAN network connection.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,3 +1,7 @@
+---
+description: Install RigPlane from PyPI on macOS, Linux, or Windows — Python 3.11+ requirements, optional extras, and verifying the install against a real radio.
+---
+
 # Installation
 
 ## Requirements

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -1,3 +1,7 @@
+---
+description: Declarative operating profiles for RigPlane — describe desired radio state (frequency, mode, data, VOX) and let the library reconcile it for you.
+---
+
 # Radio Profiles
 
 Radio profiles let you describe the **desired radio state** declaratively — set only the fields you want to change, and the system figures out how to get there.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,3 +1,7 @@
+---
+description: Get your first RigPlane connection to an Icom radio over LAN in under five minutes — credentials, discovery, and a basic frequency read in Python.
+---
+
 # Quick Start
 
 Get your first connection in under 5 minutes.

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -1,3 +1,7 @@
+---
+description: Radios supported by RigPlane — Icom IC-7610, IC-7300, IC-705, IC-9700, plus Yaesu, Xiegu, and Lab599 models defined by TOML rig profiles.
+---
+
 # Supported Radios
 
 Radio support in rigplane is defined by **TOML rig profiles** in `rigs/`.

--- a/docs/guide/rig-profiles.md
+++ b/docs/guide/rig-profiles.md
@@ -1,3 +1,7 @@
+---
+description: Add a new radio to RigPlane by writing a TOML rig profile — capabilities, CI-V commands, hardware parameters, and registration in the rig loader.
+---
+
 # Adding a New Radio (Rig Profiles)
 
 ## Overview

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+description: Troubleshooting RigPlane radio control — discovery timeouts, authentication failures, audio dropouts, USB serial issues, and Web UI connection problems.
+---
+
 # Troubleshooting
 
 ## Connection Issues

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -1,3 +1,7 @@
+---
+description: RigPlane's built-in browser Web UI for ham radio control — live tuning, scope and waterfall, meters, and RX/TX audio streaming from any browser.
+---
+
 # Web UI
 
 rigplane ships with a built-in browser UI for live control, scope/waterfall, meters,

--- a/docs/guide/wsjtx-setup.md
+++ b/docs/guide/wsjtx-setup.md
@@ -1,3 +1,7 @@
+---
+description: Configure WSJT-X, JTDX, and JS8Call against RigPlane's built-in rigctld server for FT8, FT4, and JS8 on Icom radios — no Hamlib install needed.
+---
+
 # WSJT-X / JTDX / JS8Call Setup Guide
 
 This guide covers configuring WSJT-X (and compatible apps like JTDX, JS8Call)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+---
+title: RigPlane — Ham Radio Control Library and Web UI for Icom, Yaesu, Xiegu
+description: RigPlane is a Python library and browser Web UI for controlling Icom IC-7610, IC-7300, IC-705, IC-9700 and Yaesu/Xiegu radios over LAN or USB — no wfview, hamlib, or RS-BA1 required.
+---
+
 # rigplane
 
 **Python library for controlling Icom, Yaesu, and other transceivers over LAN (UDP) or USB serial.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: rigplane
-site_description: Multi-vendor Python library and browser UI for controlling ham transceivers over LAN or USB serial
+site_name: RigPlane Docs
+site_description: RigPlane documentation — Python library and Web UI for controlling Icom, Yaesu, Xiegu and Lab599 ham transceivers over LAN or USB serial on macOS, Linux and Windows.
 site_url: https://rigplane.dev/
 repo_url: https://github.com/rigplane/rigplane-core
 repo_name: rigplane/rigplane-core


### PR DESCRIPTION
## Summary

Phase 1 SEO quick-win Q8 from the 2026-05-19 audit. The rigplane.dev
homepage previously rendered `<title>rigplane</title>` (8 chars), bleeding
click-through on every navigational and tutorial query. All child pages
inherited the same site name in the Material title template, so
`/guide/ic7610-usb-setup/`, `/guide/wsjtx-setup/`, etc. were invisible to
search for the queries operators actually type.

This PR is metadata-only: no doc page content is rewritten, no nav is
re-ordered.

### Changes

- `mkdocs.yml`:
  - `site_name`: `rigplane` -> `RigPlane Docs`
  - `site_description`: expanded with vendor + platform keywords (Icom,
    Yaesu, Xiegu, Lab599, macOS/Linux/Windows). `site_url` unchanged.
- `docs/index.md`: front-matter `title` + `description` so the homepage
  surfaces a unique query-bearing title and a 195-char meta description.
- `docs/guide/*.md` (17 files): front-matter `description:` (140-180
  chars) on every user-guide page — IC-7610 / IC-705 / IC-7300 / IC-9700
  USB setup, WSJT-X / digital modes, audio recipes, troubleshooting,
  installation, quickstart, CLI, configuration, connection lifecycle,
  supported radios, rig profiles, operating profiles, Web UI, CI-V
  commands, diagnostic reports. Material reads `description` from
  front-matter and emits `<meta name="description">` per page, so
  descriptions are no longer all duplicated from `site_description`.

### Before / after

Homepage `<title>`:
- Before: `rigplane` (8 chars)
- After: `RigPlane — Ham Radio Control Library and Web UI for Icom, Yaesu, Xiegu - RigPlane Docs`

Child page titles now render as `Page Title - RigPlane Docs`, e.g.:
- `IC-7610 USB Serial - RigPlane Docs`
- `WSJT-X / Digital Modes - RigPlane Docs`
- `Troubleshooting - RigPlane Docs`

Sample per-page meta descriptions (all unique, all 140-180 chars):

- `guide/ic7610-usb-setup/`: "Step-by-step guide to control the Icom
  IC-7610 from macOS over USB serial CI-V and USB audio with RigPlane —
  no LAN, hamlib, or RS-BA1 required."
- `guide/wsjtx-setup/`: "Configure WSJT-X, JTDX, and JS8Call against
  RigPlane's built-in rigctld server for FT8, FT4, and JS8 on Icom
  radios — no Hamlib install needed."
- `guide/audio-recipes/`: "Copy-paste recipes for RX and TX audio with
  RigPlane — PCM and Opus contracts, browser playback, microphone
  capture, and radio-native LAN audio."

### Verification

```
uv run mkdocs build --clean
```

Build succeeds. The only warnings are pre-existing (`guide/diagnostic-reports.md`
linking into the `plans/`, `architecture/`, and `contracts/` directories that
are intentionally `exclude_docs`-ed). Spot-checked
`site/index.html`, `site/guide/ic7610-usb-setup/index.html`, `site/guide/wsjtx-setup/index.html`,
`site/guide/troubleshooting/index.html`, and `site/guide/audio-recipes/index.html`:
each has the expected `<title>` and a unique `<meta name="description">`.

### Scope / boundary

`public-core candidate` — this is documentation for the public open-core
library. Per-page description front-matter is the contract; no doc
content changes.

Closes #1539
Refs rigplane/rigplane-www#34

## Test plan

- [ ] `uv run mkdocs build --clean` succeeds locally
- [ ] After merge + docs deploy, `curl -s https://rigplane.dev/ | grep -E '<title>|<meta name="description"'` shows the new homepage title and description
- [ ] Spot-check `https://rigplane.dev/guide/ic7610-usb-setup/`, `/guide/wsjtx-setup/`, and `/guide/troubleshooting/` for unique titles and meta descriptions