### PR TITLE
SEO I1: add "Download RigPlane Pro" CTAs to setup guides

### DIFF
--- a/docs/guide/ic705-usb-setup.md
+++ b/docs/guide/ic705-usb-setup.md
@@ -359,3 +359,12 @@ ls -l /dev/cu.*
 
     **Software validation:** Contract tests with mock IC-705 profile pass (13/13 tests).
     **Hardware validation:** Blocked on IC-705 procurement (tracked in MSMA-20).
+
+## Get the Packaged Desktop App
+
+!!! tip "Prefer a packaged desktop app?"
+    This guide covers the open-source `rigplane` Python library. If you want
+    a polished desktop application with a GUI for IC-705 control on macOS
+    and Linux, check out RigPlane Pro.
+
+    [Download RigPlane Pro for Mac and Linux →](https://rigplane.com/downloads/?utm_source=docs.rigplane.dev&utm_medium=cta&utm_campaign=ic705-usb-setup)

--- a/docs/guide/ic7300-usb-setup.md
+++ b/docs/guide/ic7300-usb-setup.md
@@ -250,3 +250,12 @@ os.environ["ICOM_SERIAL_CIV_MIN_INTERVAL_MS"] = "100"
 - [IC-705 USB Setup](ic705-usb-setup.md) — Portable transceiver
 - [Audio Recipes](audio-recipes.md) — RX/TX examples
 - [WSJT-X Setup](wsjtx-setup.md) — Digital mode integration
+
+## Get the Packaged Desktop App
+
+!!! tip "Prefer a packaged desktop app?"
+    This guide covers the open-source `rigplane` Python library. If you want
+    a polished desktop application with a GUI for IC-7300 control on macOS
+    and Linux, check out RigPlane Pro.
+
+    [Download RigPlane Pro for Mac and Linux →](https://rigplane.com/downloads/?utm_source=docs.rigplane.dev&utm_medium=cta&utm_campaign=ic7300-usb-setup)

--- a/docs/guide/ic7610-usb-setup.md
+++ b/docs/guide/ic7610-usb-setup.md
@@ -472,3 +472,12 @@ If you're currently using the LAN backend and want to switch to serial:
 ---
 
 **Hardware validated**: 2026-03-06, IC-7610 over USB on macOS (Darwin arm64), Python 3.11.14, pytest 9.0.2 (issue #146)
+
+## Get the Packaged Desktop App
+
+!!! tip "Prefer a packaged desktop app?"
+    This guide covers the open-source `rigplane` Python library. If you want
+    a polished desktop application with a GUI for IC-7610 control on macOS
+    and Linux, check out RigPlane Pro.
+
+    [Download RigPlane Pro for Mac and Linux →](https://rigplane.com/downloads/?utm_source=docs.rigplane.dev&utm_medium=cta&utm_campaign=ic7610-usb-setup)

--- a/docs/guide/ic9700-usb-setup.md
+++ b/docs/guide/ic9700-usb-setup.md
@@ -315,3 +315,12 @@ ConnectionError: failed to connect to 192.168.1.100
 - [IC-7300 USB Setup](ic7300-usb-setup.md) — Single-receiver desktop radio
 - [Audio Recipes](audio-recipes.md) — RX/TX dual-receiver examples
 - [Web UI Guide](web-ui.md) — Dual-receiver web interface
+
+## Get the Packaged Desktop App
+
+!!! tip "Prefer a packaged desktop app?"
+    This guide covers the open-source `rigplane` Python library. If you want
+    a polished desktop application with a GUI for IC-9700 control on macOS
+    and Linux, check out RigPlane Pro.
+
+    [Download RigPlane Pro for Mac and Linux →](https://rigplane.com/downloads/?utm_source=docs.rigplane.dev&utm_medium=cta&utm_campaign=ic9700-usb-setup)

--- a/docs/guide/wsjtx-setup.md
+++ b/docs/guide/wsjtx-setup.md
@@ -198,3 +198,12 @@ Tested with:
 - **MacLoggerDX** (macOS logging)
 
 Any application that supports `Hamlib NET rigctl` should work.
+
+## Get the Packaged Desktop App
+
+!!! tip "Prefer a packaged desktop app?"
+    This guide covers the open-source `rigplane` Python library. If you want
+    a polished desktop application with a GUI that handles WSJT-X / JTDX /
+    JS8Call integration on macOS and Linux, check out RigPlane Pro.
+
+    [Download RigPlane Pro for Mac and Linux →](https://rigplane.com/downloads/?utm_source=docs.rigplane.dev&utm_medium=cta&utm_campaign=wsjtx-setup)


### PR DESCRIPTION
## Summary

Adds a final "Get the Packaged Desktop App" CTA block at the bottom of every
USB / digital-mode setup guide on `rigplane.dev`. The block is a plain MkDocs
`!!! tip` admonition (no new plugins, no template changes) linking to
`https://rigplane.com/downloads/` with a per-page UTM campaign tag so the
marketing site can attribute traffic from each guide.

## Rationale

From the SEO audit (`rigplane-strategy/docs/market/2026-05-19-seo-audit-rigplane.md` §6):

> Every USB setup guide should end with "Now download RigPlane Pro for
> [macOS/Linux] →". Currently the docs site funnels users to GitHub.

Before this change the long-tail tutorial traffic (queries like
"IC-7610 USB serial macOS setup", "WSJT-X IC-7610 setup Mac") had zero CTAs
pointing back to the marketing site — pure top-of-funnel waste.

## Pages touched (5)

- `docs/guide/ic7610-usb-setup.md`
- `docs/guide/ic705-usb-setup.md`
- `docs/guide/ic7300-usb-setup.md`
- `docs/guide/ic9700-usb-setup.md`
- `docs/guide/wsjtx-setup.md`

Reference-style pages (CLI reference, API reference, troubleshooting catalog,
audio recipes, web UI) are intentionally NOT touched — they are not the
high-intent acquisition surface and pushing Pro on a reader hitting the open-core
CLI reference would violate the open-core boundary.

## CTA block (consistent across all pages)

```markdown
## Get the Packaged Desktop App

!!! tip "Prefer a packaged desktop app?"
    This guide covers the open-source `rigplane` Python library. If you want
    a polished desktop application with a GUI for IC-XXXX control on macOS
    and Linux, check out RigPlane Pro.

    [Download RigPlane Pro for Mac and Linux →](https://rigplane.com/downloads/?utm_source=docs.rigplane.dev&utm_medium=cta&utm_campaign=<page-slug>)
```

- Per-page radio/app name in the body (IC-7610, IC-705, IC-7300, IC-9700, WSJT-X).
- Per-page UTM campaign slug matching the page filename
  (e.g. `ic7610-usb-setup`, `wsjtx-setup`).
- `utm_source=docs.rigplane.dev`, `utm_medium=cta` — consistent.
- Honest about the open-core boundary: states up front this guide is for the
  open-source Python library; offers Pro as an alternative, not as the answer.

## Deviation from plan

The implementation plan suggested CTA copy `"Want the packaged desktop app?
Download RigPlane Pro for Mac and Linux →"` as the CTA text. I kept the
exact link text (`Download RigPlane Pro for Mac and Linux →`) but slightly
rephrased the admonition title to `Prefer a packaged desktop app?` (better
flow inside a `!!! tip` block) and added one sentence framing the open-core
boundary before the link. The link target and CTA phrasing match the
acceptance criteria.

UTM tagging was not explicitly required by the issue body but was prescribed
by the orchestrator instructions (`?utm_source=docs.rigplane.dev&utm_medium=cta&utm_campaign=<page-slug>`); applied verbatim.

## Verification

- `uv run mkdocs build --clean` succeeds with no new warnings.
- Spot-checked rendered HTML for all 5 pages: CTA renders as a tip
  admonition with a working link to the per-page UTM URL.

Closes #1540
Refs: rigplane/rigplane-www#34