### PR TITLE
fix: support PCM audio fallback for WebView clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ config/
 .firecrawl/
 .playwright-mcp/
 .copilot-tmp/
+.agents/
 
 # Backups (local safety copies, not for repo)
 .backups/

--- a/frontend/src/components-v2/controls/__tests__/CollapsiblePanel.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/CollapsiblePanel.test.ts
@@ -10,6 +10,9 @@ const localStorageMock = (() => {
     setItem: (key: string, value: string) => {
       store[key] = value;
     },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
     clear: () => {
       store = {};
     },

--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -316,6 +316,8 @@
     'var(--v2-text-dim, #555)'
   );
   let lastPttDown = 0;
+  let pttPressActive = false;
+  let txStartToken = 0;
   const DOUBLE_TAP_MS = 350;
   const PTT_SAFETY_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
   let pttSafetyTimer: ReturnType<typeof setTimeout> | null = null;
@@ -336,9 +338,18 @@
     }, PTT_SAFETY_TIMEOUT_MS);
   }
 
-  async function engageTx() {
+  async function engageTx(token: number): Promise<boolean> {
+    const err = await txAudio.startTx();
+    if (token !== txStartToken || pttMode !== 'held' || !pttPressActive) {
+      if (!err) txAudio.stopTx();
+      return false;
+    }
+    if (err) {
+      console.warn('TX audio did not start:', err);
+      return false;
+    }
     systemHandlers.onPttOn();
-    await txAudio.startTx();
+    return true;
   }
 
   function disengageTx() {
@@ -346,10 +357,12 @@
     txAudio.stopTx();
   }
 
-  function pttDown() {
+  async function pttDown() {
     const now = Date.now();
     if (pttMode === 'latched') {
       // Tap while latched → unlock, go idle
+      pttPressActive = false;
+      txStartToken += 1;
       pttMode = 'idle';
       disengageTx();
       clearPttSafety();
@@ -357,6 +370,7 @@
     }
     if (now - lastPttDown < DOUBLE_TAP_MS && pttMode === 'held') {
       // Double-tap → latch
+      pttPressActive = false;
       pttMode = 'latched';
       startPttSafety();
       lastPttDown = 0;
@@ -364,12 +378,20 @@
     }
     // Normal press → held
     lastPttDown = now;
+    pttPressActive = true;
     pttMode = 'held';
-    engageTx();
-    startPttSafety();
+    const token = ++txStartToken;
+    if (await engageTx(token)) {
+      startPttSafety();
+    } else {
+      pttMode = 'idle';
+      lastPttDown = 0;
+    }
   }
 
   function pttUp() {
+    pttPressActive = false;
+    txStartToken += 1;
     if (pttMode === 'held') {
       // Release after single tap → off
       // But give a moment for double-tap detection

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -81,9 +81,23 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 
 // -- Wiring mocks --
-const { onMainVfoClickSpy, onSubVfoClickSpy } = vi.hoisted(() => ({
+const {
+  onMainVfoClickSpy,
+  onSubVfoClickSpy,
+  mobileSystemHandlers,
+  mobileTxAudioControl,
+} = vi.hoisted(() => ({
   onMainVfoClickSpy: vi.fn(),
   onSubVfoClickSpy: vi.fn(),
+  mobileSystemHandlers: {
+    onPowerOff: vi.fn(),
+    onPttOn: vi.fn(),
+    onPttOff: vi.fn(),
+  },
+  mobileTxAudioControl: {
+    startTx: vi.fn(),
+    stopTx: vi.fn(),
+  },
 }));
 vi.mock('../../wiring/command-bus', () => {
   const n = vi.fn();
@@ -105,9 +119,12 @@ vi.mock('../../wiring/command-bus', () => {
     makeCwPanelHandlers: () => ({ onSpeedChange: n }),
     makeAntennaHandlers: () => ({ onAntennaSelect: n }),
     makeScanHandlers: () => ({ onScanStart: n, onScanStop: n, onDfSpanChange: n, onResumeChange: n }),
-    makeSystemHandlers: () => ({ onPowerOff: n, onPttOn: n, onPttOff: n }),
+    makeSystemHandlers: () => mobileSystemHandlers,
   };
 });
+vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
+  getTxAudioControl: () => mobileTxAudioControl,
+}));
 vi.mock('../wiring/state-adapter', () => {
   const vfo = { freq: 14074000, mode: 'USB', filter: 'FIL1', sValue: 0, badges: {}, receiver: 'main', isActive: true };
   return {
@@ -149,6 +166,12 @@ beforeEach(() => {
   (radio as unknown as { current: { active?: 'MAIN' | 'SUB' } | null }).current = null;
   onMainVfoClickSpy.mockClear();
   onSubVfoClickSpy.mockClear();
+  mobileSystemHandlers.onPowerOff.mockReset();
+  mobileSystemHandlers.onPttOn.mockReset();
+  mobileSystemHandlers.onPttOff.mockReset();
+  mobileTxAudioControl.startTx.mockReset();
+  mobileTxAudioControl.stopTx.mockReset();
+  mobileTxAudioControl.startTx.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -249,6 +272,30 @@ describe('MobileRadioLayout TX gating', () => {
     // ESSENTIALS chip should now be the active one in the chip bar.
     const active = t.querySelector('.m-chip-bar .m-chip-active');
     expect(active?.textContent?.trim()).toBe('ESSENTIALS');
+  });
+
+  it('does not key PTT when released before TX audio startup finishes', async () => {
+    vi.useFakeTimers();
+    let resolveStart!: (value: string | null) => void;
+    mobileTxAudioControl.startTx.mockReturnValueOnce(new Promise((resolve) => {
+      resolveStart = resolve;
+    }));
+
+    const t = mountMobile();
+    const ptt = t.querySelector<HTMLButtonElement>('.ptt-fab')!;
+    ptt.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }));
+    vi.advanceTimersByTime(60);
+    ptt.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
+    resolveStart(null);
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(mobileSystemHandlers.onPttOn).not.toHaveBeenCalled();
+    expect(mobileTxAudioControl.stopTx).toHaveBeenCalledOnce();
+
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
   });
 });
 

--- a/frontend/src/components-v2/panels/TxPanel.svelte
+++ b/frontend/src/components-v2/panels/TxPanel.svelte
@@ -43,6 +43,10 @@
   const PTT_SAFETY_MS = 3 * 60 * 1000;
   let pttMode = $state<'idle' | 'held' | 'latched'>('idle');
   let lastPttDown = 0;
+  let pttStarting = $state(false);
+  let txError = $state('');
+  let pttPressActive = false;
+  let txStartToken = 0;
   let pttSafetyTimer: ReturnType<typeof setTimeout> | null = null;
 
   function startPttSafety() {
@@ -53,20 +57,44 @@
     if (pttSafetyTimer) { clearTimeout(pttSafetyTimer); pttSafetyTimer = null; }
   }
 
-  function pttDown() {
+  async function engageTx(token: number): Promise<boolean> {
+    pttStarting = true;
+    txError = '';
+    const err = await txAudio.startTx();
+    pttStarting = false;
+    if (token !== txStartToken || pttMode !== 'held' || !pttPressActive) {
+      if (!err) txAudio.stopTx();
+      return false;
+    }
+    if (err) {
+      txError = err;
+      pttMode = 'idle';
+      lastPttDown = 0;
+      return false;
+    }
+    onPttOn?.();
+    return true;
+  }
+
+  async function pttDown() {
+    if (pttStarting) return;
     const now = Date.now();
-    if (pttMode === 'latched') { pttMode = 'idle'; onPttOff?.(); txAudio.stopTx(); clearPttSafety(); return; }
+    if (pttMode === 'latched') { pttPressActive = false; txStartToken += 1; pttMode = 'idle'; onPttOff?.(); txAudio.stopTx(); clearPttSafety(); return; }
     if (now - lastPttDown < PTT_DOUBLE_TAP_MS && pttMode === 'held') {
-      pttMode = 'latched'; startPttSafety(); lastPttDown = 0; return;
+      pttPressActive = false; pttMode = 'latched'; startPttSafety(); lastPttDown = 0; return;
     }
     lastPttDown = now;
+    pttPressActive = true;
     pttMode = 'held';
-    onPttOn?.();
-    txAudio.startTx();
-    startPttSafety();
+    const token = ++txStartToken;
+    if (await engageTx(token)) {
+      startPttSafety();
+    }
   }
 
   function pttUp() {
+    pttPressActive = false;
+    txStartToken += 1;
     if (pttMode === 'held') {
       setTimeout(() => {
         if (pttMode === 'held') { pttMode = 'idle'; onPttOff?.(); txAudio.stopTx(); clearPttSafety(); }
@@ -120,12 +148,16 @@
       class="ptt-button"
       class:ptt-held={pttMode === 'held'}
       class:ptt-latched={pttMode === 'latched'}
+      aria-disabled={pttStarting}
       onpointerdown={(e) => { e.preventDefault(); pttDown(); }}
       onpointerup={(e) => { e.preventDefault(); pttUp(); }}
       onpointerleave={() => { if (pttMode === 'held') pttUp(); }}
     >
-      {pttMode === 'latched' ? 'TX 🔒' : pttMode === 'held' ? 'TX' : 'PTT'}
+      {pttStarting ? 'MIC...' : pttMode === 'latched' ? 'TX 🔒' : pttMode === 'held' ? 'TX' : 'PTT'}
     </button>
+    {#if txError}
+      <div class="tx-error">{txError}</div>
+    {/if}
 
     <div class="tx-button-grid">
       {#if showTuner}
@@ -259,11 +291,22 @@
     background: rgba(239, 68, 68, 0.08);
   }
 
+  .ptt-button[aria-disabled="true"] {
+    cursor: wait;
+    opacity: 0.7;
+  }
+
   .ptt-button.ptt-held,
   .ptt-button.ptt-latched {
     background: var(--v2-accent-red, #ef4444);
     color: #fff;
     box-shadow: 0 0 12px rgba(239, 68, 68, 0.4);
+  }
+
+  .tx-error {
+    color: var(--v2-accent-red, #ef4444);
+    font-size: 11px;
+    line-height: 1.35;
   }
 
   .tx-button-grid > :global(button) {

--- a/frontend/src/components-v2/panels/__tests__/TxPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/TxPanel.test.ts
@@ -75,16 +75,18 @@ const mockHandlers = {
   onPttOff: vi.fn(),
 };
 
+const mockTxAudioControl = vi.hoisted(() => ({
+  startTx: vi.fn(),
+  stopTx: vi.fn(),
+}));
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveTxProps: () => mockProps,
   getTxHandlers: () => mockHandlers,
 }));
 
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
-  getTxAudioControl: () => ({
-    startTx: vi.fn(),
-    stopTx: vi.fn(),
-  }),
+  getTxAudioControl: () => mockTxAudioControl,
 }));
 
 import TxPanel from '../TxPanel.svelte';
@@ -128,6 +130,9 @@ beforeEach(() => {
   mockHandlers.onDriveGainChange = vi.fn();
   mockHandlers.onPttOn = vi.fn();
   mockHandlers.onPttOff = vi.fn();
+  mockTxAudioControl.startTx.mockReset();
+  mockTxAudioControl.stopTx.mockReset();
+  mockTxAudioControl.startTx.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -276,5 +281,66 @@ describe('callbacks', () => {
     vi.advanceTimersByTime(60);
 
     expect(mockHandlers.onMicGainChange).toHaveBeenCalled();
+  });
+
+  it('starts TX audio before keying PTT', async () => {
+    const order: string[] = [];
+    mockTxAudioControl.startTx.mockImplementationOnce(async () => {
+      order.push('audio');
+      return null;
+    });
+    mockHandlers.onPttOn.mockImplementationOnce(() => {
+      order.push('ptt');
+    });
+
+    const t = mountPanel();
+    const ptt = t.querySelector<HTMLButtonElement>('.ptt-button')!;
+    ptt.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(mockTxAudioControl.startTx).toHaveBeenCalledOnce();
+    expect(mockHandlers.onPttOn).toHaveBeenCalledOnce();
+    expect(order).toEqual(['audio', 'ptt']);
+  });
+
+  it('does not key PTT when TX audio startup fails', async () => {
+    mockTxAudioControl.startTx.mockResolvedValueOnce('TX MIC: microphone capture not supported');
+    const t = mountPanel();
+    const ptt = t.querySelector<HTMLButtonElement>('.ptt-button')!;
+    ptt.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(mockHandlers.onPttOn).not.toHaveBeenCalled();
+    expect(t.textContent).toContain('TX MIC: microphone capture not supported');
+  });
+
+  it('does not key PTT when released before TX audio startup finishes', async () => {
+    vi.useFakeTimers();
+    let resolveStart!: (value: string | null) => void;
+    mockTxAudioControl.startTx.mockReturnValueOnce(new Promise((resolve) => {
+      resolveStart = resolve;
+    }));
+
+    const t = mountPanel();
+    const ptt = t.querySelector<HTMLButtonElement>('.ptt-button')!;
+    ptt.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    flushSync();
+    expect(ptt.disabled).toBe(false);
+    expect(ptt.getAttribute('aria-disabled')).toBe('true');
+    ptt.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    resolveStart(null);
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(mockHandlers.onPttOn).not.toHaveBeenCalled();
+    expect(mockTxAudioControl.stopTx).toHaveBeenCalledOnce();
+
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/lib/audio/__tests__/audio-manager.test.ts
+++ b/frontend/src/lib/audio/__tests__/audio-manager.test.ts
@@ -79,6 +79,7 @@ class FakeWebSocket {
 describe('AudioManager websocket subscriptions', () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.unstubAllGlobals();
     FakeWebSocket.instances = [];
     vi.stubGlobal('WebSocket', FakeWebSocket);
     vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5173' });
@@ -94,7 +95,11 @@ describe('AudioManager websocket subscriptions', () => {
 
     audioManager.startRx();
 
-    expect(ws.sent).toContain(JSON.stringify({ type: 'audio_start', direction: 'rx' }));
+    expect(ws.sent).toContain(JSON.stringify({
+      type: 'audio_start',
+      direction: 'rx',
+      preferred_rx_codec: 'pcm16',
+    }));
   });
 
   it('sends rx audio_stop before closing an open websocket', async () => {
@@ -108,5 +113,36 @@ describe('AudioManager websocket subscriptions', () => {
     audioManager.stopRx();
 
     expect(ws.sent).toContain(JSON.stringify({ type: 'audio_stop', direction: 'rx' }));
+  });
+
+  it('requests opus when AudioDecoder is available', async () => {
+    vi.stubGlobal('AudioDecoder', class {});
+    const { audioManager } = await import('../audio-manager');
+
+    audioManager.startRx();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+
+    expect(ws.sent).toContain(JSON.stringify({
+      type: 'audio_start',
+      direction: 'rx',
+      preferred_rx_codec: 'opus',
+    }));
+  });
+
+  it('requests pcm16 inside the Tauri shell even when AudioDecoder is available', async () => {
+    vi.stubGlobal('AudioDecoder', class {});
+    vi.stubGlobal('__TAURI_INTERNALS__', {});
+    const { audioManager } = await import('../audio-manager');
+
+    audioManager.startRx();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+
+    expect(ws.sent).toContain(JSON.stringify({
+      type: 'audio_start',
+      direction: 'rx',
+      preferred_rx_codec: 'pcm16',
+    }));
   });
 });

--- a/frontend/src/lib/audio/__tests__/constants.test.ts
+++ b/frontend/src/lib/audio/__tests__/constants.test.ts
@@ -12,6 +12,11 @@ describe('buildTxHeader', () => {
     expect(v.getUint8(6)).toBe(CHANNELS);
     expect(v.getUint8(7)).toBe(FRAME_DURATION_MS);
   });
+  it('can mark PCM16 TX frames', () => {
+    const v = new DataView(buildTxHeader(42, CODEC_PCM16).buffer);
+    expect(v.getUint8(0)).toBe(MSG_TYPE_TX);
+    expect(v.getUint8(1)).toBe(CODEC_PCM16);
+  });
   it('wraps seq at 16-bit boundary', () => {
     // 0x10000 should roll over to 0x0000
     expect(new DataView(buildTxHeader(0x10000).buffer).getUint16(2, true)).toBe(0);

--- a/frontend/src/lib/audio/__tests__/tx-mic.test.ts
+++ b/frontend/src/lib/audio/__tests__/tx-mic.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TxMic } from '../tx-mic';
-import { SAMPLE_RATE, CHANNELS, TX_BITRATE } from '../constants';
+import { SAMPLE_RATE, CHANNELS, TX_BITRATE, AUDIO_HEADER_SIZE, CODEC_PCM16 } from '../constants';
 
 let mockTrack: any, mockEncoder: any, mockReader: any;
 beforeEach(() => {
+  delete (globalThis as any).AudioContext;
+  delete (globalThis as any).webkitAudioContext;
   mockTrack = { stop: vi.fn(), kind: 'audio' };
   mockReader = { read: vi.fn(() => Promise.resolve({ done: true })), cancel: vi.fn().mockResolvedValue(undefined) };
   mockEncoder = { configure: vi.fn(), encode: vi.fn(), close: vi.fn(), state: 'configured' };
@@ -17,7 +19,12 @@ beforeEach(() => {
     writable: true, configurable: true,
   });
 });
-afterEach(() => { delete (globalThis as any).AudioEncoder; delete (globalThis as any).MediaStreamTrackProcessor; });
+afterEach(() => {
+  delete (globalThis as any).AudioEncoder;
+  delete (globalThis as any).MediaStreamTrackProcessor;
+  delete (globalThis as any).AudioContext;
+  delete (globalThis as any).webkitAudioContext;
+});
 
 describe('TxMic', () => {
   it('detects support based on WebCodecs', () => {
@@ -25,10 +32,19 @@ describe('TxMic', () => {
     delete (globalThis as any).AudioEncoder;
     expect(TxMic.supported()).toBe(false);
   });
+  it('does not report support without a microphone capture API', () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+
+    expect(TxMic.supported()).toBe(false);
+  });
   it('errors when WebCodecs missing', async () => {
     delete (globalThis as any).AudioEncoder;
     const m = new TxMic(vi.fn());
-    expect(await m.start()).toContain('WebCodecs not supported');
+    expect(await m.start()).toContain('microphone capture not supported');
   });
   it('requests mic with correct constraints', async () => {
     const m = new TxMic(vi.fn()); await m.start();
@@ -59,5 +75,71 @@ describe('TxMic', () => {
     const m = new TxMic(vi.fn()); await m.start();
     expect(await m.start()).toBeNull();
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1); m.stop();
+  });
+
+  it('falls back to PCM16 capture when WebCodecs are unavailable', async () => {
+    delete (globalThis as any).AudioEncoder;
+    delete (globalThis as any).MediaStreamTrackProcessor;
+    let processor: any;
+    const source = { connect: vi.fn(), disconnect: vi.fn() };
+    const context = {
+      sampleRate: SAMPLE_RATE,
+      destination: {},
+      createMediaStreamSource: vi.fn(() => source),
+      createScriptProcessor: vi.fn(() => {
+        processor = { connect: vi.fn(), disconnect: vi.fn(), onaudioprocess: null };
+        return processor;
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    (globalThis as any).AudioContext = vi.fn(function () { return context; });
+    const sent = vi.fn();
+    const m = new TxMic(sent);
+
+    expect(await m.start()).toBeNull();
+    processor.onaudioprocess({
+      inputBuffer: { getChannelData: () => new Float32Array(960).fill(0.25) },
+    });
+
+    expect(sent).toHaveBeenCalledOnce();
+    const packet = sent.mock.calls[0][0] as ArrayBuffer;
+    const header = new DataView(packet);
+    expect(header.getUint8(1)).toBe(CODEC_PCM16);
+    expect(packet.byteLength).toBe(AUDIO_HEADER_SIZE + 960 * 2);
+    m.stop();
+    expect(context.close).toHaveBeenCalled();
+  });
+
+  it('uses legacy WebKit getUserMedia for PCM16 fallback', async () => {
+    delete (globalThis as any).AudioEncoder;
+    delete (globalThis as any).MediaStreamTrackProcessor;
+    const stream = { getTracks: () => [mockTrack], getAudioTracks: () => [mockTrack] };
+    const legacyGetUserMedia = vi.fn((_constraints, success) => success(stream));
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { webkitGetUserMedia: legacyGetUserMedia },
+      writable: true,
+      configurable: true,
+    });
+    const context = {
+      sampleRate: SAMPLE_RATE,
+      destination: {},
+      createMediaStreamSource: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+      createScriptProcessor: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn(), onaudioprocess: null })),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    (globalThis as any).webkitAudioContext = vi.fn(function () { return context; });
+
+    const m = new TxMic(vi.fn());
+
+    expect(TxMic.supported()).toBe(true);
+    expect(await m.start()).toBeNull();
+    expect(legacyGetUserMedia).toHaveBeenCalledWith(
+      {
+        audio: { channelCount: CHANNELS, sampleRate: SAMPLE_RATE, echoCancellation: true, noiseSuppression: true },
+      },
+      expect.any(Function),
+      expect.any(Function),
+    );
+    m.stop();
   });
 });

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -26,6 +26,17 @@ export interface AudioRoutingConfig {
 const BACKOFF_MIN = 500;
 const BACKOFF_MAX = 10000;
 
+function preferredRxCodec(): 'opus' | 'pcm16' {
+  const globals = globalThis as typeof globalThis & {
+    __TAURI__?: unknown;
+    __TAURI_INTERNALS__?: unknown;
+  };
+  if (globals.__TAURI__ !== undefined || globals.__TAURI_INTERNALS__ !== undefined) {
+    return 'pcm16';
+  }
+  return typeof AudioDecoder === 'undefined' ? 'pcm16' : 'opus';
+}
+
 class AudioManager {
   private ws: WebSocket | null = null;
   private rxPlayer = new RxPlayer();
@@ -92,7 +103,11 @@ class AudioManager {
     this.rxPlayer.start();
     this.connect();
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({ type: 'audio_start', direction: 'rx' }));
+      this.ws.send(JSON.stringify({
+        type: 'audio_start',
+        direction: 'rx',
+        preferred_rx_codec: preferredRxCodec(),
+      }));
     }
     this.notify();
   }
@@ -213,7 +228,11 @@ class AudioManager {
       setAudioConnected(true);
       console.log('[audio-ws] connected');
       if (this._rxEnabled) {
-        ws.send(JSON.stringify({ type: 'audio_start', direction: 'rx' }));
+        ws.send(JSON.stringify({
+          type: 'audio_start',
+          direction: 'rx',
+          preferred_rx_codec: preferredRxCodec(),
+        }));
       }
       if (this._txEnabled) {
         ws.send(JSON.stringify({ type: 'audio_start', direction: 'tx' }));

--- a/frontend/src/lib/audio/constants.ts
+++ b/frontend/src/lib/audio/constants.ts
@@ -11,11 +11,11 @@ export const FRAME_DURATION_MS = 20;
 export const TX_BITRATE = 32000;
 
 /** Build 8-byte audio header */
-export function buildTxHeader(seq: number): Uint8Array {
+export function buildTxHeader(seq: number, codec = CODEC_OPUS): Uint8Array {
   const h = new Uint8Array(8);
   const v = new DataView(h.buffer);
   v.setUint8(0, MSG_TYPE_TX);
-  v.setUint8(1, CODEC_OPUS);
+  v.setUint8(1, codec);
   v.setUint16(2, seq & 0xFFFF, true);
   v.setUint16(4, SAMPLE_RATE / 100, true);
   v.setUint8(6, CHANNELS);

--- a/frontend/src/lib/audio/tx-mic.ts
+++ b/frontend/src/lib/audio/tx-mic.ts
@@ -1,18 +1,34 @@
 /**
- * TX Microphone — captures mic, encodes Opus, sends via WS.
+ * TX Microphone — captures mic, encodes Opus when available, otherwise sends PCM16.
  *
- * Requires WebCodecs (AudioEncoder + MediaStreamTrackProcessor).
- * Only works on HTTPS or localhost.
+ * WebCodecs is not consistently available in embedded WebViews, so the PCM16
+ * path keeps Tauri packaged builds usable while the backend handles the radio
+ * contract.
  */
 
-import { buildTxHeader, TX_BITRATE, SAMPLE_RATE, CHANNELS } from './constants';
+import { buildTxHeader, TX_BITRATE, SAMPLE_RATE, CHANNELS, CODEC_PCM16 } from './constants';
 
 export type TxSendFn = (data: ArrayBuffer) => void;
+type LegacyGetUserMedia = (
+  constraints: MediaStreamConstraints,
+  success: (stream: MediaStream) => void,
+  failure: (error: DOMException | Error) => void,
+) => void;
+
+type NavigatorWithLegacyMedia = Navigator & {
+  getUserMedia?: LegacyGetUserMedia;
+  webkitGetUserMedia?: LegacyGetUserMedia;
+  mozGetUserMedia?: LegacyGetUserMedia;
+};
 
 export class TxMic {
   private stream: MediaStream | null = null;
   private encoder: AudioEncoder | null = null;
   private reader: ReadableStreamDefaultReader<AudioData> | null = null;
+  private audioContext: AudioContext | null = null;
+  private pcmSource: MediaStreamAudioSourceNode | null = null;
+  private pcmProcessor: ScriptProcessorNode | null = null;
+  private pcmPending: number[] = [];
   private seq = 0;
   private _active = false;
   private sendFn: TxSendFn;
@@ -27,21 +43,58 @@ export class TxMic {
 
   /** Check if browser supports TX mic */
   static supported(): boolean {
+    return TxMic.getUserMedia() !== null && (TxMic.supportsWebCodecs() || TxMic.supportsPcmCapture());
+  }
+
+  private static supportsWebCodecs(): boolean {
     return (
       typeof AudioEncoder !== 'undefined' &&
       typeof MediaStreamTrackProcessor !== 'undefined'
     );
   }
 
+  private static supportsPcmCapture(): boolean {
+    const audioContextCtor = TxMic.audioContextCtor();
+    return TxMic.getUserMedia() !== null && audioContextCtor !== null;
+  }
+
+  private static audioContextCtor(): typeof AudioContext | null {
+    const globals = globalThis as typeof globalThis & {
+      webkitAudioContext?: typeof AudioContext;
+    };
+    return globals.AudioContext ?? globals.webkitAudioContext ?? null;
+  }
+
+  private static getUserMedia(): ((constraints: MediaStreamConstraints) => Promise<MediaStream>) | null {
+    if (typeof navigator === 'undefined') return null;
+
+    if (navigator.mediaDevices?.getUserMedia) {
+      return navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+    }
+
+    const legacyNavigator = navigator as NavigatorWithLegacyMedia;
+    const legacy =
+      legacyNavigator.getUserMedia ??
+      legacyNavigator.webkitGetUserMedia ??
+      legacyNavigator.mozGetUserMedia;
+    if (!legacy) return null;
+
+    return (constraints: MediaStreamConstraints) =>
+      new Promise((resolve, reject) => {
+        legacy.call(legacyNavigator, constraints, resolve, reject);
+      });
+  }
+
   async start(): Promise<string | null> {
     if (this._active) return null;
 
-    if (!TxMic.supported()) {
-      return 'TX MIC: WebCodecs not supported (need HTTPS)';
+    const getUserMedia = TxMic.getUserMedia();
+    if (!getUserMedia || !TxMic.supported()) {
+      return 'TX MIC: microphone capture not supported';
     }
 
     try {
-      this.stream = await navigator.mediaDevices.getUserMedia({
+      this.stream = await getUserMedia({
         audio: {
           channelCount: CHANNELS,
           sampleRate: SAMPLE_RATE,
@@ -55,6 +108,11 @@ export class TxMic {
 
     this._active = true;
     this.seq = 0;
+    this.pcmPending = [];
+
+    if (!TxMic.supportsWebCodecs()) {
+      return this.startPcmFallback();
+    }
 
     const track = this.stream.getAudioTracks()[0];
     const processor = new MediaStreamTrackProcessor({ track });
@@ -94,6 +152,20 @@ export class TxMic {
 
   stop(): void {
     this._active = false;
+    if (this.pcmProcessor) {
+      this.pcmProcessor.disconnect();
+      this.pcmProcessor.onaudioprocess = null;
+      this.pcmProcessor = null;
+    }
+    if (this.pcmSource) {
+      this.pcmSource.disconnect();
+      this.pcmSource = null;
+    }
+    if (this.audioContext) {
+      this.audioContext.close().catch(() => {});
+      this.audioContext = null;
+    }
+    this.pcmPending = [];
     if (this.reader) {
       this.reader.cancel().catch(() => {});
       this.reader = null;
@@ -105,6 +177,53 @@ export class TxMic {
     if (this.stream) {
       this.stream.getTracks().forEach(t => t.stop());
       this.stream = null;
+    }
+  }
+
+  private startPcmFallback(): string | null {
+    const audioContextCtor = TxMic.audioContextCtor();
+    if (!audioContextCtor || !this.stream) {
+      return 'TX MIC: PCM capture not supported';
+    }
+
+    this.audioContext = new audioContextCtor({ sampleRate: SAMPLE_RATE });
+    if (Math.round(this.audioContext.sampleRate) !== SAMPLE_RATE) {
+      this.stop();
+      return `TX MIC: unsupported mic sample rate ${this.audioContext.sampleRate} Hz`;
+    }
+
+    this.pcmSource = this.audioContext.createMediaStreamSource(this.stream);
+    this.pcmProcessor = this.audioContext.createScriptProcessor(1024, CHANNELS, CHANNELS);
+    this.pcmProcessor.onaudioprocess = (event: AudioProcessingEvent) => {
+      if (!this._active) return;
+      const input = event.inputBuffer.getChannelData(0);
+      this.queuePcmSamples(input);
+    };
+    this.pcmSource.connect(this.pcmProcessor);
+    this.pcmProcessor.connect(this.audioContext.destination);
+    return null;
+  }
+
+  private queuePcmSamples(input: Float32Array): void {
+    for (const sample of input) {
+      this.pcmPending.push(sample);
+    }
+
+    const frameSamples = Math.floor(SAMPLE_RATE * 0.02);
+    while (this.pcmPending.length >= frameSamples) {
+      const frame = this.pcmPending.splice(0, frameSamples);
+      const payload = new Uint8Array(frameSamples * 2);
+      const view = new DataView(payload.buffer);
+      for (let i = 0; i < frameSamples; i += 1) {
+        const clamped = Math.max(-1, Math.min(1, frame[i] ?? 0));
+        const pcm = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+        view.setInt16(i * 2, Math.round(pcm), true);
+      }
+      const header = buildTxHeader(this.seq++, CODEC_PCM16);
+      const packet = new Uint8Array(header.length + payload.length);
+      packet.set(header);
+      packet.set(payload, header.length);
+      this.sendFn(packet.buffer);
     }
   }
 

--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -205,7 +205,11 @@ class ControlPhaseRuntime:
                     codec_source = h._audio_stream_contract.rx_codec_source
                     allow_stereo_fallback = (
                         h._audio_codec in _STEREO_CODECS
-                        and codec_source is not AudioConfigSource.EXPLICIT
+                        and codec_source is AudioConfigSource.GLOBAL_DEFAULT
+                    )
+                    profile_selected_stereo = (
+                        h._audio_codec in _STEREO_CODECS
+                        and codec_source is AudioConfigSource.PROFILE_DEFAULT
                     )
                     if allow_stereo_fallback:
                         # Single-RX firmwares (IC-7300/IC-705, possibly IC-9700)
@@ -251,6 +255,13 @@ class ControlPhaseRuntime:
                         # else: civ_port=0 without 0xFFFFFFFF — session still
                         # warming up after fallback. Fall through to the
                         # busy-retry loop with the now-mono codec.
+                    elif profile_selected_stereo:
+                        logger.warning(
+                            "Status rejected session (error=0xFFFFFFFF) with "
+                            "profile-selected stereo rx_codec=%s; preserving profile "
+                            "codec and entering session cooldown/retry path",
+                            h._audio_codec.name,
+                        )
                     else:
                         self._close_pending_sockets()
                         await h._ctrl_transport.disconnect()

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -19,6 +19,7 @@ from ..protocol import (  # noqa: TID251
     AUDIO_CODEC_PCM16,
     AUDIO_HEADER_SIZE,
     MSG_TYPE_AUDIO_RX,
+    MSG_TYPE_AUDIO_TX,
     decode_json,
     encode_audio_frame,
     encode_json,
@@ -35,6 +36,15 @@ from ...capabilities import CAP_AUDIO, CAP_LAN_DUAL_RX_AUDIO_ROUTING
 __all__ = ["AudioBroadcaster", "AudioHandler"]
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_preferred_rx_codec(msg: dict[str, Any]) -> int | None:
+    value = msg.get("preferred_rx_codec")
+    if value in ("pcm16", "pcm", "raw"):
+        return AUDIO_CODEC_PCM16
+    if value == "opus":
+        return AUDIO_CODEC_OPUS
+    return None
 
 
 class _AudioPacketLike(Protocol):
@@ -68,6 +78,7 @@ class AudioBroadcaster:
         self._radio = radio
         self._clients: dict[int, asyncio.Queue[bytes]] = {}
         self._client_ws: dict[int, WebSocketConnection] = {}
+        self._client_rx_codec: dict[int, int] = {}
         self._subscription: _AudioSubscription | None = None
         self._relay_task: asyncio.Task[None] | None = None
         self._seq: int = 0
@@ -100,7 +111,10 @@ class AudioBroadcaster:
         self._codec_stale: bool = False
 
     async def subscribe(
-        self, ws: WebSocketConnection | None = None
+        self,
+        ws: WebSocketConnection | None = None,
+        *,
+        preferred_rx_codec: int | None = None,
     ) -> asyncio.Queue[bytes]:
         """Register a new WebSocket client and start relaying if first."""
         queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=self.HIGH_WATERMARK)
@@ -109,6 +123,8 @@ class AudioBroadcaster:
             self._clients[client_id] = queue
             if ws is not None:
                 self._client_ws[client_id] = ws
+            if preferred_rx_codec is not None:
+                self._client_rx_codec[client_id] = preferred_rx_codec
             # Start relay if no active subscription, or if relay task died
             relay_alive = self._relay_task is not None and not self._relay_task.done()
             if self._subscription is None or not relay_alive:
@@ -122,6 +138,8 @@ class AudioBroadcaster:
                     self._subscription = None
                 if self._radio:
                     await self._start_relay()
+            elif preferred_rx_codec is not None:
+                self.invalidate_codec_state()
         logger.info("audio-broadcaster: client added (total=%d)", len(self._clients))
         return queue
 
@@ -131,6 +149,9 @@ class AudioBroadcaster:
         async with self._lock:
             self._clients.pop(client_id, None)
             self._client_ws.pop(client_id, None)
+            removed_codec = self._client_rx_codec.pop(client_id, None)
+            if removed_codec is not None:
+                self.invalidate_codec_state()
             if (
                 not self._clients
                 and self._subscription is not None
@@ -294,6 +315,13 @@ class AudioBroadcaster:
         """Resolve browser RX transport codec from profile consumer policy."""
         if radio_codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
             return AUDIO_CODEC_OPUS
+
+        # The frontend can explicitly ask for PCM16 when its WebView/browser
+        # cannot decode Opus with WebCodecs.  Keep this as an aggregate
+        # transport decision because the relay currently builds one shared
+        # frame for all browser clients.
+        if AUDIO_CODEC_PCM16 in self._client_rx_codec.values():
+            return AUDIO_CODEC_PCM16
 
         default_codec = {
             AudioCodec.PCM_1CH_16BIT: AUDIO_CODEC_PCM16,
@@ -632,7 +660,7 @@ class AudioHandler:
 
         if msg_type == "audio_start":
             if direction == "rx":
-                await self._start_rx()
+                await self._start_rx(preferred_rx_codec=_parse_preferred_rx_codec(msg))
             elif direction == "tx":
                 if self._radio and CAP_AUDIO in self._radio.capabilities:
                     self._ensure_tx_transcoder()
@@ -808,12 +836,15 @@ class AudioHandler:
             return tx_sr
         return 48000
 
-    async def _start_rx(self) -> None:
+    async def _start_rx(self, *, preferred_rx_codec: int | None = None) -> None:
         """Subscribe to audio broadcaster for RX frames."""
         if not self._broadcaster:
             return
         self._rx_active = True
-        self._frame_queue = await self._broadcaster.subscribe(ws=self._ws)
+        self._frame_queue = await self._broadcaster.subscribe(
+            ws=self._ws,
+            preferred_rx_codec=preferred_rx_codec,
+        )
         logger.info("audio: subscribed to RX broadcast")
 
     async def _stop_rx(self) -> None:
@@ -847,16 +878,24 @@ class AudioHandler:
                 AUDIO_HEADER_SIZE,
             )
             return
-        # Extract audio data after 8-byte header (frontend sends Opus)
-        opus_data = payload[AUDIO_HEADER_SIZE:]
-        if opus_data:
+        if payload[0] != MSG_TYPE_AUDIO_TX:
+            logger.warning("audio: TX frame wrong type 0x%02x, ignoring", payload[0])
+            return
+        browser_codec = payload[1]
+        audio_data = payload[AUDIO_HEADER_SIZE:]
+        if audio_data:
             try:
-                # Browser TX sends Opus; radio-native PCM TX must be decoded
-                # according to the accepted TX contract, not the RX codec.
-                if self._tx_codec() == AudioCodec.PCM_1CH_16BIT and self._transcoder:
+                if browser_codec == AUDIO_CODEC_PCM16:
+                    await self._radio.push_audio_tx_pcm(audio_data)  # type: ignore[attr-defined]
+                    tx_data_desc = f"{len(audio_data)} bytes pcm"
+                elif (
+                    browser_codec == AUDIO_CODEC_OPUS
+                    and self._tx_codec() == AudioCodec.PCM_1CH_16BIT
+                    and self._transcoder
+                ):
                     try:
                         # Decode Opus → PCM16
-                        pcm_data = self._transcoder.opus_to_pcm(opus_data)
+                        pcm_data = self._transcoder.opus_to_pcm(audio_data)
                         await self._radio.push_audio_tx_pcm(pcm_data)  # type: ignore[attr-defined]
                         tx_data_desc = f"{len(pcm_data)} bytes pcm"
                     except Exception as e:
@@ -864,10 +903,16 @@ class AudioHandler:
                             "audio: Opus decode failed: %s, dropping frame", e
                         )
                         return
-                else:
+                elif browser_codec == AUDIO_CODEC_OPUS:
                     # Radio uses Opus or PCM_1CH_8BIT/etc → send Opus as-is
-                    await self._radio.push_audio_tx_opus(opus_data)  # type: ignore[attr-defined]
-                    tx_data_desc = f"{len(opus_data)} bytes opus"
+                    await self._radio.push_audio_tx_opus(audio_data)  # type: ignore[attr-defined]
+                    tx_data_desc = f"{len(audio_data)} bytes opus"
+                else:
+                    logger.warning(
+                        "audio: unsupported browser TX codec 0x%02x, dropping frame",
+                        browser_codec,
+                    )
+                    return
 
                 # Log every 50th frame to avoid spam
                 if not hasattr(self, "_tx_frame_count"):

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -22,6 +22,8 @@ from rigplane.web.protocol import (
     AUDIO_CODEC_OPUS,
     AUDIO_CODEC_PCM16,
     AUDIO_HEADER_SIZE,
+    MSG_TYPE_AUDIO_RX,
+    MSG_TYPE_AUDIO_TX,
     decode_json,
     encode_json,
 )
@@ -1311,7 +1313,12 @@ async def test_audio_handler_reader_control_tx_and_sender_paths(
                         "utf-8"
                     ),
                 ),
-                (WS_OP_BINARY, b"\x00" * AUDIO_HEADER_SIZE + b"\x11\x22"),
+                (
+                    WS_OP_BINARY,
+                    bytes([MSG_TYPE_AUDIO_TX, AUDIO_CODEC_OPUS])
+                    + b"\x00" * (AUDIO_HEADER_SIZE - 2)
+                    + b"\x11\x22",
+                ),
                 (
                     WS_OP_TEXT,
                     encode_json({"type": "audio_stop", "direction": "tx"}).encode(
@@ -1397,7 +1404,11 @@ async def test_audio_handler_control_and_tx_guard_paths() -> None:
     radio.start_audio_tx_opus.assert_awaited_once()
     await handler._handle_tx_audio(b"\x00" * (AUDIO_HEADER_SIZE - 1))
     await handler._handle_tx_audio(b"\x00" * AUDIO_HEADER_SIZE)
-    await handler._handle_tx_audio(b"\x00" * AUDIO_HEADER_SIZE + b"\x99")
+    await handler._handle_tx_audio(
+        bytes([MSG_TYPE_AUDIO_TX, AUDIO_CODEC_OPUS])
+        + b"\x00" * (AUDIO_HEADER_SIZE - 2)
+        + b"\x99"
+    )
     radio.push_audio_tx_opus.assert_awaited_once_with(b"\x99")
     await handler._handle_control({"type": "audio_stop", "direction": "tx"})
     radio.stop_audio_tx_opus.assert_awaited_once()
@@ -1436,7 +1447,7 @@ async def test_audio_handler_tx_other_runtime_error_propagates() -> None:
         await handler._handle_control({"type": "audio_start", "direction": "tx"})
 
 
-async def test_audio_handler_uses_tx_contract_for_pcm_browser_tx() -> None:
+async def test_audio_handler_decodes_opus_browser_tx_for_pcm_contract() -> None:
     from rigplane.radio_protocol import AudioCapable
 
     contract = AudioStreamContract(
@@ -1475,7 +1486,11 @@ async def test_audio_handler_uses_tx_contract_for_pcm_browser_tx() -> None:
     handler._tx_active = True
 
     await handler._handle_control({"type": "audio_start", "direction": "tx"})
-    await handler._handle_tx_audio(b"\x00" * AUDIO_HEADER_SIZE + b"opus-frame")
+    await handler._handle_tx_audio(
+        bytes([MSG_TYPE_AUDIO_TX, AUDIO_CODEC_OPUS])
+        + b"\x00" * (AUDIO_HEADER_SIZE - 2)
+        + b"opus-frame"
+    )
     await handler._handle_control({"type": "audio_stop", "direction": "tx"})
 
     radio.start_audio_tx_pcm.assert_awaited_once_with(sample_rate=16000)
@@ -1484,6 +1499,79 @@ async def test_audio_handler_uses_tx_contract_for_pcm_browser_tx() -> None:
     radio.push_audio_tx_opus.assert_not_awaited()
     radio.stop_audio_tx_pcm.assert_awaited_once()
     radio.stop_audio_tx_opus.assert_not_awaited()
+
+
+async def test_audio_handler_pushes_pcm_browser_tx_directly() -> None:
+    from rigplane.radio_protocol import AudioCapable
+
+    contract = AudioStreamContract(
+        rx_codec=AudioCodec.PCM_2CH_16BIT,
+        tx_codec=AudioCodec.PCM_1CH_16BIT,
+        rx_sample_rate_hz=48000,
+        tx_sample_rate_hz=48000,
+        rx_channels=2,
+        tx_channels=1,
+        rx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+        tx_codec_source=AudioConfigSource.PROFILE_DEFAULT,
+        rx_sample_rate_source=AudioConfigSource.PROFILE_DEFAULT,
+        tx_sample_rate_source=AudioConfigSource.PROFILE_DEFAULT,
+    )
+
+    class _FakeAudioRadio(AudioCapable):
+        capabilities = {"audio"}
+        audio_codec = AudioCodec.PCM_2CH_16BIT
+        audio_sample_rate = 48000
+        audio_stream_contract = contract
+        push_audio_tx_opus = AsyncMock()
+        push_audio_tx_pcm = AsyncMock()
+        start_audio_rx_opus = AsyncMock()
+        stop_audio_rx_opus = AsyncMock()
+        start_audio_tx_opus = AsyncMock()
+        stop_audio_tx_opus = AsyncMock()
+        start_audio_tx_pcm = AsyncMock()
+        stop_audio_tx_pcm = AsyncMock()
+        audio_bus = None
+
+    radio = _FakeAudioRadio()
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+    handler._tx_active = True
+
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+    await handler._handle_tx_audio(
+        bytes([MSG_TYPE_AUDIO_TX, AUDIO_CODEC_PCM16])
+        + b"\x00" * (AUDIO_HEADER_SIZE - 2)
+        + b"pcm-frame"
+    )
+
+    radio.start_audio_tx_pcm.assert_awaited_once_with(sample_rate=48000)
+    radio.push_audio_tx_pcm.assert_awaited_once_with(b"pcm-frame")
+    radio.push_audio_tx_opus.assert_not_awaited()
+
+
+async def test_audio_handler_drops_non_tx_or_unknown_browser_audio_frames() -> None:
+    radio = SimpleNamespace(
+        capabilities={"audio"},
+        push_audio_tx_opus=AsyncMock(),
+        push_audio_tx_pcm=AsyncMock(),
+    )
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+    handler._tx_active = True
+
+    await handler._handle_tx_audio(
+        bytes([MSG_TYPE_AUDIO_RX, AUDIO_CODEC_PCM16])
+        + b"\x00" * (AUDIO_HEADER_SIZE - 2)
+        + b"rx-frame"
+    )
+    await handler._handle_tx_audio(
+        bytes([MSG_TYPE_AUDIO_TX, 0x99])
+        + b"\x00" * (AUDIO_HEADER_SIZE - 2)
+        + b"unknown-codec-frame"
+    )
+
+    radio.push_audio_tx_pcm.assert_not_awaited()
+    radio.push_audio_tx_opus.assert_not_awaited()
 
 
 async def test_audio_handler_run_resets_tx_active_on_exit() -> None:

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -17,6 +17,7 @@ from rigplane.radio import (
     TOKEN_ACK_SIZE,
 )
 from rigplane.audio.route import AudioConfigSource
+from rigplane.profiles import RadioProfile
 from rigplane.transport import ConnectionState
 from rigplane.types import AudioCodec
 
@@ -76,6 +77,18 @@ class ConnectMockTransport(MockTransport):
 
     def start_idle_loop(self) -> None:
         pass
+
+
+def _lan_profile_without_codec_preference() -> RadioProfile:
+    return RadioProfile(
+        id="test-lan",
+        model="Test LAN",
+        civ_addr=0x98,
+        receiver_count=1,
+        capabilities=frozenset({"lan"}),
+        cmd29_routes=frozenset(),
+        has_lan=True,
+    )
 
 
 def _build_login_response(
@@ -201,6 +214,7 @@ class TestSendConninfo:
             username="u",
             password="p",
             audio_codec=AudioCodec.PCM_2CH_16BIT,
+            profile=_lan_profile_without_codec_preference(),
         )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
@@ -526,6 +540,7 @@ class TestConnectSessionRejection:
             username="u",
             password="p",
             audio_codec=AudioCodec.PCM_2CH_16BIT,
+            profile=_lan_profile_without_codec_preference(),
         )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
@@ -652,6 +667,89 @@ class TestConnectSessionRejection:
         assert mt.disconnected is True
 
     @pytest.mark.asyncio
+    async def test_profile_stereo_rejection_uses_busy_retry_not_mono_fallback(
+        self,
+    ) -> None:
+        """Profile-selected stereo codecs are intentional; 0xFFFFFFFF is treated
+        as a busy/held session rather than proof that stereo is unsupported.
+        """
+        radio = IcomRadio(
+            "192.168.1.100",
+            username="u",
+            password="p",
+            # Default profile is IC-7610, whose stereo codec is profile-selected.
+            audio_codec=AudioCodec.PCM_2CH_16BIT,
+        )
+        mt = ConnectMockTransport()
+        radio._ctrl_transport = mt
+
+        civ_port_responses = [0, 50001]
+        status_errors = [0xFFFFFFFF, 0x00000000]
+
+        async def _status_flow() -> int:
+            radio._last_status_error = status_errors.pop(0)
+            return civ_port_responses.pop(0)
+
+        codec_per_call: list[AudioCodec] = []
+
+        async def _capture_codec(*_args: object, **_kwargs: object) -> None:
+            codec_per_call.append(radio._audio_codec)
+
+        with (
+            patch.object(radio._control_phase, "_status_retry_pause", return_value=0.0),
+            patch.object(
+                radio._control_phase,
+                "_wait_for_packet",
+                new=AsyncMock(return_value=_build_login_response()),
+            ),
+            patch.object(radio._control_phase, "_send_token_ack", new=AsyncMock()),
+            patch.object(
+                radio._control_phase,
+                "_receive_guid",
+                new=AsyncMock(return_value=b"\x00" * 16),
+            ),
+            patch.object(
+                radio._control_phase,
+                "_send_conninfo",
+                new=AsyncMock(side_effect=_capture_codec),
+            ),
+            patch.object(
+                radio._control_phase,
+                "_receive_civ_port",
+                new=AsyncMock(side_effect=_status_flow),
+            ),
+            patch.object(
+                radio._control_phase, "_flush_queue", new=AsyncMock(return_value=0)
+            ),
+            patch.object(radio._control_phase, "_start_token_renewal"),
+            patch.object(radio._control_phase, "_start_watchdog"),
+            patch.object(radio._civ_runtime, "start_pump"),
+            patch.object(radio._civ_runtime, "start_data_watchdog"),
+            patch.object(radio._civ_runtime, "start_worker"),
+            patch(
+                "rigplane.transport.IcomTransport",
+                return_value=ConnectMockTransport(),
+            ),
+            patch("rigplane._control_phase.asyncio.sleep", new=AsyncMock()),
+        ):
+            radio._civ_ready_idle_timeout = 0.0
+            try:
+                await radio.connect()
+            except ConnectionError:
+                pass
+
+        assert codec_per_call == [
+            AudioCodec.PCM_2CH_16BIT,
+            AudioCodec.PCM_2CH_16BIT,
+        ]
+        assert radio.audio_stream_contract.rx_codec == AudioCodec.PCM_2CH_16BIT
+        assert (
+            radio.audio_stream_contract.rx_codec_source
+            == AudioConfigSource.PROFILE_DEFAULT
+        )
+        assert radio._civ_port == 50001
+
+    @pytest.mark.asyncio
     async def test_stereo_codec_fallback_raises_on_second_rejection(self) -> None:
         """Stereo rx_codec rejected twice → raise, no infinite loop."""
         radio = IcomRadio(
@@ -659,6 +757,7 @@ class TestConnectSessionRejection:
             username="u",
             password="p",
             audio_codec=AudioCodec.PCM_2CH_16BIT,
+            profile=_lan_profile_without_codec_preference(),
         )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
@@ -714,6 +813,7 @@ class TestConnectSessionRejection:
             username="u",
             password="p",
             audio_codec=AudioCodec.PCM_2CH_16BIT,
+            profile=_lan_profile_without_codec_preference(),
         )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1541,6 +1541,44 @@ class TestAudioHandlerCodecDetection:
         ]
         assert len(warnings) == 1
 
+    async def test_browser_can_request_pcm16_when_opus_decode_is_unavailable(
+        self,
+    ) -> None:
+        from rigplane.audio_bus import AudioBus
+        from rigplane.radio_protocol import AudioCapable
+        from rigplane.types import AudioCodec
+        from rigplane.web.handlers import AudioBroadcaster, AudioHandler
+        from rigplane.web.protocol import AUDIO_CODEC_PCM16, AUDIO_HEADER_SIZE
+        from rigplane.web.websocket import WebSocketConnection
+
+        mock_ws = MagicMock(spec=WebSocketConnection)
+        mock_radio = MagicMock(spec=AudioCapable)
+        mock_radio.capabilities = {"audio"}
+        mock_radio.audio_codec = AudioCodec.PCM_2CH_16BIT
+        mock_radio.audio_sample_rate = 16000
+        mock_radio.profile = SimpleNamespace(
+            browser_rx_transport="auto",
+            browser_rx_transcode_to_opus=True,
+        )
+        mock_radio.start_audio_rx_opus = AsyncMock()
+        mock_radio.stop_audio_rx_opus = AsyncMock()
+        bus = AudioBus(mock_radio)
+        mock_radio.audio_bus = bus
+
+        pcm_payload = b"\x01\x02" * 640
+        broadcaster = AudioBroadcaster(mock_radio)
+        handler = AudioHandler(mock_ws, mock_radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_PCM16)
+
+        mock_pkt = MagicMock()
+        mock_pkt.data = pcm_payload
+        bus._on_opus_packet(mock_pkt)
+        await asyncio.sleep(0.1)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_PCM16
+        assert frame[AUDIO_HEADER_SIZE:] == pcm_payload
+
 
 class TestBroadcasterFrameMsInvariant:
     """Wire-header ``frame_ms`` must match the actual payload size (issue #765).


### PR DESCRIPTION
## Summary
- add PCM16 TX microphone fallback for WebView clients without WebCodecs
- let browser RX clients request PCM16 when Opus decode is unavailable
- preserve profile-selected stereo codec behavior while keeping global-default mono fallback covered
- ignore local .agents workspace artifacts

## Tests
- uv run ruff check src/ tests/
- npm run check
- npm run build
- npm run test
- uv run pytest tests/ -q --tb=short --ignore=tests/integration
