### PR TITLE
chore(release): prepare v2.3.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] — 2026-05-20
+
+### Added
+- Added the Core Svelte i18n runtime, locale store, pluralization helpers,
+  pseudo-locale tooling, and bundled `en-US`, `ru-RU`, and `ja-JP` locale
+  catalogs for the first localized Core web surfaces (#1528, #1534, #1536).
+- Added the Core language preference UX and the cross-app locale preference
+  contract used by local shells and integrations to hand off language hints
+  without overwriting the user's stable Core preference (#1529, #1531).
+- Added localization QA coverage: string inventory, runtime/unit tests,
+  pseudo-locale smoke tests, visual QA fixtures, and Playwright i18n
+  screenshot coverage for desktop and mobile app surfaces (#1530, #1533).
+- Added localized server toast reason codes and migrated the P0 Core web
+  surfaces to the i18n runtime, including app shell, status bar, install
+  prompt, language selector, diagnostics dialog, and shared toasts (#1532).
+
+### Changed
+- Moved quick/full/rebrand/agent-review CI workflows to the Mac mini
+  build-tier runner while preserving the existing required gates (#1512,
+  #1513, #1514).
+- Refined public packaging metadata and docs SEO/navigation for the
+  multi-vendor RigPlane framing, including Project Overview, migration
+  guidance, per-page descriptions, and setup-guide download CTAs (#1510,
+  #1511, #1538, #1540, #1541, #1542).
+
+### Fixed
+- Stabilized the audio-scope aspect ratio in the web UI (#1519).
+- Fixed WebView/Tauri audio compatibility by allowing browser clients to
+  request PCM16 RX transport, adding a PCM16 TX microphone fallback when
+  WebCodecs are unavailable, and guarding async PTT startup/release races
+  before keying transmit (#1543).
+- Fixed Japanese pilot copy after linguistic validation (#1537).
+- Fixed release packaging so the generated frontend bundle is included in
+  sdist/wheel artifacts without relying on a local absolute `web/static`
+  symlink.
+- Fixed PyPI runtime dependency metadata so installed wheels can import and
+  serve the Web UI diagnostics upload path without relying on dev-only
+  dependencies.
+
+### Docs
+- Added the Core user-facing string inventory, locale contract, translator
+  guide, i18n contribution notes, and visual QA documentation (#1527, #1535).
+
 ## [2.2.0] — 2026-05-11
 
 ### Added
@@ -1294,7 +1337,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/rigplane/rigplane-core/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/rigplane/rigplane-core/compare/v2.1.2...v2.2.0
 [2.1.2]: https://github.com/rigplane/rigplane-core/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/rigplane/rigplane-core/compare/v2.1.0...v2.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.2.0"
+version = "2.3.0"
 description = "Multi-vendor radio control library and Web UI for IP-connected ham transceivers (Icom, Yaesu, Xiegu, Lab599) — no wfview/hamlib required"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
+    "aiohttp>=3.13.3",
     "pyserial>=3.5",
     "pyserial-asyncio>=0.6",
     "opuslib",
@@ -58,7 +59,6 @@ dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout", "pytest-xdist
 
 [dependency-groups]
 dev = [
-    "aiohttp>=3.13.3",
     "import-linter>=2.0,<3",
     "mkdocs-material>=9.7.3",
     "mkdocstrings[python]>=1.0.3",
@@ -77,6 +77,9 @@ packages = ["src/rigplane", "src/icom_lan"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "rigs" = "rigplane/rigs"
+
+[tool.hatch.build.targets.sdist.force-include]
+"frontend/dist" = "src/rigplane/web/static"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/rigplane/__init__.py
+++ b/src/rigplane/__init__.py
@@ -13,11 +13,9 @@ Submodules and private symbols (``rigplane.web``, ``rigplane.cli``,
 may change without warning.
 """
 
-# Import directly from the submodule to bypass ``rigplane.diagnostics``
-# package init, which re-exports ``upload_bundle`` from ``upload.py`` →
-# ``aiohttp`` (a dev-only dependency). Pulling ``aiohttp`` here would
-# crash every ``import rigplane`` for users on a runtime-only install.
-# See issue #1413.
+# Import directly from the submodule to keep ``import rigplane`` lightweight.
+# The diagnostics package also exposes upload helpers that initialize the HTTP
+# client stack; package import should not pay that cost. See issue #1413.
 from rigplane.diagnostics._logging import (
     configure_diagnostic_logging as _configure_diagnostic_logging,
 )

--- a/src/rigplane/cli/_diagnose.py
+++ b/src/rigplane/cli/_diagnose.py
@@ -35,14 +35,11 @@ from typing import TYPE_CHECKING, Any
 
 import platformdirs
 
-# NOTE: ``rigplane.diagnostics`` re-exports ``upload_bundle`` from
-# ``upload.py``, which imports ``aiohttp`` at module level. ``aiohttp`` is a
-# dev-only / optional dependency, so importing it eagerly here would crash
-# every CLI invocation (``rigplane status``, ``rigplane freq`` …) for users
-# who installed only the runtime requirements. All ``rigplane.diagnostics``
-# imports are therefore deferred into the helpers/coroutine that actually
-# need them — the ``diagnose`` subcommand path. ``add_subparser`` stays
-# argparse-only and never touches diagnostics symbols.
+# NOTE: ``rigplane.diagnostics`` re-exports upload helpers from ``upload.py``.
+# Importing that path eagerly would initialize the HTTP client stack for every
+# CLI invocation (``rigplane status``, ``rigplane freq`` ...), so diagnostics
+# imports are deferred into the helpers/coroutine that actually need them. The
+# ``diagnose`` subparser registration stays argparse-only.
 if TYPE_CHECKING:
     from rigplane.diagnostics import BundleContext, ReportSubmitted
 
@@ -163,14 +160,9 @@ def _resolve_endpoint(endpoint_arg: str | None) -> str:
     env = os.environ.get("RIGPLANE_REPORT_ENDPOINT")
     if env:
         return env
-    # Try the canonical constant from the diagnostics package. On installs that
-    # omit ``aiohttp`` (a dev-only dep) the lazy ``__getattr__`` hook in
-    # ``rigplane.diagnostics.__init__`` raises ``ImportError`` while loading
-    # ``upload.py`` — silently fall back to the well-known default URL so
-    # endpoint resolution still works in the preview / save-locally display
-    # path. The actual upload (which DOES need aiohttp) will fail later with
-    # a friendly message; the duplicated string is the price of decoupling
-    # the CLI's display path from the upload module's import requirements.
+    # Try the canonical constant from the diagnostics package. Keep the local
+    # fallback so endpoint resolution can still run in constrained/broken
+    # environments where the upload module cannot be imported.
     try:
         from rigplane.diagnostics import DEFAULT_ENDPOINT
     except ImportError:
@@ -273,12 +265,10 @@ def _interactive_collect(args: argparse.Namespace) -> None:
 
 async def _run_async(args: argparse.Namespace) -> int:
     # Lazy imports — see module-level NOTE. ``build_bundle`` plus the typed
-    # error classes live in non-aiohttp submodules, so importing them here is
-    # cheap. ``upload_bundle`` (and the other ``upload``-module re-exports)
-    # transitively imports ``aiohttp`` via the lazy hook in
-    # ``rigplane.diagnostics.__init__``; that import is deferred into the
-    # ``args.upload`` branch below so ``rigplane diagnose`` (save-only) works
-    # for runtime-only installs without ``aiohttp``.
+    # error classes live in light submodules, so importing them here is cheap.
+    # ``upload_bundle`` (and the other ``upload``-module re-exports) is
+    # deferred into the ``args.upload`` branch below so ``rigplane diagnose``
+    # (save-only) avoids initializing the HTTP client stack.
     # These names land in the local scope, so test fixtures must patch
     # ``rigplane.diagnostics`` (the source module) rather than
     # ``rigplane.cli._diagnose``.
@@ -342,13 +332,13 @@ async def _run_async(args: argparse.Namespace) -> int:
             return 0
 
     # Upload (either --no-confirm path or user typed y/yes after preview).
-    # Lazy import — accessing ``upload_bundle`` is what triggers the aiohttp
-    # import via the :pep:`562` hook in ``rigplane.diagnostics.__init__``.
+    # Lazy import — accessing ``upload_bundle`` is what imports the upload
+    # module via the :pep:`562` hook in ``rigplane.diagnostics.__init__``.
     # Keeping it inside the ``args.upload`` branch lets ``rigplane diagnose``
-    # (save-only) run on installs that omit aiohttp. The error classes are
-    # imported alongside for symmetry; they live in non-aiohttp submodules
-    # and would be cheap to hoist, but bundling them here keeps the upload
-    # path self-contained.
+    # (save-only) avoid initializing the HTTP client stack. The error classes
+    # are imported alongside for symmetry; they live in lighter submodules and
+    # would be cheap to hoist, but bundling them here keeps the upload path
+    # self-contained.
     try:
         from rigplane.diagnostics import (
             BundleTooLarge,
@@ -360,17 +350,16 @@ async def _run_async(args: argparse.Namespace) -> int:
             upload_bundle,
         )
     except ImportError as exc:
-        # `aiohttp` is a dev-only / optional dependency. Pip-install users who
-        # try `--upload` without it get here. Don't show a Python traceback —
-        # they need an actionable message + the local bundle path so they can
-        # still attach it to a GitHub issue manually.
+        # Broken or partial installs may still fail to import the HTTP upload
+        # stack. Don't show a Python traceback — provide an actionable message
+        # and keep the local bundle path available for manual attachment.
         if "aiohttp" in str(exc):
             print(
-                "Upload requires the 'aiohttp' package, which is not installed.",
+                "Upload requires the 'aiohttp' package, which could not be imported.",
                 file=sys.stderr,
             )
             print(
-                "  Install it with:  pip install aiohttp",
+                "  Repair the installation, then re-run upload.",
                 file=sys.stderr,
             )
             print(
@@ -378,8 +367,8 @@ async def _run_async(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             print(
-                "  You can attach it to a GitHub issue manually, or re-run "
-                "with `pip install aiohttp` to enable upload.",
+                "  You can attach it to a GitHub issue manually, or repair "
+                "the installation and re-run upload.",
                 file=sys.stderr,
             )
             return 9

--- a/src/rigplane/diagnostics/__init__.py
+++ b/src/rigplane/diagnostics/__init__.py
@@ -2,14 +2,13 @@
 
 Subsequent issues (#1388-#1401) build on this package.
 
-Note (issue #1413): the ``upload`` submodule imports ``aiohttp``, which is a
-dev-only dependency (declared in ``[dependency-groups].dev``, not in
-``[project].dependencies``). Eagerly importing it here would break ``import
-rigplane`` for runtime-only installs, so the four upload-related names
+Note (issue #1413): the ``upload`` submodule initializes the HTTP client stack.
+Eagerly importing it here would make every ``import rigplane`` pay that cost,
+so the four upload-related names
 (``DEFAULT_ENDPOINT``, ``HeaderProvider``, ``ReportSubmitted``,
 ``upload_bundle``) are exposed lazily via :pep:`562` ``__getattr__``. They
 remain importable as ``from rigplane.diagnostics import upload_bundle``;
-the ``aiohttp`` import only fires on first access.
+the upload module import only fires on first access.
 """
 
 from __future__ import annotations
@@ -40,7 +39,7 @@ from rigplane.diagnostics.redaction import (
     redact_tokens,
 )
 
-# Lazy re-exports from ``rigplane.diagnostics.upload`` (which imports aiohttp).
+# Lazy re-exports from ``rigplane.diagnostics.upload``.
 # Map: public name → attribute on ``upload`` module.
 _LAZY_UPLOAD: dict[str, str] = {
     "DEFAULT_ENDPOINT": "DEFAULT_ENDPOINT",
@@ -50,7 +49,7 @@ _LAZY_UPLOAD: dict[str, str] = {
 }
 
 if TYPE_CHECKING:
-    # Make these names visible to typecheckers without triggering aiohttp.
+    # Make these names visible to typecheckers without eager runtime imports.
     from rigplane.diagnostics.upload import (  # noqa: F401
         DEFAULT_ENDPOINT,
         HeaderProvider,
@@ -62,8 +61,8 @@ if TYPE_CHECKING:
 def __getattr__(name: str) -> Any:
     """:pep:`562` lazy hook for upload-module re-exports.
 
-    Defers ``import aiohttp`` until a consumer actually accesses one of the
-    upload names. Cached in ``globals()`` so subsequent lookups skip the hook.
+    Defers the upload module import until a consumer actually accesses one of
+    the upload names. Cached in ``globals()`` so subsequent lookups skip the hook.
     """
     target = _LAZY_UPLOAD.get(name)
     if target is None:

--- a/src/rigplane/web/static
+++ b/src/rigplane/web/static
@@ -1,1 +1,0 @@
-/Users/moroz/Projects/icom-lan/frontend/dist

--- a/uv.lock
+++ b/uv.lock
@@ -1958,9 +1958,10 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiohttp" },
     { name = "numpy" },
     { name = "opuslib" },
     { name = "platformdirs" },
@@ -1994,7 +1995,6 @@ webrtc = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "aiohttp" },
     { name = "import-linter" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -2010,6 +2010,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "aiortc", marker = "extra == 'webrtc'", specifier = ">=1.9" },
     { name = "cryptography", marker = "extra == 'tls'", specifier = ">=41.0" },
     { name = "mypy", marker = "extra == 'dev'" },
@@ -2032,7 +2033,6 @@ provides-extras = ["audio", "bridge", "scope", "dsp", "webrtc", "tls", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "import-linter", specifier = ">=2.0,<3" },
     { name = "mkdocs-material", specifier = ">=9.7.3" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },


### PR DESCRIPTION
## Summary
- bump package version and changelog for v2.3.0
- remove local absolute web/static symlink from tracked files
- package generated frontend assets into sdists so uv build can produce release artifacts

## Release-readiness checks
- uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
- uv run lint-imports
- uv run mypy --strict src/rigplane/web
- npm run check
- npm run test
- npm run build
- uv run pytest tests/ -q --tb=short --ignore=tests/integration
- uv build
- verified wheel and sdist contain rigplane/web/static assets
