### PR TITLE
[codex] avoid spurious CI-V reconnect recovery

### DIFF
--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -455,7 +455,34 @@ class ControlPhaseRuntime:
         """Reconnect CI-V transport using existing control session."""
         h = self._host
         if h._civ_transport is not None:
-            logger.warning("soft_reconnect: CI-V transport already open")
+            now = time.monotonic()
+            last_data = getattr(h, "_last_civ_data_received", None)
+            transport_open = (
+                getattr(h._civ_transport, "_udp_transport", None) is not None
+            )
+            data_flowing = isinstance(last_data, (int, float)) and (
+                now - float(last_data)
+            ) <= getattr(h, "_civ_ready_idle_timeout", 3.0)
+            if transport_open and data_flowing:
+                h._conn_state = RadioConnectionState.CONNECTED
+                h._civ_stream_ready = True
+                h._civ_recovering = False
+                h._last_civ_data_received = now
+                logger.info(
+                    "civ.soft_reconnect.noop",
+                    extra={
+                        "reason": "already_open_data_flowing",
+                        "civ_idle_seconds": now - float(last_data),
+                    },
+                )
+            else:
+                logger.warning(
+                    "civ.soft_reconnect.already_open_stalled",
+                    extra={
+                        "transport_open": transport_open,
+                        "data_flowing": data_flowing,
+                    },
+                )
             return
         if not h._ctrl_transport or not getattr(
             h._ctrl_transport, "_udp_transport", None

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -239,19 +239,57 @@ async def test_soft_disconnect_with_audio_stream_stops_audio(
 # ---------------------------------------------------------------------------
 
 
-async def test_soft_reconnect_warns_when_civ_transport_already_open(
+async def test_soft_reconnect_noops_when_open_transport_is_receiving_data(
     radio: IcomRadio,
     mock_transport: MockTransport,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """soft_reconnect() must warn and return early when CIV is already open."""
     import logging
+    import time
 
-    # _civ_transport is already set (the mock)
-    with caplog.at_level(logging.WARNING, logger="rigplane.runtime.radio"):
+    from rigplane.runtime._connection_state import RadioConnectionState
+
+    mock_transport._udp_transport = MagicMock()
+    radio._conn_state = RadioConnectionState.RECONNECTING
+    radio._civ_stream_ready = False
+    radio._civ_recovering = True
+    radio._last_civ_data_received = time.monotonic()
+
+    with caplog.at_level(logging.INFO, logger="rigplane.runtime._control_phase"):
         await radio.soft_reconnect()
 
-    assert any("already open" in r.message for r in caplog.records)
+    assert radio._conn_state == RadioConnectionState.CONNECTED
+    assert radio._civ_stream_ready is True
+    assert radio._civ_recovering is False
+    assert any(r.message == "civ.soft_reconnect.noop" for r in caplog.records)
+    assert not any("already open" in r.message for r in caplog.records)
+
+
+async def test_soft_reconnect_already_open_stalled_keeps_recovering(
+    radio: IcomRadio,
+    mock_transport: MockTransport,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+    import time
+
+    from rigplane.runtime._connection_state import RadioConnectionState
+
+    mock_transport._udp_transport = MagicMock()
+    radio._conn_state = RadioConnectionState.RECONNECTING
+    radio._civ_stream_ready = False
+    radio._civ_recovering = True
+    radio._last_civ_data_received = time.monotonic() - 60.0
+
+    with caplog.at_level(logging.WARNING, logger="rigplane.runtime._control_phase"):
+        await radio.soft_reconnect()
+
+    assert radio._conn_state == RadioConnectionState.RECONNECTING
+    assert radio._civ_stream_ready is False
+    assert radio._civ_recovering is True
+    assert any(
+        r.message == "civ.soft_reconnect.already_open_stalled" for r in caplog.records
+    )
 
 
 async def test_soft_reconnect_does_full_connect_when_ctrl_dead(


### PR DESCRIPTION
## What changed

When a CI-V soft reconnect is requested while the transport is already open and data is still flowing, treat the reconnect as a no-op, clear transient recovering state, refresh the watchdog timestamp, and emit a structured `civ.soft_reconnect.noop` log.

The normal recovery path still runs when the transport is stalled.

## Verification

Agent-run checks:

- `uv run pytest tests/test_radio_coverage.py -k soft_reconnect` -> 6 passed
- `uv run pytest tests/test_civ_rx_coverage.py -k watchdog` -> 10 passed
- `uv run pytest tests/test_radio_coverage.py tests/test_civ_rx_coverage.py` -> 254 passed
- `uv run ruff check src/rigplane/runtime/_control_phase.py tests/test_radio_coverage.py` -> passed
- `uv run pytest` -> 5980 passed, 112 skipped, 3 deselected, 9 xfailed, 1 xpassed
