### PR TITLE
fix: make rigctld power status WSJT-X compatible

### DIFF
--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -1322,8 +1322,11 @@ class RigctldHandler:
         return RigctldResponse(values=["1" if dual else "0"])
 
     async def _cmd_get_powerstat(self, cmd: RigctldCommand) -> RigctldResponse:
-        on = await self._radio.get_powerstat()
-        return RigctldResponse(values=[str(int(bool(on)))])
+        # Hamlib calls this during NET rigctl startup and treats failures as
+        # "rig power is off". Some radios do not answer the underlying
+        # power-status CI-V query over LAN even while normal CAT reads work, so
+        # expose the server's reachable state instead of blocking on the rig.
+        return RigctldResponse(values=["1"])
 
     async def _cmd_quit(self, cmd: RigctldCommand) -> RigctldResponse:
         # Return OK; server.py detects cmd_echo == "quit" and closes the connection

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -787,31 +787,23 @@ async def test_chk_vfo(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
 
 @pytest.mark.asyncio
 async def test_get_powerstat(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
-    mock_radio.get_powerstat = AsyncMock(return_value=True)
+    mock_radio.get_powerstat = AsyncMock(side_effect=AssertionError("must not poll"))
     resp = await handler.execute(get_cmd("get_powerstat"))
     assert resp.ok
     assert resp.values == ["1"]
-    mock_radio.get_powerstat.assert_awaited_once()
+    mock_radio.get_powerstat.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_rigctld_get_powerstat_returns_real_value(
+async def test_rigctld_get_powerstat_is_wsjtx_compatibility_probe(
     handler: RigctldHandler, mock_radio: AsyncMock
 ) -> None:
-    """get_powerstat dispatches to radio and reflects ON vs STANDBY."""
-    # Radio reports STANDBY (off).
-    mock_radio.get_powerstat = AsyncMock(return_value=False)
-    resp = await handler.execute(get_cmd("get_powerstat"))
-    assert resp.ok
-    assert resp.values == ["0"]
-    mock_radio.get_powerstat.assert_awaited_once()
-
-    # Radio reports ON.
-    mock_radio.get_powerstat = AsyncMock(return_value=True)
+    """get_powerstat reports reachable NET rigctl state without CI-V polling."""
+    mock_radio.get_powerstat = AsyncMock(side_effect=IcomTimeoutError("timed out"))
     resp = await handler.execute(get_cmd("get_powerstat"))
     assert resp.ok
     assert resp.values == ["1"]
-    mock_radio.get_powerstat.assert_awaited_once()
+    mock_radio.get_powerstat.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- report rigctld `get_powerstat` as reachable when the NET rigctl server is responding
- avoid blocking WSJT-X/Hamlib startup on radios that do not answer the underlying power-status query over LAN
- update rigctld handler tests to assert the compatibility behavior

## Tests
- `uv run pytest tests/test_rigctld_handler.py tests/test_server_wire.py tests/test_rigctld_protocol.py -q`
- `uv run ruff check src/rigplane/rigctld/handler.py tests/test_rigctld_handler.py`

## Boundary
This is an open-core rigctld compatibility fix. It does not include private product code or validation details.