### PR TITLE
fix: retry CI-V reconnect with ephemeral local port

### DIFF
--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import socket as _socket
 import struct
@@ -42,6 +43,11 @@ _STEREO_CODECS = (
     AudioCodec.ULAW_2CH,
     AudioCodec.OPUS_2CH,
 )
+
+
+def _is_address_in_use(exc: OSError) -> bool:
+    return exc.errno == errno.EADDRINUSE or "Address already in use" in str(exc)
+
 
 __all__ = [
     "ControlPhaseRuntime",
@@ -497,25 +503,53 @@ class ControlPhaseRuntime:
 
         from rigplane.transport import IcomTransport
 
+        requested_local_port = getattr(h, "_civ_local_port", 0)
         h._civ_transport = IcomTransport()
         try:
             await h._civ_transport.connect(
                 h._host,
                 h._civ_port,
                 local_host=getattr(h, "_local_bind_host", None),
-                local_port=getattr(h, "_civ_local_port", 0),
+                local_port=requested_local_port,
             )
         except OSError as exc:
-            h._civ_transport = None
-            ctrl_alive = getattr(h, "control_connected", False)
-            h._conn_state = (
-                RadioConnectionState.RECONNECTING
-                if ctrl_alive
-                else RadioConnectionState.DISCONNECTED
-            )
-            h._civ_stream_ready = False
-            h._civ_recovering = ctrl_alive
-            raise ConnectionError(f"Failed to reconnect CI-V: {exc}") from exc
+            if requested_local_port and _is_address_in_use(exc):
+                logger.warning(
+                    "soft_reconnect: local CI-V port %d still busy, retrying with an ephemeral port",
+                    requested_local_port,
+                )
+                h._civ_transport = IcomTransport()
+                try:
+                    await h._civ_transport.connect(
+                        h._host,
+                        h._civ_port,
+                        local_host=getattr(h, "_local_bind_host", None),
+                        local_port=0,
+                    )
+                except OSError as retry_exc:
+                    h._civ_transport = None
+                    ctrl_alive = getattr(h, "control_connected", False)
+                    h._conn_state = (
+                        RadioConnectionState.RECONNECTING
+                        if ctrl_alive
+                        else RadioConnectionState.DISCONNECTED
+                    )
+                    h._civ_stream_ready = False
+                    h._civ_recovering = ctrl_alive
+                    raise ConnectionError(
+                        f"Failed to reconnect CI-V: {retry_exc}"
+                    ) from retry_exc
+            else:
+                h._civ_transport = None
+                ctrl_alive = getattr(h, "control_connected", False)
+                h._conn_state = (
+                    RadioConnectionState.RECONNECTING
+                    if ctrl_alive
+                    else RadioConnectionState.DISCONNECTED
+                )
+                h._civ_stream_ready = False
+                h._civ_recovering = ctrl_alive
+                raise ConnectionError(f"Failed to reconnect CI-V: {exc}") from exc
 
         h._civ_transport.start_ping_loop()
         h._civ_transport.start_retransmit_loop()

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -30,6 +30,7 @@ Covers the many methods/branches not reached by the existing test suite:
 from __future__ import annotations
 
 import asyncio
+import errno
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1453,6 +1454,49 @@ async def test_soft_reconnect_handles_connect_failure(radio: IcomRadio) -> None:
             await radio.soft_reconnect()
 
     assert radio._civ_transport is None
+
+
+async def test_soft_reconnect_retries_ephemeral_port_when_saved_local_port_busy(
+    radio: IcomRadio,
+) -> None:
+    """A stale CI-V socket can briefly keep the previous local port busy."""
+    from rigplane.runtime._connection_state import RadioConnectionState
+
+    radio._civ_transport = None
+    radio._civ_local_port = 52002
+    radio._ctrl_transport._udp_transport = MagicMock()  # type: ignore[attr-defined]
+
+    busy_transport = MagicMock()
+    busy_transport.connect = AsyncMock(
+        side_effect=OSError(errno.EADDRINUSE, "Address already in use")
+    )
+
+    retry_transport = MagicMock()
+    retry_transport.connect = AsyncMock()
+    retry_transport.send_tracked = AsyncMock()
+    retry_transport.my_id = 1
+    retry_transport.remote_id = 2
+    retry_transport._udp_error_count = 0
+
+    with (
+        patch(
+            "rigplane.transport.IcomTransport",
+            side_effect=[busy_transport, retry_transport],
+        ),
+        patch.object(radio, "_send_open_close", new=AsyncMock()),
+        patch.object(radio._civ_runtime, "stop_pump", new=AsyncMock()),
+        patch.object(radio._civ_runtime, "start_pump"),
+        patch.object(radio._civ_runtime, "start_worker"),
+        patch.object(radio._civ_runtime, "start_data_watchdog"),
+    ):
+        await radio.soft_reconnect()
+
+    busy_transport.connect.assert_awaited_once()
+    retry_transport.connect.assert_awaited_once()
+    assert busy_transport.connect.await_args.kwargs["local_port"] == 52002
+    assert retry_transport.connect.await_args.kwargs["local_port"] == 0
+    assert radio._conn_state == RadioConnectionState.CONNECTED
+    assert radio._civ_transport is retry_transport
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- recover from stale local CI-V UDP ports by retrying soft reconnect with an ephemeral local port when the saved port is still busy
- clear recovering state when a late soft reconnect finds an already-open CI-V transport
- add focused coverage for both reconnect paths

## Tests
- `uv run pytest tests/test_radio_coverage.py -q`
- `uv run ruff check src/rigplane/runtime/_control_phase.py tests/test_radio_coverage.py`
- `uv run ruff format --check src/rigplane/runtime/_control_phase.py tests/test_radio_coverage.py`

## Boundary
Open-core runtime reconnect reliability fix.