### PR TITLE
Keep PortAudio playback writes nonblocking

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -272,6 +272,7 @@ class _PortAudioTxStream:
         self._stream: Any = None
         self._task: asyncio.Task[None] | None = None
         self._queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=64)
+        self._dropped_frames: int = 0
 
     @property
     def running(self) -> bool:
@@ -319,7 +320,29 @@ class _PortAudioTxStream:
     async def write(self, frame: bytes) -> None:
         if not self.running:
             raise RuntimeError("TX stream is not running.")
-        await self._queue.put(frame)
+        try:
+            self._queue.put_nowait(frame)
+            return
+        except asyncio.QueueFull:
+            pass
+
+        # Audio playback is realtime: blocking here backpressures websocket
+        # receive and turns a brief CoreAudio stall into seconds of stale audio.
+        # Keep latency bounded by dropping the oldest queued frame.
+        try:
+            self._queue.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+        try:
+            self._queue.put_nowait(frame)
+        except asyncio.QueueFull:
+            pass
+        self._dropped_frames += 1
+        if self._dropped_frames <= 3 or self._dropped_frames % 500 == 0:
+            logger.warning(
+                "portaudio-tx: dropped stale playback frame (queue full, total=%d)",
+                self._dropped_frames,
+            )
 
     async def _loop(self) -> None:
         stream = self._stream

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 
+import asyncio
+
 import pytest
 
 from rigplane.audio.backend import (
@@ -347,3 +349,32 @@ class TestPortAudioBackendDeps:
         backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), FakeNp()))
         stream = backend.open_tx(AudioDeviceId(0))
         assert isinstance(stream, TxStream)
+
+    @pytest.mark.asyncio()
+    async def test_portaudio_tx_write_drops_oldest_when_queue_full(self) -> None:
+        class FakeSd:
+            class OutputStream:
+                def __init__(self, **kw: object) -> None:
+                    pass
+
+        class FakeNp:
+            pass
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), FakeNp()))
+        stream = backend.open_tx(AudioDeviceId(0))
+        assert hasattr(stream, "_queue")
+        assert hasattr(stream, "_task")
+
+        never_done = asyncio.Event()
+        task = asyncio.create_task(never_done.wait())
+        stream._task = task  # type: ignore[attr-defined]
+        stream._queue = asyncio.Queue(maxsize=1)  # type: ignore[attr-defined]
+        stream._queue.put_nowait(b"old")  # type: ignore[attr-defined]
+
+        try:
+            await asyncio.wait_for(stream.write(b"new"), timeout=0.1)
+            assert stream._queue.get_nowait() == b"new"  # type: ignore[attr-defined]
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task


### PR DESCRIPTION
## Summary
- keep PortAudio playback writes realtime by dropping the oldest queued frame when the local playback queue is full
- prevent playback backpressure from stalling websocket audio receive and building stale audio latency
- add coverage for full-queue write behavior

## Tests
- uv run pytest tests/test_audio_backend.py::TestPortAudioBackendDeps::test_portaudio_tx_write_drops_oldest_when_queue_full -q
- uv run pytest tests/test_audio_backend.py tests/test_audio_bridge.py -q
- uv run ruff check src/rigplane/audio/backend.py tests/test_audio_backend.py
- uv run ruff format --check src/rigplane/audio/backend.py tests/test_audio_backend.py