### PR TITLE
Fix rigctld CI-V reads after generation advance

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -160,9 +160,7 @@ class CivRuntime:
     def start_pump(self) -> None:
         """Start always-on CI-V receive pump."""
         if self._host._civ_rx_task is None or self._host._civ_rx_task.done():
-            self._host._civ_rx_task = asyncio.create_task(
-                self._civ_rx_loop(self._host._civ_epoch)
-            )
+            self._host._civ_rx_task = asyncio.create_task(self._civ_rx_loop())
 
     async def stop_pump(self) -> None:
         """Stop CI-V receive pump and fail pending request futures."""
@@ -507,7 +505,7 @@ class CivRuntime:
         )
         return non_scope_packets + kept_scope
 
-    async def _civ_rx_loop(self, generation: int) -> None:
+    async def _civ_rx_loop(self) -> None:
         """Continuously consume CI-V transport packets and route events."""
         assert self._host._civ_transport is not None
         self._host._last_civ_data_received = time.monotonic()
@@ -544,7 +542,10 @@ class CivRuntime:
                         except ValueError:
                             continue
                         try:
-                            await self._route_civ_frame(frame, generation=generation)
+                            await self._route_civ_frame(
+                                frame,
+                                generation=self._host._civ_epoch,
+                            )
                         except Exception:
                             logger.exception(
                                 "Unhandled exception while routing CI-V frame"

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -771,6 +771,23 @@ class TestAckSinkRobustness:
 
         assert radio._civ_request_tracker.pending_count == 0
 
+    @pytest.mark.asyncio
+    async def test_pump_uses_current_generation_after_reconnect(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        radio._civ_runtime.start_pump()
+        try:
+            radio._civ_runtime.advance_generation("unit-test-reconnect")
+
+            mock_transport.queue_response_on_send(1, _freq_response(14_074_000))
+            mock_transport.queue_response_on_send(2, _mode_response(Mode.USB))
+
+            assert await radio.get_freq() == 14_074_000
+            assert await radio.get_mode_info() == (Mode.USB, 1)
+            assert radio._civ_request_tracker.timeout_count == 0
+        finally:
+            await radio._civ_runtime.stop_pump()
+
 
 class TestScopeCallbackSafety:
     """Scope callback failures must not break command routing."""


### PR DESCRIPTION
## Summary
- keep the CI-V RX pump resolving incoming frames against the current request generation instead of the generation captured when the pump task started
- add a regression covering frequency and mode reads after a reconnect-style generation advance

## Root cause
After a core restart or soft reconnect, `advance_generation()` invalidated stale CI-V waiters, but an already-running RX pump kept routing responses with its old captured generation. Incoming frequency/mode responses could refresh cached state, while the matching blocking waiter was rejected as an old generation and timed out. In rigctld this surfaced as `RPRT -5` or command-timeout behavior for WSJT-X blocking reads.

## Tests
- `uv run pytest tests/test_radio.py::TestAckSinkRobustness::test_pump_uses_current_generation_after_reconnect -q --tb=short`
- `uv run pytest tests/test_radio.py tests/test_civ.py tests/test_civ_rx_coverage.py tests/test_rigctld_handler.py tests/test_rigctld_server.py -q --tb=short`
- `uv run ruff check src/rigplane/runtime/_civ_rx.py tests/test_radio.py`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -q --tb=short`

Closes #1550
