### PR TITLE
docs(seo): tune docs indexing policy

### DIFF
--- a/docs/AUDIO_STREAMING_PROFILE.md
+++ b/docs/AUDIO_STREAMING_PROFILE.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Web Audio Streaming Performance Profile (M6.P2.3)
 
 **Date**: 2026-03-24

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Performance Analysis & Optimization (M6.3)
 
 ## Baseline Metrics (2026-03-23)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Security
 
 ## Overview

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Authentication
 
 Low-level authentication functions for the Icom LAN protocol. These are used internally by the LAN backend (e.g. when using [`create_radio`](public-api-surface.md) with `LanBackendConfig`, or [`IcomRadio`](radio.md) directly).

--- a/docs/api/backends-icom7610-drivers.md
+++ b/docs/api/backends-icom7610-drivers.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Icom IC-7610 Drivers
 
 Low-level transport drivers for IC-7610 serial backend.

--- a/docs/api/backends-icom7610.md
+++ b/docs/api/backends-icom7610.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Icom IC-7610 Backend
 
 LAN and serial implementations for Icom IC-7610.

--- a/docs/api/backends.md
+++ b/docs/api/backends.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Backends
 
 Radio backend implementations (multi-radio architecture).

--- a/docs/api/commander.md
+++ b/docs/api/commander.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # IcomCommander
 
 Serialized CI-V command executor with priority queuing (wfview-style).

--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Commands Module
 
 Low-level CI-V command encoding and decoding. Most users should use the high-level **Radio** API (via [`create_radio`](public-api-surface.md)).

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Exceptions
 
 All exceptions inherit from `RigplaneError` for easy catch-all handling.

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # IcomRadio
 
 LAN-specific radio class. For new code, prefer the backend-neutral **[create_radio](public-api-surface.md)** + **Radio** API so the same code works over LAN or USB serial. Use `IcomRadio` when you need direct LAN control or are migrating from older examples.

--- a/docs/api/rig-loader.md
+++ b/docs/api/rig-loader.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Rig Loader
 
 TOML rig file loading, validation, and runtime object construction.

--- a/docs/api/rigctld.md
+++ b/docs/api/rigctld.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Rigctld Server
 
 Hamlib NET rigctld-compatible TCP server for rigplane.

--- a/docs/api/scope.md
+++ b/docs/api/scope.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Scope / Waterfall
 
 Spectrum and waterfall data from the radio's scope display.

--- a/docs/api/sync.md
+++ b/docs/api/sync.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Synchronous API
 
 Blocking wrapper around the async `IcomRadio` for use without `async/await`.

--- a/docs/api/transport.md
+++ b/docs/api/transport.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Transport
 
 Low-level async UDP transport for the Icom LAN protocol. Most users should use [`create_radio`](public-api-surface.md) and the **Radio** API instead.

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Types & Enums
 
 Core data types used throughout the library.

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Web Server API
 
 Built-in HTTP + WebSocket interface used by the browser UI and automation clients.

--- a/docs/capabilities-matrix.md
+++ b/docs/capabilities-matrix.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Capabilities Matrix — Verified from CI-V Reference
 
 Sources:

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,14 @@ Direct connection to your radio — no wfview, hamlib, or RS-BA1 required.
 
     [:octicons-arrow-right-24: CLI Reference](guide/cli.md)
 
+- :material-radio-tower:{ .lg .middle } **Supported Radios**
+
+    ---
+
+    Pick the radio you operate and follow the matching setup path.
+
+    [:octicons-arrow-right-24: Radios](guide/radios.md) · [:octicons-arrow-right-24: IC-7610 USB](guide/ic7610-usb-setup.md) · [:octicons-arrow-right-24: WSJT-X](guide/wsjtx-setup.md)
+
 - :material-api:{ .lg .middle } **API Reference**
 
     ---
@@ -97,7 +105,11 @@ Direct connection to your radio — no wfview, hamlib, or RS-BA1 required.
 | IC-7851 | CI-V `0x8E` | :material-help-circle: Should work |
 | IC-R8600 | CI-V `0x96` | :material-help-circle: Should work |
 
-See [Supported Radios](guide/radios.md) for full details. Any Icom radio with LAN/WiFi control should work — the CI-V address is configurable.
+See [Supported Radios](guide/radios.md) for full details. Any Icom radio with LAN/WiFi control should work — the CI-V address is configurable. If you're choosing the commercial desktop app first, start from the matching landing page on [rigplane.com](https://rigplane.com/): [IC-7610](https://rigplane.com/ic-7610/), [IC-7300](https://rigplane.com/ic-7300/), [IC-705](https://rigplane.com/ic-705/), [IC-9700](https://rigplane.com/ic-9700/), or the platform pages for [Mac](https://rigplane.com/ham-radio-software/mac/) and [Linux](https://rigplane.com/ham-radio-software/linux/).
+
+## Indexing policy
+
+This docs site intentionally indexes operator-facing guides, setup pages, and the public API overview. Low-level generated API pages and internal engineering notes are marked `noindex, follow`: crawlers can follow their links, but search results should prefer the pages that help an operator install, configure, and use RigPlane.
 
 ## Minimal Example
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Architecture
 
 ## Overview

--- a/docs/internals/cli-design.md
+++ b/docs/internals/cli-design.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # CLI design and technology choices
 
 ## Current implementation

--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Contributing
 
 Contributions are welcome! Here's how to get started.

--- a/docs/internals/github-project-workflow.md
+++ b/docs/internals/github-project-workflow.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # GitHub Project Workflow
 
 RigPlane Core uses GitHub Issues plus GitHub Projects as the lightweight

--- a/docs/internals/protocol.md
+++ b/docs/internals/protocol.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Protocol Deep Dive
 
 The Icom LAN protocol is a proprietary UDP-based protocol used by Icom transceivers for remote control over Ethernet/WiFi. It was reverse-engineered by the [wfview](https://wfview.org/) project.

--- a/docs/internals/reliability-semantics.md
+++ b/docs/internals/reliability-semantics.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Reliability semantics
 
 This document defines the public contract for timeouts, retries, cache TTLs, and connection/readiness state. Web UI and rigctld documentation can reference this section for consistent behavior.

--- a/docs/internals/rfc-audio-v1-mini.md
+++ b/docs/internals/rfc-audio-v1-mini.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Mini RFC: Audio API v1 (PCM-first + explicit low-level API)
 
 Status: Draft (for approval)

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -6,7 +6,8 @@
   {% set page_description = page.meta.description if page.meta and page.meta.description else config.site_description %}
   {% set page_url = page.canonical_url or config.site_url %}
   {% set image_url = config.extra.social_image %}
-  <meta name="robots" content="index, follow">
+  {% set robots = page.meta.robots if page.meta and page.meta.robots else "index, follow" %}
+  <meta name="robots" content="{{ robots }}">
   <meta property="og:type" content="{% if page.is_homepage %}website{% else %}article{% endif %}">
   <meta property="og:site_name" content="{{ config.site_name }}">
   <meta property="og:url" content="{{ page_url }}">

--- a/docs/radio-protocol.md
+++ b/docs/radio-protocol.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Radio Protocol — Multi-Backend Architecture
 
 ## Overview


### PR DESCRIPTION
## Summary
- Adds per-page robots meta support in the MkDocs override.
- Marks low-level generated API detail pages and internal engineering notes as `noindex, follow`.
- Strengthens the docs homepage with operator-facing supported-radio/setup links and explains the indexing policy.

## Linear
Refs MOR-17

## Test plan
- `.venv/bin/python -m mkdocs build --strict --site-dir /tmp/rigplane-core-site-check`
- Verified generated robots meta:
  - `api/sync/index.html` -> `noindex, follow`
  - `internals/cli-design/index.html` -> `noindex, follow`
  - `guide/quickstart/index.html` -> `index, follow`
  - `api/public-api-surface/index.html` -> `index, follow`
  - `index.html` -> `index, follow`
