### PR TITLE
audio: expose TX stream write health

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -50,6 +50,30 @@ class AudioDeviceInfo:
         return self.supports_rx and self.supports_tx
 
 
+@dataclass(frozen=True, slots=True)
+class TxStreamHealth:
+    """Snapshot of writable stream queue and backend write health."""
+
+    queued_frames: int = 0
+    frames_queued: int = 0
+    frames_dropped: int = 0
+    write_attempts: int = 0
+    writes_completed: int = 0
+    write_failures: int = 0
+    last_error: str | None = None
+
+    def to_dict(self) -> dict[str, int | str | None]:
+        return {
+            "queued_frames": self.queued_frames,
+            "frames_queued": self.frames_queued,
+            "frames_dropped": self.frames_dropped,
+            "write_attempts": self.write_attempts,
+            "writes_completed": self.writes_completed,
+            "write_failures": self.write_failures,
+            "last_error": self.last_error,
+        }
+
+
 # ---------------------------------------------------------------------------
 # Stream protocols
 # ---------------------------------------------------------------------------
@@ -75,6 +99,9 @@ class TxStream(Protocol):
 
     @property
     def running(self) -> bool: ...
+
+    @property
+    def write_health(self) -> TxStreamHealth: ...
 
     async def start(self) -> None: ...
 
@@ -273,10 +300,27 @@ class _PortAudioTxStream:
         self._task: asyncio.Task[None] | None = None
         self._queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=64)
         self._dropped_frames: int = 0
+        self._frames_queued: int = 0
+        self._write_attempts: int = 0
+        self._writes_completed: int = 0
+        self._write_failures: int = 0
+        self._last_error: str | None = None
 
     @property
     def running(self) -> bool:
         return self._task is not None and not self._task.done()
+
+    @property
+    def write_health(self) -> TxStreamHealth:
+        return TxStreamHealth(
+            queued_frames=self._queue.qsize(),
+            frames_queued=self._frames_queued,
+            frames_dropped=self._dropped_frames,
+            write_attempts=self._write_attempts,
+            writes_completed=self._writes_completed,
+            write_failures=self._write_failures,
+            last_error=self._last_error,
+        )
 
     async def start(self) -> None:
         if self.running:
@@ -319,9 +363,15 @@ class _PortAudioTxStream:
 
     async def write(self, frame: bytes) -> None:
         if not self.running:
-            raise RuntimeError("TX stream is not running.")
+            detail = (
+                f" Last writer error: {self._last_error}."
+                if self._last_error is not None
+                else ""
+            )
+            raise RuntimeError(f"TX stream is not running.{detail}")
         try:
             self._queue.put_nowait(frame)
+            self._frames_queued += 1
             return
         except asyncio.QueueFull:
             pass
@@ -335,6 +385,7 @@ class _PortAudioTxStream:
             pass
         try:
             self._queue.put_nowait(frame)
+            self._frames_queued += 1
         except asyncio.QueueFull:
             pass
         self._dropped_frames += 1
@@ -351,12 +402,18 @@ class _PortAudioTxStream:
         try:
             while True:
                 pcm = await self._queue.get()
-                arr = np.frombuffer(pcm, dtype=np.int16).reshape(-1, channels)
-                await asyncio.to_thread(stream.write, arr)
+                self._write_attempts += 1
+                try:
+                    arr = np.frombuffer(pcm, dtype=np.int16).reshape(-1, channels)
+                    await asyncio.to_thread(stream.write, arr)
+                    self._writes_completed += 1
+                except Exception as exc:
+                    self._write_failures += 1
+                    self._last_error = f"{type(exc).__name__}: {exc}"
+                    logger.warning("portaudio-tx: loop failed", exc_info=True)
+                    break
         except asyncio.CancelledError:
             pass
-        except Exception:
-            logger.warning("portaudio-tx: loop failed", exc_info=True)
 
 
 class PortAudioBackend:
@@ -540,10 +597,24 @@ class FakeTxStream:
         self.stopped_count = 0
         self.written_frames: list[bytes] = []
         self.fail_on_write: OSError | None = None
+        self.write_failures = 0
+        self.last_error: str | None = None
 
     @property
     def running(self) -> bool:
         return self._running
+
+    @property
+    def write_health(self) -> TxStreamHealth:
+        return TxStreamHealth(
+            queued_frames=0,
+            frames_queued=len(self.written_frames),
+            frames_dropped=0,
+            write_attempts=len(self.written_frames) + self.write_failures,
+            writes_completed=len(self.written_frames),
+            write_failures=self.write_failures,
+            last_error=self.last_error,
+        )
 
     async def start(self) -> None:
         if self._running:
@@ -561,6 +632,8 @@ class FakeTxStream:
         exc = self.fail_on_write
         if exc is not None:
             self.fail_on_write = None
+            self.write_failures += 1
+            self.last_error = f"{type(exc).__name__}: {exc}"
             raise exc
         self.written_frames.append(frame)
 
@@ -654,4 +727,5 @@ __all__ = [
     "PortAudioBackend",
     "RxStream",
     "TxStream",
+    "TxStreamHealth",
 ]

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -17,6 +17,7 @@ from rigplane.audio.backend import (
     PortAudioBackend,
     RxStream,
     TxStream,
+    TxStreamHealth,
 )
 
 # ---------------------------------------------------------------------------
@@ -97,6 +98,9 @@ class TestProtocolConformance:
 
     def test_fake_tx_stream_is_tx_stream(self) -> None:
         assert isinstance(FakeTxStream(), TxStream)
+
+    def test_tx_stream_health_is_exported(self) -> None:
+        assert TxStreamHealth().to_dict()["write_failures"] == 0
 
     def test_portaudio_backend_is_audio_backend(self) -> None:
         # PortAudioBackend satisfies the protocol structurally (deps not needed here)
@@ -229,6 +233,28 @@ class TestFakeTxStreamLifecycle:
         await stream.write(b"\x00\x01")
         await stream.write(b"\x02\x03")
         assert stream.written_frames == [b"\x00\x01", b"\x02\x03"]
+        assert stream.write_health.frames_queued == 2
+        assert stream.write_health.write_attempts == 2
+        assert stream.write_health.writes_completed == 2
+
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_write_health_tracks_fake_write_failure(
+        self, fake_backend: FakeAudioBackend
+    ) -> None:
+        stream = fake_backend.open_tx(DUPLEX_DEVICE.id)
+        await stream.start()
+        stream.fail_on_write = OSError("backend write failed")
+
+        with pytest.raises(OSError, match="backend write failed"):
+            await stream.write(b"\x00\x01")
+
+        health = stream.write_health
+        assert health.write_attempts == 1
+        assert health.writes_completed == 0
+        assert health.write_failures == 1
+        assert health.last_error == "OSError: backend write failed"
 
         await stream.stop()
 
@@ -378,3 +404,53 @@ class TestPortAudioBackendDeps:
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
+
+    @pytest.mark.asyncio()
+    async def test_portaudio_tx_health_tracks_background_writer_failure(self) -> None:
+        class FakeArray:
+            def reshape(self, *args: object) -> "FakeArray":
+                return self
+
+        class FakeNp:
+            int16 = object()
+
+            @staticmethod
+            def frombuffer(pcm: bytes, *, dtype: object) -> FakeArray:
+                return FakeArray()
+
+        class FakeSd:
+            class OutputStream:
+                def __init__(self, **kw: object) -> None:
+                    pass
+
+                def start(self) -> None:
+                    pass
+
+                def stop(self) -> None:
+                    pass
+
+                def close(self) -> None:
+                    pass
+
+                def write(self, arr: object) -> None:
+                    raise OSError("AUHAL -10863")
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), FakeNp()))
+        stream = backend.open_tx(AudioDeviceId(0))
+
+        await stream.start()
+        await stream.write(b"\x00\x01")
+        for _ in range(20):
+            if stream.write_health.write_failures:
+                break
+            await asyncio.sleep(0.01)
+
+        health = stream.write_health
+        assert health.frames_queued == 1
+        assert health.write_attempts == 1
+        assert health.writes_completed == 0
+        assert health.write_failures == 1
+        assert health.last_error == "OSError: AUHAL -10863"
+        assert not stream.running
+
+        await stream.stop()


### PR DESCRIPTION
## Summary
- add a generic TxStreamHealth snapshot for writable audio streams
- track PortAudio queue depth, queued/drop counts, backend write attempts, completed writes, failures, and last writer error
- expose the same health shape on FakeTxStream for consumers and tests

## Tests
- uv run pytest tests/test_audio_backend.py
- uv run ruff check src/rigplane/audio/backend.py tests/test_audio_backend.py
- uv run mypy src/rigplane/audio/backend.py

## Boundary
Open-core candidate: this is generic audio backend observability and does not include product-specific BlackHole or WSJT-X guidance.