### PR TITLE
Coalesce small PortAudio playback writes

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -11,11 +11,18 @@ opening RX/TX audio streams, plus two concrete implementations:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import math
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, NewType, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
+
+_TX_QUEUE_SIZE = 64
+_TX_WRITE_CHUNK_MS = 20
+_TX_STOP_DRAIN_TIMEOUT_S = 1.0
 
 # ---------------------------------------------------------------------------
 # Identifiers & descriptors
@@ -60,9 +67,13 @@ class TxStreamHealth:
     write_attempts: int = 0
     writes_completed: int = 0
     write_failures: int = 0
+    queued_audio_ms: float = 0.0
+    written_audio_ms: float = 0.0
+    dropped_audio_ms: float = 0.0
+    write_calls_per_sec_ewma: float | None = None
     last_error: str | None = None
 
-    def to_dict(self) -> dict[str, int | str | None]:
+    def to_dict(self) -> dict[str, int | float | str | None]:
         return {
             "queued_frames": self.queued_frames,
             "frames_queued": self.frames_queued,
@@ -70,6 +81,10 @@ class TxStreamHealth:
             "write_attempts": self.write_attempts,
             "writes_completed": self.writes_completed,
             "write_failures": self.write_failures,
+            "queued_audio_ms": self.queued_audio_ms,
+            "written_audio_ms": self.written_audio_ms,
+            "dropped_audio_ms": self.dropped_audio_ms,
+            "write_calls_per_sec_ewma": self.write_calls_per_sec_ewma,
             "last_error": self.last_error,
         }
 
@@ -298,12 +313,18 @@ class _PortAudioTxStream:
         self._blocksize = blocksize
         self._stream: Any = None
         self._task: asyncio.Task[None] | None = None
-        self._queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=64)
+        self._queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=_TX_QUEUE_SIZE)
         self._dropped_frames: int = 0
         self._frames_queued: int = 0
         self._write_attempts: int = 0
         self._writes_completed: int = 0
         self._write_failures: int = 0
+        self._queued_audio_ms: float = 0.0
+        self._written_audio_ms: float = 0.0
+        self._dropped_audio_ms: float = 0.0
+        self._write_calls_per_sec_ewma: float | None = None
+        self._last_write_rate_at: float | None = None
+        self._last_write_rate_total: int = 0
         self._last_error: str | None = None
 
     @property
@@ -319,6 +340,14 @@ class _PortAudioTxStream:
             write_attempts=self._write_attempts,
             writes_completed=self._writes_completed,
             write_failures=self._write_failures,
+            queued_audio_ms=round(self._queued_audio_ms, 3),
+            written_audio_ms=round(self._written_audio_ms, 3),
+            dropped_audio_ms=round(self._dropped_audio_ms, 3),
+            write_calls_per_sec_ewma=(
+                round(self._write_calls_per_sec_ewma, 3)
+                if self._write_calls_per_sec_ewma is not None
+                else None
+            ),
             last_error=self._last_error,
         )
 
@@ -334,7 +363,7 @@ class _PortAudioTxStream:
             latency="low",
         )
         self._stream.start()
-        self._queue = asyncio.Queue(maxsize=64)
+        self._queue = asyncio.Queue(maxsize=_TX_QUEUE_SIZE)
         self._task = asyncio.create_task(self._loop(), name="portaudio-tx")
 
     async def stop(self) -> None:
@@ -342,24 +371,22 @@ class _PortAudioTxStream:
         task = self._task
         self._stream = None
         self._task = None
-        self._queue = asyncio.Queue(maxsize=64)
-        # Close stream FIRST — unblocks executor thread stuck in stream.write()
-        if stream is not None:
-            try:
-                stream.stop()
-            except Exception:
-                logger.debug("portaudio-tx: stream stop failed", exc_info=True)
-            try:
-                stream.close()
-            except Exception:
-                logger.debug("portaudio-tx: stream close failed", exc_info=True)
-        # Now cancel the task (thread is already unblocked)
+
+        if task is not None and not task.done():
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(self._queue.put(None), timeout=0.2)
+                await asyncio.wait_for(task, timeout=_TX_STOP_DRAIN_TIMEOUT_S)
+
+        # Close the stream after the normal drain path; if the writer is still
+        # blocked, closing it before cancellation unblocks the executor thread.
+        self._close_stream(stream)
         if task is not None and not task.done():
             task.cancel()
             try:
                 await task
             except asyncio.CancelledError:
                 pass
+        self._queue = asyncio.Queue(maxsize=_TX_QUEUE_SIZE)
 
     async def write(self, frame: bytes) -> None:
         if not self.running:
@@ -372,6 +399,7 @@ class _PortAudioTxStream:
         try:
             self._queue.put_nowait(frame)
             self._frames_queued += 1
+            self._queued_audio_ms += self._audio_ms_for_bytes(len(frame))
             return
         except asyncio.QueueFull:
             pass
@@ -380,12 +408,15 @@ class _PortAudioTxStream:
         # receive and turns a brief CoreAudio stall into seconds of stale audio.
         # Keep latency bounded by dropping the oldest queued frame.
         try:
-            self._queue.get_nowait()
+            dropped = self._queue.get_nowait()
+            if dropped is not None:
+                self._dropped_audio_ms += self._audio_ms_for_bytes(len(dropped))
         except asyncio.QueueEmpty:
             pass
         try:
             self._queue.put_nowait(frame)
             self._frames_queued += 1
+            self._queued_audio_ms += self._audio_ms_for_bytes(len(frame))
         except asyncio.QueueFull:
             pass
         self._dropped_frames += 1
@@ -402,11 +433,16 @@ class _PortAudioTxStream:
         try:
             while True:
                 pcm = await self._queue.get()
+                if pcm is None:
+                    break
+                pcm = self._coalesce_ready_pcm(pcm)
                 self._write_attempts += 1
                 try:
                     arr = np.frombuffer(pcm, dtype=np.int16).reshape(-1, channels)
                     await asyncio.to_thread(stream.write, arr)
                     self._writes_completed += 1
+                    self._written_audio_ms += self._audio_ms_for_bytes(len(pcm))
+                    self._track_write_rate()
                 except Exception as exc:
                     self._write_failures += 1
                     self._last_error = f"{type(exc).__name__}: {exc}"
@@ -414,6 +450,69 @@ class _PortAudioTxStream:
                     break
         except asyncio.CancelledError:
             pass
+
+    def _coalesce_ready_pcm(self, first: bytes) -> bytes:
+        target_bytes = self._target_write_bytes()
+        if len(first) >= target_bytes:
+            return first
+
+        parts = [first]
+        total = len(first)
+        while total < target_bytes:
+            try:
+                next_pcm = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if next_pcm is None:
+                self._queue.put_nowait(None)
+                break
+            parts.append(next_pcm)
+            total += len(next_pcm)
+        return b"".join(parts)
+
+    def _target_write_bytes(self) -> int:
+        target_frames = (
+            self._blocksize
+            if self._blocksize > 0
+            else (self._sample_rate * _TX_WRITE_CHUNK_MS) // 1000
+        )
+        return max(1, target_frames) * self._channels * 2
+
+    def _audio_ms_for_bytes(self, byte_count: int) -> float:
+        bytes_per_frame = max(1, self._channels * 2)
+        frames = byte_count // bytes_per_frame
+        return (frames / self._sample_rate) * 1000.0
+
+    def _track_write_rate(self) -> None:
+        observed_at = time.monotonic()
+        if self._last_write_rate_at is None:
+            self._last_write_rate_at = observed_at
+            self._last_write_rate_total = self._writes_completed
+            self._write_calls_per_sec_ewma = 0.0
+            return
+
+        dt = observed_at - self._last_write_rate_at
+        if dt <= 0:
+            return
+        delta = self._writes_completed - self._last_write_rate_total
+        instant_rate = delta / dt
+        alpha = 1.0 - math.exp(-dt / 5.0)
+        previous = self._write_calls_per_sec_ewma or 0.0
+        self._write_calls_per_sec_ewma = previous + alpha * (instant_rate - previous)
+        self._last_write_rate_at = observed_at
+        self._last_write_rate_total = self._writes_completed
+
+    def _close_stream(self, stream: Any) -> None:
+        if stream is None:
+            return
+        try:
+            stream.stop()
+        except Exception:
+            logger.debug("portaudio-tx: stream stop failed", exc_info=True)
+        try:
+            stream.close()
+        except Exception:
+            logger.debug("portaudio-tx: stream close failed", exc_info=True)
 
 
 class PortAudioBackend:

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -101,6 +101,7 @@ class TestProtocolConformance:
 
     def test_tx_stream_health_is_exported(self) -> None:
         assert TxStreamHealth().to_dict()["write_failures"] == 0
+        assert TxStreamHealth().to_dict()["written_audio_ms"] == 0.0
 
     def test_portaudio_backend_is_audio_backend(self) -> None:
         # PortAudioBackend satisfies the protocol structurally (deps not needed here)
@@ -400,10 +401,117 @@ class TestPortAudioBackendDeps:
         try:
             await asyncio.wait_for(stream.write(b"new"), timeout=0.1)
             assert stream._queue.get_nowait() == b"new"  # type: ignore[attr-defined]
+            assert stream.write_health.frames_dropped == 1
         finally:
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
+
+    @pytest.mark.asyncio()
+    async def test_portaudio_tx_coalesces_small_frames_into_20ms_writes(self) -> None:
+        class FakeArray:
+            def __init__(self, pcm: bytes) -> None:
+                self.pcm = pcm
+
+            def reshape(self, *args: object) -> "FakeArray":
+                return self
+
+        class FakeNp:
+            int16 = object()
+
+            @staticmethod
+            def frombuffer(pcm: bytes, *, dtype: object) -> FakeArray:
+                return FakeArray(pcm)
+
+        class FakeOutputStream:
+            def __init__(self) -> None:
+                self.writes: list[bytes] = []
+
+            def write(self, arr: FakeArray) -> None:
+                self.writes.append(arr.pcm)
+
+        class FakeSd:
+            class OutputStream:
+                def __init__(self, **kw: object) -> None:
+                    pass
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), FakeNp()))
+        stream = backend.open_tx(AudioDeviceId(0), sample_rate=48_000, channels=16, frame_ms=0)
+        output = FakeOutputStream()
+        stream._stream = output  # type: ignore[attr-defined]
+        stream._task = asyncio.current_task()  # type: ignore[attr-defined]
+        stream._queue = asyncio.Queue(maxsize=200)  # type: ignore[attr-defined]
+
+        frame_bytes = 320 * 16 * 2
+        frames = [bytes([idx % 256]) * frame_bytes for idx in range(150)]
+        for frame in frames:
+            await stream.write(frame)
+        stream._queue.put_nowait(None)  # type: ignore[attr-defined]
+
+        await stream._loop()  # type: ignore[attr-defined]
+
+        assert b"".join(output.writes) == b"".join(frames)
+        assert len(output.writes) == 50
+        assert {len(write) for write in output.writes} == {960 * 16 * 2}
+
+        health = stream.write_health
+        assert health.frames_queued == 150
+        assert health.frames_dropped == 0
+        assert health.write_attempts == 50
+        assert health.writes_completed == 50
+        assert health.queued_audio_ms == pytest.approx(1000.0)
+        assert health.written_audio_ms == pytest.approx(1000.0)
+        assert health.dropped_audio_ms == 0.0
+        assert health.write_calls_per_sec_ewma is not None
+
+    @pytest.mark.asyncio()
+    async def test_portaudio_tx_flushes_partial_coalesced_chunk_on_stop_signal(self) -> None:
+        class FakeArray:
+            def __init__(self, pcm: bytes) -> None:
+                self.pcm = pcm
+
+            def reshape(self, *args: object) -> "FakeArray":
+                return self
+
+        class FakeNp:
+            int16 = object()
+
+            @staticmethod
+            def frombuffer(pcm: bytes, *, dtype: object) -> FakeArray:
+                return FakeArray(pcm)
+
+        class FakeOutputStream:
+            def __init__(self) -> None:
+                self.writes: list[bytes] = []
+
+            def write(self, arr: FakeArray) -> None:
+                self.writes.append(arr.pcm)
+
+        class FakeSd:
+            class OutputStream:
+                def __init__(self, **kw: object) -> None:
+                    pass
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), FakeNp()))
+        stream = backend.open_tx(AudioDeviceId(0), sample_rate=48_000, channels=2, frame_ms=0)
+        output = FakeOutputStream()
+        stream._stream = output  # type: ignore[attr-defined]
+        stream._task = asyncio.current_task()  # type: ignore[attr-defined]
+
+        frame_a = b"a" * (320 * 2 * 2)
+        frame_b = b"b" * (320 * 2 * 2)
+        await stream.write(frame_a)
+        await stream.write(frame_b)
+        stream._queue.put_nowait(None)  # type: ignore[attr-defined]
+
+        await stream._loop()  # type: ignore[attr-defined]
+
+        assert output.writes == [frame_a + frame_b]
+        health = stream.write_health
+        assert health.write_attempts == 1
+        assert health.writes_completed == 1
+        assert health.written_audio_ms == pytest.approx(13.333, rel=1e-3)
+        assert health.write_calls_per_sec_ewma == 0.0
 
     @pytest.mark.asyncio()
     async def test_portaudio_tx_health_tracks_background_writer_failure(self) -> None:

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -436,7 +436,9 @@ class TestPortAudioBackendDeps:
                     pass
 
         backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), FakeNp()))
-        stream = backend.open_tx(AudioDeviceId(0), sample_rate=48_000, channels=16, frame_ms=0)
+        stream = backend.open_tx(
+            AudioDeviceId(0), sample_rate=48_000, channels=16, frame_ms=0
+        )
         output = FakeOutputStream()
         stream._stream = output  # type: ignore[attr-defined]
         stream._task = asyncio.current_task()  # type: ignore[attr-defined]
@@ -465,7 +467,9 @@ class TestPortAudioBackendDeps:
         assert health.write_calls_per_sec_ewma is not None
 
     @pytest.mark.asyncio()
-    async def test_portaudio_tx_flushes_partial_coalesced_chunk_on_stop_signal(self) -> None:
+    async def test_portaudio_tx_flushes_partial_coalesced_chunk_on_stop_signal(
+        self,
+    ) -> None:
         class FakeArray:
             def __init__(self, pcm: bytes) -> None:
                 self.pcm = pcm
@@ -493,7 +497,9 @@ class TestPortAudioBackendDeps:
                     pass
 
         backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), FakeNp()))
-        stream = backend.open_tx(AudioDeviceId(0), sample_rate=48_000, channels=2, frame_ms=0)
+        stream = backend.open_tx(
+            AudioDeviceId(0), sample_rate=48_000, channels=2, frame_ms=0
+        )
         output = FakeOutputStream()
         stream._stream = output  # type: ignore[attr-defined]
         stream._task = asyncio.current_task()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- coalesce queued PCM playback frames into bounded ~20 ms PortAudio writes when callers use host-optimal blocksize (`frame_ms=0`)
- preserve source-frame accounting while making `write_attempts`/`writes_completed` represent actual backend write calls
- add audio-duration and write-rate health counters so downstream diagnostics can distinguish source frames, backend writes, stale drops, and written/dropped audio duration

Closes #1554.
Refs rigplane/rigplane-pro#955.

## Tests

- `uv run pytest tests/test_audio_backend.py -q --tb=short`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`
- `uv run ruff check src/ tests/`

## Boundary

Open-core: generic audio backend queue/write behavior and diagnostics only. No Pro-specific WSJT-X or BlackHole policy is included.
