### PR TITLE
Increase PortAudio playback write chunk for loopback throughput

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, NewType, Protocol, runtime_checkable
 logger = logging.getLogger(__name__)
 
 _TX_QUEUE_SIZE = 64
-_TX_WRITE_CHUNK_MS = 20
+_TX_WRITE_CHUNK_MS = 80
 _TX_STOP_DRAIN_TIMEOUT_S = 1.0
 
 # ---------------------------------------------------------------------------

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -408,7 +408,7 @@ class TestPortAudioBackendDeps:
                 await task
 
     @pytest.mark.asyncio()
-    async def test_portaudio_tx_coalesces_small_frames_into_20ms_writes(self) -> None:
+    async def test_portaudio_tx_coalesces_small_frames_into_80ms_writes(self) -> None:
         class FakeArray:
             def __init__(self, pcm: bytes) -> None:
                 self.pcm = pcm
@@ -453,14 +453,16 @@ class TestPortAudioBackendDeps:
         await stream._loop()  # type: ignore[attr-defined]
 
         assert b"".join(output.writes) == b"".join(frames)
-        assert len(output.writes) == 50
-        assert {len(write) for write in output.writes} == {960 * 16 * 2}
+        assert len(output.writes) == 13
+        assert [len(write) for write in output.writes] == [3840 * 16 * 2] * 12 + [
+            1920 * 16 * 2
+        ]
 
         health = stream.write_health
         assert health.frames_queued == 150
         assert health.frames_dropped == 0
-        assert health.write_attempts == 50
-        assert health.writes_completed == 50
+        assert health.write_attempts == 13
+        assert health.writes_completed == 13
         assert health.queued_audio_ms == pytest.approx(1000.0)
         assert health.written_audio_ms == pytest.approx(1000.0)
         assert health.dropped_audio_ms == 0.0


### PR DESCRIPTION
## Summary

- increase host-optimal PortAudio playback coalescing from 20 ms to 80 ms chunks
- update representative 150 fps / 16-channel playback test to prove one second of input is written as 13 backend calls instead of 50
- keep sample order, sample count, channel count, and duration unchanged

Closes #1556.
Refs rigplane/rigplane-pro#955.

## Evidence

Post-merge live validation of the 20 ms chunk fix still wrote only about 0.87 seconds of audio per wall-clock second: ~149.8 source frames/sec, ~43.35 backend writes/sec, and ~20.19 stale source-frame drops/sec, with no sequence gaps or write failures. Larger bounded chunks directly target the remaining per-write throughput bottleneck while preserving the existing diagnostics.

## Tests

- `uv run pytest tests/test_audio_backend.py -q --tb=short`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

## Boundary

Open-core: generic PortAudio playback batching only. No Pro-specific WSJT-X or BlackHole policy is included.

## Live validation requested

Rebuild the Pro app with this core head, launch via the bundled `.app`, then sample `/api/local/v1/status` for 30s. Expected diagnostic movement: `write_calls_per_sec_ewma` near ~12-13 calls/sec for live 150 fps input, `written_audio_ms` advancing near realtime, and `frames_dropped` stable during steady RX.
