### PR TITLE
[codex] Public-proof PortAudio callback comments

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -311,9 +311,9 @@ class _PortAudioRxStream:
 class _PortAudioTxStream:
     """TxStream backed by a sounddevice OutputStream callback.
 
-    The bounded callback ring decouples async producers from PortAudio for
-    consumers like WSJT-X/BlackHole (#955): ``write()`` enqueues interleaved
-    PCM and returns quickly, and the PortAudio callback is the playback clock.
+    The bounded callback ring decouples async producers from PortAudio's
+    hardware-clocked consumer: ``write()`` enqueues interleaved PCM and returns
+    quickly, and the callback drains the ring at the playback cadence.
     """
 
     def __init__(
@@ -433,7 +433,7 @@ class _PortAudioTxStream:
 
         # Keep producer writes cheap: enqueue bytes into the bounded ring and
         # let the callback clock playback. On overflow, discard oldest queued
-        # audio first so latency cannot grow without bound (#955).
+        # audio first so latency cannot grow without bound.
         incoming_drop_bytes = 0
         if len(data) > self._capacity_bytes:
             incoming_drop_bytes = self._align_byte_count(
@@ -491,7 +491,8 @@ class _PortAudioTxStream:
         self._record_callback_attempt(status)
         try:
             # Callback hot path: no logging or I/O. Copy from the ring; if the
-            # producer falls behind, fill the remainder with silence (#955).
+            # producer falls behind, fill the remainder with silence and record
+            # an underrun.
             dest = memoryview(outdata).cast("B")
             if len(dest) != byte_count:
                 raise ValueError(


### PR DESCRIPTION
## Summary
- Remove private/pro-specific issue and WSJT-X/BlackHole references from PortAudio TX comments.
- Preserve the generic callback-ring rationale: quick enqueue, hardware-clocked playback, bounded overflow handling, small callback hot path, and underrun silence behavior.

## Boundary
- Public/open-core hygiene only.
- No behavior change and no changelog update.
- No linked issue: explicit architecture-audit hygiene task from chat.

## Validation
- `uv run ruff check src/rigplane/audio/backend.py`
- `uv run pytest tests/test_audio_backend.py -q --tb=short`
- `git diff --check`