### PR TITLE
fix(#1572): recover from LAN data-port cooldown

### DIFF
--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -45,6 +45,10 @@ _STEREO_CODECS = (
 )
 
 
+class _DataPortDiscoveryCooldown(Exception):
+    """Recoverable startup failure after control auth advertised a CI-V port."""
+
+
 def _is_address_in_use(exc: OSError) -> bool:
     return exc.errno == errno.EADDRINUSE or "Address already in use" in str(exc)
 
@@ -70,6 +74,7 @@ class ControlPhaseRuntime:
     _WATCHDOG_HEALTH_LOG_INTERVAL = 30.0
     _STATUS_RETRY_PAUSE = 10.0
     _STATUS_REJECT_COOLDOWN = 30.0
+    _DATA_PORT_COOLDOWN_RETRIES = 3
 
     def __init__(self, host: ControlPhaseHost) -> None:
         self._host = host
@@ -108,6 +113,36 @@ class ControlPhaseRuntime:
     async def connect(self) -> None:
         """Open connection to the radio and authenticate."""
         h = self._host
+        max_attempts = self._DATA_PORT_COOLDOWN_RETRIES + 1
+        for attempt in range(1, max_attempts + 1):
+            try:
+                await self._connect_once()
+                return
+            except _DataPortDiscoveryCooldown as exc:
+                if attempt >= max_attempts:
+                    raise ConnectionError(
+                        "CI-V data-port discovery timed out after successful "
+                        "control auth/status; the radio may still be releasing "
+                        "a previous LAN session. Wait 30-60s and retry."
+                    ) from exc
+                retry_pause = self._status_retry_pause()
+                logger.warning(
+                    "CI-V data-port discovery timed out after successful control "
+                    "auth/status; treating as session cooldown "
+                    "(host=%s, control=%d, civ=%d, attempt=%d/%d). "
+                    "Retrying after %.0fs.",
+                    h._host,
+                    h._port,
+                    h._civ_port,
+                    attempt,
+                    max_attempts,
+                    retry_pause,
+                )
+                await asyncio.sleep(retry_pause)
+
+    async def _connect_once(self) -> None:
+        """Open connection to the radio and authenticate."""
+        h = self._host
         h._conn_state = RadioConnectionState.CONNECTING
         h._civ_stream_ready = False
         h._civ_recovering = False
@@ -133,9 +168,19 @@ class ControlPhaseRuntime:
                     local_host=local_bind_host,
                 )
         except OSError as exc:
+            logger.warning(
+                "Radio host/control UDP open failed: %s:%d: %s", h._host, h._port, exc
+            )
             raise ConnectionError(
                 f"Failed to connect to {h._host}:{h._port}: {exc}"
             ) from exc
+        except TimeoutError as exc:
+            logger.warning(
+                "Control discovery failed before auth: %s:%d: %s", h._host, h._port, exc
+            )
+            await h._ctrl_transport.disconnect()
+            h._conn_state = RadioConnectionState.DISCONNECTED
+            raise
 
         h._ctrl_transport.start_ping_loop()
         h._ctrl_transport.start_retransmit_loop()
@@ -154,6 +199,9 @@ class ControlPhaseRuntime:
         )
         auth = parse_auth_response(resp_data)
         if not auth.success:
+            logger.warning(
+                "Control auth failed: %s:%d error=0x%08X", h._host, h._port, auth.error
+            )
             raise AuthenticationError(
                 f"Authentication failed (error=0x{auth.error:08X})"
             )
@@ -338,6 +386,18 @@ class ControlPhaseRuntime:
             raise ConnectionError(
                 f"Failed to connect CI-V port {h._civ_port}: {exc}"
             ) from exc
+        except TimeoutError as exc:
+            logger.warning(
+                "CI-V data-port discovery timeout after control auth/status "
+                "(host=%s, control=%d, civ=%d, audio=%d): %s",
+                h._host,
+                h._port,
+                h._civ_port,
+                h._audio_port,
+                exc,
+            )
+            await self._cleanup_data_port_discovery_timeout()
+            raise _DataPortDiscoveryCooldown() from exc
         except Exception:
             # asyncio consumed civ_sock — don't double-close it.
             h._civ_sock_pending = None
@@ -400,6 +460,33 @@ class ControlPhaseRuntime:
             h._port,
             h._civ_port,
         )
+
+    async def _cleanup_data_port_discovery_timeout(self) -> None:
+        """Release startup resources after data-port discovery times out."""
+        h = self._host
+        # Timeout happens after asyncio has consumed civ_sock; the datagram
+        # transport owns closing it.  The audio socket has not been consumed.
+        h._civ_sock_pending = None
+        self._close_pending_sockets()
+        if h._civ_transport is not None:
+            try:
+                await h._civ_transport.disconnect()
+            except Exception:
+                logger.debug(
+                    "data-port cooldown cleanup: civ disconnect failed",
+                    exc_info=True,
+                )
+            h._civ_transport = None
+        try:
+            await h._ctrl_transport.disconnect()
+        except Exception:
+            logger.debug(
+                "data-port cooldown cleanup: control disconnect failed",
+                exc_info=True,
+            )
+        h._conn_state = RadioConnectionState.DISCONNECTED
+        h._civ_stream_ready = False
+        h._civ_recovering = False
 
     async def disconnect(self) -> None:
         """Cleanly disconnect from the radio."""

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -35,6 +35,8 @@ class ConnectMockTransport(MockTransport):
     def __init__(self) -> None:
         super().__init__()
         self.state = ConnectionState.DISCONNECTED
+        self.connect_count = 0
+        self.disconnect_count = 0
 
     async def connect(
         self,
@@ -45,6 +47,7 @@ class ConnectMockTransport(MockTransport):
         local_port: int = 0,
         sock: "object | None" = None,
     ) -> None:
+        self.connect_count += 1
         self.connected = True
         self.state = ConnectionState.CONNECTING
         self.connect_args = {
@@ -53,6 +56,10 @@ class ConnectMockTransport(MockTransport):
             "local_host": local_host,
             "local_port": local_port,
         }
+
+    async def disconnect(self) -> None:
+        self.disconnect_count += 1
+        await super().disconnect()
 
     async def reconnect(
         self,
@@ -533,6 +540,105 @@ class TestConnectSessionRejection:
         assert mt.disconnected is True
 
     @pytest.mark.asyncio
+    async def test_data_port_discovery_timeout_retries_and_closes_pending_sockets(
+        self,
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", username="u", password="p")
+        mt = ConnectMockTransport()
+        radio._ctrl_transport = mt
+
+        class TimeoutCivTransport(ConnectMockTransport):
+            async def connect(
+                self,
+                host: str,
+                port: int,
+                *,
+                local_host: str | None = None,
+                local_port: int = 0,
+                sock: object | None = None,
+            ) -> None:
+                await super().connect(
+                    host,
+                    port,
+                    local_host=local_host,
+                    local_port=local_port,
+                    sock=sock,
+                )
+                raise TimeoutError(
+                    "Radio did not respond to discovery after 10 attempts"
+                )
+
+        first_civ_sock = _FakeSocket(("192.168.2.194", 50002))
+        first_audio_sock = _FakeSocket(("192.168.2.194", 50003))
+        second_civ_sock = _FakeSocket(("192.168.2.194", 50004))
+        second_audio_sock = _FakeSocket(("192.168.2.194", 50005))
+        timeout_civ_transport = TimeoutCivTransport()
+        success_civ_transport = ConnectMockTransport()
+
+        with (
+            patch.object(
+                radio._control_phase,
+                "_resolve_local_bind_host",
+                return_value="192.168.2.194",
+            ),
+            patch(
+                "rigplane._control_phase._socket.socket",
+                side_effect=[
+                    first_civ_sock,
+                    first_audio_sock,
+                    second_civ_sock,
+                    second_audio_sock,
+                ],
+            ),
+            patch.object(
+                radio._control_phase,
+                "_status_retry_pause",
+                return_value=0.0,
+            ),
+            patch.object(
+                radio._control_phase,
+                "_wait_for_packet",
+                new=AsyncMock(return_value=_build_login_response()),
+            ),
+            patch.object(
+                radio._control_phase,
+                "_receive_guid",
+                new=AsyncMock(return_value=b"\x00" * 16),
+            ),
+            patch.object(
+                radio._control_phase,
+                "_receive_civ_port",
+                new=AsyncMock(side_effect=[50002, 50002]),
+            ),
+            patch.object(radio._control_phase, "_start_token_renewal"),
+            patch.object(radio._control_phase, "_start_watchdog"),
+            patch.object(radio._civ_runtime, "start_pump"),
+            patch.object(radio._civ_runtime, "start_data_watchdog"),
+            patch.object(radio._civ_runtime, "start_worker"),
+            patch(
+                "rigplane.transport.IcomTransport",
+                side_effect=[timeout_civ_transport, success_civ_transport],
+            ),
+            patch(
+                "rigplane.runtime._control_phase.wait_for_radio_startup_ready",
+                new=AsyncMock(),
+            ),
+            patch("rigplane._control_phase.asyncio.sleep", new=AsyncMock()),
+        ):
+            await radio._control_phase.connect()
+
+        assert mt.connect_count == 2
+        assert mt.disconnect_count == 1
+        assert timeout_civ_transport.disconnect_count == 1
+        assert first_civ_sock.close_count == 0
+        assert first_audio_sock.close_count == 1
+        assert second_civ_sock.close_count == 0
+        assert second_audio_sock.close_count == 0
+        assert radio._civ_transport is success_civ_transport
+        assert radio._civ_sock_pending is None
+        assert radio._audio_sock_pending is second_audio_sock
+
+    @pytest.mark.asyncio
     async def test_stereo_codec_fallback_succeeds(self) -> None:
         """Stereo rx_codec + 0xFFFFFFFF → retry with mono → connection succeeds."""
         radio = IcomRadio(
@@ -930,6 +1036,7 @@ class _FakeSocket:
         self.sockname = sockname
         self.bound: tuple[str, int] | None = None
         self.connected: tuple[str, int] | None = None
+        self.close_count = 0
 
     def connect(self, addr: tuple[str, int]) -> None:
         self.connected = addr
@@ -941,7 +1048,7 @@ class _FakeSocket:
         return self.sockname
 
     def close(self) -> None:
-        return None
+        self.close_count += 1
 
 
 class TestWifiBindBehavior:


### PR DESCRIPTION
## Summary
- Treat CI-V data-port discovery timeout after successful control auth/status as a recoverable Icom LAN session cooldown condition.
- Clean up pending sockets/transports before retrying startup, while preserving the existing civ_port=0/error=0xFFFFFFFF cooldown handling.
- Add focused mocked control-runtime coverage for retry and pending socket cleanup.

Closes #1572

## Tests
- uv run pytest tests/test_radio_connect.py -q --tb=short
- uv run pytest tests/ -q --tb=short
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/

## Manual validation
- Required after merge or on a hardware/VPN setup: restart the managed Pro app with explicit host 192.168.55.40 and verify startup reaches ready after the radio releases the previous LAN session.