### PR TITLE
Add Cloudflare Web Analytics snippet

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -29,4 +29,7 @@
   {% else %}
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":{{ page_title | tojson }},"description":{{ page_description | tojson }},"url":{{ page_url | tojson }},"mainEntityOfPage":{{ page_url | tojson }},"image":{{ image_url | tojson }},"inLanguage":"en","author":{"@type":"Organization","name":"RigPlane","url":"https://rigplane.com/"},"publisher":{"@type":"Organization","name":"RigPlane","url":"https://rigplane.com/"}}</script>
   {% endif %}
+  <!-- Cloudflare Web Analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "70f1b2c2b3cd474fb47c1407cd8313b6"}'></script>
+  <!-- End Cloudflare Web Analytics -->
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add Cloudflare Web Analytics beacon to the MkDocs Material `extrahead` override.
- Keeps the snippet site-wide through the existing `docs/overrides/main.html` template.

## Test Plan
- `uv run mkdocs build --strict`
- Verified generated HTML contains `static.cloudflareinsights.com/beacon.min.js` and `data-cf-beacon`.

## DNS note
- Namecheap custom nameservers have been updated to Cloudflare: `hank.ns.cloudflare.com`, `roxy.ns.cloudflare.com`.
