### PR TITLE
Align docs with Hamlib provider strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,12 @@
 > [rigplane.dev/migrate](https://rigplane.dev/migrate).
 
 **rigplane** is a multi-vendor radio control library and Web UI — Python
-asyncio core plus a self-contained browser front-end. It speaks Icom CI-V
-(LAN UDP and USB), Yaesu CAT, and Kenwood-style CAT, with stable backends
-for IC-7610, IC-7300, and Yaesu FTX-1, and profile-based support for IC-705,
-IC-9700, Xiegu X6100, and Lab599 TX-500. Direct connection to your radio:
-no wfview, no hamlib daemon, no RS-BA1. A capability-driven runtime renders
-the same Web UI and `rigctld`-compatible network bridge across every backend
-that honours the public `Radio` protocol. Tested in production against
-WSJT-X, fldigi, and JS8Call.
+asyncio core plus a self-contained browser front-end. It has native providers
+for rich Icom CI-V and Yaesu CAT paths, and is moving long-tail serial CAT
+coverage toward a Hamlib-backed provider with assisted discovery. A
+capability-driven runtime renders the same Web UI and `rigctld`-compatible
+network bridge across every backend that honours the public `Radio` protocol.
+Tested in production against WSJT-X, fldigi, and JS8Call.
 
 <p align="center">
   <img src="docs/screenshots/hero.png" alt="rigplane Web UI — IC-7610 dual-RX desktop with scope and waterfall" width="100%">
@@ -63,13 +61,13 @@ Full guides: [getting started](https://rigplane.dev/guide/quickstart/),
 | **Yaesu FTX-1**    | USB CAT            | Stable              | 17 modes, VHF/UHF, C4FM, audio FFT scope |
 | Icom IC-705        | LAN (WiFi)         | Community-validated | CI-V `0xA4`                            |
 | Icom IC-9700       | LAN, USB CI-V      | Profile only        | VHF/UHF/SHF                            |
-| Xiegu X6100        | USB CI-V           | Profile only        | IC-705 compatible, QRP                 |
-| Lab599 TX-500      | USB Kenwood CAT    | Profile only        | QRP, minimal CAT                       |
+| Xiegu X6100        | USB CI-V / Hamlib candidate | Profile only / assisted discovery planned | IC-705 compatible, QRP |
+| Lab599 TX-500      | USB Kenwood CAT / Hamlib candidate | Profile only / assisted discovery planned | QRP, minimal CAT |
 
-Radio capabilities are declared in `rigs/*.toml` — adding a new model is
-typically a profile change, not Python code. Three protocol families are
-supported: CI-V (Icom binary), Kenwood CAT (text), Yaesu CAT (text). See
-[adding a new radio](https://rigplane.dev/guide/rig-profiles/).
+Native radio capabilities are declared in `rigs/*.toml`. For long-tail serial
+CAT radios, the intended path is Hamlib-backed control underneath RigPlane's
+capability model, with structured discovery candidates and safe read-only
+probing where possible. See [adding a new radio](https://rigplane.dev/guide/rig-profiles/).
 
 ## Why 1.0
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -2,11 +2,17 @@
 
 ## Goal
 
-Create a Python library for direct control of Icom transceivers with a shared radio core:
-- LAN backend (UDP, native Icom protocol)
-- serial backend (USB CI-V + exported USB audio devices, in progress)
+Create a Python library for direct control of transceivers through a shared
+radio core:
+- native Icom LAN backend (UDP, native Icom protocol)
+- native Icom serial backend (USB CI-V + exported USB audio devices)
+- native Yaesu CAT paths where RigPlane can provide richer state, audio, or diagnostics
+- Hamlib-backed provider path for broader long-tail serial CAT coverage
 
-No intermediary software (wfview, RS-BA1, hamlib) is required for supported paths.
+RigPlane owns the public UX, state model, audio path, diagnostics, and
+`rigctld`-compatible client surface. Native providers stay direct where that is
+valuable; long-tail CAT coverage can use Hamlib underneath RigPlane's provider
+boundary.
 
 ### Objectives
 - Connect to Icom over network (authentication, keep-alive)
@@ -14,11 +20,11 @@ No intermediary software (wfview, RS-BA1, hamlib) is required for supported path
 - Receive/transmit audio stream (PCM default, Opus optional)
 - Simple Pythonic API (sync + async)
 - Keep one `Radio` contract for API/CLI/Web/rigctld consumers
-- Support IC-7610 first, then expand to other models/families via backend/profile architecture
+- Support IC-7610 first, then expand to other models/families via provider/profile architecture
 
 ### Non-goals (for now)
 - Full wfview replacement
-- Non-IC-7610 serial expansion before IC-7610 USB MVP is stable
+- Leaking Hamlib model IDs, command names, or raw error semantics into the Web UI/API
 - Cross-platform USB/audio polish beyond macOS-first rollout
 
 ## Architecture

--- a/docs/api/rig-loader.md
+++ b/docs/api/rig-loader.md
@@ -228,5 +228,5 @@ Unknown sections or extra fields are silently ignored (forward-compatible).
 
 ## See Also
 
-- [`docs/guide/rig-profiles.md`](../guide/rig-profiles.md) — complete TOML schema reference and guide for adding new radios
+- [`docs/guide/rig-profiles.md`](../guide/rig-profiles.md) — native TOML schema reference and guidance on when long-tail radios belong on the Hamlib-backed provider path
 - [`docs/api/commands.md`](commands.md) — using `CommandMap` with command functions

--- a/docs/api/rigctld.md
+++ b/docs/api/rigctld.md
@@ -4,11 +4,16 @@ robots: noindex, follow
 
 # Rigctld Server
 
-Hamlib NET rigctld-compatible TCP server for rigplane.
+Client-facing Hamlib NET rigctld-compatible TCP server for rigplane.
 
-Provides a drop-in replacement for `rigctld` that bridges the hamlib line-based TCP
-protocol to a **Radio** instance (from `create_radio`). Clients such as WSJT-X, JS8Call, fldigi, and
-rigctl connect over TCP (default port 4532) and issue standard hamlib CAT commands.
+Provides a `rigctld`-compatible endpoint that bridges the Hamlib line-based TCP
+protocol to a **Radio** instance (from `create_radio`). Clients such as WSJT-X,
+JS8Call, fldigi, and `rigctl` connect over TCP (default port 4532) and issue
+standard Hamlib CAT commands.
+
+This server is the client-facing compatibility surface. It is separate from any
+Hamlib-backed provider RigPlane may use underneath to control long-tail CAT
+radios.
 
 ## Architecture
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -541,7 +541,11 @@ The JSON payload also reports current platform limitations:
 
 ### `serve`
 
-Start a rigctld-compatible TCP server so that logging and contesting software (WSJT-X, JS8Call, Ham Radio Deluxe, etc.) can control the radio without a full Hamlib installation.
+Start a client-facing `rigctld`-compatible TCP server so that logging and
+contesting software (WSJT-X, JS8Call, Ham Radio Deluxe, etc.) can control the
+radio through RigPlane's active provider path. This endpoint is distinct from a
+Hamlib-backed provider that RigPlane may use underneath for long-tail CAT
+coverage.
 
 ```bash
 # Basic rigctld server on default port 4532

--- a/docs/guide/ic705-usb-setup.md
+++ b/docs/guide/ic705-usb-setup.md
@@ -81,7 +81,7 @@ ls -l /dev/cu.usbserial-*
 
 The IC-705 typically appears as `/dev/cu.usbserial-*` where the suffix may include "IC705" or the radio's serial number.
 
-You can also use `rigplane discover --serial-only` to find USB-connected radios automatically:
+You can also use `rigplane discover --serial-only` to list USB serial candidates and identify likely supported radios:
 
 ```bash
 rigplane discover --serial-only

--- a/docs/guide/ic7300-usb-setup.md
+++ b/docs/guide/ic7300-usb-setup.md
@@ -1,5 +1,5 @@
 ---
-description: Set up the Icom IC-7300 over USB serial CI-V and USB audio from macOS with RigPlane — low-latency direct control without LAN, hamlib, or RS-BA1.
+description: Set up the Icom IC-7300 over USB serial CI-V and USB audio from macOS with RigPlane's native Icom provider.
 ---
 
 # IC-7300 USB Serial Backend Setup (macOS)

--- a/docs/guide/ic7610-usb-setup.md
+++ b/docs/guide/ic7610-usb-setup.md
@@ -1,5 +1,5 @@
 ---
-description: Step-by-step guide to control the Icom IC-7610 from macOS over USB serial CI-V and USB audio with RigPlane — no LAN, hamlib, or RS-BA1 required.
+description: Step-by-step guide to control the Icom IC-7610 from macOS over USB serial CI-V and USB audio with RigPlane's native Icom provider.
 ---
 
 # IC-7610 USB Serial Backend Setup (macOS)
@@ -77,7 +77,7 @@ ls -l /dev/cu.usbserial-*
 
 The IC-7610 typically appears as `/dev/cu.usbserial-XXXXXX` where `XXXXXX` is the radio's serial number.
 
-You can also use `rigplane discover --serial-only` to find USB-connected radios automatically:
+You can also use `rigplane discover --serial-only` to list USB serial candidates and identify likely supported radios:
 
 ```bash
 rigplane discover --serial-only

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -1,11 +1,14 @@
 ---
-description: Radios supported by RigPlane — Icom IC-7610, IC-7300, IC-705, IC-9700, plus Yaesu, Xiegu, and Lab599 models defined by TOML rig profiles.
+description: Radios supported by RigPlane — native Icom and Yaesu providers today, plus Xiegu, Lab599, and other serial CAT candidates moving toward Hamlib-backed assisted discovery.
 ---
 
 # Supported Radios
 
-Radio support in rigplane is defined by **TOML rig profiles** in `rigs/`.
-Adding a new radio = adding a new `.toml` file — see [Adding a New Radio](rig-profiles.md).
+Radio support in rigplane is provider-based. Native providers use **TOML rig
+profiles** in `rigs/` to describe capabilities and protocol details. Long-tail
+serial CAT radios are moving toward a Hamlib-backed provider path that emits
+structured discovery candidates and maps Hamlib control into RigPlane
+capabilities.
 
 ## Tested
 
@@ -81,27 +84,29 @@ The Web UI automatically hides DIGI-SEL and IP+ controls when connected to an IC
     Full frequency, mode, PTT, and audio control is working.
     The Web UI uses the Audio FFT Scope for spectrum display (no hardware panadapter on FTX-1).
 
-## Non-Icom Radios (Profile Only)
+## Long-tail CAT / Profile Candidates
 
-The TOML rig profile system supports multiple protocols. These profiles exist but
-backend adapters are not yet implemented or tested:
+These radios have profiles or known CAT surfaces, but they are not yet
+first-party hardware-validated. The intended direction is assisted discovery and
+Hamlib-backed control where that gives broader coverage than maintaining a
+bespoke backend for each dialect.
 
 ### Xiegu X6100
 
-- **Protocol:** CI-V (IC-705 compatible subset)
+- **Protocol:** CI-V (IC-705 compatible subset) / Hamlib candidate
 - **CI-V Address:** `0x70`
 - **Rig profile:** `rigs/x6100.toml`
 - **Features:** HF + 6m, QRP 8W, built-in ATU, WiFi
 - **VFO scheme:** `ab`
-- **Status:** Profile only. May work with CI-V backend (untested).
+- **Status:** Profile only. May work with CI-V backend (untested); assisted discovery and Hamlib-backed fallback planned.
 
 ### Lab599 TX-500
 
-- **Protocol:** Kenwood CAT (text)
+- **Protocol:** Kenwood CAT (text) / Hamlib candidate
 - **Rig profile:** `rigs/tx500.toml`
 - **Features:** HF + 6m, QRP 10W, built-in ATU, minimal CAT (ID FA FB MD FR FT PA RA)
 - **VFO scheme:** `ab`
-- **Status:** Profile only. Kenwood CAT backend not yet implemented.
+- **Status:** Profile only. Product direction is Hamlib-backed provider plus assisted discovery, not a bespoke Kenwood CAT backend first.
 
 ## Community-Validated / Maintainer Hardware Pending
 
@@ -188,14 +193,16 @@ async with create_radio(config) as radio:
 See **[Adding a New Radio (Rig Profiles)](rig-profiles.md)** for the complete guide.
 In brief:
 
-1. Copy the closest reference rig file as a template:
+1. Decide whether the radio belongs on an existing native provider path or the
+   Hamlib-backed provider path.
+2. For native provider work, copy the closest reference rig file as a template:
    - Icom CI-V → `rigs/ic7610.toml`
    - Kenwood CAT → `rigs/tx500.toml`
    - Yaesu CAT → `rigs/ftx1.toml`
-2. Update `[radio]` and `[protocol]` sections
-3. Update `[capabilities]`, `[controls]`, `[meters]`, `[[rules]]` as needed
-4. For CI-V radios: update `[commands]` section
-5. Run `uv run pytest tests/test_rig_loader.py tests/test_rig_multi_vendor.py -v` to validate
+3. Update `[radio]` and `[protocol]` sections.
+4. Update `[capabilities]`, `[controls]`, `[meters]`, `[[rules]]` as needed.
+5. For CI-V radios: update `[commands]` section.
+6. Run `uv run pytest tests/test_rig_loader.py tests/test_rig_multi_vendor.py -v` to validate.
 
 The library is CI-V address agnostic — any radio that speaks the Icom LAN protocol should
 work. If you test with a new model:

--- a/docs/guide/rig-profiles.md
+++ b/docs/guide/rig-profiles.md
@@ -1,14 +1,17 @@
 ---
-description: Add a new radio to RigPlane by writing a TOML rig profile — capabilities, CI-V commands, hardware parameters, and registration in the rig loader.
+description: Add a native radio profile to RigPlane, and understand when long-tail CAT support should route through the Hamlib-backed provider path instead.
 ---
 
 # Adding a New Radio (Rig Profiles)
 
 ## Overview
 
-rigplane uses **TOML rig files** to define radio capabilities, protocol type, CI-V commands,
-and hardware parameters. Adding a new radio means adding a new `.toml` file — no Python
-changes required for most radios.
+rigplane uses **TOML rig files** to define native radio capabilities, protocol
+type, CI-V/CAT commands, and hardware parameters. For radios that share an
+existing native provider, adding a model is often a profile change. For
+long-tail serial CAT radios, prefer the Hamlib-backed provider direction unless
+RigPlane can deliver meaningfully richer control, audio, discovery, or
+diagnostics through a native provider.
 
 Rig files live in `rigs/`. Reference files:
 
@@ -34,7 +37,7 @@ cp rigs/ftx1.toml rigs/ft710.toml      # for Yaesu CAT
 uv run pytest tests/test_rig_loader.py tests/test_rig_multi_vendor.py -v
 ```
 
-## Supported Protocols
+## Native Profile Protocols
 
 | Protocol | Type string | Examples | Description |
 |----------|------------|----------|-------------|
@@ -48,6 +51,11 @@ type = "civ"  # or "kenwood_cat" or "yaesu_cat"
 ```
 
 For CI-V radios, `[radio].civ_addr` is required. For Kenwood/Yaesu, omit it.
+
+Hamlib-backed support is a provider path, not just another TOML dialect. It
+should use Hamlib model metadata, safe read-only probing, and RigPlane's
+capability normalization instead of leaking Hamlib model IDs or command names to
+upper layers.
 
 ## TOML Schema Reference
 

--- a/docs/guide/wsjtx-setup.md
+++ b/docs/guide/wsjtx-setup.md
@@ -1,11 +1,13 @@
 ---
-description: Configure WSJT-X, JTDX, and JS8Call against RigPlane's built-in rigctld server for FT8, FT4, and JS8 on Icom radios — no Hamlib install needed.
+description: Configure WSJT-X, JTDX, and JS8Call against RigPlane's rigctld-compatible endpoint for FT8, FT4, and JS8.
 ---
 
 # WSJT-X / JTDX / JS8Call Setup Guide
 
 This guide covers configuring WSJT-X (and compatible apps like JTDX, JS8Call)
-to work with `rigplane serve` as a Hamlib NET rigctld replacement.
+to work with RigPlane's client-facing `rigctld`-compatible endpoint. This is
+separate from the provider layer underneath RigPlane, which may be native or
+Hamlib-backed depending on the radio path.
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 ---
 title: RigPlane — Ham Radio Control Library and Web UI for Icom, Yaesu, Xiegu
-description: RigPlane is a Python library and browser Web UI for controlling Icom IC-7610, IC-7300, IC-705, IC-9700 and Yaesu/Xiegu radios over LAN or USB — no wfview, hamlib, or RS-BA1 required.
+description: RigPlane is a Python library and browser Web UI for controlling ham radios through native providers and planned Hamlib-backed CAT coverage while keeping one capability-driven station model.
 ---
 
 # rigplane
 
-**Python library for controlling Icom, Yaesu, and other transceivers over LAN (UDP) or USB serial.**
+**Python library for controlling Icom, Yaesu, and other transceivers through native providers and planned Hamlib-backed CAT coverage.**
 
-Direct connection to your radio — no wfview, hamlib, or RS-BA1 required.
+RigPlane keeps the browser UI, audio path, diagnostics, and `rigctld`-compatible endpoint consistent across provider paths.
 
 ---
 
@@ -57,7 +57,7 @@ Direct connection to your radio — no wfview, hamlib, or RS-BA1 required.
 
     ---
 
-    Add support for new radios with a TOML file — no Python required.
+    Add native radio profiles and understand where Hamlib-backed provider work fits.
 
     [:octicons-arrow-right-24: Adding a New Radio](guide/rig-profiles.md)
 
@@ -75,14 +75,15 @@ Direct connection to your radio — no wfview, hamlib, or RS-BA1 required.
 
 ## Features
 
-- :white_check_mark: **Multi-vendor support** — Icom CI-V, Yaesu CAT, Kenwood CAT (future); data-driven rig profiles
+- :white_check_mark: **Multi-vendor support** — native Icom CI-V and Yaesu CAT, plus planned Hamlib-backed long-tail CAT coverage
 - :white_check_mark: **Direct UDP connection** — no intermediate software (LAN backend)
 - :white_check_mark: **USB serial backend** — CI-V over USB for IC-7610, IC-7300; USB audio devices
 - :white_check_mark: **Full CI-V command set** — frequency, mode/filter, power, meters, PTT, CW keying, VFO, split, ATT/PREAMP
-- :white_check_mark: **Yaesu CAT backend** — full working backend for Yaesu FTX-1 (USB serial)
+- :white_check_mark: **Yaesu CAT backend** — full working native backend for Yaesu FTX-1 (USB serial)
+- :white_check_mark: **Hamlib provider direction** — broad serial CAT coverage through assisted discovery and normalized RigPlane capabilities
 - :white_check_mark: **Audio streaming** — RX/TX with jitter buffer and full-duplex support
 - :white_check_mark: **Audio FFT Scope** — real-time FFT on USB/LAN audio for radios without hardware spectrum
-- :white_check_mark: **Network discovery** — find radios on your LAN automatically
+- :white_check_mark: **Discovery** — find supported LAN radios automatically; assisted serial CAT discovery is the long-tail direction
 - :white_check_mark: **CLI tool** — `rigplane status`, `rigplane freq 14.074m`
 - :white_check_mark: **Built-in Web UI** — spectrum, waterfall, controls, meters, audio in browser; LCD layout for non-scope radios
 - :white_check_mark: **Async + Sync API** — async by default, blocking wrapper available
@@ -100,8 +101,8 @@ Direct connection to your radio — no wfview, hamlib, or RS-BA1 required.
 | Yaesu FTX-1 | Yaesu CAT | :white_check_mark: Tested (USB) |
 | IC-705 | CI-V `0xA4` | :white_check_mark: Validated (LAN/WiFi community-tested) |
 | IC-9700 | CI-V `0xA2` | :material-help-circle: Profile — not yet tested |
-| Xiegu X6100 | CI-V `0x70` | :material-help-circle: Profile only |
-| Lab599 TX-500 | Kenwood CAT | :material-help-circle: Profile only |
+| Xiegu X6100 | CI-V `0x70` / Hamlib candidate | :material-help-circle: Profile only; assisted discovery planned |
+| Lab599 TX-500 | Kenwood CAT / Hamlib candidate | :material-help-circle: Profile only; assisted discovery planned |
 | IC-7851 | CI-V `0x8E` | :material-help-circle: Should work |
 | IC-R8600 | CI-V `0x96` | :material-help-circle: Should work |
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -191,9 +191,11 @@ USB Audio CODEC entries in IORegistry  →  filter by same hub prefix   │
 
 ## Rig Profiles (Data-Driven Radio Config)
 
-rigplane uses **TOML rig profiles** to define per-radio capabilities, CI-V wire bytes,
-and hardware parameters. This makes adding new radio support a data task — not a code
-change.
+rigplane uses **TOML rig profiles** to define native per-radio capabilities,
+CI-V/CAT wire details, and hardware parameters. Profiles remain the right path
+for native providers. Long-tail serial CAT coverage should route through the
+Hamlib-backed provider path unless a native provider gives RigPlane meaningfully
+richer UX, state, audio, discovery, or diagnostics.
 
 ### Data Flow
 
@@ -396,9 +398,10 @@ Used by the web UI to find available radios without manual IP entry.
 
 ### `rigctld/` — Hamlib NET rigctld Server
 
-TCP server that exposes the radio via the Hamlib `NET rigctld` protocol, enabling control
-from WSJT-X, fldigi, and any other Hamlib-aware software without needing a physical serial
-port.
+TCP server that exposes the radio via the Hamlib `NET rigctld` protocol,
+enabling control from WSJT-X, fldigi, and any other Hamlib-aware software
+without needing a physical serial port. This is the client-facing compatibility
+surface, separate from any Hamlib-backed provider RigPlane may use underneath.
 
 **`rigctld/server.py`** — asyncio TCP server (`asyncio.start_server`) implementing the hamlib
 NET rigctld protocol. Manages the TCP listener, per-client session lifecycle, connection
@@ -517,7 +520,10 @@ CI-V event classification, request-response matching, and frame scanning utiliti
 
 ### `radio_protocol.py` — Abstract Radio Protocols
 
-Runtime-checkable `Protocol` interfaces for multi-backend radio control. Web UI, rigctld, and CLI program against these interfaces so any backend (Icom LAN, serial, Yaesu CAT) can be substituted without changing consumers.
+Runtime-checkable `Protocol` interfaces for multi-backend radio control. Web
+UI, rigctld, and CLI program against these interfaces so native providers
+(Icom LAN, serial, Yaesu CAT) and a Hamlib-backed provider can be substituted
+without changing consumers.
 
 - **`Radio`**: core interface — lifecycle (`connect`/`disconnect`), frequency, mode, PTT, meters, power, levels, `radio_state`, `capabilities` set
 - **`AudioCapable`**: `audio_bus`, `start_audio_rx_opus`, `push_audio_tx_opus`

--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -158,11 +158,13 @@ Always include the issue number in the scope (e.g., `#123`) for feature, fix, an
 
 ## Adding a New Radio Model
 
-1. Look up the radio's default CI-V address
-2. Test basic operations (frequency, mode, meters)
-3. Document any model-specific behavior
-4. Add to the radios table in `docs/guide/radios.md`
-5. Add the CI-V address constant in `commands.py` if desired
+1. Decide whether the radio belongs on an existing native provider path or the
+   Hamlib-backed provider path.
+2. For native CI-V radios, look up the default CI-V address and profile data.
+3. Test basic operations (frequency, mode, meters/PTT as applicable).
+4. Document any model-specific behavior and provider limitations.
+5. Add to the radios table in `docs/guide/radios.md`.
+6. Add protocol constants only when they belong to a native provider surface.
 
 ## Reporting Bugs
 

--- a/docs/radio-protocol.md
+++ b/docs/radio-protocol.md
@@ -6,7 +6,11 @@ robots: noindex, follow
 
 ## Overview
 
-The Radio Protocol defines a vendor-neutral interface for controlling amateur radio transceivers. Any backend that implements the `Radio` protocol can be used with the Web UI, rigctld server, and CLI without modification.
+The Radio Protocol defines a vendor-neutral interface for controlling amateur
+radio transceivers. Any provider/backend that implements the `Radio` protocol
+can be used with the Web UI, rigctld server, and CLI without modification.
+Native providers and the planned Hamlib-backed provider meet the same contract;
+consumer layers should not depend on which path is underneath.
 
 ```
 ┌──────────────────────────────────────────────┐
@@ -17,13 +21,14 @@ The Radio Protocol defines a vendor-neutral interface for controlling amateur ra
 │  │ AudioCapable │ ScopeCapable│ DualRxCap. │ │
 │  └──────────────┴─────────────┴────────────┘ │
 ├────────┬──────────┬──────────┬───────────────┤
-│IcomLAN │IcomSerial│ YaesuCAT │  Future...    │
+│IcomLAN │IcomSerial│ YaesuCAT │ HamlibProvider│
 └────────┴──────────┴──────────┴───────────────┘
 ```
 
 ## Core Protocol: `Radio`
 
-Every backend **must** implement this. It covers the essentials that any transceiver supports.
+Every provider/backend **must** implement this. It covers the essentials that any
+transceiver supports.
 
 ```python
 from rigplane.radio_protocol import Radio
@@ -179,11 +184,14 @@ if isinstance(radio, DualReceiverCapable):
     await radio.vfo_equalize()   # Sub = Main
 ```
 
-## Implementing a New Backend
+## Implementing a New Provider/Backend
 
-1. Create a class that implements `Radio` (and optional protocols as needed)
-2. Register it in the radio factory
-3. The Web UI, rigctld, and CLI will work automatically
+1. Decide whether the radio needs a native provider or belongs on the
+   Hamlib-backed provider path.
+2. Create a class that implements `Radio` (and optional protocols as needed),
+   or map Hamlib control into the same capability model.
+3. Register it in the radio factory.
+4. The Web UI, rigctld, and CLI will work through the same contract.
 
 ```python
 from rigplane.radio_protocol import Radio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rigplane"
 version = "2.3.1"
-description = "Multi-vendor radio control library and Web UI for IP-connected ham transceivers (Icom, Yaesu, Xiegu, Lab599) — no wfview/hamlib required"
+description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Reframes public core docs around native providers plus planned Hamlib-backed CAT coverage.
- Removes absolute no-Hamlib positioning from README, docs index, rigctld/WSJT-X docs, and radio support pages.
- Updates TX-500/X6100 and adding-radio guidance so long-tail support routes through provider-path choice instead of assuming bespoke native backend work.

## Validation
- uv run mkdocs build --strict
- git diff --check

Tracks rigplane/rigplane-core#1576.
