### PR TITLE
[codex] Add fake rigctld simulator tests

### DIFF
--- a/tests/fake_rigctld.py
+++ b/tests/fake_rigctld.py
@@ -1,0 +1,237 @@
+"""Reusable fake external Hamlib ``rigctld`` TCP simulator for tests."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+from rigplane.rigctld.contract import HamlibError
+
+_GET_FREQ = {"f", r"\get_freq"}
+_SET_FREQ = {"F", r"\set_freq"}
+_GET_MODE = {"m", r"\get_mode"}
+_SET_MODE = {"M", r"\set_mode"}
+_GET_PTT = {"t", r"\get_ptt"}
+_SET_PTT = {"T", r"\set_ptt"}
+_GET_VFO = {"v", r"\get_vfo"}
+_SET_VFO = {"V", r"\set_vfo"}
+_QUIT = {"q", r"\quit"}
+
+
+@dataclass(slots=True)
+class FakeRigctldState:
+    """Mutable radio state exposed through fake ``rigctld`` commands."""
+
+    frequency_hz: int = 14_074_000
+    mode: str = "USB"
+    passband_hz: int = 2400
+    ptt: int = 0
+    vfo: str = "VFOA"
+
+
+@dataclass(slots=True)
+class FakeRigctldBehavior:
+    """Scriptable edge-case behavior for the fake simulator.
+
+    Keys in the command collections may be either the first command token
+    (``"f"``) or the complete stripped command line (``"F 7050000"``).
+    """
+
+    response_delay: float = 0.0
+    command_delays: dict[str, float] = field(default_factory=dict)
+    disconnect_commands: set[str] = field(default_factory=set)
+    malformed_responses: dict[str, bytes] = field(default_factory=dict)
+    unsupported_commands: set[str] = field(default_factory=set)
+
+
+class FakeRigctldServer:
+    """Small asyncio TCP server that speaks the Hamlib ``rigctld`` wire shape."""
+
+    def __init__(
+        self,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        state: FakeRigctldState | None = None,
+        behavior: FakeRigctldBehavior | None = None,
+    ) -> None:
+        self.host = host
+        self._port_hint = port
+        self.state = state or FakeRigctldState()
+        self.behavior = behavior or FakeRigctldBehavior()
+        self.commands_seen: list[str] = []
+        self._server: asyncio.AbstractServer | None = None
+        self._writers: set[asyncio.StreamWriter] = set()
+
+    @property
+    def port(self) -> int:
+        return self.address[1]
+
+    @property
+    def address(self) -> tuple[str, int]:
+        if self._server is None or self._server.sockets is None:
+            raise RuntimeError("fake rigctld server is not started")
+        host, port = self._server.sockets[0].getsockname()[:2]
+        return str(host), int(port)
+
+    async def __aenter__(self) -> FakeRigctldServer:
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc: object,
+        tb: object,
+    ) -> None:
+        await self.stop()
+
+    async def start(self) -> None:
+        if self._server is not None:
+            return
+        self._server = await asyncio.start_server(
+            self._handle_client,
+            self.host,
+            self._port_hint,
+        )
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        writers = list(self._writers)
+        for writer in writers:
+            writer.close()
+        for writer in writers:
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass
+        self._writers.clear()
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        self._writers.add(writer)
+        try:
+            while True:
+                raw_line = await reader.readline()
+                if raw_line == b"":
+                    break
+
+                line = raw_line.decode("ascii", errors="replace").strip()
+                if not line:
+                    continue
+
+                self.commands_seen.append(line)
+                key = _command_key(line)
+
+                if _matches(self.behavior.disconnect_commands, line, key):
+                    break
+
+                delay = _lookup_delay(self.behavior, line, key)
+                if delay > 0:
+                    await asyncio.sleep(delay)
+
+                malformed = _lookup(self.behavior.malformed_responses, line, key)
+                if malformed is not None:
+                    await _write_response(writer, malformed)
+                    continue
+
+                if _matches(self.behavior.unsupported_commands, line, key):
+                    await _write_response(writer, _error(HamlibError.ENIMPL))
+                    continue
+
+                if key in _QUIT:
+                    break
+
+                await _write_response(writer, self._response_for(line, key))
+        except (ConnectionError, OSError):
+            pass
+        finally:
+            self._writers.discard(writer)
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass
+
+    def _response_for(self, line: str, key: str) -> bytes:
+        tokens = line.split()
+
+        if key in _GET_FREQ:
+            return f"{self.state.frequency_hz}\n".encode("ascii")
+        if key in _SET_FREQ:
+            if len(tokens) != 2:
+                return _error(HamlibError.EINVAL)
+            try:
+                self.state.frequency_hz = int(tokens[1])
+            except ValueError:
+                return _error(HamlibError.EINVAL)
+            return _ok()
+
+        if key in _GET_MODE:
+            return f"{self.state.mode}\n{self.state.passband_hz}\n".encode("ascii")
+        if key in _SET_MODE:
+            if len(tokens) not in {2, 3}:
+                return _error(HamlibError.EINVAL)
+            self.state.mode = tokens[1].upper()
+            self.state.passband_hz = int(tokens[2]) if len(tokens) == 3 else 0
+            return _ok()
+
+        if key in _GET_PTT:
+            return f"{self.state.ptt}\n".encode("ascii")
+        if key in _SET_PTT:
+            if len(tokens) != 2 or tokens[1] not in {"0", "1"}:
+                return _error(HamlibError.EINVAL)
+            self.state.ptt = int(tokens[1])
+            return _ok()
+
+        if key in _GET_VFO:
+            return f"{self.state.vfo}\n".encode("ascii")
+        if key in _SET_VFO:
+            if len(tokens) != 2:
+                return _error(HamlibError.EINVAL)
+            self.state.vfo = tokens[1].upper()
+            return _ok()
+
+        return _error(HamlibError.ENIMPL)
+
+
+def _command_key(line: str) -> str:
+    return line.split(maxsplit=1)[0]
+
+
+def _matches(candidates: set[str], line: str, key: str) -> bool:
+    return line in candidates or key in candidates
+
+
+def _lookup(mapping: dict[str, bytes], line: str, key: str) -> bytes | None:
+    if line in mapping:
+        return mapping[line]
+    return mapping.get(key)
+
+
+def _lookup_delay(behavior: FakeRigctldBehavior, line: str, key: str) -> float:
+    if line in behavior.command_delays:
+        return behavior.command_delays[line]
+    return behavior.command_delays.get(key, behavior.response_delay)
+
+
+async def _write_response(writer: asyncio.StreamWriter, response: bytes) -> None:
+    if writer.is_closing():
+        return
+    writer.write(response)
+    await writer.drain()
+
+
+def _ok() -> bytes:
+    return _error(HamlibError.OK)
+
+
+def _error(code: int | HamlibError) -> bytes:
+    return f"RPRT {int(code)}\n".encode("ascii")

--- a/tests/fake_rigctld.py
+++ b/tests/fake_rigctld.py
@@ -61,6 +61,8 @@ class FakeRigctldServer:
         self.behavior = behavior or FakeRigctldBehavior()
         self.commands_seen: list[str] = []
         self._server: asyncio.AbstractServer | None = None
+        self._stopping = False
+        self._tasks: set[asyncio.Task[None]] = set()
         self._writers: set[asyncio.StreamWriter] = set()
 
     @property
@@ -89,6 +91,7 @@ class FakeRigctldServer:
     async def start(self) -> None:
         if self._server is not None:
             return
+        self._stopping = False
         self._server = await asyncio.start_server(
             self._handle_client,
             self.host,
@@ -96,26 +99,44 @@ class FakeRigctldServer:
         )
 
     async def stop(self) -> None:
+        self._stopping = True
+        server = self._server
         if self._server is not None:
             self._server.close()
-            await self._server.wait_closed()
             self._server = None
 
         writers = list(self._writers)
         for writer in writers:
-            writer.close()
+            _abort_writer(writer)
+
+        current_task = asyncio.current_task()
+        tasks = [task for task in self._tasks if task is not current_task]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
         for writer in writers:
             try:
-                await writer.wait_closed()
-            except OSError:
+                await asyncio.wait_for(writer.wait_closed(), timeout=0.1)
+            except (OSError, TimeoutError):
                 pass
         self._writers.clear()
+
+        if server is not None:
+            try:
+                await asyncio.wait_for(server.wait_closed(), timeout=0.1)
+            except TimeoutError:
+                pass
 
     async def _handle_client(
         self,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._tasks.add(task)
         self._writers.add(writer)
         try:
             while True:
@@ -153,7 +174,12 @@ class FakeRigctldServer:
         except (ConnectionError, OSError):
             pass
         finally:
+            if task is not None:
+                self._tasks.discard(task)
             self._writers.discard(writer)
+            if self._stopping:
+                _abort_writer(writer)
+                return
             writer.close()
             try:
                 await writer.wait_closed()
@@ -227,6 +253,11 @@ async def _write_response(writer: asyncio.StreamWriter, response: bytes) -> None
         return
     writer.write(response)
     await writer.drain()
+
+
+def _abort_writer(writer: asyncio.StreamWriter) -> None:
+    writer.close()
+    writer.transport.abort()
 
 
 def _ok() -> bytes:

--- a/tests/test_fake_rigctld.py
+++ b/tests/test_fake_rigctld.py
@@ -1,0 +1,146 @@
+"""Tests for the reusable fake external ``rigctld`` simulator."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer
+
+
+async def _connect(
+    server: FakeRigctldServer,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    return await asyncio.open_connection(*server.address)
+
+
+async def _close(writer: asyncio.StreamWriter) -> None:
+    writer.close()
+    await writer.wait_closed()
+
+
+async def _send_line(
+    writer: asyncio.StreamWriter,
+    command: str,
+) -> None:
+    writer.write(f"{command}\n".encode("ascii"))
+    await writer.drain()
+
+
+async def _read_lines(
+    reader: asyncio.StreamReader,
+    count: int,
+) -> list[str]:
+    lines: list[str] = []
+    for _ in range(count):
+        line = await asyncio.wait_for(reader.readline(), timeout=1.0)
+        assert line != b""
+        lines.append(line.decode("ascii").rstrip("\n"))
+    return lines
+
+
+async def test_rigctld_owned_frequency_mode_ptt_and_vfo_happy_paths() -> None:
+    async with FakeRigctldServer() as server:
+        reader, writer = await _connect(server)
+        try:
+            await _send_line(writer, "f")
+            assert await _read_lines(reader, 1) == ["14074000"]
+
+            await _send_line(writer, "F 7050000")
+            assert await _read_lines(reader, 1) == ["RPRT 0"]
+            await _send_line(writer, "f")
+            assert await _read_lines(reader, 1) == ["7050000"]
+
+            await _send_line(writer, "m")
+            assert await _read_lines(reader, 2) == ["USB", "2400"]
+            await _send_line(writer, "M LSB 1800")
+            assert await _read_lines(reader, 1) == ["RPRT 0"]
+            await _send_line(writer, "m")
+            assert await _read_lines(reader, 2) == ["LSB", "1800"]
+
+            await _send_line(writer, "t")
+            assert await _read_lines(reader, 1) == ["0"]
+            await _send_line(writer, "T 1")
+            assert await _read_lines(reader, 1) == ["RPRT 0"]
+            await _send_line(writer, "t")
+            assert await _read_lines(reader, 1) == ["1"]
+
+            await _send_line(writer, "v")
+            assert await _read_lines(reader, 1) == ["VFOA"]
+            await _send_line(writer, "V VFOB")
+            assert await _read_lines(reader, 1) == ["RPRT 0"]
+            await _send_line(writer, "v")
+            assert await _read_lines(reader, 1) == ["VFOB"]
+        finally:
+            await _close(writer)
+
+    assert server.commands_seen == [
+        "f",
+        "F 7050000",
+        "f",
+        "m",
+        "M LSB 1800",
+        "m",
+        "t",
+        "T 1",
+        "t",
+        "v",
+        "V VFOB",
+        "v",
+    ]
+
+
+async def test_rigctld_owned_unsupported_command_returns_enimpl() -> None:
+    async with FakeRigctldServer() as server:
+        reader, writer = await _connect(server)
+        try:
+            await _send_line(writer, r"\dump_state")
+            assert await _read_lines(reader, 1) == ["RPRT -4"]
+        finally:
+            await _close(writer)
+
+
+async def test_rigctld_owned_disconnect_closes_socket_without_response() -> None:
+    behavior = FakeRigctldBehavior(disconnect_commands={"f"})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        reader, writer = await _connect(server)
+        try:
+            await _send_line(writer, "f")
+            data = await asyncio.wait_for(reader.read(4096), timeout=1.0)
+            assert data == b""
+        finally:
+            await _close(writer)
+
+
+async def test_rigctld_owned_malformed_response_can_be_scripted() -> None:
+    behavior = FakeRigctldBehavior(malformed_responses={"f": b"not-a-frequency\n"})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        reader, writer = await _connect(server)
+        try:
+            await _send_line(writer, "f")
+            assert await _read_lines(reader, 1) == ["not-a-frequency"]
+        finally:
+            await _close(writer)
+
+
+async def test_rigctld_owned_delayed_response_can_be_scripted() -> None:
+    behavior = FakeRigctldBehavior(command_delays={"f": 0.02})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        reader, writer = await _connect(server)
+        try:
+            await _send_line(writer, "f")
+            assert await _read_lines(reader, 1) == ["14074000"]
+        finally:
+            await _close(writer)
+
+
+async def test_rigctld_owned_busy_port_rejects_second_simulator() -> None:
+    async with FakeRigctldServer() as first:
+        second = FakeRigctldServer(port=first.port)
+        with pytest.raises(OSError):
+            await second.start()
+        await second.stop()

--- a/tests/test_fake_rigctld.py
+++ b/tests/test_fake_rigctld.py
@@ -138,9 +138,37 @@ async def test_rigctld_owned_delayed_response_can_be_scripted() -> None:
             await _close(writer)
 
 
+async def test_rigctld_owned_stop_cancels_active_delayed_response() -> None:
+    behavior = FakeRigctldBehavior(command_delays={"f": 10.0})
+    server = FakeRigctldServer(behavior=behavior)
+    await server.start()
+    reader, writer = await _connect(server)
+    try:
+        await _send_line(writer, "f")
+        await asyncio.wait_for(_wait_for_command(server, "f"), timeout=1.0)
+
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        await asyncio.wait_for(server.stop(), timeout=0.5)
+
+        assert loop.time() - started_at < 0.5
+        assert server._tasks == set()
+        assert server._writers == set()
+        assert await asyncio.wait_for(reader.read(4096), timeout=0.5) == b""
+    finally:
+        await server.stop()
+        if not writer.is_closing():
+            await _close(writer)
+
+
 async def test_rigctld_owned_busy_port_rejects_second_simulator() -> None:
     async with FakeRigctldServer() as first:
         second = FakeRigctldServer(port=first.port)
         with pytest.raises(OSError):
             await second.start()
         await second.stop()
+
+
+async def _wait_for_command(server: FakeRigctldServer, command: str) -> None:
+    while command not in server.commands_seen:
+        await asyncio.sleep(0)

--- a/tests/test_hamlib_external_rigctld_contract.py
+++ b/tests/test_hamlib_external_rigctld_contract.py
@@ -1,0 +1,223 @@
+"""Provider-facing contract tests for a future external Hamlib backend."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer
+from rigplane.rigctld.contract import HamlibError
+
+
+@dataclass(frozen=True, slots=True)
+class _ModeReply:
+    mode: str
+    passband_hz: int
+
+
+class _ProviderFacingRigctldClient:
+    """Minimal test-local client that documents future backend assumptions."""
+
+    def __init__(self, host: str, port: int, *, timeout: float = 0.5) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    async def get_freq(self) -> int:
+        line = (await self._request("f", value_lines=1))[0]
+        try:
+            return int(line)
+        except ValueError as exc:
+            raise ValueError("Malformed rigctld frequency response") from exc
+
+    async def set_freq(self, frequency_hz: int) -> None:
+        await self._request(f"F {frequency_hz}", value_lines=0)
+
+    async def get_mode(self) -> _ModeReply:
+        mode, passband = await self._request("m", value_lines=2)
+        try:
+            passband_hz = int(passband)
+        except ValueError as exc:
+            raise ValueError("Malformed rigctld mode response") from exc
+        return _ModeReply(mode=mode, passband_hz=passband_hz)
+
+    async def set_mode(self, mode: str, passband_hz: int) -> None:
+        await self._request(f"M {mode} {passband_hz}", value_lines=0)
+
+    async def get_ptt(self) -> bool:
+        line = (await self._request("t", value_lines=1))[0]
+        if line not in {"0", "1"}:
+            raise ValueError("Malformed rigctld PTT response")
+        return line == "1"
+
+    async def set_ptt(self, enabled: bool) -> None:
+        await self._request(f"T {int(enabled)}", value_lines=0)
+
+    async def get_vfo(self) -> str:
+        return (await self._request("v", value_lines=1))[0]
+
+    async def set_vfo(self, vfo: str) -> None:
+        await self._request(f"V {vfo}", value_lines=0)
+
+    async def unsupported_probe(self) -> None:
+        await self._request(r"\dump_state", value_lines=1)
+
+    async def _request(self, command: str, *, value_lines: int) -> list[str]:
+        reader: asyncio.StreamReader | None = None
+        writer: asyncio.StreamWriter | None = None
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, self.port),
+                timeout=self.timeout,
+            )
+            writer.write(f"{command}\n".encode("ascii"))
+            await writer.drain()
+
+            first = await self._read_line(reader)
+            if first.startswith("RPRT "):
+                self._handle_report(first)
+                return []
+            if value_lines == 0:
+                raise ValueError(f"Expected RPRT response, got {first!r}")
+
+            values = [first]
+            for _ in range(value_lines - 1):
+                values.append(await self._read_line(reader))
+            return values
+        finally:
+            if writer is not None:
+                writer.close()
+                await writer.wait_closed()
+
+    async def _read_line(self, reader: asyncio.StreamReader) -> str:
+        line = await asyncio.wait_for(reader.readline(), timeout=self.timeout)
+        if line == b"":
+            raise ConnectionError("rigctld disconnected")
+        return line.decode("ascii").rstrip("\n")
+
+    @staticmethod
+    def _handle_report(line: str) -> None:
+        try:
+            code = int(line.split(maxsplit=1)[1])
+        except (IndexError, ValueError) as exc:
+            raise ValueError("Malformed rigctld RPRT response") from exc
+
+        if code == HamlibError.OK:
+            return
+        if code == HamlibError.ENIMPL:
+            raise NotImplementedError("rigctld command is unsupported")
+        raise RuntimeError(f"rigctld command failed with RPRT {code}")
+
+
+def _client(
+    server: FakeRigctldServer, *, timeout: float = 0.5
+) -> _ProviderFacingRigctldClient:
+    host, port = server.address
+    return _ProviderFacingRigctldClient(host, port, timeout=timeout)
+
+
+async def test_rigplane_owned_provider_happy_path_golden() -> None:
+    async with FakeRigctldServer() as server:
+        client = _client(server)
+
+        assert await client.get_freq() == 14_074_000
+        await client.set_freq(7_050_000)
+        assert await client.get_freq() == 7_050_000
+
+        assert await client.get_mode() == _ModeReply("USB", 2400)
+        await client.set_mode("LSB", 1800)
+        assert await client.get_mode() == _ModeReply("LSB", 1800)
+
+        assert await client.get_ptt() is False
+        await client.set_ptt(True)
+        assert await client.get_ptt() is True
+
+        assert await client.get_vfo() == "VFOA"
+        await client.set_vfo("VFOB")
+        assert await client.get_vfo() == "VFOB"
+
+    assert server.commands_seen == [
+        "f",
+        "F 7050000",
+        "f",
+        "m",
+        "M LSB 1800",
+        "m",
+        "t",
+        "T 1",
+        "t",
+        "v",
+        "V VFOB",
+        "v",
+    ]
+
+
+async def test_rigplane_owned_provider_times_out_when_rigctld_delays_reply() -> None:
+    behavior = FakeRigctldBehavior(command_delays={"f": 0.2})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        client = _client(server, timeout=0.05)
+        with pytest.raises(asyncio.TimeoutError):
+            await client.get_freq()
+
+
+async def test_rigplane_owned_provider_rejects_malformed_frequency_response() -> None:
+    behavior = FakeRigctldBehavior(malformed_responses={"f": b"not-a-frequency\n"})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        client = _client(server)
+        with pytest.raises(ValueError, match="Malformed rigctld frequency response"):
+            await client.get_freq()
+
+
+async def test_rigplane_owned_provider_reports_rigctld_disconnect() -> None:
+    behavior = FakeRigctldBehavior(disconnect_commands={"f"})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        client = _client(server)
+        with pytest.raises(ConnectionError, match="rigctld disconnected"):
+            await client.get_freq()
+
+
+async def test_rigplane_owned_provider_maps_unsupported_to_not_implemented() -> None:
+    async with FakeRigctldServer() as server:
+        client = _client(server)
+        with pytest.raises(NotImplementedError, match="unsupported"):
+            await client.unsupported_probe()
+
+
+@pytest.mark.parametrize(
+    ("operation", "command", "malformed_response", "expected_message"),
+    [
+        pytest.param(
+            lambda client: client.get_mode(),
+            "m",
+            b"USB\nwide\n",
+            "Malformed rigctld mode response",
+            id="mode-passband",
+        ),
+        pytest.param(
+            lambda client: client.get_ptt(),
+            "t",
+            b"enabled\n",
+            "Malformed rigctld PTT response",
+            id="ptt-bool",
+        ),
+    ],
+)
+async def test_rigplane_owned_provider_rejects_other_malformed_responses(
+    operation: Callable[[_ProviderFacingRigctldClient], Awaitable[Any]],
+    command: str,
+    malformed_response: bytes,
+    expected_message: str,
+) -> None:
+    behavior = FakeRigctldBehavior(malformed_responses={command: malformed_response})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        client = _client(server)
+        with pytest.raises(ValueError, match=expected_message):
+            await operation(client)


### PR DESCRIPTION
## Summary

- Add a reusable asyncio fake external Hamlib `rigctld` TCP simulator under `tests/`.
- Add simulator coverage for frequency, mode, PTT, VFO, unsupported commands, scripted malformed replies, delayed replies, disconnects, and busy port binding.
- Add provider-facing golden tests with a minimal test-local client that documents future Hamlib backend expectations without adding production backend code.

Closes #1578

## Validation

- `uv run pytest tests/test_fake_rigctld.py tests/test_hamlib_external_rigctld_contract.py -q --tb=short`
- `uv run pytest tests/test_rigctld_protocol.py tests/test_rigctld_server.py tests/test_server_wire.py tests/test_rigctld_handler.py tests/test_rigctld_utils.py tests/test_golden_protocol.py tests/test_rigctld_consistency.py tests/test_fake_rigctld.py tests/test_hamlib_external_rigctld_contract.py -q --tb=short`
- `uv run pytest tests/ -q --tb=short`
- `uv run ruff check src/ tests/`