### PR TITLE
feat(#1579): add external rigctld client backend

### DIFF
--- a/src/rigplane/__init__.py
+++ b/src/rigplane/__init__.py
@@ -33,6 +33,7 @@ __version__ = _pkg_version("rigplane")
 from .backends import (  # noqa: F401, E402
     BackendConfig,
     LanBackendConfig,
+    RigctldBackendConfig,
     SerialBackendConfig,
     YaesuCatBackendConfig,
     create_radio,
@@ -272,6 +273,7 @@ __all__ = [
     # --- Tier 1: Backend configs ---
     "BackendConfig",
     "LanBackendConfig",
+    "RigctldBackendConfig",
     "SerialBackendConfig",
     "YaesuCatBackendConfig",
     # --- Tier 1: Radio + capability protocols ---

--- a/src/rigplane/backends/__init__.py
+++ b/src/rigplane/backends/__init__.py
@@ -3,6 +3,7 @@
 from .config import (
     BackendConfig,
     LanBackendConfig,
+    RigctldBackendConfig,
     SerialBackendConfig,
     YaesuCatBackendConfig,
 )
@@ -11,6 +12,7 @@ from .factory import create_radio
 __all__ = [
     "BackendConfig",
     "LanBackendConfig",
+    "RigctldBackendConfig",
     "SerialBackendConfig",
     "YaesuCatBackendConfig",
     "create_radio",

--- a/src/rigplane/backends/config.py
+++ b/src/rigplane/backends/config.py
@@ -140,7 +140,10 @@ class RigctldBackendConfig:
 
 
 BackendConfig = (
-    LanBackendConfig | SerialBackendConfig | YaesuCatBackendConfig | RigctldBackendConfig
+    LanBackendConfig
+    | SerialBackendConfig
+    | YaesuCatBackendConfig
+    | RigctldBackendConfig
 )
 
 __all__ = [

--- a/src/rigplane/backends/config.py
+++ b/src/rigplane/backends/config.py
@@ -120,11 +120,33 @@ class YaesuCatBackendConfig:
             raise ValueError("tx_device override must be a non-empty string.")
 
 
-BackendConfig = LanBackendConfig | SerialBackendConfig | YaesuCatBackendConfig
+@dataclass(frozen=True, slots=True)
+class RigctldBackendConfig:
+    """Configuration for an external Hamlib rigctld TCP backend."""
+
+    backend: Literal["rigctld"] = "rigctld"
+    host: str = ""
+    port: int = 4532
+    timeout: float = 5.0
+    model: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.host.strip():
+            raise ValueError("rigctld backend requires non-empty host.")
+        if not (1 <= self.port <= 65535):
+            raise ValueError("rigctld backend port must be in range 1..65535.")
+        if self.timeout <= 0:
+            raise ValueError("timeout must be > 0.")
+
+
+BackendConfig = (
+    LanBackendConfig | SerialBackendConfig | YaesuCatBackendConfig | RigctldBackendConfig
+)
 
 __all__ = [
     "BackendConfig",
     "LanBackendConfig",
+    "RigctldBackendConfig",
     "SerialBackendConfig",
     "YaesuCatBackendConfig",
 ]

--- a/src/rigplane/backends/factory.py
+++ b/src/rigplane/backends/factory.py
@@ -9,6 +9,7 @@ from ..radio_protocol import Radio
 from .config import (
     BackendConfig,
     LanBackendConfig,
+    RigctldBackendConfig,
     SerialBackendConfig,
     YaesuCatBackendConfig,
 )
@@ -16,6 +17,7 @@ from .ic7300.serial import Ic7300SerialRadio
 from .ic705.serial import Ic705SerialRadio
 from .ic9700.serial import Ic9700SerialRadio
 from .icom7610.serial import Icom7610SerialRadio
+from .rigctld_client.radio import RigctldClientRadio
 from .yaesu_cat.radio import YaesuCatRadio
 
 
@@ -53,6 +55,13 @@ def create_radio(config: BackendConfig) -> Radio:
             rx_device=config.rx_device,
             tx_device=config.tx_device,
             audio_sample_rate=config.audio_sample_rate,
+        )
+    if isinstance(config, RigctldBackendConfig):
+        return RigctldClientRadio(
+            host=config.host,
+            port=config.port,
+            timeout=config.timeout,
+            model=config.model,
         )
     if isinstance(config, SerialBackendConfig):
         # Route to model-specific serial backend
@@ -105,13 +114,14 @@ def create_radio(config: BackendConfig) -> Radio:
         )
 
     backend = getattr(config, "backend", None)
-    if backend in {"lan", "serial", "yaesu-cat"}:
+    if backend in {"lan", "serial", "yaesu-cat", "rigctld"}:
         raise TypeError(
             "Unsupported config instance for backend "
             f"{backend!r}; use typed backend config dataclasses."
         )
     raise ValueError(
-        "Unsupported backend. Expected backend 'lan', 'serial', or 'yaesu-cat'."
+        "Unsupported backend. Expected backend 'lan', 'serial', "
+        "'yaesu-cat', or 'rigctld'."
     )
 
 

--- a/src/rigplane/backends/rigctld_client/__init__.py
+++ b/src/rigplane/backends/rigctld_client/__init__.py
@@ -1,0 +1,6 @@
+"""External Hamlib ``rigctld`` client backend."""
+
+from .radio import RigctldClientRadio
+from .transport import RigctldTransport
+
+__all__ = ["RigctldClientRadio", "RigctldTransport"]

--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -1,0 +1,205 @@
+"""RigPlane Radio adapter for an external Hamlib ``rigctld`` server."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...exceptions import CommandError
+from ...radio_state import RadioState
+from .transport import RigctldTransport
+
+_SUPPORTED_COMMANDS = {
+    "get_freq",
+    "set_freq",
+    "get_mode",
+    "set_mode",
+    "get_ptt",
+    "set_ptt",
+    "get_vfo_slot",
+    "set_vfo_slot",
+}
+
+
+class RigctldClientRadio:
+    """Minimal Radio implementation backed by external Hamlib ``rigctld``."""
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int = 4532,
+        timeout: float = 5.0,
+        model: str | None = None,
+        transport: RigctldTransport | None = None,
+    ) -> None:
+        self._transport = transport or RigctldTransport(
+            host=host,
+            port=port,
+            timeout=timeout,
+        )
+        self._model = model or "External rigctld"
+        self._state = RadioState()
+        self._vfo_supported = False
+
+    async def connect(self) -> None:
+        await self._transport.connect()
+        await self._probe_vfo_support()
+
+    async def disconnect(self) -> None:
+        await self._transport.close()
+
+    async def __aenter__(self) -> "RigctldClientRadio":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.disconnect()
+
+    @property
+    def connected(self) -> bool:
+        return self._transport.connected
+
+    @property
+    def radio_ready(self) -> bool:
+        return self.connected
+
+    @property
+    def radio_state(self) -> RadioState:
+        return self._state
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def backend_id(self) -> str:
+        return "rigctld"
+
+    @property
+    def capabilities(self) -> set[str]:
+        caps = {"tx"}
+        if self._vfo_supported:
+            caps.add("vfo")
+        return caps
+
+    def supports_command(self, command: str) -> bool:
+        if command in {"get_vfo_slot", "set_vfo_slot"}:
+            return self._vfo_supported
+        return command in _SUPPORTED_COMMANDS
+
+    async def get_freq(self, receiver: int = 0) -> int:
+        self._require_main_receiver(receiver, "get_freq")
+        line = (await self._transport.query("f", response_lines=1))[0]
+        try:
+            freq = int(line)
+        except ValueError as exc:
+            raise CommandError(
+                f"External rigctld returned malformed frequency: {line!r}."
+            ) from exc
+        if freq < 0:
+            raise CommandError(
+                f"External rigctld returned invalid negative frequency: {freq}."
+            )
+        self._state.main.freq = freq
+        return freq
+
+    async def set_freq(self, freq: int, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_freq")
+        if freq <= 0:
+            raise ValueError("freq must be > 0 Hz")
+        await self._transport.command(f"F {int(freq)}")
+        self._state.main.freq = int(freq)
+
+    async def get_mode(self, receiver: int = 0) -> tuple[str, int | None]:
+        self._require_main_receiver(receiver, "get_mode")
+        mode, passband = await self._transport.query("m", response_lines=2)
+        mode = mode.strip().upper()
+        if not mode:
+            raise CommandError("External rigctld returned an empty mode.")
+        try:
+            passband_hz = int(passband)
+        except ValueError as exc:
+            raise CommandError(
+                f"External rigctld returned malformed passband: {passband!r}."
+            ) from exc
+        self._state.main.mode = mode
+        self._state.main.filter_width = passband_hz
+        return mode, passband_hz
+
+    async def set_mode(
+        self,
+        mode: str,
+        filter_width: int | None = None,
+        receiver: int = 0,
+    ) -> None:
+        self._require_main_receiver(receiver, "set_mode")
+        normalized = mode.strip().upper()
+        if not normalized:
+            raise ValueError("mode must be non-empty")
+        command = f"M {normalized}"
+        if filter_width is not None:
+            if filter_width < 0:
+                raise ValueError("filter_width must be >= 0")
+            command = f"{command} {int(filter_width)}"
+        await self._transport.command(command)
+        self._state.main.mode = normalized
+        self._state.main.filter_width = filter_width
+
+    async def get_data_mode(self) -> bool:
+        return False
+
+    async def set_data_mode(self, on: int | bool, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_data_mode")
+        if on:
+            raise CommandError(
+                "External rigctld backend does not support RigPlane data mode."
+            )
+
+    async def get_ptt(self) -> bool:
+        line = (await self._transport.query("t", response_lines=1))[0]
+        if line not in {"0", "1"}:
+            raise CommandError(f"External rigctld returned malformed PTT: {line!r}.")
+        ptt = line == "1"
+        self._state.ptt = ptt
+        return ptt
+
+    async def set_ptt(self, on: bool) -> None:
+        await self._transport.command(f"T {1 if on else 0}")
+        self._state.ptt = bool(on)
+
+    async def get_vfo_slot(self, receiver: int = 0) -> str:
+        self._require_main_receiver(receiver, "get_vfo_slot")
+        line = (await self._transport.query("v", response_lines=1))[0]
+        slot = _normalize_vfo_slot(line)
+        self._state.main.active_slot = slot
+        return slot
+
+    async def set_vfo_slot(self, slot: str, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_vfo_slot")
+        normalized = _normalize_vfo_slot(slot)
+        await self._transport.command(f"V VFO{normalized}")
+        self._state.main.active_slot = normalized
+
+    async def _probe_vfo_support(self) -> None:
+        try:
+            await self.get_vfo_slot()
+        except CommandError:
+            self._vfo_supported = False
+        else:
+            self._vfo_supported = True
+
+    @staticmethod
+    def _require_main_receiver(receiver: int, operation: str) -> None:
+        if receiver != 0:
+            raise ValueError(
+                f"{operation}: external rigctld backend only supports receiver 0"
+            )
+
+
+def _normalize_vfo_slot(value: str) -> str:
+    normalized = value.strip().upper()
+    if normalized in {"A", "VFOA"}:
+        return "A"
+    if normalized in {"B", "VFOB"}:
+        return "B"
+    raise CommandError(f"External rigctld returned unsupported VFO: {value!r}.")

--- a/src/rigplane/backends/rigctld_client/transport.py
+++ b/src/rigplane/backends/rigctld_client/transport.py
@@ -1,0 +1,174 @@
+"""TCP text transport for external Hamlib ``rigctld`` instances."""
+
+from __future__ import annotations
+
+import asyncio
+
+from ...exceptions import CommandError
+from ...exceptions import ConnectionError as RadioConnectionError
+from ...exceptions import TimeoutError as RadioTimeoutError
+
+_ERROR_HINTS = {
+    -1: "invalid parameter",
+    -4: "unsupported command",
+    -5: "invalid configuration",
+    -6: "protocol error",
+    -8: "communication bus error",
+}
+
+
+class RigctldTransport:
+    """Serialized line-oriented TCP client for external ``rigctld``."""
+
+    def __init__(self, *, host: str, port: int = 4532, timeout: float = 5.0) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def connected(self) -> bool:
+        writer = self._writer
+        return writer is not None and not writer.is_closing()
+
+    async def connect(self) -> None:
+        if self.connected:
+            return
+        try:
+            self._reader, self._writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, self.port),
+                timeout=self.timeout,
+            )
+        except TimeoutError as exc:
+            raise RadioTimeoutError(
+                f"Timed out connecting to external rigctld at "
+                f"{self.host}:{self.port} after {self.timeout:.3g}s."
+            ) from exc
+        except OSError as exc:
+            raise RadioConnectionError(
+                f"Failed to connect to external rigctld at "
+                f"{self.host}:{self.port}: {exc}"
+            ) from exc
+
+    async def close(self) -> None:
+        writer = self._writer
+        self._reader = None
+        self._writer = None
+        if writer is None:
+            return
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except OSError:
+            pass
+
+    async def query(self, command: str, *, response_lines: int) -> list[str]:
+        """Send a command and read a fixed number of response lines."""
+        if response_lines <= 0:
+            raise ValueError("response_lines must be > 0")
+
+        async with self._lock:
+            await self._write_line(command)
+            lines: list[str] = []
+            for _ in range(response_lines):
+                line = await self._read_line(command)
+                if line.startswith("RPRT "):
+                    code = _parse_rprt(line, command)
+                    if code < 0:
+                        _raise_rprt(command, code)
+                    raise CommandError(
+                        f"External rigctld returned status {line!r} for query "
+                        f"{command!r}; expected {response_lines} data line(s)."
+                    )
+                lines.append(line)
+        return lines
+
+    async def command(self, command: str) -> None:
+        """Send a write command and require ``RPRT 0`` success."""
+        async with self._lock:
+            await self._write_line(command)
+            line = await self._read_line(command)
+
+        code = _parse_rprt(line, command)
+        if code < 0:
+            _raise_rprt(command, code)
+
+    async def _write_line(self, command: str) -> None:
+        reader = self._reader
+        writer = self._writer
+        if reader is None or writer is None or writer.is_closing():
+            raise RadioConnectionError(
+                "External rigctld is not connected; call connect() first."
+            )
+        line = command.strip()
+        if not line:
+            raise CommandError("External rigctld command must be non-empty.")
+        try:
+            writer.write(f"{line}\n".encode("ascii"))
+            await asyncio.wait_for(writer.drain(), timeout=self.timeout)
+        except TimeoutError as exc:
+            await self.close()
+            raise RadioTimeoutError(
+                f"External rigctld command {line!r} timed out while writing "
+                f"after {self.timeout:.3g}s."
+            ) from exc
+        except (OSError, RuntimeError) as exc:
+            await self.close()
+            raise RadioConnectionError(
+                f"Connection to external rigctld at {self.host}:{self.port} "
+                f"failed while sending {line!r}: {exc}"
+            ) from exc
+
+    async def _read_line(self, command: str) -> str:
+        reader = self._reader
+        if reader is None:
+            raise RadioConnectionError("External rigctld connection is closed.")
+        try:
+            raw = await asyncio.wait_for(reader.readline(), timeout=self.timeout)
+        except TimeoutError as exc:
+            await self.close()
+            raise RadioTimeoutError(
+                f"External rigctld command {command!r} timed out after "
+                f"{self.timeout:.3g}s."
+            ) from exc
+        except OSError as exc:
+            await self.close()
+            raise RadioConnectionError(
+                f"Connection to external rigctld at {self.host}:{self.port} "
+                f"failed while reading response to {command!r}: {exc}"
+            ) from exc
+        if raw == b"":
+            await self.close()
+            raise RadioConnectionError(
+                f"External rigctld at {self.host}:{self.port} closed the "
+                f"connection while handling {command!r}."
+            )
+        try:
+            return raw.decode("ascii").rstrip("\r\n")
+        except UnicodeDecodeError as exc:
+            raise CommandError(
+                f"External rigctld returned non-ASCII response to {command!r}."
+            ) from exc
+
+
+def _parse_rprt(line: str, command: str) -> int:
+    parts = line.split()
+    if len(parts) != 2 or parts[0] != "RPRT":
+        raise CommandError(
+            f"External rigctld returned malformed status for {command!r}: {line!r}."
+        )
+    try:
+        return int(parts[1])
+    except ValueError as exc:
+        raise CommandError(
+            f"External rigctld returned malformed status for {command!r}: {line!r}."
+        ) from exc
+
+
+def _raise_rprt(command: str, code: int) -> None:
+    hint = _ERROR_HINTS.get(code, "command failed")
+    raise CommandError(
+        f"External rigctld command {command!r} failed with RPRT {code} ({hint})."
+    )

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -62,6 +62,7 @@ from rigplane.audio.route import resolve_audio_route, rigctld_wsjtx_policy  # no
 from rigplane.backends.config import (  # noqa: E402
     BackendConfig,
     LanBackendConfig,
+    RigctldBackendConfig,
     SerialBackendConfig,
     YaesuCatBackendConfig,
 )
@@ -434,6 +435,13 @@ class _RigplaneArgumentParser(argparse.ArgumentParser):
             if exc.code != 0:
                 _print_common_cli_hint(argv)
             raise
+        parsed._explicit_control_port = any(  # noqa: SLF001
+            _token_matches_option(
+                token,
+                {"--control-port", "--port", "--radio-control-port"},
+            )
+            for token in argv
+        )
         _apply_managed_runtime_defaults(parsed)
         _warn_web_host_ambiguity(parsed)
         return parsed
@@ -546,9 +554,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--backend",
-        choices=["lan", "serial", "yaesu-cat"],
+        choices=["lan", "serial", "yaesu-cat", "rigctld"],
         default=None,
-        help="Backend type: lan (default), serial, or yaesu-cat. Auto-inferred from --serial-port if set.",
+        help="Backend type: lan (default), serial, yaesu-cat, or rigctld. Auto-inferred from --serial-port if set.",
     )
     p.add_argument(
         "--serial-port",
@@ -1115,7 +1123,7 @@ def _build_parser() -> argparse.ArgumentParser:
     web_radio.add_argument(
         "--radio-backend",
         dest="backend",
-        choices=["lan", "serial", "yaesu-cat"],
+        choices=["lan", "serial", "yaesu-cat", "rigctld"],
         default=argparse.SUPPRESS,
         metavar="TYPE",
         help="Radio backend type for the web UI backend",
@@ -1541,7 +1549,12 @@ def check_ports_available(ports: list[int]) -> None:
 
 async def _build_backend_config(
     args: argparse.Namespace,
-) -> LanBackendConfig | SerialBackendConfig | YaesuCatBackendConfig:
+) -> (
+    LanBackendConfig
+    | SerialBackendConfig
+    | YaesuCatBackendConfig
+    | RigctldBackendConfig
+):
     """Build typed backend config from parsed CLI args.
 
     Runs auto-discovery when host / serial-port is not provided.
@@ -1570,6 +1583,24 @@ async def _build_backend_config(
             model=model_name,
             rx_device=getattr(args, "rx_device", None) or None,
             tx_device=getattr(args, "tx_device", None) or None,
+        )
+    if backend == "rigctld":
+        if serial_port:
+            print(
+                "Warning: --serial-port is ignored when --backend rigctld is used.",
+                file=sys.stderr,
+            )
+        host = getattr(args, "host", _HOST_NOT_SET)
+        if not host or host == _HOST_NOT_SET:
+            raise ValueError("rigctld backend requires --host.")
+        explicit_port = bool(getattr(args, "_explicit_control_port", False))
+        env_port = bool(_get_env("ICOM_PORT", ""))
+        port = args.control_port if explicit_port or env_port else 4532
+        return RigctldBackendConfig(
+            host=host,
+            port=port,
+            timeout=args.timeout,
+            model=model_name,
         )
     if backend == "serial":
         host = getattr(args, "host", _HOST_NOT_SET)

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -374,6 +374,22 @@ def _has_global_connection_options_after_command(argv: list[str]) -> bool:
     )
 
 
+def _has_explicit_radio_control_port(argv: list[str]) -> bool:
+    command_index = _first_command_index(argv)
+    global_tokens = argv if command_index is None else argv[:command_index]
+    if any(
+        _token_matches_option(token, {"--control-port", "--port"})
+        for token in global_tokens
+    ):
+        return True
+    if command_index is not None and argv[command_index] == "web":
+        return any(
+            _token_matches_option(token, {"--radio-control-port"})
+            for token in argv[command_index + 1 :]
+        )
+    return False
+
+
 def _print_common_cli_hint(argv: list[str]) -> None:
     if "discover" in argv and "web" in argv:
         print(
@@ -435,13 +451,7 @@ class _RigplaneArgumentParser(argparse.ArgumentParser):
             if exc.code != 0:
                 _print_common_cli_hint(argv)
             raise
-        parsed._explicit_control_port = any(  # noqa: SLF001
-            _token_matches_option(
-                token,
-                {"--control-port", "--port", "--radio-control-port"},
-            )
-            for token in argv
-        )
+        parsed._explicit_control_port = _has_explicit_radio_control_port(argv)  # noqa: SLF001
         _apply_managed_runtime_defaults(parsed)
         _warn_web_host_ambiguity(parsed)
         return parsed

--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -232,6 +232,7 @@ class Radio(Protocol):
           - ``"rigplane"``    — Icom LAN/CI-V-over-Ethernet (IC-7610, IC-9700, …)
           - ``"icom_serial"`` — Icom serial CI-V (IC-7300, IC-705, …)
           - ``"yaesu_cat"``   — Yaesu CAT (FTX-1, …)
+          - ``"rigctld"``     — external Hamlib rigctld TCP adapter
         """
         ...
 

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -9,11 +9,13 @@ import pytest
 from rigplane import IcomRadio, create_radio
 from rigplane.backends.config import (
     LanBackendConfig,
+    RigctldBackendConfig,
     SerialBackendConfig,
     YaesuCatBackendConfig,
 )
 from rigplane.backends.icom7610 import Icom7610SerialRadio
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.backends.rigctld_client.radio import RigctldClientRadio
 from rigplane.backends.icom7610.drivers.contracts import (
     AudioDriver,
     CivLink,
@@ -127,6 +129,11 @@ class TestCreateRadioFactory:
         radio = create_radio(YaesuCatBackendConfig(device="/dev/ttyUSB0"))
         assert isinstance(radio, YaesuCatRadio)
         assert radio.backend_id == "yaesu_cat"
+
+    def test_rigctld_backend_config_has_rigctld_backend_id(self) -> None:
+        radio = create_radio(RigctldBackendConfig(host="localhost"))
+        assert isinstance(radio, RigctldClientRadio)
+        assert radio.backend_id == "rigctld"
 
     def test_create_radio_rejects_unknown_backend(self) -> None:
         @dataclass(slots=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,11 @@ from rigplane.cli import (
     check_ports_available,
     main,
 )
-from rigplane.backends.config import LanBackendConfig, SerialBackendConfig
+from rigplane.backends.config import (
+    LanBackendConfig,
+    RigctldBackendConfig,
+    SerialBackendConfig,
+)
 
 
 class TestParseFrequency:
@@ -561,6 +565,11 @@ class TestBackendArgs:
         assert args.backend == "serial"
         assert args.serial_port == "/dev/tty.test"
 
+    def test_backend_rigctld(self):
+        p = _build_parser()
+        args = p.parse_args(["--backend", "rigctld", "--host", "localhost", "status"])
+        assert args.backend == "rigctld"
+
     def test_serial_port_flag(self):
         p = _build_parser()
         args = p.parse_args(["--serial-port", "/dev/tty.usbmodem1", "status"])
@@ -787,6 +796,31 @@ class TestAutoDiscovery:
         args = p.parse_args(["--serial-port", "/dev/ttyUSB0", "status"])
         config = await _build_backend_config(args)
         assert isinstance(config, SerialBackendConfig)
+
+    async def test_rigctld_backend_uses_external_default_port(self):
+        p = _build_parser()
+        args = p.parse_args(["--backend", "rigctld", "--host", "localhost", "status"])
+        config = await _build_backend_config(args)
+        assert isinstance(config, RigctldBackendConfig)
+        assert config.host == "localhost"
+        assert config.port == 4532
+
+    async def test_rigctld_backend_honors_explicit_control_port(self):
+        p = _build_parser()
+        args = p.parse_args(
+            [
+                "--backend",
+                "rigctld",
+                "--host",
+                "localhost",
+                "--control-port",
+                "4540",
+                "status",
+            ]
+        )
+        config = await _build_backend_config(args)
+        assert isinstance(config, RigctldBackendConfig)
+        assert config.port == 4540
 
 
 class TestPresets:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -805,6 +805,24 @@ class TestAutoDiscovery:
         assert config.host == "localhost"
         assert config.port == 4532
 
+    async def test_web_rigctld_backend_ignores_server_port_for_radio_port(self):
+        p = _build_parser()
+        args = p.parse_args(
+            [
+                "web",
+                "--radio-backend",
+                "rigctld",
+                "--radio-host",
+                "localhost",
+                "--port",
+                "8081",
+            ]
+        )
+        config = await _build_backend_config(args)
+        assert isinstance(config, RigctldBackendConfig)
+        assert config.port == 4532
+        assert args.web_port == 8081
+
     async def test_rigctld_backend_honors_explicit_control_port(self):
         p = _build_parser()
         args = p.parse_args(

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -25,6 +25,7 @@ def test_public_api_surface() -> None:
         # --- Tier 1: Backend configs ---
         "BackendConfig",
         "LanBackendConfig",
+        "RigctldBackendConfig",
         "SerialBackendConfig",
         "YaesuCatBackendConfig",
         # --- Tier 1: Radio + capability protocols ---

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -1,0 +1,176 @@
+"""Tests for the external Hamlib ``rigctld`` client backend."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer
+from rigplane.backends.config import RigctldBackendConfig
+from rigplane.backends.factory import create_radio
+from rigplane.backends.rigctld_client import RigctldClientRadio, RigctldTransport
+from rigplane.exceptions import CommandError
+from rigplane.exceptions import ConnectionError as RadioConnectionError
+from rigplane.exceptions import TimeoutError as RadioTimeoutError
+
+
+async def test_transport_connect_query_and_close() -> None:
+    async with FakeRigctldServer() as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+
+        await transport.connect()
+        try:
+            assert transport.connected
+            assert await transport.query("f", response_lines=1) == ["14074000"]
+        finally:
+            await transport.close()
+
+        assert not transport.connected
+
+
+async def test_transport_serializes_requests() -> None:
+    behavior = FakeRigctldBehavior(command_delays={"f": 0.02})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            results = await asyncio.gather(
+                transport.query("f", response_lines=1),
+                transport.query("t", response_lines=1),
+            )
+        finally:
+            await transport.close()
+
+    assert results == [["14074000"], ["0"]]
+    assert server.commands_seen == ["f", "t"]
+
+
+async def test_transport_timeout_eof_malformed_and_negative_rprt() -> None:
+    timeout_behavior = FakeRigctldBehavior(command_delays={"f": 0.2})
+    async with FakeRigctldServer(behavior=timeout_behavior) as server:
+        transport = RigctldTransport(
+            host=server.host,
+            port=server.port,
+            timeout=0.01,
+        )
+        await transport.connect()
+        try:
+            with pytest.raises(RadioTimeoutError, match="timed out"):
+                await transport.query("f", response_lines=1)
+        finally:
+            await transport.close()
+
+    eof_behavior = FakeRigctldBehavior(disconnect_commands={"f"})
+    async with FakeRigctldServer(behavior=eof_behavior) as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            with pytest.raises(RadioConnectionError, match="closed"):
+                await transport.query("f", response_lines=1)
+        finally:
+            await transport.close()
+
+    malformed_behavior = FakeRigctldBehavior(malformed_responses={"F": b"nope\n"})
+    async with FakeRigctldServer(behavior=malformed_behavior) as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            with pytest.raises(CommandError, match="malformed"):
+                await transport.command("F 14074000")
+        finally:
+            await transport.close()
+
+    unsupported_behavior = FakeRigctldBehavior(unsupported_commands={"F"})
+    async with FakeRigctldServer(behavior=unsupported_behavior) as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            with pytest.raises(CommandError, match="unsupported"):
+                await transport.command("F 14074000")
+        finally:
+            await transport.close()
+
+    unsupported_query = FakeRigctldBehavior(unsupported_commands={"m"})
+    async with FakeRigctldServer(behavior=unsupported_query) as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            with pytest.raises(CommandError, match="unsupported"):
+                await transport.query("m", response_lines=2)
+        finally:
+            await transport.close()
+
+
+async def test_radio_core_frequency_mode_ptt_and_vfo() -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            assert radio.connected
+            assert radio.radio_ready
+            assert radio.backend_id == "rigctld"
+            assert radio.model == "External rigctld"
+            assert radio.capabilities == {"tx", "vfo"}
+            assert radio.supports_command("set_freq")
+            assert radio.supports_command("get_vfo_slot")
+            assert not radio.supports_command("start_audio_rx_opus")
+
+            assert await radio.get_freq() == 14_074_000
+            await radio.set_freq(7_050_000)
+            assert radio.radio_state.main.freq == 7_050_000
+
+            assert await radio.get_mode() == ("USB", 2400)
+            await radio.set_mode("LSB", 1800)
+            assert radio.radio_state.main.mode == "LSB"
+            assert radio.radio_state.main.filter_width == 1800
+
+            assert await radio.get_ptt() is False
+            await radio.set_ptt(True)
+            assert radio.radio_state.ptt is True
+
+            assert await radio.get_vfo_slot() == "A"
+            await radio.set_vfo_slot("B")
+            assert radio.radio_state.main.active_slot == "B"
+        finally:
+            await radio.disconnect()
+
+
+async def test_radio_reports_actionable_connection_failure() -> None:
+    radio = RigctldClientRadio(host="127.0.0.1", port=9, timeout=0.01)
+
+    with pytest.raises(RadioConnectionError, match="127.0.0.1:9"):
+        await radio.connect()
+
+
+async def test_radio_rejects_unsupported_data_mode() -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            assert await radio.get_data_mode() is False
+            with pytest.raises(CommandError, match="data mode"):
+                await radio.set_data_mode(True)
+        finally:
+            await radio.disconnect()
+
+
+def test_config_factory_builds_rigctld_client_backend() -> None:
+    config = RigctldBackendConfig(host="localhost")
+
+    radio = create_radio(config)
+
+    assert isinstance(radio, RigctldClientRadio)
+    assert config.backend == "rigctld"
+    assert config.port == 4532
+    assert radio.backend_id == "rigctld"
+
+
+def test_config_validates_rigctld_client_backend() -> None:
+    with pytest.raises(ValueError, match="host"):
+        RigctldBackendConfig(host="")
+    with pytest.raises(ValueError, match="port"):
+        RigctldBackendConfig(host="localhost", port=0)
+    with pytest.raises(ValueError, match="timeout"):
+        RigctldBackendConfig(host="localhost", timeout=0)


### PR DESCRIPTION
## Summary

- Add an external Hamlib `rigctld` TCP backend with serialized, timeout-bounded line protocol transport.
- Map minimal RigPlane `Radio` behavior for frequency, mode/passband, PTT, and optional VFO slot support.
- Add `RigctldBackendConfig`, factory/export wiring, and CLI `--backend rigctld` / `--radio-backend rigctld` selection with default port 4532.

## Tests

- `uv run pytest tests/test_rigctld_client_backend.py tests/test_backend_factory.py tests/test_cli.py::TestBackendArgs tests/test_cli.py::TestAutoDiscovery tests/test_exports.py -q --tb=short`
- `uv run lint-imports`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -q --tb=short`

Closes #1579.
