### PR TITLE
[codex] Add serial inventory Hamlib metadata

### DIFF
--- a/src/rigplane/backends/discovery.py
+++ b/src/rigplane/backends/discovery.py
@@ -85,12 +85,12 @@ class RadioDiscoveryResult:
     address: int | str
     description: str | None = None
     hwid: str | None = None
+    usb_audio: dict[str, Any] | None = None
     vid: int | None = None
     pid: int | None = None
     manufacturer: str | None = None
     product: str | None = None
     serial_number: str | None = None
-    usb_audio: dict[str, Any] | None = None
 
 
 @dataclass

--- a/src/rigplane/backends/discovery.py
+++ b/src/rigplane/backends/discovery.py
@@ -47,6 +47,11 @@ class SerialPortCandidate:
     device: str
     description: str
     hwid: str | None
+    vid: int | None = None
+    pid: int | None = None
+    manufacturer: str | None = None
+    product: str | None = None
+    serial_number: str | None = None
 
 
 @dataclass
@@ -62,6 +67,11 @@ class RadioDiscoveryResult:
         address: CI-V address (``int``) for Icom radios; CAT model ID string for others.
         description: Human-readable OS serial port description, if available.
         hwid: OS hardware ID string, if available.
+        vid: USB vendor ID from pySerial, if available.
+        pid: USB product ID from pySerial, if available.
+        manufacturer: USB manufacturer string from pySerial, if available.
+        product: USB product string from pySerial, if available.
+        serial_number: USB serial number from pySerial, if available.
         usb_audio: Optional USB audio resolution metadata. Keys match
             :class:`rigplane.usb_audio_resolve.AudioDeviceMapping` field names
             when topology resolution is available.
@@ -75,6 +85,11 @@ class RadioDiscoveryResult:
     address: int | str
     description: str | None = None
     hwid: str | None = None
+    vid: int | None = None
+    pid: int | None = None
+    manufacturer: str | None = None
+    product: str | None = None
+    serial_number: str | None = None
     usb_audio: dict[str, Any] | None = None
 
 
@@ -432,6 +447,11 @@ def enumerate_serial_ports() -> list[SerialPortCandidate]:
                     device=port.device,
                     description=port.description,
                     hwid=port.hwid,
+                    vid=getattr(port, "vid", None),
+                    pid=getattr(port, "pid", None),
+                    manufacturer=getattr(port, "manufacturer", None),
+                    product=getattr(port, "product", None),
+                    serial_number=getattr(port, "serial_number", None),
                 )
             )
             logger.debug("Serial candidate: %s (%s)", port.device, port.description)
@@ -542,6 +562,11 @@ async def discover_serial_radios(
                     address=civ.address,
                     description=port.description,
                     hwid=port.hwid,
+                    vid=port.vid,
+                    pid=port.pid,
+                    manufacturer=port.manufacturer,
+                    product=port.product,
+                    serial_number=port.serial_number,
                     usb_audio=_resolve_usb_audio_metadata(civ.port),
                 )
             )
@@ -555,6 +580,11 @@ async def discover_serial_radios(
         if yaesu:
             yaesu.description = port.description
             yaesu.hwid = port.hwid
+            yaesu.vid = port.vid
+            yaesu.pid = port.pid
+            yaesu.manufacturer = port.manufacturer
+            yaesu.product = port.product
+            yaesu.serial_number = port.serial_number
             yaesu.usb_audio = _resolve_usb_audio_metadata(yaesu.port)
             results.append(yaesu)
             continue
@@ -564,6 +594,11 @@ async def discover_serial_radios(
         if kenwood:
             kenwood.description = port.description
             kenwood.hwid = port.hwid
+            kenwood.vid = port.vid
+            kenwood.pid = port.pid
+            kenwood.manufacturer = port.manufacturer
+            kenwood.product = port.product
+            kenwood.serial_number = port.serial_number
             kenwood.usb_audio = _resolve_usb_audio_metadata(kenwood.port)
             results.append(kenwood)
 
@@ -679,6 +714,11 @@ def build_setup_discovery_payload(
                 "address": serial.get("address"),
                 "description": serial.get("description"),
                 "hwid": serial.get("hwid"),
+                "vid": serial.get("vid"),
+                "pid": serial.get("pid"),
+                "manufacturer": serial.get("manufacturer"),
+                "product": serial.get("product"),
+                "serialNumber": serial.get("serial_number"),
                 "requiresCredentials": False,
             }
             usb_audio = _normalize_usb_audio_metadata(serial.get("usb_audio"))

--- a/src/rigplane/backends/hamlib_models.py
+++ b/src/rigplane/backends/hamlib_models.py
@@ -1,0 +1,138 @@
+"""Hamlib model metadata catalog loaded from installed Hamlib tools."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+__all__ = [
+    "HamlibModelCatalog",
+    "HamlibModelMetadata",
+    "load_hamlib_model_catalog",
+    "parse_hamlib_model_list",
+]
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TOOLS = ("rigctld", "rigctl")
+_DEFAULT_TIMEOUT = 2.0
+_CATALOG_CACHE: dict[tuple[tuple[str, ...], float], "HamlibModelCatalog"] = {}
+
+
+@dataclass(frozen=True)
+class HamlibModelMetadata:
+    """Metadata for one Hamlib rig model entry."""
+
+    model_id: int
+    name: str
+    version: str | None = None
+    status: str | None = None
+    default_connection_hints: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class HamlibModelCatalog:
+    """Parsed Hamlib model catalog, or a degraded empty catalog."""
+
+    models: dict[int, HamlibModelMetadata]
+    degraded_reason: str | None = None
+    source_tool: str | None = None
+
+
+def parse_hamlib_model_list(text: str) -> dict[int, HamlibModelMetadata]:
+    """Parse ``rigctld -l`` / ``rigctl -l`` model output by stable columns.
+
+    Hamlib model names may contain spaces. Parse each line from the right:
+    first token is the numeric model ID, last token is status, penultimate
+    token is version, and the middle tokens form the display name.
+    """
+    models: dict[int, HamlibModelMetadata] = {}
+    for raw_line in text.splitlines():
+        fields = raw_line.split()
+        if len(fields) < 4:
+            continue
+        try:
+            model_id = int(fields[0])
+        except ValueError:
+            continue
+
+        name = " ".join(fields[1:-2]).strip()
+        if not name:
+            continue
+        models[model_id] = HamlibModelMetadata(
+            model_id=model_id,
+            name=name,
+            version=fields[-2],
+            status=fields[-1],
+        )
+    return models
+
+
+def load_hamlib_model_catalog(
+    tools: Iterable[str] = _DEFAULT_TOOLS,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> HamlibModelCatalog:
+    """Load and cache Hamlib rig model metadata from installed command-line tools.
+
+    ``rigctld -l`` is preferred, with ``rigctl -l`` as fallback. Missing tools,
+    timeouts, nonzero exits, and unparseable output degrade to an empty catalog
+    instead of raising.
+    """
+    tool_tuple = tuple(tools)
+    cache_key = (tool_tuple, timeout)
+    cached = _CATALOG_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    last_reason = "hamlib model list unavailable: no tools configured"
+    for tool in tool_tuple:
+        catalog, reason = _load_from_tool(tool, timeout)
+        if catalog is not None:
+            _CATALOG_CACHE[cache_key] = catalog
+            return catalog
+        last_reason = reason
+
+    degraded = HamlibModelCatalog(models={}, degraded_reason=last_reason)
+    _CATALOG_CACHE[cache_key] = degraded
+    return degraded
+
+
+def _load_from_tool(
+    tool: str,
+    timeout: float,
+) -> tuple[HamlibModelCatalog | None, str]:
+    try:
+        completed = subprocess.run(
+            [tool, "-l"],
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        logger.debug("hamlib model list tool not found: %s", tool)
+        return None, "hamlib model list unavailable: tool not found"
+    except subprocess.TimeoutExpired:
+        logger.debug("hamlib model list command timed out: %s", tool)
+        return None, "hamlib model list unavailable: command timed out"
+    except OSError as exc:
+        logger.debug("hamlib model list command failed to start: %s: %s", tool, exc)
+        return None, "hamlib model list unavailable: command failed"
+
+    if completed.returncode != 0:
+        logger.debug(
+            "hamlib model list command failed: %s rc=%d",
+            tool,
+            completed.returncode,
+        )
+        return None, "hamlib model list unavailable: command failed"
+
+    models = parse_hamlib_model_list(completed.stdout or "")
+    if not models:
+        logger.debug("hamlib model list had no parseable models: %s", tool)
+        return None, "hamlib model list unavailable: no parseable models"
+
+    return HamlibModelCatalog(models=models, source_tool=tool), ""

--- a/tests/fixtures/hamlib_rigctl_list.txt
+++ b/tests/fixtures/hamlib_rigctl_list.txt
@@ -1,0 +1,5 @@
+Rig #  Mfg                 Model                         Version  Status
+1      Hamlib              Dummy                         20240312 Stable
+2      Hamlib              NET rigctl                    20240312 Beta
+3073   Icom                IC-7610                       20240312 Stable
+1040   Yaesu               FTX-1                         20240312 Untested

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -787,6 +787,26 @@ class TestProbeSerialYaesuCat:
 # ---------------------------------------------------------------------------
 
 
+def test_radio_discovery_result_legacy_positional_usb_audio_binding() -> None:
+    usb_audio = {"rx_device_index": 6}
+
+    result = RadioDiscoveryResult(
+        "/dev/ttyUSB0",
+        "civ",
+        "IC-7610",
+        "icom_ic7610",
+        115200,
+        0x98,
+        "USB Serial",
+        "USB VID:PID=10C4:EA60",
+        usb_audio,
+    )
+
+    assert result.usb_audio is usb_audio
+    assert result.vid is None
+    assert result.pid is None
+
+
 class TestDiscoverSerialRadios:
     @pytest.mark.asyncio
     async def test_civ_radio_detected(self) -> None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 from contextlib import ExitStack, contextmanager
 from functools import partial
-from unittest.mock import Mock, patch
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -251,12 +252,18 @@ class TestParseProbeResponse:
         assert _parse_probe_response("/dev/x", 19200, data) is None
 
 
-def _make_port(device: str, description: str = "", hwid: str | None = None) -> Mock:
-    port = Mock()
-    port.device = device
-    port.description = description
-    port.hwid = hwid
-    return port
+def _make_port(
+    device: str,
+    description: str = "",
+    hwid: str | None = None,
+    **metadata: object,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        device=device,
+        description=description,
+        hwid=hwid,
+        **metadata,
+    )
 
 
 class TestIsCandidate:
@@ -302,7 +309,16 @@ class TestIsCandidate:
 
 class TestEnumerateSerialPorts:
     def test_usb_port_returned(self) -> None:
-        port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=10C4:EA60")
+        port = _make_port(
+            "/dev/ttyUSB0",
+            "USB Serial",
+            "USB VID:PID=10C4:EA60",
+            vid=0x10C4,
+            pid=0xEA60,
+            manufacturer="Silicon Labs",
+            product="CP210x USB to UART Bridge",
+            serial_number="0001",
+        )
         with patch("serial.tools.list_ports.comports", return_value=[port]):
             result = enumerate_serial_ports()
         assert len(result) == 1
@@ -310,7 +326,22 @@ class TestEnumerateSerialPorts:
             device="/dev/ttyUSB0",
             description="USB Serial",
             hwid="USB VID:PID=10C4:EA60",
+            vid=0x10C4,
+            pid=0xEA60,
+            manufacturer="Silicon Labs",
+            product="CP210x USB to UART Bridge",
+            serial_number="0001",
         )
+
+    def test_missing_usb_metadata_attrs_are_optional(self) -> None:
+        port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=10C4:EA60")
+        with patch("serial.tools.list_ports.comports", return_value=[port]):
+            result = enumerate_serial_ports()
+        assert result[0].vid is None
+        assert result[0].pid is None
+        assert result[0].manufacturer is None
+        assert result[0].product is None
+        assert result[0].serial_number is None
 
     def test_bluetooth_excluded(self) -> None:
         port = _make_port("/dev/tty.Bluetooth-Incoming-Port", "Bluetooth")
@@ -465,6 +496,13 @@ def test_build_setup_discovery_payload_is_stable_and_credential_free() -> None:
                     "address": 0x98,
                     "description": "IC-7610 USB",
                     "hwid": "USB VID:PID=10C4:EA60",
+                    "vid": 0x10C4,
+                    "pid": 0xEA60,
+                    "manufacturer": "Silicon Labs",
+                    "product": "CP210x USB to UART Bridge",
+                    "serial_number": "0001",
+                    "token": "must-not-leak",
+                    "hostname": "private-host.local",
                 }
             ],
         }
@@ -486,7 +524,14 @@ def test_build_setup_discovery_payload_is_stable_and_credential_free() -> None:
     assert radio["connections"][1]["type"] == "serial"
     assert radio["connections"][1]["description"] == "IC-7610 USB"
     assert radio["connections"][1]["hwid"] == "USB VID:PID=10C4:EA60"
+    assert radio["connections"][1]["vid"] == 0x10C4
+    assert radio["connections"][1]["pid"] == 0xEA60
+    assert radio["connections"][1]["manufacturer"] == "Silicon Labs"
+    assert radio["connections"][1]["product"] == "CP210x USB to UART Bridge"
+    assert radio["connections"][1]["serialNumber"] == "0001"
     assert "password" not in str(payload).lower()
+    assert "token" not in str(payload).lower()
+    assert "private-host" not in str(payload).lower()
     assert payload["limitations"]["windowsUsbAudio"] == "manual-device-selection"
 
 
@@ -513,6 +558,7 @@ def test_setup_payload_preserves_usb_audio_metadata_without_credentials() -> Non
                     },
                     "user": "must-not-leak",
                     "password": "must-not-leak",
+                    "private_key": "must-not-leak",
                 }
             ],
         }
@@ -529,6 +575,7 @@ def test_setup_payload_preserves_usb_audio_metadata_without_credentials() -> Non
         "locationPrefix": 0x0111,
     }
     assert "password" not in str(payload).lower()
+    assert "private_key" not in str(payload).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -766,6 +813,36 @@ class TestDiscoverSerialRadios:
         assert r.hwid == "USB VID:PID=10C4:EA60"
 
     @pytest.mark.asyncio
+    async def test_civ_radio_preserves_serial_usb_metadata(self) -> None:
+        reader = _FakeReader([_IC7610_RESPONSE])
+        writer = _FakeWriter()
+
+        port = _make_port(
+            "/dev/ttyUSB0",
+            "USB Serial",
+            "USB VID:PID=10C4:EA60",
+            vid=0x10C4,
+            pid=0xEA60,
+            manufacturer="Silicon Labs",
+            product="CP210x USB to UART Bridge",
+            serial_number="0001",
+        )
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+        ):
+            results = await discover_serial_radios(
+                _open_serial=_make_open(reader, writer),
+            )
+
+        r = results[0]
+        assert r.vid == 0x10C4
+        assert r.pid == 0xEA60
+        assert r.manufacturer == "Silicon Labs"
+        assert r.product == "CP210x USB to UART Bridge"
+        assert r.serial_number == "0001"
+
+    @pytest.mark.asyncio
     async def test_civ_radio_preserves_usb_audio_resolution_metadata(self) -> None:
         reader = _FakeReader([_IC7610_RESPONSE])
         writer = _FakeWriter()
@@ -804,7 +881,16 @@ class TestDiscoverSerialRadios:
 
         yaesu_factory = _make_yaesu_factory("ID0840")
 
-        port = _make_port("/dev/ttyUSB0", "USB Serial", "USB VID:PID=0403:6001")
+        port = _make_port(
+            "/dev/ttyUSB0",
+            "USB Serial",
+            "USB VID:PID=0403:6001",
+            vid=0x0403,
+            pid=0x6001,
+            manufacturer="FTDI",
+            product="USB Serial Converter",
+            serial_number="YAESU1",
+        )
         with (
             _fast_probes(),
             patch("serial.tools.list_ports.comports", return_value=[port]),
@@ -819,6 +905,11 @@ class TestDiscoverSerialRadios:
         assert r.protocol == "yaesu_cat"
         assert r.model == "FTX-1"
         assert r.profile_id == "yaesu_ftx1"
+        assert r.vid == 0x0403
+        assert r.pid == 0x6001
+        assert r.manufacturer == "FTDI"
+        assert r.product == "USB Serial Converter"
+        assert r.serial_number == "YAESU1"
 
     @pytest.mark.asyncio
     async def test_no_radio_on_port(self) -> None:

--- a/tests/test_hamlib_models.py
+++ b/tests/test_hamlib_models.py
@@ -1,0 +1,162 @@
+"""Tests for Hamlib model list parsing and subprocess loading."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+from rigplane.backends.hamlib_models import (
+    HamlibModelCatalog,
+    HamlibModelMetadata,
+    load_hamlib_model_catalog,
+    parse_hamlib_model_list,
+)
+
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "hamlib_rigctl_list.txt"
+
+
+def test_parse_hamlib_model_list_fixture() -> None:
+    models = parse_hamlib_model_list(_FIXTURE.read_text(encoding="utf-8"))
+
+    assert models[3073] == HamlibModelMetadata(
+        model_id=3073,
+        name="Icom IC-7610",
+        version="20240312",
+        status="Stable",
+    )
+    assert models[2].name == "Hamlib NET rigctl"
+    assert models[1040].status == "Untested"
+
+
+def test_parse_hamlib_model_list_skips_unparseable_lines() -> None:
+    models = parse_hamlib_model_list(
+        """
+        heading without model id
+        42 Example Radio With Spaces 1.0 Stable
+        not-a-number Example Broken 1.0 Stable
+        43 missing-status
+        """
+    )
+
+    assert list(models) == [42]
+    assert models[42].name == "Example Radio With Spaces"
+
+
+def test_load_catalog_prefers_rigctld(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        assert kwargs["shell"] is False
+        return subprocess.CompletedProcess(
+            args, 0, stdout=_FIXTURE.read_text(), stderr=""
+        )
+
+    monkeypatch.setattr("rigplane.backends.hamlib_models.subprocess.run", fake_run)
+
+    catalog = load_hamlib_model_catalog(tools=("rigctld-success",), timeout=0.1)
+
+    assert isinstance(catalog, HamlibModelCatalog)
+    assert catalog.degraded_reason is None
+    assert catalog.source_tool == "rigctld-success"
+    assert 3073 in catalog.models
+    assert calls == [["rigctld-success", "-l"]]
+
+
+def test_load_catalog_falls_back_when_first_tool_missing(monkeypatch) -> None:
+    def fake_run(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        if args[0] == "missing-rigctld":
+            raise FileNotFoundError(args[0])
+        return subprocess.CompletedProcess(
+            args, 0, stdout=_FIXTURE.read_text(), stderr=""
+        )
+
+    monkeypatch.setattr("rigplane.backends.hamlib_models.subprocess.run", fake_run)
+
+    catalog = load_hamlib_model_catalog(
+        tools=("missing-rigctld", "rigctl-fallback"),
+        timeout=0.1,
+    )
+
+    assert catalog.degraded_reason is None
+    assert catalog.source_tool == "rigctl-fallback"
+    assert catalog.models[3073].name == "Icom IC-7610"
+
+
+def test_load_catalog_degrades_when_all_tools_missing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "rigplane.backends.hamlib_models.subprocess.run",
+        Mock(side_effect=FileNotFoundError("rigctld")),
+    )
+
+    catalog = load_hamlib_model_catalog(tools=("all-missing-a", "all-missing-b"))
+
+    assert catalog.models == {}
+    assert catalog.degraded_reason == "hamlib model list unavailable: tool not found"
+    assert catalog.source_tool is None
+
+
+def test_load_catalog_degrades_on_timeout_without_exposing_output(monkeypatch) -> None:
+    def fake_run(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(
+            args,
+            timeout=0.1,
+            output="PRIVATE_KEY=abc123",
+            stderr="token=secret",
+        )
+
+    monkeypatch.setattr("rigplane.backends.hamlib_models.subprocess.run", fake_run)
+
+    catalog = load_hamlib_model_catalog(tools=("timeout-tool",), timeout=0.1)
+
+    assert catalog.models == {}
+    assert catalog.degraded_reason == "hamlib model list unavailable: command timed out"
+    assert "PRIVATE_KEY" not in str(catalog)
+    assert "secret" not in str(catalog)
+
+
+def test_load_catalog_degrades_on_nonzero_without_exposing_stderr(
+    monkeypatch,
+) -> None:
+    def fake_run(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args,
+            2,
+            stdout="",
+            stderr="hostname=private.local token=secret",
+        )
+
+    monkeypatch.setattr("rigplane.backends.hamlib_models.subprocess.run", fake_run)
+
+    catalog = load_hamlib_model_catalog(tools=("nonzero-tool",), timeout=0.1)
+
+    assert catalog.models == {}
+    assert catalog.degraded_reason == "hamlib model list unavailable: command failed"
+    assert "private.local" not in str(catalog)
+    assert "secret" not in str(catalog)
+
+
+def test_load_catalog_degrades_on_empty_parse(monkeypatch) -> None:
+    def fake_run(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args, 0, stdout="Rig #  Mfg Model", stderr=""
+        )
+
+    monkeypatch.setattr("rigplane.backends.hamlib_models.subprocess.run", fake_run)
+
+    catalog = load_hamlib_model_catalog(tools=("empty-parse-tool",), timeout=0.1)
+
+    assert catalog.models == {}
+    assert (
+        catalog.degraded_reason == "hamlib model list unavailable: no parseable models"
+    )


### PR DESCRIPTION
## Summary

- Extend serial discovery candidates/results with optional pySerial VID/PID/manufacturer/product/serial number fields.
- Preserve setup discovery payload allowlisting while adding explicit serial metadata keys.
- Add a backend Hamlib model catalog parser/cache using `rigctld -l` with `rigctl -l` fallback and degraded mode for missing/failing tools.

Closes #1580

## Validation

- `uv run pytest tests/test_discovery.py tests/test_hamlib_models.py -q --tb=short`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`

## Notes

Candidate ranking and safe probing are intentionally out of scope for #1581. The pre-existing local `uv.lock` version-sync change was not included.