### PR TITLE
[codex] Add safe Hamlib probe ranking internals

### DIFF
--- a/docs/plans/2026-05-23-hamlib-provider-contract.md
+++ b/docs/plans/2026-05-23-hamlib-provider-contract.md
@@ -101,6 +101,23 @@ Discovery rules:
 - If no safe read probe exists, return a manual-configuration candidate with
   clear evidence and next action.
 
+### Read-only Hamlib probe safety
+
+The core probe internals for external `rigctld` targets are opt-in only. When
+probe options are disabled, no transport is constructed and no network or serial
+I/O is attempted.
+
+Allowed probe operations are limited to the read-only rigctld commands
+`\get_info`, `f`, and `m`. Probe code must not send PTT, transmit audio, CW,
+tuner, frequency/mode write, memory write, raw CI-V, `\dump_state`, or other
+state-changing commands. Probe audit records use semantic operation names and a
+redacted target reference; they must not include raw host/IP values, private
+hostnames, serial numbers, full device paths, credentials, raw command
+arguments, raw frequency values, or raw stdout/stderr.
+
+This probe layer does not add CLI flags or output. User-facing assisted
+discovery flows remain a separate implementation concern.
+
 ## Open-Core and Pro Boundary
 
 The open-core repository owns the generic public contract:

--- a/src/rigplane/backends/discovery.py
+++ b/src/rigplane/backends/discovery.py
@@ -10,18 +10,37 @@ from typing import Any, cast
 
 from rigplane.usb_audio_resolve import AudioDeviceMapping, resolve_audio_for_serial_port
 
+from .hamlib_probe import (
+    DiscoveryCandidate,
+    DiscoveryEvidence,
+    HamlibProbeTarget,
+    ProbeAuditRecord,
+    ProbeOptions,
+    ProbeResult,
+    probe_hamlib_rigctld_targets,
+    rank_hamlib_probe,
+)
+
 __all__ = [
     "build_setup_discovery_payload",
     "CivProbeResult",
+    "DiscoveryCandidate",
+    "DiscoveryEvidence",
+    "HamlibProbeTarget",
+    "ProbeAuditRecord",
+    "ProbeOptions",
+    "ProbeResult",
     "RadioDiscoveryResult",
     "SerialPortCandidate",
     "dedupe_radios",
     "discover_lan_radios",
     "discover_serial_radios",
     "enumerate_serial_ports",
+    "probe_hamlib_rigctld_targets",
     "probe_serial_civ",
     "probe_serial_kenwood_cat",
     "probe_serial_yaesu_cat",
+    "rank_hamlib_probe",
 ]
 
 _CIV_PROBE_CMD = bytes([0xFE, 0xFE, 0x00, 0xE0, 0x19, 0x00, 0xFD])

--- a/src/rigplane/backends/hamlib_probe.py
+++ b/src/rigplane/backends/hamlib_probe.py
@@ -1,0 +1,652 @@
+"""Safe read-only probing and ranking for external Hamlib ``rigctld`` targets."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import re
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from rigplane.exceptions import CommandError
+from rigplane.exceptions import ConnectionError as RadioConnectionError
+from rigplane.exceptions import TimeoutError as RadioTimeoutError
+
+from .hamlib_models import HamlibModelCatalog, HamlibModelMetadata
+from .rigctld_client import RigctldTransport
+
+__all__ = [
+    "DiscoveryCandidate",
+    "DiscoveryEvidence",
+    "HamlibProbeTarget",
+    "ProbeAuditRecord",
+    "ProbeOptions",
+    "ProbeResult",
+    "probe_hamlib_rigctld_targets",
+    "rank_hamlib_probe",
+]
+
+Confidence = Literal["high", "medium", "low"]
+AuditStatus = Literal[
+    "ok",
+    "unsupported",
+    "timeout",
+    "malformed",
+    "error",
+    "cancelled",
+]
+
+_READ_INFO = r"\get_info"
+_READ_FREQUENCY = "f"
+_READ_MODE = "m"
+_TARGET_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveryEvidence:
+    """Privacy-safe evidence explaining a discovery candidate ranking."""
+
+    source: str
+    kind: str
+    status: str
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveryCandidate:
+    """Ranked setup candidate produced from safe discovery evidence."""
+
+    transport: str
+    address: str
+    observed_identity: dict[str, object]
+    suggested_backend: str
+    suggested_model: str | None
+    confidence: Confidence
+    evidence: list[DiscoveryEvidence]
+    safe_next_action: str
+
+
+@dataclass(frozen=True, slots=True)
+class HamlibProbeTarget:
+    """External ``rigctld`` endpoint to probe with read-only commands."""
+
+    host: str
+    port: int = 4532
+    model_id: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeOptions:
+    """Safety controls for Hamlib probing.
+
+    Probing is disabled by default. When disabled, callers must receive an empty
+    result without constructing transports or touching any target.
+    """
+
+    enabled: bool = False
+    max_concurrency: int = 2
+    command_timeout: float = 0.25
+    target_timeout: float = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeAuditRecord:
+    """Privacy-safe audit record for one semantic read operation."""
+
+    target_ref: str
+    operation: str
+    status: AuditStatus
+    duration_ms: int
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeResult:
+    """Read-only probe outcome for one redacted target."""
+
+    target_ref: str
+    candidates: list[DiscoveryCandidate]
+    audit: list[ProbeAuditRecord] = field(default_factory=list)
+
+
+async def probe_hamlib_rigctld_targets(
+    targets: Iterable[HamlibProbeTarget],
+    *,
+    options: ProbeOptions | None = None,
+    catalog: HamlibModelCatalog | None = None,
+    _transport_factory: Any = RigctldTransport,
+) -> list[ProbeResult]:
+    """Probe external ``rigctld`` targets using only safe read commands.
+
+    The runner sends only ``\\get_info``, ``f``, and ``m``. It does not call the
+    higher-level radio backend because backend connection setup may perform
+    additional reads outside this discovery safety envelope.
+    """
+    probe_options = options or ProbeOptions()
+    if not probe_options.enabled:
+        return []
+
+    target_list = list(targets)
+    if not target_list:
+        return []
+
+    model_catalog = catalog or HamlibModelCatalog(models={})
+    semaphore = asyncio.Semaphore(max(1, probe_options.max_concurrency))
+    tasks = [
+        asyncio.create_task(
+            _probe_one_with_limits(
+                target,
+                options=probe_options,
+                catalog=model_catalog,
+                semaphore=semaphore,
+                transport_factory=_transport_factory,
+            )
+        )
+        for target in target_list
+    ]
+    try:
+        return await asyncio.gather(*tasks)
+    except asyncio.CancelledError:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
+async def _probe_one_with_limits(
+    target: HamlibProbeTarget,
+    *,
+    options: ProbeOptions,
+    catalog: HamlibModelCatalog,
+    semaphore: asyncio.Semaphore,
+    transport_factory: Any,
+) -> ProbeResult:
+    target_ref = _target_ref(target)
+    async with semaphore:
+        lock = _lock_for(target)
+        async with lock:
+            try:
+                return await asyncio.wait_for(
+                    _probe_one(
+                        target,
+                        options=options,
+                        catalog=catalog,
+                        target_ref=target_ref,
+                        transport_factory=transport_factory,
+                    ),
+                    timeout=options.target_timeout,
+                )
+            except TimeoutError:
+                audit = [
+                    ProbeAuditRecord(
+                        target_ref=target_ref,
+                        operation="probe_target",
+                        status="timeout",
+                        duration_ms=int(options.target_timeout * 1000),
+                    )
+                ]
+                candidates = rank_hamlib_probe(target=target, catalog=catalog)
+                return ProbeResult(
+                    target_ref=target_ref,
+                    candidates=candidates,
+                    audit=audit,
+                )
+
+
+async def _probe_one(
+    target: HamlibProbeTarget,
+    *,
+    options: ProbeOptions,
+    catalog: HamlibModelCatalog,
+    target_ref: str,
+    transport_factory: Any,
+) -> ProbeResult:
+    audit: list[ProbeAuditRecord] = []
+    transport = transport_factory(
+        host=target.host,
+        port=target.port,
+        timeout=options.command_timeout,
+    )
+
+    info_text: str | None = None
+    frequency_readable = False
+    mode_readable = False
+
+    try:
+        await asyncio.wait_for(transport.connect(), timeout=options.command_timeout)
+        info_text = await _query_info(transport, options, target_ref, audit)
+        frequency_readable = await _query_frequency(
+            transport,
+            options,
+            target_ref,
+            audit,
+        )
+        mode_readable = await _query_mode(transport, options, target_ref, audit)
+    except asyncio.CancelledError:
+        audit.append(
+            ProbeAuditRecord(
+                target_ref=target_ref,
+                operation="probe_target",
+                status="cancelled",
+                duration_ms=0,
+            )
+        )
+        raise
+    except (RadioTimeoutError, TimeoutError):
+        audit.append(
+            ProbeAuditRecord(
+                target_ref=target_ref,
+                operation="connect",
+                status="timeout",
+                duration_ms=0,
+                detail="timeout",
+            )
+        )
+    except (CommandError, RadioConnectionError, OSError, RuntimeError):
+        audit.append(
+            ProbeAuditRecord(
+                target_ref=target_ref,
+                operation="connect",
+                status="error",
+                duration_ms=0,
+            )
+        )
+    finally:
+        await transport.close()
+
+    candidates = rank_hamlib_probe(
+        target=target,
+        catalog=catalog,
+        info_text=info_text,
+        frequency_readable=frequency_readable,
+        mode_readable=mode_readable,
+    )
+    return ProbeResult(target_ref=target_ref, candidates=candidates, audit=audit)
+
+
+async def _query_info(
+    transport: RigctldTransport,
+    options: ProbeOptions,
+    target_ref: str,
+    audit: list[ProbeAuditRecord],
+) -> str | None:
+    lines, status, duration_ms = await _query_read(
+        transport,
+        command=_READ_INFO,
+        response_lines=1,
+        timeout=options.command_timeout,
+    )
+    audit.append(
+        ProbeAuditRecord(
+            target_ref=target_ref,
+            operation="read_info",
+            status=status,
+            duration_ms=duration_ms,
+            detail=_status_detail(status),
+        )
+    )
+    if status != "ok" or not lines:
+        return None
+    return lines[0]
+
+
+async def _query_frequency(
+    transport: RigctldTransport,
+    options: ProbeOptions,
+    target_ref: str,
+    audit: list[ProbeAuditRecord],
+) -> bool:
+    lines, status, duration_ms = await _query_read(
+        transport,
+        command=_READ_FREQUENCY,
+        response_lines=1,
+        timeout=options.command_timeout,
+    )
+    if status == "ok" and (not lines or not _is_sane_frequency(lines[0])):
+        status = "malformed"
+    audit.append(
+        ProbeAuditRecord(
+            target_ref=target_ref,
+            operation="read_frequency",
+            status=status,
+            duration_ms=duration_ms,
+            detail=_status_detail(status),
+        )
+    )
+    return status == "ok"
+
+
+async def _query_mode(
+    transport: RigctldTransport,
+    options: ProbeOptions,
+    target_ref: str,
+    audit: list[ProbeAuditRecord],
+) -> bool:
+    lines, status, duration_ms = await _query_read(
+        transport,
+        command=_READ_MODE,
+        response_lines=2,
+        timeout=options.command_timeout,
+    )
+    if status == "ok" and not _is_sane_mode(lines):
+        status = "malformed"
+    audit.append(
+        ProbeAuditRecord(
+            target_ref=target_ref,
+            operation="read_mode",
+            status=status,
+            duration_ms=duration_ms,
+            detail=_status_detail(status),
+        )
+    )
+    return status == "ok"
+
+
+async def _query_read(
+    transport: RigctldTransport,
+    *,
+    command: str,
+    response_lines: int,
+    timeout: float,
+) -> tuple[list[str], AuditStatus, int]:
+    start = time.monotonic()
+    try:
+        lines = await asyncio.wait_for(
+            transport.query(command, response_lines=response_lines),
+            timeout=timeout,
+        )
+    except asyncio.CancelledError:
+        raise
+    except (RadioTimeoutError, TimeoutError):
+        return [], "timeout", _duration_ms(start)
+    except CommandError as exc:
+        if "unsupported" in str(exc).lower():
+            return [], "unsupported", _duration_ms(start)
+        return [], "error", _duration_ms(start)
+    except (OSError, RuntimeError):
+        return [], "error", _duration_ms(start)
+    return lines, "ok", _duration_ms(start)
+
+
+def rank_hamlib_probe(
+    *,
+    target: HamlibProbeTarget,
+    catalog: HamlibModelCatalog,
+    info_text: str | None = None,
+    frequency_readable: bool = False,
+    mode_readable: bool = False,
+) -> list[DiscoveryCandidate]:
+    """Rank safe Hamlib observations into one or more candidates."""
+    matches = _matched_models(target, catalog, info_text)
+    evidence = _ranking_evidence(
+        target=target,
+        catalog=catalog,
+        info_text=info_text,
+        frequency_readable=frequency_readable,
+        mode_readable=mode_readable,
+    )
+
+    if len(matches) > 1:
+        return [
+            _candidate(
+                target=target,
+                model=model,
+                confidence="medium",
+                evidence=evidence,
+                safe_next_action="confirm_model",
+            )
+            for model in matches
+        ]
+
+    if len(matches) == 1:
+        confidence: Confidence = (
+            "high" if info_text and frequency_readable and mode_readable else "medium"
+        )
+        return [
+            _candidate(
+                target=target,
+                model=matches[0],
+                confidence=confidence,
+                evidence=evidence,
+                safe_next_action=(
+                    "read_only_probe_confirmed"
+                    if confidence == "high"
+                    else "confirm_model"
+                ),
+            )
+        ]
+
+    confidence = _fallback_confidence(
+        target=target,
+        catalog=catalog,
+        info_text=info_text,
+        frequency_readable=frequency_readable,
+        mode_readable=mode_readable,
+    )
+    return [
+        _candidate(
+            target=target,
+            model=None,
+            confidence=confidence,
+            evidence=evidence,
+            safe_next_action=(
+                "confirm_model"
+                if confidence == "medium"
+                else "manual_configuration_required"
+            ),
+        )
+    ]
+
+
+def _candidate(
+    *,
+    target: HamlibProbeTarget,
+    model: HamlibModelMetadata | None,
+    confidence: Confidence,
+    evidence: list[DiscoveryEvidence],
+    safe_next_action: str,
+) -> DiscoveryCandidate:
+    observed_identity: dict[str, object] = {
+        "rigctld_endpoint": "redacted",
+    }
+    if target.model_id is not None:
+        observed_identity["target_model_id"] = target.model_id
+    if any(
+        item.kind == "rigctld_info" and item.status == "available" for item in evidence
+    ):
+        observed_identity["rigctld_info"] = "available"
+    if any(item.kind == "frequency" and item.status == "readable" for item in evidence):
+        observed_identity["frequency"] = "readable"
+    if any(item.kind == "mode" and item.status == "readable" for item in evidence):
+        observed_identity["mode"] = "readable"
+
+    return DiscoveryCandidate(
+        transport="rigctld",
+        address=_target_ref(target),
+        observed_identity=observed_identity,
+        suggested_backend="hamlib",
+        suggested_model=_model_label(model),
+        confidence=confidence,
+        evidence=evidence,
+        safe_next_action=safe_next_action,
+    )
+
+
+def _matched_models(
+    target: HamlibProbeTarget,
+    catalog: HamlibModelCatalog,
+    info_text: str | None,
+) -> list[HamlibModelMetadata]:
+    if target.model_id is not None and target.model_id in catalog.models:
+        return [catalog.models[target.model_id]]
+    if not info_text or not catalog.models:
+        return []
+
+    info = info_text.lower()
+    ids = {int(value) for value in re.findall(r"\b\d{2,6}\b", info)}
+    id_matches = [
+        model for model_id, model in catalog.models.items() if model_id in ids
+    ]
+    if id_matches:
+        return sorted(id_matches, key=lambda item: item.model_id)
+
+    full_name_matches = [
+        model for model in catalog.models.values() if model.name.lower() in info
+    ]
+    if full_name_matches:
+        return sorted(full_name_matches, key=lambda item: item.model_id)
+
+    info_tokens = {
+        token
+        for token in re.split(r"[^a-z0-9]+", info)
+        if len(token) >= 4 and not token.isdigit()
+    }
+    if not info_tokens:
+        return []
+    token_matches = [
+        model
+        for model in catalog.models.values()
+        if info_tokens & set(re.split(r"[^a-z0-9]+", model.name.lower()))
+    ]
+    return sorted(token_matches, key=lambda item: item.model_id)
+
+
+def _ranking_evidence(
+    *,
+    target: HamlibProbeTarget,
+    catalog: HamlibModelCatalog,
+    info_text: str | None,
+    frequency_readable: bool,
+    mode_readable: bool,
+) -> list[DiscoveryEvidence]:
+    evidence: list[DiscoveryEvidence] = []
+    if target.model_id is not None:
+        evidence.append(
+            DiscoveryEvidence(
+                source="inventory",
+                kind="hamlib_model_id",
+                status=(
+                    "catalog_match"
+                    if target.model_id in catalog.models
+                    else "catalog_unknown"
+                ),
+            )
+        )
+    if info_text:
+        evidence.append(
+            DiscoveryEvidence(
+                source="rigctld_probe",
+                kind="rigctld_info",
+                status="available",
+            )
+        )
+    if frequency_readable:
+        evidence.append(
+            DiscoveryEvidence(
+                source="rigctld_probe",
+                kind="frequency",
+                status="readable",
+            )
+        )
+    if mode_readable:
+        evidence.append(
+            DiscoveryEvidence(
+                source="rigctld_probe",
+                kind="mode",
+                status="readable",
+            )
+        )
+    if catalog.degraded_reason is not None:
+        evidence.append(
+            DiscoveryEvidence(
+                source="hamlib_catalog",
+                kind="catalog",
+                status="degraded",
+                detail=catalog.degraded_reason,
+            )
+        )
+    if not evidence:
+        evidence.append(
+            DiscoveryEvidence(
+                source="rigctld_probe",
+                kind="probe",
+                status="unconfirmed",
+            )
+        )
+    return evidence
+
+
+def _fallback_confidence(
+    *,
+    target: HamlibProbeTarget,
+    catalog: HamlibModelCatalog,
+    info_text: str | None,
+    frequency_readable: bool,
+    mode_readable: bool,
+) -> Confidence:
+    if catalog.degraded_reason is not None:
+        return "low"
+    if target.model_id is not None and target.model_id in catalog.models:
+        return "medium"
+    if info_text and frequency_readable and mode_readable and catalog.models:
+        return "medium"
+    return "low"
+
+
+def _is_sane_frequency(value: str) -> bool:
+    try:
+        frequency = int(value)
+    except ValueError:
+        return False
+    return 1_000 <= frequency <= 3_000_000_000
+
+
+def _is_sane_mode(lines: list[str]) -> bool:
+    if len(lines) != 2:
+        return False
+    mode = lines[0].strip()
+    if not mode or not mode.replace("-", "").isalnum():
+        return False
+    try:
+        passband = int(lines[1])
+    except ValueError:
+        return False
+    return passband >= 0
+
+
+def _target_ref(target: HamlibProbeTarget) -> str:
+    digest = hashlib.sha256(f"{target.host}:{target.port}".encode("utf-8")).hexdigest()
+    return f"rigctld:{digest[:12]}"
+
+
+def _target_key(target: HamlibProbeTarget) -> str:
+    return f"{target.host}:{target.port}"
+
+
+def _lock_for(target: HamlibProbeTarget) -> asyncio.Lock:
+    key = _target_key(target)
+    lock = _TARGET_LOCKS.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _TARGET_LOCKS[key] = lock
+    return lock
+
+
+def _duration_ms(start: float) -> int:
+    return max(0, int((time.monotonic() - start) * 1000))
+
+
+def _status_detail(status: AuditStatus) -> str | None:
+    if status == "ok":
+        return "readable"
+    if status in {"unsupported", "timeout", "malformed", "cancelled"}:
+        return status
+    return None
+
+
+def _model_label(model: HamlibModelMetadata | None) -> str | None:
+    if model is None:
+        return None
+    return f"{model.model_id} {model.name}"

--- a/tests/fake_rigctld.py
+++ b/tests/fake_rigctld.py
@@ -15,6 +15,7 @@ _GET_PTT = {"t", r"\get_ptt"}
 _SET_PTT = {"T", r"\set_ptt"}
 _GET_VFO = {"v", r"\get_vfo"}
 _SET_VFO = {"V", r"\set_vfo"}
+_GET_INFO = {r"\get_info"}
 _QUIT = {"q", r"\quit"}
 
 
@@ -27,6 +28,7 @@ class FakeRigctldState:
     passband_hz: int = 2400
     ptt: int = 0
     vfo: str = "VFOA"
+    info: str = "Fake rigctld"
 
 
 @dataclass(slots=True)
@@ -224,6 +226,9 @@ class FakeRigctldServer:
                 return _error(HamlibError.EINVAL)
             self.state.vfo = tokens[1].upper()
             return _ok()
+
+        if key in _GET_INFO:
+            return f"{self.state.info}\n".encode("ascii")
 
         return _error(HamlibError.ENIMPL)
 

--- a/tests/test_hamlib_probe.py
+++ b/tests/test_hamlib_probe.py
@@ -1,0 +1,247 @@
+"""Tests for safe read-only Hamlib probing and candidate ranking."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer, FakeRigctldState
+from rigplane.backends.hamlib_models import HamlibModelCatalog, HamlibModelMetadata
+from rigplane.discovery import (
+    HamlibProbeTarget,
+    ProbeOptions,
+    probe_hamlib_rigctld_targets,
+    rank_hamlib_probe,
+)
+
+_ALLOWED_PROBE_COMMANDS = {r"\get_info", "f", "m"}
+_FORBIDDEN_PROBE_COMMANDS = {
+    "t",
+    "T",
+    "F",
+    "M",
+    "V",
+    "L",
+    "U",
+    "S",
+    "w",
+    r"\dump_state",
+}
+
+
+def _catalog(*models: HamlibModelMetadata) -> HamlibModelCatalog:
+    return HamlibModelCatalog(models={model.model_id: model for model in models})
+
+
+def test_disabled_probe_options_do_no_io() -> None:
+    def transport_factory(**_kwargs: object) -> object:
+        raise AssertionError("disabled probe must not create a transport")
+
+    result = asyncio.run(
+        probe_hamlib_rigctld_targets(
+            [HamlibProbeTarget(host="127.0.0.1", port=4532)],
+            options=ProbeOptions(enabled=False),
+            _transport_factory=transport_factory,
+        )
+    )
+
+    assert result == []
+
+
+async def test_successful_probe_ranks_exact_identity_high_and_uses_read_only_commands() -> (
+    None
+):
+    catalog = _catalog(
+        HamlibModelMetadata(model_id=3073, name="Icom IC-7610", status="Stable")
+    )
+    state = FakeRigctldState(info="Model 3073 Icom IC-7610")
+
+    async with FakeRigctldServer(state=state) as server:
+        results = await probe_hamlib_rigctld_targets(
+            [HamlibProbeTarget(host=server.host, port=server.port, model_id=3073)],
+            options=ProbeOptions(enabled=True, command_timeout=0.1),
+            catalog=catalog,
+        )
+
+    assert len(results) == 1
+    candidate = results[0].candidates[0]
+    assert candidate.confidence == "high"
+    assert candidate.suggested_backend == "hamlib"
+    assert candidate.suggested_model == "3073 Icom IC-7610"
+    assert candidate.safe_next_action == "read_only_probe_confirmed"
+    assert {record.operation for record in results[0].audit} == {
+        "read_info",
+        "read_frequency",
+        "read_mode",
+    }
+    assert set(server.commands_seen) <= _ALLOWED_PROBE_COMMANDS
+    assert not (set(server.commands_seen) & _FORBIDDEN_PROBE_COMMANDS)
+
+
+def test_ranking_returns_multiple_confirmation_candidates_when_ambiguous() -> None:
+    catalog = _catalog(
+        HamlibModelMetadata(model_id=3073, name="Icom IC-7610"),
+        HamlibModelMetadata(model_id=3074, name="Icom IC-7600"),
+    )
+
+    candidates = rank_hamlib_probe(
+        target=HamlibProbeTarget(host="private-radio.lan", port=4532),
+        catalog=catalog,
+        info_text="Icom",
+        frequency_readable=True,
+        mode_readable=True,
+    )
+
+    assert [candidate.suggested_model for candidate in candidates] == [
+        "3073 Icom IC-7610",
+        "3074 Icom IC-7600",
+    ]
+    assert {candidate.confidence for candidate in candidates} == {"medium"}
+    assert {candidate.safe_next_action for candidate in candidates} == {"confirm_model"}
+
+
+def test_ranking_degrades_to_low_when_catalog_is_unavailable() -> None:
+    candidates = rank_hamlib_probe(
+        target=HamlibProbeTarget(host="127.0.0.1", port=4532, model_id=9999),
+        catalog=HamlibModelCatalog(
+            models={},
+            degraded_reason="hamlib model list unavailable: tool not found",
+        ),
+        info_text="Model 9999 Example Rig",
+        frequency_readable=True,
+        mode_readable=True,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].confidence == "low"
+    assert candidates[0].safe_next_action == "manual_configuration_required"
+
+
+async def test_probe_handles_unsupported_get_info_and_malformed_reads() -> None:
+    behavior = FakeRigctldBehavior(
+        unsupported_commands={r"\get_info"},
+        malformed_responses={"f": b"PRIVATE_FREQUENCY=14074000\n", "m": b"USB\nbad\n"},
+    )
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        results = await probe_hamlib_rigctld_targets(
+            [HamlibProbeTarget(host=server.host, port=server.port)],
+            options=ProbeOptions(enabled=True, command_timeout=0.1),
+            catalog=_catalog(),
+        )
+
+    assert len(results) == 1
+    assert results[0].candidates[0].confidence == "low"
+    assert {record.status for record in results[0].audit} == {
+        "unsupported",
+        "malformed",
+    }
+    assert set(server.commands_seen) <= _ALLOWED_PROBE_COMMANDS
+
+
+async def test_probe_timeout_audit_is_redacted() -> None:
+    behavior = FakeRigctldBehavior(command_delays={"f": 0.2})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        port = server.port
+        results = await probe_hamlib_rigctld_targets(
+            [HamlibProbeTarget(host=server.host, port=server.port)],
+            options=ProbeOptions(enabled=True, command_timeout=0.01),
+            catalog=_catalog(),
+        )
+
+    audit_text = repr(results[0].audit)
+    assert "timeout" in audit_text
+    assert server.host not in audit_text
+    assert str(port) not in audit_text
+    assert "14074000" not in audit_text
+    assert r"\get_info" not in audit_text
+    assert "PRIVATE" not in audit_text
+
+
+async def test_probe_cancellation_closes_transport() -> None:
+    behavior = FakeRigctldBehavior(command_delays={"f": 1.0})
+
+    async with FakeRigctldServer(behavior=behavior) as server:
+        task = asyncio.create_task(
+            probe_hamlib_rigctld_targets(
+                [HamlibProbeTarget(host=server.host, port=server.port)],
+                options=ProbeOptions(enabled=True, command_timeout=2.0),
+                catalog=_catalog(),
+            )
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert set(server.commands_seen) <= _ALLOWED_PROBE_COMMANDS
+
+
+async def test_probe_bounds_concurrency_and_serializes_same_target() -> None:
+    active_total = 0
+    max_total = 0
+    active_by_target: dict[tuple[str, int], int] = {}
+    max_by_target: dict[tuple[str, int], int] = {}
+    commands: list[str] = []
+
+    class TrackingTransport:
+        def __init__(self, *, host: str, port: int, timeout: float) -> None:
+            self.host = host
+            self.port = port
+            self.timeout = timeout
+            self.closed = False
+            self.connected = False
+
+        async def connect(self) -> None:
+            nonlocal active_total, max_total
+            key = (self.host, self.port)
+            active_total += 1
+            active_by_target[key] = active_by_target.get(key, 0) + 1
+            max_total = max(max_total, active_total)
+            max_by_target[key] = max(
+                max_by_target.get(key, 0),
+                active_by_target[key],
+            )
+            self.connected = True
+
+        async def query(self, command: str, *, response_lines: int) -> list[str]:
+            commands.append(command)
+            await asyncio.sleep(0.01)
+            if command == r"\get_info":
+                return ["Model 3073 Icom IC-7610"]
+            if command == "f":
+                return ["14074000"]
+            if command == "m":
+                return ["USB", "2400"]
+            raise AssertionError(f"unexpected command {command}")
+
+        async def close(self) -> None:
+            nonlocal active_total
+            if self.closed or not self.connected:
+                return
+            key = (self.host, self.port)
+            self.closed = True
+            self.connected = False
+            active_total -= 1
+            active_by_target[key] -= 1
+
+    catalog = _catalog(HamlibModelMetadata(model_id=3073, name="Icom IC-7610"))
+
+    results = await probe_hamlib_rigctld_targets(
+        [
+            HamlibProbeTarget(host="target-a.example", port=4532, model_id=3073),
+            HamlibProbeTarget(host="target-a.example", port=4532, model_id=3073),
+            HamlibProbeTarget(host="target-b.example", port=4532, model_id=3073),
+        ],
+        options=ProbeOptions(enabled=True, max_concurrency=2, command_timeout=0.2),
+        catalog=catalog,
+        _transport_factory=TrackingTransport,
+    )
+
+    assert len(results) == 3
+    assert max_total <= 2
+    assert max_by_target[("target-a.example", 4532)] == 1
+    assert set(commands) <= _ALLOWED_PROBE_COMMANDS


### PR DESCRIPTION
## Summary

- Adds provisional DiscoveryCandidate/evidence/probe option/audit/result types for safe Hamlib-assisted discovery.
- Adds an explicit opt-in external rigctld probe runner that uses only read commands: `\get_info`, `f`, and `m`.
- Adds explainable high/medium/low ranking with confirmation required for ambiguous matches.
- Redacts probe audit output and documents the safety boundary.
- Extends fake rigctld with read-only `\get_info` and adds regression coverage for read-only probing.

## Scope notes

- No CLI flags, commands, or output changes.
- No direct libhamlib integration.
- No backend import from `rigplane.rigctld`.

## Checks

- `uv run pytest tests/test_hamlib_probe.py tests/test_discovery.py tests/test_rigctld_client_backend.py -q --tb=short`
- `uv run lint-imports`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`

Closes #1581
Linear: MOR-24
