### PR TITLE
feat(#1582): add Hamlib discover CLI validation

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -146,6 +146,9 @@ The `discover` command scans both LAN (UDP broadcast) and USB serial ports concu
 rigplane discover                      # LAN + serial (default)
 rigplane discover --lan-only           # UDP broadcast only
 rigplane discover --serial-only        # USB serial ports only
+rigplane discover --serial             # Alias for --serial-only
+rigplane --json discover --serial --hamlib-candidates
+rigplane --json discover --hamlib-validate --rigctld-host 127.0.0.1
 rigplane discover --timeout 5          # Longer LAN listen window
 rigplane --json discover               # Stable setup-wizard JSON
 ```
@@ -491,8 +494,11 @@ Discover Icom radios on LAN and USB serial ports. Results are grouped by radio i
 rigplane discover                   # LAN + serial
 rigplane discover --lan-only        # UDP broadcast only
 rigplane discover --serial-only     # USB serial ports only
+rigplane discover --serial          # Alias for --serial-only
 rigplane discover --timeout 5       # Longer LAN listen window (default: 3s)
 rigplane --json discover            # Stable setup-wizard JSON
+rigplane --json discover --serial --hamlib-candidates
+rigplane discover --hamlib-validate --rigctld-host 127.0.0.1
 ```
 
 ```
@@ -521,8 +527,13 @@ IC-705:
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--lan-only` | off | Only scan via UDP broadcast |
-| `--serial-only` | off | Only scan USB serial ports |
+| `--serial-only`, `--serial` | off | Only scan USB serial ports |
 | `--timeout SECONDS` | `3.0` | LAN broadcast listen timeout |
+| `--hamlib-candidates` | off | Add explicit Hamlib setup candidates to human and JSON output |
+| `--hamlib-validate` | off | Run read-only validation against an external `rigctld` endpoint |
+| `--rigctld-host HOST` | `127.0.0.1` | Target host for `--hamlib-validate` |
+| `--rigctld-port PORT` | `4532` | Target TCP port for `--hamlib-validate` |
+| `--hamlib-model-id ID` | unset | Optional Hamlib model ID hint for validation ranking |
 
 With global `--json`, `discover` emits `schema: rigplane.discovery.v1` for
 first-run setup wizards. Each radio has stable `connections` entries for LAN
@@ -530,6 +541,96 @@ and USB serial candidates. LAN entries include `host`, `remoteId`, and
 `requiresCredentials: true`; serial entries include `port`, `protocol`,
 `profileId`, `baudrate`, CI-V/CAT `address`, OS `description`, and `hwid` when
 available. Credentials are never included in discovery output.
+
+Hamlib assisted discovery is fully opt-in. `rigplane discover` does not load
+the Hamlib model catalog and does not probe `rigctld` unless
+`--hamlib-candidates` or `--hamlib-validate` is present.
+
+When Hamlib output is requested with global `--json`, the existing top-level
+`schema: rigplane.discovery.v1` payload remains in place and a top-level
+`hamlib` object is added:
+
+```json
+{
+  "schema": "rigplane.discovery.v1",
+  "radios": [],
+  "hamlib": {
+    "schema": "rigplane.discovery.hamlib.v1",
+    "catalog": {
+      "available": true,
+      "sourceTool": "rigctld",
+      "modelCount": 314,
+      "degradedReason": null
+    },
+    "candidates": [
+      {
+        "id": "hamlib-validation-1-1",
+        "transport": "rigctld",
+        "address": "rigctld:1a2b3c4d5e6f",
+        "observedIdentity": {
+          "targetModelId": 3073,
+          "rigctldInfo": "available",
+          "frequency": "readable",
+          "mode": "readable"
+        },
+        "suggestedBackend": "hamlib",
+        "suggestedModel": "3073 Icom IC-7610",
+        "confidence": "high",
+        "evidence": [
+          {
+            "source": "rigctld_probe",
+            "kind": "frequency",
+            "status": "readable"
+          }
+        ],
+        "safeNextAction": "read_only_probe_confirmed",
+        "autoSelectable": true
+      }
+    ],
+    "summary": {
+      "candidateCount": 1,
+      "highConfidenceCount": 1,
+      "autoSelectableCount": 1
+    }
+  }
+}
+```
+
+Candidate fields use stable camelCase for Pro and other setup tools:
+
+| Field | Meaning |
+|-------|---------|
+| `id` | Stable ID within the current discovery response |
+| `transport` | Observed path, such as `serial` or `rigctld` |
+| `address` | Serial device path or redacted `rigctld:<hash>` target reference |
+| `observedIdentity` | Read-only facts such as protocol, model hint, frequency-readable, and mode-readable |
+| `suggestedBackend` | Suggested RigPlane backend, currently `hamlib` for Hamlib candidates |
+| `suggestedModel` | Best model hint, or `null` when manual selection is required |
+| `confidence` | `high`, `medium`, or `low` |
+| `evidence` | Structured observations explaining the ranking |
+| `safeNextAction` | Next safe action, such as `run_read_only_validation`, `confirm_model`, or `manual_configuration_required` |
+| `autoSelectable` | `true` only when exactly one candidate is high confidence |
+
+Degraded cases are reported in `hamlib.messages`. Missing Hamlib tools produce
+`hamlibCatalogUnavailable`; an empty serial scan produces `noSerialCandidates`;
+ambiguous read-only validation returns multiple medium-confidence candidates
+with `safeNextAction: confirm_model` and `autoSelectable: false`.
+
+`--hamlib-validate` is read-only. It sends only the safe `rigctld` read
+operations used by the backend probe layer: identity evidence, frequency read,
+and mode read. It does not set frequency or mode, toggle PTT, transmit audio,
+send CW, write memories, issue raw CI-V, or call `\dump_state`. Validation JSON
+includes:
+
+| Field | Meaning |
+|-------|---------|
+| `status` | `confirmed`, `partial`, or `unconfirmed` |
+| `readOnly` | Always `true` |
+| `safeOperations` | Semantic operations attempted: `read_info`, `read_frequency`, `read_mode` |
+| `frequencyReadable` | Whether the current frequency was read successfully |
+| `modeReadable` | Whether the current mode was read successfully |
+| `identityEvidence` | Whether safe identity evidence was available |
+| `audit` | Redacted per-operation status and duration |
 
 The JSON payload also reports current platform limitations:
 

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -988,13 +988,16 @@ def _build_parser() -> argparse.ArgumentParser:
     discover_p = sub.add_parser(
         "discover", help="Discover Icom radios on LAN and serial ports"
     )
-    discover_p.add_argument(
+    discover_scope = discover_p.add_mutually_exclusive_group()
+    discover_scope.add_argument(
         "--serial-only",
+        "--serial",
+        dest="serial_only",
         action="store_true",
         default=False,
         help="Only scan serial (USB) ports; skip LAN broadcast",
     )
-    discover_p.add_argument(
+    discover_scope.add_argument(
         "--lan-only",
         action="store_true",
         default=False,
@@ -1006,6 +1009,38 @@ def _build_parser() -> argparse.ArgumentParser:
         default=3.0,
         metavar="SECONDS",
         help="LAN broadcast listen timeout in seconds (default: 3.0)",
+    )
+    discover_p.add_argument(
+        "--hamlib-candidates",
+        action="store_true",
+        default=False,
+        help="Include explicit Hamlib setup candidates in discovery output",
+    )
+    discover_p.add_argument(
+        "--hamlib-validate",
+        action="store_true",
+        default=False,
+        help="Run read-only rigctld validation using safe Hamlib probe commands",
+    )
+    discover_p.add_argument(
+        "--rigctld-host",
+        default="127.0.0.1",
+        metavar="HOST",
+        help="rigctld host for --hamlib-validate (default: 127.0.0.1)",
+    )
+    discover_p.add_argument(
+        "--rigctld-port",
+        type=int,
+        default=4532,
+        metavar="PORT",
+        help="rigctld port for --hamlib-validate (default: 4532)",
+    )
+    discover_p.add_argument(
+        "--hamlib-model-id",
+        type=int,
+        default=None,
+        metavar="ID",
+        help="Optional Hamlib model ID hint for read-only validation",
     )
 
     # serve
@@ -3445,11 +3480,16 @@ async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
         dedupe_radios,
         discover_lan_radios,
         discover_serial_radios,
+        HamlibProbeTarget,
+        ProbeOptions,
+        probe_hamlib_rigctld_targets,
     )
 
     serial_only: bool = getattr(args, "serial_only", False)
     lan_only: bool = getattr(args, "lan_only", False)
     timeout: float = getattr(args, "timeout", 3.0)
+    hamlib_candidates: bool = getattr(args, "hamlib_candidates", False)
+    hamlib_validate: bool = getattr(args, "hamlib_validate", False)
 
     if serial_only and lan_only:
         print(
@@ -3507,13 +3547,46 @@ async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
         scan_failed = True
 
     grouped = dedupe_radios(lan_radios, serial_radios)
+    hamlib_payload: dict[str, object] | None = None
+    if hamlib_candidates or hamlib_validate:
+        from rigplane.backends.hamlib_models import load_hamlib_model_catalog
+        from rigplane.cli._discover_hamlib import (
+            build_hamlib_discovery_payload,
+            print_hamlib_human,
+        )
+
+        catalog = load_hamlib_model_catalog()
+        validation_results: list[object] = []
+        if hamlib_validate:
+            target = HamlibProbeTarget(
+                host=str(getattr(args, "rigctld_host", "127.0.0.1")),
+                port=int(getattr(args, "rigctld_port", 4532)),
+                model_id=getattr(args, "hamlib_model_id", None),
+            )
+            validation_results = await probe_hamlib_rigctld_targets(
+                [target],
+                options=ProbeOptions(enabled=True),
+                catalog=catalog,
+            )
+        hamlib_payload = build_hamlib_discovery_payload(
+            catalog=catalog,
+            serial_radios=serial_radios,
+            serial_scan_enabled=not lan_only,
+            candidates_requested=hamlib_candidates,
+            validation_results=validation_results,
+        )
 
     if json_output:
-        print(json.dumps(build_setup_discovery_payload(grouped)))
+        payload = build_setup_discovery_payload(grouped)
+        if hamlib_payload is not None:
+            payload["hamlib"] = hamlib_payload
+        print(json.dumps(payload))
         return 1 if scan_failed else 0
 
     if not grouped:
         print("No radios found.")
+        if hamlib_payload is not None:
+            print_hamlib_human(hamlib_payload)
         return 1 if scan_failed else 0
 
     total_connections = sum(len(r["lan"]) + len(r["serial"]) for r in grouped)
@@ -3531,6 +3604,8 @@ async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
         for serial in radio["serial"]:
             baud = serial.get("baudrate") or serial.get("baud", "?")
             print(f"  \u2022 Serial: {serial['port']} ({baud} baud)")
+    if hamlib_payload is not None:
+        print_hamlib_human(hamlib_payload)
     return 0
 
 

--- a/src/rigplane/cli/_discover_hamlib.py
+++ b/src/rigplane/cli/_discover_hamlib.py
@@ -1,0 +1,367 @@
+"""Hamlib-assisted discovery payload and human-output helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _camelize_discovery_key(key: str) -> str:
+    parts = key.split("_")
+    return parts[0] + "".join(part[:1].upper() + part[1:] for part in parts[1:])
+
+
+def _camelize_discovery_value(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            _camelize_discovery_key(str(key)): _camelize_discovery_value(item)
+            for key, item in value.items()
+            if item is not None
+        }
+    if isinstance(value, list):
+        return [_camelize_discovery_value(item) for item in value]
+    return value
+
+
+def _hamlib_catalog_payload(catalog: Any) -> dict[str, object]:
+    return {
+        "available": catalog.degraded_reason is None and bool(catalog.models),
+        "sourceTool": catalog.source_tool,
+        "modelCount": len(catalog.models),
+        "degradedReason": catalog.degraded_reason,
+    }
+
+
+def _hamlib_evidence_payload(evidence: object) -> dict[str, object]:
+    payload = {
+        "source": getattr(evidence, "source"),
+        "kind": getattr(evidence, "kind"),
+        "status": getattr(evidence, "status"),
+        "detail": getattr(evidence, "detail"),
+    }
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _hamlib_candidate_payload(
+    candidate: object,
+    *,
+    candidate_id: str,
+    auto_selectable: bool,
+) -> dict[str, object]:
+    return {
+        "id": candidate_id,
+        "transport": getattr(candidate, "transport"),
+        "address": getattr(candidate, "address"),
+        "observedIdentity": _camelize_discovery_value(
+            getattr(candidate, "observed_identity")
+        ),
+        "suggestedBackend": getattr(candidate, "suggested_backend"),
+        "suggestedModel": getattr(candidate, "suggested_model"),
+        "confidence": getattr(candidate, "confidence"),
+        "evidence": [
+            _hamlib_evidence_payload(item) for item in getattr(candidate, "evidence")
+        ],
+        "safeNextAction": getattr(candidate, "safe_next_action"),
+        "autoSelectable": auto_selectable,
+    }
+
+
+def _match_hamlib_catalog_model(serial: dict[str, object], catalog: Any) -> Any | None:
+    if catalog.degraded_reason is not None:
+        return None
+    serial_model = str(serial.get("model") or "").lower()
+    if not serial_model:
+        return None
+    serial_tokens = {
+        token
+        for token in serial_model.replace("-", " ").replace("_", " ").split()
+        if token
+    }
+    for model in sorted(catalog.models.values(), key=lambda item: item.model_id):
+        catalog_name = model.name.lower()
+        catalog_tokens = {
+            token
+            for token in catalog_name.replace("-", " ").replace("_", " ").split()
+            if token
+        }
+        if serial_model in catalog_name or serial_tokens <= catalog_tokens:
+            return model
+    return None
+
+
+def _build_hamlib_serial_candidate(
+    serial: dict[str, object],
+    *,
+    catalog: Any,
+    candidate_id: str,
+) -> dict[str, object]:
+    from rigplane.discovery import DiscoveryCandidate, DiscoveryEvidence
+
+    catalog_match = _match_hamlib_catalog_model(serial, catalog)
+    evidence = [
+        DiscoveryEvidence(
+            source="serial_discovery",
+            kind="identity",
+            status="detected",
+            detail=str(serial.get("model") or serial.get("protocol") or "serial"),
+        )
+    ]
+    if catalog.degraded_reason is not None:
+        evidence.append(
+            DiscoveryEvidence(
+                source="hamlib_catalog",
+                kind="catalog",
+                status="degraded",
+                detail=catalog.degraded_reason,
+            )
+        )
+    elif catalog_match is not None:
+        evidence.append(
+            DiscoveryEvidence(
+                source="hamlib_catalog",
+                kind="model",
+                status="catalog_match",
+                detail=f"{catalog_match.model_id} {catalog_match.name}",
+            )
+        )
+    else:
+        evidence.append(
+            DiscoveryEvidence(
+                source="hamlib_catalog",
+                kind="model",
+                status="no_match",
+            )
+        )
+
+    confidence = "medium" if catalog_match is not None else "low"
+    if catalog_match is not None:
+        safe_next_action = "run_read_only_validation"
+        suggested_model = f"{catalog_match.model_id} {catalog_match.name}"
+    elif catalog.degraded_reason is not None:
+        safe_next_action = "install_hamlib_then_validate"
+        suggested_model = None
+    else:
+        safe_next_action = "manual_configuration_required"
+        suggested_model = None
+
+    candidate = DiscoveryCandidate(
+        transport="serial",
+        address=str(serial.get("port") or ""),
+        observed_identity={
+            "model": serial.get("model"),
+            "protocol": serial.get("protocol"),
+            "profile_id": serial.get("profile_id"),
+            "baudrate": serial.get("baudrate", serial.get("baud")),
+            "radio_address": serial.get("address"),
+            "description": serial.get("description"),
+            "hwid": serial.get("hwid"),
+            "vid": serial.get("vid"),
+            "pid": serial.get("pid"),
+            "manufacturer": serial.get("manufacturer"),
+            "product": serial.get("product"),
+        },
+        suggested_backend="hamlib",
+        suggested_model=suggested_model,
+        confidence=confidence,
+        evidence=evidence,
+        safe_next_action=safe_next_action,
+    )
+    return _hamlib_candidate_payload(
+        candidate,
+        candidate_id=candidate_id,
+        auto_selectable=False,
+    )
+
+
+def _hamlib_audit_payload(audit: object) -> dict[str, object]:
+    payload = {
+        "targetRef": getattr(audit, "target_ref"),
+        "operation": getattr(audit, "operation"),
+        "status": getattr(audit, "status"),
+        "durationMs": getattr(audit, "duration_ms"),
+        "detail": getattr(audit, "detail"),
+    }
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _hamlib_validation_payload(results: list[object]) -> dict[str, object]:
+    audit_records = [
+        record for result in results for record in getattr(result, "audit", [])
+    ]
+    frequency_readable = any(
+        getattr(record, "operation") == "read_frequency"
+        and getattr(record, "status") == "ok"
+        for record in audit_records
+    )
+    mode_readable = any(
+        getattr(record, "operation") == "read_mode"
+        and getattr(record, "status") == "ok"
+        for record in audit_records
+    )
+    identity_readable = any(
+        getattr(record, "operation") == "read_info"
+        and getattr(record, "status") == "ok"
+        for record in audit_records
+    )
+    high_confidence = any(
+        getattr(candidate, "confidence") == "high"
+        for result in results
+        for candidate in getattr(result, "candidates", [])
+    )
+    if high_confidence and frequency_readable and mode_readable:
+        status = "confirmed"
+    elif frequency_readable or mode_readable or identity_readable:
+        status = "partial"
+    else:
+        status = "unconfirmed"
+
+    return {
+        "status": status,
+        "readOnly": True,
+        "safeOperations": ["read_info", "read_frequency", "read_mode"],
+        "targetRefs": [getattr(result, "target_ref") for result in results],
+        "frequencyReadable": frequency_readable,
+        "modeReadable": mode_readable,
+        "identityEvidence": "available" if identity_readable else "unconfirmed",
+        "audit": [_hamlib_audit_payload(record) for record in audit_records],
+    }
+
+
+def build_hamlib_discovery_payload(
+    *,
+    catalog: Any,
+    serial_radios: list[dict[str, object]],
+    serial_scan_enabled: bool,
+    candidates_requested: bool,
+    validation_results: list[object],
+) -> dict[str, object]:
+    messages: list[dict[str, object]] = []
+    candidates: list[dict[str, object]] = []
+
+    if catalog.degraded_reason is not None:
+        messages.append(
+            {
+                "severity": "warning",
+                "code": "hamlibCatalogUnavailable",
+                "message": catalog.degraded_reason,
+            }
+        )
+
+    if candidates_requested:
+        if serial_scan_enabled and not serial_radios:
+            messages.append(
+                {
+                    "severity": "info",
+                    "code": "noSerialCandidates",
+                    "message": "No serial radio candidates were found.",
+                }
+            )
+        elif not serial_scan_enabled:
+            messages.append(
+                {
+                    "severity": "info",
+                    "code": "serialScanSkipped",
+                    "message": "Serial scanning was skipped by --lan-only.",
+                }
+            )
+        for index, serial in enumerate(serial_radios, start=1):
+            candidates.append(
+                _build_hamlib_serial_candidate(
+                    serial,
+                    catalog=catalog,
+                    candidate_id=f"hamlib-serial-{index}",
+                )
+            )
+
+    for result_index, result in enumerate(validation_results, start=1):
+        for candidate_index, candidate in enumerate(
+            getattr(result, "candidates", []),
+            start=1,
+        ):
+            candidates.append(
+                _hamlib_candidate_payload(
+                    candidate,
+                    candidate_id=f"hamlib-validation-{result_index}-{candidate_index}",
+                    auto_selectable=False,
+                )
+            )
+
+    high_candidate_ids = [
+        str(candidate["id"])
+        for candidate in candidates
+        if candidate.get("confidence") == "high"
+    ]
+    if len(high_candidate_ids) == 1:
+        for candidate in candidates:
+            candidate["autoSelectable"] = candidate["id"] == high_candidate_ids[0]
+
+    payload: dict[str, object] = {
+        "schema": "rigplane.discovery.hamlib.v1",
+        "catalog": _hamlib_catalog_payload(catalog),
+        "candidates": candidates,
+        "messages": messages,
+        "summary": {
+            "candidateCount": len(candidates),
+            "highConfidenceCount": len(high_candidate_ids),
+            "autoSelectableCount": 1 if len(high_candidate_ids) == 1 else 0,
+        },
+    }
+    if validation_results:
+        payload["validation"] = _hamlib_validation_payload(validation_results)
+    return payload
+
+
+def print_hamlib_human(payload: dict[str, object]) -> None:
+    catalog = payload["catalog"]
+    assert isinstance(catalog, dict)
+    candidates = payload["candidates"]
+    assert isinstance(candidates, list)
+    messages = payload["messages"]
+    assert isinstance(messages, list)
+
+    print("\nHamlib assisted discovery:")
+    if catalog.get("available"):
+        source = catalog.get("sourceTool") or "hamlib"
+        print(
+            f"  Catalog: available from {source} ({catalog.get('modelCount')} models)"
+        )
+    else:
+        reason = catalog.get("degradedReason") or "no Hamlib models available"
+        print(f"  Catalog: unavailable ({reason})")
+
+    for message in messages:
+        print(f"  {message.get('code')}: {message.get('message')}")
+
+    if not candidates:
+        print("  Candidates: none")
+    for candidate in candidates:
+        print(
+            "  "
+            f"{candidate['id']}: {candidate['confidence']} confidence, "
+            f"{candidate['transport']} {candidate['address']}"
+        )
+        suggested = candidate.get("suggestedModel") or "manual model selection"
+        print(f"    Suggested: {candidate['suggestedBackend']} / {suggested}")
+        evidence = candidate.get("evidence")
+        assert isinstance(evidence, list)
+        for item in evidence:
+            assert isinstance(item, dict)
+            detail = f" ({item['detail']})" if item.get("detail") else ""
+            print(
+                f"    Evidence: {item['source']} {item['kind']}="
+                f"{item['status']}{detail}"
+            )
+        print(f"    Next action: {candidate['safeNextAction']}")
+        if candidate.get("autoSelectable"):
+            print("    Auto-selectable: yes")
+
+    validation = payload.get("validation")
+    if isinstance(validation, dict):
+        print("  Read-only validation:")
+        print(f"    Status: {validation['status']}")
+        print(
+            "    Frequency/mode: "
+            f"{'readable' if validation['frequencyReadable'] else 'not readable'} / "
+            f"{'readable' if validation['modeReadable'] else 'not readable'}"
+        )
+        print(f"    Identity evidence: {validation['identityEvidence']}")
+        print("    Safety: read-only; no writes, PTT, raw CI-V, or transmit commands")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,6 +221,34 @@ class TestBuildParser:
         args = p.parse_args(["discover"])
         assert args.command == "discover"
 
+    def test_discover_serial_alias_and_hamlib_flags(self):
+        p = _build_parser()
+        args = p.parse_args(
+            [
+                "discover",
+                "--serial",
+                "--hamlib-candidates",
+                "--hamlib-validate",
+                "--rigctld-host",
+                "radio.local",
+                "--rigctld-port",
+                "4533",
+                "--hamlib-model-id",
+                "3073",
+            ]
+        )
+        assert args.serial_only is True
+        assert args.hamlib_candidates is True
+        assert args.hamlib_validate is True
+        assert args.rigctld_host == "radio.local"
+        assert args.rigctld_port == 4533
+        assert args.hamlib_model_id == 3073
+
+    def test_discover_lan_and_serial_filters_are_mutually_exclusive(self):
+        p = _build_parser()
+        with pytest.raises(SystemExit):
+            p.parse_args(["discover", "--serial", "--lan-only"])
+
     def test_json_flag(self):
         p = _build_parser()
         args = p.parse_args(["status", "--json"])

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1197,6 +1197,227 @@ async def test_cmd_discover_json_preserves_usb_audio_resolution_metadata(
     assert "password" not in str(payload).lower()
 
 
+@pytest.mark.asyncio
+async def test_cmd_discover_does_not_load_hamlib_without_explicit_flags(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = SimpleNamespace(serial_only=True, lan_only=False, timeout=0.1, json=True)
+    with (
+        patch(
+            "rigplane.discovery.discover_serial_radios",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "rigplane.backends.hamlib_models.load_hamlib_model_catalog",
+            side_effect=AssertionError("Hamlib catalog must be opt-in"),
+        ),
+    ):
+        rc = await _cmd_discover(None, args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "rigplane.discovery.v1"
+    assert "hamlib" not in payload
+
+
+@pytest.mark.asyncio
+async def test_cmd_discover_hamlib_candidates_degrade_without_catalog_or_serial(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from rigplane.backends.hamlib_models import HamlibModelCatalog
+
+    args = SimpleNamespace(
+        serial_only=True,
+        lan_only=False,
+        timeout=0.1,
+        json=True,
+        hamlib_candidates=True,
+        hamlib_validate=False,
+    )
+    degraded_catalog = HamlibModelCatalog(
+        models={},
+        degraded_reason="hamlib model list unavailable: tool not found",
+    )
+    with (
+        patch(
+            "rigplane.discovery.discover_serial_radios",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "rigplane.backends.hamlib_models.load_hamlib_model_catalog",
+            return_value=degraded_catalog,
+        ),
+    ):
+        rc = await _cmd_discover(None, args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    hamlib = payload["hamlib"]
+    assert hamlib["schema"] == "rigplane.discovery.hamlib.v1"
+    assert hamlib["catalog"]["available"] is False
+    assert hamlib["candidates"] == []
+    assert {message["code"] for message in hamlib["messages"]} == {
+        "hamlibCatalogUnavailable",
+        "noSerialCandidates",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cmd_discover_hamlib_serial_candidate_json_and_human_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from rigplane.backends.hamlib_models import HamlibModelCatalog, HamlibModelMetadata
+
+    args = SimpleNamespace(
+        serial_only=True,
+        lan_only=False,
+        timeout=0.1,
+        json=False,
+        hamlib_candidates=True,
+        hamlib_validate=False,
+    )
+    catalog = HamlibModelCatalog(
+        models={
+            3073: HamlibModelMetadata(model_id=3073, name="Icom IC-7610"),
+        },
+        source_tool="rigctld",
+    )
+    with (
+        patch(
+            "rigplane.discovery.discover_serial_radios",
+            AsyncMock(
+                return_value=[
+                    RadioDiscoveryResult(
+                        port="/dev/cu.usbmodem7610",
+                        protocol="civ",
+                        model="IC-7610",
+                        profile_id="icom_ic7610",
+                        baudrate=115200,
+                        address=0x98,
+                    )
+                ]
+            ),
+        ),
+        patch(
+            "rigplane.backends.hamlib_models.load_hamlib_model_catalog",
+            return_value=catalog,
+        ),
+    ):
+        rc = await _cmd_discover(None, args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Hamlib assisted discovery:" in out
+    assert "medium confidence" in out
+    assert "Evidence: hamlib_catalog model=catalog_match" in out
+    assert "Next action: run_read_only_validation" in out
+
+
+@pytest.mark.asyncio
+async def test_cmd_discover_hamlib_validation_is_read_only_and_auto_selects_single_high(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from fake_rigctld import FakeRigctldServer, FakeRigctldState
+    from rigplane.backends.hamlib_models import HamlibModelCatalog, HamlibModelMetadata
+
+    catalog = HamlibModelCatalog(
+        models={
+            3073: HamlibModelMetadata(model_id=3073, name="Icom IC-7610"),
+        },
+        source_tool="rigctld",
+    )
+    async with FakeRigctldServer(
+        state=FakeRigctldState(info="Model 3073 Icom IC-7610")
+    ) as server:
+        args = SimpleNamespace(
+            serial_only=True,
+            lan_only=False,
+            timeout=0.1,
+            json=True,
+            hamlib_candidates=False,
+            hamlib_validate=True,
+            rigctld_host=server.host,
+            rigctld_port=server.port,
+            hamlib_model_id=3073,
+        )
+        with (
+            patch(
+                "rigplane.discovery.discover_serial_radios",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "rigplane.backends.hamlib_models.load_hamlib_model_catalog",
+                return_value=catalog,
+            ),
+        ):
+            rc = await _cmd_discover(None, args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    hamlib = payload["hamlib"]
+    assert hamlib["validation"]["status"] == "confirmed"
+    assert hamlib["validation"]["frequencyReadable"] is True
+    assert hamlib["validation"]["modeReadable"] is True
+    assert hamlib["summary"]["autoSelectableCount"] == 1
+    assert hamlib["candidates"][0]["confidence"] == "high"
+    assert hamlib["candidates"][0]["autoSelectable"] is True
+    assert set(server.commands_seen) <= {r"\get_info", "f", "m"}
+
+
+@pytest.mark.asyncio
+async def test_cmd_discover_hamlib_validation_keeps_ambiguous_candidates_manual(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from fake_rigctld import FakeRigctldServer, FakeRigctldState
+    from rigplane.backends.hamlib_models import HamlibModelCatalog, HamlibModelMetadata
+
+    catalog = HamlibModelCatalog(
+        models={
+            3073: HamlibModelMetadata(model_id=3073, name="Icom IC-7610"),
+            3074: HamlibModelMetadata(model_id=3074, name="Icom IC-7600"),
+        },
+        source_tool="rigctld",
+    )
+    async with FakeRigctldServer(state=FakeRigctldState(info="Icom")) as server:
+        args = SimpleNamespace(
+            serial_only=True,
+            lan_only=False,
+            timeout=0.1,
+            json=True,
+            hamlib_candidates=False,
+            hamlib_validate=True,
+            rigctld_host=server.host,
+            rigctld_port=server.port,
+            hamlib_model_id=None,
+        )
+        with (
+            patch(
+                "rigplane.discovery.discover_serial_radios",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "rigplane.backends.hamlib_models.load_hamlib_model_catalog",
+                return_value=catalog,
+            ),
+        ):
+            rc = await _cmd_discover(None, args)
+
+    assert rc == 0
+    hamlib = json.loads(capsys.readouterr().out)["hamlib"]
+    assert [candidate["confidence"] for candidate in hamlib["candidates"]] == [
+        "medium",
+        "medium",
+    ]
+    assert {candidate["safeNextAction"] for candidate in hamlib["candidates"]} == {
+        "confirm_model"
+    }
+    assert hamlib["summary"]["autoSelectableCount"] == 0
+    assert {candidate["autoSelectable"] for candidate in hamlib["candidates"]} == {
+        False
+    }
+    assert set(server.commands_seen) <= {r"\get_info", "f", "m"}
+
+
 def test_main_branches(monkeypatch, capsys: pytest.CaptureFixture[str]) -> None:
     class DummyParser:
         def __init__(self, args):


### PR DESCRIPTION
## Summary

Closes #1582.

- Add explicit `rigplane discover` Hamlib flags: `--serial` alias, `--hamlib-candidates`, `--hamlib-validate`, `--rigctld-host`, `--rigctld-port`, and `--hamlib-model-id`.
- Keep default `rigplane.discovery.v1` JSON unchanged unless Hamlib flags are present; opt-in output adds `hamlib.schema: rigplane.discovery.hamlib.v1` with candidate, confidence, evidence, next-action, validation, and auto-select metadata.
- Wire validation through the #1581 safe probe path so it reads only identity/frequency/mode and preserves the command allowlist.
- Document flags, schema, safety limits, degraded cases, and examples.

## Validation

- `uv run pytest tests/test_cli.py::TestBuildParser tests/test_cli_coverage.py::test_cmd_discover_does_not_load_hamlib_without_explicit_flags tests/test_cli_coverage.py::test_cmd_discover_hamlib_candidates_degrade_without_catalog_or_serial tests/test_cli_coverage.py::test_cmd_discover_hamlib_serial_candidate_json_and_human_output tests/test_cli_coverage.py::test_cmd_discover_hamlib_validation_is_read_only_and_auto_selects_single_high tests/test_cli_coverage.py::test_cmd_discover_hamlib_validation_keeps_ambiguous_candidates_manual tests/test_hamlib_probe.py -q --tb=short`
- `uv run lint-imports`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mkdocs build --strict`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`

## Notes

- Existing local `uv.lock` changes were intentionally left out of this branch.