### PR TITLE
[codex] Add Hamlib rigctld provider docs

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5,6 +5,8 @@ description: Full RigPlane CLI reference — connect, scan, tune, serve the Web 
 # CLI Reference
 
 The `rigplane` CLI provides quick access to radio control from the terminal.
+It can connect through native LAN/serial providers or through an external
+Hamlib `rigctld` process.
 
 ## Global Options
 
@@ -18,7 +20,7 @@ All commands accept these options:
 | `--pass` | `ICOM_PASS` | `""` | Password (LAN backend) |
 | `--timeout` | — | `5.0` | Timeout in seconds |
 | `--json` | — | `false` | Emit JSON when supported by the selected command |
-| `--backend` | — | auto | Backend type: `lan`, `serial`, or `yaesu-cat`. Auto-inferred from `--serial-port` if set. |
+| `--backend` | — | auto | Backend type: `lan`, `serial`, `yaesu-cat`, or `rigctld`. Auto-inferred from `--serial-port` if set. |
 | `--serial-port` | `ICOM_SERIAL_DEVICE` | auto-discover | Serial device path. If omitted with `--backend serial`, discovers via USB scan. |
 | `--serial-baud` | `ICOM_SERIAL_BAUDRATE` | env or backend default | Serial baud (`115200` for `serial`, `38400` for `yaesu-cat` when env is unset) |
 | `--serial-ptt-mode` | `ICOM_SERIAL_PTT_MODE` | `civ` | Serial PTT mode (`civ` currently supported) |
@@ -76,8 +78,9 @@ User-provided flags override preset values: `--preset digimode --bridge "MyDevic
 
 ## Backend Selection
 
-rigplane supports three backends: **LAN** (default), **serial** (USB CI-V), and
-**yaesu-cat** (text CAT over serial).
+rigplane supports four backends: **LAN** (default), **serial** (USB CI-V),
+**yaesu-cat** (text CAT over serial), and **rigctld** (external Hamlib
+`rigctld` over TCP).
 
 ### LAN backend (default)
 
@@ -114,6 +117,21 @@ rigplane status    # auto-infers --backend serial
 rigplane --backend yaesu-cat --serial-port /dev/tty.usbserial-FTX1 status
 rigplane --backend yaesu-cat --serial-port /dev/tty.usbserial-FTX1 freq
 ```
+
+### External rigctld backend
+
+Use this backend when Hamlib controls the radio through an external `rigctld`
+process and RigPlane should consume that endpoint:
+
+```bash
+# Start Hamlib separately, then point RigPlane at it
+rigplane --backend rigctld --host 127.0.0.1 --control-port 4532 status
+rigplane --backend rigctld --host 127.0.0.1 --control-port 4532 web
+```
+
+This provider-facing endpoint is separate from RigPlane's own client-facing
+`rigctld` server for WSJT-X and other applications. See the
+[Hamlib / external rigctld provider guide](hamlib-rigctld-provider.md).
 
 ### Serial baud defaults by backend
 
@@ -488,7 +506,7 @@ rigplane power-off
 
 ### `discover`
 
-Discover Icom radios on LAN and USB serial ports. Results are grouped by radio identity — the same physical radio connected via both LAN and USB appears as one entry with two connection methods.
+Discover Icom radios on LAN and USB serial ports. Results are grouped by radio identity — the same physical radio connected via both LAN and USB appears as one entry with two connection methods. Optional Hamlib flags add assisted discovery and read-only validation for external `rigctld` provider setup.
 
 ```bash
 rigplane discover                   # LAN + serial

--- a/docs/guide/hamlib-rigctld-provider.md
+++ b/docs/guide/hamlib-rigctld-provider.md
@@ -1,0 +1,203 @@
+---
+description: Use Hamlib through an external rigctld process as a RigPlane provider, with assisted discovery, read-only validation, and troubleshooting guidance.
+---
+
+# Hamlib / External rigctld Provider
+
+RigPlane can use Hamlib-supported radios through an external `rigctld` process.
+In this mode, Hamlib talks to the radio and RigPlane talks to `rigctld` over the
+standard TCP rigctl text protocol. The result is a normal RigPlane radio
+connection for the Web UI, CLI, API, diagnostics, and the client-facing
+`rigctld` endpoint.
+
+This is different from RigPlane's native providers. Native providers speak the
+radio protocol directly, such as Icom CI-V over LAN or USB serial, and can expose
+radio-specific features when RigPlane has a tested profile for that model. The
+Hamlib-backed provider is the long-tail compatibility path for radios where
+Hamlib already has the CAT dialect.
+
+## Why an external rigctld process?
+
+RigPlane starts with this boundary:
+
+```text
+RigPlane -> TCP rigctld protocol -> external rigctld -> Hamlib -> radio
+```
+
+That boundary keeps Hamlib optional, process-isolated, and easy to install or
+upgrade with your operating system's normal package manager. It also avoids
+linking RigPlane directly to `libhamlib`, which is deferred unless a future
+accepted spike proves that direct binding is needed and covers licensing,
+packaging, API compatibility, and crash-containment requirements.
+
+## Setup flow
+
+### 1. Install Hamlib
+
+Install Hamlib with your platform package manager:
+
+```bash
+# macOS
+brew install hamlib
+
+# Debian / Ubuntu
+sudo apt install hamlib-utils
+
+# Fedora
+sudo dnf install hamlib
+```
+
+Confirm that `rigctld` and `rigctl` are available:
+
+```bash
+rigctld --version
+rigctl --list | head
+```
+
+### 2. Start rigctld for the radio
+
+Choose the Hamlib model ID for your radio, then start `rigctld` on loopback:
+
+```bash
+rigctld -m <HAMLIB_MODEL_ID> -r /dev/ttyUSB0 -s 38400 -T 127.0.0.1 -t 4532
+```
+
+The serial device, baud rate, and model ID depend on the radio. Keep the
+`rigctld` listen address on `127.0.0.1` unless you intentionally expose it on a
+trusted network.
+
+Verify the endpoint with a read:
+
+```bash
+rigctl -m 2 -r 127.0.0.1:4532 f
+rigctl -m 2 -r 127.0.0.1:4532 m
+```
+
+### 3. Point RigPlane at rigctld
+
+Use the `rigctld` backend and the `rigctld` host/port:
+
+```bash
+rigplane --backend rigctld --host 127.0.0.1 --control-port 4532 status
+rigplane --backend rigctld --host 127.0.0.1 --control-port 4532 web
+```
+
+You can also validate the running endpoint before selecting it:
+
+```bash
+rigplane discover --hamlib-validate --rigctld-host 127.0.0.1 --rigctld-port 4532
+rigplane --json discover --serial --hamlib-candidates
+```
+
+## Assisted discovery
+
+Assisted discovery helps setup tools and operators choose a Hamlib path. It can:
+
+- list local serial devices that may be CAT control ports;
+- load the installed Hamlib model catalog when `rigctl` or `rigctld` is present;
+- attach model hints when device descriptions match known Hamlib metadata;
+- validate a running external `rigctld` endpoint with safe reads;
+- return structured JSON candidates for setup wizards.
+
+It does not:
+
+- auto-install Hamlib;
+- start or supervise `rigctld`;
+- try every Hamlib model against a serial port;
+- claim that a low-confidence serial candidate is safe to auto-select;
+- replace radio-specific setup checks such as baud rate, CI-V address, or CAT
+  mode settings.
+
+## Safety model
+
+Discovery and validation are read-only first. `--hamlib-validate` uses only safe
+read operations against the external `rigctld` endpoint:
+
+- identity or info evidence;
+- current frequency read;
+- current mode read.
+
+During discovery, RigPlane does not transmit, toggle PTT, write memories, set
+frequency, set mode, send CW, issue raw CI-V, run `dump_state`, or make
+persistent rig setting changes. Candidates that need operator confirmation are
+reported as manual or confirm-model next actions instead of being auto-selected.
+
+## Two rigctld directions
+
+RigPlane uses the word `rigctld` in two separate places:
+
+| Direction | What it is | Typical use |
+|-----------|------------|-------------|
+| Provider-facing external `rigctld` | Hamlib's `rigctld` process under RigPlane | RigPlane controls a Hamlib-supported radio |
+| Client-facing RigPlane `rigctld` endpoint | RigPlane's own compatible TCP server | WSJT-X, JTDX, JS8Call, loggers, and other apps connect to RigPlane |
+
+They can be used together, but they are not the same endpoint. For example,
+RigPlane may connect to an external Hamlib `rigctld` on `127.0.0.1:4532` as its
+radio provider, then expose its own client-facing endpoint on another port for
+WSJT-X:
+
+```bash
+rigplane --backend rigctld --host 127.0.0.1 --control-port 4532 web --rigctld-port 4533
+```
+
+In WSJT-X, choose `Hamlib NET rigctl` and point it at RigPlane's client-facing
+port, not the provider-facing Hamlib port, when you want RigPlane to remain the
+station control point.
+
+## Troubleshooting
+
+### Hamlib tools are missing
+
+If `rigplane discover --hamlib-candidates` reports
+`hamlibCatalogUnavailable`, install Hamlib and confirm that `rigctl --list`
+works in the same shell where you run RigPlane.
+
+### Serial permission denied
+
+On Linux, your user may need access to the serial device group, commonly
+`dialout`:
+
+```bash
+sudo usermod -aG dialout "$USER"
+```
+
+Log out and back in after changing groups. On macOS, check Privacy & Security
+prompts and make sure the terminal app can access removable devices if the OS
+asks.
+
+### Serial port is busy
+
+Only one process can usually hold a USB serial CAT port. Stop other radio apps
+such as flrig, wfview, vendor utilities, or another `rigctld` instance, then
+restart the external `rigctld`.
+
+### Model mismatch
+
+If frequency or mode reads fail, confirm the Hamlib model ID:
+
+```bash
+rigctl --list | grep -Ei "IC-7300|FT-710|TX-500|X6100"
+```
+
+Restart `rigctld` with the corrected `-m` value. Also verify the radio-side CAT
+settings: baud rate, CI-V address where applicable, CAT mode, and USB/serial
+port selection.
+
+### Validation fails
+
+Run the same reads directly:
+
+```bash
+rigctl -m 2 -r 127.0.0.1:4532 f
+rigctl -m 2 -r 127.0.0.1:4532 m
+```
+
+If those fail, fix the Hamlib/serial setup first. If they pass but RigPlane
+validation does not, rerun with the same host and port and open an issue with
+the model, OS, `rigctld` command line, and redacted RigPlane output.
+
+## Related pages
+
+- [Supported Radios](radios.md)
+- [CLI Reference](cli.md#discover)
+- [WSJT-X / JTDX / JS8Call Setup Guide](wsjtx-setup.md)

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -1,14 +1,14 @@
 ---
-description: Radios supported by RigPlane — native Icom and Yaesu providers today, plus Xiegu, Lab599, and other serial CAT candidates moving toward Hamlib-backed assisted discovery.
+description: Radios supported by RigPlane — native Icom and Yaesu providers today, plus Xiegu, Lab599, and other serial CAT candidates through Hamlib-backed assisted discovery.
 ---
 
 # Supported Radios
 
 Radio support in rigplane is provider-based. Native providers use **TOML rig
 profiles** in `rigs/` to describe capabilities and protocol details. Long-tail
-serial CAT radios are moving toward a Hamlib-backed provider path that emits
-structured discovery candidates and maps Hamlib control into RigPlane
-capabilities.
+serial CAT radios can use the [Hamlib / external rigctld provider](hamlib-rigctld-provider.md),
+which emits structured discovery candidates and maps Hamlib control into
+RigPlane capabilities through an external `rigctld` process.
 
 ## Tested
 
@@ -88,8 +88,8 @@ The Web UI automatically hides DIGI-SEL and IP+ controls when connected to an IC
 
 These radios have profiles or known CAT surfaces, but they are not yet
 first-party hardware-validated. The intended direction is assisted discovery and
-Hamlib-backed control where that gives broader coverage than maintaining a
-bespoke backend for each dialect.
+Hamlib-backed control through an external `rigctld` process where that gives
+broader coverage than maintaining a bespoke backend for each dialect.
 
 ### Xiegu X6100
 
@@ -98,7 +98,7 @@ bespoke backend for each dialect.
 - **Rig profile:** `rigs/x6100.toml`
 - **Features:** HF + 6m, QRP 8W, built-in ATU, WiFi
 - **VFO scheme:** `ab`
-- **Status:** Profile only. May work with CI-V backend (untested); assisted discovery and Hamlib-backed fallback planned.
+- **Status:** Profile only. May work with CI-V backend (untested); also a Hamlib assisted-discovery candidate.
 
 ### Lab599 TX-500
 
@@ -106,7 +106,7 @@ bespoke backend for each dialect.
 - **Rig profile:** `rigs/tx500.toml`
 - **Features:** HF + 6m, QRP 10W, built-in ATU, minimal CAT (ID FA FB MD FR FT PA RA)
 - **VFO scheme:** `ab`
-- **Status:** Profile only. Product direction is Hamlib-backed provider plus assisted discovery, not a bespoke Kenwood CAT backend first.
+- **Status:** Profile only. Hamlib-backed provider plus assisted discovery is the preferred first path, not a bespoke Kenwood CAT backend.
 
 ## Community-Validated / Maintainer Hardware Pending
 
@@ -194,7 +194,8 @@ See **[Adding a New Radio (Rig Profiles)](rig-profiles.md)** for the complete gu
 In brief:
 
 1. Decide whether the radio belongs on an existing native provider path or the
-   Hamlib-backed provider path.
+   Hamlib-backed provider path. For Hamlib, start with the
+   [external rigctld provider guide](hamlib-rigctld-provider.md).
 2. For native provider work, copy the closest reference rig file as a template:
    - Icom CI-V → `rigs/ic7610.toml`
    - Kenwood CAT → `rigs/tx500.toml`

--- a/docs/guide/wsjtx-setup.md
+++ b/docs/guide/wsjtx-setup.md
@@ -7,7 +7,9 @@ description: Configure WSJT-X, JTDX, and JS8Call against RigPlane's rigctld-comp
 This guide covers configuring WSJT-X (and compatible apps like JTDX, JS8Call)
 to work with RigPlane's client-facing `rigctld`-compatible endpoint. This is
 separate from the provider layer underneath RigPlane, which may be native or
-Hamlib-backed depending on the radio path.
+Hamlib-backed depending on the radio path. If RigPlane itself is using Hamlib,
+see the [Hamlib / external rigctld provider guide](hamlib-rigctld-provider.md)
+for the provider-facing setup.
 
 ## Quick Start
 
@@ -56,6 +58,11 @@ In **Settings → Radio**:
 
 Press **Test CAT** — the button should turn green.
 Press **Test PTT** — the radio should key up briefly.
+
+!!! note "Which port?"
+    Point WSJT-X at RigPlane's client-facing `rigctld` endpoint. If RigPlane is
+    also consuming an external Hamlib `rigctld` provider underneath, keep the two
+    TCP ports distinct so WSJT-X talks to RigPlane, not around it.
 
 ### 3. Configure WSJT-X Audio (with BlackHole bridge)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 ---
 title: RigPlane — Ham Radio Control Library and Web UI for Icom, Yaesu, Xiegu
-description: RigPlane is a Python library and browser Web UI for controlling ham radios through native providers and planned Hamlib-backed CAT coverage while keeping one capability-driven station model.
+description: RigPlane is a Python library and browser Web UI for controlling ham radios through native providers and external rigctld-backed Hamlib CAT coverage while keeping one capability-driven station model.
 ---
 
 # rigplane
 
-**Python library for controlling Icom, Yaesu, and other transceivers through native providers and planned Hamlib-backed CAT coverage.**
+**Python library for controlling Icom, Yaesu, and other transceivers through native providers and external `rigctld`-backed Hamlib CAT coverage.**
 
 RigPlane keeps the browser UI, audio path, diagnostics, and `rigctld`-compatible endpoint consistent across provider paths.
 
@@ -59,7 +59,7 @@ RigPlane keeps the browser UI, audio path, diagnostics, and `rigctld`-compatible
 
     Add native radio profiles and understand where Hamlib-backed provider work fits.
 
-    [:octicons-arrow-right-24: Adding a New Radio](guide/rig-profiles.md)
+    [:octicons-arrow-right-24: Adding a New Radio](guide/rig-profiles.md) · [:octicons-arrow-right-24: Hamlib Guide](guide/hamlib-rigctld-provider.md)
 
 - :material-monitor:{ .lg .middle } **Web UI**
 
@@ -75,15 +75,15 @@ RigPlane keeps the browser UI, audio path, diagnostics, and `rigctld`-compatible
 
 ## Features
 
-- :white_check_mark: **Multi-vendor support** — native Icom CI-V and Yaesu CAT, plus planned Hamlib-backed long-tail CAT coverage
-- :white_check_mark: **Direct UDP connection** — no intermediate software (LAN backend)
+- :white_check_mark: **Multi-vendor support** — native Icom CI-V and Yaesu CAT, plus external `rigctld`-backed Hamlib long-tail CAT coverage
+- :white_check_mark: **Direct UDP connection** — no intermediate software for native LAN operation
 - :white_check_mark: **USB serial backend** — CI-V over USB for IC-7610, IC-7300; USB audio devices
 - :white_check_mark: **Full CI-V command set** — frequency, mode/filter, power, meters, PTT, CW keying, VFO, split, ATT/PREAMP
 - :white_check_mark: **Yaesu CAT backend** — full working native backend for Yaesu FTX-1 (USB serial)
-- :white_check_mark: **Hamlib provider direction** — broad serial CAT coverage through assisted discovery and normalized RigPlane capabilities
+- :white_check_mark: **Hamlib provider** — broad serial CAT coverage through an external `rigctld` process, assisted discovery, and normalized RigPlane capabilities
 - :white_check_mark: **Audio streaming** — RX/TX with jitter buffer and full-duplex support
 - :white_check_mark: **Audio FFT Scope** — real-time FFT on USB/LAN audio for radios without hardware spectrum
-- :white_check_mark: **Discovery** — find supported LAN radios automatically; assisted serial CAT discovery is the long-tail direction
+- :white_check_mark: **Discovery** — find supported LAN radios automatically; assisted serial CAT discovery can suggest and validate Hamlib candidates
 - :white_check_mark: **CLI tool** — `rigplane status`, `rigplane freq 14.074m`
 - :white_check_mark: **Built-in Web UI** — spectrum, waterfall, controls, meters, audio in browser; LCD layout for non-scope radios
 - :white_check_mark: **Async + Sync API** — async by default, blocking wrapper available
@@ -101,12 +101,12 @@ RigPlane keeps the browser UI, audio path, diagnostics, and `rigctld`-compatible
 | Yaesu FTX-1 | Yaesu CAT | :white_check_mark: Tested (USB) |
 | IC-705 | CI-V `0xA4` | :white_check_mark: Validated (LAN/WiFi community-tested) |
 | IC-9700 | CI-V `0xA2` | :material-help-circle: Profile — not yet tested |
-| Xiegu X6100 | CI-V `0x70` / Hamlib candidate | :material-help-circle: Profile only; assisted discovery planned |
-| Lab599 TX-500 | Kenwood CAT / Hamlib candidate | :material-help-circle: Profile only; assisted discovery planned |
+| Xiegu X6100 | CI-V `0x70` / Hamlib candidate | :material-help-circle: Profile only; assisted discovery candidate |
+| Lab599 TX-500 | Kenwood CAT / Hamlib candidate | :material-help-circle: Profile only; assisted discovery candidate |
 | IC-7851 | CI-V `0x8E` | :material-help-circle: Should work |
 | IC-R8600 | CI-V `0x96` | :material-help-circle: Should work |
 
-See [Supported Radios](guide/radios.md) for full details. Any Icom radio with LAN/WiFi control should work — the CI-V address is configurable. If you're choosing the commercial desktop app first, start from the matching landing page on [rigplane.com](https://rigplane.com/): [IC-7610](https://rigplane.com/ic-7610/), [IC-7300](https://rigplane.com/ic-7300/), [IC-705](https://rigplane.com/ic-705/), [IC-9700](https://rigplane.com/ic-9700/), or the platform pages for [Mac](https://rigplane.com/ham-radio-software/mac/) and [Linux](https://rigplane.com/ham-radio-software/linux/).
+See [Supported Radios](guide/radios.md) and the [Hamlib provider guide](guide/hamlib-rigctld-provider.md) for full details. Any Icom radio with LAN/WiFi control should work — the CI-V address is configurable. If you're choosing the commercial desktop app first, start from the matching landing page on [rigplane.com](https://rigplane.com/): [IC-7610](https://rigplane.com/ic-7610/), [IC-7300](https://rigplane.com/ic-7300/), [IC-705](https://rigplane.com/ic-705/), [IC-9700](https://rigplane.com/ic-9700/), or the platform pages for [Mac](https://rigplane.com/ham-radio-software/mac/) and [Linux](https://rigplane.com/ham-radio-software/linux/).
 
 ## Indexing policy
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
   - User Guide:
       - Connection Lifecycle: guide/connection.md
       - Supported Radios: guide/radios.md
+      - Hamlib / external rigctld provider: guide/hamlib-rigctld-provider.md
       - Rig Profiles: guide/rig-profiles.md
       - Radio Setup Guides:
           - IC-7610 USB Serial: guide/ic7610-usb-setup.md


### PR DESCRIPTION
## Summary

- Add a public rigplane.dev guide for the Hamlib-backed provider through an external `rigctld` process.
- Document assisted discovery behavior, read-only safety limits, setup flow, endpoint separation, and troubleshooting.
- Align homepage, supported radio, CLI, WSJT-X, and MkDocs navigation wording so native-provider value remains clear without stale absolute Hamlib claims.

Closes #1592
Linear: MOR-32

Note: any rigplane-www cleanup is separate from this rigplane-core/MkDocs docs change.

## Validation

- `uv run mkdocs build --strict`
- `git diff --check`
- `git diff --cached --check`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -q --tb=short`
