### PR TITLE
chore: refresh core lockfile version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Refresh `uv.lock` so the editable `rigplane` package version matches `pyproject.toml` (`2.3.1`).

## Scope
- Lockfile metadata only.
- No source, dependency, API, or behavior changes.

## Verification
- `uv lock --check`
- `git diff --check`