### PR TITLE
feat(api): add ordered HTTP command batches

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -58,6 +58,8 @@ These routes are part of the Pro/supervisor compatibility surface:
 | `GET` | `/api/v1/bridge` | Audio bridge status |
 | `POST` | `/api/v1/bridge` | Start audio bridge |
 | `DELETE` | `/api/v1/bridge` | Stop audio bridge |
+| `POST` | `/api/v1/commands` | Enqueue one structured radio command |
+| `POST` | `/api/v1/commands/batch` | Apply a stateless ordered command batch |
 
 ### Other Web UI Endpoints
 
@@ -80,6 +82,8 @@ These routes are part of the Pro/supervisor compatibility surface:
 | `POST` | `/api/v1/radio/connect` | Connect/reconnect radio control path |
 | `POST` | `/api/v1/radio/disconnect` | Disconnect radio control path |
 | `POST` | `/api/v1/radio/power` | Power on/off via CI-V power control |
+| `POST` | `/api/v1/commands` | Enqueue one structured radio command |
+| `POST` | `/api/v1/commands/batch` | Apply a stateless ordered command batch |
 | `POST` | `/api/v1/band-plan/config` | Change active region and reload band plans |
 | `POST` | `/api/v1/eibi/fetch` | Fetch/refresh EiBi dataset |
 
@@ -169,6 +173,235 @@ When auth is configured, this endpoint requires the same bearer token as other
   },
   "lastError": null
 }
+```
+
+## `POST /api/v1/commands`
+
+HTTP command envelope for automation clients that do not need WebSocket
+delivery. The command names and `params` match the `/api/v1/ws` command channel.
+The endpoint accepts the command into RigPlane's normal command queue and
+returns the same acknowledgement shape as the WebSocket command handler.
+
+Request:
+
+```json
+{
+  "id": "button-1",
+  "name": "set_freq",
+  "params": { "freq": 144030000, "receiver": 0 }
+}
+```
+
+Response:
+
+```json
+{
+  "id": "button-1",
+  "ok": true,
+  "name": "set_freq",
+  "result": { "freq": 144030000, "receiver": 0 }
+}
+```
+
+`id` is optional and echoed when present. Unknown command names and malformed
+parameters return HTTP `400`. Read-only mode rejects transmit commands with
+HTTP `403`.
+
+## `POST /api/v1/commands/batch`
+
+Stateless ordered batch apply for local automation. RigPlane does not store,
+name, schedule, or share batches in Core. Clients send the full sequence on
+each request.
+
+Batch steps are validated and executed in request order. Each executable step
+is placed on an exact-order command-queue lane and the HTTP handler waits for
+the poller/backend to finish that step before advancing to the next step.
+Repeated commands are not deduplicated inside the ordered lane.
+
+Request:
+
+```json
+{
+  "id": "vara-fm",
+  "continue_on_error": false,
+  "steps": [
+    { "name": "set_freq", "params": { "freq": 144030000 } },
+    { "name": "set_mode", "params": { "mode": "FM" } }
+  ]
+}
+```
+
+Successful response:
+
+```json
+{
+  "id": "vara-fm",
+  "ok": true,
+  "results": [
+    {
+      "index": 0,
+      "name": "set_freq",
+      "ok": true,
+      "status": "executed",
+      "result": { "freq": 144030000, "receiver": 0 }
+    },
+    {
+      "index": 1,
+      "name": "set_mode",
+      "ok": true,
+      "status": "executed",
+      "result": { "mode": "FM", "receiver": 0 }
+    }
+  ]
+}
+```
+
+Partial-failure response:
+
+```json
+{
+  "ok": false,
+  "results": [
+    {
+      "index": 0,
+      "name": "set_freq",
+      "ok": true,
+      "status": "executed",
+      "result": { "freq": 144030000, "receiver": 0 }
+    },
+    {
+      "index": 1,
+      "name": "no_such_command",
+      "ok": false,
+      "status": "failed_validation",
+      "error": "unknown_command",
+      "message": "unknown command: 'no_such_command'"
+    },
+    {
+      "index": 2,
+      "name": "set_mode",
+      "ok": false,
+      "status": "skipped",
+      "error": "skipped_after_failure",
+      "message": "skipped after earlier batch failure"
+    }
+  ]
+}
+```
+
+Set `continue_on_error` to `true` to keep applying later valid steps after a
+validation, timeout, or execution failure. When present, `continue_on_error`
+must be a JSON boolean. Queue-bypassing commands such as `get_*`,
+`send_cw_text`, and direct helper operations are rejected in batches with
+`unsupported_in_batch`; use `POST /api/v1/commands` for those one-off calls.
+
+If a queued step is not consumed by the poller before the step timeout, the
+result status is `timed_out` with error `command_timeout`. Unconsumed timed-out
+steps are cancelled before execution.
+
+### Automation Examples
+
+Check capabilities before building model-specific batches. The capability
+payload tells clients which receivers, modes, filters, audio controls, memory
+operations, and feature toggles are available on the active radio:
+
+```bash
+curl http://127.0.0.1:8080/api/v1/capabilities
+```
+
+Prefer structured commands whenever a command exists. Raw CI-V is useful for
+diagnostics and experiments, but normal automation should let RigPlane own the
+radio connection, queueing, pacing, auth policy, and safety checks.
+
+Python example:
+
+```python
+import json
+import urllib.request
+
+base_url = "http://127.0.0.1:8080"
+token = None  # or "your-token"
+
+batch = {
+    "id": "vara-fm",
+    "steps": [
+        {"name": "set_freq", "params": {"freq": 144030000}},
+        {"name": "set_mode", "params": {"mode": "FM"}},
+        {"name": "set_af_level", "params": {"level": 72}},
+    ],
+}
+
+body = json.dumps(batch).encode("utf-8")
+request = urllib.request.Request(
+    f"{base_url}/api/v1/commands/batch",
+    data=body,
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+if token:
+    request.add_header("Authorization", f"Bearer {token}")
+
+with urllib.request.urlopen(request, timeout=30) as response:
+    result = json.load(response)
+
+if not result["ok"]:
+    raise SystemExit(result)
+```
+
+Minimal MQTT gateway sketch:
+
+```python
+import json
+import urllib.request
+
+import paho.mqtt.client as mqtt
+
+RIGPLANE_URL = "http://127.0.0.1:8080"
+
+BATCHES = {
+    "vara-fm": {
+        "id": "vara-fm",
+        "steps": [
+            {"name": "set_freq", "params": {"freq": 144030000}},
+            {"name": "set_mode", "params": {"mode": "FM"}},
+        ],
+    },
+    "fm-voice": {
+        "id": "fm-voice",
+        "steps": [
+            {"name": "set_mode", "params": {"mode": "FM"}},
+            {"name": "set_af_level", "params": {"level": 50}},
+        ],
+    },
+}
+
+
+def post_batch(batch: dict) -> None:
+    body = json.dumps(batch).encode("utf-8")
+    request = urllib.request.Request(
+        f"{RIGPLANE_URL}/api/v1/commands/batch",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        result = json.load(response)
+    if not result["ok"]:
+        print("RigPlane batch failed:", result)
+
+
+def on_message(client, userdata, message) -> None:
+    profile_name = message.payload.decode("utf-8").strip()
+    batch = BATCHES.get(profile_name)
+    if batch is not None:
+        post_batch(batch)
+
+
+client = mqtt.Client()
+client.on_message = on_message
+client.connect("127.0.0.1", 1883)
+client.subscribe("radio/profile")
+client.loop_forever()
 ```
 
 ## `GET /api/v1/station`

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -55,6 +55,8 @@ These are primarily used by automation, deployment scripts, and operator tooling
 | `POST` | `/api/v1/radio/connect` | Trigger backend connect/reconnect |
 | `POST` | `/api/v1/radio/disconnect` | Trigger backend disconnect |
 | `POST` | `/api/v1/radio/power` | CI-V power control (`{"state":"on" \| "off"}`) |
+| `POST` | `/api/v1/commands` | Enqueue one structured control command |
+| `POST` | `/api/v1/commands/batch` | Apply an ordered stateless command batch |
 | `POST` | `/api/v1/bridge` | Start audio bridge |
 | `DELETE` | `/api/v1/bridge` | Stop audio bridge |
 | `GET` | `/api/v1/band-plan/config` | Active band-plan region |
@@ -140,6 +142,108 @@ If backend recovery is already in progress, `radio_connect` returns:
 - DSP/features: `set_nb`, `set_nr`, `set_digisel`, `set_ipplus`, `set_comp`
 - Receiver/routing: `select_vfo`, `vfo_swap`, `vfo_equalize`, `set_dual_watch`
 - Scope control: `switch_scope_receiver`, `set_scope_during_tx`, `set_scope_center_type`
+
+## HTTP Structured Commands
+
+Automation clients can send the same structured command names over HTTP:
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/commands \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"deck-1","name":"set_freq","params":{"freq":144030000}}'
+```
+
+For ordered profile-like changes, send a stateless batch:
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/commands/batch \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "id": "vara-fm",
+    "steps": [
+      {"name":"set_freq","params":{"freq":144030000}},
+      {"name":"set_mode","params":{"mode":"FM"}},
+      {"name":"set_af_level","params":{"level":72}}
+    ]
+  }'
+```
+
+Batch steps are executed in exact request order through the radio command queue.
+Repeated commands in one batch are preserved. The response includes one result
+per executed, timed-out, failed, or skipped step. `continue_on_error`, when
+provided, must be a JSON boolean. Core does not persist named profiles or stored
+batches; callers send the full sequence each time.
+
+Use `/api/v1/capabilities` before sending model-specific batches; not every
+radio exposes the same receivers, memory operations, audio routing controls, or
+feature toggles. Prefer these structured commands over raw CI-V for routine
+automation so RigPlane remains the single owner of the radio connection,
+queueing, pacing, auth policy, and safety checks.
+
+Minimal Python client:
+
+```python
+import json
+import urllib.request
+
+batch = {
+    "id": "vara-fm",
+    "steps": [
+        {"name": "set_freq", "params": {"freq": 144030000}},
+        {"name": "set_mode", "params": {"mode": "FM"}},
+    ],
+}
+
+request = urllib.request.Request(
+    "http://127.0.0.1:8080/api/v1/commands/batch",
+    data=json.dumps(batch).encode("utf-8"),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+
+with urllib.request.urlopen(request, timeout=30) as response:
+    result = json.load(response)
+```
+
+Minimal MQTT gateway shape:
+
+```python
+import json
+import urllib.request
+
+import paho.mqtt.client as mqtt
+
+BATCHES = {
+    "vara-fm": {
+        "steps": [
+            {"name": "set_freq", "params": {"freq": 144030000}},
+            {"name": "set_mode", "params": {"mode": "FM"}},
+        ],
+    }
+}
+
+
+def on_message(client, userdata, message) -> None:
+    batch = BATCHES.get(message.payload.decode("utf-8").strip())
+    if batch is None:
+        return
+    urllib.request.urlopen(
+        urllib.request.Request(
+            "http://127.0.0.1:8080/api/v1/commands/batch",
+            data=json.dumps(batch).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        ),
+        timeout=30,
+    )
+
+
+client = mqtt.Client()
+client.on_message = on_message
+client.connect("127.0.0.1", 1883)
+client.subscribe("radio/profile")
+client.loop_forever()
+```
 
 ### Band switching with `set_band` (`bsrCode` workflow)
 

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -231,11 +231,22 @@ class YaesuCatPoller:
         if self._command_queue is None or not self._command_queue.has_commands:
             return
 
-        commands = self._command_queue.drain()
-        for cmd in commands:
+        entries = self._command_queue.drain_entries()
+        for entry in entries:
+            cmd = entry.command
+            if entry.future is not None and entry.future.cancelled():
+                logger.debug(
+                    "YaesuCatPoller: skipping cancelled queued command %s",
+                    type(cmd).__name__,
+                )
+                continue
             try:
                 await self._execute_command(cmd)
-            except Exception:
+                if entry.future is not None and not entry.future.done():
+                    entry.future.set_result(None)
+            except Exception as exc:
+                if entry.future is not None and not entry.future.done():
+                    entry.future.set_exception(exc)
                 logger.warning(
                     "YaesuCatPoller: command %s failed",
                     type(cmd).__name__,

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -8,12 +8,13 @@ a neutral module avoids backend → web import cycles.
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
 __all__ = [
     "Command",
     "CommandQueue",
+    "CommandQueueEntry",
     # -- command dataclasses (alphabetical) --
     "DisableScope",
     "EnableScope",
@@ -945,31 +946,87 @@ Command = (
 # ------------------------------------------------------------------
 
 
-class CommandQueue:
-    def __init__(self) -> None:
-        self._dedup: dict[type, Command] = {}
-        self._ptt: list[PttOn | PttOff] = []
-        self._notify: asyncio.Event = asyncio.Event()
+@dataclass(frozen=True, slots=True)
+class CommandQueueEntry:
+    command: Command
+    future: asyncio.Future[None] | None = None
 
-    def put(self, cmd: Command) -> None:
-        if isinstance(cmd, (PttOn, PttOff)):
-            self._ptt.append(cmd)
-        else:
-            self._dedup[type(cmd)] = cmd
-        self._notify.set()
 
-    def drain(self) -> list[Command]:
-        self._notify.clear()
-        cmds: list[Command] = []
-        cmds.extend(self._ptt)
-        self._ptt.clear()
-        cmds.extend(self._dedup.values())
-        self._dedup.clear()
-        return cmds
+@dataclass(slots=True)
+class _CommandQueueSegment:
+    kind: Literal["coalesced", "ordered"]
+    ptt: list[CommandQueueEntry] = field(default_factory=list)
+    dedup: dict[type, CommandQueueEntry] = field(default_factory=dict)
+    ordered: list[CommandQueueEntry] = field(default_factory=list)
+
+    @classmethod
+    def coalesced(cls) -> "_CommandQueueSegment":
+        return cls(kind="coalesced")
+
+    @classmethod
+    def ordered_entry(cls, entry: CommandQueueEntry) -> "_CommandQueueSegment":
+        return cls(kind="ordered", ordered=[entry])
 
     @property
     def has_commands(self) -> bool:
-        return bool(self._ptt or self._dedup)
+        return bool(self.ptt or self.dedup or self.ordered)
+
+    def entries(self) -> list[CommandQueueEntry]:
+        if self.kind == "ordered":
+            return list(self.ordered)
+        entries: list[CommandQueueEntry] = []
+        entries.extend(self.ptt)
+        entries.extend(self.dedup.values())
+        return entries
+
+
+class CommandQueue:
+    def __init__(self) -> None:
+        self._segments: list[_CommandQueueSegment] = []
+        self._notify: asyncio.Event = asyncio.Event()
+
+    def _coalesced_tail(self) -> _CommandQueueSegment:
+        if self._segments and self._segments[-1].kind == "coalesced":
+            return self._segments[-1]
+        segment = _CommandQueueSegment.coalesced()
+        self._segments.append(segment)
+        return segment
+
+    def put(self, cmd: Command) -> None:
+        entry = CommandQueueEntry(cmd)
+        segment = self._coalesced_tail()
+        if isinstance(cmd, (PttOn, PttOff)):
+            segment.ptt.append(entry)
+        else:
+            segment.dedup[type(cmd)] = entry
+        self._notify.set()
+
+    def put_ordered(
+        self,
+        cmd: Command,
+        *,
+        future: asyncio.Future[None] | None = None,
+    ) -> None:
+        self._segments.append(
+            _CommandQueueSegment.ordered_entry(CommandQueueEntry(cmd, future=future))
+        )
+        self._notify.set()
+
+    def drain(self) -> list[Command]:
+        return [entry.command for entry in self.drain_entries()]
+
+    def drain_entries(self) -> list["CommandQueueEntry"]:
+        self._notify.clear()
+        segments = self._segments
+        self._segments = []
+        entries: list[CommandQueueEntry] = []
+        for segment in segments:
+            entries.extend(segment.entries())
+        return entries
+
+    @property
+    def has_commands(self) -> bool:
+        return any(segment.has_commands for segment in self._segments)
 
     async def wait(self, timeout: float | None = None) -> None:
         try:

--- a/src/rigplane/web/api_contract.py
+++ b/src/rigplane/web/api_contract.py
@@ -92,6 +92,18 @@ STABLE_HTTP_ENDPOINTS: Final[tuple[HttpEndpoint, ...]] = (
         "purpose": "stop audio bridge",
         "auth": "bearer",
     },
+    {
+        "method": "POST",
+        "path": "/api/v1/commands",
+        "purpose": "enqueue one structured radio command",
+        "auth": "bearer",
+    },
+    {
+        "method": "POST",
+        "path": "/api/v1/commands/batch",
+        "purpose": "apply ordered stateless radio command batch",
+        "auth": "bearer",
+    },
 )
 
 STABLE_WEBSOCKET_ROUTES: Final[tuple[WebSocketRoute, ...]] = (
@@ -178,4 +190,6 @@ RESPONSE_FIELD_CONTRACTS: Final[dict[str, ResponseFieldContract]] = {
             "webrtc",
         )
     },
+    "/api/v1/commands": {"required": ("ok", "name", "result")},
+    "/api/v1/commands/batch": {"required": ("ok", "results")},
 }

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -629,13 +629,26 @@ class RadioPoller:
             while True:
                 # 1. Drain command queue (fire-and-forget writes)
                 if self._queue.has_commands:
-                    for cmd in self._queue.drain():
+                    for entry in self._queue.drain_entries():
+                        cmd = entry.command
+                        if entry.future is not None and entry.future.cancelled():
+                            logger.debug(
+                                "radio-poller: skipping cancelled queued cmd: %s",
+                                type(cmd).__name__,
+                            )
+                            continue
                         try:
                             await self._execute(cmd)
+                            if entry.future is not None and not entry.future.done():
+                                entry.future.set_result(None)
                             _backoff = 0.0
-                        except (ConnectionError, RadioConnectionError):
+                        except (ConnectionError, RadioConnectionError) as exc:
+                            if entry.future is not None and not entry.future.done():
+                                entry.future.set_exception(exc)
                             _backoff = min(_backoff + 0.5, _MAX_BACKOFF)
-                        except Exception:
+                        except Exception as exc:
+                            if entry.future is not None and not entry.future.done():
+                                entry.future.set_exception(exc)
                             logger.warning(
                                 "radio-poller: cmd error: %s",
                                 type(cmd).__name__,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -95,6 +95,30 @@ def _install_shutdown_signal_handlers(
 _DEFAULT_STATIC_DIR = pathlib.Path(__file__).parent / "static"
 _RADIO_MODEL = "IC-7610"
 _MAX_POST_BODY = 256 * 1024  # 256 KiB — hard ceiling for all POST body reads
+_MAX_COMMAND_BATCH_STEPS = 128
+_COMMAND_BATCH_STEP_TIMEOUT = 10.0
+
+
+class _HttpBatchValidationError(ValueError):
+    def __init__(self, error: str, message: str) -> None:
+        super().__init__(message)
+        self.error = error
+
+
+@dataclass(frozen=True, slots=True)
+class _HttpBatchStep:
+    index: int
+    name: str
+    command: Any
+    result: dict[str, Any]
+
+
+class _HttpCommandCollector:
+    def __init__(self) -> None:
+        self.commands: list[Any] = []
+
+    def put(self, command: Any) -> None:
+        self.commands.append(command)
 
 
 async def _read_capped_body(
@@ -2063,6 +2087,437 @@ class WebServer:
             body,
             {"Content-Type": "application/json"},
         )
+
+    async def _send_json(
+        self,
+        writer: asyncio.StreamWriter,
+        status: int,
+        reason: str,
+        payload: dict[str, Any],
+    ) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        await _send_response(
+            writer,
+            status,
+            reason,
+            body,
+            {"Content-Type": "application/json"},
+        )
+
+    async def _read_json_object(
+        self,
+        writer: asyncio.StreamWriter,
+        headers: dict[str, str] | None,
+        reader: asyncio.StreamReader | None,
+    ) -> dict[str, Any] | None:
+        try:
+            content_length = int((headers or {}).get("content-length", "0"))
+        except ValueError:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {
+                    "error": "invalid_content_length",
+                    "message": "Content-Length must be an integer",
+                },
+            )
+            return None
+        if reader is None or content_length <= 0:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "missing_body", "message": "JSON request body required"},
+            )
+            return None
+        read_result = await _read_capped_body(reader, content_length)
+        if read_result is None:
+            await self._send_json(
+                writer,
+                413,
+                "Content Too Large",
+                {"error": "request_too_large"},
+            )
+            writer.close()
+            return None
+        try:
+            payload = json.loads(read_result)
+        except json.JSONDecodeError as exc:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "invalid_json", "message": str(exc)},
+            )
+            return None
+        if not isinstance(payload, dict):
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {
+                    "error": "invalid_request",
+                    "message": "JSON body must be an object",
+                },
+            )
+            return None
+        return payload
+
+    def _control_handler_for(self, *, server: Any | None = None) -> ControlHandler:
+        return ControlHandler(
+            None,  # type: ignore[arg-type]
+            self._radio,
+            __version__,
+            self._config.radio_model,
+            server=server if server is not None else self,
+            read_only=self._config.read_only,
+        )
+
+    async def _handle_http_commands(
+        self,
+        path: str,
+        writer: asyncio.StreamWriter,
+        headers: dict[str, str] | None = None,
+        reader: asyncio.StreamReader | None = None,
+    ) -> None:
+        """Handle POST /api/v1/commands and /api/v1/commands/batch."""
+        if self._radio is None:
+            await self._send_json(
+                writer,
+                503,
+                "Service Unavailable",
+                {"error": "no_radio", "message": "No radio configured"},
+            )
+            return
+
+        payload = await self._read_json_object(writer, headers, reader)
+        if payload is None:
+            return
+
+        if path == "/api/v1/commands":
+            await self._handle_http_single_command(writer, payload)
+            return
+        if path == "/api/v1/commands/batch":
+            await self._handle_http_command_batch(writer, payload)
+            return
+
+        await _send_response(writer, 404, "Not Found", b"", {})
+
+    async def _handle_http_single_command(
+        self,
+        writer: asyncio.StreamWriter,
+        payload: dict[str, Any],
+    ) -> None:
+        raw_name = payload.get("name")
+        if not isinstance(raw_name, str) or not raw_name:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "invalid_request", "message": "name must be a string"},
+            )
+            return
+        if raw_name not in ControlHandler._COMMANDS:  # noqa: SLF001
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {
+                    "error": "unknown_command",
+                    "message": f"unknown command: {raw_name!r}",
+                },
+            )
+            return
+        raw_params = payload.get("params", {})
+        if not isinstance(raw_params, dict):
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "invalid_request", "message": "params must be an object"},
+            )
+            return
+        try:
+            result = await self._control_handler_for()._enqueue_command(  # noqa: SLF001
+                raw_name,
+                raw_params,
+            )
+        except PermissionError as exc:
+            await self._send_json(
+                writer,
+                403,
+                "Forbidden",
+                {"error": "read_only", "message": str(exc)},
+            )
+            return
+        except ValueError as exc:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "invalid_request", "message": str(exc)},
+            )
+            return
+        except RuntimeError as exc:
+            message = str(exc)
+            status, reason, code = (
+                (409, "Conflict", "unsupported_command")
+                if "does not support" in message
+                else (500, "Internal Server Error", "command_failed")
+            )
+            await self._send_json(
+                writer,
+                status,
+                reason,
+                {"error": code, "message": message},
+            )
+            return
+
+        response: dict[str, Any] = {
+            "ok": True,
+            "name": raw_name,
+            "result": result,
+        }
+        if "id" in payload:
+            response["id"] = payload["id"]
+        await self._send_json(writer, 200, "OK", response)
+
+    async def _prepare_http_batch_step(
+        self,
+        index: int,
+        raw_step: Any,
+    ) -> _HttpBatchStep:
+        if not isinstance(raw_step, dict):
+            raise _HttpBatchValidationError(
+                "invalid_step",
+                f"step {index} must be an object",
+            )
+        raw_name = raw_step.get("name")
+        if not isinstance(raw_name, str) or not raw_name:
+            raise _HttpBatchValidationError(
+                "invalid_step",
+                f"step {index} name must be a string",
+            )
+        raw_params = raw_step.get("params", {})
+        if not isinstance(raw_params, dict):
+            raise _HttpBatchValidationError(
+                "invalid_step",
+                f"step {index} params must be an object",
+            )
+        if raw_name not in ControlHandler._COMMANDS:  # noqa: SLF001
+            raise _HttpBatchValidationError(
+                "unknown_command",
+                f"unknown command: {raw_name!r}",
+            )
+        if raw_name in ControlHandler._READ_ONLY_HANDLERS:  # noqa: SLF001
+            raise _HttpBatchValidationError(
+                "unsupported_in_batch",
+                f"command {raw_name!r} bypasses the command queue",
+            )
+
+        collector = _HttpCommandCollector()
+        proxy_server = type("_HttpBatchProxy", (), {"command_queue": collector})()
+        result = await self._control_handler_for(server=proxy_server)._enqueue_command(  # noqa: SLF001
+            raw_name,
+            raw_params,
+        )
+        if len(collector.commands) != 1:
+            raise _HttpBatchValidationError(
+                "unsupported_in_batch",
+                f"command {raw_name!r} did not produce exactly one queued command",
+            )
+        return _HttpBatchStep(
+            index=index,
+            name=raw_name,
+            command=collector.commands[0],
+            result=result,
+        )
+
+    @staticmethod
+    def _skipped_batch_result(index: int, name: str | None = None) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "index": index,
+            "ok": False,
+            "status": "skipped",
+            "error": "skipped_after_failure",
+            "message": "skipped after earlier batch failure",
+        }
+        if name is not None:
+            result["name"] = name
+        return result
+
+    async def _handle_http_command_batch(
+        self,
+        writer: asyncio.StreamWriter,
+        payload: dict[str, Any],
+    ) -> None:
+        raw_steps = payload.get("steps")
+        if not isinstance(raw_steps, list):
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "invalid_request", "message": "steps must be a list"},
+            )
+            return
+        if not raw_steps:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "invalid_request", "message": "steps must not be empty"},
+            )
+            return
+        if len(raw_steps) > _MAX_COMMAND_BATCH_STEPS:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {
+                    "error": "batch_too_large",
+                    "message": f"max {_MAX_COMMAND_BATCH_STEPS} steps supported",
+                },
+            )
+            return
+
+        raw_continue_on_error = payload.get("continue_on_error", False)
+        if not isinstance(raw_continue_on_error, bool):
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {
+                    "error": "invalid_request",
+                    "message": "continue_on_error must be a boolean",
+                },
+            )
+            return
+        continue_on_error = raw_continue_on_error
+        results: list[dict[str, Any]] = []
+
+        for index, raw_step in enumerate(raw_steps):
+            name = raw_step.get("name") if isinstance(raw_step, dict) else None
+            try:
+                step = await self._prepare_http_batch_step(index, raw_step)
+            except PermissionError as exc:
+                results.append(
+                    {
+                        "index": index,
+                        "name": name,
+                        "ok": False,
+                        "status": "failed_validation",
+                        "error": "read_only",
+                        "message": str(exc),
+                    }
+                )
+                step = None
+            except _HttpBatchValidationError as exc:
+                results.append(
+                    {
+                        "index": index,
+                        "name": name,
+                        "ok": False,
+                        "status": "failed_validation",
+                        "error": exc.error,
+                        "message": str(exc),
+                    }
+                )
+                step = None
+            except (ValueError, RuntimeError) as exc:
+                results.append(
+                    {
+                        "index": index,
+                        "name": name,
+                        "ok": False,
+                        "status": "failed_validation",
+                        "error": "invalid_request",
+                        "message": str(exc),
+                    }
+                )
+                step = None
+
+            if step is None:
+                if continue_on_error:
+                    continue
+                for skip_index in range(index + 1, len(raw_steps)):
+                    skip = raw_steps[skip_index]
+                    skip_name = skip.get("name") if isinstance(skip, dict) else None
+                    results.append(self._skipped_batch_result(skip_index, skip_name))
+                await self._send_batch_response(writer, payload, results)
+                return
+
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future[None] = loop.create_future()
+            self._command_queue.put_ordered(step.command, future=future)
+            try:
+                await asyncio.wait_for(future, timeout=_COMMAND_BATCH_STEP_TIMEOUT)
+            except TimeoutError as exc:
+                results.append(
+                    {
+                        "index": step.index,
+                        "name": step.name,
+                        "ok": False,
+                        "status": "timed_out",
+                        "error": "command_timeout",
+                        "message": str(exc) or type(exc).__name__,
+                    }
+                )
+                if not continue_on_error:
+                    for skip_index in range(step.index + 1, len(raw_steps)):
+                        skip = raw_steps[skip_index]
+                        skip_name = skip.get("name") if isinstance(skip, dict) else None
+                        results.append(
+                            self._skipped_batch_result(skip_index, skip_name)
+                        )
+                    await self._send_batch_response(writer, payload, results)
+                    return
+            except Exception as exc:
+                results.append(
+                    {
+                        "index": step.index,
+                        "name": step.name,
+                        "ok": False,
+                        "status": "failed_execution",
+                        "error": "command_failed",
+                        "message": str(exc) or type(exc).__name__,
+                    }
+                )
+                if not continue_on_error:
+                    for skip_index in range(step.index + 1, len(raw_steps)):
+                        skip = raw_steps[skip_index]
+                        skip_name = skip.get("name") if isinstance(skip, dict) else None
+                        results.append(
+                            self._skipped_batch_result(skip_index, skip_name)
+                        )
+                    await self._send_batch_response(writer, payload, results)
+                    return
+            else:
+                results.append(
+                    {
+                        "index": step.index,
+                        "name": step.name,
+                        "ok": True,
+                        "status": "executed",
+                        "result": step.result,
+                    }
+                )
+
+        await self._send_batch_response(writer, payload, results)
+
+    async def _send_batch_response(
+        self,
+        writer: asyncio.StreamWriter,
+        payload: dict[str, Any],
+        results: list[dict[str, Any]],
+    ) -> None:
+        response: dict[str, Any] = {
+            "ok": all(result.get("ok") is True for result in results),
+            "results": results,
+        }
+        if "id" in payload:
+            response["id"] = payload["id"]
+        await self._send_json(writer, 200, "OK", response)
 
     async def _handle_radio_control(
         self,

--- a/src/rigplane/web/web_routing.py
+++ b/src/rigplane/web/web_routing.py
@@ -94,11 +94,16 @@ async def dispatch_http_request(
         "/api/v1/radio/power",
         "/api/v1/radio/cw/send",
         "/api/v1/radio/cw/stop",
+        "/api/v1/commands",
+        "/api/v1/commands/batch",
     ):
         if method != "POST":
             await _send_response(writer, 405, "Method Not Allowed", b"", {})
             return
-        await server._handle_radio_control(path, writer, headers, reader)
+        if path.startswith("/api/v1/commands"):
+            await server._handle_http_commands(path, writer, headers, reader)
+        else:
+            await server._handle_radio_control(path, writer, headers, reader)
         return
 
     if path == "/api/v1/band-plan/config":

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -200,6 +200,58 @@ async def test_command_queue_wait_and_drain_behavior() -> None:
 
 
 @pytest.mark.asyncio
+async def test_command_queue_ordered_lane_preserves_repeated_commands() -> None:
+    q = CommandQueue()
+    q.put_ordered(SetFreq(14_030_000))
+    q.put_ordered(SetMode("FM"))
+    q.put_ordered(SetFreq(144_030_000))
+    q.put_ordered(PttOn())
+    q.put_ordered(PttOff())
+
+    cmds = q.drain()
+
+    assert cmds == [
+        SetFreq(14_030_000),
+        SetMode("FM"),
+        SetFreq(144_030_000),
+        PttOn(),
+        PttOff(),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_command_queue_ordered_lane_preserves_segment_order() -> None:
+    q = CommandQueue()
+    q.put(SetFreq(7_000_000))
+    q.put(SetFreq(7_074_000))
+    q.put_ordered(SetFreq(144_030_000))
+    q.put(SetFreq(14_000_000))
+    q.put(SetFreq(14_074_000))
+
+    assert q.drain() == [
+        SetFreq(7_074_000),
+        SetFreq(144_030_000),
+        SetFreq(14_074_000),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_radio_poller_skips_ordered_command_with_cancelled_future() -> None:
+    radio = _make_radio(active="MAIN")
+    q = CommandQueue()
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    future.cancel()
+    q.put_ordered(SetFreq(144_030_000), future=future)
+    poller = RadioPoller(radio, StateCache(), q)
+
+    poller.start()
+    await asyncio.sleep(0.05)
+    poller.stop()
+
+    radio.set_freq.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_current_active_defaults_and_setfreq_setmode_branches() -> None:
     radio = _make_radio(active="MAIN")
     poller = RadioPoller(radio, StateCache(), CommandQueue())

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -48,6 +48,8 @@ def test_pro_web_api_contract_lists_stable_surface() -> None:
     assert ("GET", "/api/v1/bridge") in http
     assert ("POST", "/api/v1/bridge") in http
     assert ("DELETE", "/api/v1/bridge") in http
+    assert ("POST", "/api/v1/commands") in http
+    assert ("POST", "/api/v1/commands/batch") in http
 
     ws = {route["path"] for route in STABLE_WEBSOCKET_ROUTES}
     assert "/api/v1/ws" in ws
@@ -63,6 +65,15 @@ def test_pro_web_api_contract_lists_stable_surface() -> None:
         "model",
         "capabilities",
         "connection",
+    )
+    assert RESPONSE_FIELD_CONTRACTS["/api/v1/commands"]["required"] == (
+        "ok",
+        "name",
+        "result",
+    )
+    assert RESPONSE_FIELD_CONTRACTS["/api/v1/commands/batch"]["required"] == (
+        "ok",
+        "results",
     )
 
 

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -1,0 +1,295 @@
+"""HTTP structured command and ordered batch endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from rigplane.profiles import resolve_radio_profile
+from rigplane.web import server as web_server
+from rigplane.web.radio_poller import CommandQueue, SetFreq, SetMode
+from rigplane.web.server import WebConfig, WebServer
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+    def get_extra_info(self, name: str, default=None):
+        if name == "peername":
+            return ("127.0.0.1", 55555)
+        return default
+
+    @property
+    def response_status(self) -> int:
+        line = self.buffer.split(b"\r\n", 1)[0]
+        return int(line.split(b" ")[1])
+
+    @property
+    def response_body(self) -> dict:
+        body = self.buffer.split(b"\r\n\r\n", 1)[1]
+        return json.loads(body) if body else {}
+
+
+def _reader_for(payload: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(payload)
+    reader.feed_eof()
+    return reader
+
+
+def _radio() -> MagicMock:
+    profile = resolve_radio_profile(model="IC-9700")
+    radio = MagicMock()
+    radio.profile = profile
+    radio.model = profile.model
+    radio.capabilities = set(profile.capabilities)
+    return radio
+
+
+async def _post_json(
+    srv: WebServer,
+    path: str,
+    payload: dict,
+    *,
+    headers: dict[str, str] | None = None,
+) -> _FakeWriter:
+    body = json.dumps(payload).encode()
+    writer = _FakeWriter()
+    request_headers = {"content-length": str(len(body))}
+    if headers:
+        request_headers.update(headers)
+    await srv._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        path,
+        headers=request_headers,
+        reader=_reader_for(body),
+    )
+    return writer
+
+
+async def _complete_ordered_commands(
+    queue: CommandQueue,
+    count: int,
+    captured: list[object],
+) -> None:
+    while len(captured) < count:
+        await queue.wait(timeout=1.0)
+        for entry in queue.drain_entries():
+            captured.append(entry.command)
+            if entry.future is not None and not entry.future.done():
+                entry.future.set_result(None)
+
+
+@pytest.mark.asyncio
+async def test_http_command_enqueues_single_structured_command() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {"id": "single-1", "name": "set_freq", "params": {"freq": 144_030_000}},
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body == {
+        "id": "single-1",
+        "ok": True,
+        "name": "set_freq",
+        "result": {"freq": 144_030_000, "receiver": 0},
+    }
+    assert srv.command_queue.drain() == [SetFreq(144_030_000, receiver=0)]
+
+
+@pytest.mark.asyncio
+async def test_http_command_requires_auth_when_configured() -> None:
+    srv = WebServer(
+        _radio(),
+        WebConfig(host="127.0.0.1", port=0, auth_token="secret"),
+    )
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {"name": "set_freq", "params": {"freq": 144_030_000}},
+    )
+
+    assert writer.response_status == 401
+    assert writer.response_body["error"] == "unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_preserves_exact_order_and_repeated_commands() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+    captured: list[object] = []
+    consumer = asyncio.create_task(
+        _complete_ordered_commands(srv.command_queue, 3, captured)
+    )
+    try:
+        writer = await _post_json(
+            srv,
+            "/api/v1/commands/batch",
+            {
+                "id": "profile-vara-fm",
+                "steps": [
+                    {"name": "set_freq", "params": {"freq": 144_030_000}},
+                    {"name": "set_mode", "params": {"mode": "FM"}},
+                    {"name": "set_freq", "params": {"freq": 144_031_000}},
+                ],
+            },
+        )
+    finally:
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+    assert writer.response_status == 200
+    assert writer.response_body["id"] == "profile-vara-fm"
+    assert writer.response_body["ok"] is True
+    assert [r["status"] for r in writer.response_body["results"]] == [
+        "executed",
+        "executed",
+        "executed",
+    ]
+    assert captured == [
+        SetFreq(144_030_000, receiver=0),
+        SetMode("FM", receiver=0),
+        SetFreq(144_031_000, receiver=0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_reports_validation_failure_and_skips_remaining() -> (
+    None
+):
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {"name": "no_such_command", "params": {}},
+                {"name": "set_freq", "params": {"freq": 144_030_000}},
+            ],
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"][0]["status"] == "failed_validation"
+    assert writer.response_body["results"][0]["error"] == "unknown_command"
+    assert writer.response_body["results"][1]["status"] == "skipped"
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_requires_boolean_continue_on_error() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "continue_on_error": "false",
+            "steps": [{"name": "set_freq", "params": {"freq": 144_030_000}}],
+        },
+    )
+
+    assert writer.response_status == 400
+    assert writer.response_body["error"] == "invalid_request"
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_timeout_cancels_unconsumed_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(web_server, "_COMMAND_BATCH_STEP_TIMEOUT", 0.001)
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {"steps": [{"name": "set_freq", "params": {"freq": 144_030_000}}]},
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"][0]["status"] == "timed_out"
+    assert writer.response_body["results"][0]["error"] == "command_timeout"
+
+    [entry] = srv.command_queue.drain_entries()
+    assert entry.command == SetFreq(144_030_000, receiver=0)
+    assert entry.future is not None
+    assert entry.future.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_reports_prior_executed_step_before_failure() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+    captured: list[object] = []
+    consumer = asyncio.create_task(
+        _complete_ordered_commands(srv.command_queue, 1, captured)
+    )
+    try:
+        writer = await _post_json(
+            srv,
+            "/api/v1/commands/batch",
+            {
+                "steps": [
+                    {"name": "set_freq", "params": {"freq": 144_030_000}},
+                    {"name": "no_such_command", "params": {}},
+                    {"name": "set_mode", "params": {"mode": "FM"}},
+                ],
+            },
+        )
+    finally:
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert [r["status"] for r in writer.response_body["results"]] == [
+        "executed",
+        "failed_validation",
+        "skipped",
+    ]
+    assert captured == [SetFreq(144_030_000, receiver=0)]
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_rejects_queue_bypass_commands() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {"name": "get_tuner_status", "params": {}},
+                {"name": "set_freq", "params": {"freq": 144_030_000}},
+            ],
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"][0]["status"] == "failed_validation"
+    assert writer.response_body["results"][0]["error"] == "unsupported_in_batch"
+    assert writer.response_body["results"][1]["status"] == "skipped"
+    assert srv.command_queue.drain() == []

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.3.1"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Adds the Core side of the structured HTTP command and batch epic:

- `POST /api/v1/commands` for one structured command using the existing `ControlHandler` command names and params
- `POST /api/v1/commands/batch` for stateless ordered batch apply with per-step `executed`, `failed_validation`, `failed_execution`, `timed_out`, and `skipped` results
- segmented `CommandQueue` semantics so existing UI/WebSocket `put()` remains coalesced last-write-wins while batch steps preserve exact order relative to already pending commands
- poller future completion/cancellation handling for Icom and Yaesu command queues
- stable API contract entries and public docs for Core automation clients

Core remains stateless: it does not store named profiles, profile builders, sharing, scheduling, or hosted/service behavior.

## Compatibility

This is additive for HTTP routes and keeps existing WebSocket command envelopes unchanged. Existing `CommandQueue.put()` behavior remains coalesced by command type with PTT entries not deduped. New exact-order behavior is opt-in through `put_ordered()` and the HTTP batch endpoint.

The PR also syncs the editable `rigplane` entry in `uv.lock` from `2.3.1` to the current `pyproject.toml` version `2.4.0` after `uv run` touched the lockfile.

## Verification

- `uv run ruff check .`
- `uv run pytest tests/test_web_command_batch_http.py tests/test_radio_poller_coverage.py::test_command_queue_wait_and_drain_behavior tests/test_radio_poller_coverage.py::test_command_queue_ordered_lane_preserves_repeated_commands tests/test_radio_poller_coverage.py::test_command_queue_ordered_lane_preserves_segment_order tests/test_radio_poller_coverage.py::test_radio_poller_skips_ordered_command_with_cancelled_future tests/test_web_api_contract.py tests/test_web_cw_http_control.py tests/test_web_server.py::TestRadioPoller::test_command_queue_dedup tests/test_web_server.py::TestRadioPoller::test_poller_executes_commands tests/test_yaesu_cat_poller.py tests/test_yaesu_cat_transport.py`
- `uv run pytest` -> `6063 passed, 112 skipped, 3 deselected, 9 xfailed, 1 xpassed`

Closes #1596
Closes #1599
Closes #1600
Closes #1601
Closes #1602
