### PR TITLE
docs(api): explain HTTP command batches

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -101,6 +101,22 @@ Stable supervisor routes:
 WebSocket auth accepts the same bearer header as HTTP. Query token auth is also
 accepted for browser/WebSocket clients that cannot set headers.
 
+### Structured Command Surface
+
+`/api/v1/ws`, `POST /api/v1/commands`, and
+`POST /api/v1/commands/batch` use the same structured command names and
+`params` objects. For example, `set_freq` and `set_mode` mean the same thing
+over WebSocket, single-command HTTP, and batch HTTP.
+
+The current public docs include common command examples in
+[Web UI: Common commands](../guide/web-ui.md#common-commands), and lower-level
+Python/CI-V command examples in [CI-V Commands](../guide/commands.md). A full
+machine-readable HTTP/WS command catalog with every command name, parameter
+shape, capability gate, and batch-eligibility flag is tracked in
+[rigplane-core#1604](https://github.com/rigplane/rigplane-core/issues/1604).
+Until that catalog is published, the implementation source of truth is
+`ControlHandler` in `src/rigplane/web/handlers/control.py`.
+
 ### Internal And Diagnostic Surface
 
 Browser static files, `src/rigplane/web/static*`, handler class names, queue
@@ -213,10 +229,34 @@ Stateless ordered batch apply for local automation. RigPlane does not store,
 name, schedule, or share batches in Core. Clients send the full sequence on
 each request.
 
+Use this endpoint when an external controller needs an all-or-reported-nothing
+profile switch: tune frequency, select mode/filter, adjust levels, switch
+audio/data state, recall memory, or apply other supported structured commands
+as one ordered operation.
+
 Batch steps are validated and executed in request order. Each executable step
 is placed on an exact-order command-queue lane and the HTTP handler waits for
 the poller/backend to finish that step before advancing to the next step.
 Repeated commands are not deduplicated inside the ordered lane.
+
+Maximum batch size is 128 steps. Each step has a 10 second execution timeout.
+If the radio link is slow or disconnected, the failing step is reported and
+later steps are skipped unless `continue_on_error` is `true`.
+
+Data flow:
+
+```mermaid
+flowchart LR
+  Client["curl / Python / MQTT gateway"] --> HTTP["POST /api/v1/commands/batch"]
+  HTTP --> Validate["Validate JSON and command params"]
+  Validate --> Translate["ControlHandler builds Command objects"]
+  Translate --> Queue["CommandQueue.put_ordered"]
+  Queue --> Poller["radio poller drains queue"]
+  Poller --> Backend["LAN / serial / CAT backend"]
+  Backend --> Radio["physical radio"]
+  Poller --> Result["per-step future result"]
+  Result --> HTTP
+```
 
 Request:
 
@@ -298,6 +338,41 @@ must be a JSON boolean. Queue-bypassing commands such as `get_*`,
 If a queued step is not consumed by the poller before the step timeout, the
 result status is `timed_out` with error `command_timeout`. Unconsumed timed-out
 steps are cancelled before execution.
+
+### Profile-Switching Example
+
+Core treats a radio profile as a caller-owned batch, not as stored server
+state. This keeps the open-core API generic while still supporting local
+Stream Deck, MQTT, shell, and Python automation.
+
+Example IC-9700-style local batches:
+
+```json
+{
+  "vara-fm": {
+    "id": "vara-fm",
+    "steps": [
+      { "name": "set_freq", "params": { "freq": 144030000, "receiver": 0 } },
+      { "name": "set_mode", "params": { "mode": "FM", "receiver": 0 } },
+      { "name": "set_data_mode", "params": { "enabled": true, "receiver": 0 } },
+      { "name": "set_af_level", "params": { "level": 72, "receiver": 0 } },
+      { "name": "set_squelch", "params": { "level": 0, "receiver": 0 } }
+    ]
+  },
+  "fm-voice": {
+    "id": "fm-voice",
+    "steps": [
+      { "name": "set_mode", "params": { "mode": "FM", "receiver": 0 } },
+      { "name": "set_data_mode", "params": { "enabled": false, "receiver": 0 } },
+      { "name": "set_af_level", "params": { "level": 50, "receiver": 0 } }
+    ]
+  }
+}
+```
+
+Actual command availability depends on the active radio profile and backend.
+Fetch `/api/v1/capabilities` before enabling buttons or publishing a reusable
+profile.
 
 ### Automation Examples
 

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -143,6 +143,12 @@ If backend recovery is already in progress, `radio_connect` returns:
 - Receiver/routing: `select_vfo`, `vfo_swap`, `vfo_equalize`, `set_dual_watch`
 - Scope control: `switch_scope_receiver`, `set_scope_during_tx`, `set_scope_center_type`
 
+These are representative command names, not the complete catalog. The HTTP and
+WebSocket command surfaces share the same command names and `params` objects.
+Lower-level Python/CI-V examples are documented in
+[CI-V Commands](commands.md). A full HTTP/WS command catalog is tracked in
+[rigplane-core#1604](https://github.com/rigplane/rigplane-core/issues/1604).
+
 ## HTTP Structured Commands
 
 Automation clients can send the same structured command names over HTTP:
@@ -174,11 +180,27 @@ per executed, timed-out, failed, or skipped step. `continue_on_error`, when
 provided, must be a JSON boolean. Core does not persist named profiles or stored
 batches; callers send the full sequence each time.
 
+The batch path is designed for local profile switching from tools such as
+Stream Deck, MQTT gateways, shell scripts, and station supervisors:
+
+```mermaid
+flowchart LR
+  Button["operator button"] --> MQTT["MQTT/profile event"]
+  MQTT --> Gateway["local gateway maps name to steps"]
+  Gateway --> Batch["POST /api/v1/commands/batch"]
+  Batch --> Queue["RigPlane ordered command queue"]
+  Queue --> Radio["radio backend and hardware"]
+```
+
 Use `/api/v1/capabilities` before sending model-specific batches; not every
 radio exposes the same receivers, memory operations, audio routing controls, or
 feature toggles. Prefer these structured commands over raw CI-V for routine
 automation so RigPlane remains the single owner of the radio connection,
 queueing, pacing, auth policy, and safety checks.
+
+The batch endpoint is stateless. In Core, a "profile" is simply the JSON batch
+the caller sends. Stored named profiles, profile builders, account sync, and
+profile sharing are product-layer concerns outside this open-core endpoint.
 
 Minimal Python client:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ RigPlane keeps the browser UI, audio path, diagnostics, and `rigctld`-compatible
 - :white_check_mark: **Full CI-V command set** — frequency, mode/filter, power, meters, PTT, CW keying, VFO, split, ATT/PREAMP
 - :white_check_mark: **Yaesu CAT backend** — full working native backend for Yaesu FTX-1 (USB serial)
 - :white_check_mark: **Hamlib provider** — broad serial CAT coverage through an external `rigctld` process, assisted discovery, and normalized RigPlane capabilities
+- :white_check_mark: **HTTP automation batches** — structured command batches for ordered local profile switching from curl, Python, MQTT, or Stream Deck gateways
 - :white_check_mark: **Audio streaming** — RX/TX with jitter buffer and full-duplex support
 - :white_check_mark: **Audio FFT Scope** — real-time FFT on USB/LAN audio for radios without hardware spectrum
 - :white_check_mark: **Discovery** — find supported LAN radios automatically; assisted serial CAT discovery can suggest and validate Hamlib candidates


### PR DESCRIPTION
## Summary

- expand Web API docs for `POST /api/v1/commands/batch` with purpose, ordered data flow, limits, timeout behavior, and IC-9700-style profile-switching examples
- clarify that HTTP, WS, and batch use the same structured command names and that Core keeps batches stateless
- link existing command docs and add the full command-catalog follow-up issue (#1604)
- surface HTTP automation batches on the docs landing page

Fixes #1605
Refs #1604

## Verification

- `uv run ruff format --check src/ tests/`
- `uv run ruff check .`
- `uv run pytest tests/test_web_api_contract.py tests/test_web_command_batch_http.py -q`
- `uv run mkdocs build --strict`
