### PR TITLE
docs(api): fix batch DATA mode examples

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -354,7 +354,9 @@ Example IC-9700-style local batches:
     "steps": [
       { "name": "set_freq", "params": { "freq": 144030000, "receiver": 0 } },
       { "name": "set_mode", "params": { "mode": "FM", "receiver": 0 } },
-      { "name": "set_data_mode", "params": { "enabled": true, "receiver": 0 } },
+      { "name": "set_data_mode", "params": { "mode": 1, "receiver": 0 } },
+      { "name": "set_data1_mod_input", "params": { "source": 3 } },
+      { "name": "set_usb_mod_level", "params": { "level": 72 } },
       { "name": "set_af_level", "params": { "level": 72, "receiver": 0 } },
       { "name": "set_squelch", "params": { "level": 0, "receiver": 0 } }
     ]
@@ -363,12 +365,18 @@ Example IC-9700-style local batches:
     "id": "fm-voice",
     "steps": [
       { "name": "set_mode", "params": { "mode": "FM", "receiver": 0 } },
-      { "name": "set_data_mode", "params": { "enabled": false, "receiver": 0 } },
+      { "name": "set_data_mode", "params": { "mode": 0, "receiver": 0 } },
+      { "name": "set_data_off_mod_input", "params": { "source": 0 } },
       { "name": "set_af_level", "params": { "level": 50, "receiver": 0 } }
     ]
   }
 }
 ```
+
+For `set_data_mode`, HTTP/WS params use the numeric DATA mode value from the
+active radio profile, not an `enabled` boolean. The current IC-9700 profile
+defines `0 = OFF`, `1 = DATA`. Its modulation input source values are
+`0 = MIC`, `1 = ACC`, `2 = MIC+ACC`, `3 = USB`, and `4 = MIC+USB`.
 
 Actual command availability depends on the active radio profile and backend.
 Fetch `/api/v1/capabilities` before enabling buttons or publishing a reusable
@@ -402,6 +410,9 @@ batch = {
     "steps": [
         {"name": "set_freq", "params": {"freq": 144030000}},
         {"name": "set_mode", "params": {"mode": "FM"}},
+        {"name": "set_data_mode", "params": {"mode": 1}},
+        {"name": "set_data1_mod_input", "params": {"source": 3}},
+        {"name": "set_usb_mod_level", "params": {"level": 72}},
         {"name": "set_af_level", "params": {"level": 72}},
     ],
 }
@@ -439,12 +450,17 @@ BATCHES = {
         "steps": [
             {"name": "set_freq", "params": {"freq": 144030000}},
             {"name": "set_mode", "params": {"mode": "FM"}},
+            {"name": "set_data_mode", "params": {"mode": 1}},
+            {"name": "set_data1_mod_input", "params": {"source": 3}},
+            {"name": "set_usb_mod_level", "params": {"level": 72}},
         ],
     },
     "fm-voice": {
         "id": "fm-voice",
         "steps": [
             {"name": "set_mode", "params": {"mode": "FM"}},
+            {"name": "set_data_mode", "params": {"mode": 0}},
+            {"name": "set_data_off_mod_input", "params": {"source": 0}},
             {"name": "set_af_level", "params": {"level": 50}},
         ],
     },

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -169,6 +169,9 @@ curl -X POST http://127.0.0.1:8080/api/v1/commands/batch \
     "steps": [
       {"name":"set_freq","params":{"freq":144030000}},
       {"name":"set_mode","params":{"mode":"FM"}},
+      {"name":"set_data_mode","params":{"mode":1}},
+      {"name":"set_data1_mod_input","params":{"source":3}},
+      {"name":"set_usb_mod_level","params":{"level":72}},
       {"name":"set_af_level","params":{"level":72}}
     ]
   }'
@@ -198,6 +201,14 @@ feature toggles. Prefer these structured commands over raw CI-V for routine
 automation so RigPlane remains the single owner of the radio connection,
 queueing, pacing, auth policy, and safety checks.
 
+DATA mode commands use the active radio profile's numeric DATA value. For the
+current IC-9700 profile, `set_data_mode` uses `mode: 0` for OFF and `mode: 1`
+for DATA. Its modulation input source values are `0 = MIC`, `1 = ACC`,
+`2 = MIC+ACC`, `3 = USB`, and `4 = MIC+USB`; use
+`set_data1_mod_input`, `set_data_off_mod_input`, and modulation level commands
+such as `set_usb_mod_level` or `set_acc1_mod_level` to build audio-route
+specific profiles.
+
 The batch endpoint is stateless. In Core, a "profile" is simply the JSON batch
 the caller sends. Stored named profiles, profile builders, account sync, and
 profile sharing are product-layer concerns outside this open-core endpoint.
@@ -213,6 +224,8 @@ batch = {
     "steps": [
         {"name": "set_freq", "params": {"freq": 144030000}},
         {"name": "set_mode", "params": {"mode": "FM"}},
+        {"name": "set_data_mode", "params": {"mode": 1}},
+        {"name": "set_data1_mod_input", "params": {"source": 3}},
     ],
 }
 
@@ -240,6 +253,8 @@ BATCHES = {
         "steps": [
             {"name": "set_freq", "params": {"freq": 144030000}},
             {"name": "set_mode", "params": {"mode": "FM"}},
+            {"name": "set_data_mode", "params": {"mode": 1}},
+            {"name": "set_data1_mod_input", "params": {"source": 3}},
         ],
     }
 }

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -75,6 +76,22 @@ def test_pro_web_api_contract_lists_stable_surface() -> None:
         "ok",
         "results",
     )
+
+
+def test_command_batch_docs_use_numeric_data_mode_contract() -> None:
+    root = Path(__file__).resolve().parents[1]
+    docs = [
+        root / "docs/api/web.md",
+        root / "docs/guide/web-ui.md",
+    ]
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        assert '"name": "set_data_mode"' in text or '"name":"set_data_mode"' in text
+        assert '"set_data_mode", "params": { "enabled"' not in text
+        assert '"set_data_mode","params":{"enabled"' not in text
+        assert '"set_data_mode", "params": {"enabled"' not in text
+        assert '"set_data_mode","params": {"enabled"' not in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- fix command batch examples to use `set_data_mode` with numeric `mode` values instead of an unsupported `enabled` boolean
- add IC-9700 modulation input source examples for USB/MIC audio routing
- add a focused docs contract test so the incorrect boolean form does not come back

Fixes #1608
Refs #1604

## Validation

- `uv run ruff format --check src/ tests/ && uv run ruff check .`
- `uv run pytest tests/test_web_api_contract.py tests/test_web_command_batch_http.py tests/test_handlers_coverage.py::test_handle_command_set_data_mode_enqueues_numeric_mode -q`
- `uv run mkdocs build --strict`