### PR TITLE
feat(MOR-164): raw CI-V pipe API for Hamlib A1 bridge

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -541,6 +541,7 @@ class CivRuntime:
                             frame = parse_civ_frame(frame_bytes)
                         except ValueError:
                             continue
+                        self.deliver_raw_civ(frame_bytes)
                         try:
                             await self._route_civ_frame(
                                 frame,
@@ -594,6 +595,31 @@ class CivRuntime:
             self._update_state_cache_from_frame(frame)
         self._publish_civ_event(event)
         self._host._civ_request_tracker.resolve(event, generation=generation)
+
+    def deliver_raw_civ(self, frame_bytes: bytes) -> None:
+        """Forward a raw inbound CI-V frame to registered raw-pipe listeners.
+
+        Supports the Hamlib A1 transparent-bridge seam (MOR-164): listeners get
+        the exact on-wire bytes (including bare ACK frames such as
+        ``FE FE E0 98 FB FD``). Only frames from this radio addressed to the
+        controller are delivered; unsolicited transceive broadcasts
+        (``to_addr == 0x00``) are filtered out so they cannot pollute a
+        Hamlib-owned byte stream.
+        """
+        listeners = self._host._raw_civ_listeners
+        if not listeners:
+            return
+        # CI-V frame layout: FE FE <to_addr> <from_addr> <cmd> ... FD
+        if len(frame_bytes) < 5 or frame_bytes[3] != self._host._radio_addr:
+            return
+        if frame_bytes[2] != CONTROLLER_ADDR:  # drops transceive broadcasts (0x00)
+            return
+        raw = bytes(frame_bytes)
+        for listener in list(listeners):
+            try:
+                listener(raw)
+            except Exception:  # noqa: BLE001 — isolate listener failures
+                logger.exception("Raw CI-V listener raised")
 
     def _update_state_cache_from_frame(self, frame: CivFrame) -> None:
         """Best-effort update of state cache from an incoming CI-V frame."""

--- a/src/rigplane/runtime/_runtime_protocols.py
+++ b/src/rigplane/runtime/_runtime_protocols.py
@@ -70,6 +70,7 @@ class CivRuntimeHost(Protocol):
     _scope_assembler: "ScopeAssembler"
     _scope_frame_queue: "BoundedQueue[ScopeFrame]"
     _scope_callback: "Callable[[ScopeFrame], Any] | None"
+    _raw_civ_listeners: "list[Callable[[bytes], Any]]"
     _scope_activity_counter: int
     _scope_activity_event: asyncio.Event
     _civ_event_queue: "BoundedQueue[CivEvent]"

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -295,6 +295,7 @@ __all__ = [
     "AudioRecoveryState",
     "CoreRadio",
     "IcomRadio",
+    "RawCivSubscription",
     "RadioProfile",
     "AudioCodec",
     "RadioConnectionState",
@@ -317,6 +318,40 @@ _DEFAULT_CACHE_TTL: dict[str, float] = {"freq": 10.0, "mode": 10.0, "rf_power": 
 # cumulative and only the 30s watchdog resets it via ``soft_reconnect``.
 # Require >=3 accumulated errors before reporting ``connected = False``.
 _UDP_ERROR_THRESHOLD: int = 3
+
+
+class RawCivSubscription:
+    """Handle for a raw CI-V listener registered via ``add_raw_civ_listener``.
+
+    Part of the raw CI-V pipe seam (MOR-164) that lets a transparent Hamlib A1
+    bridge use RigPlane purely as a CI-V byte transport. Call :meth:`close` (or
+    use the handle as a context manager) to unregister the listener.
+    """
+
+    def __init__(
+        self,
+        registry: list[Callable[[bytes], Any]],
+        callback: Callable[[bytes], Any],
+    ) -> None:
+        self._registry = registry
+        self._callback = callback
+        self._closed = False
+
+    def close(self) -> None:
+        """Unregister the listener. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._registry.remove(self._callback)
+        except ValueError:
+            pass
+
+    def __enter__(self) -> "RawCivSubscription":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
 
 
 class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
@@ -725,6 +760,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._audio_bus: Any = None
         self._scope_assembler: ScopeAssembler = ScopeAssembler()
         self._scope_callback: Callable[[ScopeFrame], Any] | None = None
+        # Raw CI-V pipe listeners (MOR-164): receive inbound on-wire frame bytes.
+        self._raw_civ_listeners: list[Callable[[bytes], Any]] = []
         self._civ_rx_task: asyncio.Task[None] | None = None
         self._civ_data_watchdog_task: asyncio.Task[None] | None = None
         self._audio_watchdog_task: asyncio.Task[None] | None = None
@@ -1238,6 +1275,42 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             self._radio_addr, CONTROLLER_ADDR, command, sub=sub, data=data
         )
         return await self._send_civ_raw(frame, wait_response=wait_response)
+
+    # ------------------------------------------------------------------
+    # Raw CI-V pipe (MOR-164) — transparent byte transport for Hamlib A1
+    # ------------------------------------------------------------------
+
+    async def send_civ_raw_fire_and_forget(self, frame: bytes) -> None:
+        """Transmit a raw CI-V frame without waiting for or matching a response.
+
+        For the Hamlib A1 bridge, where the *external* CAT master (Hamlib) owns
+        request/response matching and RigPlane is used purely as a byte
+        transport. Unlike :meth:`send_civ`, this never registers a response
+        waiter, so it does **not** time out merely because the radio answered a
+        write with a bare ACK (``FE FE E0 98 FB FD``); the ACK is observed via
+        :meth:`add_raw_civ_listener` instead.
+        """
+        self._check_connected()
+        await self._send_civ_raw(frame, wait_response=False)
+
+    def add_raw_civ_listener(
+        self, callback: Callable[[bytes], Any]
+    ) -> RawCivSubscription:
+        """Register a listener for inbound raw CI-V frame bytes.
+
+        The callback receives the exact on-wire frame bytes of each inbound
+        frame addressed to the controller (including bare ACK/NAK frames).
+        Unsolicited transceive broadcasts (``to_addr == 0x00``) are filtered out
+        so they do not pollute a Hamlib-owned byte stream. Returns a
+        :class:`RawCivSubscription`; call ``.close()`` to unregister.
+
+        Note (MOR-164 limitation): while a raw-pipe consumer is active, RigPlane's
+        own poller/readback traffic is *not* yet automatically quiesced — the
+        bridge consumer is responsible for not issuing competing reads. Scoped
+        ownership is deferred to the bridge daemon issue.
+        """
+        self._raw_civ_listeners.append(callback)
+        return RawCivSubscription(self._raw_civ_listeners, callback)
 
     async def get_freq(
         self, receiver: int = RECEIVER_MAIN, *, bypass_cache: bool = False

--- a/tests/test_raw_civ_pipe.py
+++ b/tests/test_raw_civ_pipe.py
@@ -1,0 +1,144 @@
+"""Raw CI-V pipe API (MOR-164) — transparent CI-V byte transport for Hamlib A1.
+
+Covers the seam that replaces the MOR-159 monkeypatch:
+- fire-and-forget raw TX that does not wait for / match a response;
+- raw inbound listener that receives exact on-wire bytes incl. bare ACK frames;
+- transceive-broadcast (to_addr == 0x00) filtering;
+- subscription removal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from test_radio import MockTransport
+
+from rigplane import IC_7610_ADDR
+from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
+from rigplane.radio import IcomRadio
+from rigplane.runtime.radio import RawCivSubscription
+from rigplane.types import bcd_encode
+
+
+@pytest.fixture
+def transport() -> MockTransport:
+    return MockTransport()
+
+
+@pytest.fixture
+def radio(transport: MockTransport):
+    r = IcomRadio("192.168.1.100")
+    r._civ_transport = transport
+    r._ctrl_transport = transport
+    r._connected = True
+    r._radio_addr = IC_7610_ADDR
+    yield r
+    # Teardown: drop the fake connection so the radio finalizer stays quiet.
+    r._connected = False
+    r._civ_transport = None
+    r._ctrl_transport = None
+
+
+def _ack() -> bytes:
+    # Bare ACK from the radio: FE FE E0 98 FB FD
+    return build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0xFB)
+
+
+def test_listener_receives_bare_ack(radio: IcomRadio) -> None:
+    received: list[bytes] = []
+    sub = radio.add_raw_civ_listener(received.append)
+    assert isinstance(sub, RawCivSubscription)
+
+    ack = _ack()
+    assert ack == bytes([0xFE, 0xFE, 0xE0, 0x98, 0xFB, 0xFD])
+    radio._civ_runtime.deliver_raw_civ(ack)
+
+    assert received == [ack]
+
+
+def test_listener_receives_data_frame(radio: IcomRadio) -> None:
+    received: list[bytes] = []
+    radio.add_raw_civ_listener(received.append)
+
+    frame = build_civ_frame(
+        CONTROLLER_ADDR, IC_7610_ADDR, 0x03, data=bcd_encode(14_074_000)
+    )
+    radio._civ_runtime.deliver_raw_civ(frame)
+
+    assert received == [frame]
+
+
+def test_transceive_broadcast_is_filtered(radio: IcomRadio) -> None:
+    received: list[bytes] = []
+    radio.add_raw_civ_listener(received.append)
+
+    # Unsolicited transceive broadcast: to_addr == 0x00 — must NOT reach Hamlib.
+    bcast = (
+        bytes([0xFE, 0xFE, 0x00, IC_7610_ADDR, 0x00]) + bcd_encode(14_074_000) + b"\xfd"
+    )
+    radio._civ_runtime.deliver_raw_civ(bcast)
+
+    assert received == []
+
+
+def test_foreign_source_is_filtered(radio: IcomRadio) -> None:
+    received: list[bytes] = []
+    radio.add_raw_civ_listener(received.append)
+
+    # Frame from a different radio address — not our session.
+    frame = (
+        bytes([0xFE, 0xFE, CONTROLLER_ADDR, 0xAA, 0x03])
+        + bcd_encode(14_074_000)
+        + b"\xfd"
+    )
+    radio._civ_runtime.deliver_raw_civ(frame)
+
+    assert received == []
+
+
+def test_subscription_close_stops_delivery(radio: IcomRadio) -> None:
+    received: list[bytes] = []
+    sub = radio.add_raw_civ_listener(received.append)
+    ack = _ack()
+
+    radio._civ_runtime.deliver_raw_civ(ack)
+    assert len(received) == 1
+
+    sub.close()
+    radio._civ_runtime.deliver_raw_civ(ack)
+    assert len(received) == 1  # no second delivery after close
+
+    sub.close()  # idempotent — must not raise
+
+
+def test_listener_failure_is_isolated(radio: IcomRadio) -> None:
+    seen: list[bytes] = []
+
+    def boom(_frame: bytes) -> None:
+        raise RuntimeError("listener bug")
+
+    radio.add_raw_civ_listener(boom)
+    radio.add_raw_civ_listener(seen.append)
+
+    ack = _ack()
+    radio._civ_runtime.deliver_raw_civ(ack)  # must not propagate the exception
+    assert seen == [ack]
+
+
+async def test_fire_and_forget_transmits_without_waiting(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    # A write frame (set-freq) — the radio answers only with a bare ACK.
+    frame = build_civ_frame(
+        IC_7610_ADDR, CONTROLLER_ADDR, 0x05, data=bcd_encode(14_100_000)
+    )
+
+    # No response is ever queued; this must still return promptly (no matcher,
+    # no timeout) rather than blocking on a response that never comes.
+    await asyncio.wait_for(radio.send_civ_raw_fire_and_forget(frame), timeout=1.0)
+
+    assert transport.sent_packets, "fire-and-forget must transmit the frame"
+    assert frame in transport.sent_packets[-1]
+
+    await radio._civ_runtime.stop_pump()


### PR DESCRIPTION
## Summary
Implements **MOR-164**: a narrow, first-class **raw CI-V pipe** seam on the Icom backend so a future *transparent* Hamlib A1 bridge can use RigPlane purely as a CI-V byte transport. Replaces the MOR-159 prototype monkeypatch of `_route_civ_frame`.

## API (Icom `CoreRadio`)
- `await radio.send_civ_raw_fire_and_forget(frame: bytes)` — fire-and-forget TX; **no response matcher, no timeout on a bare ACK** (the external CAT master, e.g. Hamlib, owns request/response matching).
- `sub = radio.add_raw_civ_listener(cb)` → `RawCivSubscription` (`.close()` / context manager). The callback receives the **exact on-wire inbound frame bytes**, including bare ACK frames like `FE FE E0 98 FB FD`.

## Behavior / policy
- Inbound tap lives in the CI-V RX pump (`_civ_rx.deliver_raw_civ`), using raw `frame_bytes` (pre-`_route_civ_frame`).
- **Transceive broadcasts (`to_addr == 0x00`) are filtered out** of the raw stream; only frames from this radio addressed to the controller (`0xE0`) are delivered.
- Listener exceptions are isolated (one bad listener cannot break routing).

## Documented limitations (for the bridge-daemon follow-up)
- RigPlane's own poller/readback traffic is **not yet auto-quiesced** during a raw-pipe session — the bridge consumer must avoid competing reads (scoped ownership deferred).
- Inbound bytes are reconstructed from the parsed `CivFrame` in the pump — byte-exact for freq/mode/PTT/ACK; raw pre-parse capture for exotic frames (scope `0x27`) left as future work.

## Tests
`tests/test_raw_civ_pipe.py` (7): ACK delivery, data-frame delivery, transceive filtering, foreign-address filtering, subscription removal (+ idempotent close), listener-failure isolation, and fire-and-forget transmit-without-waiting/timeout.

## Validation
- `pytest --ignore=integration`: **5829 passed**, 57 skipped, 9 xfailed.
- `ruff check src/ tests/`: clean · `lint-imports`: 4 contracts kept.
- PR-gate mypy `mypy --strict src/rigplane/web`: **clean**. (This change adds **0** errors to `mypy src/`; the pre-existing `mypy src/` debt is tracked in a separate issue.)

## Scope
No Hamlib process orchestration, UI, Pro workflow, or credential handling. The full Hamlib A1 bridge daemon (rigctld orchestration, poller quiescing, product-level transceive policy) is a **separate follow-up issue** that will consume this seam.

> Per repo policy this implementation PR requires an **independent agent review** (`Agent Review: PASS`) before merge — not self-reviewed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
