### PR TITLE
docs: deduplicate sitemap descriptions (drop noindex pages from sitemap.xml)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # rigplane — Project Documentation
 
 ## Goal

--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Audio Streaming
 
 Audio RX/TX via the Icom audio UDP port (default 50003).

--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Public API Surface
 
 This page defines the **officially supported** public API of `rigplane`. Use these exports for stable, documented behavior. Other symbols re-exported from `rigplane` are available for advanced or legacy use but may have looser backward-compatibility guarantees.

--- a/docs/api/radios.md
+++ b/docs/api/radios.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Radio Models
 
 Presets for known Icom radios with CI-V addresses and capabilities.

--- a/docs/i18n/core-string-inventory.md
+++ b/docs/i18n/core-string-inventory.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # RigPlane Core — Hardcoded User-Facing String Inventory
 
 Issue: [RP-ML-002 — Inventory Core hardcoded user-facing strings](https://github.com/rigplane/rigplane-core/issues/1520)

--- a/docs/i18n/locale-contract.md
+++ b/docs/i18n/locale-contract.md
@@ -1,3 +1,7 @@
+---
+robots: noindex, follow
+---
+
 # Cross-app locale preference contract (RP-ML-012)
 
 Status: Phase 3 wave 2 — public-core.

--- a/docs/i18n/translating.md
+++ b/docs/i18n/translating.md
@@ -1,3 +1,7 @@
+---
+description: Translate the RigPlane Web UI and CLI strings — workflow for translators, where source strings live, language fallback rules, and how to submit a translation PR.
+---
+
 # Contributing translations to RigPlane Core
 
 Thank you for helping localize RigPlane Core. This document is the

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -1,3 +1,7 @@
+---
+description: "Migrate from icom-lan to RigPlane: import paths, async API differences, configuration changes, and a checklist for existing scripts and Web UI deployments."
+---
+
 # Migrating from `icom-lan` to `rigplane`
 
 `rigplane` is the new name of the project formerly known as `icom-lan` (v1.x).

--- a/docs/opuslib-macos-fix.md
+++ b/docs/opuslib-macos-fix.md
@@ -1,3 +1,7 @@
+---
+description: Fix opuslib install errors on macOS for RigPlane audio streaming — Homebrew opus dependency, dynamic library path, and verifying that codec loading succeeds.
+---
+
 # macOS Opus Library Fix
 
 ## Problem

--- a/hooks/sitemap_noindex.py
+++ b/hooks/sitemap_noindex.py
@@ -1,0 +1,74 @@
+"""MkDocs hook: drop pages flagged robots: noindex from sitemap.xml.
+
+mkdocs-material always includes every published page in sitemap.xml, regardless
+of page-level `robots: noindex` frontmatter. Search engines therefore see the
+URL in the sitemap, fetch it, see the noindex meta — and may still flag the
+page in tooling like Bing Webmaster Tools (e.g. as a duplicate of the site-
+wide description fallback).
+
+This hook runs at on_post_build:
+  1. Collect every page from the build whose effective robots meta contains
+     "noindex".
+  2. Rewrite site/sitemap.xml (and the gzipped variant) to drop those URLs.
+"""
+from __future__ import annotations
+
+import gzip
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+ET.register_namespace("", NS["sm"])
+
+
+
+def on_post_build(config, **kwargs):  # noqa: D401 — mkdocs hook signature
+    site_dir = Path(config["site_dir"])
+    sitemap_path = site_dir / "sitemap.xml"
+    sitemap_gz = site_dir / "sitemap.xml.gz"
+    if not sitemap_path.exists():
+        return
+
+    # Source of truth is the rendered HTML: every page advertises its final
+    # robots meta. Walk site_dir, find the noindex pages, map to canonical URL.
+    noindex_paths: set[str] = set()
+    site_url = (config.get("site_url") or "").rstrip("/")
+    pattern = re.compile(
+        rb"<meta\s+name=\"robots\"\s+content=\"[^\"]*noindex[^\"]*\"",
+        re.IGNORECASE,
+    )
+    for html in site_dir.rglob("*.html"):
+        try:
+            head = html.read_bytes()[:8192]
+        except OSError:
+            continue
+        if pattern.search(head):
+            rel = html.relative_to(site_dir).as_posix()
+            if rel.endswith("/index.html"):
+                rel = rel[: -len("index.html")]
+            elif rel == "index.html":
+                rel = ""
+            noindex_paths.add(f"{site_url}/{rel}")
+
+    if not noindex_paths:
+        return
+
+    tree = ET.parse(sitemap_path)
+    root = tree.getroot()
+    removed = 0
+    for url in list(root.findall("sm:url", NS)):
+        loc_el = url.find("sm:loc", NS)
+        if loc_el is None or loc_el.text is None:
+            continue
+        loc = loc_el.text.strip()
+        if loc in noindex_paths:
+            root.remove(url)
+            removed += 1
+
+    tree.write(sitemap_path, encoding="utf-8", xml_declaration=True)
+    if sitemap_gz.exists():
+        with open(sitemap_path, "rb") as f_in, gzip.open(sitemap_gz, "wb") as f_out:
+            f_out.write(f_in.read())
+
+    print(f"sitemap_noindex hook: removed {removed} noindex URL(s) from sitemap.xml")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,10 @@ theme:
   icon:
     repo: fontawesome/brands/github
 
+# MkDocs hooks. See hooks/ directory.
+hooks:
+  - hooks/sitemap_noindex.py
+
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
## Why

Bing Webmaster Tools flagged `rigplane.dev` with the recommendation **"Pages with short, duplicate, or missing meta descriptions"**. Audit confirmed it was right.

- Production `sitemap.xml` listed **57 URLs**.
- **37 of them** shared the exact same description (the site-wide `site_description` fallback, 165 chars: *"RigPlane documentation — Python library and Web UI for controlling Icom, Yaesu, Xiegu and Lab599..."*).
- Most of those 37 already had `robots: noindex, follow` in their page frontmatter (the whole `/api/*` tree, `/internals/*`, `/capabilities-matrix`, `/radio-protocol/`, `/AUDIO_STREAMING_PROFILE/`, `/PERFORMANCE/`). mkdocs-material lists them in `sitemap.xml` anyway, so Bing sees them by URL, fetches them, and reports the duplicate.

## What this PR does

1. **Zero-dep MkDocs hook** (`hooks/sitemap_noindex.py`) — runs at `on_post_build`, scans the rendered HTML, and removes URLs of `noindex` pages from `sitemap.xml` + `sitemap.xml.gz`. Output during build:
   ```
   sitemap_noindex hook: removed 34 noindex URL(s) from sitemap.xml
   ```

2. **Adds `description:` frontmatter** to pages that were leaking the site-wide fallback while still being legitimately indexable:
   - `docs/migrate.md`
   - `docs/opuslib-macos-fix.md`
   - `docs/i18n/translating.md`

3. **Marks internal-but-published pages as `noindex, follow`** so they leave the sitemap on next deploy:
   - `docs/CHANGELOG.md`, `docs/PROJECT.md`
   - `docs/i18n/core-string-inventory.md`, `docs/i18n/locale-contract.md`
   - `docs/api/audio.md`, `docs/api/public-api-surface.md`, `docs/api/radios.md` (these three were the only API pages missing the noindex flag that the rest of `/api/` already had — almost certainly an oversight)

## Verification

After `mkdocs build`:

- `sitemap.xml` shrinks from **57 → 23** URLs.
- Every URL in the new sitemap has a **unique** `<meta name="description">`.
- All other site behaviour unchanged (pages still publish and remain reachable, internal links work, schema markup unchanged).

## After merge

1. Deploy the docs site.
2. In Bing Webmaster Tools, manually re-submit at least `https://rigplane.dev/` and `https://rigplane.dev/guide/rig-profiles/` via URL Submission (or just wait — Bing will re-crawl on its own within ~7 days and the recommendation will clear).
3. Optional: register `rigplane.dev` for IndexNow to make future re-crawls instant.

## Notes

- The hook does not introduce a new Python dependency. It uses only stdlib (`xml.etree.ElementTree`, `gzip`, `re`, `pathlib`).
- I picked a hook over the `mkdocs-exclude-sitemap` plugin to keep the docs build dependency surface unchanged. If you prefer the plugin, swap is straightforward.
- mkdocs-material warns about MkDocs 2.0 incompatibility on build; that is pre-existing and unrelated to this change.

Closes the Bing Webmaster recommendation: *"Pages with short, duplicate, or missing meta descriptions"*.
