### PR TITLE
feat(MOR-166): CAT-session ownership + poller quiesce + reconcile (slice 2)

### DIFF
--- a/src/rigplane/hamlib_bridge.py
+++ b/src/rigplane/hamlib_bridge.py
@@ -108,6 +108,7 @@ class HamlibBridge:
         self._writer: asyncio.StreamWriter | None = None
         self._subscription: Any = None
         self._proc: asyncio.subprocess.Process | None = None
+        self._stderr_file: Any = None
         self._t0 = time.monotonic()
 
     # ------------------------------------------------------------------
@@ -127,6 +128,7 @@ class HamlibBridge:
         """
         if self._server is not None:
             return self.back_port
+        self._begin_session()  # take ownership: pause RigPlane's own pollers
         self._subscription = self._radio.add_raw_civ_listener(self._on_radio_frame)
         self._server = await asyncio.start_server(self._handle_back, self.host, 0)
         self._back_port = self._server.sockets[0].getsockname()[1]
@@ -156,11 +158,13 @@ class HamlibBridge:
 
     async def spawn_rigctld(self) -> asyncio.subprocess.Process:
         """Launch stock rigctld pointed at the back-side listener."""
-        stderr = (
-            open(self._stderr_path, "wb")  # noqa: SIM115 - lifetime tied to proc
-            if self._stderr_path
-            else asyncio.subprocess.DEVNULL
-        )
+        if self._proc is not None and self._proc.returncode is None:
+            raise RuntimeError("rigctld is already running for this bridge")
+        if self._stderr_path:
+            self._stderr_file = open(self._stderr_path, "wb")  # noqa: SIM115
+            stderr: Any = self._stderr_file
+        else:
+            stderr = asyncio.subprocess.DEVNULL
         self._proc = await asyncio.create_subprocess_exec(
             *self.rigctld_argv(),
             stdout=asyncio.subprocess.DEVNULL,
@@ -183,6 +187,9 @@ class HamlibBridge:
             except asyncio.TimeoutError:
                 self._proc.kill()
         self._proc = None
+        if self._stderr_file is not None:
+            self._stderr_file.close()
+            self._stderr_file = None
 
         if self._subscription is not None:
             self._subscription.close()
@@ -194,12 +201,39 @@ class HamlibBridge:
         self._back_port = None
         self._writer = None
 
+        # Release ownership and reconcile RigPlane's state from the wire.
+        await self._end_session_and_reconcile()
+
     async def __aenter__(self) -> HamlibBridge:
         await self.start()
         return self
 
     async def __aexit__(self, *exc: object) -> None:
         await self.stop()
+
+    # ------------------------------------------------------------------
+    # External CAT-session ownership (MOR-166 slice 2)
+    # ------------------------------------------------------------------
+
+    def _begin_session(self) -> None:
+        """Claim external-CAT-session ownership if the radio supports it."""
+        begin = getattr(self._radio, "begin_external_cat_session", None)
+        if callable(begin):
+            begin()
+
+    async def _end_session_and_reconcile(self) -> None:
+        """Release ownership and refresh RigPlane state (both best-effort)."""
+        end = getattr(self._radio, "end_external_cat_session", None)
+        if callable(end):
+            end()
+        reconcile = getattr(self._radio, "reconcile_state", None)
+        if callable(reconcile):
+            try:
+                await reconcile()
+            except Exception:  # noqa: BLE001 - reconcile is best-effort
+                logger.warning(
+                    "hamlib-bridge: post-session reconcile failed", exc_info=True
+                )
 
     # ------------------------------------------------------------------
     # Transparent pipe

--- a/src/rigplane/rigctld/poller.py
+++ b/src/rigplane/rigctld/poller.py
@@ -198,6 +198,12 @@ class RadioPoller:
 
     async def _poll_once(self) -> None:
         """Execute one poll cycle: get frequency, then (if not a probe) mode."""
+        # External CAT session (e.g. Hamlib A1 bridge) owns the wire — issue no
+        # RigPlane reads so we don't pollute the owner's byte stream (MOR-166
+        # slice 2). ``is True`` (not just truthy) so mock/duck-typed radios never
+        # quiesce by accident — only a real bool flag does.
+        if getattr(self._radio, "external_cat_session_active", False) is True:
+            return
         cb = self._circuit_breaker
         is_probe = cb is not None and cb.state == CircuitState.HALF_OPEN
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -762,6 +762,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._scope_callback: Callable[[ScopeFrame], Any] | None = None
         # Raw CI-V pipe listeners (MOR-164): receive inbound on-wire frame bytes.
         self._raw_civ_listeners: list[Callable[[bytes], Any]] = []
+        # External CAT-session ownership (MOR-166 slice 2): when True, cooperating
+        # pollers pause so they do not pollute an external master's byte stream.
+        self._external_cat_session: bool = False
         self._civ_rx_task: asyncio.Task[None] | None = None
         self._civ_data_watchdog_task: asyncio.Task[None] | None = None
         self._audio_watchdog_task: asyncio.Task[None] | None = None
@@ -1304,13 +1307,42 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         so they do not pollute a Hamlib-owned byte stream. Returns a
         :class:`RawCivSubscription`; call ``.close()`` to unregister.
 
-        Note (MOR-164 limitation): while a raw-pipe consumer is active, RigPlane's
-        own poller/readback traffic is *not* yet automatically quiesced — the
-        bridge consumer is responsible for not issuing competing reads. Scoped
-        ownership is deferred to the bridge daemon issue.
+        To stop RigPlane's own pollers from competing on the wire while an
+        external CAT master consumes this stream, wrap the session with
+        :meth:`begin_external_cat_session` / :meth:`end_external_cat_session`
+        (MOR-166 slice 2).
         """
         self._raw_civ_listeners.append(callback)
         return RawCivSubscription(self._raw_civ_listeners, callback)
+
+    # ---- External CAT-session ownership (MOR-166 slice 2) ----
+
+    @property
+    def external_cat_session_active(self) -> bool:
+        """True while an external CAT master (e.g. a Hamlib bridge) owns the wire."""
+        return self._external_cat_session
+
+    def begin_external_cat_session(self) -> None:
+        """Mark the radio as owned by an external CAT session.
+
+        Cooperating pollers (e.g. the web ``RadioPoller``) pause their own CI-V
+        traffic while this is set, so they do not pollute the owner's byte
+        stream. Idempotent.
+        """
+        self._external_cat_session = True
+
+    def end_external_cat_session(self) -> None:
+        """Release external-CAT-session ownership. Idempotent."""
+        self._external_cat_session = False
+
+    async def reconcile_state(self) -> None:
+        """Re-read full radio state after an external session changed the rig.
+
+        Call once the external CAT master has finished; refreshes RigPlane's
+        ``RadioState`` from the wire so it reflects any frequency/mode/etc. the
+        external master applied while it owned the session.
+        """
+        await self._fetch_initial_state()
 
     async def get_freq(
         self, receiver: int = RECEIVER_MAIN, *, bypass_cache: bool = False

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -627,6 +627,16 @@ class RadioPoller:
 
         try:
             while True:
+                # 0. External CAT session (e.g. Hamlib A1 bridge) owns the wire —
+                # pause RigPlane's own polling/commands to avoid CI-V cross-talk
+                # in the owner's byte stream (MOR-166 slice 2). Queued commands
+                # stay buffered and drain once the session ends. ``is True`` (not
+                # just truthy) so duck-typed / mock radios never quiesce by
+                # accident — only a real bool flag does.
+                if getattr(self._radio, "external_cat_session_active", False) is True:
+                    await asyncio.sleep(self._adaptive_gap())
+                    continue
+
                 # 1. Drain command queue (fire-and-forget writes)
                 if self._queue.has_commands:
                     for entry in self._queue.drain_entries():

--- a/tests/test_hamlib_bridge.py
+++ b/tests/test_hamlib_bridge.py
@@ -35,6 +35,8 @@ class FakeRawPipeRadio:
     def __init__(self) -> None:
         self.sent: list[bytes] = []
         self._listeners: list[Any] = []
+        self.session_active = False
+        self.reconcile_count = 0
 
     async def send_civ_raw_fire_and_forget(self, frame: bytes) -> None:
         self.sent.append(frame)
@@ -47,6 +49,16 @@ class FakeRawPipeRadio:
         """Simulate an inbound frame from the radio."""
         for cb in list(self._listeners):
             cb(frame)
+
+    # External CAT-session ownership surface (MOR-166 slice 2)
+    def begin_external_cat_session(self) -> None:
+        self.session_active = True
+
+    def end_external_cat_session(self) -> None:
+        self.session_active = False
+
+    async def reconcile_state(self) -> None:
+        self.reconcile_count += 1
 
 
 @pytest.fixture
@@ -168,4 +180,60 @@ async def test_spawn_rigctld_invokes_subprocess(radio: FakeRawPipeRadio) -> None
     assert argv == bridge.rigctld_argv()
 
     bridge._proc = None  # avoid stop() awaiting the mock's terminate/wait
+    await bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# Slice 2: ownership / quiesce / reconcile + review nits
+# ---------------------------------------------------------------------------
+
+
+async def test_owns_session_and_reconciles_on_stop(radio: FakeRawPipeRadio) -> None:
+    bridge = HamlibBridge(radio, model="3078")
+    await bridge.open_transport()
+    assert radio.session_active is True  # ownership claimed while the bridge runs
+    await bridge.stop()
+    assert radio.session_active is False  # released on stop
+    assert radio.reconcile_count == 1  # state reconciled exactly once
+
+
+async def test_stderr_handle_closed_on_stop(
+    radio: FakeRawPipeRadio, tmp_path: Any
+) -> None:
+    log = tmp_path / "rigctld.log"
+    bridge = HamlibBridge(radio, model="3078", stderr_path=str(log))
+    await bridge.open_transport()
+
+    fake_proc = AsyncMock()
+    fake_proc.pid = 1
+    fake_proc.returncode = None
+    with patch(
+        "rigplane.hamlib_bridge.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=fake_proc),
+    ):
+        await bridge.spawn_rigctld()
+
+    handle = bridge._stderr_file
+    assert handle is not None and not handle.closed
+
+    bridge._proc = None  # avoid stop() awaiting the mock
+    await bridge.stop()
+    assert handle.closed
+    assert bridge._stderr_file is None
+
+
+async def test_double_spawn_is_rejected(radio: FakeRawPipeRadio) -> None:
+    bridge = HamlibBridge(radio, model="3078")
+    await bridge.open_transport()
+    fake_proc = AsyncMock()
+    fake_proc.returncode = None
+    with patch(
+        "rigplane.hamlib_bridge.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=fake_proc),
+    ):
+        await bridge.spawn_rigctld()
+        with pytest.raises(RuntimeError):
+            await bridge.spawn_rigctld()
+
+    bridge._proc = None
     await bridge.stop()

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -516,3 +516,20 @@ async def test_poller_without_circuit_breaker_still_works(
 
     assert cache.freq == 7_000_000
     assert cache.is_fresh("freq", 1.0) is True
+
+
+async def test_external_cat_session_quiesces_poller(
+    poller: RadioPoller,
+    mock_radio: AsyncMock,
+) -> None:
+    """While an external CAT session owns the wire, the poller issues no radio I/O.
+
+    (MOR-166 slice 2 — the Hamlib bridge sets this flag so RigPlane's own
+    polling does not pollute the external master's byte stream.)
+    """
+    mock_radio.get_freq.return_value = 7_000_000
+    mock_radio.external_cat_session_active = True
+    await poller.start()
+    await asyncio.sleep(0.05)
+    await poller.stop()
+    assert mock_radio.get_freq.await_count == 0


### PR DESCRIPTION
## Summary
**MOR-166 slice 2** — *ownership / quiesce / reconcile* for the Hamlib A1 bridge. While an external CAT master (the bridge) owns the wire, RigPlane's own pollers must not inject CI-V that would pollute the owner's byte stream; RigPlane re-syncs once the session ends.

## Changes
- **`CoreRadio`** — external-CAT-session ownership:
  - `begin_external_cat_session()` / `end_external_cat_session()` (idempotent) + `external_cat_session_active` property,
  - `reconcile_state()` — re-fetch full state from the wire after an external session.
- **Both pollers quiesce** while a session is active (a bridge can run alongside either UI server): `web.RadioPoller` skips its loop iteration; `rigctld.RadioPoller` skips `_poll_once()`. Guarded with **`is True`** (not just truthy) so duck-typed / mock radios never quiesce by accident.
- **`HamlibBridge`** claims the session in `open_transport()` and, on `stop()`, releases it and reconciles RigPlane state.
- **Slice-1 review nits fixed:** the rigctld `stderr` file handle is now closed in `stop()`, and `spawn_rigctld()` rejects a double-spawn.

## Tests
- `tests/test_hamlib_bridge.py`: ownership claimed/released + `reconcile_state()` called once on stop; stderr handle closed on stop; double-spawn raises.
- `tests/test_poller.py`: rigctld poller issues **zero** radio reads while a session is active.

## Gates
`pytest --ignore=integration`: **5851 passed**. `ruff` clean · `lint-imports` 4 kept · PR-gate `mypy --strict src/rigplane/web` clean (touches `web/radio_poller.py`, in gate scope).

## Scope
Still no UI/Pro/discovery/credential handling. Slice 3 (non-Icom / serial rigs) is the remaining piece of MOR-166.

> Implementation PR — requires an **independent agent review** (`Agent Review: PASS`); not self-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
