### PR TITLE
feat(MOR-166): bridge generalizes to Icom serial backends (slice 3)

### DIFF
--- a/src/rigplane/hamlib_bridge.py
+++ b/src/rigplane/hamlib_bridge.py
@@ -9,9 +9,15 @@ transport; Hamlib stays the sole CAT master.
         ↳ RX: radio.add_raw_civ_listener(cb) → frame written back to rigctld
 
 This is an internal module: no UI, no Pro workflow, no assisted discovery, and
-no credential handling (the caller owns the already-connected radio). Session
-ownership / poller quiescing (slice 2) and non-Icom serial rigs (slice 3) are
-intentionally out of scope here.
+no credential handling (the caller owns the already-connected radio).
+
+Supported radios: any backend exposing the raw CI-V pipe (``RawCivPipe``). That
+covers every CoreRadio-derived Icom backend — **Icom LAN and Icom serial alike**
+(IC-7610/7300/705/9700, Xiegu X6200, …) — since the serial backends inherit the
+pipe from ``CoreRadio``. The session-ownership hooks (slice 2) are used when the
+radio provides them. Non-CI-V ASCII rigs (Yaesu/Kenwood, e.g. FTX-1 / TX-500)
+speak a different wire shape and need a separate raw-*byte* pipe seam; that is
+tracked as a follow-up, not handled here.
 """
 
 from __future__ import annotations

--- a/tests/test_hamlib_bridge.py
+++ b/tests/test_hamlib_bridge.py
@@ -263,7 +263,7 @@ def test_icom_serial_backend_exposes_bridge_surface() -> None:
 async def test_bridge_runs_against_icom_serial_backend() -> None:
     """End-to-end-ish: the bridge claims ownership of a real Icom *serial*
     backend and forwards an inbound CI-V frame (raw pipe inherited via
-    _IcomSerialRadioBase(CoreRadio)) — proving it is not Icom-LAN-only."""
+    _IcomSerialRadioBase(CoreRadio)) — proving it is not limited to Icom LAN."""
     from rigplane.backends.icom7610.serial import Icom7610SerialRadio
 
     radio = Icom7610SerialRadio(device="/dev/null")

--- a/tests/test_hamlib_bridge.py
+++ b/tests/test_hamlib_bridge.py
@@ -237,3 +237,47 @@ async def test_double_spawn_is_rejected(radio: FakeRawPipeRadio) -> None:
 
     bridge._proc = None
     await bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# Slice 3: the bridge generalizes beyond Icom LAN — Icom *serial* backends
+# (Xiegu X6200, IC-7300/705/9700 serial) inherit the raw CI-V pipe + ownership
+# from CoreRadio, so the bridge drives them unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_icom_serial_backend_exposes_bridge_surface() -> None:
+    from rigplane.backends.icom7610.serial import Icom7610SerialRadio
+
+    radio = Icom7610SerialRadio(device="/dev/null")  # constructed, not connected
+    for attr in (
+        "send_civ_raw_fire_and_forget",
+        "add_raw_civ_listener",
+        "begin_external_cat_session",
+        "end_external_cat_session",
+        "reconcile_state",
+    ):
+        assert hasattr(radio, attr), f"serial backend missing {attr}"
+
+
+async def test_bridge_runs_against_icom_serial_backend() -> None:
+    """End-to-end-ish: the bridge claims ownership of a real Icom *serial*
+    backend and forwards an inbound CI-V frame (raw pipe inherited via
+    _IcomSerialRadioBase(CoreRadio)) — proving it is not Icom-LAN-only."""
+    from rigplane.backends.icom7610.serial import Icom7610SerialRadio
+
+    radio = Icom7610SerialRadio(device="/dev/null")
+    bridge = HamlibBridge(radio, model="3078")
+    port = await bridge.open_transport()
+    assert radio.external_cat_session_active is True  # ownership on a serial rig
+
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    await asyncio.sleep(0.02)
+    ack = bytes.fromhex("fefee098fbfd")  # FE FE E0 98 FB FD from the serial radio
+    radio._civ_runtime.deliver_raw_civ(ack)
+    got = await asyncio.wait_for(reader.readexactly(len(ack)), timeout=1.0)
+    assert got == ack
+
+    writer.close()
+    await bridge.stop()  # reconcile is best-effort (radio not connected) — tolerated
+    assert radio.external_cat_session_active is False


### PR DESCRIPTION
## Summary
**MOR-166 slice 3** — prove the Hamlib A1 bridge is **not Icom-LAN-only**. Icom **serial** backends (Xiegu X6200, IC-7300/705/9700 serial) inherit the raw CI-V pipe (MOR-164) **and** the slice-2 session-ownership hooks from `CoreRadio` (`_IcomSerialRadioBase(CoreRadio)`), so the bridge drives them unchanged.

## Changes
- **Tests** (`tests/test_hamlib_bridge.py`):
  - the Icom serial backend exposes the full bridge surface (raw pipe + ownership);
  - the bridge claims ownership of a **real `Icom7610SerialRadio` instance** and forwards an inbound CI-V frame to a connected client — hardware-free, exercising the inherited pipe.
- **Docstring** (`hamlib_bridge.py`): documents supported radios (any CoreRadio-derived Icom — LAN or serial) and that non-CI-V ASCII rigs need a separate seam.

## Honest scope note (non-Icom ASCII rigs)
**FTX-1 / TX-500** (Yaesu/Kenwood) are *not* CI-V — they use ASCII CAT via a different backend (`YaesuCatRadio`) with no raw CI-V pipe. Supporting them needs a separate **raw-byte** pipe seam (analogous to MOR-164 but byte-oriented) **and** real non-Icom hardware to validate. That is split into a follow-up issue rather than faked here. The earlier fake-rigctld spike already proved the *seam* works for those vendors; only the RigPlane-side byte pipe + hardware run remain.

## Gates
`pytest --ignore=integration`: **5853 passed**. `ruff` clean · `lint-imports` 4 kept · gate `mypy --strict src/rigplane/web` clean.

> Implementation PR — requires an **independent agent review** (`Agent Review: PASS`); not self-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
