### PR TITLE
feat(#1616): expose raw CI-V HTTP command

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -223,6 +223,28 @@ Response:
 parameters return HTTP `400`. Read-only mode rejects transmit commands with
 HTTP `403`.
 
+Low-level CI-V escape hatch:
+
+```json
+{
+  "id": "display-type-b",
+  "name": "send_civ",
+  "params": {
+    "command": 26,
+    "sub": 5,
+    "data": "015301"
+  }
+}
+```
+
+`send_civ` is for Icom/vendor-specific commands that are not yet exposed as
+structured RigPlane commands. `command` and `sub` are byte values from `0` to
+`255`; `sub` may be omitted. `data` is an even-length hexadecimal string. The
+HTTP command is fire-and-forget: RigPlane enqueues the CI-V write through the
+same single-owner command queue, but does not return CI-V response bytes or
+claim readback verification. `wait_response` is reserved for a future
+transaction-capable API and is rejected when `true`.
+
 ## `POST /api/v1/commands/batch`
 
 Stateless ordered batch apply for local automation. RigPlane does not store,
@@ -266,7 +288,11 @@ Request:
   "continue_on_error": false,
   "steps": [
     { "name": "set_freq", "params": { "freq": 144030000 } },
-    { "name": "set_mode", "params": { "mode": "FM" } }
+    { "name": "set_mode", "params": { "mode": "FM" } },
+    {
+      "name": "send_civ",
+      "params": { "command": 26, "sub": 5, "data": "015301" }
+    }
   ]
 }
 ```
@@ -291,6 +317,18 @@ Successful response:
       "ok": true,
       "status": "executed",
       "result": { "mode": "FM", "receiver": 0 }
+    },
+    {
+      "index": 2,
+      "name": "send_civ",
+      "ok": true,
+      "status": "executed",
+      "result": {
+        "command": 26,
+        "sub": 5,
+        "data": "015301",
+        "wait_response": false
+      }
     }
   ]
 }
@@ -392,9 +430,10 @@ operations, and feature toggles are available on the active radio:
 curl http://127.0.0.1:8080/api/v1/capabilities
 ```
 
-Prefer structured commands whenever a command exists. Raw CI-V is useful for
-diagnostics and experiments, but normal automation should let RigPlane own the
-radio connection, queueing, pacing, auth policy, and safety checks.
+Prefer structured commands whenever a command exists. Use `send_civ` for
+vendor-specific CI-V that is not yet abstracted, such as display/menu settings.
+It still lets RigPlane own the radio connection, queueing, pacing, auth policy,
+and safety checks; it just does not return response bytes.
 
 Python example:
 

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -201,6 +201,31 @@ feature toggles. Prefer these structured commands over raw CI-V for routine
 automation so RigPlane remains the single owner of the radio connection,
 queueing, pacing, auth policy, and safety checks.
 
+For vendor-specific CI-V commands that are not yet covered by structured
+commands, use the queued `send_civ` escape hatch. The payload mirrors the
+Python `radio.send_civ(command=..., sub=..., data=...)` call, but `data` is an
+even-length hex string:
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/commands \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "id": "display-type-b",
+    "name": "send_civ",
+    "params": {
+      "command": 26,
+      "sub": 5,
+      "data": "015301"
+    }
+  }'
+```
+
+`send_civ` is fire-and-forget in the HTTP/WS command queue. It preserves order,
+including repeated raw CI-V steps in batches, but it does not return response
+bytes or readback verification. Use it for model-specific gaps such as
+display/menu settings; prefer structured commands for normal profile steps
+where RigPlane already has a command.
+
 DATA mode commands use the active radio profile's numeric DATA value. For the
 current IC-9700 profile, `set_data_mode` uses `mode: 0` for OFF and `mode: 1`
 for DATA. Its modulation input source values are `0 = MIC`, `1 = ACC`,

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -32,6 +32,7 @@ __all__ = [
     "ScanStart",
     "ScanStop",
     "SelectVfo",
+    "SendCiv",
     "SetAcc1ModLevel",
     "SetAfLevel",
     "SetAfMute",
@@ -154,6 +155,13 @@ class SetMode:
     mode: str
     filter_width: int | None = None
     receiver: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class SendCiv:
+    command: int
+    sub: int | None = None
+    data: bytes = b""
 
 
 @dataclass(frozen=True, slots=True)
@@ -822,6 +830,7 @@ class Speak:
 Command = (
     SetFreq
     | SetMode
+    | SendCiv
     | SetFilter
     | SetFilterWidth
     | SetPower

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -23,6 +23,7 @@ from ..radio_poller import (  # noqa: TID251
     ScanStart,
     ScanStop,
     SelectVfo,
+    SendCiv,
     SetAcc1ModLevel,
     SetAfLevel,
     SetAgc,
@@ -161,7 +162,7 @@ from ...capabilities import (
     CAP_TX,
     CAP_XFC,
 )
-from ...radio_protocol import MemoryCapable, PowerControlCapable
+from ...radio_protocol import CivCommandCapable, MemoryCapable, PowerControlCapable
 
 __all__ = ["ControlHandler"]
 
@@ -189,6 +190,7 @@ class ControlHandler:
             "set_freq",
             "set_band",
             "set_mode",
+            "send_civ",
             "set_filter",
             "set_filter_width",
             "set_filter_shape",
@@ -349,13 +351,14 @@ class ControlHandler:
         ]
     )
 
-    # Commands that key the transmitter — rejected when read_only=True.
+    # Commands that can transmit or send arbitrary radio writes — rejected when read_only=True.
     # set_tuner_status value=2 (TUNING) is handled inline in _enqueue_read_only.
     _TX_COMMANDS: frozenset[str] = frozenset(
         {
             "ptt",
             "ptt_on",
             "ptt_off",
+            "send_civ",
             "send_cw_text",
         }
     )
@@ -833,14 +836,20 @@ class ControlHandler:
             )
         except Exception as exc:
             logger.warning("control: command %r failed: %s", name, exc)
+            message = str(exc)
+            error = (
+                "unsupported_command"
+                if "does not support" in message or "not supported" in message
+                else "command_failed"
+            )
             await self._ws.send_text(
                 encode_json(
                     {
                         "type": "response",
                         "id": cmd_id,
                         "ok": False,
-                        "error": "command_failed",
-                        "message": str(exc),
+                        "error": error,
+                        "message": message,
                     }
                 )
             )
@@ -1278,6 +1287,43 @@ class ControlHandler:
         radio: "Radio | None",
     ) -> dict[str, Any] | None:
         match name:
+            case "send_civ":
+                if radio is None or not isinstance(radio, CivCommandCapable):
+                    raise RuntimeError("radio does not support send_civ")
+                if "command" not in params:
+                    raise ValueError("missing required 'command' parameter")
+                command = int(params["command"])
+                if not 0 <= command <= 0xFF:
+                    raise ValueError(f"command must be 0-255, got {command}")
+                raw_sub = params.get("sub")
+                sub = None if raw_sub is None else int(raw_sub)
+                if sub is not None and not 0 <= sub <= 0xFF:
+                    raise ValueError(f"sub must be 0-255, got {sub}")
+                wait_response = bool(params.get("wait_response", False))
+                if wait_response:
+                    raise ValueError(
+                        "wait_response is not supported for HTTP send_civ yet"
+                    )
+                raw_data = params.get("data", "")
+                if not isinstance(raw_data, str):
+                    raise ValueError("data must be a hex string")
+                if len(raw_data) % 2 != 0:
+                    raise ValueError("data must be an even-length hex string")
+                if any(ch not in "0123456789abcdefABCDEF" for ch in raw_data):
+                    raise ValueError("data must be a compact hex string")
+                data = bytes.fromhex(raw_data)
+                queue_cmd = SendCiv(command=command, sub=sub, data=data)
+                put_ordered = getattr(q, "put_ordered", None)
+                if callable(put_ordered):
+                    put_ordered(queue_cmd)
+                else:
+                    q.put(queue_cmd)
+                return {
+                    "command": command,
+                    "sub": sub,
+                    "data": data.hex().upper(),
+                    "wait_response": False,
+                }
             case "set_band":
                 band = int(params["band"])
                 q.put(SetBand(band))

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -122,6 +122,7 @@ __all__ = [
     "ScanSetResume",
     "ScanStart",
     "ScanStop",
+    "SendCiv",
     "SetToneFreq",
     "SetTsqlFreq",
     "SetMainSubTracking",
@@ -196,6 +197,7 @@ from .._poller_types import (  # noqa: E402
     ScanStart,
     ScanStop,
     SelectVfo,
+    SendCiv,
     SetAcc1ModLevel,
     SetAfLevel,
     SetAfMute,
@@ -757,6 +759,17 @@ class RadioPoller:
         )
 
         match cmd:
+            case SendCiv(command=command, sub=sub, data=data):
+                from ..radio_protocol import CivCommandCapable
+
+                if not isinstance(radio, CivCommandCapable):
+                    raise CommandError("send_civ is not supported by this backend")
+                await radio.send_civ(
+                    command,
+                    sub=sub,
+                    data=data,
+                    wait_response=False,
+                )
             case SetFreq(freq=freq, receiver=rx):
                 self._last_user_write_ts = time.monotonic()
                 self._ensure_receiver_supported(rx, operation="set_freq")

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2425,14 +2425,20 @@ class WebServer:
                 )
                 step = None
             except (ValueError, RuntimeError) as exc:
+                message = str(exc)
+                error = (
+                    "unsupported_command"
+                    if "does not support" in message or "not supported" in message
+                    else "invalid_request"
+                )
                 results.append(
                     {
                         "index": index,
                         "name": name,
                         "ok": False,
                         "status": "failed_validation",
-                        "error": "invalid_request",
-                        "message": str(exc),
+                        "error": error,
+                        "message": message,
                     }
                 )
                 step = None

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -22,6 +22,7 @@ from rigplane.web.radio_poller import (
     QuickSplitTrigger,
     RadioPoller,
     SelectVfo,
+    SendCiv,
     SetAgc,
     SetAttenuator,
     SetDataMode,
@@ -217,6 +218,32 @@ async def test_command_queue_ordered_lane_preserves_repeated_commands() -> None:
         PttOn(),
         PttOff(),
     ]
+
+
+@pytest.mark.asyncio
+async def test_radio_poller_executes_raw_civ_fire_and_forget() -> None:
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    await poller._execute(  # noqa: SLF001
+        SendCiv(command=0x1A, sub=0x05, data=b"\x01\x53\x01")
+    )
+
+    radio.send_civ.assert_awaited_once_with(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x53\x01",
+        wait_response=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_radio_poller_rejects_raw_civ_without_backend_support() -> None:
+    radio = SimpleNamespace(profile=resolve_radio_profile(model="FTX-1"))
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    with pytest.raises(CommandError, match="send_civ is not supported"):
+        await poller._execute(SendCiv(command=0x1A, data=b"\x01"))  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
 
 from rigplane.profiles import resolve_radio_profile
 from rigplane.web import server as web_server
-from rigplane.web.radio_poller import CommandQueue, SetFreq, SetMode
+from rigplane.web.radio_poller import CommandQueue, SendCiv, SetFreq, SetMode
 from rigplane.web.server import WebConfig, WebServer
 
 
@@ -60,7 +62,17 @@ def _radio() -> MagicMock:
     radio.profile = profile
     radio.model = profile.model
     radio.capabilities = set(profile.capabilities)
+    radio.send_civ = AsyncMock()
     return radio
+
+
+def _radio_without_civ() -> SimpleNamespace:
+    profile = resolve_radio_profile(model="FTX-1")
+    return SimpleNamespace(
+        profile=profile,
+        model=profile.model,
+        capabilities=set(profile.capabilities),
+    )
 
 
 async def _post_json(
@@ -119,6 +131,156 @@ async def test_http_command_enqueues_single_structured_command() -> None:
 
 
 @pytest.mark.asyncio
+async def test_http_command_enqueues_raw_civ_command() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {
+            "id": "display-type-b",
+            "name": "send_civ",
+            "params": {"command": 0x1A, "sub": 0x05, "data": "015301"},
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body == {
+        "id": "display-type-b",
+        "ok": True,
+        "name": "send_civ",
+        "result": {
+            "command": 0x1A,
+            "sub": 0x05,
+            "data": "015301",
+            "wait_response": False,
+        },
+    }
+    assert srv.command_queue.drain() == [
+        SendCiv(command=0x1A, sub=0x05, data=b"\x01\x53\x01")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_http_command_rejects_invalid_raw_civ_hex() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {
+            "name": "send_civ",
+            "params": {"command": 0x1A, "sub": 0x05, "data": "01530"},
+        },
+    )
+
+    assert writer.response_status == 400
+    assert writer.response_body["error"] == "invalid_request"
+    assert "data must be an even-length hex string" in writer.response_body["message"]
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_command_rejects_raw_civ_hex_with_spaces() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {
+            "name": "send_civ",
+            "params": {"command": 0x1A, "sub": 0x05, "data": "01 53 01"},
+        },
+    )
+
+    assert writer.response_status == 400
+    assert writer.response_body["error"] == "invalid_request"
+    assert "data must be a compact hex string" in writer.response_body["message"]
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_command_rejects_raw_civ_wait_response() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {
+            "name": "send_civ",
+            "params": {
+                "command": 0x1A,
+                "sub": 0x05,
+                "data": "015301",
+                "wait_response": True,
+            },
+        },
+    )
+
+    assert writer.response_status == 400
+    assert writer.response_body["error"] == "invalid_request"
+    assert "wait_response is not supported" in writer.response_body["message"]
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_command_rejects_raw_civ_when_backend_does_not_support_it() -> None:
+    srv = WebServer(_radio_without_civ(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {"name": "send_civ", "params": {"command": 0x1A, "data": "015301"}},
+    )
+
+    assert writer.response_status == 409
+    assert writer.response_body["error"] == "unsupported_command"
+    assert "does not support send_civ" in writer.response_body["message"]
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_single_commands_preserve_repeated_steps() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+
+    writer1 = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {"name": "send_civ", "params": {"command": 0x1A, "data": "0001"}},
+    )
+    writer2 = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {"name": "send_civ", "params": {"command": 0x1A, "data": "0002"}},
+    )
+
+    assert writer1.response_status == 200
+    assert writer2.response_status == 200
+    assert srv.command_queue.drain() == [
+        SendCiv(command=0x1A, data=b"\x00\x01"),
+        SendCiv(command=0x1A, data=b"\x00\x02"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_rejected_in_read_only_mode() -> None:
+    srv = WebServer(
+        _radio(),
+        WebConfig(host="127.0.0.1", port=0, read_only=True),
+    )
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {"name": "send_civ", "params": {"command": 0x1A, "data": "015301"}},
+    )
+
+    assert writer.response_status == 403
+    assert writer.response_body["error"] == "read_only"
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
 async def test_http_command_requires_auth_when_configured() -> None:
     srv = WebServer(
         _radio(),
@@ -171,6 +333,72 @@ async def test_http_command_batch_preserves_exact_order_and_repeated_commands() 
         SetMode("FM", receiver=0),
         SetFreq(144_031_000, receiver=0),
     ]
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_preserves_raw_civ_step_order() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+    captured: list[object] = []
+    consumer = asyncio.create_task(
+        _complete_ordered_commands(srv.command_queue, 3, captured)
+    )
+    try:
+        writer = await _post_json(
+            srv,
+            "/api/v1/commands/batch",
+            {
+                "id": "profile-display",
+                "steps": [
+                    {"name": "set_freq", "params": {"freq": 144_030_000}},
+                    {
+                        "name": "send_civ",
+                        "params": {"command": 0x1A, "sub": 0x05, "data": "015301"},
+                    },
+                    {"name": "set_mode", "params": {"mode": "FM"}},
+                ],
+            },
+        )
+    finally:
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+    assert writer.response_status == 200
+    assert writer.response_body["id"] == "profile-display"
+    assert writer.response_body["ok"] is True
+    assert [r["status"] for r in writer.response_body["results"]] == [
+        "executed",
+        "executed",
+        "executed",
+    ]
+    assert captured == [
+        SetFreq(144_030_000, receiver=0),
+        SendCiv(command=0x1A, sub=0x05, data=b"\x01\x53\x01"),
+        SetMode("FM", receiver=0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_rejects_raw_civ_when_backend_does_not_support_it() -> (
+    None
+):
+    srv = WebServer(_radio_without_civ(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {"name": "send_civ", "params": {"command": 0x1A, "data": "015301"}},
+                {"name": "set_freq", "params": {"freq": 144_030_000}},
+            ],
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"][0]["status"] == "failed_validation"
+    assert writer.response_body["results"][0]["error"] == "unsupported_command"
+    assert writer.response_body["results"][1]["status"] == "skipped"
+    assert srv.command_queue.drain() == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add queued fire-and-forget `send_civ` to the HTTP/WS command surface
- preserve repeated raw CI-V writes by routing them through the ordered queue lane
- reject read-only, unsupported backends, invalid hex, and `wait_response=true`
- document curl/batch usage for vendor-specific CI-V escape-hatch workflows

Closes #1616
Linear: MOR-168

## Verification

- `uv run pytest tests/test_web_command_batch_http.py tests/test_radio_poller_coverage.py -q --tb=short` -> 67 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` -> 5914 passed, 7 skipped, 3 deselected, 9 xfailed, 1 xpassed
- `uv run pytest tests/ -q --tb=short` -> 6144 passed, 62 skipped, 3 deselected, 9 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` -> passed
- `uv run mypy src/rigplane/web/handlers/control.py src/rigplane/web/radio_poller.py src/rigplane/runtime/_poller_types.py` -> passed
- `uv run mkdocs build --strict` -> passed