### PR TITLE
feat: add response-capable raw CI-V transactions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HTTP/WS command surface and ordered batch endpoint so automation clients can
   send vendor-specific CI-V without opening a competing radio session (#1616,
   #1617, 1437232d).
+- Added `POST /api/v1/civ/transaction` for scoped raw CI-V transactions with
+  explicit `expect` modes (`none`, `ack`, `data`), deterministic ACK/NAK/data
+  JSON results, bounded timeouts, and CI-V ownership guarding (#1622, #1623).
 
 ## [2.4.0] — 2026-05-24
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `POST /api/v1/civ/transaction` for scoped raw CI-V transactions with
   explicit `expect` modes (`none`, `ack`, `data`), deterministic ACK/NAK/data
   JSON results, bounded timeouts, and CI-V ownership guarding (#1622, #1623).
+- Documented Python usage for response-capable raw CI-V HTTP transactions
+  (#1626).
 
 ## [2.4.0] — 2026-05-24
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -283,6 +283,40 @@ behavior, defaults to `"data"` for compatibility, and must be one of:
 `timeout_ms` is optional and must be positive when present. All waits are
 bounded by the timeout.
 
+Python example:
+
+```python
+import json
+import urllib.request
+
+base_url = "http://127.0.0.1:8080"
+token = None  # or "your-token"
+
+payload = {
+    "id": "display-type-b",
+    "command": 26,
+    "sub": 5,
+    "data": "015301",
+    "expect": "ack",
+    "timeout_ms": 1000,
+}
+
+request = urllib.request.Request(
+    f"{base_url}/api/v1/civ/transaction",
+    data=json.dumps(payload).encode("utf-8"),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+if token:
+    request.add_header("Authorization", f"Bearer {token}")
+
+with urllib.request.urlopen(request, timeout=5) as response:
+    result = json.load(response)
+
+if not result["ok"]:
+    raise SystemExit(result)
+```
+
 ACK response:
 
 ```json

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -60,6 +60,7 @@ These routes are part of the Pro/supervisor compatibility surface:
 | `DELETE` | `/api/v1/bridge` | Stop audio bridge |
 | `POST` | `/api/v1/commands` | Enqueue one structured radio command |
 | `POST` | `/api/v1/commands/batch` | Apply a stateless ordered command batch |
+| `POST` | `/api/v1/civ/transaction` | Send one scoped raw CI-V transaction with explicit response handling |
 
 ### Other Web UI Endpoints
 
@@ -84,6 +85,7 @@ These routes are part of the Pro/supervisor compatibility surface:
 | `POST` | `/api/v1/radio/power` | Power on/off via CI-V power control |
 | `POST` | `/api/v1/commands` | Enqueue one structured radio command |
 | `POST` | `/api/v1/commands/batch` | Apply a stateless ordered command batch |
+| `POST` | `/api/v1/civ/transaction` | Send one scoped raw CI-V transaction |
 | `POST` | `/api/v1/band-plan/config` | Change active region and reload band plans |
 | `POST` | `/api/v1/eibi/fetch` | Fetch/refresh EiBi dataset |
 
@@ -242,8 +244,91 @@ structured RigPlane commands. `command` and `sub` are byte values from `0` to
 `255`; `sub` may be omitted. `data` is an even-length hexadecimal string. The
 HTTP command is fire-and-forget: RigPlane enqueues the CI-V write through the
 same single-owner command queue, but does not return CI-V response bytes or
-claim readback verification. `wait_response` is reserved for a future
-transaction-capable API and is rejected when `true`.
+claim readback verification. `wait_response` is rejected when `true`; use
+`POST /api/v1/civ/transaction` when the caller needs an ACK, NAK, or data
+response.
+
+## `POST /api/v1/civ/transaction`
+
+Scoped raw CI-V transaction endpoint for local automation that needs a
+deterministic radio response. This endpoint bypasses the normal
+`RadioPoller` command queue, claims the CI-V stream while the transaction is
+active, and releases that claim on success, NAK, timeout, error, or
+cancellation. It uses the existing runtime CI-V receive pump and request
+tracker; it does not create a second raw listener path.
+
+Request:
+
+```json
+{
+  "id": "display-type-b",
+  "command": 26,
+  "sub": 5,
+  "data": "015301",
+  "expect": "ack",
+  "timeout_ms": 1000
+}
+```
+
+`command` and `sub` are byte values from `0` to `255`; `sub` may be omitted.
+`data` is an even-length compact hexadecimal string. `expect` is required by
+behavior, defaults to `"data"` for compatibility, and must be one of:
+
+| Value | Behavior |
+|-------|----------|
+| `"none"` | Send the raw CI-V frame and return `status: "sent"` without waiting |
+| `"ack"` | Wait for the next CI-V ACK or NAK and return `status: "ack"` or `"nak"` |
+| `"data"` | Wait for the matching data response for the request command/sub |
+
+`timeout_ms` is optional and must be positive when present. All waits are
+bounded by the timeout.
+
+ACK response:
+
+```json
+{
+  "id": "display-type-b",
+  "ok": true,
+  "status": "ack",
+  "result": {
+    "frame": "FEFEE0A2FBFD",
+    "command": 251,
+    "sub": null,
+    "data": ""
+  }
+}
+```
+
+NAK response uses HTTP `200` with deterministic failure JSON:
+
+```json
+{
+  "ok": false,
+  "status": "nak",
+  "error": "radio_nak",
+  "result": {
+    "frame": "FEFEE0A2FAFD",
+    "command": 250,
+    "sub": null,
+    "data": ""
+  }
+}
+```
+
+Errors:
+
+| HTTP | Error | Meaning |
+|------|-------|---------|
+| `400` | `invalid_request` | Malformed command/sub/data/expect/timeout |
+| `403` | `read_only` | Server is running in read-only mode |
+| `409` | `unsupported_command` | Active backend does not expose raw CI-V transactions |
+| `409` | `civ_owner_conflict` | Another external CAT/transaction owner already owns the CI-V stream |
+| `503` | `no_radio` | No radio backend is configured |
+| `504` | `transaction_timeout` | Expected ACK/data response did not arrive before timeout |
+
+Use this endpoint only for model-specific commands where callers need the
+wire-level result. Keep normal profile/control automation on
+`/api/v1/commands` or `/api/v1/commands/batch`.
 
 ## `POST /api/v1/commands/batch`
 

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -226,6 +226,30 @@ bytes or readback verification. Use it for model-specific gaps such as
 display/menu settings; prefer structured commands for normal profile steps
 where RigPlane already has a command.
 
+When a raw CI-V operation needs a radio response, use
+`POST /api/v1/civ/transaction` instead of `send_civ`. The transaction endpoint
+temporarily claims the CI-V stream, sends one frame, and waits according to an
+explicit expectation:
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/civ/transaction \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "id": "display-type-b",
+    "command": 26,
+    "sub": 5,
+    "data": "015301",
+    "expect": "ack",
+    "timeout_ms": 1000
+  }'
+```
+
+`expect` must be `none`, `ack`, or `data`. `none` sends without waiting and
+returns `status: "sent"`; `ack` waits for ACK/NAK; `data` waits for the
+matching data response. NAK returns HTTP `200` with `ok: false`,
+`status: "nak"`, and `error: "radio_nak"`. Timeouts return HTTP `504`.
+Transactions are not batch steps; keep batches fire-and-forget or structured.
+
 DATA mode commands use the active radio profile's numeric DATA value. For the
 current IC-9700 profile, `set_data_mode` uses `mode: 0` for OFF and `mode: 1`
 for DATA. Its modulation input source values are `0 = MIC`, `1 = ACC`,

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -250,6 +250,40 @@ matching data response. NAK returns HTTP `200` with `ok: false`,
 `status: "nak"`, and `error: "radio_nak"`. Timeouts return HTTP `504`.
 Transactions are not batch steps; keep batches fire-and-forget or structured.
 
+The same transaction can be sent from a small Python tool:
+
+```python
+import json
+import urllib.request
+
+base_url = "http://127.0.0.1:8080"
+token = None  # or "your-token"
+
+payload = {
+    "id": "display-type-b",
+    "command": 26,
+    "sub": 5,
+    "data": "015301",
+    "expect": "ack",
+    "timeout_ms": 1000,
+}
+
+request = urllib.request.Request(
+    f"{base_url}/api/v1/civ/transaction",
+    data=json.dumps(payload).encode("utf-8"),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+if token:
+    request.add_header("Authorization", f"Bearer {token}")
+
+with urllib.request.urlopen(request, timeout=5) as response:
+    result = json.load(response)
+
+if not result["ok"]:
+    raise SystemExit(result)
+```
+
 DATA mode commands use the active radio profile's numeric DATA value. For the
 current IC-9700 profile, `set_data_mode` uses `mode: 0` for OFF and `mode: 1`
 for DATA. Its modulation input source values are `0 = MIC`, `1 = ACC`,

--- a/docs/internals/raw-civ-transactions.md
+++ b/docs/internals/raw-civ-transactions.md
@@ -1,0 +1,42 @@
+# Raw CI-V Transactions
+
+Raw CI-V transactions are the response-capable counterpart to the
+fire-and-forget `send_civ` command path. They are intentionally scoped to one
+frame and one explicit expectation.
+
+## Ownership
+
+`CoreRadio.send_civ_transaction()` claims the existing external CAT-session
+guard before sending the frame. While the guard is active, cooperating pollers
+pause through `external_cat_session_active`, preventing background CI-V reads
+or writes from consuming the caller's response. The guard is released in a
+`finally` block on success, timeout, cancellation, and errors.
+
+`begin_external_cat_session()` remains idempotent when the external CAT owner
+already holds the guard, and `end_external_cat_session()` remains idempotent.
+A transaction rejects overlapping ownership instead of interrupting an existing
+external CAT session; external CAT begin likewise fails cleanly while a raw
+transaction owns the guard.
+
+## Response Matching
+
+Transactions run on `CivRuntime`, not `RadioPoller`. They reuse the existing
+CI-V RX pump and `CivRequestTracker`:
+
+- `expect="none"` sends once and returns `status: "sent"`.
+- `expect="ack"` drops orphan ACK/NAK backlog, then registers an ACK waiter
+  and resolves only a fresh ACK or NAK from the active transaction.
+- `expect="data"` registers a keyed response waiter and a NAK-only waiter, so
+  a radio NAK returns `status: "nak"` without allowing unrelated ACK frames to
+  satisfy the data expectation.
+
+The runtime does not infer response behavior from `_civ_expects_response()` for
+transactions. Callers must choose the expectation mode so vendor-specific
+commands remain explicit.
+
+## HTTP Surface
+
+`POST /api/v1/civ/transaction` is the only HTTP endpoint that waits for raw
+CI-V responses. `/api/v1/commands` and `/api/v1/commands/batch` remain queued
+fire-and-forget surfaces for `send_civ`, and `wait_response=true` stays
+rejected there.

--- a/src/rigplane/core/civ.py
+++ b/src/rigplane/core/civ.py
@@ -55,6 +55,7 @@ class _AckWaiter:
     token: int
     created_monotonic: float
     generation: int
+    nak_only: bool = False
 
 
 @dataclass(slots=True)
@@ -160,7 +161,13 @@ class CivRequestTracker:
             "ack_orphans": self._ack_orphans,
         }
 
-    def register_ack(self, wait: bool = True) -> asyncio.Future[CivFrame] | int:
+    def register_ack(
+        self,
+        wait: bool = True,
+        *,
+        consume_backlog: bool = True,
+        nak_only: bool = False,
+    ) -> asyncio.Future[CivFrame] | int:
         """Register a pending request that expects an ACK/NAK.
 
         Returns:
@@ -176,8 +183,11 @@ class CivRequestTracker:
             future: asyncio.Future[CivFrame] = (
                 asyncio.get_running_loop().create_future()
             )
-            if self._ack_backlog:
-                cached = self._ack_backlog.popleft()
+            if consume_backlog:
+                cached = self._pop_matching_ack_backlog(nak_only=nak_only)
+            else:
+                cached = None
+            if cached is not None:
                 future.set_result(cached.frame)
                 self._ack_backlog_hits += 1
                 return future
@@ -187,6 +197,7 @@ class CivRequestTracker:
                     token=token,
                     created_monotonic=created,
                     generation=self._generation,
+                    nak_only=nak_only,
                 )
             )
             return future
@@ -239,6 +250,13 @@ class CivRequestTracker:
         before = len(self._ack_waiters)
         self._ack_waiters = [w for w in self._ack_waiters if w.future is not None]
         return before - len(self._ack_waiters)
+
+    def drop_ack_backlog(self) -> int:
+        """Drop orphan ACK/NAK backlog without touching active waiters."""
+        dropped = len(self._ack_backlog)
+        self._ack_backlog.clear()
+        self._ack_backlog_drops += dropped
+        return dropped
 
     def cleanup_stale(self, *, now_monotonic: float | None = None) -> int:
         """Drop stale waiters that exceeded the TTL budget."""
@@ -293,6 +311,21 @@ class CivRequestTracker:
             self._ack_backlog.popleft()
             self._ack_backlog_drops += 1
 
+    def _pop_matching_ack_backlog(
+        self, *, nak_only: bool
+    ) -> _AckBacklogEntry | None:
+        """Pop the oldest backlog entry matching an ACK waiter filter."""
+        if not self._ack_backlog:
+            return None
+        if not nak_only:
+            return self._ack_backlog.popleft()
+
+        for index, entry in enumerate(self._ack_backlog):
+            if entry.frame.command == 0xFA:
+                del self._ack_backlog[index]
+                return entry
+        return None
+
     def advance_generation(self, exc: Exception | None = None) -> int:
         """Advance generation and fail all pending waiters."""
         if exc is None:
@@ -312,10 +345,16 @@ class CivRequestTracker:
 
         if event.type in (CivEventType.ACK, CivEventType.NAK):
             self._prune_ack_backlog()
-            while self._ack_waiters:
-                waiter = self._ack_waiters.pop(0)
+            index = 0
+            while index < len(self._ack_waiters):
+                waiter = self._ack_waiters[index]
                 if waiter.generation != self._generation:
+                    self._ack_waiters.pop(index)
                     continue
+                if waiter.nak_only and event.type != CivEventType.NAK:
+                    index += 1
+                    continue
+                self._ack_waiters.pop(index)
                 if waiter.future is not None and not waiter.future.done():
                     waiter.future.set_result(frame)
                     return True

--- a/src/rigplane/core/civ.py
+++ b/src/rigplane/core/civ.py
@@ -311,9 +311,7 @@ class CivRequestTracker:
             self._ack_backlog.popleft()
             self._ack_backlog_drops += 1
 
-    def _pop_matching_ack_backlog(
-        self, *, nak_only: bool
-    ) -> _AckBacklogEntry | None:
+    def _pop_matching_ack_backlog(self, *, nak_only: bool) -> _AckBacklogEntry | None:
         """Pop the oldest backlog entry matching an ACK waiter filter."""
         if not self._ack_backlog:
             return None

--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -76,6 +76,7 @@ __all__ = [
     "VfoSlotState",
     "AudioCapable",
     "CivCommandCapable",
+    "CivTransactionCapable",
     "ModeInfoCapable",
     "ScopeCapable",
     "DualReceiverCapable",
@@ -779,6 +780,23 @@ class CivCommandCapable(Protocol):
         wait_response: bool = True,
     ) -> Any:
         """Send a CI-V command through the active backend transport."""
+        ...
+
+
+@runtime_checkable
+class CivTransactionCapable(Protocol):
+    """Radio exposes scoped raw CI-V transactions with explicit expectations."""
+
+    async def send_civ_transaction(
+        self,
+        command: int,
+        sub: int | None = None,
+        data: bytes | None = None,
+        *,
+        expect: Literal["none", "ack", "data"] = "data",
+        timeout: float | None = None,
+    ) -> Any:
+        """Send one raw CI-V transaction and return a deterministic result."""
         ...
 
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -72,6 +72,7 @@ class RawCivTransactionResult:
     frame: CivFrame | None = None
     frame_bytes: bytes | None = None
 
+
 _CMD14_RECEIVER_LEVEL_FIELDS = {
     0x01: "af_level",
     0x02: "rf_gain",

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+from typing import Literal
 
 from rigplane.core.civ import (
     CivEvent,
@@ -16,6 +18,7 @@ from rigplane.core.civ import (
 from rigplane.commands.commander import IcomCommander, Priority
 from rigplane.commands import (
     CONTROLLER_ADDR,
+    build_civ_frame,
     parse_bool_response,
     parse_civ_frame,
     parse_frequency_response,
@@ -49,7 +52,25 @@ CIV_HEADER_SIZE = 0x15
 _SCOPE_BACKLOG_SHED_THRESHOLD = 256
 _SCOPE_BACKLOG_KEEP_LATEST = 64
 
-__all__ = ["CivRuntime", "CIV_HEADER_SIZE"]
+__all__ = [
+    "CivRuntime",
+    "CIV_HEADER_SIZE",
+    "RawCivExpectation",
+    "RawCivTransactionResult",
+    "RawCivTransactionStatus",
+]
+
+RawCivExpectation = Literal["none", "ack", "data"]
+RawCivTransactionStatus = Literal["sent", "ack", "nak", "response"]
+
+
+@dataclass(frozen=True, slots=True)
+class RawCivTransactionResult:
+    """Deterministic result for one response-capable raw CI-V transaction."""
+
+    status: RawCivTransactionStatus
+    frame: CivFrame | None = None
+    frame_bytes: bytes | None = None
 
 _CMD14_RECEIVER_LEVEL_FIELDS = {
     0x01: "af_level",
@@ -230,6 +251,110 @@ class CivRuntime:
             deadline_monotonic=deadline_monotonic,
         )
 
+    async def execute_civ_transaction(
+        self,
+        civ_frame: bytes,
+        *,
+        expect: RawCivExpectation,
+        timeout: float | None = None,
+    ) -> RawCivTransactionResult:
+        """Execute one explicitly-scoped raw CI-V transaction.
+
+        Unlike the poller/commander path, this does not infer whether a command
+        should ACK or return data. The caller must choose ``none``, ``ack``, or
+        ``data`` so vendor-specific commands remain deterministic.
+        """
+        assert self._host._civ_transport is not None
+        self._ensure_civ_runtime()
+
+        if expect not in ("none", "ack", "data"):
+            raise ValueError(f"unsupported CI-V expectation: {expect!r}")
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout must be positive")
+
+        parsed_frame = parse_civ_frame(civ_frame)
+        request_key = request_key_from_frame(parsed_frame)
+        deadline_monotonic = time.monotonic() + (
+            timeout if timeout is not None else self._host._civ_get_timeout
+        )
+
+        self._cleanup_stale_civ_waiters()
+
+        if expect == "none":
+            self.start_pump()
+            await self._send_civ_frame_now(civ_frame)
+            return RawCivTransactionResult(status="sent")
+
+        await self._drain_ack_sinks_before_blocking()
+        dropped_backlog = self._host._civ_request_tracker.drop_ack_backlog()
+        if dropped_backlog:
+            logger.debug(
+                "Dropped %d orphan ACK/NAK backlog frame(s) before raw transaction",
+                dropped_backlog,
+            )
+        remaining_total = deadline_monotonic - time.monotonic()
+        if remaining_total <= 0:
+            raise asyncio.TimeoutError("CI-V response timed out")
+
+        pending_waiters: list[asyncio.Future[CivFrame]] = []
+        try:
+            if expect == "ack":
+                pending_or_token = self._host._civ_request_tracker.register_ack(
+                    wait=True,
+                    consume_backlog=False,
+                )
+                if isinstance(pending_or_token, int):
+                    raise RuntimeError("ACK waiter registration returned sink token")
+                pending_waiters.append(pending_or_token)
+            else:
+                pending_waiters.append(
+                    self._host._civ_request_tracker.register_response(request_key)
+                )
+                nak_pending_or_token = self._host._civ_request_tracker.register_ack(
+                    wait=True,
+                    consume_backlog=False,
+                    nak_only=True,
+                )
+                if isinstance(nak_pending_or_token, int):
+                    raise RuntimeError("ACK waiter registration returned sink token")
+                pending_waiters.append(nak_pending_or_token)
+
+            self.start_pump()
+            await self._send_civ_frame_now(civ_frame)
+            remaining = deadline_monotonic - time.monotonic()
+            if remaining <= 0:
+                raise asyncio.TimeoutError("CI-V response timed out")
+            done, _ = await asyncio.wait(
+                pending_waiters,
+                timeout=remaining,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                raise asyncio.TimeoutError("CI-V response timed out")
+            frame = next(iter(done)).result()
+        except asyncio.TimeoutError:
+            self._host._civ_request_tracker.note_timeout()
+            logger.debug(
+                "CI-V transaction 0x%02X timed out",
+                request_key.command,
+            )
+            raise asyncio.TimeoutError("CI-V response timed out") from None
+        finally:
+            for pending in pending_waiters:
+                self._host._civ_request_tracker.unregister(pending)
+
+        if frame.command == 0xFA:
+            status: RawCivTransactionStatus = "nak"
+        elif frame.command == 0xFB:
+            status = "ack"
+        else:
+            status = "response"
+        return RawCivTransactionResult(
+            status=status,
+            frame=frame,
+            frame_bytes=self._civ_frame_to_bytes(frame),
+        )
+
     async def send_civ_raw(
         self,
         civ_frame: bytes,
@@ -248,6 +373,32 @@ class CivRuntime:
             dedupe=dedupe,
             wait_response=wait_response,
             timeout=timeout,
+        )
+
+    async def _send_civ_frame_now(self, civ_frame: bytes) -> None:
+        """Send one CI-V frame directly through the runtime transport."""
+        assert self._host._civ_transport is not None
+        now = time.monotonic()
+        delta = now - self._host._last_civ_send_monotonic
+        if delta < self._host._civ_min_interval:
+            await asyncio.sleep(self._host._civ_min_interval - delta)
+
+        pkt = self._wrap_civ(civ_frame)
+        await self._host._civ_transport.send_tracked(pkt)
+        self._host._last_civ_send_monotonic = time.monotonic()
+
+    @staticmethod
+    def _civ_frame_to_bytes(frame: CivFrame) -> bytes:
+        """Rebuild canonical CI-V bytes from a parsed frame."""
+        return cast(
+            bytes,
+            build_civ_frame(
+                frame.to_addr,
+                frame.from_addr,
+                frame.command,
+                sub=frame.sub,
+                data=frame.data,
+            ),
         )
 
     def start_worker(self) -> None:

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -51,6 +51,7 @@ logger = logging.getLogger(__name__)
 CIV_HEADER_SIZE = 0x15
 _SCOPE_BACKLOG_SHED_THRESHOLD = 256
 _SCOPE_BACKLOG_KEEP_LATEST = 64
+_RAW_RECEIVED_FRAME_BYTES_LIMIT = 256
 
 __all__ = [
     "CivRuntime",
@@ -174,6 +175,7 @@ class CivRuntime:
         # late soft_reconnect from firing after an explicit disconnect
         # (Codex P1 on PR #851).
         self._reconnect_task: asyncio.Task[None] | None = None
+        self._raw_received_frame_bytes: dict[int, bytes] = {}
 
     # ------------------------------------------------------------------
     # Public API (design doc)
@@ -353,7 +355,8 @@ class CivRuntime:
         return RawCivTransactionResult(
             status=status,
             frame=frame,
-            frame_bytes=self._civ_frame_to_bytes(frame),
+            frame_bytes=self._take_raw_received_frame_bytes(frame)
+            or self._civ_frame_to_bytes(frame),
         )
 
     async def send_civ_raw(
@@ -401,6 +404,20 @@ class CivRuntime:
                 data=frame.data,
             ),
         )
+
+    def _remember_raw_received_frame_bytes(
+        self, frame: CivFrame, frame_bytes: bytes
+    ) -> None:
+        """Keep exact inbound bytes for parsed frames returned through futures."""
+        self._raw_received_frame_bytes[id(frame)] = bytes(frame_bytes)
+        while len(self._raw_received_frame_bytes) > _RAW_RECEIVED_FRAME_BYTES_LIMIT:
+            self._raw_received_frame_bytes.pop(
+                next(iter(self._raw_received_frame_bytes))
+            )
+
+    def _take_raw_received_frame_bytes(self, frame: CivFrame) -> bytes | None:
+        """Return exact inbound bytes for a parsed frame when still available."""
+        return self._raw_received_frame_bytes.pop(id(frame), None)
 
     def start_worker(self) -> None:
         """Start serialized CI-V commander."""
@@ -693,6 +710,7 @@ class CivRuntime:
                             frame = parse_civ_frame(frame_bytes)
                         except ValueError:
                             continue
+                        self._remember_raw_received_frame_bytes(frame, frame_bytes)
                         self.deliver_raw_civ(frame_bytes)
                         try:
                             await self._route_civ_frame(

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -37,7 +37,11 @@ from rigplane.audio.route import (
     resolve_lan_audio_stream_request,
 )
 from rigplane.core._bounded_queue import BoundedQueue
-from rigplane.runtime._civ_rx import CivRuntime
+from rigplane.runtime._civ_rx import (
+    CivRuntime,
+    RawCivExpectation,
+    RawCivTransactionResult,
+)
 from rigplane.runtime._dual_rx_runtime import DualRxRuntimeMixin
 from rigplane.runtime._scope_runtime import ScopeRuntimeMixin
 
@@ -765,6 +769,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         # External CAT-session ownership (MOR-166 slice 2): when True, cooperating
         # pollers pause so they do not pollute an external master's byte stream.
         self._external_cat_session: bool = False
+        self._external_cat_session_owner: str | None = None
         self._civ_rx_task: asyncio.Task[None] | None = None
         self._civ_data_watchdog_task: asyncio.Task[None] | None = None
         self._audio_watchdog_task: asyncio.Task[None] | None = None
@@ -1327,13 +1332,75 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
         Cooperating pollers (e.g. the web ``RadioPoller``) pause their own CI-V
         traffic while this is set, so they do not pollute the owner's byte
-        stream. Idempotent.
+        stream. Idempotent when the external owner already holds the session.
         """
+        if self._external_cat_session:
+            current = self._external_cat_session_owner or "external"
+            if current == "external":
+                self._external_cat_session_owner = "external"
+                return
+            raise RuntimeError(f"CI-V stream is already owned by {current}")
         self._external_cat_session = True
+        self._external_cat_session_owner = "external"
 
     def end_external_cat_session(self) -> None:
         """Release external-CAT-session ownership. Idempotent."""
         self._external_cat_session = False
+        self._external_cat_session_owner = None
+
+    def _claim_external_cat_session(self, owner: str) -> None:
+        """Claim exclusive CI-V stream ownership for a scoped transaction."""
+        if self._external_cat_session:
+            current = self._external_cat_session_owner or "external"
+            raise RuntimeError(f"CI-V stream is already owned by {current}")
+        self._external_cat_session = True
+        self._external_cat_session_owner = owner
+
+    def _release_external_cat_session(self, owner: str) -> None:
+        """Release a transaction claim without disturbing another owner."""
+        if self._external_cat_session_owner not in (None, owner):
+            return
+        self._external_cat_session = False
+        self._external_cat_session_owner = None
+
+    async def send_civ_transaction(
+        self,
+        command: int,
+        sub: int | None = None,
+        data: bytes | None = None,
+        *,
+        expect: RawCivExpectation = "data",
+        timeout: float | None = None,
+    ) -> RawCivTransactionResult:
+        """Send one raw CI-V command with explicit response semantics.
+
+        This is intentionally separate from the web poller's fire-and-forget
+        queue. While the transaction is active, cooperating pollers pause via
+        ``external_cat_session_active`` so their background traffic cannot
+        consume or pollute the caller's response.
+        """
+        self._check_connected()
+        if not 0 <= command <= 0xFF:
+            raise ValueError(f"command must be 0-255, got {command}")
+        if sub is not None and not 0 <= sub <= 0xFF:
+            raise ValueError(f"sub must be 0-255, got {sub}")
+        if expect not in ("none", "ack", "data"):
+            raise ValueError(f"unsupported CI-V expectation: {expect!r}")
+
+        payload = data or b""
+        frame = build_civ_frame(
+            self._radio_addr, CONTROLLER_ADDR, command, sub=sub, data=payload
+        )
+        owner = "raw-civ-transaction"
+        self._claim_external_cat_session(owner)
+        try:
+            return await self._civ_runtime.execute_civ_transaction(
+                frame,
+                expect=expect,
+                timeout=timeout,
+            )
+        finally:
+            self._release_external_cat_session(owner)
 
     async def reconcile_state(self) -> None:
         """Re-read full radio state after an external session changed the rig.

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -1344,7 +1344,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._external_cat_session_owner = "external"
 
     def end_external_cat_session(self) -> None:
-        """Release external-CAT-session ownership. Idempotent."""
+        """Release legacy external-CAT-session ownership. Idempotent."""
+        if self._external_cat_session_owner not in (None, "external"):
+            return
         self._external_cat_session = False
         self._external_cat_session_owner = None
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -33,7 +33,7 @@ import time
 import urllib.parse
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TextIO, cast
+from typing import TYPE_CHECKING, Any, TextIO
 
 from .. import __version__
 from .._bounded_queue import BoundedQueue
@@ -253,7 +253,7 @@ def _serialize_keyboard_config(profile: "RadioProfile") -> dict[str, object] | N
 
 def _runtime_capabilities(radio: "Radio | None") -> set[str]:
     """Backward-compatible alias to shared runtime_capabilities helper."""
-    return cast(set[str], runtime_capabilities(radio))
+    return runtime_capabilities(radio)
 
 
 def _supports_scope(radio: "Radio | None") -> bool:
@@ -510,7 +510,7 @@ class WebServer:
 
     def _radio_ready(self) -> bool:
         """Backend view of radio readiness (CI-V healthy)."""
-        return cast(bool, radio_ready(self._radio))
+        return radio_ready(self._radio)
 
     async def ensure_startup_ready(self, timeout: float = 5.0) -> None:
         """Assert that the attached radio is ready before exposing the server."""
@@ -726,20 +726,17 @@ class WebServer:
         """Return the canonical public state payload for web consumers."""
         revision = self._radio_poller.revision if self._radio_poller is not None else 0
         health = self._build_radio_health()
-        return cast(
-            dict[str, Any],
-            build_public_state_payload(
-                self._radio_state,
-                radio=self._radio,
-                revision=revision,
-                receiver_count=self._get_profile().receiver_count,
-                updated_at=updated_at,
-                scope_clients=len(self._scope_handlers),
-                control_clients=len(self._control_event_queues),
-                audio_clients=len(self._audio_broadcaster._clients),
-                radio_health=health,
-                health_revision=self._health_revision,
-            ),
+        return build_public_state_payload(
+            self._radio_state,
+            radio=self._radio,
+            revision=revision,
+            receiver_count=self._get_profile().receiver_count,
+            updated_at=updated_at,
+            scope_clients=len(self._scope_handlers),
+            control_clients=len(self._control_event_queues),
+            audio_clients=len(self._audio_broadcaster._clients),
+            radio_health=health,
+            health_revision=self._health_revision,
         )
 
     def _build_radio_health(self) -> dict[str, Any]:
@@ -762,7 +759,7 @@ class WebServer:
             self._health_revision += 1
             self._health_since_monotonic = now
         health["sinceMs"] = int(max(0.0, now - self._health_since_monotonic) * 1000)
-        return cast(dict[str, Any], health)
+        return health
 
     def broadcast_notification(
         self,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -33,12 +33,13 @@ import time
 import urllib.parse
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TextIO
+from typing import TYPE_CHECKING, Any, TextIO, cast
 
 from .. import __version__
 from .._bounded_queue import BoundedQueue
 from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO, CAP_SCOPE
+from ..exceptions import TimeoutError as RigplaneTimeoutError
 from ..audio_analyzer import AudioAnalyzer
 from ..audio_fft_scope import AudioFftScope
 from ..env_config import (
@@ -70,6 +71,7 @@ from .websocket import (  # noqa: TID251
     make_accept_key,
     negotiate_deflate,
 )
+from ..radio_protocol import CivTransactionCapable
 
 if TYPE_CHECKING:
     from ..audio_bridge import AudioBridge
@@ -251,7 +253,7 @@ def _serialize_keyboard_config(profile: "RadioProfile") -> dict[str, object] | N
 
 def _runtime_capabilities(radio: "Radio | None") -> set[str]:
     """Backward-compatible alias to shared runtime_capabilities helper."""
-    return runtime_capabilities(radio)
+    return cast(set[str], runtime_capabilities(radio))
 
 
 def _supports_scope(radio: "Radio | None") -> bool:
@@ -508,7 +510,7 @@ class WebServer:
 
     def _radio_ready(self) -> bool:
         """Backend view of radio readiness (CI-V healthy)."""
-        return radio_ready(self._radio)
+        return cast(bool, radio_ready(self._radio))
 
     async def ensure_startup_ready(self, timeout: float = 5.0) -> None:
         """Assert that the attached radio is ready before exposing the server."""
@@ -724,17 +726,20 @@ class WebServer:
         """Return the canonical public state payload for web consumers."""
         revision = self._radio_poller.revision if self._radio_poller is not None else 0
         health = self._build_radio_health()
-        return build_public_state_payload(
-            self._radio_state,
-            radio=self._radio,
-            revision=revision,
-            receiver_count=self._get_profile().receiver_count,
-            updated_at=updated_at,
-            scope_clients=len(self._scope_handlers),
-            control_clients=len(self._control_event_queues),
-            audio_clients=len(self._audio_broadcaster._clients),
-            radio_health=health,
-            health_revision=self._health_revision,
+        return cast(
+            dict[str, Any],
+            build_public_state_payload(
+                self._radio_state,
+                radio=self._radio,
+                revision=revision,
+                receiver_count=self._get_profile().receiver_count,
+                updated_at=updated_at,
+                scope_clients=len(self._scope_handlers),
+                control_clients=len(self._control_event_queues),
+                audio_clients=len(self._audio_broadcaster._clients),
+                radio_health=health,
+                health_revision=self._health_revision,
+            ),
         )
 
     def _build_radio_health(self) -> dict[str, Any]:
@@ -757,7 +762,7 @@ class WebServer:
             self._health_revision += 1
             self._health_since_monotonic = now
         health["sinceMs"] = int(max(0.0, now - self._health_since_monotonic) * 1000)
-        return health
+        return cast(dict[str, Any], health)
 
     def broadcast_notification(
         self,
@@ -2203,6 +2208,181 @@ class WebServer:
             return
 
         await _send_response(writer, 404, "Not Found", b"", {})
+
+    @staticmethod
+    def _parse_civ_byte(value: Any, name: str, *, required: bool = True) -> int | None:
+        if value is None:
+            if required:
+                raise ValueError(f"missing required '{name}' parameter")
+            return None
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be an integer byte") from exc
+        if not 0 <= parsed <= 0xFF:
+            raise ValueError(f"{name} must be 0-255, got {parsed}")
+        return parsed
+
+    @staticmethod
+    def _parse_civ_hex_data(value: Any) -> bytes:
+        if value is None:
+            return b""
+        if not isinstance(value, str):
+            raise ValueError("data must be a hex string")
+        if len(value) % 2 != 0:
+            raise ValueError("data must be an even-length hex string")
+        if any(ch not in "0123456789abcdefABCDEF" for ch in value):
+            raise ValueError("data must be a compact hex string")
+        return bytes.fromhex(value)
+
+    @staticmethod
+    def _parse_civ_transaction_timeout(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            timeout_ms = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("timeout_ms must be a positive number") from exc
+        if timeout_ms <= 0:
+            raise ValueError("timeout_ms must be positive")
+        return timeout_ms / 1000.0
+
+    @staticmethod
+    def _serialize_civ_transaction_result(result: Any) -> dict[str, Any]:
+        frame = getattr(result, "frame", None)
+        frame_bytes = getattr(result, "frame_bytes", None)
+        if frame is None:
+            return {
+                "frame": None,
+                "command": None,
+                "sub": None,
+                "data": None,
+            }
+        return {
+            "frame": frame_bytes.hex().upper() if frame_bytes is not None else None,
+            "command": frame.command,
+            "sub": frame.sub,
+            "data": frame.data.hex().upper(),
+        }
+
+    async def _handle_http_civ_transaction(
+        self,
+        writer: asyncio.StreamWriter,
+        headers: dict[str, str] | None = None,
+        reader: asyncio.StreamReader | None = None,
+    ) -> None:
+        """Handle POST /api/v1/civ/transaction."""
+        if self._radio is None:
+            await self._send_json(
+                writer,
+                503,
+                "Service Unavailable",
+                {"error": "no_radio", "message": "No radio configured"},
+            )
+            return
+
+        payload = await self._read_json_object(writer, headers, reader)
+        if payload is None:
+            return
+
+        if self._config.read_only:
+            await self._send_json(
+                writer,
+                403,
+                "Forbidden",
+                {
+                    "error": "read_only",
+                    "message": "raw CI-V transactions are disabled in read-only mode",
+                },
+            )
+            return
+
+        if not isinstance(self._radio, CivTransactionCapable):
+            await self._send_json(
+                writer,
+                409,
+                "Conflict",
+                {
+                    "error": "unsupported_command",
+                    "message": "active backend does not support raw CI-V transactions",
+                },
+            )
+            return
+
+        try:
+            command = self._parse_civ_byte(payload.get("command"), "command")
+            sub = self._parse_civ_byte(payload.get("sub"), "sub", required=False)
+            data = self._parse_civ_hex_data(payload.get("data", ""))
+            raw_expect = payload.get("expect", "data")
+            if raw_expect not in ("none", "ack", "data"):
+                raise ValueError("expect must be one of: none, ack, data")
+            timeout = self._parse_civ_transaction_timeout(payload.get("timeout_ms"))
+        except ValueError as exc:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "invalid_request", "message": str(exc)},
+            )
+            return
+
+        try:
+            assert command is not None
+            result = await self._radio.send_civ_transaction(
+                command,
+                sub=sub,
+                data=data,
+                expect=raw_expect,
+                timeout=timeout,
+            )
+        except (RigplaneTimeoutError, TimeoutError):
+            await self._send_json(
+                writer,
+                504,
+                "Gateway Timeout",
+                {
+                    "error": "transaction_timeout",
+                    "message": "raw CI-V transaction timed out",
+                },
+            )
+            return
+        except RuntimeError as exc:
+            message = str(exc)
+            if "already owned" in message:
+                await self._send_json(
+                    writer,
+                    409,
+                    "Conflict",
+                    {"error": "civ_owner_conflict", "message": message},
+                )
+                return
+            await self._send_json(
+                writer,
+                500,
+                "Internal Server Error",
+                {"error": "transaction_failed", "message": message},
+            )
+            return
+        except ValueError as exc:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "invalid_request", "message": str(exc)},
+            )
+            return
+
+        status = getattr(result, "status", "response")
+        response: dict[str, Any] = {
+            "ok": status != "nak",
+            "status": status,
+            "result": self._serialize_civ_transaction_result(result),
+        }
+        if status == "nak":
+            response["error"] = "radio_nak"
+        if "id" in payload:
+            response["id"] = payload["id"]
+        await self._send_json(writer, 200, "OK", response)
 
     async def _handle_http_single_command(
         self,

--- a/src/rigplane/web/web_routing.py
+++ b/src/rigplane/web/web_routing.py
@@ -96,9 +96,13 @@ async def dispatch_http_request(
         "/api/v1/radio/cw/stop",
         "/api/v1/commands",
         "/api/v1/commands/batch",
+        "/api/v1/civ/transaction",
     ):
         if method != "POST":
             await _send_response(writer, 405, "Method Not Allowed", b"", {})
+            return
+        if path == "/api/v1/civ/transaction":
+            await server._handle_http_civ_transaction(writer, headers, reader)
             return
         if path.startswith("/api/v1/commands"):
             await server._handle_http_commands(path, writer, headers, reader)

--- a/tests/test_civ_transaction_ownership.py
+++ b/tests/test_civ_transaction_ownership.py
@@ -1,0 +1,145 @@
+"""Scoped raw CI-V transaction ownership and poller quiesce coverage."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+from test_radio import MockTransport
+
+from rigplane import IC_7610_ADDR
+from rigplane.radio import IcomRadio
+from rigplane.radio_state import RadioState
+from rigplane.rigctld.state_cache import StateCache
+from rigplane.web.radio_poller import CommandQueue, RadioPoller, SetFreq
+
+
+@pytest.fixture
+def transport() -> MockTransport:
+    return MockTransport()
+
+
+@pytest.fixture
+def radio(transport: MockTransport):
+    r = IcomRadio("192.168.1.100", timeout=0.05)
+    r._civ_transport = transport
+    r._ctrl_transport = transport
+    r._connected = True
+    r._radio_addr = IC_7610_ADDR
+    r._civ_ack_sink_grace = 0.001
+    yield r
+    r._connected = False
+    r._civ_transport = None
+    r._ctrl_transport = None
+
+
+async def _wait_until(predicate: Callable[[], bool], *, timeout: float = 0.5) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    assert predicate()
+
+
+async def test_raw_transaction_holding_owner_blocks_competing_external_owner(
+    radio: IcomRadio,
+) -> None:
+    task = asyncio.create_task(
+        radio.send_civ_transaction(0x03, expect="data", timeout=1.0)
+    )
+    try:
+        await _wait_until(lambda: radio.external_cat_session_active is True)
+
+        with pytest.raises(RuntimeError, match="CI-V stream is already owned"):
+            radio.begin_external_cat_session()
+    finally:
+        task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert radio.external_cat_session_active is False
+
+
+async def test_legacy_end_does_not_release_active_raw_transaction_owner(
+    radio: IcomRadio,
+) -> None:
+    queue = CommandQueue()
+    queue.put_ordered(SetFreq(7_074_000))
+    poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
+    poller._execute = AsyncMock()  # noqa: SLF001
+    poller._send_query = AsyncMock()  # noqa: SLF001
+    poller._poll_unselected_slot = AsyncMock()  # noqa: SLF001
+
+    task = asyncio.create_task(
+        radio.send_civ_transaction(0x03, expect="data", timeout=1.0)
+    )
+    poller_started = False
+    try:
+        await _wait_until(lambda: radio.external_cat_session_active is True)
+
+        radio.end_external_cat_session()
+
+        poller.start()
+        poller_started = True
+        await asyncio.sleep(0.05)
+
+        assert radio.external_cat_session_active is True
+        poller._execute.assert_not_awaited()  # noqa: SLF001
+        assert queue.has_commands is True
+        with pytest.raises(RuntimeError, match="CI-V stream is already owned"):
+            radio.begin_external_cat_session()
+    finally:
+        if not task.done():
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        if poller_started:
+            poller.stop()
+            await asyncio.sleep(0)
+
+    assert radio.external_cat_session_active is False
+
+
+async def test_raw_transaction_quiesces_web_poller_and_defers_queue_until_release(
+    radio: IcomRadio,
+) -> None:
+    queue = CommandQueue()
+    queue.put_ordered(SetFreq(7_074_000))
+    poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
+    poller._execute = AsyncMock()  # noqa: SLF001
+    poller._send_query = AsyncMock()  # noqa: SLF001
+    poller._poll_unselected_slot = AsyncMock()  # noqa: SLF001
+
+    task = asyncio.create_task(
+        radio.send_civ_transaction(0x03, expect="data", timeout=1.0)
+    )
+    poller_started = False
+    try:
+        await _wait_until(lambda: radio.external_cat_session_active is True)
+
+        poller.start()
+        poller_started = True
+        await asyncio.sleep(0.05)
+
+        poller._execute.assert_not_awaited()  # noqa: SLF001
+        assert queue.has_commands is True
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert radio.external_cat_session_active is False
+
+        await _wait_until(lambda: poller._execute.await_count == 1)  # noqa: SLF001
+        assert queue.has_commands is False
+    finally:
+        if not task.done():
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        if poller_started:
+            poller.stop()
+            await asyncio.sleep(0)

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -1,0 +1,209 @@
+"""Response-capable raw CI-V transaction path (MOR-169)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from test_radio import MockTransport
+
+from rigplane import IC_7610_ADDR
+from rigplane.commands import CONTROLLER_ADDR, build_civ_frame, parse_civ_frame
+from rigplane.core.civ import CivEvent, CivEventType
+from rigplane.radio import IcomRadio
+from rigplane.types import bcd_encode
+
+
+@pytest.fixture
+def transport() -> MockTransport:
+    return MockTransport()
+
+
+@pytest.fixture
+def radio(transport: MockTransport):
+    r = IcomRadio("192.168.1.100", timeout=0.05)
+    r._civ_transport = transport
+    r._ctrl_transport = transport
+    r._connected = True
+    r._radio_addr = IC_7610_ADDR
+    r._civ_ack_sink_grace = 0.001
+    yield r
+    r._connected = False
+    r._civ_transport = None
+    r._ctrl_transport = None
+
+
+def _ack() -> bytes:
+    return build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0xFB)
+
+
+def _nak() -> bytes:
+    return build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0xFA)
+
+
+async def test_raw_civ_transaction_ack_success_releases_owner(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    transport.queue_response_on_send(1, _wrap(_ack()))
+
+    result = await radio.send_civ_transaction(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x53\x01",
+        expect="ack",
+        timeout=0.2,
+    )
+
+    assert result.status == "ack"
+    assert result.frame_bytes == _ack()
+    assert result.frame.command == 0xFB
+    assert radio.external_cat_session_active is False
+    assert transport.sent_packets[-1].endswith(b"\x1a\x05\x01\x53\x01\xfd")
+
+
+async def test_raw_civ_transaction_data_response_success(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    response = build_civ_frame(
+        CONTROLLER_ADDR,
+        IC_7610_ADDR,
+        0x03,
+        data=bcd_encode(14_074_000),
+    )
+    transport.queue_response_on_send(1, _wrap(response))
+
+    result = await radio.send_civ_transaction(0x03, expect="data", timeout=0.2)
+
+    assert result.status == "response"
+    assert result.frame_bytes == response
+    assert result.frame.command == 0x03
+    assert result.frame.data == bcd_encode(14_074_000)
+
+
+async def test_raw_civ_transaction_expect_none_is_fire_and_forget(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    result = await radio.send_civ_transaction(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x53\x01",
+        expect="none",
+        timeout=0.2,
+    )
+
+    assert result.status == "sent"
+    assert result.frame is None
+    assert result.frame_bytes is None
+    assert radio.external_cat_session_active is False
+    assert transport.sent_packets[-1].endswith(b"\x1a\x05\x01\x53\x01\xfd")
+
+
+async def test_raw_civ_transaction_nak_is_deterministic_failure_result(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    transport.queue_response_on_send(1, _wrap(_nak()))
+
+    result = await radio.send_civ_transaction(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x53\x01",
+        expect="ack",
+        timeout=0.2,
+    )
+
+    assert result.status == "nak"
+    assert result.frame.command == 0xFA
+    assert radio.external_cat_session_active is False
+
+
+async def test_raw_civ_transaction_data_nak_is_deterministic_failure_result(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    transport.queue_response_on_send(1, _wrap(_nak()))
+
+    result = await radio.send_civ_transaction(0x03, expect="data", timeout=0.2)
+
+    assert result.status == "nak"
+    assert result.frame.command == 0xFA
+    assert radio.external_cat_session_active is False
+
+
+async def test_raw_civ_transaction_ack_ignores_orphan_ack_backlog(
+    radio: IcomRadio,
+) -> None:
+    tracker = radio._civ_request_tracker
+    assert tracker.resolve(
+        CivEvent(type=CivEventType.ACK, frame=parse_civ_frame(_ack()))
+    )
+    assert tracker.resolve(
+        CivEvent(type=CivEventType.NAK, frame=parse_civ_frame(_nak()))
+    )
+
+    with pytest.raises(TimeoutError):
+        await radio.send_civ_transaction(
+            0x1A,
+            sub=0x05,
+            data=b"\x01\x53\x01",
+            expect="ack",
+            timeout=0.01,
+        )
+
+    assert radio.external_cat_session_active is False
+
+
+async def test_raw_civ_transaction_timeout_releases_owner(radio: IcomRadio) -> None:
+    with pytest.raises(TimeoutError):
+        await radio.send_civ_transaction(0x03, expect="data", timeout=0.01)
+
+    assert radio.external_cat_session_active is False
+
+
+async def test_raw_civ_transaction_rejects_competing_owner(radio: IcomRadio) -> None:
+    radio.begin_external_cat_session()
+
+    try:
+        with pytest.raises(RuntimeError, match="CI-V stream is already owned"):
+            await radio.send_civ_transaction(0x03, expect="data", timeout=0.01)
+    finally:
+        radio.end_external_cat_session()
+
+
+async def test_external_cat_begin_rejects_active_raw_transaction(
+    radio: IcomRadio,
+) -> None:
+    task = asyncio.create_task(
+        radio.send_civ_transaction(0x03, expect="data", timeout=1.0)
+    )
+    await asyncio.sleep(0)
+    assert radio.external_cat_session_active is True
+
+    with pytest.raises(RuntimeError, match="CI-V stream is already owned"):
+        radio.begin_external_cat_session()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert radio.external_cat_session_active is False
+
+
+async def test_raw_civ_transaction_session_releases_on_cancellation(
+    radio: IcomRadio,
+) -> None:
+    task = asyncio.create_task(
+        radio.send_civ_transaction(0x03, expect="data", timeout=1.0)
+    )
+    await asyncio.sleep(0)
+    assert radio.external_cat_session_active is True
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert radio.external_cat_session_active is False
+
+
+def _wrap(civ_frame: bytes) -> bytes:
+    pkt = bytearray(0x16 + len(civ_frame))
+    pkt[0x10] = 0xC1
+    pkt[0x16:] = civ_frame
+    return bytes(pkt)

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -9,7 +9,13 @@ from test_radio import MockTransport
 
 from rigplane import IC_7610_ADDR
 from rigplane.commands import CONTROLLER_ADDR, build_civ_frame, parse_civ_frame
-from rigplane.core.civ import CivEvent, CivEventType
+from rigplane.core.civ import (
+    CivEvent,
+    CivEventType,
+    CivRequestTracker,
+    request_key_from_frame,
+)
+from rigplane.core.exceptions import ConnectionError as RigplaneConnectionError
 from rigplane.radio import IcomRadio
 from rigplane.types import bcd_encode
 
@@ -78,6 +84,25 @@ async def test_raw_civ_transaction_data_response_success(
     assert result.frame_bytes == response
     assert result.frame.command == 0x03
     assert result.frame.data == bcd_encode(14_074_000)
+
+
+async def test_raw_civ_transaction_command29_response_preserves_wire_bytes(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    response = bytes.fromhex("FEFEE098290103FD")
+    transport.queue_response_on_send(1, _wrap(response))
+
+    result = await radio.send_civ_transaction(
+        0x29,
+        data=b"\x01\x03",
+        expect="data",
+        timeout=0.2,
+    )
+
+    assert result.status == "response"
+    assert result.frame.command == 0x03
+    assert result.frame.receiver == 0x01
+    assert result.frame_bytes == response
 
 
 async def test_raw_civ_transaction_expect_none_is_fire_and_forget(
@@ -149,6 +174,65 @@ async def test_raw_civ_transaction_ack_ignores_orphan_ack_backlog(
         )
 
     assert radio.external_cat_session_active is False
+    assert tracker.pending_count == 0
+
+
+async def test_raw_civ_transaction_rejects_missing_civ_transport_without_claim(
+    radio: IcomRadio,
+) -> None:
+    radio._civ_transport = None
+
+    with pytest.raises(RigplaneConnectionError, match="Not connected to radio"):
+        await radio.send_civ_transaction(
+            0x1A,
+            sub=0x05,
+            data=b"\x01\x53\x01",
+            expect="ack",
+            timeout=0.01,
+        )
+
+    assert radio.external_cat_session_active is False
+    assert radio._civ_request_tracker.pending_count == 0
+
+
+async def test_raw_civ_transaction_cleans_stale_waiters_and_backlog(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    tracker = CivRequestTracker(stale_ttl=0.0)
+    radio._civ_request_tracker = tracker
+    radio._civ_epoch = tracker.generation
+    radio._civ_waiter_ttl_gc_interval = 0.0
+
+    assert tracker.resolve(
+        CivEvent(type=CivEventType.ACK, frame=parse_civ_frame(_ack()))
+    )
+
+    stale_ack = tracker.register_ack(wait=True, consume_backlog=False)
+    stale_response = tracker.register_response(
+        request_key_from_frame(
+            parse_civ_frame(build_civ_frame(radio._radio_addr, CONTROLLER_ADDR, 0x03))
+        )
+    )
+    assert tracker.pending_count == 2
+
+    transport.queue_response_on_send(1, _wrap(_ack()))
+
+    result = await radio.send_civ_transaction(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x53\x01",
+        expect="ack",
+        timeout=0.2,
+    )
+
+    assert result.status == "ack"
+    assert tracker.pending_count == 0
+    assert tracker.snapshot_stats()["stale_cleaned"] == 2
+    assert tracker.snapshot_stats()["ack_backlog_drops"] == 1
+    with pytest.raises(asyncio.TimeoutError, match="CI-V ACK waiter expired"):
+        stale_ack.result()
+    with pytest.raises(asyncio.TimeoutError, match="CI-V response waiter expired"):
+        stale_response.result()
 
 
 async def test_raw_civ_transaction_timeout_releases_owner(radio: IcomRadio) -> None:
@@ -156,6 +240,8 @@ async def test_raw_civ_transaction_timeout_releases_owner(radio: IcomRadio) -> N
         await radio.send_civ_transaction(0x03, expect="data", timeout=0.01)
 
     assert radio.external_cat_session_active is False
+    assert radio._civ_request_tracker.pending_count == 0
+    assert radio._civ_request_tracker.timeout_count == 1
 
 
 async def test_raw_civ_transaction_rejects_competing_owner(radio: IcomRadio) -> None:
@@ -184,6 +270,8 @@ async def test_external_cat_begin_rejects_active_raw_transaction(
     with pytest.raises(asyncio.CancelledError):
         await task
     assert radio.external_cat_session_active is False
+    assert radio._civ_request_tracker.pending_count == 0
+    assert radio._civ_request_tracker.timeout_count == 0
 
 
 async def test_raw_civ_transaction_session_releases_on_cancellation(
@@ -200,6 +288,8 @@ async def test_raw_civ_transaction_session_releases_on_cancellation(
         await task
 
     assert radio.external_cat_session_active is False
+    assert radio._civ_request_tracker.pending_count == 0
+    assert radio._civ_request_tracker.timeout_count == 0
 
 
 def _wrap(civ_frame: bytes) -> bytes:

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -418,6 +418,43 @@ async def test_http_raw_civ_transaction_rejects_read_only() -> None:
 
 
 @pytest.mark.asyncio
+async def test_http_raw_civ_transaction_requires_auth_when_configured() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock()
+    srv = WebServer(
+        radio,
+        WebConfig(host="127.0.0.1", port=0, auth_token="secret"),
+    )
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x1A, "data": "015301", "expect": "ack"},
+    )
+
+    assert writer.response_status == 401
+    assert writer.response_body["error"] == "unauthorized"
+    radio.send_civ_transaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_rejects_missing_radio() -> None:
+    srv = WebServer(None, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x1A, "data": "015301", "expect": "ack"},
+    )
+
+    assert writer.response_status == 503
+    assert writer.response_body == {
+        "error": "no_radio",
+        "message": "No radio configured",
+    }
+
+
+@pytest.mark.asyncio
 async def test_http_raw_civ_transaction_rejects_unsupported_backend() -> None:
     srv = WebServer(_radio_without_civ(), WebConfig(host="127.0.0.1", port=0))
 
@@ -429,6 +466,34 @@ async def test_http_raw_civ_transaction_rejects_unsupported_backend() -> None:
 
     assert writer.response_status == 409
     assert writer.response_body["error"] == "unsupported_command"
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_owner_conflict_maps_to_409() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock(
+        side_effect=RuntimeError("CI-V stream is already owned by external")
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x03, "expect": "data", "timeout_ms": 10},
+    )
+
+    assert writer.response_status == 409
+    assert writer.response_body == {
+        "error": "civ_owner_conflict",
+        "message": "CI-V stream is already owned by external",
+    }
+    radio.send_civ_transaction.assert_awaited_once_with(
+        0x03,
+        sub=None,
+        data=b"",
+        expect="data",
+        timeout=0.01,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -224,6 +224,230 @@ async def test_http_command_rejects_raw_civ_wait_response() -> None:
 
 
 @pytest.mark.asyncio
+async def test_http_raw_civ_transaction_ack_success() -> None:
+    radio = _radio()
+    frame = SimpleNamespace(
+        command=0xFB,
+        sub=None,
+        data=b"",
+    )
+    radio.send_civ_transaction = AsyncMock(
+        return_value=SimpleNamespace(
+            status="ack",
+            frame=frame,
+            frame_bytes=bytes.fromhex("fefee0a2fbfd"),
+        )
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {
+            "id": "display-type-b",
+            "command": 0x1A,
+            "sub": 0x05,
+            "data": "015301",
+            "expect": "ack",
+            "timeout_ms": 1000,
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body == {
+        "id": "display-type-b",
+        "ok": True,
+        "status": "ack",
+        "result": {
+            "frame": "FEFEE0A2FBFD",
+            "command": 0xFB,
+            "sub": None,
+            "data": "",
+        },
+    }
+    radio.send_civ_transaction.assert_awaited_once_with(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x53\x01",
+        expect="ack",
+        timeout=1.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_nak_returns_ok_false() -> None:
+    radio = _radio()
+    frame = SimpleNamespace(command=0xFA, sub=None, data=b"")
+    radio.send_civ_transaction = AsyncMock(
+        return_value=SimpleNamespace(
+            status="nak",
+            frame=frame,
+            frame_bytes=bytes.fromhex("fefee0a2fafd"),
+        )
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x1A, "data": "015301", "expect": "ack"},
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["status"] == "nak"
+    assert writer.response_body["error"] == "radio_nak"
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_data_nak_returns_ok_false() -> None:
+    radio = _radio()
+    frame = SimpleNamespace(command=0xFA, sub=None, data=b"")
+    radio.send_civ_transaction = AsyncMock(
+        return_value=SimpleNamespace(
+            status="nak",
+            frame=frame,
+            frame_bytes=bytes.fromhex("fefee0a2fafd"),
+        )
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x03, "expect": "data"},
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["status"] == "nak"
+    assert writer.response_body["error"] == "radio_nak"
+    radio.send_civ_transaction.assert_awaited_once_with(
+        0x03,
+        sub=None,
+        data=b"",
+        expect="data",
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_expect_none_returns_sent() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock(
+        return_value=SimpleNamespace(
+            status="sent",
+            frame=None,
+            frame_bytes=None,
+        )
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x1A, "sub": 0x05, "data": "015301", "expect": "none"},
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body == {
+        "ok": True,
+        "status": "sent",
+        "result": {"frame": None, "command": None, "sub": None, "data": None},
+    }
+    radio.send_civ_transaction.assert_awaited_once_with(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x53\x01",
+        expect="none",
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_rejects_invalid_expect() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x1A, "data": "015301", "expect": "auto"},
+    )
+
+    assert writer.response_status == 400
+    assert writer.response_body["error"] == "invalid_request"
+    assert "expect must be one of" in writer.response_body["message"]
+    radio.send_civ_transaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_rejects_nonpositive_timeout() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x1A, "data": "015301", "expect": "ack", "timeout_ms": 0},
+    )
+
+    assert writer.response_status == 400
+    assert writer.response_body["error"] == "invalid_request"
+    assert "timeout_ms must be positive" in writer.response_body["message"]
+    radio.send_civ_transaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_rejects_read_only() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0, read_only=True))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x1A, "data": "015301", "expect": "ack"},
+    )
+
+    assert writer.response_status == 403
+    assert writer.response_body["error"] == "read_only"
+    radio.send_civ_transaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_rejects_unsupported_backend() -> None:
+    srv = WebServer(_radio_without_civ(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x1A, "data": "015301", "expect": "ack"},
+    )
+
+    assert writer.response_status == 409
+    assert writer.response_body["error"] == "unsupported_command"
+
+
+@pytest.mark.asyncio
+async def test_http_raw_civ_transaction_timeout_maps_to_504() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock(side_effect=TimeoutError("timed out"))
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/civ/transaction",
+        {"command": 0x03, "expect": "data", "timeout_ms": 10},
+    )
+
+    assert writer.response_status == 504
+    assert writer.response_body["error"] == "transaction_timeout"
+
+
+@pytest.mark.asyncio
 async def test_http_command_rejects_raw_civ_when_backend_does_not_support_it() -> None:
     srv = WebServer(_radio_without_civ(), WebConfig(host="127.0.0.1", port=0))
 


### PR DESCRIPTION
## Summary

- Adds scoped raw CI-V transactions via `POST /api/v1/civ/transaction` with explicit `expect` modes: `none`, `ack`, and `data`.
- Adds a CI-V ownership guard so response-capable transactions quiesce cooperating pollers and conflict cleanly with external CAT sessions.
- Reuses the existing CI-V RX pump and `CivRequestTracker`, including deterministic NAK handling for data transactions and stale ACK backlog protection.
- Keeps `/api/v1/commands` and `/api/v1/commands/batch` fire-and-forget; batch transaction support remains deferred.
- Updates web API docs, Web UI guide, changelog, and internals notes.

Closes #1620.
Closes #1621.
Closes #1622.
Closes #1623.
Closes #1626.
Part of #1619.

## Verification

- `uv run pytest tests/test_raw_civ_transaction.py tests/test_web_command_batch_http.py tests/test_hamlib_bridge.py tests/test_poller.py -q --tb=short` → 76 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → 5883 passed, 57 skipped, 3 deselected, 9 xfailed, 1 xpassed
- `uv run pytest tests/ -q --tb=short` → 6113 passed, 112 skipped, 3 deselected, 9 xfailed, 1 xpassed
- `uv run ruff check src/ tests/ docs/CHANGELOG.md` → passed
- `uv run mypy src/rigplane/runtime/radio.py src/rigplane/runtime/_civ_rx.py src/rigplane/web/server.py src/rigplane/web/web_routing.py` → passed
- `uv run mkdocs build --strict` → passed; existing MkDocs/material warning and excluded-link info messages only

## Review

Independent sub-agent review found and fixed initial matcher blockers, then re-reviewed current diff with `Agent Review: PASS`.