### PR TITLE
fix(MOR-165): align audio TX PCM signatures to satisfy mypy

### DIFF
--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -454,10 +454,19 @@ class _IcomSerialRadioBase(CoreRadio):
     async def start_audio_tx_pcm(
         self,
         *,
-        sample_rate: int = 48000,
-        channels: int = 1,
-        frame_ms: int = 20,
+        sample_rate: int | None = None,
+        channels: int | None = None,
+        frame_ms: int | None = None,
     ) -> None:
+        # Signature mirrors the base ``AudioRuntimeMixin`` contract (``int |
+        # None``) so subclassing does not violate the Liskov substitution
+        # principle; ``None`` resolves to the serial-path defaults.
+        if sample_rate is None:
+            sample_rate = 48000
+        if channels is None:
+            channels = 1
+        if frame_ms is None:
+            frame_ms = 20
         for name, value in (
             ("sample_rate", sample_rate),
             ("channels", channels),

--- a/src/rigplane/backends/icom7610/serial.py
+++ b/src/rigplane/backends/icom7610/serial.py
@@ -62,10 +62,19 @@ class Icom7610SerialRadio(_IcomSerialRadioBase):
     async def start_audio_tx_pcm(
         self,
         *,
-        sample_rate: int = 48000,
-        channels: int = 1,
-        frame_ms: int = 20,
+        sample_rate: int | None = None,
+        channels: int | None = None,
+        frame_ms: int | None = None,
     ) -> None:
+        # Signature mirrors the base ``AudioRuntimeMixin`` contract (``int |
+        # None``) so subclassing does not violate the Liskov substitution
+        # principle; ``None`` resolves to the serial-path defaults.
+        if sample_rate is None:
+            sample_rate = 48000
+        if channels is None:
+            channels = 1
+        if frame_ms is None:
+            frame_ms = 20
         for name, value in (
             ("sample_rate", sample_rate),
             ("channels", channels),

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -215,13 +215,17 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         if frame_ms is None:
             frame_ms = 20
 
-        for name, value in (
-            ("sample_rate", sample_rate),
-            ("channels", channels),
-            ("frame_ms", frame_ms),
-        ):
-            if isinstance(value, bool) or not isinstance(value, int):
-                raise TypeError(f"{name} must be an int, got {type(value).__name__}.")
+        # Explicit per-arg validation (rather than a loop) so the type checker
+        # can narrow each value from ``int | None`` to ``int`` for the format
+        # construction and the ``_pcm_tx_fmt`` tuple below.
+        if isinstance(sample_rate, bool) or not isinstance(sample_rate, int):
+            raise TypeError(
+                f"sample_rate must be an int, got {type(sample_rate).__name__}."
+            )
+        if isinstance(channels, bool) or not isinstance(channels, int):
+            raise TypeError(f"channels must be an int, got {type(channels).__name__}.")
+        if isinstance(frame_ms, bool) or not isinstance(frame_ms, int):
+            raise TypeError(f"frame_ms must be an int, got {type(frame_ms).__name__}.")
 
         self._check_connected()
 

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -534,3 +534,27 @@ async def test_serial_tx_default_uses_mono_channels() -> None:
     assert usb_audio.tx_start_kwargs.get("channels") == 1
     await radio.stop_audio_tx_pcm()
     await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_tx_accepts_none_args_resolving_to_defaults() -> None:
+    """Explicit None args resolve to serial defaults (LSP parity with base).
+
+    The base ``AudioRuntimeMixin.start_audio_tx_pcm`` accepts ``int | None``;
+    the serial override must too, so a base-typed caller passing ``None`` does
+    not hit a ``TypeError``.  ``None`` resolves to sample_rate=48000,
+    frame_ms=20, channels=1 (USB CODEC mono clamp).
+    """
+    usb_audio = _FakeUsbAudioDriver()
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=usb_audio,
+    )
+    await radio.connect()
+    await radio.start_audio_tx_pcm(sample_rate=None, channels=None, frame_ms=None)
+    assert usb_audio.tx_start_kwargs.get("sample_rate") == 48000
+    assert usb_audio.tx_start_kwargs.get("frame_ms") == 20
+    assert usb_audio.tx_start_kwargs.get("channels") == 1
+    await radio.stop_audio_tx_pcm()
+    await radio.disconnect()


### PR DESCRIPTION
## What

Part of **MOR-165** (mypy `src/` hygiene), **group B** — the only group that
touches the audio TX contract. Trivial typing groups (A: PIL stubs, C: CLI,
D: one-liners) will follow in a separate PR.

`start_audio_tx_pcm` on the Icom serial backends (`_icom_serial_base.py`,
`icom7610/serial.py`) narrowed `sample_rate` / `channels` / `frame_ms` to
`int`, while the base `AudioRuntimeMixin.start_audio_tx_pcm` declares them
`int | None` (resolving `None` → contract defaults). That is a Liskov
substitution violation: a base-typed caller passing `None` would hit a runtime
`TypeError` on the subclass.

## Changes

- **Backends** (`_icom_serial_base.py`, `icom7610/serial.py`): widen the
  override signatures to `int | None` and resolve `None` → serial defaults
  (`48000` / `1` / `20`), matching the base contract. Existing validation,
  the mono-channel clamp (GH#1382), and the frame-size check are unchanged.
- **Base mixin** (`_audio_runtime_mixin.py`): replace the loop-based arg
  validation with explicit per-arg checks so mypy narrows each value from
  `int | None` to `int` for `PcmAudioFormat` and the `_pcm_tx_fmt` tuple.
  Same `TypeError` messages, same behaviour.
- **Test**: add `test_serial_tx_accepts_none_args_resolving_to_defaults`
  locking the LSP-parity `None`-resolution behaviour.

## Verification

- `mypy src/`: clears the 9 group-B errors (mixin + both serial overrides).
- `ruff check src/ tests/`: clean.
- `pytest tests/ --ignore=tests/integration`: 5915 passed, 0 failures.

No protocol/transport changes. Behaviour preserved for all previously valid
inputs; `None` on the serial backend now resolves to defaults instead of
raising (the LSP-correct behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)