### PR TITLE
feat(MOR-170): distinct X6200 profile + discovery hwid disambiguation vs IC-705

### DIFF
--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -1,0 +1,346 @@
+# Rig Configuration — Xiegu X6200
+#
+# Xiegu X6200 ultra-portable HF/50MHz transceiver.
+# Protocol: CI-V (subset of standard Icom CI-V, similar to X6100 family).
+#
+# Sources of truth (cross-referenced):
+#   1. Radioddity "Xiegu X6200 CI-V implementation V1.0.6" (firmware V1.0.6).
+#      All commands below come from the documented Table 1 (parts 1-5),
+#      pages 5-9 of that PDF.
+#   2. Hamlib master ``rigs/icom/xiegu.c`` — ``x6200_caps`` reuses the same
+#      ``x6100_priv_caps`` struct (line ~690), confirming X6100 and X6200
+#      share the same CI-V personality at the protocol level even though
+#      they're separate Hamlib ``RIG_MODEL_*`` entries.
+#
+# History: MOR-170. Filed after the IC-705 profile (which X6200 was
+# misidentified as by default — both default to CI-V address 0xA4) drove
+# the radio's display into a flicker → wedge state on real hardware.
+# The X6200 documented CI-V envelope is narrower than IC-705's, and
+# crucially does NOT include the CI-V power command 0x18; this profile
+# therefore omits ``power_on`` / ``power_off`` entirely so the runtime
+# cannot send 0x18 on behalf of an X6200.
+
+[radio]
+id = "xiegu_x6200"
+model = "X6200"
+civ_addr = 0xA4
+receiver_count = 1
+has_lan = false
+has_wifi = true
+# PDF page 4: "For CAT control, a speed of 19.200 bps on the SERIAL-B port
+# is used." SERIAL-A at up to 115200 is the terminal port, not CAT.
+default_baud = 19200
+
+[protocol]
+type = "civ"
+address = 0xA4
+
+[capabilities]
+# Aligned to Hamlib's ``X108G_LEVELS`` / ``X108G_FUNCS`` envelope
+# (xiegu.c lines 52, 54) intersected with what the Radioddity X6200 PDF
+# explicitly documents as supported by firmware V1.0.6. Intentionally
+# narrower than the IC-705 envelope:
+#   - no ``power_control`` (no documented CI-V 0x18)
+#   - no ``scope`` (no documented 0x27 family)
+#   - no ``filter_width`` SET (PDF table 5 documents widths but encoding
+#     is the segmented BCD index family; mirror x6100.toml's "feature not
+#     advertised until tables are confirmed on hardware" stance — see
+#     issue #1159 referenced in x6100.toml)
+features = [
+    "audio",
+    "af_level",
+    "rf_gain",
+    "squelch",
+    "attenuator",
+    "preamp",
+    "nb",
+    "nr",
+    "notch",
+    "pbt",
+    "tx",
+    "split",
+    "vox",
+    "compressor",
+    "cw",
+    "break_in",
+    "rit",
+    "xit",
+    "tuner",
+    "meters",
+    "repeater_tone",
+    "tsql",
+    "data_mode",
+    "scan",
+    "dial_lock",
+    "agc",
+]
+
+# PDF page 10 (Table 3 — Mode, Data & filter bandwidth) documents:
+# LSB, LSB-D, USB, USB-D, AM, CW, NFM, CWR. The ``-D`` variants are the
+# data-mode flavours selected via byte 2 of mode commands 0x26 0x00/0x01.
+[modes]
+list = ["USB", "LSB", "CW", "CW-R", "AM", "FM", "RTTY", "DIGI"]
+
+[filters]
+list = ["FIL1", "FIL2", "FIL3"]
+
+[vfo]
+scheme = "ab"
+
+# PDF page 5: ``0x11 0x00`` (off) / ``0x11 0x01`` (on) — binary toggle.
+[attenuator]
+values = [0, 1]
+
+# PDF page 8: ``0x16 0x02 0x00`` / ``0x16 0x02 0x01`` — binary toggle.
+[preamp]
+values = [0, 1]
+
+# PDF page 8: ``0x16 0x12 0x00..0x03`` — off / fast / slow / auto.
+[agc]
+modes = [0, 1, 2, 3]
+labels = { "0" = "OFF", "1" = "FAST", "2" = "SLOW", "3" = "AUTO" }
+
+[controls.attenuator]
+style = "toggle"
+
+# Level control ranges — CI-V compatible (Xiegu X6200).
+# Every "raw_min/raw_max" pair below is documented in the PDF as
+# "BCD format 0-255" (pages 6-7).
+[controls.pbt_inner]
+raw_min = 0
+raw_max = 255
+raw_center = 128
+display_min = -1200
+display_max = 1200
+display_unit = "Hz"
+
+[controls.pbt_outer]
+raw_min = 0
+raw_max = 255
+raw_center = 128
+display_min = -1200
+display_max = 1200
+display_unit = "Hz"
+
+[controls.af_level]
+raw_min = 0
+raw_max = 255
+
+[controls.rf_gain]
+raw_min = 0
+raw_max = 255
+
+[controls.squelch]
+raw_min = 0
+raw_max = 255
+
+[controls.nr_level]
+raw_min = 0
+raw_max = 255
+
+[controls.nb_level]
+raw_min = 0
+raw_max = 255
+
+[controls.compressor_level]
+raw_min = 0
+raw_max = 255
+
+# PDF page 6: "0=400Hz, 255=1200Hz" for CW sidetone.
+[controls.cw_pitch]
+raw_min = 0
+raw_max = 255
+display_min = 400
+display_max = 1200
+display_unit = "Hz"
+
+[controls.rit]
+raw_min = -9999
+raw_max = 9999
+raw_center = 0
+display_min = -9999
+display_max = 9999
+display_unit = "Hz"
+
+# Same HF coverage envelope as X6100 (Xiegu HF/50MHz portables).
+[[freq_ranges.ranges]]
+label = "HF"
+start_hz = 100000
+end_hz = 54000000
+
+[[freq_ranges.ranges.bands]]
+name = "160m"
+start_hz = 1800000
+end_hz = 2000000
+default_hz = 1825000
+
+[[freq_ranges.ranges.bands]]
+name = "80m"
+start_hz = 3500000
+end_hz = 3800000
+default_hz = 3600000
+
+[[freq_ranges.ranges.bands]]
+name = "40m"
+start_hz = 7000000
+end_hz = 7200000
+default_hz = 7100000
+
+[[freq_ranges.ranges.bands]]
+name = "30m"
+start_hz = 10100000
+end_hz = 10150000
+default_hz = 10125000
+
+[[freq_ranges.ranges.bands]]
+name = "20m"
+start_hz = 14000000
+end_hz = 14350000
+default_hz = 14200000
+
+[[freq_ranges.ranges.bands]]
+name = "17m"
+start_hz = 18068000
+end_hz = 18168000
+default_hz = 18100000
+
+[[freq_ranges.ranges.bands]]
+name = "15m"
+start_hz = 21000000
+end_hz = 21450000
+default_hz = 21200000
+
+[[freq_ranges.ranges.bands]]
+name = "12m"
+start_hz = 24890000
+end_hz = 24990000
+default_hz = 24940000
+
+[[freq_ranges.ranges.bands]]
+name = "10m"
+start_hz = 28000000
+end_hz = 29700000
+default_hz = 28500000
+
+[[freq_ranges.ranges.bands]]
+name = "6m"
+start_hz = 50000000
+end_hz = 54000000
+default_hz = 51000000
+
+[[freq_ranges.ranges]]
+label = "WFM"
+start_hz = 88000000
+end_hz = 108000000
+
+[[freq_ranges.ranges]]
+label = "Air"
+start_hz = 108000000
+end_hz = 136000000
+
+# ── CI-V Commands ────────────────────────────────────────────────
+# Only opcodes documented in Radioddity X6200 CI-V V1.0.6.
+# NOTE: ``power_on`` / ``power_off`` are INTENTIONALLY OMITTED — CI-V
+# 0x18 is not in the X6200 documented command set, and sending it from
+# the IC-705 profile is the suspected wedge trigger that motivated this
+# file. Do NOT add a 0x18 mapping here without re-validating on hardware.
+[commands]
+
+# Frequency / mode (compatible Icom CI-V subset — PDF page 4 example)
+get_freq         = [0x03]
+set_freq         = [0x05]
+get_mode         = [0x04]
+set_mode         = [0x06]
+
+# Get receiver frequency range — PDF page 5
+get_band_edge_freq = [0x02]
+
+# VFO selection / swap — PDF page 5 (0x07 family)
+get_vfo          = [0x07]
+set_vfo          = [0x07]
+
+# Split — PDF page 5 (NOTE: Hamlib xiegu.c contains a comment that the
+# *X6100* rejected ``0x0f 0x01``; the X6200 PDF explicitly documents both
+# ``0x0f 0x00`` (split off) and ``0x0f 0x01`` (split on). If a runtime
+# wedge reappears tied to set_split, audit this entry against firmware.)
+set_split        = [0x0F]
+
+# Attenuator / preamp — PDF pages 5, 8
+get_attenuator   = [0x11]
+set_attenuator   = [0x11]
+get_preamp       = [0x16, 0x02]
+set_preamp       = [0x16, 0x02]
+
+# Levels (gets and sets — PDF pages 6-7, same opcode pair for both
+# directions, distinguished by frame data presence)
+get_af_level     = [0x14, 0x01]
+set_af_level     = [0x14, 0x01]
+get_rf_gain      = [0x14, 0x02]
+set_rf_gain      = [0x14, 0x02]
+get_squelch      = [0x14, 0x03]
+set_squelch      = [0x14, 0x03]
+get_nr_level     = [0x14, 0x06]
+set_nr_level     = [0x14, 0x06]
+get_cw_pitch     = [0x14, 0x09]
+set_cw_pitch     = [0x14, 0x09]
+get_rf_power     = [0x14, 0x0A]
+set_rf_power     = [0x14, 0x0A]
+get_mic_gain     = [0x14, 0x0B]
+set_mic_gain     = [0x14, 0x0B]
+get_key_speed    = [0x14, 0x0C]
+set_key_speed    = [0x14, 0x0C]
+get_nb_level     = [0x14, 0x12]
+set_nb_level     = [0x14, 0x12]
+get_monitor_gain = [0x14, 0x15]
+set_monitor_gain = [0x14, 0x15]
+
+# Meters — PDF page 7 (all returns BCD 0-255 → 0-100%)
+get_s_meter      = [0x15, 0x02]
+get_power_meter  = [0x15, 0x11]
+get_swr          = [0x15, 0x12]
+get_vd_meter     = [0x15, 0x15]
+
+# Functions — PDF page 8 (0x16 family)
+get_agc          = [0x16, 0x12]
+set_agc          = [0x16, 0x12]
+get_nb           = [0x16, 0x22]
+set_nb           = [0x16, 0x22]
+get_dial_lock    = [0x16, 0x50]
+set_dial_lock    = [0x16, 0x50]
+
+# Identification — PDF page 8
+get_transceiver_id = [0x19, 0x00]
+
+# 0x1A family — PDF pages 8-9 (band/spectrum, filter width)
+get_band_spectrum_display = [0x1A, 0x01]
+get_filter_width          = [0x1A, 0x03]
+
+# PTT / tuner — PDF page 9 (0x1C family)
+ptt_on           = [0x1C, 0x00]
+ptt_off          = [0x1C, 0x00]
+get_transceiver_status = [0x1C, 0x00]
+set_transceiver_status = [0x1C, 0x00]
+get_tuner_status = [0x1C, 0x01]
+set_tuner_status = [0x1C, 0x01]
+
+# Xiegu model ID — PDF page 9. Returns 0x6200 on this rig; intended as
+# a positive disambiguator vs Icom CI-V at the same address (IC-705 has
+# no 0x1D 0x19 opcode). Future improvement: probe this in discovery
+# rather than relying on hwid fingerprint.
+get_xiegu_model_id = [0x1D, 0x19]
+
+# Selected / unselected VFO (PDF page 9, 0x25 / 0x26)
+get_selected_freq    = [0x25, 0x00]
+set_selected_freq    = [0x25, 0x00]
+get_unselected_freq  = [0x25, 0x01]
+set_unselected_freq  = [0x25, 0x01]
+get_selected_mode    = [0x26, 0x00]
+set_selected_mode    = [0x26, 0x00]
+get_unselected_mode  = [0x26, 0x01]
+set_unselected_mode  = [0x26, 0x01]
+
+# Protocol ack/nak echoes (Icom common, used by transport-level matchers)
+get_command_error_fa = [0xFA]
+get_command_ok_fb    = [0xFB]
+
+[commands.overrides]

--- a/src/rigplane/backends/discovery.py
+++ b/src/rigplane/backends/discovery.py
@@ -542,6 +542,37 @@ async def discover_lan_radios(timeout: float = 3.0) -> list[dict[str, object]]:
     return await asyncio.get_running_loop().run_in_executor(None, _scan)
 
 
+def _resolve_xiegu_x6200_override(
+    address: int, port: SerialPortCandidate
+) -> tuple[str, str] | None:
+    """Disambiguate Xiegu X6200 from Icom IC-705 at the shared CI-V address 0xA4.
+
+    Both rigs default to CI-V address 0xA4 (Hamlib ``rigs/icom/xiegu.c``
+    ``x6100_priv_caps``; Radioddity *X6200 CI-V implementation V1.0.6*
+    PDF page 4). The address probe alone cannot distinguish them, so this
+    helper looks at the USB hardware fingerprint instead:
+
+    - X6200 enumerates over a Nanjing QinHeng / WCH CH342 chip
+      (``VID:PID = 1A86:55D2``) as a composite dual-ACM device with
+      product name ``"USB Dual_Serial"``. IC-705 uses an Icom-made USB
+      controller and never matches that fingerprint.
+    - Either signal alone is sufficient. VID/PID is the strong match;
+      the product-name fallback covers OS-level enumerations where
+      ``vid``/``pid`` were not surfaced by pyserial.
+
+    Returns ``(model_name, profile_id)`` when the fingerprint matches;
+    otherwise ``None`` (the caller falls back to the address-based
+    mapping, which keeps the existing IC-705 behaviour intact). MOR-170.
+    """
+    if address != 0xA4:
+        return None
+    if port.vid == 0x1A86 and port.pid == 0x55D2:
+        return ("X6200", "xiegu_x6200")
+    if port.product and "USB Dual_Serial" in port.product:
+        return ("X6200", "xiegu_x6200")
+    return None
+
+
 async def discover_serial_radios(
     *,
     _open_serial: _OpenSerial | None = None,
@@ -571,6 +602,11 @@ async def discover_serial_radios(
         if civ:
             model = identify_radio(civ.address, civ.model_id)
             profile_id = CIV_PROFILE_MAP.get(civ.address, "")
+            # Hardware-fingerprint override for the IC-705 / X6200 CI-V
+            # address collision (both default to 0xA4). MOR-170.
+            xiegu_override = _resolve_xiegu_x6200_override(civ.address, port)
+            if xiegu_override is not None:
+                model, profile_id = xiegu_override
             results.append(
                 RadioDiscoveryResult(
                     port=civ.port,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -92,6 +92,9 @@ def _make_open(reader: _FakeReader, writer: _FakeWriter):
 
 
 _IC7610_RESPONSE = bytes([0xFE, 0xFE, 0xE0, 0x98, 0x19, 0x00, 0x01, 0x06, 0xFD])
+# IC-705 / X6200 share CI-V address 0xA4; the wire response is identical
+# at the address level — disambiguation is by USB hwid, not CI-V payload.
+_IC705_RESPONSE = bytes([0xFE, 0xFE, 0xE0, 0xA4, 0x19, 0x00, 0x01, 0x05, 0xFD])
 _PROBE_CMD = bytes([0xFE, 0xFE, 0x00, 0xE0, 0x19, 0x00, 0xFD])
 
 
@@ -861,6 +864,105 @@ class TestDiscoverSerialRadios:
         assert r.manufacturer == "Silicon Labs"
         assert r.product == "CP210x USB to UART Bridge"
         assert r.serial_number == "0001"
+
+    @pytest.mark.asyncio
+    async def test_civ_addr_0xA4_with_xiegu_hwid_resolves_to_x6200(self) -> None:
+        """MOR-170: at the shared 0xA4 address, the WCH CH342 VID:PID
+        + ``USB Dual_Serial`` product name must classify as Xiegu X6200,
+        not the address-default IC-705.
+        """
+        reader = _FakeReader([_IC705_RESPONSE])
+        writer = _FakeWriter()
+
+        port = _make_port(
+            "/dev/cu.usbmodem58910181093",
+            "USB Dual_Serial",
+            "USB VID:PID=1A86:55D2 SER=5891018109 LOCATION=0-1.2.4",
+            vid=0x1A86,
+            pid=0x55D2,
+            manufacturer=None,
+            product="USB Dual_Serial",
+            serial_number="5891018109",
+        )
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+        ):
+            results = await discover_serial_radios(
+                _open_serial=_make_open(reader, writer),
+            )
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.protocol == "civ"
+        assert r.address == 0xA4
+        assert r.model == "X6200"
+        assert r.profile_id == "xiegu_x6200"
+        # USB metadata still surfaced unmodified
+        assert r.vid == 0x1A86
+        assert r.pid == 0x55D2
+        assert r.product == "USB Dual_Serial"
+
+    @pytest.mark.asyncio
+    async def test_civ_addr_0xA4_without_xiegu_hwid_stays_ic705(self) -> None:
+        """MOR-170: at 0xA4, ports that do NOT match the X6200 fingerprint
+        must keep classifying as IC-705 — the existing behaviour for
+        actual IC-705 owners is preserved.
+        """
+        reader = _FakeReader([_IC705_RESPONSE])
+        writer = _FakeWriter()
+
+        port = _make_port(
+            "/dev/ttyUSB0",
+            "USB Serial",
+            "USB VID:PID=0C26:0036",
+            vid=0x0C26,
+            pid=0x0036,
+            manufacturer="Icom Inc.",
+            product="IC-705",
+            serial_number="0001",
+        )
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+        ):
+            results = await discover_serial_radios(
+                _open_serial=_make_open(reader, writer),
+            )
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.address == 0xA4
+        assert r.model == "IC-705"
+        assert r.profile_id == "icom_ic705"
+
+    @pytest.mark.asyncio
+    async def test_civ_addr_0xA4_xiegu_product_name_fallback(self) -> None:
+        """MOR-170: even when pyserial does not surface VID/PID (some OSes /
+        permission setups), a ``product`` field containing ``"USB Dual_Serial"``
+        is enough to classify as X6200.
+        """
+        reader = _FakeReader([_IC705_RESPONSE])
+        writer = _FakeWriter()
+
+        port = _make_port(
+            "/dev/cu.usbmodem58910181093",
+            "USB Dual_Serial",
+            "USB Dual_Serial",
+            vid=None,
+            pid=None,
+            product="USB Dual_Serial",
+        )
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+        ):
+            results = await discover_serial_radios(
+                _open_serial=_make_open(reader, writer),
+            )
+
+        assert results[0].model == "X6200"
+        assert results[0].profile_id == "xiegu_x6200"
 
     @pytest.mark.asyncio
     async def test_civ_radio_preserves_usb_audio_resolution_metadata(self) -> None:


### PR DESCRIPTION
## What

Closes the Xiegu X6200 / Icom IC-705 misidentification at the shared CI-V
address `0xA4` that wedged the operator's X6200 during real-hardware testing
(see [MOR-170](https://linear.app/morozsm/issue/MOR-170/) for the full
diagnostic trail).

## Background

Both rigs default to CI-V address `0xA4` (Hamlib `rigs/icom/xiegu.c`
`x6100_priv_caps`; Radioddity *Xiegu X6200 CI-V Implementation V1.0.6*, page 4
verbatim: *"the preamble for all commands is FE FE **A4** 00"*). The existing
address-only auto-detect classified every X6200 as IC-705 and drove it with
the IC-705 profile. On real hardware the rig displayed a flicker per CAT burst
and entered an unresponsive state after 3-4 sequential `rigplane status`
invocations. WSJT-X on the same rig over the same USB cable does NOT cause
this — Hamlib ships a dedicated `RIG_MODEL_X6200` (reuses `x6100_priv_caps`)
with a narrower `X108G_LEVELS` / `X108G_FUNCS` envelope.

## Changes (3 files, +484/-0)

### `rigs/x6200.toml` (new)

Near-copy of `rigs/x6100.toml` with:
- `civ_addr = 0xA4` (X6200/IC-705 collision — Radioddity PDF + Hamlib)
- `default_baud = 19200` (SERIAL-B per PDF page 4 — not 115200, which is
  SERIAL-A terminal speed)
- `[commands]` drawn strictly from PDF Table 1 (parts 1-5)
- **`power_on` / `power_off` INTENTIONALLY OMITTED** — CI-V `0x18` is not
  in the X6200 documented command set and is the leading suspect for the
  wedge if the IC-705 profile path ever sends it on the X6200
- Header comment cross-references both the PDF (with firmware version) and
  Hamlib `xiegu.c` (with line numbers) as joint sources of truth

### `src/rigplane/backends/discovery.py`

New module-level helper `_resolve_xiegu_x6200_override(address, port)` and a
one-line call in `discover_serial_radios` after the address-based lookup.
At address `0xA4`, a port whose USB hwid matches the X6200 fingerprint
(`VID:PID=1A86:55D2` — Nanjing QinHeng / WCH CH342 — or product name
containing `"USB Dual_Serial"`) classifies as `xiegu_x6200` instead of
`icom_ic705`. All other 0xA4 ports keep the existing IC-705 behaviour.
Other addresses are unaffected.

### `tests/test_discovery.py`

Three regression tests in `TestDiscoverSerialRadios`:
1. X6200 fingerprint at 0xA4 → `model="X6200"`, `profile_id="xiegu_x6200"`.
2. Non-Xiegu hwid at 0xA4 → `model="IC-705"`, `profile_id="icom_ic705"` —
   existing IC-705 owners unaffected.
3. Product-name-only fallback (no VID/PID surfaced by pyserial) → X6200.

## Verification

- `uv run pytest tests/ --ignore=tests/integration`: **5947 passed, 0 failures**
- `uv run mypy --strict src/rigplane/web` (the CI gate): clean
- `uv run ruff check src/ tests/`: clean
- New TOML round-trips through `tomllib.load`; rig_loader picks up 8 profiles
  (was 7) including "X6200"

**Not verified on live hardware in this PR** — live X6200 smoke is gated on
operator OK after merge (the radio just recovered from a wedge during the
diagnostic session; defensive posture is to ship the test-verified fix first,
then run the live smoke with the new profile).

## Pre-existing main state (NOT this PR)

`uv run mypy src/` reports one error introduced by MOR-169 (#1627):
`src/rigplane/runtime/_civ_rx.py:397: error: Redundant cast to "bytes"`.
Reproduced on `origin/main` with this PR's changes stashed — not a regression
from this PR. `mypy src/` is not a CI gate (only the strict `web` gate is),
so it does not block this PR; flagging for a follow-up.

## Out of scope (separate follow-up tickets — see MOR-170 thread)

1. **CI-V-level disambiguation via `0x1D 0x19`** (Xiegu model ID probe,
   returns `0x6200` on this rig per PDF page 9). Firmware-authored,
   hwid-independent, survives future USB-chip changes.
2. **Connection-lifecycle audit** for stray `0x18` sends — guard behind a
   per-profile capability flag so future conservative profiles can't trip
   the same wedge.
3. **`rigs/x6100.toml` civ_addr** — currently `0x70`, Hamlib says `0xA4` for
   the same rig family. Needs validation on actual X6100 hardware before
   changing; operator only has X6200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)