### PR TITLE
fix(MOR-170): register Xiegu X6200 in CLI model registry (no silent IC-7610 fallback)

### DIFF
--- a/src/rigplane/backends/factory.py
+++ b/src/rigplane/backends/factory.py
@@ -84,7 +84,14 @@ def create_radio(config: BackendConfig) -> Radio:
             | type[Ic9700SerialRadio]
             | type[Icom7610SerialRadio]
         )
-        if model == "IC-705":
+        if model in ("IC-705", "X6200"):
+            # X6200 shares the IC-705 CI-V personality (same default address
+            # 0xA4, same transport class is fine — see MOR-170, Hamlib's
+            # x6100_priv_caps reused by both x6100_caps and x6200_caps).
+            # The actual command set comes from the loaded rigs/x6200.toml
+            # via the ``model="X6200"`` argument passed through to the
+            # serial class constructor; the transport machinery here is
+            # transport-only, not personality-bearing.
             serial_class = Ic705SerialRadio
         elif model == "IC-7300":
             serial_class = Ic7300SerialRadio

--- a/src/rigplane/runtime/radios.py
+++ b/src/rigplane/runtime/radios.py
@@ -70,6 +70,20 @@ RADIOS: dict[str, RadioModel] = {
         civ_addr=0x8E,
         receivers=2,
     ),
+    # Xiegu X6200: shares CI-V address 0xA4 with Icom IC-705 by factory
+    # default (Radioddity X6200 CI-V Implementation V1.0.6, page 4; Hamlib
+    # rigs/icom/xiegu.c x6100_priv_caps). MOR-170 added a distinct profile
+    # (rigs/x6200.toml) and hwid-based discovery disambiguation; this entry
+    # makes ``--model X6200`` resolve in the parallel hardcoded registry so
+    # the CLI path stops silently falling back to IC-7610. The discovery-
+    # time override on address 0xA4 (discovery._resolve_xiegu_x6200_override)
+    # remains the source of truth for *auto-detected* radios.
+    "X6200": RadioModel(
+        name="X6200",
+        civ_addr=0xA4,
+        has_lan=False,
+        has_wifi=True,
+    ),
 }
 
 

--- a/tests/test_ic705_backend.py
+++ b/tests/test_ic705_backend.py
@@ -32,6 +32,30 @@ def test_ic7610_factory_creates_correct_backend():
     assert not isinstance(radio, Ic705SerialRadio)
 
 
+def test_x6200_factory_routes_to_ic705_class_without_warning(caplog):
+    """Regression for MOR-170: ``--model X6200`` must route to the IC-705
+    serial transport class (X6200 shares the IC-705 CI-V personality —
+    Hamlib ``x6100_priv_caps`` is reused by ``x6200_caps``) and MUST NOT
+    log the "Unknown model … defaulting to IC-7610" fallback warning.
+
+    Behaviour separation from IC-705 happens via the loaded
+    ``rigs/x6200.toml`` profile, not via a distinct serial class.
+    """
+    config = SerialBackendConfig(
+        device="/dev/ttyUSB0",
+        model="X6200",
+    )
+    with caplog.at_level("WARNING", logger="rigplane.backends.factory"):
+        radio = create_radio(config)
+    assert isinstance(radio, Ic705SerialRadio)
+    assert radio.model == "X6200"
+    # No silent fallback to IC-7610.
+    assert not any(
+        "defaulting to IC-7610" in rec.getMessage() for rec in caplog.records
+    )
+    assert not any("Unknown model" in rec.getMessage() for rec in caplog.records)
+
+
 def test_ic705_backend_default_model():
     """IC-705 backend should default model to IC-705."""
     radio = Ic705SerialRadio(device="/dev/ttyUSB0")

--- a/tests/test_radios.py
+++ b/tests/test_radios.py
@@ -38,15 +38,37 @@ class TestRadioModels:
         r = RADIOS["IC-R8600"]
         assert r.civ_addr == 0x96
 
-    def test_all_have_lan(self) -> None:
-        for name, r in RADIOS.items():
-            assert r.has_lan, f"{name} should have LAN"
+    def test_x6200(self) -> None:
+        # Xiegu X6200 shares CI-V address 0xA4 with IC-705; the discovery
+        # path disambiguates by USB hwid (see MOR-170). Has WiFi, no LAN.
+        r = RADIOS["X6200"]
+        assert r.civ_addr == 0xA4
+        assert r.has_lan is False
+        assert r.has_wifi is True
+        assert r.receivers == 1
+
+    def test_lan_capable_radios(self) -> None:
+        # All Icom rigs in this registry are LAN-capable. The Xiegu X6200
+        # is the first registry entry that is USB-only; documented as the
+        # exception so future non-LAN rigs don't trip this assertion.
+        lan_capable = set(RADIOS) - {"X6200"}
+        for name in lan_capable:
+            assert RADIOS[name].has_lan, f"{name} should have LAN"
+        assert RADIOS["X6200"].has_lan is False
 
 
 class TestGetCivAddr:
     def test_known_model(self) -> None:
         assert get_civ_addr("IC-7610") == 0x98
         assert get_civ_addr("IC-705") == 0xA4
+
+    def test_x6200(self) -> None:
+        # Regression for MOR-170: the CLI ``--model X6200`` path used to
+        # fall through to "Unknown model, defaulting to IC-7610" because
+        # X6200 wasn't in the RADIOS registry.
+        assert get_civ_addr("X6200") == 0xA4
+        assert get_civ_addr("x6200") == 0xA4
+        assert get_civ_addr("X-6200") == 0xA4
 
     def test_case_insensitive(self) -> None:
         assert get_civ_addr("ic-7300") == 0x94


### PR DESCRIPTION
PR-B in the MOR-170 trail. PR #1630 (PR-A) added the X6200 profile (`rigs/x6200.toml`) and discovery-time hwid disambiguation, but the CLI `--model X6200` flag still silently fell back to IC-7610 because of a parallel hardcoded registry (`runtime/radios.RADIOS` + `backends/factory.create_radio` model→class dispatch). This PR closes that hole.

## Changes (4 files, +71/-4)

- `src/rigplane/runtime/radios.py`: add `X6200` to `RADIOS` with `civ_addr=0xA4`, `has_lan=False`, `has_wifi=True`. Address shared with IC-705 by design — matches Radioddity X6200 CI-V V1.0.6 spec page 4 and Hamlib `xiegu.c` `x6100_priv_caps` (reused by `x6200_caps`). Discovery-time override (`discovery._resolve_xiegu_x6200_override`) remains source of truth for auto-detected radios.
- `src/rigplane/backends/factory.py`: route `model="X6200"` through the existing `Ic705SerialRadio` transport class via `if model in ("IC-705", "X6200"):`. Behaviour separation comes from the loaded `rigs/x6200.toml` profile (via the `model="X6200"` constructor argument), not from a distinct serial class.
- `tests/test_radios.py`: add `TestRadioModels.test_x6200` (registry fields) and `TestGetCivAddr.test_x6200` (normalized lookup); rename `test_all_have_lan` → `test_lan_capable_radios` (X6200 is the first USB-only registry entry).
- `tests/test_ic705_backend.py`: add `test_x6200_factory_routes_to_ic705_class_without_warning` — full regression test that `SerialBackendConfig(model="X6200")` returns `Ic705SerialRadio` AND the "Unknown model … defaulting to IC-7610" warning is NOT logged.

## Verification (clean worktree)

- `uv run pytest tests/ --ignore=tests/integration` — **5950 passed, 7 skipped, 0 failures**
- `uv run mypy --strict src/rigplane/web` — clean
- `uv run ruff check src/ tests/` — clean

Not verified on live hardware in this PR; gated on operator OK after merge.

## Follow-up

The parallel registries (`RADIOS` / `SERIAL_RADIO_MAP` / `CIV_PROFILE_MAP` in `runtime/radios.py` vs `rigs/*.toml`) remain a double-edit hazard. Long-term fix is single source of truth (derive dicts from `rigs/*.toml` at import time, or delete them). Filed as MOR-171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)