### PR TITLE
fix(MOR-172): drop LAN OpenClose packets on serial CI-V wire (X6200 wedge)

### DIFF
--- a/src/rigplane/backends/icom7610/drivers/serial_session.py
+++ b/src/rigplane/backends/icom7610/drivers/serial_session.py
@@ -13,6 +13,12 @@ _CIV_HEADER_SIZE = 0x15
 _CLIENT_ID = 0x00010001
 _RADIO_ID = 0x00000098
 
+# Type marker at offset 0x10-0x11 (little-endian u16) for LAN-style OpenClose
+# session-control packets emitted by ``_send_open_close_on_transport`` in
+# ``runtime/_control_phase.py``. These packets have no CI-V payload and must
+# never be forwarded onto a serial CI-V wire — see MOR-172.
+_LAN_OPENCLOSE_TYPE_MARKER = 0x01C0
+
 
 class _LifecycleCivLink(CivLink, Protocol):
     """CivLink with connect/disconnect lifecycle required by serial session."""
@@ -29,13 +35,33 @@ class _LifecycleCivLink(CivLink, Protocol):
 
 
 def _unwrap_civ_frame(packet: bytes) -> bytes:
-    """Extract CI-V frame payload from shared-core UDP envelope."""
+    """Extract CI-V frame payload from shared-core UDP envelope.
+
+    Session-control packets such as OpenClose share the envelope layout
+    but stamp the LAN type marker ``0x01C0`` at offset 0x10 (LE u16) and
+    carry no CI-V payload. Note that the marker's high byte spills into
+    offsets 0x11-0x12, so a payload-length-only check misreads it as
+    ``payload_len = 1`` and extracts the trailing close-flag byte — which
+    the serial codec then wraps as a malformed CI-V frame ``FE FE 00 FD``
+    that wedged the Xiegu X6200's CI-V parser on every session close
+    (MOR-172). Reject the marker explicitly.
+
+    DATA packets can come from either :func:`_wrap_civ_frame` (byte 0x10
+    = 0x00) or from runtime ``_civ_rx._wrap_civ`` (byte 0x10 = 0xC1);
+    both layouts must pass through. Hence we gate on the OpenClose
+    marker exactly, not on "byte 0x10 not zero".
+    """
     if len(packet) <= _CIV_HEADER_SIZE:
         return b""
+    if (
+        len(packet) >= 0x12
+        and int.from_bytes(packet[0x10:0x12], "little") == _LAN_OPENCLOSE_TYPE_MARKER
+    ):
+        return b""
     payload_len = int.from_bytes(packet[0x11:0x13], "little", signed=False)
-    start = _CIV_HEADER_SIZE
     if payload_len <= 0:
-        return packet[start:]
+        return b""
+    start = _CIV_HEADER_SIZE
     end = start + payload_len
     if end > len(packet):
         return packet[start:]
@@ -133,7 +159,23 @@ class SerialCivTransport:
         return None
 
     async def send_tracked(self, data: bytes) -> None:
-        frame = _unwrap_civ_frame(bytes(data))
+        # MOR-172: ``_send_open_close_on_transport`` in ``_control_phase.py``
+        # emits a LAN-style binary OpenClose packet (type marker 0x01C0 at
+        # offset 0x10) that the shared-core lifecycle calls on session
+        # open/close. The serial CI-V wire has no LAN session-control layer;
+        # these packets carry no CI-V payload and must be dropped here, not
+        # forwarded. ``_unwrap_civ_frame`` already short-circuits non-DATA
+        # packets as a backstop (it gates on byte 0x10), but matching the
+        # type marker explicitly here keeps the intent self-documenting
+        # and resistant to future changes in the LAN packet layout.
+        data_bytes = bytes(data)
+        if (
+            len(data_bytes) >= 0x12
+            and int.from_bytes(data_bytes[0x10:0x12], "little")
+            == _LAN_OPENCLOSE_TYPE_MARKER
+        ):
+            return
+        frame = _unwrap_civ_frame(data_bytes)
         if not frame:
             return
         try:

--- a/tests/test_serial_session.py
+++ b/tests/test_serial_session.py
@@ -1,0 +1,182 @@
+"""Tests for serial session transports — regression coverage for MOR-172.
+
+MOR-172: the shared-core ``_send_open_close_on_transport`` in
+``runtime/_control_phase.py`` emits a LAN-style binary OpenClose packet
+(type marker 0x01C0) on every session open/close. On the serial backend the
+serial transport adapter must drop those packets — forwarding them produced
+a malformed CI-V frame ``FE FE 00 FD`` on the wire that wedged the Xiegu
+X6200's CI-V parser for ~5-10s.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from rigplane.backends.icom7610.drivers.serial_session import (
+    _CIV_HEADER_SIZE,
+    _LAN_OPENCLOSE_TYPE_MARKER,
+    SerialCivTransport,
+    _unwrap_civ_frame,
+    _wrap_civ_frame,
+)
+
+
+def _build_openclose_packet(*, open_stream: bool) -> bytes:
+    """Build the exact 22-byte OpenClose packet that
+    ``_send_open_close_on_transport`` emits.
+    """
+    pkt = bytearray(0x16)
+    struct.pack_into("<I", pkt, 0x00, 0x16)
+    struct.pack_into("<H", pkt, 0x10, _LAN_OPENCLOSE_TYPE_MARKER)
+    pkt[0x15] = 0x04 if open_stream else 0x00
+    return bytes(pkt)
+
+
+class _RecordingCivLink:
+    """Minimal CivLink that records what got sent through it."""
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+        self.connected = True
+        self.ready = True
+        self.healthy = True
+
+    async def send(self, frame: bytes) -> None:
+        self.sent.append(bytes(frame))
+
+    async def receive(self, *, timeout: float = 5.0) -> bytes:  # pragma: no cover
+        raise NotImplementedError
+
+    async def connect(self) -> None:  # pragma: no cover
+        pass
+
+    async def disconnect(self) -> None:  # pragma: no cover
+        pass
+
+
+@pytest.mark.asyncio
+async def test_send_tracked_drops_openclose_close_packet() -> None:
+    """MOR-172: an OpenClose(close) LAN packet must NOT be forwarded to the
+    serial CI-V wire. Forwarding it produced ``FE FE 00 FD`` which wedged X6200.
+    """
+    link = _RecordingCivLink()
+    transport = SerialCivTransport(link)
+    pkt = _build_openclose_packet(open_stream=False)
+    assert len(pkt) == 0x16
+    # Sanity: the type marker really is at 0x10 in this packet shape.
+    assert int.from_bytes(pkt[0x10:0x12], "little") == _LAN_OPENCLOSE_TYPE_MARKER
+
+    await transport.send_tracked(pkt)
+
+    assert link.sent == [], f"OpenClose(close) leaked to serial CI-V wire: {link.sent}"
+
+
+@pytest.mark.asyncio
+async def test_send_tracked_drops_openclose_open_packet() -> None:
+    """Same as close, but for the open variant (pkt[0x15]=0x04). Symmetry
+    matters — both directions of the session-control lifecycle must be
+    blocked on serial.
+    """
+    link = _RecordingCivLink()
+    transport = SerialCivTransport(link)
+    pkt = _build_openclose_packet(open_stream=True)
+
+    await transport.send_tracked(pkt)
+
+    assert link.sent == [], f"OpenClose(open) leaked to serial CI-V wire: {link.sent}"
+
+
+@pytest.mark.asyncio
+async def test_send_tracked_forwards_real_civ_frame() -> None:
+    """A real CI-V data frame (wrapped via ``_wrap_civ_frame``) must still be
+    forwarded unchanged — the OpenClose guard must not over-shoot.
+    """
+    link = _RecordingCivLink()
+    transport = SerialCivTransport(link)
+    civ_frame = bytes([0xFE, 0xFE, 0xA4, 0xE0, 0x03, 0xFD])  # get_freq to 0xA4
+    packet = _wrap_civ_frame(civ_frame, seq=0)
+    # Sanity: the wrapper packet does NOT have the OpenClose type marker.
+    assert int.from_bytes(packet[0x10:0x12], "little") != _LAN_OPENCLOSE_TYPE_MARKER
+
+    await transport.send_tracked(packet)
+
+    assert link.sent == [civ_frame], (
+        f"Real CI-V frame should be forwarded as-is, got {link.sent}"
+    )
+
+
+def test_unwrap_civ_frame_returns_empty_on_openclose_packet() -> None:
+    """MOR-172 root-cause fix: ``_unwrap_civ_frame`` must NOT extract any
+    bytes from an OpenClose packet. The type marker ``0x01C0`` at offset
+    0x10 (LE u16) lays its low byte ``0xC0`` over byte 0x10 and its high
+    byte ``0x01`` over byte 0x11 — which used to be misread as
+    ``payload_len = 1`` by the previous code, causing extraction of the
+    single close-flag byte at offset 0x15 and downstream emission of the
+    wedge frame ``FE FE 00 FD``.
+    """
+    pkt = _build_openclose_packet(open_stream=False)
+    # Sanity: byte 0x10 is the low byte of type marker 0x01C0 = 0xC0,
+    # NOT 0x00 (the DATA type indicator). This is the discriminator.
+    assert pkt[0x10] == 0xC0
+    # And the OLD bug: reading payload_len from offsets 0x11-0x12 gives
+    # 0x01 (the high byte of the type marker), which the previous code
+    # would have treated as a valid 1-byte payload.
+    assert int.from_bytes(pkt[0x11:0x13], "little") == 0x01
+
+    assert _unwrap_civ_frame(pkt) == b"", (
+        "OpenClose packet (byte 0x10 != 0x00) must unwrap to b'', not "
+        "spilled bytes from the close-flag region"
+    )
+
+
+def test_unwrap_civ_frame_returns_empty_on_zero_payload_data_packet() -> None:
+    """A DATA packet (byte 0x10 == 0x00) with payload_len = 0 still
+    unwraps to ``b""``. Belt-and-braces for the original ``payload_len <= 0``
+    branch that the previous regression test (incorrectly) tried to exercise.
+    """
+    pkt = bytearray(_CIV_HEADER_SIZE + 1)  # 22 bytes, all zero
+    # byte 0x10 = 0 (DATA); bytes 0x11-0x12 = 0 (payload_len = 0)
+    assert pkt[0x10] == 0x00
+    assert int.from_bytes(pkt[0x11:0x13], "little") == 0
+
+    assert _unwrap_civ_frame(bytes(pkt)) == b""
+
+
+def test_unwrap_civ_frame_extracts_real_civ_payload() -> None:
+    """Non-zero payload_len still extracts the CI-V frame correctly — the
+    fix must not regress the normal path. ``_wrap_civ_frame`` here is the
+    serial_session-side wrap (``pkt[0x10] = 0x00``).
+    """
+    civ_frame = bytes([0xFE, 0xFE, 0xA4, 0xE0, 0x03, 0xFD])
+    packet = _wrap_civ_frame(civ_frame, seq=0)
+    assert _unwrap_civ_frame(packet) == civ_frame
+
+
+def test_unwrap_civ_frame_extracts_runtime_wrap_civ_payload() -> None:
+    """Regression for the bug introduced in the first iteration of this
+    fix: ``runtime/_civ_rx.py:_wrap_civ`` sets ``pkt[0x10] = 0xC1`` (not
+    0x00) but the packet still carries a valid CI-V payload. The OpenClose
+    discriminator must match the type marker exactly (``0x01C0``), not
+    "byte 0x10 != 0x00", otherwise every real CI-V command sent by the
+    runtime gets silently dropped on serial. MOR-172.
+    """
+    civ_frame = bytes([0xFE, 0xFE, 0xA4, 0xE0, 0x03, 0xFD])
+    # Mimic runtime/_civ_rx.py::_wrap_civ layout exactly.
+    total_len = _CIV_HEADER_SIZE + len(civ_frame)
+    pkt = bytearray(total_len)
+    struct.pack_into("<I", pkt, 0, total_len)
+    struct.pack_into("<H", pkt, 4, 0x00)
+    struct.pack_into("<I", pkt, 8, 0)
+    struct.pack_into("<I", pkt, 0x0C, 0)
+    pkt[0x10] = (
+        0xC1  # <-- the byte that the previous Fix-A iteration falsely treated as "non-DATA"
+    )
+    struct.pack_into("<H", pkt, 0x11, len(civ_frame))
+    pkt[_CIV_HEADER_SIZE:] = civ_frame
+    # Sanity: this is NOT an OpenClose packet.
+    assert int.from_bytes(pkt[0x10:0x12], "little") != _LAN_OPENCLOSE_TYPE_MARKER
+    assert pkt[0x10] == 0xC1
+
+    assert _unwrap_civ_frame(bytes(pkt)) == civ_frame


### PR DESCRIPTION
## What

Fixes [MOR-172](https://linear.app/morozsm/issue/MOR-172/) — the Xiegu X6200 CI-V wedge isolated to the malformed 4-byte frame `FE FE 00 FD` that the serial transport stack emitted on every session close.

## Root cause

`_send_open_close_on_transport` in `runtime/_control_phase.py` builds a 22-byte LAN-style binary OpenClose packet (type marker `0x01C0` at offset 0x10) for every session open/close. On serial, `SerialCivTransport.send_tracked` handed that packet to `_unwrap_civ_frame`, which misread the type marker's high byte as `payload_len = 1` and extracted the single close-flag byte at offset 0x15. The serial codec then wrapped that single byte as `FE FE 00 FD` — a malformed CI-V frame (no source, no command, addressed to PC `0x00`) that wedged the X6200's CI-V parser for ~5-10 seconds.

Confirmed on live X6200 hardware (operator session 2026-05-28): display blanks for ~1s timed exactly with the malformed-frame TX; subsequent CI-V transactions timeout until natural recovery. WSJT-X over the same USB cable never sees this because it holds one long-lived serial session and never triggers the OpenClose pass-through.

## Changes (2 files, +228/-4)

### `src/rigplane/backends/icom7610/drivers/serial_session.py`

Two-layer defence:

**Fix A** — `_unwrap_civ_frame` rejects packets carrying the OpenClose type marker `0x01C0` at offset 0x10–0x11 (LE u16). DATA packets pass through unchanged whether they come from this module's `_wrap_civ_frame` (`pkt[0x10] = 0x00`) or from `runtime/_civ_rx.py::_wrap_civ` (`pkt[0x10] = 0xC1`); the discriminator is the **exact type-marker value**, not "byte 0x10 ≠ 0x00" (an earlier draft of this fix made that mistake and silently dropped every real CI-V command).

**Fix B** — `SerialCivTransport.send_tracked` short-circuits on the same type marker at the higher layer before unwrap is attempted. Belt and braces — either guard alone fixes the bug; both together make the intent self-documenting at both layers and resistant to future refactors on either side.

### `tests/test_serial_session.py` (new)

7 regression tests covering both directions of the defence plus the bug introduced and fixed during this PR's iteration:

1. `test_send_tracked_drops_openclose_close_packet` — Fix B, close direction
2. `test_send_tracked_drops_openclose_open_packet` — Fix B, open direction
3. `test_send_tracked_forwards_real_civ_frame` — Fix B does not over-shoot
4. `test_unwrap_civ_frame_returns_empty_on_openclose_packet` — Fix A
5. `test_unwrap_civ_frame_returns_empty_on_zero_payload_data_packet` — original branch
6. `test_unwrap_civ_frame_extracts_real_civ_payload` — DATA from `_wrap_civ_frame` (`pkt[0x10]=0x00`)
7. `test_unwrap_civ_frame_extracts_runtime_wrap_civ_payload` — DATA from `runtime._civ_rx::_wrap_civ` (`pkt[0x10]=0xC1`); locks in the "match marker exactly, not 'non-zero'" lesson

**Mutation testing** (manual, in worktree): reverting Fix A alone breaks exactly test #4; reverting both fixes additionally breaks tests #1 and #2. Each test is load-bearing for the protection it covers.

## Verification

- `uv run pytest tests/ --ignore=tests/integration`: **5957 passed, 0 failures** (+7 new tests; +5 previously-failing `test_icom7610_serial_radio.py` tests that were briefly broken by the wrong-discriminator first draft of Fix A — now back to green with the correct discriminator).
- `uv run mypy --strict src/rigplane/web` (CI gate): clean.
- `uv run ruff check src/ tests/`: clean.

**Not verified on live hardware in this PR** — gated next step: operator runs `rigplane status` 3x consecutive against the real X6200 with display in view; success criterion = no flicker, no wedge, all three reads return data. If it passes, MOR-172 closes.

## Out of scope

Why the `_send_open_close → no-op` override on `_IcomSerialRadioBase` doesn't actually reach this code path remains unresolved — the wire-tap evidence in the MOR-172 investigation shows `OpenClose(close) sent` is logged on serial despite the override. This PR works around it at the serial-transport layer; the architectural cleanup belongs in MOR-173 (single source of truth) once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)