### PR TITLE
#1624 ordered batch raw CI-V transactions

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -372,17 +372,34 @@ each request.
 
 Use this endpoint when an external controller needs an all-or-reported-nothing
 profile switch: tune frequency, select mode/filter, adjust levels, switch
-audio/data state, recall memory, or apply other supported structured commands
-as one ordered operation.
+audio/data state, recall memory, query model-specific CI-V state, or apply
+other supported operations as one ordered operation.
 
-Batch steps are validated and executed in request order. Each executable step
-is placed on an exact-order command-queue lane and the HTTP handler waits for
+Batch steps are validated and executed in request order. Legacy command steps
+are placed on an exact-order command-queue lane, and the HTTP handler waits for
 the poller/backend to finish that step before advancing to the next step.
-Repeated commands are not deduplicated inside the ordered lane.
+Raw CI-V transaction steps execute through `send_civ_transaction()` outside
+`RadioPoller`; the handler still waits for each transaction result before
+considering the next request step. Repeated commands are not deduplicated
+inside the ordered lane.
 
-Maximum batch size is 128 steps. Each step has a 10 second execution timeout.
-If the radio link is slow or disconnected, the failing step is reported and
-later steps are skipped unless `continue_on_error` is `true`.
+Maximum batch size is 128 steps. Legacy command steps use a 10 second
+execution timeout. Raw CI-V transaction steps use `timeout_ms` when present,
+otherwise the same 10 second default. If the radio link is slow or
+disconnected, the failing step is reported and later steps are skipped unless
+`continue_on_error` is `true`.
+
+Batch steps can use either shape:
+
+- legacy command steps: `{ "name": "set_freq", "params": { ... } }`;
+- response-capable raw CI-V transaction steps:
+  `{ "type": "raw_civ_transaction", ... }`.
+
+`send_civ` remains the fire-and-forget raw CI-V command. It is queued like
+other legacy command steps, returns the command parameters that were accepted,
+does not wait for ACK/data/NAK frames, and still rejects `wait_response=true`.
+Use a `raw_civ_transaction` step when the caller needs the radio's wire-level
+ACK, NAK, or data response inside the ordered batch.
 
 Data flow:
 
@@ -390,12 +407,15 @@ Data flow:
 flowchart LR
   Client["curl / Python / MQTT gateway"] --> HTTP["POST /api/v1/commands/batch"]
   HTTP --> Validate["Validate JSON and command params"]
-  Validate --> Translate["ControlHandler builds Command objects"]
-  Translate --> Queue["CommandQueue.put_ordered"]
+  Validate --> Dispatch["Legacy command or raw transaction step"]
+  Dispatch --> Queue["CommandQueue.put_ordered"]
+  Dispatch --> Transaction["CoreRadio.send_civ_transaction"]
   Queue --> Poller["radio poller drains queue"]
   Poller --> Backend["LAN / serial / CAT backend"]
+  Transaction --> Backend
   Backend --> Radio["physical radio"]
   Poller --> Result["per-step future result"]
+  Transaction --> Result
   Result --> HTTP
 ```
 
@@ -407,14 +427,46 @@ Request:
   "continue_on_error": false,
   "steps": [
     { "name": "set_freq", "params": { "freq": 144030000 } },
-    { "name": "set_mode", "params": { "mode": "FM" } },
     {
       "name": "send_civ",
       "params": { "command": 26, "sub": 5, "data": "015301" }
+    },
+    {
+      "type": "raw_civ_transaction",
+      "id": "display-type-query",
+      "command": 26,
+      "sub": 5,
+      "data": "0153",
+      "expect": "data",
+      "timeout_ms": 250
+    },
+    {
+      "type": "raw_civ_transaction",
+      "id": "display-type-apply",
+      "command": 26,
+      "sub": 5,
+      "data": "015301",
+      "expect": "ack"
+    },
+    {
+      "name": "set_mode",
+      "params": { "mode": "FM" }
     }
   ]
 }
 ```
+
+Raw CI-V transaction step fields:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `type` | yes | Must be `"raw_civ_transaction"` |
+| `command` | yes | CI-V command byte, `0` through `255` |
+| `expect` | yes | `"none"`, `"ack"`, or `"data"` |
+| `id` | no | Caller-owned value echoed in this step's result |
+| `sub` | no | CI-V subcommand byte, `0` through `255` |
+| `data` | no | Compact even-length hexadecimal string; response hex is uppercase |
+| `timeout_ms` | no | Positive finite timeout in milliseconds for this transaction step |
 
 Successful response:
 
@@ -432,13 +484,6 @@ Successful response:
     },
     {
       "index": 1,
-      "name": "set_mode",
-      "ok": true,
-      "status": "executed",
-      "result": { "mode": "FM", "receiver": 0 }
-    },
-    {
-      "index": 2,
       "name": "send_civ",
       "ok": true,
       "status": "executed",
@@ -448,12 +493,50 @@ Successful response:
         "data": "015301",
         "wait_response": false
       }
+    },
+    {
+      "index": 2,
+      "type": "raw_civ_transaction",
+      "id": "display-type-query",
+      "ok": true,
+      "status": "response",
+      "result": {
+        "frame": "FEFEE0981A050153FD",
+        "command": 26,
+        "sub": 5,
+        "data": "0153"
+      }
+    },
+    {
+      "index": 3,
+      "type": "raw_civ_transaction",
+      "id": "display-type-apply",
+      "ok": true,
+      "status": "ack",
+      "result": {
+        "frame": "FEFEE0A2FBFD",
+        "command": 251,
+        "sub": null,
+        "data": ""
+      }
+    },
+    {
+      "index": 4,
+      "name": "set_mode",
+      "ok": true,
+      "status": "executed",
+      "result": { "mode": "FM", "receiver": 0 }
     }
   ]
 }
 ```
 
-Partial-failure response:
+`expect: "none"` sends one CI-V frame and returns `status: "sent"` without
+waiting for a radio frame. `expect: "ack"` waits for ACK or NAK.
+`expect: "data"` waits for the matching data response, while a fresh NAK still
+returns `status: "nak"` and `error: "radio_nak"`.
+
+NAK failure with skipped later steps:
 
 ```json
 {
@@ -461,21 +544,20 @@ Partial-failure response:
   "results": [
     {
       "index": 0,
-      "name": "set_freq",
-      "ok": true,
-      "status": "executed",
-      "result": { "freq": 144030000, "receiver": 0 }
+      "type": "raw_civ_transaction",
+      "ok": false,
+      "status": "nak",
+      "error": "radio_nak",
+      "message": "radio returned CI-V NAK",
+      "result": {
+        "frame": "FEFEE0A2FAFD",
+        "command": 250,
+        "sub": null,
+        "data": ""
+      }
     },
     {
       "index": 1,
-      "name": "no_such_command",
-      "ok": false,
-      "status": "failed_validation",
-      "error": "unknown_command",
-      "message": "unknown command: 'no_such_command'"
-    },
-    {
-      "index": 2,
       "name": "set_mode",
       "ok": false,
       "status": "skipped",
@@ -488,19 +570,70 @@ Partial-failure response:
 
 Set `continue_on_error` to `true` to keep applying later valid steps after a
 validation, timeout, or execution failure. When present, `continue_on_error`
-must be a JSON boolean. Queue-bypassing commands such as `get_*`,
-`send_cw_text`, and direct helper operations are rejected in batches with
+must be a JSON boolean at the batch root. A transaction step-level
+`continue_on_error` field is invalid. Raw CI-V transaction failures that obey
+the continuation rule include `nak`, `timed_out`, `owner_conflict`,
+`unsupported`, `read_only`, `no_radio`, `failed_validation`, and
+`failed_execution`. Queue-bypassing commands such as `get_*`, `send_cw_text`,
+and direct helper operations are rejected in batches with
 `unsupported_in_batch`; use `POST /api/v1/commands` for those one-off calls.
+
+Timeout with `continue_on_error: true`:
+
+```json
+{
+  "ok": false,
+  "results": [
+    {
+      "index": 0,
+      "type": "raw_civ_transaction",
+      "ok": false,
+      "status": "timed_out",
+      "error": "transaction_timeout",
+      "message": "raw CI-V transaction timed out"
+    },
+    {
+      "index": 1,
+      "name": "set_mode",
+      "ok": true,
+      "status": "executed",
+      "result": { "mode": "FM", "receiver": 0 }
+    }
+  ]
+}
+```
+
+Other raw CI-V transaction step failures use these per-step `status` and
+`error` values:
+
+| Case | `status` | `error` |
+|------|----------|---------|
+| Timeout | `timed_out` | `transaction_timeout` |
+| Another CAT/transaction owner is active | `owner_conflict` | `civ_owner_conflict` |
+| Backend lacks raw transaction support | `unsupported` | `unsupported_command` |
+| Server is read-only | `read_only` | `read_only` |
+| No active radio for a transaction-only batch | `no_radio` | `no_radio` |
+| Malformed transaction step | `failed_validation` | `invalid_request` or `invalid_step` |
+| Runtime failure from `send_civ_transaction()` | `failed_execution` | `transaction_failed` |
+| Later step skipped after failure | `skipped` | `skipped_after_failure` |
+
+Unsupported typed batch steps are handled separately from malformed
+`raw_civ_transaction` steps. If a step has `type` present, the type is not
+supported, and no legacy `name` is present, that step returns
+`status: "failed_validation"` with `error: "unknown_step_type"`.
 
 If a queued step is not consumed by the poller before the step timeout, the
 result status is `timed_out` with error `command_timeout`. Unconsumed timed-out
-steps are cancelled before execution.
+steps are cancelled before execution. If a batch mixes legacy command steps
+with raw transaction steps and no radio is configured, the endpoint keeps the
+legacy behavior and returns HTTP `503 no_radio` before per-step execution.
 
 ### Profile-Switching Example
 
 Core treats a radio profile as a caller-owned batch, not as stored server
-state. This keeps the open-core API generic while still supporting local
-Stream Deck, MQTT, shell, and Python automation.
+state. Core does not store, name, schedule, or share profiles; callers own any
+batch/profile catalog they build. This keeps the open-core API generic while
+still supporting local Stream Deck, MQTT, shell, and Python automation.
 
 Example IC-9700-style local batches:
 

--- a/docs/internals/raw-civ-transactions.md
+++ b/docs/internals/raw-civ-transactions.md
@@ -36,7 +36,309 @@ commands remain explicit.
 
 ## HTTP Surface
 
-`POST /api/v1/civ/transaction` is the only HTTP endpoint that waits for raw
-CI-V responses. `/api/v1/commands` and `/api/v1/commands/batch` remain queued
-fire-and-forget surfaces for `send_civ`, and `wait_response=true` stays
-rejected there.
+`POST /api/v1/civ/transaction` and explicit
+`type: "raw_civ_transaction"` steps in `/api/v1/commands/batch` are the HTTP
+surfaces that wait for raw CI-V responses. `/api/v1/commands` and legacy
+`send_civ` steps in `/api/v1/commands/batch` remain queued fire-and-forget
+surfaces, and `wait_response=true` stays rejected there.
+
+## Ordered Batch Transaction Contract
+
+Issue #1633 defines the contract for response-capable raw CI-V transaction
+steps in `POST /api/v1/commands/batch`; #1634 and #1635 implement and test the
+server behavior under parent #1624. This is a Core API/protocol feature: it
+defines generic ordered-batch behavior, backend-neutral radio ownership, and
+deterministic per-step results. Core does not store named radio profiles,
+managed setup data, hosted-account state, or customer-specific workflows.
+Callers may still send caller-owned profile batches as ordinary request bodies.
+
+The batch endpoint must keep the existing legacy command step shape unchanged:
+
+```json
+{ "name": "set_freq", "params": { "freq": 144030000 } }
+```
+
+Raw CI-V transactions use a new explicit step type, not `name`/`params`:
+
+```json
+{
+  "type": "raw_civ_transaction",
+  "id": "display-type-query",
+  "command": 26,
+  "sub": 5,
+  "data": "0153",
+  "expect": "data",
+  "timeout_ms": 1000
+}
+```
+
+Required transaction step fields:
+
+- `type`: exactly `"raw_civ_transaction"`.
+- `command`: integer byte from `0` through `255`.
+- `expect`: one of `"none"`, `"ack"`, or `"data"`.
+
+Optional transaction step fields:
+
+- `id`: caller-owned JSON value echoed in that step result when present.
+- `sub`: integer byte from `0` through `255`.
+- `data`: compact even-length hexadecimal string. Input is case-insensitive;
+  output hex is uppercase.
+- `timeout_ms`: positive finite number of milliseconds for this transaction
+  step. If omitted, the transaction step uses the batch step timeout default:
+  `10000` milliseconds.
+
+`continue_on_error` remains a batch-level option only. A
+`raw_civ_transaction` step-level `continue_on_error` field is invalid, because
+mixing batch-level and step-level continuation rules would make ordering hard
+to reason about. Legacy command steps keep their existing tolerance for extra
+fields; the new transaction step contract should be strict.
+
+## Batch Ordering
+
+The batch executor processes `steps` in array order. It must not enqueue or
+start step `N + 1` until step `N` has either succeeded, failed with
+`continue_on_error: true`, or caused later steps to be skipped.
+
+Legacy command steps continue to use the ordered command queue. The HTTP
+handler waits for the poller/backend future for that queued step before
+advancing. Transaction steps bypass `RadioPoller`, acquire the scoped CI-V
+transaction owner, send exactly one frame, wait according to `expect`, and
+release ownership before the next batch step is considered.
+
+When legacy command steps and transaction steps are mixed, ordering is
+therefore:
+
+1. queued command step is enqueued on the exact-order lane;
+2. handler waits for that queued command's completion or timeout;
+3. transaction step acquires CI-V ownership and completes or fails;
+4. later queued command steps are enqueued only after the transaction releases
+   ownership.
+
+The ordering guarantee is for steps inside this batch. Existing cross-request
+queue behavior is otherwise unchanged. If another external CAT session or raw
+transaction already owns the backend when the transaction step tries to start,
+the step returns `civ_owner_conflict`.
+
+## Per-Step Timeout
+
+Queued command steps keep the existing 10 second command batch step timeout.
+Transaction steps use `timeout_ms` when present, otherwise `10000`
+milliseconds. Units are always milliseconds in JSON and seconds only inside
+Python internals. Timeout covers ownership acquisition plus the send/wait path
+for the transaction step; it does not include earlier or later batch steps.
+
+On timeout, the transaction primitive must unregister pending CI-V waiters,
+release ownership, and return a per-step timeout result. It must not leave the
+poller paused or the request tracker polluted for later steps.
+
+## Transaction Step Results
+
+The batch response remains HTTP `200` after the request body is accepted. The
+top-level `ok` is `true` only when every reported step has `ok: true`.
+Transport/auth/root JSON failures keep the existing endpoint-level HTTP error
+behavior.
+
+Successful transaction result shapes:
+
+```json
+{
+  "index": 0,
+  "type": "raw_civ_transaction",
+  "id": "display-type-query",
+  "ok": true,
+  "status": "response",
+  "result": {
+    "frame": "FEFEE0981A050153FD",
+    "command": 26,
+    "sub": 5,
+    "data": "0153"
+  }
+}
+```
+
+`expect: "none"` returns `status: "sent"` and does not wait for a radio frame:
+
+```json
+{
+  "index": 0,
+  "type": "raw_civ_transaction",
+  "ok": true,
+  "status": "sent",
+  "result": {
+    "frame": null,
+    "command": null,
+    "sub": null,
+    "data": null
+  }
+}
+```
+
+ACK and NAK results use the same `result` object shape as the single
+transaction endpoint:
+
+```json
+{
+  "index": 0,
+  "type": "raw_civ_transaction",
+  "ok": true,
+  "status": "ack",
+  "result": {
+    "frame": "FEFEE0A2FBFD",
+    "command": 251,
+    "sub": null,
+    "data": ""
+  }
+}
+```
+
+```json
+{
+  "index": 0,
+  "type": "raw_civ_transaction",
+  "ok": false,
+  "status": "nak",
+  "error": "radio_nak",
+  "message": "radio returned CI-V NAK",
+  "result": {
+    "frame": "FEFEE0A2FAFD",
+    "command": 250,
+    "sub": null,
+    "data": ""
+  }
+}
+```
+
+Failure results:
+
+| Case | `status` | `error` | Notes |
+|------|----------|---------|-------|
+| timeout | `timed_out` | `transaction_timeout` | Timeout before expected ACK/data response or before ownership could complete |
+| owner conflict | `owner_conflict` | `civ_owner_conflict` | Another transaction or external CAT owner already owns the CI-V stream |
+| unsupported backend | `unsupported` | `unsupported_command` | Active backend does not implement `CivTransactionCapable` |
+| read-only server | `read_only` | `read_only` | Raw CI-V transaction steps are disabled in read-only mode |
+| no radio during execution | `no_radio` | `no_radio` | No active radio is available for this step |
+| validation failure | `failed_validation` | `invalid_request` or `invalid_step` | Malformed transaction shape, byte range, hex data, expectation, or timeout |
+| runtime failure | `failed_execution` | `transaction_failed` | Non-owner-conflict `RuntimeError` raised by `send_civ_transaction()` |
+| skipped after failure | `skipped` | `skipped_after_failure` | Step was not validated or executed because an earlier step stopped the batch |
+
+Unsupported typed batch steps are handled separately from malformed
+`raw_civ_transaction` steps. If a step has `type` present, the type is not
+supported, and no legacy `name` is present, that step returns
+`status: "failed_validation"` with `error: "unknown_step_type"`.
+
+Examples:
+
+```json
+{
+  "index": 0,
+  "type": "raw_civ_transaction",
+  "ok": false,
+  "status": "timed_out",
+  "error": "transaction_timeout",
+  "message": "raw CI-V transaction timed out"
+}
+```
+
+```json
+{
+  "index": 0,
+  "type": "raw_civ_transaction",
+  "ok": false,
+  "status": "owner_conflict",
+  "error": "civ_owner_conflict",
+  "message": "CI-V stream is already owned by another transaction"
+}
+```
+
+```json
+{
+  "index": 0,
+  "type": "raw_civ_transaction",
+  "ok": false,
+  "status": "failed_validation",
+  "error": "invalid_request",
+  "message": "timeout_ms must be a positive finite number"
+}
+```
+
+Skipped legacy command steps keep the existing skipped result shape with
+`name`. Skipped transaction steps use `type` and echo `id` when those fields
+are readable without full validation:
+
+```json
+{
+  "index": 2,
+  "type": "raw_civ_transaction",
+  "id": "later-query",
+  "ok": false,
+  "status": "skipped",
+  "error": "skipped_after_failure",
+  "message": "skipped after earlier batch failure"
+}
+```
+
+## `continue_on_error`
+
+`continue_on_error` defaults to `false` and remains a JSON boolean at the
+batch root. It applies uniformly to legacy queued command failures and raw
+CI-V transaction failures.
+
+When `continue_on_error` is `false`, these failures stop the batch and mark
+all later steps as `skipped`:
+
+- transaction `nak`;
+- transaction `timed_out`;
+- transaction `owner_conflict`;
+- transaction `unsupported`;
+- transaction `read_only`;
+- transaction `no_radio`;
+- transaction `failed_validation`;
+- transaction `failed_execution`;
+- queued command `failed_validation`;
+- queued command `timed_out`;
+- queued command `failed_execution`.
+
+When `continue_on_error` is `true`, the failing step is reported with
+`ok: false` and the executor proceeds to the next step after cleanup. For
+transaction failures this means ownership has been released and pending CI-V
+waiters have been unregistered before the next step starts. For queued command
+timeouts this keeps the current behavior: the unconsumed timed-out queued step
+is cancelled before the next batch step is prepared.
+
+Batch root validation failures are not per-step failures and do not honor
+`continue_on_error`. Examples include malformed JSON, missing or non-list
+`steps`, empty `steps`, too many steps, and a non-boolean batch-level
+`continue_on_error`.
+
+## Compatibility
+
+Existing fire-and-forget batch behavior is unchanged:
+
+- legacy `{ "name": ..., "params": ... }` steps retain their request and
+  result shape;
+- `send_civ` in `/api/v1/commands` and `/api/v1/commands/batch` remains
+  queued and fire-and-forget;
+- `send_civ` still rejects `wait_response=true`;
+- response-capable waiting is used only when the new
+  `"type": "raw_civ_transaction"` step is explicitly requested;
+- the single `POST /api/v1/civ/transaction` endpoint keeps its current
+  contract.
+
+## Implementation Test Matrix
+
+Implementation issues for #1633/#1624 should cover:
+
+| Case | Expected coverage |
+|------|-------------------|
+| legacy-only batch regression | Existing `{ "name": ..., "params": ... }` batches keep their request shape, result shape, ordering, and success behavior |
+| mixed `command -> transaction -> command` batch | The first command completes before the transaction starts, and the later command is enqueued only after transaction ownership is released |
+| transaction timeout | A transaction step returns `status: "timed_out"` and `error: "transaction_timeout"`, unregisters waiters, releases ownership, and skips later steps when `continue_on_error` is `false` |
+| transaction NAK | A fresh radio NAK returns `status: "nak"` and `error: "radio_nak"` with the NAK result frame, then applies the configured continuation rule |
+| owner conflict | Existing external CAT or transaction ownership returns `status: "owner_conflict"` and `error: "civ_owner_conflict"` without interrupting the current owner |
+| read-only server | A transaction step in read-only mode returns `status: "read_only"` and `error: "read_only"` before sending any CI-V frame |
+| no radio during execution | A transaction step with no active radio returns `status: "no_radio"` and `error: "no_radio"` as a per-step failure |
+| unsupported backend | A backend without `CivTransactionCapable` returns `status: "unsupported"` and `error: "unsupported_command"` as a per-step failure |
+| `continue_on_error: false` | Transaction failures stop the batch and report later steps as `status: "skipped"` with `error: "skipped_after_failure"` |
+| `continue_on_error: true` | Transaction failures are reported with `ok: false`, cleanup completes, and the executor proceeds to the next step in order |
+| fire-and-forget `send_civ` regression | `send_civ` in `/api/v1/commands` and legacy batch steps remains queued and fire-and-forget, and `wait_response=true` remains rejected |

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -24,6 +24,7 @@ import gzip as _gzip
 import hmac
 import json
 import logging
+import math
 import mimetypes
 import os
 import pathlib
@@ -33,7 +34,7 @@ import time
 import urllib.parse
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TextIO
+from typing import TYPE_CHECKING, Any, Literal, TextIO
 
 from .. import __version__
 from .._bounded_queue import BoundedQueue
@@ -99,6 +100,13 @@ _RADIO_MODEL = "IC-7610"
 _MAX_POST_BODY = 256 * 1024  # 256 KiB — hard ceiling for all POST body reads
 _MAX_COMMAND_BATCH_STEPS = 128
 _COMMAND_BATCH_STEP_TIMEOUT = 10.0
+_CIV_TRANSACTION_BATCH_STEP_TYPE = "raw_civ_transaction"
+_CIV_TRANSACTION_BATCH_STEP_KEYS = frozenset(
+    {"type", "id", "command", "sub", "data", "expect", "timeout_ms"}
+)
+
+_CivTransactionExpect = Literal["none", "ack", "data"]
+_MISSING_BATCH_STEP_ID = object()
 
 
 class _HttpBatchValidationError(ValueError):
@@ -113,6 +121,17 @@ class _HttpBatchStep:
     name: str
     command: Any
     result: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _HttpBatchTransactionStep:
+    index: int
+    step_id: Any
+    command: int
+    sub: int | None
+    data: bytes
+    expect: _CivTransactionExpect
+    timeout: float
 
 
 class _HttpCommandCollector:
@@ -2184,7 +2203,7 @@ class WebServer:
         reader: asyncio.StreamReader | None = None,
     ) -> None:
         """Handle POST /api/v1/commands and /api/v1/commands/batch."""
-        if self._radio is None:
+        if self._radio is None and path != "/api/v1/commands/batch":
             await self._send_json(
                 writer,
                 503,
@@ -2201,6 +2220,23 @@ class WebServer:
             await self._handle_http_single_command(writer, payload)
             return
         if path == "/api/v1/commands/batch":
+            if self._radio is None:
+                raw_steps = payload.get("steps")
+                is_transaction_only_batch = (
+                    isinstance(raw_steps, list)
+                    and bool(raw_steps)
+                    and all(
+                        self._is_http_batch_transaction_step(step) for step in raw_steps
+                    )
+                )
+                if not is_transaction_only_batch:
+                    await self._send_json(
+                        writer,
+                        503,
+                        "Service Unavailable",
+                        {"error": "no_radio", "message": "No radio configured"},
+                    )
+                    return
             await self._handle_http_command_batch(writer, payload)
             return
 
@@ -2212,10 +2248,9 @@ class WebServer:
             if required:
                 raise ValueError(f"missing required '{name}' parameter")
             return None
-        try:
-            parsed = int(value)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"{name} must be an integer byte") from exc
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"{name} must be an integer byte")
+        parsed = int(value)
         if not 0 <= parsed <= 0xFF:
             raise ValueError(f"{name} must be 0-255, got {parsed}")
         return parsed
@@ -2236,10 +2271,11 @@ class WebServer:
     def _parse_civ_transaction_timeout(value: Any) -> float | None:
         if value is None:
             return None
-        try:
-            timeout_ms = float(value)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("timeout_ms must be a positive number") from exc
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError("timeout_ms must be a positive finite number")
+        timeout_ms = float(value)
+        if not math.isfinite(timeout_ms):
+            raise ValueError("timeout_ms must be a positive finite number")
         if timeout_ms <= 0:
             raise ValueError("timeout_ms must be positive")
         return timeout_ms / 1000.0
@@ -2511,6 +2547,168 @@ class WebServer:
             result=result,
         )
 
+    def _prepare_http_batch_transaction_step(
+        self,
+        index: int,
+        raw_step: Any,
+    ) -> _HttpBatchTransactionStep:
+        if not isinstance(raw_step, dict):
+            raise _HttpBatchValidationError(
+                "invalid_step",
+                f"step {index} must be an object",
+            )
+        extra_keys = set(raw_step) - _CIV_TRANSACTION_BATCH_STEP_KEYS
+        if extra_keys:
+            extra = ", ".join(sorted(extra_keys))
+            raise _HttpBatchValidationError(
+                "invalid_step",
+                f"step {index} has unsupported raw CI-V transaction field(s): {extra}",
+            )
+        try:
+            if raw_step.get("type") != _CIV_TRANSACTION_BATCH_STEP_TYPE:
+                raise ValueError("type must be raw_civ_transaction")
+            command = self._parse_civ_byte(raw_step.get("command"), "command")
+            sub = self._parse_civ_byte(raw_step.get("sub"), "sub", required=False)
+            data = self._parse_civ_hex_data(raw_step.get("data", ""))
+            raw_expect = raw_step.get("expect")
+            if raw_expect not in ("none", "ack", "data"):
+                raise ValueError("expect must be one of: none, ack, data")
+            timeout = self._parse_civ_transaction_timeout(raw_step.get("timeout_ms"))
+        except ValueError as exc:
+            raise _HttpBatchValidationError("invalid_request", str(exc)) from exc
+        assert command is not None
+        return _HttpBatchTransactionStep(
+            index=index,
+            step_id=raw_step.get("id", _MISSING_BATCH_STEP_ID),
+            command=command,
+            sub=sub,
+            data=data,
+            expect=raw_expect,
+            timeout=timeout if timeout is not None else _COMMAND_BATCH_STEP_TIMEOUT,
+        )
+
+    @staticmethod
+    def _is_http_batch_transaction_step(raw_step: Any) -> bool:
+        return (
+            isinstance(raw_step, dict)
+            and raw_step.get("type") == _CIV_TRANSACTION_BATCH_STEP_TYPE
+        )
+
+    @staticmethod
+    def _is_http_batch_typed_step(raw_step: Any) -> bool:
+        return (
+            isinstance(raw_step, dict) and "type" in raw_step and "name" not in raw_step
+        )
+
+    def _failed_transaction_batch_result(
+        self,
+        step: _HttpBatchTransactionStep,
+        *,
+        status: str,
+        error: str,
+        message: str,
+        result: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        response: dict[str, Any] = {
+            "index": step.index,
+            "type": _CIV_TRANSACTION_BATCH_STEP_TYPE,
+            "ok": False,
+            "status": status,
+            "error": error,
+            "message": message,
+        }
+        if step.step_id is not _MISSING_BATCH_STEP_ID:
+            response["id"] = step.step_id
+        if result is not None:
+            response["result"] = result
+        return response
+
+    async def _execute_http_batch_transaction_step(
+        self,
+        step: _HttpBatchTransactionStep,
+    ) -> dict[str, Any]:
+        if self._config.read_only:
+            return self._failed_transaction_batch_result(
+                step,
+                status="read_only",
+                error="read_only",
+                message="raw CI-V transactions are disabled in read-only mode",
+            )
+        if self._radio is None:
+            return self._failed_transaction_batch_result(
+                step,
+                status="no_radio",
+                error="no_radio",
+                message="No radio configured",
+            )
+        if not isinstance(self._radio, CivTransactionCapable):
+            return self._failed_transaction_batch_result(
+                step,
+                status="unsupported",
+                error="unsupported_command",
+                message="active backend does not support raw CI-V transactions",
+            )
+
+        try:
+            result = await self._radio.send_civ_transaction(
+                step.command,
+                sub=step.sub,
+                data=step.data,
+                expect=step.expect,
+                timeout=step.timeout,
+            )
+        except (RigplaneTimeoutError, TimeoutError):
+            return self._failed_transaction_batch_result(
+                step,
+                status="timed_out",
+                error="transaction_timeout",
+                message="raw CI-V transaction timed out",
+            )
+        except RuntimeError as exc:
+            message = str(exc)
+            if "already owned" in message:
+                return self._failed_transaction_batch_result(
+                    step,
+                    status="owner_conflict",
+                    error="civ_owner_conflict",
+                    message=message,
+                )
+            return self._failed_transaction_batch_result(
+                step,
+                status="failed_execution",
+                error="transaction_failed",
+                message=message,
+            )
+        except ValueError as exc:
+            return self._failed_transaction_batch_result(
+                step,
+                status="failed_validation",
+                error="invalid_request",
+                message=str(exc),
+            )
+
+        status = getattr(result, "status", "response")
+        response: dict[str, Any] = {
+            "index": step.index,
+            "type": _CIV_TRANSACTION_BATCH_STEP_TYPE,
+            "ok": status != "nak",
+            "status": status,
+        }
+        if step.step_id is not _MISSING_BATCH_STEP_ID:
+            response["id"] = step.step_id
+        serialized = self._serialize_civ_transaction_result(result)
+        if status == "nak":
+            response.update(
+                {
+                    "error": "radio_nak",
+                    "message": "radio returned CI-V NAK",
+                    "result": serialized,
+                }
+            )
+        else:
+            response["result"] = serialized
+        return response
+
     @staticmethod
     def _skipped_batch_result(index: int, name: str | None = None) -> dict[str, Any]:
         result: dict[str, Any] = {
@@ -2523,6 +2721,24 @@ class WebServer:
         if name is not None:
             result["name"] = name
         return result
+
+    @classmethod
+    def _skipped_batch_result_for_raw_step(
+        cls,
+        index: int,
+        raw_step: Any,
+    ) -> dict[str, Any]:
+        if (
+            isinstance(raw_step, dict)
+            and raw_step.get("type") == _CIV_TRANSACTION_BATCH_STEP_TYPE
+        ):
+            result = cls._skipped_batch_result(index)
+            result["type"] = _CIV_TRANSACTION_BATCH_STEP_TYPE
+            if "id" in raw_step:
+                result["id"] = raw_step["id"]
+            return result
+        name = raw_step.get("name") if isinstance(raw_step, dict) else None
+        return cls._skipped_batch_result(index, name)
 
     async def _handle_http_command_batch(
         self,
@@ -2574,7 +2790,88 @@ class WebServer:
         results: list[dict[str, Any]] = []
 
         for index, raw_step in enumerate(raw_steps):
+            if self._is_http_batch_transaction_step(raw_step):
+                try:
+                    transaction_step = self._prepare_http_batch_transaction_step(
+                        index,
+                        raw_step,
+                    )
+                    transaction_result = (
+                        await self._execute_http_batch_transaction_step(
+                            transaction_step
+                        )
+                    )
+                except _HttpBatchValidationError as exc:
+                    transaction_result = {
+                        "index": index,
+                        "type": _CIV_TRANSACTION_BATCH_STEP_TYPE,
+                        "ok": False,
+                        "status": "failed_validation",
+                        "error": exc.error,
+                        "message": str(exc),
+                    }
+                    if isinstance(raw_step, dict) and "id" in raw_step:
+                        transaction_result["id"] = raw_step["id"]
+
+                results.append(transaction_result)
+                if transaction_result.get("ok") is True or continue_on_error:
+                    continue
+                for skip_index in range(index + 1, len(raw_steps)):
+                    results.append(
+                        self._skipped_batch_result_for_raw_step(
+                            skip_index,
+                            raw_steps[skip_index],
+                        )
+                    )
+                await self._send_batch_response(writer, payload, results)
+                return
+
+            if self._is_http_batch_typed_step(raw_step):
+                raw_type = raw_step.get("type")
+                results.append(
+                    {
+                        "index": index,
+                        "ok": False,
+                        "status": "failed_validation",
+                        "error": "unknown_step_type",
+                        "message": f"unknown step type: {raw_type!r}",
+                    }
+                )
+                if continue_on_error:
+                    continue
+                for skip_index in range(index + 1, len(raw_steps)):
+                    results.append(
+                        self._skipped_batch_result_for_raw_step(
+                            skip_index,
+                            raw_steps[skip_index],
+                        )
+                    )
+                await self._send_batch_response(writer, payload, results)
+                return
+
             name = raw_step.get("name") if isinstance(raw_step, dict) else None
+            if self._radio is None:
+                results.append(
+                    {
+                        "index": index,
+                        "name": name,
+                        "ok": False,
+                        "status": "no_radio",
+                        "error": "no_radio",
+                        "message": "No radio configured",
+                    }
+                )
+                if continue_on_error:
+                    continue
+                for skip_index in range(index + 1, len(raw_steps)):
+                    results.append(
+                        self._skipped_batch_result_for_raw_step(
+                            skip_index,
+                            raw_steps[skip_index],
+                        )
+                    )
+                await self._send_batch_response(writer, payload, results)
+                return
             try:
                 step = await self._prepare_http_batch_step(index, raw_step)
             except PermissionError as exc:
@@ -2624,9 +2921,12 @@ class WebServer:
                 if continue_on_error:
                     continue
                 for skip_index in range(index + 1, len(raw_steps)):
-                    skip = raw_steps[skip_index]
-                    skip_name = skip.get("name") if isinstance(skip, dict) else None
-                    results.append(self._skipped_batch_result(skip_index, skip_name))
+                    results.append(
+                        self._skipped_batch_result_for_raw_step(
+                            skip_index,
+                            raw_steps[skip_index],
+                        )
+                    )
                 await self._send_batch_response(writer, payload, results)
                 return
 
@@ -2648,10 +2948,11 @@ class WebServer:
                 )
                 if not continue_on_error:
                     for skip_index in range(step.index + 1, len(raw_steps)):
-                        skip = raw_steps[skip_index]
-                        skip_name = skip.get("name") if isinstance(skip, dict) else None
                         results.append(
-                            self._skipped_batch_result(skip_index, skip_name)
+                            self._skipped_batch_result_for_raw_step(
+                                skip_index,
+                                raw_steps[skip_index],
+                            )
                         )
                     await self._send_batch_response(writer, payload, results)
                     return
@@ -2668,10 +2969,11 @@ class WebServer:
                 )
                 if not continue_on_error:
                     for skip_index in range(step.index + 1, len(raw_steps)):
-                        skip = raw_steps[skip_index]
-                        skip_name = skip.get("name") if isinstance(skip, dict) else None
                         results.append(
-                            self._skipped_batch_result(skip_index, skip_name)
+                            self._skipped_batch_result_for_raw_step(
+                                skip_index,
+                                raw_steps[skip_index],
+                            )
                         )
                     await self._send_batch_response(writer, payload, results)
                     return

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -666,6 +666,672 @@ async def test_http_command_batch_preserves_raw_civ_step_order() -> None:
 
 
 @pytest.mark.asyncio
+async def test_http_command_batch_mixes_command_transaction_command_in_order() -> None:
+    radio = _radio()
+    frame = SimpleNamespace(
+        command=0x1A,
+        sub=0x05,
+        data=b"\x01\x53",
+    )
+    events: list[object] = []
+
+    async def transaction(
+        command: int,
+        *,
+        sub: int | None = None,
+        data: bytes | None = None,
+        expect: str = "data",
+        timeout: float | None = None,
+    ) -> SimpleNamespace:
+        events.append(("transaction", command, sub, data, expect, timeout))
+        return SimpleNamespace(
+            status="response",
+            frame=frame,
+            frame_bytes=bytes.fromhex("fefee0981a050153fd"),
+        )
+
+    radio.send_civ_transaction = AsyncMock(side_effect=transaction)
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    async def complete_commands() -> None:
+        while sum(1 for event in events if event[0] == "command") < 2:
+            await srv.command_queue.wait(timeout=1.0)
+            for entry in srv.command_queue.drain_entries():
+                events.append(("command", entry.command))
+                if entry.future is not None and not entry.future.done():
+                    entry.future.set_result(None)
+
+    consumer = asyncio.create_task(complete_commands())
+    try:
+        writer = await _post_json(
+            srv,
+            "/api/v1/commands/batch",
+            {
+                "id": "mixed-profile",
+                "steps": [
+                    {"name": "set_freq", "params": {"freq": 144_030_000}},
+                    {
+                        "type": "raw_civ_transaction",
+                        "id": "display-type-query",
+                        "command": 0x1A,
+                        "sub": 0x05,
+                        "data": "0153",
+                        "expect": "data",
+                        "timeout_ms": 250,
+                    },
+                    {"name": "set_mode", "params": {"mode": "FM"}},
+                ],
+            },
+        )
+    finally:
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+    assert writer.response_status == 200
+    assert writer.response_body["id"] == "mixed-profile"
+    assert writer.response_body["ok"] is True
+    assert writer.response_body["results"] == [
+        {
+            "index": 0,
+            "name": "set_freq",
+            "ok": True,
+            "status": "executed",
+            "result": {"freq": 144_030_000, "receiver": 0},
+        },
+        {
+            "index": 1,
+            "type": "raw_civ_transaction",
+            "id": "display-type-query",
+            "ok": True,
+            "status": "response",
+            "result": {
+                "frame": "FEFEE0981A050153FD",
+                "command": 0x1A,
+                "sub": 0x05,
+                "data": "0153",
+            },
+        },
+        {
+            "index": 2,
+            "name": "set_mode",
+            "ok": True,
+            "status": "executed",
+            "result": {"mode": "FM", "receiver": 0},
+        },
+    ]
+    assert events == [
+        ("command", SetFreq(144_030_000, receiver=0)),
+        ("transaction", 0x1A, 0x05, b"\x01\x53", "data", 0.25),
+        ("command", SetMode("FM", receiver=0)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_raw_civ_transaction_ack_success() -> None:
+    radio = _radio()
+    frame = SimpleNamespace(command=0xFB, sub=None, data=b"")
+    radio.send_civ_transaction = AsyncMock(
+        return_value=SimpleNamespace(
+            status="ack",
+            frame=frame,
+            frame_bytes=bytes.fromhex("fefee0a2fbfd"),
+        )
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {
+                    "type": "raw_civ_transaction",
+                    "command": 0x1A,
+                    "sub": 0x05,
+                    "data": "015301",
+                    "expect": "ack",
+                }
+            ]
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is True
+    assert writer.response_body["results"] == [
+        {
+            "index": 0,
+            "type": "raw_civ_transaction",
+            "ok": True,
+            "status": "ack",
+            "result": {
+                "frame": "FEFEE0A2FBFD",
+                "command": 0xFB,
+                "sub": None,
+                "data": "",
+            },
+        }
+    ]
+    radio.send_civ_transaction.assert_awaited_once_with(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x53\x01",
+        expect="ack",
+        timeout=10.0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("command", True),
+        ("command", "26"),
+        ("command", 26.9),
+        ("sub", True),
+        ("sub", "5"),
+        ("sub", 5.1),
+        ("timeout_ms", "1000"),
+        ("timeout_ms", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_command_batch_raw_civ_transaction_rejects_non_strict_scalars(
+    field: str,
+    value: object,
+) -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock()
+    step: dict[str, object] = {
+        "type": "raw_civ_transaction",
+        "command": 0x1A,
+        "sub": 0x05,
+        "expect": "ack",
+    }
+    step[field] = value
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {"steps": [step, {"name": "set_freq", "params": {"freq": 144_030_000}}]},
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"][0]["status"] == "failed_validation"
+    assert writer.response_body["results"][0]["error"] == "invalid_request"
+    assert writer.response_body["results"][1]["status"] == "skipped"
+    radio.send_civ_transaction.assert_not_awaited()
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_reports_unknown_typed_step_type() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {"type": "bogus", "command": 0x1A, "expect": "ack"},
+                {"name": "set_freq", "params": {"freq": 144_030_000}},
+            ]
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"][0]["status"] == "failed_validation"
+    assert writer.response_body["results"][0]["error"] == "unknown_step_type"
+    assert writer.response_body["results"][1]["status"] == "skipped"
+    radio.send_civ_transaction.assert_not_awaited()
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_legacy_command_tolerates_extra_type_field() -> None:
+    srv = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+    captured: list[object] = []
+    consumer = asyncio.create_task(
+        _complete_ordered_commands(srv.command_queue, 1, captured)
+    )
+    try:
+        writer = await _post_json(
+            srv,
+            "/api/v1/commands/batch",
+            {
+                "steps": [
+                    {
+                        "type": "ignored_legacy_extra",
+                        "name": "set_freq",
+                        "params": {"freq": 144_030_000},
+                    }
+                ]
+            },
+        )
+    finally:
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is True
+    assert writer.response_body["results"][0]["status"] == "executed"
+    assert captured == [SetFreq(144_030_000, receiver=0)]
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_raw_civ_transaction_nak_stops_and_skips_later() -> (
+    None
+):
+    radio = _radio()
+    frame = SimpleNamespace(command=0xFA, sub=None, data=b"")
+    radio.send_civ_transaction = AsyncMock(
+        return_value=SimpleNamespace(
+            status="nak",
+            frame=frame,
+            frame_bytes=bytes.fromhex("fefee0a2fafd"),
+        )
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {
+                    "type": "raw_civ_transaction",
+                    "command": 0x1A,
+                    "expect": "ack",
+                },
+                {"name": "set_freq", "params": {"freq": 144_030_000}},
+            ]
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"] == [
+        {
+            "index": 0,
+            "type": "raw_civ_transaction",
+            "ok": False,
+            "status": "nak",
+            "error": "radio_nak",
+            "message": "radio returned CI-V NAK",
+            "result": {
+                "frame": "FEFEE0A2FAFD",
+                "command": 0xFA,
+                "sub": None,
+                "data": "",
+            },
+        },
+        {
+            "index": 1,
+            "name": "set_freq",
+            "ok": False,
+            "status": "skipped",
+            "error": "skipped_after_failure",
+            "message": "skipped after earlier batch failure",
+        },
+    ]
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_transaction_timeout_can_continue() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock(side_effect=TimeoutError("timed out"))
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    captured: list[object] = []
+    consumer = asyncio.create_task(
+        _complete_ordered_commands(srv.command_queue, 1, captured)
+    )
+    try:
+        writer = await _post_json(
+            srv,
+            "/api/v1/commands/batch",
+            {
+                "continue_on_error": True,
+                "steps": [
+                    {
+                        "type": "raw_civ_transaction",
+                        "command": 0x03,
+                        "expect": "data",
+                        "timeout_ms": 10,
+                    },
+                    {"name": "set_mode", "params": {"mode": "FM"}},
+                ],
+            },
+        )
+    finally:
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert [result["status"] for result in writer.response_body["results"]] == [
+        "timed_out",
+        "executed",
+    ]
+    assert writer.response_body["results"][0] == {
+        "index": 0,
+        "type": "raw_civ_transaction",
+        "ok": False,
+        "status": "timed_out",
+        "error": "transaction_timeout",
+        "message": "raw CI-V transaction timed out",
+    }
+    assert captured == [SetMode("FM", receiver=0)]
+    radio.send_civ_transaction.assert_awaited_once_with(
+        0x03,
+        sub=None,
+        data=b"",
+        expect="data",
+        timeout=0.01,
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_transaction_timeout_stops_and_skips_later() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock(side_effect=TimeoutError("timed out"))
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "continue_on_error": False,
+            "steps": [
+                {
+                    "type": "raw_civ_transaction",
+                    "command": 0x03,
+                    "expect": "data",
+                    "timeout_ms": 10,
+                },
+                {"name": "set_mode", "params": {"mode": "FM"}},
+            ],
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert [result["status"] for result in writer.response_body["results"]] == [
+        "timed_out",
+        "skipped",
+    ]
+    assert writer.response_body["results"][0]["error"] == "transaction_timeout"
+    assert writer.response_body["results"][1] == {
+        "index": 1,
+        "name": "set_mode",
+        "ok": False,
+        "status": "skipped",
+        "error": "skipped_after_failure",
+        "message": "skipped after earlier batch failure",
+    }
+    assert srv.command_queue.drain() == []
+    radio.send_civ_transaction.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_transaction_owner_conflict_stops_batch() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock(
+        side_effect=RuntimeError("CI-V stream is already owned by external")
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {"type": "raw_civ_transaction", "command": 0x03, "expect": "data"},
+                {"name": "set_freq", "params": {"freq": 144_030_000}},
+            ]
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"][0] == {
+        "index": 0,
+        "type": "raw_civ_transaction",
+        "ok": False,
+        "status": "owner_conflict",
+        "error": "civ_owner_conflict",
+        "message": "CI-V stream is already owned by external",
+    }
+    assert writer.response_body["results"][1]["status"] == "skipped"
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_transaction_reports_unsupported_backend() -> None:
+    srv = WebServer(_radio_without_civ(), WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {
+                    "type": "raw_civ_transaction",
+                    "command": 0x1A,
+                    "expect": "ack",
+                }
+            ]
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"] == [
+        {
+            "index": 0,
+            "type": "raw_civ_transaction",
+            "ok": False,
+            "status": "unsupported",
+            "error": "unsupported_command",
+            "message": "active backend does not support raw CI-V transactions",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_transaction_reports_read_only() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock()
+    srv = WebServer(
+        radio,
+        WebConfig(host="127.0.0.1", port=0, read_only=True),
+    )
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {
+                    "type": "raw_civ_transaction",
+                    "command": 0x1A,
+                    "expect": "ack",
+                }
+            ]
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"] == [
+        {
+            "index": 0,
+            "type": "raw_civ_transaction",
+            "ok": False,
+            "status": "read_only",
+            "error": "read_only",
+            "message": "raw CI-V transactions are disabled in read-only mode",
+        }
+    ]
+    radio.send_civ_transaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_transaction_reports_no_radio() -> None:
+    srv = WebServer(None, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {
+                    "type": "raw_civ_transaction",
+                    "command": 0x1A,
+                    "expect": "ack",
+                }
+            ]
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"] == [
+        {
+            "index": 0,
+            "type": "raw_civ_transaction",
+            "ok": False,
+            "status": "no_radio",
+            "error": "no_radio",
+            "message": "No radio configured",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_legacy_no_radio_stays_service_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(web_server, "_COMMAND_BATCH_STEP_TIMEOUT", 0.001)
+    srv = WebServer(None, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {"steps": [{"name": "set_freq", "params": {"freq": 144_030_000}}]},
+    )
+
+    assert writer.response_status == 503
+    assert writer.response_body == {
+        "error": "no_radio",
+        "message": "No radio configured",
+    }
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_mixed_legacy_then_transaction_no_radio_stays_service_unavailable() -> (
+    None
+):
+    srv = WebServer(None, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {"name": "set_freq", "params": {"freq": 144_030_000}},
+                {
+                    "type": "raw_civ_transaction",
+                    "command": 0x1A,
+                    "expect": "ack",
+                },
+            ]
+        },
+    )
+
+    assert writer.response_status == 503
+    assert writer.response_body == {
+        "error": "no_radio",
+        "message": "No radio configured",
+    }
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_legacy_send_civ_stays_fire_and_forget() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    captured: list[object] = []
+    consumer = asyncio.create_task(
+        _complete_ordered_commands(srv.command_queue, 1, captured)
+    )
+    try:
+        writer = await _post_json(
+            srv,
+            "/api/v1/commands/batch",
+            {
+                "steps": [
+                    {
+                        "name": "send_civ",
+                        "params": {
+                            "command": 0x1A,
+                            "sub": 0x05,
+                            "data": "015301",
+                        },
+                    }
+                ]
+            },
+        )
+    finally:
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is True
+    assert writer.response_body["results"][0]["status"] == "executed"
+    assert captured == [
+        SendCiv(command=0x1A, sub=0x05, data=b"\x01\x53\x01"),
+    ]
+    radio.send_civ_transaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_legacy_send_civ_rejects_wait_response() -> None:
+    radio = _radio()
+    radio.send_civ_transaction = AsyncMock()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands/batch",
+        {
+            "steps": [
+                {
+                    "name": "send_civ",
+                    "params": {
+                        "command": 0x1A,
+                        "sub": 0x05,
+                        "data": "015301",
+                        "wait_response": True,
+                    },
+                },
+                {"name": "set_freq", "params": {"freq": 144_030_000}},
+            ]
+        },
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert writer.response_body["results"][0]["status"] == "failed_validation"
+    assert writer.response_body["results"][0]["error"] in {
+        "invalid_request",
+        "unsupported_command",
+    }
+    assert writer.response_body["results"][1]["status"] == "skipped"
+    radio.send_civ_transaction.assert_not_awaited()
+    assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
 async def test_http_command_batch_rejects_raw_civ_when_backend_does_not_support_it() -> (
     None
 ):


### PR DESCRIPTION
## Summary

- Adds raw CI-V transaction support to ordered command batches while preserving ordered response semantics.
- Documents raw transaction request/response behavior in the web API docs and internal raw CI-V transaction notes.
- Adds targeted HTTP batch coverage for mixed commands, raw transactions, validation, and execution edge cases.

## Test plan

- `git diff --check` - passed
- `uv run ruff check src/ tests/` - passed
- `uv run ruff format --check src/rigplane/web/server.py tests/test_web_command_batch_http.py` - passed
- `uv run mypy --strict src/rigplane/web` - passed
- Targeted pytest - 68 passed
- Full pytest - 6160 passed, 112 skipped, 3 deselected, 11 xfailed, 1 xpassed
- `mkdocs build --strict` - passed

## Review

- Final independent review approved.
- Residual nonblocking test gaps from reviewer:
- batch `expect: "none"` is covered by the single transaction endpoint but not by a direct batch test.
- runtime `failed_execution` non-owner-conflict and strict extra-field rejection are lightly tested.
- CI-V scalar parsing is stricter but compatible with documented numeric JSON usage.

Closes #1624.
Addresses #1633, #1634, #1635, #1636.
