### PR TITLE
docs: update release readiness docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,15 +12,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added ordered HTTP command batches so local automation can run structured
+  commands in request order with per-step results and timeout handling (#1606,
+  31c41425).
+- Published the full HTTP/WebSocket command catalog in the API docs so client
+  authors can discover the supported command names, parameters, and response
+  shapes without reading server code (#1607, f4c113e7).
 - Exposed a queued, fire-and-forget raw CI-V `send_civ` command through the
   HTTP/WS command surface and ordered batch endpoint so automation clients can
   send vendor-specific CI-V without opening a competing radio session (#1616,
-  #1617, 1437232d).
+  fb2965ee).
 - Added `POST /api/v1/civ/transaction` for scoped raw CI-V transactions with
   explicit `expect` modes (`none`, `ack`, `data`), deterministic ACK/NAK/data
   JSON results, bounded timeouts, and CI-V ownership guarding (#1622, #1623).
+- Added response-capable raw CI-V transaction steps to ordered HTTP batches via
+  `type: "raw_civ_transaction"`, preserving order when mixed with queued
+  command steps (#1637, 06c4c7b0).
+- Added an internal raw CI-V pipe and local Hamlib A1 bridge runner for
+  development of transparent external-CAT ownership over CI-V serial backends
+  (#1610, #1612, #1614, #1615, c371bc3b, 085cd617, c3a09e1e, deabb95d).
+- Added a distinct Xiegu X6200 native rig profile and discovery
+  disambiguation from IC-705 despite the shared factory CI-V address `0xA4`
+  (#1630, 7b593eee).
 - Documented Python usage for response-capable raw CI-V HTTP transactions
   (#1626).
+
+### Changed
+- Cleaned up type-checking visible at integration boundaries, including raw
+  CI-V transaction coverage and audio TX PCM signatures, reducing false
+  positives for typed downstream users (#1628, #1629, db90a992, bda2ed0a,
+  a356a1ab).
+
+### Fixed
+- Registered Xiegu X6200 in the CLI model registry so `--model X6200` resolves
+  to the X6200 preset instead of silently falling back to IC-7610 (#1631,
+  204aea24).
+- Stopped sending LAN `OpenClose` packets on the serial CI-V wire, avoiding an
+  X6200 flicker/wedge failure mode observed on hardware (#1632, 28a962d0).
+
+### Docs
+- Clarified raw CI-V transaction and batch contracts, including the split
+  between public/dev-facing raw transaction APIs and the internal experimental
+  Hamlib A1 raw-pipe bridge path (#1616, #1637, #1638).
 
 ## [2.4.0] — 2026-05-24
 

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -567,15 +567,65 @@ async def send_civ(
     command: int,
     sub: int | None = None,
     data: bytes | None = None,
-) -> CivFrame
+    *,
+    wait_response: bool = True,
+) -> CivFrame | None
 ```
 
-Send an arbitrary CI-V command and return the response.
+Send an arbitrary CI-V command through the active backend transport.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `command` | `int` | CI-V command byte |
 | `sub` | `int \| None` | Optional sub-command byte |
 | `data` | `bytes \| None` | Optional payload data |
+| `wait_response` | `bool` | When `True`, wait for and return the parsed response frame. When `False`, send the frame without registering a response waiter. |
 
-**Returns:** `CivFrame` with the radio's response.
+**Returns:** `CivFrame` with the radio's response when `wait_response=True`;
+`None` when `wait_response=False`.
+
+Use `wait_response=False` for fire-and-forget writes where a later response is
+not needed. Use `send_civ_transaction()` when the caller needs explicit
+ACK/NAK/data semantics and bounded response handling.
+
+### `send_civ_transaction()`
+
+```python
+async def send_civ_transaction(
+    self,
+    command: int,
+    sub: int | None = None,
+    data: bytes | None = None,
+    *,
+    expect: Literal["none", "ack", "data"] = "data",
+    timeout: float | None = None,
+) -> RawCivTransactionResult
+```
+
+Send one raw CI-V command with explicit response semantics.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `command` | `int` | CI-V command byte, `0` through `255` |
+| `sub` | `int \| None` | Optional CI-V sub-command byte, `0` through `255` |
+| `data` | `bytes \| None` | Optional payload bytes |
+| `expect` | `"none" \| "ack" \| "data"` | Response contract for this transaction |
+| `timeout` | `float \| None` | Optional timeout in seconds |
+
+`expect="none"` sends one frame and returns a sent result without waiting.
+`expect="ack"` waits for a fresh CI-V ACK or NAK. `expect="data"` waits for
+the keyed data response, while still treating a fresh NAK as a deterministic
+failure result.
+
+While the transaction is active, cooperating pollers pause via the external
+CAT-session ownership guard so background CI-V traffic cannot consume or
+pollute the caller's response.
+
+**Returns:** `RawCivTransactionResult` with `status`, optional parsed frame
+fields, and explicit ACK/NAK/data/sent outcome metadata.
+
+!!! note "Public surface"
+    `send_civ_transaction()` is the Python counterpart to the public/dev-facing
+    raw CI-V HTTP transaction APIs. The lower-level raw CI-V pipe used by the
+    local Hamlib A1 bridge runner is internal experimental infrastructure and
+    should not be treated as a stable application API.

--- a/docs/api/radios.md
+++ b/docs/api/radios.md
@@ -4,7 +4,7 @@ robots: noindex, follow
 
 # Radio Models
 
-Presets for known Icom radios with CI-V addresses and capabilities.
+Presets for known native radio models with CI-V addresses and capabilities.
 
 ::: rigplane.runtime.radios.RadioModel
 
@@ -20,6 +20,13 @@ Presets for known Icom radios with CI-V addresses and capabilities.
 | IC-9700 | 0xA2 | 2 | ✅ | ❌ |
 | IC-R8600 | 0x96 | 1 | ✅ | ❌ |
 | IC-7851 | 0x8E | 2 | ✅ | ❌ |
+| X6200 | 0xA4 | 1 | ❌ | ✅ |
+
+!!! note "X6200 and IC-705 share address 0xA4"
+    `get_civ_addr("X6200")` returns the Xiegu factory CI-V address, but
+    discovery still performs model disambiguation because IC-705 uses the same
+    default address. For automatic serial discovery, trust the resolved model
+    and profile rather than address alone.
 
 ## Usage
 
@@ -28,6 +35,7 @@ from rigplane import create_radio, LanBackendConfig, get_civ_addr
 
 # Look up CI-V address by model name
 addr = get_civ_addr("IC-705")  # returns 0xA4
+x6200_addr = get_civ_addr("X6200")  # also returns 0xA4
 
 # Use with create_radio (recommended)
 config = LanBackendConfig(host="192.168.1.100", username="u", password="p", radio_addr=addr)

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -100,6 +100,22 @@ broader coverage than maintaining a bespoke backend for each dialect.
 - **VFO scheme:** `ab`
 - **Status:** Profile only. May work with CI-V backend (untested); also a Hamlib assisted-discovery candidate.
 
+### Xiegu X6200
+
+- **Protocol:** CI-V (Xiegu/Icom-compatible subset)
+- **CI-V Address:** `0xA4` by factory default, shared with IC-705
+- **Connectivity:** USB serial CAT on `SERIAL-B`; default baud `19200`
+- **Rig profile:** `rigs/x6200.toml`
+- **Features:** HF + 6m, QRP, single receiver, VFO A/B, audio controls, PTT,
+  split, VOX, compressor, CW, RIT/XIT, tuner, meters, tones, data mode, scan,
+  dial lock, AGC
+- **Not advertised:** CI-V power control and spectrum scope; the documented
+  X6200 CI-V command envelope does not include those IC-705-style commands.
+- **Status:** Native profile and CLI preset are present. Discovery includes
+  X6200-vs-IC-705 disambiguation because both radios can report CI-V address
+  `0xA4`. First-party maintainer hardware validation is still pending; hardware
+  reports are welcome.
+
 ### Lab599 TX-500
 
 - **Protocol:** Kenwood CAT (text) / Hamlib candidate

--- a/docs/guide/rig-profiles.md
+++ b/docs/guide/rig-profiles.md
@@ -19,6 +19,7 @@ Rig files live in `rigs/`. Reference files:
 - `rigs/ic7300.toml` — IC-7300 (single receiver, USB serial, CI-V)
 - `rigs/ftx1.toml` — Yaesu FTX-1 (Yaesu CAT protocol, dual RX)
 - `rigs/x6100.toml` — Xiegu X6100 (CI-V, IC-705 compatible subset, QRP)
+- `rigs/x6200.toml` — Xiegu X6200 (CI-V subset, shares `0xA4` with IC-705)
 - `rigs/tx500.toml` — Lab599 TX-500 (Kenwood CAT protocol, QRP)
 
 ## Quick Start
@@ -51,6 +52,9 @@ type = "civ"  # or "kenwood_cat" or "yaesu_cat"
 ```
 
 For CI-V radios, `[radio].civ_addr` is required. For Kenwood/Yaesu, omit it.
+Do not assume a CI-V address uniquely identifies a model: Xiegu X6200 and
+Icom IC-705 both use `0xA4` by default, so discovery and profile selection must
+also consider model evidence such as hardware IDs and the resolved rig profile.
 
 Hamlib-backed support is a provider path, not just another TOML dialect. It
 should use Hamlib model metadata, safe read-only probing, and RigPlane's

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,7 @@ RigPlane keeps the browser UI, audio path, diagnostics, and `rigctld`-compatible
 | Yaesu FTX-1 | Yaesu CAT | :white_check_mark: Tested (USB) |
 | IC-705 | CI-V `0xA4` | :white_check_mark: Validated (LAN/WiFi community-tested) |
 | IC-9700 | CI-V `0xA2` | :material-help-circle: Profile — not yet tested |
+| Xiegu X6200 | CI-V `0xA4` | :material-help-circle: Native profile + discovery disambiguation; hardware reports welcome |
 | Xiegu X6100 | CI-V `0x70` / Hamlib candidate | :material-help-circle: Profile only; assisted discovery candidate |
 | Lab599 TX-500 | Kenwood CAT / Hamlib candidate | :material-help-circle: Profile only; assisted discovery candidate |
 | IC-7851 | CI-V `0x8E` | :material-help-circle: Should work |

--- a/docs/internals/raw-civ-transactions.md
+++ b/docs/internals/raw-civ-transactions.md
@@ -4,6 +4,25 @@ Raw CI-V transactions are the response-capable counterpart to the
 fire-and-forget `send_civ` command path. They are intentionally scoped to one
 frame and one explicit expectation.
 
+## Release Status
+
+The response-capable transaction surface is public/dev-facing for v2.5-style
+release readers:
+
+- Python: `CoreRadio.send_civ_transaction()`;
+- HTTP: `POST /api/v1/civ/transaction`;
+- ordered batches: `type: "raw_civ_transaction"` steps in
+  `POST /api/v1/commands/batch`.
+
+The transparent raw CI-V pipe used by the local Hamlib A1 bridge runner
+(`send_civ_raw_fire_and_forget()` plus `add_raw_civ_listener()`) remains
+internal experimental infrastructure. It exists to validate external CAT
+session ownership and bridge behavior without committing the pipe itself as a
+stable application API. The open-core boundary remains the generic provider
+contract, external `rigctld` client behavior, discovery candidates, and public
+CLI/docs; managed setup UX, support-evidence workflows, packaging decisions,
+and hosted/customer-specific flows belong outside Core.
+
 ## Ownership
 
 `CoreRadio.send_civ_transaction()` claims the existing external CAT-session

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
       - Protocol Deep Dive: internals/protocol.md
       - Radio Protocol: radio-protocol.md
       - Reliability semantics: internals/reliability-semantics.md
+      - Raw CI-V transactions: internals/raw-civ-transactions.md
       - GitHub Project workflow: internals/github-project-workflow.md
       - Capabilities Matrix: capabilities-matrix.md
       - CLI design: internals/cli-design.md


### PR DESCRIPTION
Refs #1638

## Summary
- update Unreleased changelog entries for post-v2.4.0 release-readiness work
- document Xiegu X6200 in operator and API/model docs
- correct Python raw CI-V API docs and link raw CI-V transaction internals in MkDocs nav

## Verification
- uv run pytest tests/test_command_catalog_docs.py tests/test_web_api_contract.py -q
- uv run mkdocs build --strict --site-dir /tmp/rigplane-core-docs-release-readiness
- git diff --check