### PR TITLE
chore(release): bump to 2.5.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] — 2026-05-28
+
 ### Added
 - Added ordered HTTP command batches so local automation can run structured
   commands in request order with per-step results and timeout handling (#1606,
@@ -1443,7 +1445,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/rigplane/rigplane-core/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/rigplane/rigplane-core/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/rigplane/rigplane-core/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/rigplane/rigplane-core/compare/v2.2.0...v2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.4.0"
+version = "2.5.0"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.4.0"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- bump package version to 2.5.0
- promote the prepared changelog from [Unreleased] to [2.5.0] — 2026-05-28
- refresh uv.lock project version

Closes #1640.

## Verification
Preflight on current main before the release bump:
- uv sync --extra dev --extra bridge
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run lint-imports
- uv run mypy --strict src/rigplane/web
- frontend: npm ci, npm run check, npx vitest run, npm run build
- uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread
- Python 3.12 backend matrix: ruff, format, lint-imports, mypy, pytest
- frontend build + uv build produced rigplane-2.5.0 artifacts locally
