### PR TITLE
fix(cli): honor serial model default baud

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Use the selected serial rig profile's `default_baud` when `--model` is
+  provided without `--serial-baud`, fixing Xiegu X6200 managed/local launches
+  that otherwise fell back to 115200 baud and timed out CAT/control reads
+  (#1642).
+
 ## [2.5.0] — 2026-05-28
 
 ### Added

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -1517,11 +1517,11 @@ def _rigs_dir() -> Path:
 
 def _resolve_model(
     args: argparse.Namespace,
-) -> tuple[int | None, str | None]:
+) -> tuple[int | None, str | None, int | None]:
     """Resolve radio_addr and model name from --model / --radio-addr flags.
 
     Returns:
-        (radio_addr, model_name) — either may be None.
+        (radio_addr, model_name, default_baud) — each may be None.
     """
     from rigplane.rig_loader import discover_rigs
 
@@ -1529,7 +1529,7 @@ def _resolve_model(
     radio_addr: int | None = getattr(args, "radio_addr", None)
 
     if model_name is None:
-        return radio_addr, None
+        return radio_addr, None, None
 
     rigs = discover_rigs(_rigs_dir())
 
@@ -1551,7 +1551,7 @@ def _resolve_model(
     if radio_addr is None:
         radio_addr = matched.civ_addr
 
-    return radio_addr, matched.model
+    return radio_addr, matched.model, matched.default_baud
 
 
 def _find_port_pid(port: int) -> str | None:
@@ -1610,7 +1610,7 @@ async def _build_backend_config(
     Runs auto-discovery when host / serial-port is not provided.
     Infers backend type from --serial-port when --backend is not set.
     """
-    radio_addr, model_name = _resolve_model(args)
+    radio_addr, model_name, model_default_baud = _resolve_model(args)
 
     # Infer backend from context when not explicitly set.
     backend = getattr(args, "backend", None)
@@ -1666,7 +1666,7 @@ async def _build_backend_config(
                 args.serial_baud = discovered_baud
         return SerialBackendConfig(
             device=device,
-            baudrate=getattr(args, "serial_baud", None) or 115200,
+            baudrate=getattr(args, "serial_baud", None) or model_default_baud or 115200,
             timeout=args.timeout,
             radio_addr=radio_addr,
             model=model_name,

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -133,6 +133,46 @@ class TestSerialBackend:
         assert cfg.model == "IC-7300"
         assert cfg.backend == "serial"
 
+    async def test_serial_model_uses_profile_default_baud(
+        self, parser: argparse.ArgumentParser
+    ) -> None:
+        ns = _parse(
+            parser,
+            [
+                "--backend",
+                "serial",
+                "--serial-port",
+                "/dev/ttyUSB0",
+                "--model",
+                "X6200",
+                "status",
+            ],
+        )
+        cfg = await _build_backend_config(ns)
+        assert cfg.model == "X6200"
+        assert cfg.baudrate == 19200
+
+    async def test_serial_baud_overrides_profile_default_baud(
+        self, parser: argparse.ArgumentParser
+    ) -> None:
+        ns = _parse(
+            parser,
+            [
+                "--backend",
+                "serial",
+                "--serial-port",
+                "/dev/ttyUSB0",
+                "--model",
+                "X6200",
+                "--serial-baud",
+                "38400",
+                "status",
+            ],
+        )
+        cfg = await _build_backend_config(ns)
+        assert cfg.model == "X6200"
+        assert cfg.baudrate == 38400
+
     async def test_radio_addr_with_serial(
         self, parser: argparse.ArgumentParser
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes #1642.

Core serial CLI launches now use the selected rig profile's `default_baud` when `--model` is provided and `--serial-baud` is omitted. This fixes Xiegu X6200 managed/local launches where Pro passes an explicit serial port plus `--model X6200`, which bypasses serial discovery and previously fell back to the generic 115200 baud default.

## Root Cause

`_build_backend_config()` only used discovered baud when it had to run serial auto-discovery. Pro local USB profiles launch Core with an explicit `--serial-port`, so discovery does not run, no discovered baud exists, and the serial backend fell back to 115200 instead of `rigs/x6200.toml`'s `default_baud = 19200`.

## Validation

- `uv run pytest tests/test_cli_model.py -q`
- `uv run pytest tests/test_cli_model.py tests/test_backend_factory.py tests/test_ic705_backend.py -q`
- `uv run ruff check src/ tests/test_cli_model.py`
- `uv run ruff format --check src/ tests/test_cli_model.py`
- `uv run lint-imports`
- `uv run mypy --strict src/rigplane/web`
- Hardware smoke on X6200 USB: `uv run rigplane --backend serial --model X6200 --serial-port /dev/cu.usbmodem58910181093 web ...` started at `@ 19200 baud`; `/api/v1/state` returned `14191000/USB`; rigctld `f`/`m` returned `14191000`, `USB`, `3000`.

## Notes

Pro should still persist/pass discovery baud in station targets as a follow-up, but this Core hotfix removes the immediate failure for model-backed serial launches.
