### PR TITLE
chore(release): bump to 2.5.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.1] — 2026-05-28
+
 ### Fixed
 - Use the selected serial rig profile's `default_baud` when `--model` is
   provided without `--serial-baud`, fixing Xiegu X6200 managed/local launches
@@ -1451,7 +1453,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.5.1...HEAD
+[2.5.1]: https://github.com/rigplane/rigplane-core/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/rigplane/rigplane-core/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/rigplane/rigplane-core/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/rigplane/rigplane-core/compare/v2.3.0...v2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.5.0"
+version = "2.5.1"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release bump for v2.5.1 after #1643.

## Changes

- Bump `rigplane` package version from 2.5.0 to 2.5.1.
- Move the X6200 serial default-baud hotfix changelog entry into the v2.5.1 section.

## Validation

Release preflight completed before this PR:
- `uv sync --extra dev --extra bridge`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run lint-imports`
- `uv run mypy --strict src/rigplane/web`
- `uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread` (`5937 passed, 57 skipped, 11 xfailed, 1 xpassed`)
- `npm ci`
- `npm run check`
- `npx vitest run` (`105 files / 1842 tests passed`)
- `npm run build`
- `uv build && rm -rf dist/` built `rigplane-2.5.1` artifacts successfully.

Note: an initial direct push to protected `main` was rejected as expected; the accidentally pushed remote tag was deleted before this PR.
