### PR TITLE
feat: Core real-radio validation matrix — schema, templates, dry-run runner (#1646)

### DIFF
--- a/docs/contracts/validation-matrix-v1.md
+++ b/docs/contracts/validation-matrix-v1.md
@@ -1,0 +1,226 @@
+# Validation Matrix Contract — `rigplane-validation-matrix-v1`
+
+**Schema name:** `rigplane-validation-matrix`
+**Schema version:** `1`
+**Status:** stable, public, open-source contract.
+**Last updated:** 2026-05-28
+
+## Purpose
+
+This contract documents the public, machine-readable shapes used by the
+`rigplane validate` vertical: capability-declaration **templates** (the planned
+validation matrix for one radio) and validation **artifacts** (the recorded
+evidence of a run). It is the spec that `rigplane.validation` builds against and
+that any tooling consuming validation output should target.
+
+The current release ships the **dry-run** path only. The artifact shape is
+forward-compatible with hardware runs, but hardware execution is intentionally
+not implemented and is double-gated (see [Safety policy](#safety-policy)).
+
+## Core boundary
+
+This document is open-source and authoritative for the open-core validation
+matrix. The validation runner lives behind the `Radio` protocol and the
+`local-extensions/` Pro boundary described in
+`docs/architecture/open-core-policy.md`; any Pro-tier validation extensions
+(extended check libraries, signed result attestation, fleet aggregation) are
+governed by a separate private contract and are deliberately out of scope here.
+The schema in this document carries no telemetry and no licence context.
+
+## Template schema
+
+A template plans the matrix for one radio. Top-level object:
+
+| Field            | Type     | Required | Notes                                       |
+| ---------------- | -------- | -------- | ------------------------------------------- |
+| `schema_version` | integer  | yes      | Must equal `1`.                             |
+| `radio`          | object   | yes      | `{ model, profile_id }`, both non-empty.    |
+| `entries`        | array    | yes      | Non-empty list of entry objects (below).    |
+
+Each `entries[]` object:
+
+| Field         | Type    | Required | Notes                                                              |
+| ------------- | ------- | -------- | ------------------------------------------------------------------ |
+| `check_id`    | string  | yes      | Non-empty; unique within the template.                             |
+| `capability`  | string  | yes      | `""` or a member of `KNOWN_CAPABILITIES`.                          |
+| `level`       | integer | yes      | `0`–`5` (see [Levels](#levels)).                                   |
+| `declaration` | string  | yes      | One of the [declaration vocabulary](#capability-declaration-vocabulary). |
+| `summary`     | string  | yes      | Human-readable description.                                        |
+| `tx_adjacent` | boolean | no       | Default `false`; gates the check behind operator authorization.    |
+
+## Artifact schema
+
+An artifact records the evidence of a run. Top-level object:
+
+| Field            | Type    | Required | Notes                                                    |
+| ---------------- | ------- | -------- | -------------------------------------------------------- |
+| `schema_version` | integer | yes      | Must equal `1`.                                          |
+| `tool`           | string  | yes      | `"rigplane-validation-matrix"`.                          |
+| `mode`           | string  | no       | `"dry-run"` by default.                                  |
+| `core_version`   | string  | yes\*    | rigplane version that produced the artifact.             |
+| `core_commit`    | string  | no       | Git commit; omitted when unavailable.                    |
+| `logs_path`      | string  | no       | Path to run logs; omitted when unavailable.              |
+| `radio`          | object  | yes      | `{ model, profile_id }`.                                 |
+| `transport`      | object  | yes      | `{ backend, host?, port?, baud? }`.                      |
+| `safety`         | object  | yes      | See [Safety policy](#safety-policy).                     |
+| `levels`         | array   | yes      | List of level objects, each `{ level, checks[] }`.       |
+| `metadata`       | object  | no       | Free-form; carries `summary` status counts.              |
+
+\* `core_version` is required by the producer; the validator accepts an empty
+string for robustness but the CLI always populates it.
+
+Each `levels[].checks[]` object:
+
+| Field            | Type    | Required | Notes                                                       |
+| ---------------- | ------- | -------- | ----------------------------------------------------------- |
+| `check_id`       | string  | yes      |                                                             |
+| `capability`     | string  | yes      | `""` or a member of `KNOWN_CAPABILITIES`.                   |
+| `level`          | integer | yes      | `0`–`5`.                                                    |
+| `level_name`     | string  | (emitted)| Lower-cased level name (producer output).                   |
+| `status`         | string  | yes      | One of the [status vocabulary](#status-vocabulary).         |
+| `declaration`    | string  | yes      | One of the declaration vocabulary.                          |
+| `summary`        | string  | yes      |                                                             |
+| `failure_domain` | string  | cond.    | **Required** when `status` is `fail` or `blocked`.          |
+| `evidence`       | object  | no       | Free-form evidence; omitted when empty.                     |
+| `error`          | string  | no       | Error detail; omitted when absent.                          |
+
+## Status vocabulary
+
+| Status            | Meaning                                                      |
+| ----------------- | ------------------------------------------------------------ |
+| `pass`            | Check executed and succeeded.                                |
+| `fail`            | Check executed and failed (carries `failure_domain`).        |
+| `skip`            | Not executed this run (e.g. supported, dry-run planned).     |
+| `unsupported`     | Capability not declared/available for this radio.            |
+| `manual_required` | Requires an operator to perform/verify out of band.          |
+| `blocked`         | Not run because authorization was withheld (carries domain). |
+
+## Capability declaration vocabulary
+
+| Declaration                    | Meaning                                                |
+| ------------------------------ | ------------------------------------------------------ |
+| `supported`                    | Capability is declared in the radio profile.           |
+| `unsupported_pending_evidence` | Not declared; absence pending evidence to confirm.     |
+| `manual_required`              | Requires manual/operator verification.                 |
+
+## Levels
+
+| Level | Name                     | Scope                                          |
+| ----- | ------------------------ | ---------------------------------------------- |
+| `0`   | `static_profile`         | Static profile inspection, no I/O.             |
+| `1`   | `discovery`              | Discovery / identification.                    |
+| `2`   | `basic_control`          | Basic read/write control (freq, mode).         |
+| `3`   | `capability_matrix`      | Per-capability functional checks.              |
+| `4`   | `compatibility_surfaces` | Audio, scope, rigctld surfaces.                |
+| `5`   | `stress_recovery`        | Stress, recovery, TX-adjacent operations.      |
+
+## Failure domains
+
+A `fail` or `blocked` check must name the responsible subsystem:
+
+`discovery`, `transport`, `command_execution`, `readback`,
+`state_publishing`, `rigctld`, `audio`, `scope_waterfall`.
+
+## Safety policy
+
+The `safety` block records operator authorization:
+
+| Field                | Type    | Default | Notes                                         |
+| -------------------- | ------- | ------- | --------------------------------------------- |
+| `tx_allowed`         | boolean | `false` | Authorizes TX-adjacent checks (PTT/TX).       |
+| `tuner_allowed`      | boolean | `false` | Authorizes tuner tune-cycle checks.           |
+| `operator_id`        | string  | omitted | Operator identifier when supplied.            |
+| `authorized_at_unix` | integer | omitted | Authorization timestamp when supplied.        |
+
+Both `tx_allowed` and `tuner_allowed` default to `false`. TX-adjacent checks —
+including the antenna tuner tune cycle, which can key the transmitter — are
+**opt-in only**. A `tx_adjacent` entry that is not authorized is reported as
+`blocked` with the `command_execution` failure domain; it is never silently
+skipped.
+
+Hardware execution is additionally double-gated at the CLI: `--hardware`
+requires both the `--allow-hardware` flag and the
+`RIGPLANE_VALIDATION_ALLOW_HARDWARE=1` environment variable. Even with both
+gates open, the current release refuses hardware runs (exit code `3`) because
+the hardware path is not implemented.
+
+## Versioning
+
+`schema_version` is `1` for this contract revision. Non-breaking changes
+(adding optional fields) keep the version. Breaking changes (removing/renaming
+required fields, changing types or status/declaration semantics) mint a new
+`schema_version` (e.g. `2`).
+
+## JSON examples
+
+### Template
+
+```json
+{
+  "schema_version": 1,
+  "radio": { "model": "IC-7300", "profile_id": "ic7300" },
+  "entries": [
+    {
+      "check_id": "discovery.identify",
+      "capability": "",
+      "level": 1,
+      "declaration": "supported",
+      "summary": "Radio identifies on the configured transport.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "tx.ptt",
+      "capability": "tx",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "PTT key/unkey (requires operator authorization).",
+      "tx_adjacent": true
+    }
+  ]
+}
+```
+
+### Artifact (dry-run)
+
+```json
+{
+  "schema_version": 1,
+  "tool": "rigplane-validation-matrix",
+  "mode": "dry-run",
+  "core_version": "2.5.1",
+  "radio": { "model": "IC-7300", "profile_id": "ic7300" },
+  "transport": { "backend": "fixture" },
+  "safety": { "tx_allowed": false, "tuner_allowed": false },
+  "levels": [
+    {
+      "level": 5,
+      "level_name": "stress_recovery",
+      "checks": [
+        {
+          "check_id": "tx.ptt",
+          "capability": "tx",
+          "level": 5,
+          "level_name": "stress_recovery",
+          "status": "blocked",
+          "declaration": "manual_required",
+          "summary": "PTT key/unkey (requires operator authorization).",
+          "failure_domain": "command_execution"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "summary": {
+      "pass": 0, "fail": 0, "skip": 3,
+      "unsupported": 0, "manual_required": 1, "blocked": 2
+    }
+  }
+}
+```
+
+## See also
+
+- Design plan: `docs/plans/2026-05-28-real-radio-validation-matrix.md`
+- Schema source: `src/rigplane/validation/schema.py`
+- Layer charter: `src/rigplane/validation/LAYER.md`
+- Open-core policy: `docs/architecture/open-core-policy.md`

--- a/docs/plans/2026-05-28-real-radio-validation-matrix.md
+++ b/docs/plans/2026-05-28-real-radio-validation-matrix.md
@@ -1,0 +1,86 @@
+# Real-radio validation matrix — Core vertical
+
+**Date:** 2026-05-28
+**Issues:** #1645, #1646, #1647, #1651
+**Status:** dry-run vertical landed; hardware execution stubbed.
+
+## Summary
+
+The validation matrix gives RigPlane Core a versioned, machine-readable way to
+declare *what should work* on a given radio (a **template**) and to record
+*what was observed* (an **artifact**). This vertical lands the schema, the
+validators, a dry-run runner, the `rigplane validate` CLI, four seed radio
+templates, and the public contract. Hardware execution is intentionally
+deferred and stubbed behind explicit opt-in gates.
+
+## Scope
+
+In scope for this vertical:
+
+- Frozen schema dataclasses + enums (`schema_version = 1`).
+- `validate_template_dict` / `validate_artifact_dict` validators that narrow
+  untrusted JSON into typed dataclasses without `type: ignore`.
+- Dry-run runner: map a template into per-level `CheckResult` skeletons,
+  gating TX-adjacent and tuner checks behind operator authorization.
+- `rigplane validate` CLI (dry-run; JSON or human summary).
+- Seed templates for IC-7300, FTX-1, TX-500, X6200.
+- Public contract `docs/contracts/validation-matrix-v1.md`.
+- `validation_hardware` pytest marker registration.
+
+Out of scope (stubbed or deferred):
+
+- **Hardware I/O** — no transport, radio, or audio access. `--hardware` is
+  double-gated (`--allow-hardware` + `RIGPLANE_VALIDATION_ALLOW_HARDWARE=1`)
+  and still refuses with exit `3` because no hardware path exists yet.
+- Capability bug fixes, Pro code, resume/persistence engines, new
+  abstractions, YAML or new third-party dependencies, `.importlinter` changes.
+
+## File layout
+
+```
+src/rigplane/validation/
+  __init__.py        public re-exports
+  schema.py          enums, dataclasses, validators
+  runner.py          dry-run runner + artifact assembly
+  LAYER.md           layer charter
+src/rigplane/cli/_validate.py   CLI subcommand (mirrors _diagnose.py)
+docs/contracts/validation-matrix-v1.md
+docs/validation/templates/{ic7300,ftx1,tx500,x6200}.json
+tests/test_validation_{schema,runner,templates}.py
+tests/fixtures/validation_template_ic7300.json
+tests/fixtures/validation_artifact_mixed.json
+tests/fixtures/validation_artifact_reverse_sync_fail.json
+```
+
+The `validation` layer imports only `rigplane.core.capabilities` and the
+standard library; `cli._validate` is its sole CLI consumer.
+
+## Safety model
+
+`tx_allowed` and `tuner_allowed` default to `false`. TX-adjacent checks
+(PTT/TX and the tuner tune cycle, which can key the transmitter) are opt-in
+only; an unauthorized `tx_adjacent` entry is reported `blocked` with the
+`command_execution` failure domain, never silently skipped.
+
+## What is stubbed
+
+The hardware execution path. The artifact shape is forward-compatible with
+real runs (`mode`, `transport`, `failure_domain`, `evidence`, `error`,
+`logs_path` are all part of the v1 contract), but this release produces only
+dry-run plans.
+
+## TDD order
+
+1. `schema.py` → `tests/test_validation_schema.py`
+2. `runner.py` → `tests/test_validation_runner.py`
+3. `cli/_validate.py` + CLI wiring
+4. seed templates → `tests/test_validation_templates.py`
+5. contract doc + this plan
+6. `validation_hardware` pytest marker
+
+## Links
+
+- #1645 — schema + contract
+- #1646 — dry-run runner + CLI (this vertical)
+- #1647 — seed templates
+- #1651 — hardware execution (future, stubbed here)

--- a/docs/validation/templates/ftx1.json
+++ b/docs/validation/templates/ftx1.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "radio": {
+    "model": "FTX-1",
+    "profile_id": "ftx1"
+  },
+  "entries": [
+    {
+      "check_id": "discovery.identify",
+      "capability": "",
+      "level": 1,
+      "declaration": "supported",
+      "summary": "Radio identifies on the configured transport.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.write",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Set frequency via CAT write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.reverse_sync",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Radio-side frequency change is reflected back to core state.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "audio.rx",
+      "capability": "audio",
+      "level": 4,
+      "declaration": "manual_required",
+      "summary": "Receive audio stream check (operator-verified).",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "scope.capture",
+      "capability": "scope",
+      "level": 4,
+      "declaration": "unsupported_pending_evidence",
+      "summary": "Spectrum scope not declared in the FTX-1 profile; pending evidence.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "tuner.tune",
+      "capability": "tuner",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "Antenna tuner tune cycle (requires operator authorization).",
+      "tx_adjacent": true
+    },
+    {
+      "check_id": "tx.ptt",
+      "capability": "tx",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "PTT key/unkey (requires operator authorization).",
+      "tx_adjacent": true
+    }
+  ]
+}

--- a/docs/validation/templates/ic7300.json
+++ b/docs/validation/templates/ic7300.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "radio": {
+    "model": "IC-7300",
+    "profile_id": "ic7300"
+  },
+  "entries": [
+    {
+      "check_id": "discovery.identify",
+      "capability": "",
+      "level": 1,
+      "declaration": "supported",
+      "summary": "Radio identifies on the configured transport.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.write",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Set frequency via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.reverse_sync",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Radio-side frequency change is reflected back to core state.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "audio.rx",
+      "capability": "audio",
+      "level": 4,
+      "declaration": "manual_required",
+      "summary": "Receive audio stream check (operator-verified).",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "scope.capture",
+      "capability": "scope",
+      "level": 4,
+      "declaration": "supported",
+      "summary": "Spectrum scope frame capture.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "tuner.tune",
+      "capability": "tuner",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "Antenna tuner tune cycle (requires operator authorization).",
+      "tx_adjacent": true
+    },
+    {
+      "check_id": "tx.ptt",
+      "capability": "tx",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "PTT key/unkey (requires operator authorization).",
+      "tx_adjacent": true
+    }
+  ]
+}

--- a/docs/validation/templates/tx500.json
+++ b/docs/validation/templates/tx500.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "radio": {
+    "model": "TX-500",
+    "profile_id": "tx500"
+  },
+  "entries": [
+    {
+      "check_id": "discovery.identify",
+      "capability": "",
+      "level": 1,
+      "declaration": "supported",
+      "summary": "Radio identifies on the configured transport.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.write",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Set frequency via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.reverse_sync",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Radio-side frequency change is reflected back to core state.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "audio.rx",
+      "capability": "audio",
+      "level": 4,
+      "declaration": "manual_required",
+      "summary": "Receive audio stream check (operator-verified).",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "scope.capture",
+      "capability": "scope",
+      "level": 4,
+      "declaration": "unsupported_pending_evidence",
+      "summary": "Spectrum scope not declared in the TX-500 profile; pending evidence.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "tuner.tune",
+      "capability": "tuner",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "Antenna tuner tune cycle (requires operator authorization).",
+      "tx_adjacent": true
+    },
+    {
+      "check_id": "tx.ptt",
+      "capability": "tx",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "PTT key/unkey (requires operator authorization).",
+      "tx_adjacent": true
+    }
+  ]
+}

--- a/docs/validation/templates/x6200.json
+++ b/docs/validation/templates/x6200.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "radio": {
+    "model": "X6200",
+    "profile_id": "x6200"
+  },
+  "entries": [
+    {
+      "check_id": "discovery.identify",
+      "capability": "",
+      "level": 1,
+      "declaration": "supported",
+      "summary": "Radio identifies on the configured transport.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.write",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Set frequency via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.reverse_sync",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Radio-side frequency change is reflected back to core state.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "audio.rx",
+      "capability": "audio",
+      "level": 4,
+      "declaration": "manual_required",
+      "summary": "Receive audio stream check (operator-verified).",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "scope.capture",
+      "capability": "scope",
+      "level": 4,
+      "declaration": "unsupported_pending_evidence",
+      "summary": "Spectrum scope not declared in the X6200 profile; pending evidence.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "tuner.tune",
+      "capability": "tuner",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "Antenna tuner tune cycle (requires operator authorization).",
+      "tx_adjacent": true
+    },
+    {
+      "check_id": "tx.ptt",
+      "capability": "tx",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "PTT key/unkey (requires operator authorization).",
+      "tx_adjacent": true
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ markers = [
     "hardware: opt-in tests that may key a real transmitter or require attached devices",
     "e2e: end-to-end tests for PCM API and CLI audio workflows",
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "validation_hardware: real-radio validation runs; requires explicit env opt-in",
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -86,6 +86,10 @@ from rigplane.cli._diagnose import (  # noqa: E402
     add_subparser as _add_diagnose_subparser,
     run as _run_diagnose,
 )
+from rigplane.cli._validate import (  # noqa: E402
+    add_subparser as _add_validate_subparser,
+    run as _run_validate,
+)
 from rigplane.core.radio_protocol import Radio  # noqa: E402
 from rigplane.core.types import Mode, get_audio_capabilities  # noqa: E402
 
@@ -327,6 +331,7 @@ _COMMAND_NAMES = {
     "proxy",
     "scope",
     "diagnose",
+    "validate",
 }
 
 _GLOBAL_CONNECTION_OPTIONS = {
@@ -1480,6 +1485,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # diagnose — build (and optionally upload) a diagnostic report bundle
     _add_diagnose_subparser(sub)
+
+    # validate — run the real-radio validation matrix (dry-run by default)
+    _add_validate_subparser(sub)
 
     return p
 
@@ -3713,6 +3721,8 @@ def main() -> None:
         sys.exit(0)
     elif args.command == "diagnose":
         sys.exit(_run_diagnose(args))
+    elif args.command == "validate":
+        sys.exit(_run_validate(args))
     elif args.command is None:
         parser.print_help()
         sys.exit(0)

--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -1,0 +1,157 @@
+"""``rigplane validate`` subcommand — real-radio validation matrix runner.
+
+This ships the dry-run path only: it loads a capability-declaration template,
+applies operator-safety gating, and emits a machine-readable validation
+artifact (or a human summary). Hardware execution is intentionally not
+implemented in this version; the ``--hardware`` flag is double-gated by
+``--allow-hardware`` and the ``RIGPLANE_VALIDATION_ALLOW_HARDWARE=1`` environment
+variable, and even when both gates are open the command refuses with exit 3
+because no hardware path exists yet.
+
+Exit codes:
+
+* ``0`` — success (dry-run artifact emitted). Failed/blocked dry-run checks do
+  NOT change the exit code.
+* ``2`` — template missing, unreadable, or schema-invalid.
+* ``3`` — hardware run requested but blocked (gates closed or not implemented).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from rigplane import __version__
+from rigplane.validation import (
+    HARDWARE_OPT_IN_ENV,
+    OperatorSafetyBlock,
+    TransportInfo,
+    build_validation_artifact,
+    dry_run_results,
+    human_summary,
+    load_template,
+)
+from rigplane.validation.schema import SchemaValidationError
+
+
+def add_subparser(sub: Any) -> argparse.ArgumentParser:
+    """Register the ``validate`` subparser on ``sub`` (an ``_SubParsersAction``).
+
+    Typed as ``Any`` because ``argparse._SubParsersAction`` is private and the
+    surrounding parser code in ``cli/__init__.py`` follows the same convention.
+    """
+    p: argparse.ArgumentParser = sub.add_parser(
+        "validate",
+        help="Run the real-radio validation matrix (dry-run by default).",
+    )
+    p.add_argument(
+        "--template",
+        required=True,
+        help="Path to a validation matrix template JSON file.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan checks without touching hardware (default behavior).",
+    )
+    p.add_argument(
+        "--hardware",
+        action="store_true",
+        help="Request a real-radio run (double-gated; not implemented this release).",
+    )
+    p.add_argument(
+        "--allow-hardware",
+        action="store_true",
+        help=f"First hardware gate; also requires {HARDWARE_OPT_IN_ENV}=1.",
+    )
+    p.add_argument(
+        "--tx-allowed",
+        dest="tx_allowed",
+        action="store_true",
+        help="Authorize TX-adjacent checks (PTT/TX).",
+    )
+    p.add_argument(
+        "--tuner-allowed",
+        dest="tuner_allowed",
+        action="store_true",
+        help="Authorize tuner tune-cycle checks.",
+    )
+    p.add_argument(
+        "--operator-id",
+        dest="operator_id",
+        default=None,
+        help="Operator identifier recorded in the safety block.",
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        help="Write the JSON artifact to this path instead of stdout.",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the artifact as JSON (default: human summary).",
+    )
+    return p
+
+
+def run(args: argparse.Namespace) -> int:
+    try:
+        template = load_template(Path(args.template))
+    except (SchemaValidationError, OSError) as exc:
+        print(f"Error: cannot load template: {exc}", file=sys.stderr)
+        return 2
+
+    authorized = bool(args.tx_allowed or args.tuner_allowed)
+    safety = OperatorSafetyBlock(
+        tx_allowed=args.tx_allowed,
+        tuner_allowed=args.tuner_allowed,
+        operator_id=args.operator_id,
+        authorized_at_unix=int(time.time()) if authorized else None,
+    )
+
+    if args.hardware:
+        if not (args.allow_hardware and os.environ.get(HARDWARE_OPT_IN_ENV) == "1"):
+            print(
+                "Error: hardware validation is blocked. Both gates are required:\n"
+                "  1. pass --allow-hardware on the command line, and\n"
+                f"  2. set {HARDWARE_OPT_IN_ENV}=1 in the environment.",
+                file=sys.stderr,
+            )
+            return 3
+        # Even with both gates open, the hardware path is not implemented in
+        # this release. Refuse explicitly rather than silently dry-running.
+        print(
+            "Error: hardware validation is not implemented in this release; "
+            "run without --hardware for a dry-run plan.",
+            file=sys.stderr,
+        )
+        return 3
+
+    levels = dry_run_results(template, safety)
+    transport = TransportInfo(backend="fixture")
+    artifact = build_validation_artifact(
+        template=template,
+        levels=levels,
+        transport=transport,
+        safety=safety,
+        core_version=__version__,
+        core_commit=None,
+        mode="dry-run",
+    )
+
+    if args.json or args.output:
+        text = json.dumps(artifact.to_dict(), indent=2)
+        if args.output:
+            Path(args.output).write_text(text + "\n", encoding="utf-8")
+            print(f"Artifact written to: {args.output}", file=sys.stderr)
+        else:
+            print(text)
+    else:
+        print(human_summary(artifact))
+    return 0

--- a/src/rigplane/validation/LAYER.md
+++ b/src/rigplane/validation/LAYER.md
@@ -1,0 +1,50 @@
+# `validation` layer
+
+## Charter
+
+Real-radio validation matrix: the versioned schema and dry-run runner for the
+`rigplane validate` vertical. It defines two machine-readable shapes —
+capability-declaration **templates** (the planned per-radio matrix) and
+validation **artifacts** (recorded evidence) — plus validators that narrow
+untrusted JSON into typed dataclasses, and a dry-run runner that maps a
+template into per-level `CheckResult` skeletons with operator-safety gating.
+
+Hardware execution is **out of scope** for this layer in the current release.
+The runner only produces dry-run plans; the CLI refuses `--hardware` even when
+both opt-in gates are open. No transport, radio, or audio I/O happens here.
+
+## Public API
+
+`validation/__init__.py` re-exports the full surface:
+
+- **Enums**: `CheckStatus`, `CapabilityDeclaration`, `ValidationLevel`,
+  `FailureDomain`.
+- **Dataclasses** (frozen + slots): `CheckResult`, `LevelResult`,
+  `OperatorSafetyBlock`, `TransportInfo`, `RadioTarget`,
+  `CapabilityDeclarationEntry`, `MatrixTemplate`, `ValidationArtifact`.
+- **Validators**: `validate_template_dict`, `validate_artifact_dict`, raising
+  `SchemaValidationError`.
+- **Runner**: `load_template`, `dry_run_results`, `summarize_results`,
+  `build_validation_artifact`, `human_summary`, plus `HARDWARE_OPT_IN_ENV` and
+  `HardwareExecutionBlocked`.
+- **Constants**: `SCHEMA_VERSION`, `TOOL_NAME`.
+
+## Dependencies
+
+Imports only `rigplane.core.capabilities` (`KNOWN_CAPABILITIES`) and the
+standard library. It must not import from upper layers (`web/`, `rigctld/`,
+`backends/`, `runtime/`, `cli/`). The `cli._validate` module is the sole
+consumer wiring `validate` into the CLI.
+
+The upward-import boundary (no imports from `web/`, `rigctld/`, `cli/`) is
+governed by this charter and enforced by the ruff TID251 banned-import rule.
+`rigplane.validation` is not currently listed in `.importlinter` — it sits
+outside the layer DAG, mirroring `rigplane.diagnostics`. Adding it to the
+import-linter contract is deferred; do not claim import-linter enforcement
+that does not exist.
+
+## Contract
+
+The template and artifact shapes are a public, versioned contract — see
+`docs/contracts/validation-matrix-v1.md`. Field names, types, and `to_dict`
+shapes are frozen for `schema_version = 1`.

--- a/src/rigplane/validation/__init__.py
+++ b/src/rigplane/validation/__init__.py
@@ -1,0 +1,65 @@
+"""Real-radio validation matrix: schema, validators, and dry-run runner.
+
+Public surface for the ``rigplane validate`` vertical. The schema dataclasses
+and validators form a versioned contract (see
+``docs/contracts/validation-matrix-v1.md``); the runner provides the dry-run
+path that plans checks from a template without touching hardware.
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.runner import (
+    HARDWARE_OPT_IN_ENV,
+    HardwareExecutionBlocked,
+    build_validation_artifact,
+    dry_run_results,
+    human_summary,
+    load_template,
+    summarize_results,
+)
+from rigplane.validation.schema import (
+    SCHEMA_VERSION,
+    TOOL_NAME,
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckResult,
+    CheckStatus,
+    FailureDomain,
+    LevelResult,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    SchemaValidationError,
+    TransportInfo,
+    ValidationArtifact,
+    ValidationLevel,
+    validate_artifact_dict,
+    validate_template_dict,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "TOOL_NAME",
+    "CheckStatus",
+    "CapabilityDeclaration",
+    "ValidationLevel",
+    "FailureDomain",
+    "CheckResult",
+    "LevelResult",
+    "OperatorSafetyBlock",
+    "TransportInfo",
+    "RadioTarget",
+    "CapabilityDeclarationEntry",
+    "MatrixTemplate",
+    "ValidationArtifact",
+    "SchemaValidationError",
+    "validate_template_dict",
+    "validate_artifact_dict",
+    "HARDWARE_OPT_IN_ENV",
+    "HardwareExecutionBlocked",
+    "load_template",
+    "dry_run_results",
+    "summarize_results",
+    "build_validation_artifact",
+    "human_summary",
+]

--- a/src/rigplane/validation/runner.py
+++ b/src/rigplane/validation/runner.py
@@ -1,0 +1,184 @@
+"""Validation matrix runner helpers (dry-run + artifact assembly).
+
+This PR ships only the dry-run path: it maps a planned ``MatrixTemplate`` into
+``CheckResult`` skeletons, gating TX-adjacent and tuner checks behind explicit
+operator authorization. Hardware execution is intentionally out of scope and
+guarded by ``HARDWARE_OPT_IN_ENV`` plus a CLI refusal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckResult,
+    CheckStatus,
+    FailureDomain,
+    LevelResult,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    TransportInfo,
+    ValidationArtifact,
+    ValidationLevel,
+    validate_template_dict,
+)
+
+HARDWARE_OPT_IN_ENV = "RIGPLANE_VALIDATION_ALLOW_HARDWARE"
+
+# Capability tags whose checks require explicit operator authorization.
+_TUNER_CAPABILITY = "tuner"
+_TX_CAPABILITY = "tx"
+
+
+class HardwareExecutionBlocked(RuntimeError):
+    """Raised when a hardware validation run is attempted without opt-in."""
+
+
+_DECLARATION_TO_STATUS: dict[CapabilityDeclaration, CheckStatus] = {
+    CapabilityDeclaration.SUPPORTED: CheckStatus.SKIP,
+    CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE: CheckStatus.UNSUPPORTED,
+    CapabilityDeclaration.MANUAL_REQUIRED: CheckStatus.MANUAL_REQUIRED,
+}
+
+
+def load_template(path: Path) -> MatrixTemplate:
+    """Read and validate a template JSON file.
+
+    Propagates ``OSError`` on read failure and ``SchemaValidationError`` on bad
+    content.
+    """
+    text = path.read_text(encoding="utf-8")
+    data = json.loads(text)
+    return validate_template_dict(data)
+
+
+def _is_authorized(
+    entry: CapabilityDeclarationEntry, safety: OperatorSafetyBlock
+) -> bool:
+    """Return True when the operator is authorized to run ``entry``.
+
+    Fail-closed: any tx_adjacent entry is blocked by default.
+
+    - Non-TX-adjacent entries are always authorized.
+    - Tuner capability is gated solely by ``tuner_allowed`` (independent of
+      ``tx_allowed``), because the tuner keys TX into the ATU and has its own
+      operator gate.
+    - ALL other tx_adjacent entries — regardless of capability or check_id —
+      require ``tx_allowed``. There is no residual fail-open path.
+    """
+    if not entry.tx_adjacent:
+        return True
+    if entry.capability == _TUNER_CAPABILITY:
+        return safety.tuner_allowed
+    return safety.tx_allowed
+
+
+def dry_run_results(
+    template: MatrixTemplate, safety: OperatorSafetyBlock
+) -> list[LevelResult]:
+    """Map a template into per-level dry-run ``CheckResult`` skeletons.
+
+    Each entry's declaration maps to a base status; TX-adjacent entries that
+    are not authorized are overridden to ``BLOCKED`` with a
+    ``command_execution`` failure domain. Empty levels are omitted; levels are
+    returned in ascending order.
+    """
+    by_level: dict[ValidationLevel, list[CheckResult]] = {}
+    for entry in template.entries:
+        status = _DECLARATION_TO_STATUS[entry.declaration]
+        failure_domain: FailureDomain | None = None
+        if entry.tx_adjacent and not _is_authorized(entry, safety):
+            status = CheckStatus.BLOCKED
+            failure_domain = FailureDomain.COMMAND_EXECUTION
+        result = CheckResult(
+            check_id=entry.check_id,
+            capability=entry.capability,
+            level=entry.level,
+            status=status,
+            declaration=entry.declaration,
+            summary=entry.summary,
+            failure_domain=failure_domain,
+        )
+        by_level.setdefault(entry.level, []).append(result)
+
+    return [
+        LevelResult(level=level, checks=by_level[level]) for level in sorted(by_level)
+    ]
+
+
+def summarize_results(levels: list[LevelResult]) -> dict[str, int]:
+    """Count checks by status across all levels, zero-filling every status."""
+    summary = {status.value: 0 for status in CheckStatus}
+    for level in levels:
+        for check in level.checks:
+            summary[check.status.value] += 1
+    return summary
+
+
+def build_validation_artifact(
+    *,
+    template: MatrixTemplate,
+    levels: list[LevelResult],
+    transport: TransportInfo,
+    safety: OperatorSafetyBlock,
+    core_version: str,
+    core_commit: str | None = None,
+    logs_path: str | None = None,
+    mode: str = "dry-run",
+) -> ValidationArtifact:
+    """Assemble a ``ValidationArtifact`` with a stable status summary."""
+    metadata: dict[str, object] = {"summary": summarize_results(levels)}
+    return ValidationArtifact(
+        radio=template.radio,
+        transport=transport,
+        safety=safety,
+        levels=levels,
+        core_version=core_version,
+        core_commit=core_commit,
+        logs_path=logs_path,
+        mode=mode,
+        metadata=metadata,
+    )
+
+
+def human_summary(artifact: ValidationArtifact) -> str:
+    """Render a human-readable multi-line summary of a validation artifact."""
+    lines: list[str] = []
+    lines.append(f"Radio:  {artifact.radio.model} ({artifact.radio.profile_id})")
+    lines.append(f"Mode:   {artifact.mode}")
+    lines.append(
+        f"Safety: tx_allowed={artifact.safety.tx_allowed} "
+        f"tuner_allowed={artifact.safety.tuner_allowed}"
+    )
+    blocked: list[str] = []
+    for level in artifact.levels:
+        counts: dict[str, int] = {}
+        for check in level.checks:
+            counts[check.status.value] = counts.get(check.status.value, 0) + 1
+            if check.status is CheckStatus.BLOCKED:
+                blocked.append(check.check_id)
+        count_str = ", ".join(
+            f"{status}={count}" for status, count in sorted(counts.items())
+        )
+        lines.append(f"  L{int(level.level)} {level.level.name.lower()}: {count_str}")
+    if blocked:
+        lines.append("Blocked checks (authorization required):")
+        for check_id in blocked:
+            lines.append(f"  - {check_id}")
+    else:
+        lines.append("Blocked checks: none")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "HARDWARE_OPT_IN_ENV",
+    "HardwareExecutionBlocked",
+    "load_template",
+    "dry_run_results",
+    "summarize_results",
+    "build_validation_artifact",
+    "human_summary",
+]

--- a/src/rigplane/validation/schema.py
+++ b/src/rigplane/validation/schema.py
@@ -1,0 +1,579 @@
+"""Real-radio validation matrix schema models and validators.
+
+This module defines the frozen, machine-readable contract for the
+``rigplane validate`` vertical: capability-declaration templates (the planned
+matrix per radio) and validation artifacts (the recorded evidence). Both
+shapes are versioned by ``SCHEMA_VERSION`` and emitted by
+``rigplane-validation-matrix``.
+
+The dataclasses mirror the audio-probe style (frozen + slots, ``to_dict``
+shaping) and the validators narrow ``object`` with ``isinstance`` before
+indexing so the public API stays type-safe without ``type: ignore``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum, StrEnum
+
+from rigplane.core.capabilities import KNOWN_CAPABILITIES
+
+SCHEMA_VERSION = 1
+TOOL_NAME = "rigplane-validation-matrix"
+
+
+class CheckStatus(StrEnum):
+    """Normalized outcome of a single validation check."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    SKIP = "skip"
+    UNSUPPORTED = "unsupported"
+    MANUAL_REQUIRED = "manual_required"
+    BLOCKED = "blocked"
+
+
+class CapabilityDeclaration(StrEnum):
+    """Declared support posture for a capability in a template."""
+
+    SUPPORTED = "supported"
+    UNSUPPORTED_PENDING_EVIDENCE = "unsupported_pending_evidence"
+    MANUAL_REQUIRED = "manual_required"
+
+
+class ValidationLevel(IntEnum):
+    """Validation depth, ascending from static inspection to stress."""
+
+    STATIC_PROFILE = 0
+    DISCOVERY = 1
+    BASIC_CONTROL = 2
+    CAPABILITY_MATRIX = 3
+    COMPATIBILITY_SURFACES = 4
+    STRESS_RECOVERY = 5
+
+
+class FailureDomain(StrEnum):
+    """Subsystem responsible for a failed or blocked check."""
+
+    DISCOVERY = "discovery"
+    TRANSPORT = "transport"
+    COMMAND_EXECUTION = "command_execution"
+    READBACK = "readback"
+    STATE_PUBLISHING = "state_publishing"
+    RIGCTLD = "rigctld"
+    AUDIO = "audio"
+    SCOPE_WATERFALL = "scope_waterfall"
+
+
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    """Observed result for a single validation check."""
+
+    check_id: str
+    capability: str
+    level: ValidationLevel
+    status: CheckStatus
+    declaration: CapabilityDeclaration
+    summary: str
+    failure_domain: FailureDomain | None = None
+    evidence: dict[str, object] = field(default_factory=dict)
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "check_id": self.check_id,
+            "capability": self.capability,
+            "level": int(self.level),
+            "level_name": self.level.name.lower(),
+            "status": self.status.value,
+            "declaration": self.declaration.value,
+            "summary": self.summary,
+        }
+        if self.failure_domain is not None:
+            payload["failure_domain"] = self.failure_domain.value
+        if self.evidence:
+            payload["evidence"] = dict(self.evidence)
+        if self.error:
+            payload["error"] = self.error
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class LevelResult:
+    """All checks observed at one validation level."""
+
+    level: ValidationLevel
+    checks: list[CheckResult]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "level": int(self.level),
+            "level_name": self.level.name.lower(),
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorSafetyBlock:
+    """Operator authorization gating TX-adjacent and tuner checks."""
+
+    tx_allowed: bool = False
+    tuner_allowed: bool = False
+    operator_id: str | None = None
+    authorized_at_unix: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "tx_allowed": self.tx_allowed,
+            "tuner_allowed": self.tuner_allowed,
+        }
+        if self.operator_id is not None:
+            payload["operator_id"] = self.operator_id
+        if self.authorized_at_unix is not None:
+            payload["authorized_at_unix"] = self.authorized_at_unix
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class TransportInfo:
+    """Transport the validation run was executed against."""
+
+    backend: str
+    host: str | None = None
+    port: int | None = None
+    baud: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {"backend": self.backend}
+        if self.host is not None:
+            payload["host"] = self.host
+        if self.port is not None:
+            payload["port"] = self.port
+        if self.baud is not None:
+            payload["baud"] = self.baud
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class RadioTarget:
+    """Radio under validation."""
+
+    model: str
+    profile_id: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {"model": self.model, "profile_id": self.profile_id}
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityDeclarationEntry:
+    """One planned capability check in a validation template."""
+
+    check_id: str
+    capability: str
+    level: ValidationLevel
+    declaration: CapabilityDeclaration
+    summary: str
+    tx_adjacent: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "check_id": self.check_id,
+            "capability": self.capability,
+            "level": int(self.level),
+            "declaration": self.declaration.value,
+            "summary": self.summary,
+            "tx_adjacent": self.tx_adjacent,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixTemplate:
+    """Planned validation matrix for one radio."""
+
+    radio: RadioTarget
+    entries: list[CapabilityDeclarationEntry]
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "radio": self.radio.to_dict(),
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationArtifact:
+    """Machine-readable evidence artifact emitted by a validation run."""
+
+    radio: RadioTarget
+    transport: TransportInfo
+    safety: OperatorSafetyBlock
+    levels: list[LevelResult]
+    core_version: str
+    core_commit: str | None = None
+    logs_path: str | None = None
+    mode: str = "dry-run"
+    schema_version: int = SCHEMA_VERSION
+    tool: str = TOOL_NAME
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "tool": self.tool,
+            "mode": self.mode,
+            "core_version": self.core_version,
+            "radio": self.radio.to_dict(),
+            "transport": self.transport.to_dict(),
+            "safety": self.safety.to_dict(),
+            "levels": [level.to_dict() for level in self.levels],
+            "metadata": dict(self.metadata),
+        }
+        if self.core_commit is not None:
+            payload["core_commit"] = self.core_commit
+        if self.logs_path is not None:
+            payload["logs_path"] = self.logs_path
+        return payload
+
+
+class SchemaValidationError(ValueError):
+    """Raised when a template or artifact dict violates the schema."""
+
+
+_LEVEL_RANGE = range(0, 6)
+
+
+def _require_dict(value: object, where: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise SchemaValidationError(f"{where} must be an object")
+    return value
+
+
+def _require_str(value: object, where: str, *, non_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise SchemaValidationError(f"{where} must be a string")
+    if non_empty and not value:
+        raise SchemaValidationError(f"{where} must be a non-empty string")
+    return value
+
+
+def _require_int(value: object, where: str) -> int:
+    # bool is a subclass of int; reject it so flags don't masquerade as levels.
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SchemaValidationError(f"{where} must be an integer")
+    return value
+
+
+def validate_template_dict(data: object) -> MatrixTemplate:
+    """Validate a template dict and build a ``MatrixTemplate``.
+
+    Raises ``SchemaValidationError`` on the first violation. Does not mutate
+    the input.
+    """
+    root = _require_dict(data, "template")
+
+    if "schema_version" not in root:
+        raise SchemaValidationError("template.schema_version is required")
+    schema_version = _require_int(root["schema_version"], "template.schema_version")
+    if schema_version != SCHEMA_VERSION:
+        raise SchemaValidationError(
+            f"template.schema_version must be {SCHEMA_VERSION}, got {schema_version}"
+        )
+
+    if "radio" not in root:
+        raise SchemaValidationError("template.radio is required")
+    radio_dict = _require_dict(root["radio"], "template.radio")
+    model = _require_str(
+        radio_dict.get("model"), "template.radio.model", non_empty=True
+    )
+    profile_id = _require_str(
+        radio_dict.get("profile_id"), "template.radio.profile_id", non_empty=True
+    )
+    radio = RadioTarget(model=model, profile_id=profile_id)
+
+    entries_obj = root.get("entries")
+    if not isinstance(entries_obj, list):
+        raise SchemaValidationError("template.entries must be a list")
+    if not entries_obj:
+        raise SchemaValidationError("template.entries must be non-empty")
+
+    seen_ids: set[str] = set()
+    entries: list[CapabilityDeclarationEntry] = []
+    for index, raw_entry in enumerate(entries_obj):
+        where = f"template.entries[{index}]"
+        entry_dict = _require_dict(raw_entry, where)
+        check_id = _require_str(
+            entry_dict.get("check_id"), f"{where}.check_id", non_empty=True
+        )
+        if check_id in seen_ids:
+            raise SchemaValidationError(f"{where}.check_id {check_id!r} is duplicated")
+        seen_ids.add(check_id)
+
+        capability = _require_str(entry_dict.get("capability"), f"{where}.capability")
+        if capability and capability not in KNOWN_CAPABILITIES:
+            raise SchemaValidationError(
+                f"{where}.capability {capability!r} is not a known capability"
+            )
+
+        level_int = _require_int(entry_dict.get("level"), f"{where}.level")
+        if level_int not in _LEVEL_RANGE:
+            raise SchemaValidationError(f"{where}.level must be in 0..5")
+
+        declaration_str = _require_str(
+            entry_dict.get("declaration"), f"{where}.declaration"
+        )
+        if declaration_str not in {d.value for d in CapabilityDeclaration}:
+            raise SchemaValidationError(
+                f"{where}.declaration {declaration_str!r} is invalid"
+            )
+
+        summary = _require_str(entry_dict.get("summary"), f"{where}.summary")
+
+        tx_adjacent_obj = entry_dict.get("tx_adjacent", False)
+        if not isinstance(tx_adjacent_obj, bool):
+            raise SchemaValidationError(f"{where}.tx_adjacent must be a boolean")
+
+        entries.append(
+            CapabilityDeclarationEntry(
+                check_id=check_id,
+                capability=capability,
+                level=ValidationLevel(level_int),
+                declaration=CapabilityDeclaration(declaration_str),
+                summary=summary,
+                tx_adjacent=tx_adjacent_obj,
+            )
+        )
+
+    return MatrixTemplate(radio=radio, entries=entries)
+
+
+def _validate_safety_dict(data: object) -> OperatorSafetyBlock:
+    safety_dict = _require_dict(data, "artifact.safety")
+    tx_allowed = safety_dict.get("tx_allowed", False)
+    if not isinstance(tx_allowed, bool):
+        raise SchemaValidationError("artifact.safety.tx_allowed must be a boolean")
+    tuner_allowed = safety_dict.get("tuner_allowed", False)
+    if not isinstance(tuner_allowed, bool):
+        raise SchemaValidationError("artifact.safety.tuner_allowed must be a boolean")
+    operator_id_obj = safety_dict.get("operator_id")
+    operator_id = (
+        None
+        if operator_id_obj is None
+        else _require_str(operator_id_obj, "artifact.safety.operator_id")
+    )
+    authorized_obj = safety_dict.get("authorized_at_unix")
+    authorized_at_unix = (
+        None
+        if authorized_obj is None
+        else _require_int(authorized_obj, "artifact.safety.authorized_at_unix")
+    )
+    return OperatorSafetyBlock(
+        tx_allowed=tx_allowed,
+        tuner_allowed=tuner_allowed,
+        operator_id=operator_id,
+        authorized_at_unix=authorized_at_unix,
+    )
+
+
+def _validate_transport_dict(data: object) -> TransportInfo:
+    transport_dict = _require_dict(data, "artifact.transport")
+    backend = _require_str(
+        transport_dict.get("backend"), "artifact.transport.backend", non_empty=True
+    )
+    host_obj = transport_dict.get("host")
+    host = (
+        None if host_obj is None else _require_str(host_obj, "artifact.transport.host")
+    )
+    port_obj = transport_dict.get("port")
+    port = (
+        None if port_obj is None else _require_int(port_obj, "artifact.transport.port")
+    )
+    baud_obj = transport_dict.get("baud")
+    baud = (
+        None if baud_obj is None else _require_int(baud_obj, "artifact.transport.baud")
+    )
+    return TransportInfo(backend=backend, host=host, port=port, baud=baud)
+
+
+def _validate_check_dict(data: object, where: str) -> CheckResult:
+    check_dict = _require_dict(data, where)
+    check_id = _require_str(check_dict.get("check_id"), f"{where}.check_id")
+    capability = _require_str(check_dict.get("capability"), f"{where}.capability")
+    if capability and capability not in KNOWN_CAPABILITIES:
+        raise SchemaValidationError(
+            f"{where}.capability {capability!r} is not a known capability"
+        )
+
+    level_int = _require_int(check_dict.get("level"), f"{where}.level")
+    if level_int not in _LEVEL_RANGE:
+        raise SchemaValidationError(f"{where}.level must be in 0..5")
+
+    status_str = _require_str(check_dict.get("status"), f"{where}.status")
+    if status_str not in {s.value for s in CheckStatus}:
+        raise SchemaValidationError(f"{where}.status {status_str!r} is invalid")
+    status = CheckStatus(status_str)
+
+    declaration_str = _require_str(
+        check_dict.get("declaration"), f"{where}.declaration"
+    )
+    if declaration_str not in {d.value for d in CapabilityDeclaration}:
+        raise SchemaValidationError(
+            f"{where}.declaration {declaration_str!r} is invalid"
+        )
+
+    summary = _require_str(check_dict.get("summary"), f"{where}.summary")
+
+    failure_domain_obj = check_dict.get("failure_domain")
+    failure_domain: FailureDomain | None = None
+    if failure_domain_obj is not None:
+        domain_str = _require_str(failure_domain_obj, f"{where}.failure_domain")
+        if domain_str not in {d.value for d in FailureDomain}:
+            raise SchemaValidationError(
+                f"{where}.failure_domain {domain_str!r} is invalid"
+            )
+        failure_domain = FailureDomain(domain_str)
+
+    if status in {CheckStatus.FAIL, CheckStatus.BLOCKED} and failure_domain is None:
+        raise SchemaValidationError(
+            f"{where}.failure_domain is required when status is {status.value!r}"
+        )
+
+    evidence_obj = check_dict.get("evidence", {})
+    if not isinstance(evidence_obj, dict):
+        raise SchemaValidationError(f"{where}.evidence must be an object")
+
+    error_obj = check_dict.get("error")
+    error = None if error_obj is None else _require_str(error_obj, f"{where}.error")
+
+    return CheckResult(
+        check_id=check_id,
+        capability=capability,
+        level=ValidationLevel(level_int),
+        status=status,
+        declaration=CapabilityDeclaration(declaration_str),
+        summary=summary,
+        failure_domain=failure_domain,
+        evidence=dict(evidence_obj),
+        error=error,
+    )
+
+
+def validate_artifact_dict(data: object) -> ValidationArtifact:
+    """Validate an artifact dict and build a ``ValidationArtifact``.
+
+    Raises ``SchemaValidationError`` on the first violation. Does not mutate
+    the input.
+    """
+    root = _require_dict(data, "artifact")
+
+    if "schema_version" not in root:
+        raise SchemaValidationError("artifact.schema_version is required")
+    schema_version = _require_int(root["schema_version"], "artifact.schema_version")
+    if schema_version != SCHEMA_VERSION:
+        raise SchemaValidationError(
+            f"artifact.schema_version must be {SCHEMA_VERSION}, got {schema_version}"
+        )
+
+    if "tool" not in root:
+        raise SchemaValidationError("artifact.tool is required")
+    tool = _require_str(root["tool"], "artifact.tool")
+
+    if "radio" not in root:
+        raise SchemaValidationError("artifact.radio is required")
+    radio_dict = _require_dict(root["radio"], "artifact.radio")
+    radio = RadioTarget(
+        model=_require_str(
+            radio_dict.get("model"), "artifact.radio.model", non_empty=True
+        ),
+        profile_id=_require_str(
+            radio_dict.get("profile_id"), "artifact.radio.profile_id", non_empty=True
+        ),
+    )
+
+    if "transport" not in root:
+        raise SchemaValidationError("artifact.transport is required")
+    transport = _validate_transport_dict(root["transport"])
+
+    if "safety" not in root:
+        raise SchemaValidationError("artifact.safety is required")
+    safety = _validate_safety_dict(root["safety"])
+
+    levels_obj = root.get("levels")
+    if not isinstance(levels_obj, list):
+        raise SchemaValidationError("artifact.levels must be a list")
+
+    levels: list[LevelResult] = []
+    for index, raw_level in enumerate(levels_obj):
+        where = f"artifact.levels[{index}]"
+        level_dict = _require_dict(raw_level, where)
+        level_int = _require_int(level_dict.get("level"), f"{where}.level")
+        if level_int not in _LEVEL_RANGE:
+            raise SchemaValidationError(f"{where}.level must be in 0..5")
+        checks_obj = level_dict.get("checks")
+        if not isinstance(checks_obj, list):
+            raise SchemaValidationError(f"{where}.checks must be a list")
+        checks = [
+            _validate_check_dict(raw_check, f"{where}.checks[{check_index}]")
+            for check_index, raw_check in enumerate(checks_obj)
+        ]
+        levels.append(LevelResult(level=ValidationLevel(level_int), checks=checks))
+
+    core_version_obj = root.get("core_version", "")
+    core_version = _require_str(core_version_obj, "artifact.core_version")
+
+    core_commit_obj = root.get("core_commit")
+    core_commit = (
+        None
+        if core_commit_obj is None
+        else _require_str(core_commit_obj, "artifact.core_commit")
+    )
+
+    logs_path_obj = root.get("logs_path")
+    logs_path = (
+        None
+        if logs_path_obj is None
+        else _require_str(logs_path_obj, "artifact.logs_path")
+    )
+
+    mode_obj = root.get("mode", "dry-run")
+    mode = _require_str(mode_obj, "artifact.mode")
+
+    metadata_obj = root.get("metadata", {})
+    if not isinstance(metadata_obj, dict):
+        raise SchemaValidationError("artifact.metadata must be an object")
+
+    return ValidationArtifact(
+        radio=radio,
+        transport=transport,
+        safety=safety,
+        levels=levels,
+        core_version=core_version,
+        core_commit=core_commit,
+        logs_path=logs_path,
+        mode=mode,
+        tool=tool,
+        metadata=dict(metadata_obj),
+    )
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "TOOL_NAME",
+    "CheckStatus",
+    "CapabilityDeclaration",
+    "ValidationLevel",
+    "FailureDomain",
+    "CheckResult",
+    "LevelResult",
+    "OperatorSafetyBlock",
+    "TransportInfo",
+    "RadioTarget",
+    "CapabilityDeclarationEntry",
+    "MatrixTemplate",
+    "ValidationArtifact",
+    "SchemaValidationError",
+    "validate_template_dict",
+    "validate_artifact_dict",
+]

--- a/tests/fixtures/validation_artifact_mixed.json
+++ b/tests/fixtures/validation_artifact_mixed.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": 1,
+  "tool": "rigplane-validation-matrix",
+  "mode": "hardware",
+  "core_version": "2.5.1",
+  "radio": {
+    "model": "IC-7300",
+    "profile_id": "ic7300"
+  },
+  "transport": {
+    "backend": "lan",
+    "host": "192.168.55.40",
+    "port": 50001
+  },
+  "safety": {
+    "tx_allowed": false,
+    "tuner_allowed": false
+  },
+  "levels": [
+    {
+      "level": 1,
+      "checks": [
+        {
+          "check_id": "discovery.identify",
+          "capability": "",
+          "level": 1,
+          "status": "pass",
+          "declaration": "supported",
+          "summary": "Radio identified."
+        }
+      ]
+    },
+    {
+      "level": 2,
+      "checks": [
+        {
+          "check_id": "freq.write",
+          "capability": "",
+          "level": 2,
+          "status": "pass",
+          "declaration": "supported",
+          "summary": "Frequency set accepted."
+        }
+      ]
+    },
+    {
+      "level": 4,
+      "checks": [
+        {
+          "check_id": "audio.rx",
+          "capability": "audio",
+          "level": 4,
+          "status": "fail",
+          "declaration": "supported",
+          "summary": "No RX audio packets observed.",
+          "failure_domain": "audio",
+          "evidence": {
+            "packets": 0
+          },
+          "error": "rx-stream-timeout"
+        },
+        {
+          "check_id": "scope.capture",
+          "capability": "scope",
+          "level": 4,
+          "status": "unsupported",
+          "declaration": "unsupported_pending_evidence",
+          "summary": "Scope capture not attempted."
+        }
+      ]
+    },
+    {
+      "level": 5,
+      "checks": [
+        {
+          "check_id": "tx.ptt",
+          "capability": "tx",
+          "level": 5,
+          "status": "blocked",
+          "declaration": "manual_required",
+          "summary": "TX not authorized by operator.",
+          "failure_domain": "command_execution"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "summary": {
+      "pass": 2,
+      "fail": 1,
+      "skip": 0,
+      "unsupported": 1,
+      "manual_required": 0,
+      "blocked": 1
+    }
+  }
+}

--- a/tests/fixtures/validation_artifact_reverse_sync_fail.json
+++ b/tests/fixtures/validation_artifact_reverse_sync_fail.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "tool": "rigplane-validation-matrix",
+  "mode": "hardware",
+  "core_version": "2.5.1",
+  "radio": {
+    "model": "IC-7300",
+    "profile_id": "ic7300"
+  },
+  "transport": {
+    "backend": "lan",
+    "host": "192.168.55.40",
+    "port": 50001
+  },
+  "safety": {
+    "tx_allowed": false,
+    "tuner_allowed": false
+  },
+  "levels": [
+    {
+      "level": 2,
+      "checks": [
+        {
+          "check_id": "freq.write",
+          "capability": "",
+          "level": 2,
+          "status": "pass",
+          "declaration": "supported",
+          "summary": "Frequency set accepted."
+        },
+        {
+          "check_id": "freq.reverse_sync",
+          "capability": "",
+          "level": 2,
+          "status": "fail",
+          "declaration": "supported",
+          "summary": "Radio-side frequency change not reflected in core state.",
+          "failure_domain": "readback",
+          "evidence": {
+            "write_ok": true,
+            "readback_ok": false
+          }
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "summary": {
+      "pass": 1,
+      "fail": 1,
+      "skip": 0,
+      "unsupported": 0,
+      "manual_required": 0,
+      "blocked": 0
+    }
+  }
+}

--- a/tests/fixtures/validation_template_ic7300.json
+++ b/tests/fixtures/validation_template_ic7300.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "radio": {
+    "model": "IC-7300",
+    "profile_id": "ic7300"
+  },
+  "entries": [
+    {
+      "check_id": "discovery.identify",
+      "capability": "",
+      "level": 1,
+      "declaration": "supported",
+      "summary": "Radio identifies on the configured transport.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.write",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Set frequency via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "freq.reverse_sync",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Radio-side frequency change is reflected back to core state.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "audio.rx",
+      "capability": "audio",
+      "level": 4,
+      "declaration": "manual_required",
+      "summary": "Receive audio stream check (operator-verified).",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "scope.capture",
+      "capability": "scope",
+      "level": 4,
+      "declaration": "supported",
+      "summary": "Spectrum scope frame capture.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "tuner.tune",
+      "capability": "tuner",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "Antenna tuner tune cycle (requires operator authorization).",
+      "tx_adjacent": true
+    },
+    {
+      "check_id": "tx.ptt",
+      "capability": "tx",
+      "level": 5,
+      "declaration": "manual_required",
+      "summary": "PTT key/unkey (requires operator authorization).",
+      "tx_adjacent": true
+    }
+  ]
+}

--- a/tests/test_validation_runner.py
+++ b/tests/test_validation_runner.py
@@ -1,0 +1,161 @@
+"""Runner tests for the validation matrix dry-run path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rigplane.validation import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckStatus,
+    FailureDomain,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    TransportInfo,
+    ValidationLevel,
+    build_validation_artifact,
+    dry_run_results,
+    human_summary,
+    load_template,
+    validate_artifact_dict,
+)
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "tests" / "fixtures"
+_TEMPLATE = _FIXTURES / "validation_template_ic7300.json"
+
+
+def _checks_by_id(levels: list) -> dict[str, object]:
+    return {check.check_id: check for level in levels for check in level.checks}
+
+
+def test_load_template_round_trips_fixture() -> None:
+    template = load_template(_TEMPLATE)
+    assert template.radio.profile_id == "ic7300"
+    assert {entry.check_id for entry in template.entries} >= {
+        "discovery.identify",
+        "freq.write",
+        "freq.reverse_sync",
+    }
+
+
+def test_dry_run_declaration_mapping() -> None:
+    template = load_template(_TEMPLATE)
+    levels = dry_run_results(template, OperatorSafetyBlock())
+    checks = _checks_by_id(levels)
+    # supported -> skip
+    assert checks["discovery.identify"].status is CheckStatus.SKIP
+    # unsupported_pending_evidence -> unsupported (none here for ic7300 scope;
+    # audio.rx is manual_required -> manual_required)
+    assert checks["audio.rx"].status is CheckStatus.MANUAL_REQUIRED
+    # scope.capture is supported on ic7300 -> skip
+    assert checks["scope.capture"].status is CheckStatus.SKIP
+
+
+def test_tx_adjacent_blocked_without_authorization() -> None:
+    template = load_template(_TEMPLATE)
+    levels = dry_run_results(template, OperatorSafetyBlock())
+    checks = _checks_by_id(levels)
+    assert checks["tuner.tune"].status is CheckStatus.BLOCKED
+    assert checks["tx.ptt"].status is CheckStatus.BLOCKED
+
+
+def test_tx_adjacent_unblocked_with_authorization() -> None:
+    template = load_template(_TEMPLATE)
+    safety = OperatorSafetyBlock(tx_allowed=True, tuner_allowed=True)
+    levels = dry_run_results(template, safety)
+    checks = _checks_by_id(levels)
+    # Authorized but still dry-run: never PASS, stays at the declaration status.
+    assert checks["tuner.tune"].status is CheckStatus.MANUAL_REQUIRED
+    assert checks["tx.ptt"].status is CheckStatus.MANUAL_REQUIRED
+    assert checks["tuner.tune"].status is not CheckStatus.PASS
+    assert checks["tx.ptt"].status is not CheckStatus.PASS
+
+
+def test_build_artifact_round_trips_through_validator() -> None:
+    template = load_template(_TEMPLATE)
+    levels = dry_run_results(template, OperatorSafetyBlock())
+    artifact = build_validation_artifact(
+        template=template,
+        levels=levels,
+        transport=TransportInfo(backend="fixture"),
+        safety=OperatorSafetyBlock(),
+        core_version="2.5.1",
+    )
+    reparsed = validate_artifact_dict(artifact.to_dict())
+    assert reparsed.radio.profile_id == "ic7300"
+    assert reparsed.metadata["summary"] == artifact.metadata["summary"]
+
+
+def test_human_summary_lists_blocked_items() -> None:
+    template = load_template(_TEMPLATE)
+    levels = dry_run_results(template, OperatorSafetyBlock())
+    artifact = build_validation_artifact(
+        template=template,
+        levels=levels,
+        transport=TransportInfo(backend="fixture"),
+        safety=OperatorSafetyBlock(),
+        core_version="2.5.1",
+    )
+    text = human_summary(artifact)
+    assert text
+    assert "tuner.tune" in text
+    assert "tx.ptt" in text
+
+
+def _make_split_template() -> MatrixTemplate:
+    """Build an in-memory template with a generic tx_adjacent entry (capability='split').
+
+    Constructed directly from dataclasses — no validate_template_dict — so
+    capability membership is not checked.
+    """
+    entry = CapabilityDeclarationEntry(
+        check_id="split.enable",
+        capability="split",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+        summary="Split TX",
+        tx_adjacent=True,
+    )
+    return MatrixTemplate(
+        radio=RadioTarget(model="Test Radio", profile_id="test"),
+        entries=[entry],
+    )
+
+
+def test_generic_tx_adjacent_blocked_by_default() -> None:
+    """Fail-closed: a tx_adjacent entry with capability other than 'tuner'/'tx'
+    must be BLOCKED under the default OperatorSafetyBlock (both flags False).
+    """
+    template = _make_split_template()
+    levels = dry_run_results(template, OperatorSafetyBlock())
+    checks = _checks_by_id(levels)
+    result = checks["split.enable"]
+    assert result.status is CheckStatus.BLOCKED
+    assert result.failure_domain is FailureDomain.COMMAND_EXECUTION
+
+
+def test_generic_tx_adjacent_unblocked_by_tx_allowed() -> None:
+    """tx_allowed=True must unblock a generic tx_adjacent entry (e.g. 'split')."""
+    template = _make_split_template()
+    levels = dry_run_results(template, OperatorSafetyBlock(tx_allowed=True))
+    checks = _checks_by_id(levels)
+    result = checks["split.enable"]
+    # Authorized in dry-run: stays at declaration status, never PASS or BLOCKED.
+    assert result.status is not CheckStatus.BLOCKED
+    assert result.status is not CheckStatus.PASS
+    assert result.status is CheckStatus.MANUAL_REQUIRED
+
+
+def test_generic_tx_adjacent_still_blocked_by_tuner_only() -> None:
+    """tuner_allowed=True must NOT unblock a non-tuner tx_adjacent entry.
+
+    Proves the tuner flag is scoped exclusively to capability='tuner' and does
+    not open the gate for any other tx_adjacent check.
+    """
+    template = _make_split_template()
+    levels = dry_run_results(template, OperatorSafetyBlock(tuner_allowed=True))
+    checks = _checks_by_id(levels)
+    result = checks["split.enable"]
+    assert result.status is CheckStatus.BLOCKED
+    assert result.failure_domain is FailureDomain.COMMAND_EXECUTION

--- a/tests/test_validation_schema.py
+++ b/tests/test_validation_schema.py
@@ -1,0 +1,97 @@
+"""Schema tests for the real-radio validation matrix contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rigplane.validation import (
+    CheckStatus,
+    FailureDomain,
+    MatrixTemplate,
+    SchemaValidationError,
+    ValidationArtifact,
+    validate_artifact_dict,
+    validate_template_dict,
+)
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "tests" / "fixtures"
+
+
+def _load_json(name: str) -> object:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def test_valid_template_fixture_builds_matrix_template() -> None:
+    template = validate_template_dict(_load_json("validation_template_ic7300.json"))
+    assert isinstance(template, MatrixTemplate)
+    assert template.radio.model == "IC-7300"
+    assert template.radio.profile_id == "ic7300"
+    assert any(entry.check_id == "tuner.tune" for entry in template.entries)
+
+
+def test_invalid_capability_tag_raises() -> None:
+    data = _load_json("validation_template_ic7300.json")
+    assert isinstance(data, dict)
+    entries = data["entries"]
+    assert isinstance(entries, list)
+    entries[0]["capability"] = "not_a_real_capability"
+    with pytest.raises(SchemaValidationError):
+        validate_template_dict(data)
+
+
+def test_mixed_artifact_fixture_validates() -> None:
+    artifact = validate_artifact_dict(_load_json("validation_artifact_mixed.json"))
+    assert isinstance(artifact, ValidationArtifact)
+    statuses = {check.status for level in artifact.levels for check in level.checks}
+    assert CheckStatus.PASS in statuses
+    assert CheckStatus.FAIL in statuses
+    assert CheckStatus.UNSUPPORTED in statuses
+
+
+def test_reverse_sync_fail_fixture_carries_readback_domain() -> None:
+    artifact = validate_artifact_dict(
+        _load_json("validation_artifact_reverse_sync_fail.json")
+    )
+    reverse_sync = [
+        check
+        for level in artifact.levels
+        for check in level.checks
+        if check.check_id == "freq.reverse_sync"
+    ]
+    assert len(reverse_sync) == 1
+    check = reverse_sync[0]
+    assert check.status is CheckStatus.FAIL
+    assert check.failure_domain is FailureDomain.READBACK
+
+
+def test_fail_without_failure_domain_raises() -> None:
+    data = {
+        "schema_version": 1,
+        "tool": "rigplane-validation-matrix",
+        "mode": "hardware",
+        "core_version": "2.5.1",
+        "radio": {"model": "IC-7300", "profile_id": "ic7300"},
+        "transport": {"backend": "lan"},
+        "safety": {"tx_allowed": False, "tuner_allowed": False},
+        "levels": [
+            {
+                "level": 2,
+                "checks": [
+                    {
+                        "check_id": "freq.write",
+                        "capability": "",
+                        "level": 2,
+                        "status": "fail",
+                        "declaration": "supported",
+                        "summary": "Failed without a domain.",
+                    }
+                ],
+            }
+        ],
+        "metadata": {},
+    }
+    with pytest.raises(SchemaValidationError):
+        validate_artifact_dict(data)

--- a/tests/test_validation_templates.py
+++ b/tests/test_validation_templates.py
@@ -1,0 +1,32 @@
+"""Template tests: every shipped validation template parses and is valid."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rigplane.core.capabilities import KNOWN_CAPABILITIES
+from rigplane.validation import validate_template_dict
+
+_TEMPLATES_DIR = (
+    Path(__file__).resolve().parents[1] / "docs" / "validation" / "templates"
+)
+
+
+def _template_paths() -> list[Path]:
+    return sorted(_TEMPLATES_DIR.glob("*.json"))
+
+
+def test_templates_dir_has_templates() -> None:
+    assert _template_paths(), "expected at least one validation template"
+
+
+@pytest.mark.parametrize("path", _template_paths(), ids=lambda p: p.stem)
+def test_template_parses_and_validates(path: Path) -> None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    template = validate_template_dict(data)
+    for entry in template.entries:
+        if entry.capability:
+            assert entry.capability in KNOWN_CAPABILITIES


### PR DESCRIPTION
## Summary

First Core-first vertical of the **real-radio validation matrix** (epic #1645). Delivers the schema/safety contract, data-only per-radio templates, and a headless dry-run runner so we can later run repeatable, evidence-backed support validation against FTX-1, TX-500, IC-7300, and X6200 — without Pro.

This PR is **matrix infrastructure only**. It does *not* fix any capability bugs (PRE/ATT/Notch/mode-filter/reverse-sync); those field observations are encoded as *data/result entries*, not patched.

Closes #1646. Advances #1647 and #1651 (initial useful base).

## What's included

- **Schema + safety contract** (`src/rigplane/validation/schema.py`, new `rigplane.validation` package, sibling of `diagnostics`, outside the import-linter DAG):
  - Status vocabulary: `pass / fail / skip / unsupported / manual_required / blocked`.
  - Capability declarations: `supported / unsupported_pending_evidence / manual_required` — unknowns are never silently assumed.
  - Levels 0–5, eight failure domains (discovery / transport / command_execution / readback / state_publishing / rigctld / audio / scope_waterfall).
  - Operator/safety block with **independent** `tx_allowed` and `tuner_allowed` gates (the tuner keys TX into the ATU → its own gate).
  - Pure-Python validators (`validate_template_dict`, `validate_artifact_dict`); no `jsonschema`/`pyyaml` dependency. Enforces `fail|blocked ⇒ failure_domain`.
- **Headless dry-run runner + CLI** (`rigplane validate`, `src/rigplane/validation/runner.py`, `src/rigplane/cli/_validate.py`):
  - Loads a template, validates it, synthesizes per-level results, emits a JSON artifact + human summary.
  - **Fail-closed** TX-adjacency gate: any TX-adjacent check is `blocked` unless explicitly authorized.
  - `--hardware` is a **double-gated refusal stub** (needs `--allow-hardware` *and* `RIGPLANE_VALIDATION_ALLOW_HARDWARE=1`) and performs **zero I/O** — CI never touches hardware.
- **Four data-only templates** (`docs/validation/templates/*.json`) referencing only real capability tags from `rigs/*.toml` / `KNOWN_CAPABILITIES`.
- **Contract + design docs** (`docs/contracts/validation-matrix-v1.md`, `docs/plans/2026-05-28-real-radio-validation-matrix.md`).
- **Tests**: schema validation, mixed pass/fail/unsupported fixture, failed reverse-state-sync fixture (`readback` domain), dry-run artifact serialization round-trip, fail-closed safety gate, template integrity.

## Safety policy

- `tx_allowed=false` and `tuner_allowed=false` by default; no TX/PTT writes.
- Any TX-adjacent action (including tuner) requires an explicit operator flag.
- Hardware execution is opt-in and blocked by default; this PR ships only the dry-run/fixture path.

## Verification

- `uv run pytest tests/ -q --ignore=tests/integration` → **5956 passed**, 57 skipped, 11 xfailed.
- `uv run mypy src/` → clean for new code. `uv run ruff check` → clean. `uv run lint-imports` → 4 kept, 0 broken.
- Independent agent review: **PASS** (initial review BLOCKED a fail-open safety gate; fixed fail-closed + regression-tested, then re-reviewed PASS).

## Out of scope

Hardware I/O, capability bug fixes, Pro/proprietary code, YAML/new deps, adding `validation` to `.importlinter`, persistence/resume engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
