### PR TITLE
feat: hardware validation runner — read/write diagnostics with restore (#1647)

### DIFF
--- a/docs/validation/templates/ftx1.json
+++ b/docs/validation/templates/ftx1.json
@@ -30,6 +30,102 @@
       "tx_adjacent": false
     },
     {
+      "check_id": "mode.set",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Set operating mode via CI-V write (filter coupling).",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "filter_width.set",
+      "capability": "filter_width",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set DSP IF filter width via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "rf_gain.set",
+      "capability": "rf_gain",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set RF gain level via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "af_level.set",
+      "capability": "af_level",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set AF output level via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "preamp.set",
+      "capability": "preamp",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set preamp state via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "attenuator.set",
+      "capability": "attenuator",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set attenuator state via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "notch.set",
+      "capability": "notch",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle manual notch via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "nb.set",
+      "capability": "nb",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle noise blanker via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "nr.set",
+      "capability": "nr",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle noise reduction via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "agc.set",
+      "capability": "agc",
+      "level": 3,
+      "declaration": "unsupported_pending_evidence",
+      "summary": "agc.set not declared in the FTX-1 profile; pending evidence.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "rit.set",
+      "capability": "rit",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set RIT frequency offset via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "xit.set",
+      "capability": "xit",
+      "level": 3,
+      "declaration": "unsupported_pending_evidence",
+      "summary": "xit.set not declared in the FTX-1 profile; pending evidence.",
+      "tx_adjacent": false
+    },
+    {
       "check_id": "audio.rx",
       "capability": "audio",
       "level": 4,

--- a/docs/validation/templates/ic7300.json
+++ b/docs/validation/templates/ic7300.json
@@ -30,6 +30,102 @@
       "tx_adjacent": false
     },
     {
+      "check_id": "mode.set",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Set operating mode via CI-V write (filter coupling).",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "filter_width.set",
+      "capability": "filter_width",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set DSP IF filter width via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "rf_gain.set",
+      "capability": "rf_gain",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set RF gain level via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "af_level.set",
+      "capability": "af_level",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set AF output level via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "preamp.set",
+      "capability": "preamp",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set preamp state via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "attenuator.set",
+      "capability": "attenuator",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set attenuator state via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "notch.set",
+      "capability": "notch",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle manual notch via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "nb.set",
+      "capability": "nb",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle noise blanker via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "nr.set",
+      "capability": "nr",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle noise reduction via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "agc.set",
+      "capability": "agc",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set AGC mode via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "rit.set",
+      "capability": "rit",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set RIT frequency offset via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "xit.set",
+      "capability": "xit",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle XIT (TX clarifier) via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
       "check_id": "audio.rx",
       "capability": "audio",
       "level": 4,

--- a/docs/validation/templates/tx500.json
+++ b/docs/validation/templates/tx500.json
@@ -30,6 +30,102 @@
       "tx_adjacent": false
     },
     {
+      "check_id": "mode.set",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Set operating mode via CI-V write (filter coupling).",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "filter_width.set",
+      "capability": "filter_width",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set DSP IF filter width via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "rf_gain.set",
+      "capability": "rf_gain",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set RF gain level via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "af_level.set",
+      "capability": "af_level",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set AF output level via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "preamp.set",
+      "capability": "preamp",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set preamp state via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "attenuator.set",
+      "capability": "attenuator",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set attenuator state via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "notch.set",
+      "capability": "notch",
+      "level": 3,
+      "declaration": "unsupported_pending_evidence",
+      "summary": "notch.set not declared in the TX-500 profile; pending evidence.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "nb.set",
+      "capability": "nb",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle noise blanker via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "nr.set",
+      "capability": "nr",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle noise reduction via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "agc.set",
+      "capability": "agc",
+      "level": 3,
+      "declaration": "unsupported_pending_evidence",
+      "summary": "agc.set not declared in the TX-500 profile; pending evidence.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "rit.set",
+      "capability": "rit",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set RIT frequency offset via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "xit.set",
+      "capability": "xit",
+      "level": 3,
+      "declaration": "unsupported_pending_evidence",
+      "summary": "xit.set not declared in the TX-500 profile; pending evidence.",
+      "tx_adjacent": false
+    },
+    {
       "check_id": "audio.rx",
       "capability": "audio",
       "level": 4,

--- a/docs/validation/templates/x6200.json
+++ b/docs/validation/templates/x6200.json
@@ -30,6 +30,102 @@
       "tx_adjacent": false
     },
     {
+      "check_id": "mode.set",
+      "capability": "",
+      "level": 2,
+      "declaration": "supported",
+      "summary": "Set operating mode via CI-V write (filter coupling).",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "filter_width.set",
+      "capability": "filter_width",
+      "level": 3,
+      "declaration": "unsupported_pending_evidence",
+      "summary": "filter_width.set not declared in the X6200 profile; pending evidence.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "rf_gain.set",
+      "capability": "rf_gain",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set RF gain level via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "af_level.set",
+      "capability": "af_level",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set AF output level via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "preamp.set",
+      "capability": "preamp",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set preamp state via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "attenuator.set",
+      "capability": "attenuator",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set attenuator state via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "notch.set",
+      "capability": "notch",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle manual notch via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "nb.set",
+      "capability": "nb",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle noise blanker via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "nr.set",
+      "capability": "nr",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle noise reduction via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "agc.set",
+      "capability": "agc",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set AGC mode via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "rit.set",
+      "capability": "rit",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Set RIT frequency offset via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
+      "check_id": "xit.set",
+      "capability": "xit",
+      "level": 3,
+      "declaration": "supported",
+      "summary": "Toggle XIT (TX clarifier) via CI-V write.",
+      "tx_adjacent": false
+    },
+    {
       "check_id": "audio.rx",
       "capability": "audio",
       "level": 4,

--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -1,24 +1,32 @@
 """``rigplane validate`` subcommand — real-radio validation matrix runner.
 
-This ships the dry-run path only: it loads a capability-declaration template,
-applies operator-safety gating, and emits a machine-readable validation
-artifact (or a human summary). Hardware execution is intentionally not
-implemented in this version; the ``--hardware`` flag is double-gated by
-``--allow-hardware`` and the ``RIGPLANE_VALIDATION_ALLOW_HARDWARE=1`` environment
-variable, and even when both gates are open the command refuses with exit 3
-because no hardware path exists yet.
+By default this runs the dry-run path: it loads a capability-declaration
+template, applies operator-safety gating, and emits a machine-readable
+validation artifact (or a human summary). The ``--hardware`` flag is
+double-gated by ``--allow-hardware`` and the
+``RIGPLANE_VALIDATION_ALLOW_HARDWARE=1`` environment variable; when both gates
+are open it connects to the configured radio and executes the checks. The
+default posture is read/write with automatic restore: each RX-safe write check
+reads the original value, writes a different one, verifies the readback, then
+restores the original. ``--read-only`` disables all writes (write checks SKIP).
+TX and tuner are never auto-actuated.
 
 Exit codes:
 
-* ``0`` — success (dry-run artifact emitted). Failed/blocked dry-run checks do
-  NOT change the exit code.
+* ``0`` — success (dry-run or hardware artifact emitted). Failed/blocked checks
+  do NOT change the exit code.
 * ``2`` — template missing, unreadable, or schema-invalid.
-* ``3`` — hardware run requested but blocked (gates closed or not implemented).
+* ``3`` — hardware run requested but blocked (gates closed), or the radio could
+  not connect / authenticate / build a backend config (artifact still emitted
+  on connect failure).
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
+import dataclasses
+import datetime
 import json
 import os
 import sys
@@ -29,14 +37,37 @@ from typing import Any
 from rigplane import __version__
 from rigplane.validation import (
     HARDWARE_OPT_IN_ENV,
+    MatrixTemplate,
     OperatorSafetyBlock,
     TransportInfo,
+    ValidationArtifact,
     build_validation_artifact,
     dry_run_results,
     human_summary,
     load_template,
 )
-from rigplane.validation.schema import SchemaValidationError
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CheckResult,
+    CheckStatus,
+    FailureDomain,
+    LevelResult,
+    SchemaValidationError,
+    ValidationLevel,
+)
+
+
+def _utcnow_iso() -> str:
+    """Return the current UTC time as an ISO-8601 millisecond ``...Z`` string.
+
+    Local duplicate of ``rigplane.validation.hardware._utcnow_iso`` so this
+    module keeps its ``validation.hardware`` import deferred (function-local).
+    """
+    return (
+        datetime.datetime.now(datetime.UTC)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
 
 
 def add_subparser(sub: Any) -> argparse.ArgumentParser:
@@ -62,7 +93,7 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
     p.add_argument(
         "--hardware",
         action="store_true",
-        help="Request a real-radio run (double-gated; not implemented this release).",
+        help="Run against a real connected radio (double-gated; read/write with restore by default).",
     )
     p.add_argument(
         "--allow-hardware",
@@ -80,6 +111,16 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
         dest="tuner_allowed",
         action="store_true",
         help="Authorize tuner tune-cycle checks.",
+    )
+    p.add_argument(
+        "--read-only",
+        dest="read_only",
+        action="store_true",
+        help=(
+            "Disable all writes (write checks SKIP). Default is read/write "
+            "with automatic restore: read the original, write a different "
+            "value, verify the readback, then restore the original."
+        ),
     )
     p.add_argument(
         "--operator-id",
@@ -124,14 +165,7 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 3
-        # Even with both gates open, the hardware path is not implemented in
-        # this release. Refuse explicitly rather than silently dry-running.
-        print(
-            "Error: hardware validation is not implemented in this release; "
-            "run without --hardware for a dry-run plan.",
-            file=sys.stderr,
-        )
-        return 3
+        return asyncio.run(_run_hardware(args, template, safety))
 
     levels = dry_run_results(template, safety)
     transport = TransportInfo(backend="fixture")
@@ -144,14 +178,104 @@ def run(args: argparse.Namespace) -> int:
         core_commit=None,
         mode="dry-run",
     )
+    artifact = dataclasses.replace(artifact, generated_at=_utcnow_iso())
+    _emit_artifact(artifact, args)
+    return 0
 
-    if args.json or args.output:
+
+def _emit_artifact(artifact: ValidationArtifact, args: argparse.Namespace) -> None:
+    """Render the artifact: file on --output, JSON on --json, else human text."""
+    if args.output:
         text = json.dumps(artifact.to_dict(), indent=2)
-        if args.output:
-            Path(args.output).write_text(text + "\n", encoding="utf-8")
-            print(f"Artifact written to: {args.output}", file=sys.stderr)
-        else:
-            print(text)
+        Path(args.output).write_text(text + "\n", encoding="utf-8")
+        print(f"Artifact written to: {args.output}", file=sys.stderr)
+    elif args.json:
+        print(json.dumps(artifact.to_dict(), indent=2))
     else:
         print(human_summary(artifact))
-    return 0
+
+
+def _transport_info_from_config(config: Any) -> TransportInfo:
+    """Map a backend config into a :class:`TransportInfo` (no device path)."""
+    backend = config.backend
+    if backend in ("serial", "yaesu-cat"):
+        return TransportInfo(backend=backend, baud=getattr(config, "baudrate", None))
+    return TransportInfo(
+        backend=backend,
+        host=getattr(config, "host", None),
+        port=getattr(config, "port", None),
+    )
+
+
+def _transport_failure_levels(
+    template: MatrixTemplate, exc: BaseException
+) -> list[LevelResult]:
+    """Build a single DISCOVERY-level FAIL/TRANSPORT result for a connect failure."""
+    check = CheckResult(
+        check_id="discovery.identify",
+        capability="",
+        level=ValidationLevel.DISCOVERY,
+        status=CheckStatus.FAIL,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="Radio failed to connect on the configured transport.",
+        failure_domain=FailureDomain.TRANSPORT,
+        evidence={"error_type": type(exc).__name__},
+        error=str(exc),
+    )
+    return [LevelResult(level=ValidationLevel.DISCOVERY, checks=[check])]
+
+
+async def _run_hardware(
+    args: argparse.Namespace,
+    template: MatrixTemplate,
+    safety: OperatorSafetyBlock,
+) -> int:
+    """Connect to the configured radio and execute the validation checks.
+
+    Imports of the CLI backend-config builder, the backend factory, and the
+    hardware runner are deferred to function scope to avoid a circular import
+    between this module and ``rigplane.cli``.
+    """
+    from rigplane.backends.factory import create_radio
+    from rigplane.cli import _build_backend_config
+    from rigplane.core.exceptions import (
+        AuthenticationError,
+        ConnectionError as RigConnectionError,
+        RigplaneError,
+    )
+    from rigplane.validation.hardware import execute_hardware_checks
+
+    try:
+        config = await _build_backend_config(args)
+    except ValueError as exc:
+        print(f"Error: cannot build backend config: {exc}", file=sys.stderr)
+        return 3
+
+    transport = _transport_info_from_config(config)
+    radio = create_radio(config)
+    exit_code = 0
+    try:
+        async with radio:
+            levels = await execute_hardware_checks(
+                radio,
+                template,
+                safety,
+                allow_writes=not bool(getattr(args, "read_only", False)),
+                per_check_timeout=getattr(args, "timeout", 5.0) or 5.0,
+            )
+    except (RigConnectionError, AuthenticationError, OSError, RigplaneError) as exc:
+        levels = _transport_failure_levels(template, exc)
+        exit_code = 3
+
+    artifact = build_validation_artifact(
+        template=template,
+        levels=levels,
+        transport=transport,
+        safety=safety,
+        core_version=__version__,
+        core_commit=None,
+        mode="hardware",
+    )
+    artifact = dataclasses.replace(artifact, generated_at=_utcnow_iso())
+    _emit_artifact(artifact, args)
+    return exit_code

--- a/src/rigplane/validation/__init__.py
+++ b/src/rigplane/validation/__init__.py
@@ -8,6 +8,7 @@ path that plans checks from a template without touching hardware.
 
 from __future__ import annotations
 
+from rigplane.validation.hardware import execute_hardware_checks
 from rigplane.validation.runner import (
     HARDWARE_OPT_IN_ENV,
     HardwareExecutionBlocked,
@@ -62,4 +63,5 @@ __all__ = [
     "summarize_results",
     "build_validation_artifact",
     "human_summary",
+    "execute_hardware_checks",
 ]

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1,0 +1,953 @@
+"""Hardware-execution path for the ``rigplane validate`` vertical.
+
+Given an *already-connected* :class:`~rigplane.core.radio_protocol.Radio`,
+execute the planned checks in a :class:`MatrixTemplate` against the live
+radio and return per-level :class:`LevelResult` evidence.
+
+Safety posture (read/write by default, with automatic restore):
+
+* RX-safe write checks default to a read-modify-verify-restore (RMVR) cycle:
+  read the original value, write a different value, verify the readback, then
+  always restore the original in a ``finally`` block that never raises.
+* When ``allow_writes`` is ``False`` (the CLI ``--read-only`` flag) every write
+  check is SKIPPED — only pure-read checks (``discovery.identify``,
+  ``freq.reverse_sync``) and observation-only checks run.
+* TX-adjacent checks (``tx.ptt``, ``tuner.tune``) are BLOCKED without operator
+  authorization and only ever reported as ``MANUAL_REQUIRED`` when authorized
+  — they are NEVER actuated (no PTT keying, no tune cycle).
+
+This module imports only the standard library, ``rigplane.core.*`` and
+``rigplane.validation.*`` — it must not depend on the CLI, backends, or
+runtime layers. The caller owns connection lifecycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import datetime
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TypeVar, cast
+
+from rigplane.core.exceptions import (
+    AuthenticationError,
+    CommandError,
+    ConnectionError as RigConnectionError,
+    RigplaneError,
+    TimeoutError as RigTimeoutError,
+)
+from rigplane.core.radio_protocol import (
+    AntennaControlCapable,
+    AudioCapable,
+    DspControlCapable,
+    LevelsCapable,
+    Radio,
+    RitXitCapable,
+    ScopeCapable,
+    SystemControlCapable,
+    UsbAudioCapable,
+)
+from rigplane.core.types import AgcMode
+from rigplane.validation.runner import _is_authorized
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckResult,
+    CheckStatus,
+    FailureDomain,
+    LevelResult,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    ValidationLevel,
+)
+
+__all__ = ["execute_hardware_checks", "DEFAULT_PER_CHECK_TIMEOUT"]
+
+DEFAULT_PER_CHECK_TIMEOUT = 5.0
+
+_LOGGER = logging.getLogger("rigplane.validation")
+
+T = TypeVar("T")
+
+# Exceptions handled by the best-effort restore path; never escapes ``finally``.
+_RESTORE_ERRORS = (
+    asyncio.TimeoutError,
+    RigTimeoutError,
+    RigplaneError,
+    RigConnectionError,
+    AuthenticationError,
+    CommandError,
+    OSError,
+)
+
+# Capability tag -> capability Protocol used for runtime ``isinstance`` checks.
+# ``tx`` intentionally has no protocol (tag-only).
+_CAP_PROTOCOL: dict[str, type] = {
+    "audio": AudioCapable,
+    "scope": ScopeCapable,
+    "tuner": SystemControlCapable,
+    "rf_gain": LevelsCapable,
+    "af_level": LevelsCapable,
+    "squelch": LevelsCapable,
+    "nb": LevelsCapable,
+    "nr": LevelsCapable,
+    "attenuator": AntennaControlCapable,
+    "preamp": AntennaControlCapable,
+    "antenna": AntennaControlCapable,
+    "rx_antenna": AntennaControlCapable,
+    "filter_width": DspControlCapable,
+    "agc": DspControlCapable,
+    "notch": DspControlCapable,
+    "apf": DspControlCapable,
+    "pbt": DspControlCapable,
+    "digisel": DspControlCapable,
+    "ip_plus": DspControlCapable,
+    "rit": RitXitCapable,
+    "xit": RitXitCapable,
+}
+
+
+def _utcnow_iso() -> str:
+    """Return the current UTC time as an ISO-8601 millisecond ``...Z`` string."""
+    return (
+        datetime.datetime.now(datetime.UTC)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+async def execute_hardware_checks(
+    radio: Radio,
+    template: MatrixTemplate,
+    safety: OperatorSafetyBlock,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float = DEFAULT_PER_CHECK_TIMEOUT,
+) -> list[LevelResult]:
+    """Run a template's checks against an already-connected ``radio``.
+
+    Iterates ``template.entries`` in order, producing one :class:`CheckResult`
+    per entry, then groups results by validation level (ascending, empty
+    levels omitted, original order preserved within a level). Each result is
+    stamped with ISO-8601 ``started_at``/``finished_at`` timestamps and a single
+    INFO log line is emitted per check. The radio is assumed connected; this
+    function neither connects nor disconnects.
+    """
+    by_level: dict[ValidationLevel, list[CheckResult]] = {}
+    for entry in template.entries:
+        started = _utcnow_iso()
+        result = await _run_one_check(
+            radio,
+            entry,
+            safety,
+            allow_writes=allow_writes,
+            per_check_timeout=per_check_timeout,
+        )
+        finished = _utcnow_iso()
+        result = dataclasses.replace(result, started_at=started, finished_at=finished)
+        _LOGGER.info(
+            "validate check %s -> %s (%s)",
+            result.check_id,
+            result.status.value,
+            finished,
+        )
+        if result.status in {CheckStatus.FAIL, CheckStatus.BLOCKED}:
+            _LOGGER.info(
+                "validate check %s failure domain=%s error=%s",
+                result.check_id,
+                result.failure_domain.value if result.failure_domain else None,
+                result.error,
+            )
+        by_level.setdefault(entry.level, []).append(result)
+    return [
+        LevelResult(level=level, checks=by_level[level]) for level in sorted(by_level)
+    ]
+
+
+def _capability_present(radio: Radio, entry: CapabilityDeclarationEntry) -> bool | None:
+    """Return whether ``entry``'s capability is present, or None if untagged."""
+    if not entry.capability:
+        return None
+    if entry.capability in radio.capabilities:
+        return True
+    proto = _CAP_PROTOCOL.get(entry.capability)
+    if proto is not None and isinstance(radio, proto):
+        return True
+    return False
+
+
+def _base_result(
+    entry: CapabilityDeclarationEntry,
+    status: CheckStatus,
+    *,
+    failure_domain: FailureDomain | None = None,
+    evidence: dict[str, object] | None = None,
+    error: str | None = None,
+) -> CheckResult:
+    """Build a :class:`CheckResult` carrying ``entry``'s static fields."""
+    return CheckResult(
+        check_id=entry.check_id,
+        capability=entry.capability,
+        level=entry.level,
+        status=status,
+        declaration=entry.declaration,
+        summary=entry.summary,
+        failure_domain=failure_domain,
+        evidence=evidence or {},
+        error=error,
+    )
+
+
+async def _run_one_check(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    safety: OperatorSafetyBlock,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    """Execute a single template entry, applying universal pre-gates first."""
+    # Pre-gate 1: authorization for TX-adjacent checks.
+    if entry.tx_adjacent and not _is_authorized(entry, safety):
+        return _base_result(
+            entry,
+            CheckStatus.BLOCKED,
+            failure_domain=FailureDomain.COMMAND_EXECUTION,
+            evidence={"reason": "operator authorization required"},
+        )
+
+    # Pre-gate 2: manual-required (authorized / non-TX-adjacent).
+    if entry.declaration == CapabilityDeclaration.MANUAL_REQUIRED:
+        return _manual_required_result(radio, entry)
+
+    # Pre-gate 3: declared unsupported pending evidence.
+    if entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE:
+        evidence: dict[str, object] = {"declared": "unsupported_pending_evidence"}
+        present = _capability_present(radio, entry)
+        if present is not None and entry.check_id == "scope.capture":
+            evidence["scope_capability_present"] = present
+        elif present is not None:
+            evidence["capability_present"] = present
+        return _base_result(entry, CheckStatus.UNSUPPORTED, evidence=evidence)
+
+    # Pre-gate 4: SUPPORTED -> check-specific logic.
+    handler = _SUPPORTED_HANDLERS.get(entry.check_id)
+    if handler is None:
+        return _base_result(
+            entry,
+            CheckStatus.SKIP,
+            evidence={"reason": f"no hardware handler for check_id '{entry.check_id}'"},
+        )
+    return await handler(
+        radio,
+        entry,
+        allow_writes=allow_writes,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+def _manual_required_result(
+    radio: Radio, entry: CapabilityDeclarationEntry
+) -> CheckResult:
+    """Build a MANUAL_REQUIRED result with read-only evidence enrichment.
+
+    Performs NO actuation: never keys TX, never triggers a tune cycle, never
+    starts a stream.
+    """
+    if entry.check_id == "audio.rx":
+        present = (
+            isinstance(radio, AudioCapable | UsbAudioCapable)
+            or "audio" in radio.capabilities
+        )
+        return _base_result(
+            entry,
+            CheckStatus.MANUAL_REQUIRED,
+            evidence={"audio_capability_present": present},
+        )
+    if entry.check_id == "tuner.tune":
+        return _base_result(
+            entry,
+            CheckStatus.MANUAL_REQUIRED,
+            evidence={
+                "tuner_status": radio.radio_state.tuner_status,
+                "note": "tune cycle not auto-run (keys TX)",
+            },
+        )
+    if entry.check_id == "tx.ptt":
+        return _base_result(
+            entry,
+            CheckStatus.MANUAL_REQUIRED,
+            evidence={
+                "ptt": radio.radio_state.ptt,
+                "note": "PTT not auto-keyed",
+            },
+        )
+    if entry.check_id == "scope.capture":
+        scope_present = _capability_present(radio, entry)
+        evidence: dict[str, object] = {}
+        if scope_present is not None:
+            evidence["scope_capability_present"] = scope_present
+        return _base_result(entry, CheckStatus.MANUAL_REQUIRED, evidence=evidence)
+    return _base_result(entry, CheckStatus.MANUAL_REQUIRED)
+
+
+async def _guard(
+    coro: Awaitable[T],
+    entry: CapabilityDeclarationEntry,
+    *,
+    per_check_timeout: float,
+) -> tuple[T | None, CheckResult | None]:
+    """Await a radio coroutine, mapping failures to a :class:`CheckResult`.
+
+    Returns ``(value, None)`` on success or ``(None, failure_result)`` on any
+    handled error. Never swallows ``KeyboardInterrupt``/``SystemExit``.
+    """
+    try:
+        value = await asyncio.wait_for(coro, timeout=per_check_timeout)
+        return value, None
+    except (asyncio.TimeoutError, RigTimeoutError):
+        return None, _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.COMMAND_EXECUTION,
+            error=f"timeout after {per_check_timeout}s",
+        )
+    except (RigConnectionError, AuthenticationError) as exc:
+        return None, _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.TRANSPORT,
+            error=str(exc),
+        )
+    except CommandError as exc:
+        return None, _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.COMMAND_EXECUTION,
+            error=str(exc),
+        )
+    except RigplaneError as exc:
+        return None, _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.COMMAND_EXECUTION,
+            error=str(exc),
+        )
+
+
+def _default_equal(a: T, b: T) -> bool:
+    """Default equality comparator for RMVR readbacks."""
+    return bool(a == b)
+
+
+async def _read_modify_verify_restore(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    read: Callable[[], Awaitable[T]],
+    write: Callable[[T], Awaitable[None]],
+    make_changed: Callable[[T], T],
+    per_check_timeout: float,
+    equal: Callable[[T, T], bool] = _default_equal,
+    extra_evidence: dict[str, object] | None = None,
+) -> CheckResult:
+    """Read-modify-verify-restore an RX-safe control and report the outcome.
+
+    Reads the original value, writes a different value, verifies the readback
+    reacted, and always restores the original in a ``finally`` that never
+    raises. The original is restored even if the write or readback failed.
+    """
+    original, fail = await _guard(read(), entry, per_check_timeout=per_check_timeout)
+    if fail is not None:
+        return fail
+    # ``original`` is a valid value (bool/0 included); cast for typing.
+    original = cast(T, original)
+
+    changed = make_changed(original)
+    evidence: dict[str, object] = {"original": original, "changed": changed}
+    if extra_evidence:
+        evidence.update(extra_evidence)
+
+    reacted = False
+    readback: T | None = None
+    restored = False
+    outcome: CheckResult | None = None
+
+    try:
+        _, w_fail = await _guard(
+            write(changed), entry, per_check_timeout=per_check_timeout
+        )
+        if w_fail is not None:
+            evidence["write_error"] = w_fail.error
+            outcome = w_fail
+        else:
+            readback, r_fail = await _guard(
+                read(), entry, per_check_timeout=per_check_timeout
+            )
+            if r_fail is not None:
+                evidence["readback_error"] = r_fail.error
+                outcome = r_fail
+            else:
+                evidence["readback"] = readback
+                reacted = equal(cast(T, readback), changed)
+    finally:
+        # Best-effort restore that must never raise.
+        try:
+            _, restore_fail = await _guard(
+                write(original), entry, per_check_timeout=per_check_timeout
+            )
+            if restore_fail is not None:
+                evidence["restore_error"] = restore_fail.error
+            else:
+                ctrl, ctrl_fail = await _guard(
+                    read(), entry, per_check_timeout=per_check_timeout
+                )
+                if ctrl_fail is not None:
+                    evidence["restore_read_error"] = ctrl_fail.error
+                else:
+                    restored = equal(cast(T, ctrl), original)
+                    evidence["restore_readback"] = ctrl
+        except _RESTORE_ERRORS as exc:
+            evidence["restore_error"] = str(exc)
+        evidence["restored"] = restored
+
+    if outcome is not None:
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=outcome.failure_domain,
+            evidence=evidence,
+            error=outcome.error,
+        )
+    if reacted and restored:
+        return _base_result(entry, CheckStatus.PASS, evidence=evidence)
+    if not reacted:
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.READBACK,
+            evidence=evidence,
+            error="control did not react: readback equals original",
+        )
+    return _base_result(
+        entry,
+        CheckStatus.FAIL,
+        failure_domain=FailureDomain.READBACK,
+        evidence=evidence,
+        error="control reacted but restore failed",
+    )
+
+
+def _write_gate(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+) -> CheckResult | None:
+    """Apply the allow_writes + capability-present gate for write checks.
+
+    Returns a short-circuit :class:`CheckResult` (SKIP/UNSUPPORTED) or ``None``
+    if the RMVR cycle should proceed.
+    """
+    if not allow_writes:
+        return _base_result(
+            entry,
+            CheckStatus.SKIP,
+            evidence={
+                "reason": (
+                    "writes disabled (--read-only); pass without --read-only "
+                    f"to exercise {entry.check_id}"
+                )
+            },
+        )
+    present = _capability_present(radio, entry)
+    if present is False:
+        return _base_result(
+            entry,
+            CheckStatus.UNSUPPORTED,
+            evidence={"capability_present": False},
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Read-only handlers
+# ---------------------------------------------------------------------------
+
+
+async def _check_discovery_identify(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    if not radio.connected:
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.TRANSPORT,
+            evidence={"connected": False, "model": radio.model},
+            error="radio reports not connected",
+        )
+    freq, failure = await _guard(
+        radio.get_freq(), entry, per_check_timeout=per_check_timeout
+    )
+    if failure is not None:
+        return failure
+    return _base_result(
+        entry,
+        CheckStatus.PASS,
+        evidence={"connected": True, "model": radio.model, "freq_hz": freq},
+    )
+
+
+async def _check_freq_reverse_sync(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    command_freq, failure = await _guard(
+        radio.get_freq(), entry, per_check_timeout=per_check_timeout
+    )
+    if failure is not None:
+        return failure
+    assert command_freq is not None
+    state_freq = radio.radio_state.main.freq
+    if state_freq == command_freq:
+        return _base_result(
+            entry,
+            CheckStatus.PASS,
+            evidence={
+                "command_freq_hz": command_freq,
+                "state_freq_hz": state_freq,
+                "delta_hz": 0,
+            },
+        )
+    return _base_result(
+        entry,
+        CheckStatus.FAIL,
+        failure_domain=FailureDomain.STATE_PUBLISHING,
+        evidence={
+            "command_freq_hz": command_freq,
+            "state_freq_hz": state_freq,
+            "delta_hz": command_freq - state_freq,
+        },
+        error="core state frequency does not match the command-path read",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write handlers (RMVR)
+# ---------------------------------------------------------------------------
+
+
+async def _check_freq_write(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    # ``freq.write`` is untagged (cap ""): gate on allow_writes only.
+    if not allow_writes:
+        return _base_result(
+            entry,
+            CheckStatus.SKIP,
+            evidence={
+                "reason": (
+                    "writes disabled (--read-only); pass without --read-only "
+                    "to exercise freq.write"
+                )
+            },
+        )
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: radio.get_freq(0),
+        write=lambda value: radio.set_freq(value, 0),
+        make_changed=lambda f: f + 1000,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_mode_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    # ``mode.set`` is untagged (cap ""): gate on allow_writes only.
+    if not allow_writes:
+        return _base_result(
+            entry,
+            CheckStatus.SKIP,
+            evidence={
+                "reason": (
+                    "writes disabled (--read-only); pass without --read-only "
+                    "to exercise mode.set"
+                )
+            },
+        )
+
+    original, fail = await _guard(
+        radio.get_mode(0), entry, per_check_timeout=per_check_timeout
+    )
+    if fail is not None:
+        return fail
+    assert original is not None
+    orig_mode, orig_filter = original
+    changed_mode = next(
+        candidate for candidate in ("USB", "LSB", "CW", "AM") if candidate != orig_mode
+    )
+
+    evidence: dict[str, object] = {
+        "original_mode": orig_mode,
+        "original_filter": orig_filter,
+        "changed_mode": changed_mode,
+    }
+    reacted = False
+    restored = False
+    outcome: CheckResult | None = None
+
+    try:
+        _, w_fail = await _guard(
+            radio.set_mode(changed_mode, None, 0),
+            entry,
+            per_check_timeout=per_check_timeout,
+        )
+        if w_fail is not None:
+            evidence["write_error"] = w_fail.error
+            outcome = w_fail
+        else:
+            readback, r_fail = await _guard(
+                radio.get_mode(0), entry, per_check_timeout=per_check_timeout
+            )
+            if r_fail is not None:
+                evidence["readback_error"] = r_fail.error
+                outcome = r_fail
+            else:
+                assert readback is not None
+                evidence["readback_mode"] = readback[0]
+                reacted = readback[0] == changed_mode
+    finally:
+        try:
+            _, restore_fail = await _guard(
+                radio.set_mode(orig_mode, orig_filter, 0),
+                entry,
+                per_check_timeout=per_check_timeout,
+            )
+            if restore_fail is not None:
+                evidence["restore_error"] = restore_fail.error
+            else:
+                ctrl, ctrl_fail = await _guard(
+                    radio.get_mode(0), entry, per_check_timeout=per_check_timeout
+                )
+                if ctrl_fail is not None:
+                    evidence["restore_read_error"] = ctrl_fail.error
+                else:
+                    assert ctrl is not None
+                    restored = ctrl[0] == orig_mode
+        except _RESTORE_ERRORS as exc:
+            evidence["restore_error"] = str(exc)
+        evidence["restored"] = restored
+
+    if outcome is not None:
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=outcome.failure_domain,
+            evidence=evidence,
+            error=outcome.error,
+        )
+    if reacted and restored:
+        return _base_result(entry, CheckStatus.PASS, evidence=evidence)
+    if not reacted:
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.READBACK,
+            evidence=evidence,
+            error="control did not react: readback equals original",
+        )
+    return _base_result(
+        entry,
+        CheckStatus.FAIL,
+        failure_domain=FailureDomain.READBACK,
+        evidence=evidence,
+        error="control reacted but restore failed",
+    )
+
+
+async def _check_filter_width_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    dsp = cast(DspControlCapable, radio)
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: dsp.get_filter_width(0),
+        write=lambda value: dsp.set_filter_width(value, 0),
+        make_changed=lambda w: w + 200 if w <= 2600 else w - 200,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_rf_gain_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    levels = cast(LevelsCapable, radio)
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: levels.get_rf_gain(0),
+        write=lambda value: levels.set_rf_gain(value, 0),
+        make_changed=lambda v: 200 if v < 128 else 50,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_af_level_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    levels = cast(LevelsCapable, radio)
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: levels.get_af_level(0),
+        write=lambda value: levels.set_af_level(value, 0),
+        make_changed=lambda v: 200 if v < 128 else 50,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_preamp_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    antenna = cast(AntennaControlCapable, radio)
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: antenna.get_preamp(0),
+        write=lambda value: antenna.set_preamp(value, 0),
+        make_changed=lambda v: 1 if v == 0 else 0,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_attenuator_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    antenna = cast(AntennaControlCapable, radio)
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: antenna.get_attenuator(0),
+        write=lambda value: antenna.set_attenuator(value, 0),
+        make_changed=lambda b: not b,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_notch_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    dsp = cast(DspControlCapable, radio)
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: dsp.get_manual_notch(0),
+        write=lambda value: dsp.set_manual_notch(value, 0),
+        make_changed=lambda b: not b,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_nb_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    read_fn = getattr(radio, "get_nb", None)
+    if not callable(read_fn):
+        return _base_result(
+            entry,
+            CheckStatus.UNSUPPORTED,
+            evidence={"reason": "radio exposes set_nb but no get_nb readback"},
+        )
+    write_fn = cast(Callable[[bool], Awaitable[None]], getattr(radio, "set_nb"))
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: cast(Awaitable[bool], read_fn()),
+        write=write_fn,
+        make_changed=lambda b: not b,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_nr_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    read_fn = getattr(radio, "get_nr", None)
+    if not callable(read_fn):
+        return _base_result(
+            entry,
+            CheckStatus.UNSUPPORTED,
+            evidence={"reason": "radio exposes set_nr but no get_nr readback"},
+        )
+    write_fn = cast(Callable[[bool], Awaitable[None]], getattr(radio, "set_nr"))
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: cast(Awaitable[bool], read_fn()),
+        write=write_fn,
+        make_changed=lambda b: not b,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_agc_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    dsp = cast(DspControlCapable, radio)
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=lambda: dsp.get_agc(0),
+        write=lambda value: dsp.set_agc(value, 0),
+        make_changed=lambda m: (
+            int(AgcMode.SLOW) if m != AgcMode.SLOW else int(AgcMode.FAST)
+        ),
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_rit_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    rit = cast(RitXitCapable, radio)
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=rit.get_rit_frequency,
+        write=rit.set_rit_frequency,
+        make_changed=lambda v: v + 100,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+async def _check_xit_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+    rit = cast(RitXitCapable, radio)
+    return await _read_modify_verify_restore(
+        radio,
+        entry,
+        read=rit.get_rit_tx_status,
+        write=rit.set_rit_tx_status,
+        make_changed=lambda b: not b,
+        per_check_timeout=per_check_timeout,
+    )
+
+
+# Dispatch table for SUPPORTED check-specific handlers.
+_SUPPORTED_HANDLERS: dict[
+    str,
+    Callable[..., Awaitable[CheckResult]],
+] = {
+    "discovery.identify": _check_discovery_identify,
+    "freq.write": _check_freq_write,
+    "freq.reverse_sync": _check_freq_reverse_sync,
+    "mode.set": _check_mode_set,
+    "filter_width.set": _check_filter_width_set,
+    "rf_gain.set": _check_rf_gain_set,
+    "af_level.set": _check_af_level_set,
+    "preamp.set": _check_preamp_set,
+    "attenuator.set": _check_attenuator_set,
+    "notch.set": _check_notch_set,
+    "nb.set": _check_nb_set,
+    "nr.set": _check_nr_set,
+    "agc.set": _check_agc_set,
+    "rit.set": _check_rit_set,
+    "xit.set": _check_xit_set,
+}

--- a/src/rigplane/validation/schema.py
+++ b/src/rigplane/validation/schema.py
@@ -78,6 +78,8 @@ class CheckResult:
     failure_domain: FailureDomain | None = None
     evidence: dict[str, object] = field(default_factory=dict)
     error: str | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -95,6 +97,10 @@ class CheckResult:
             payload["evidence"] = dict(self.evidence)
         if self.error:
             payload["error"] = self.error
+        if self.started_at is not None:
+            payload["started_at"] = self.started_at
+        if self.finished_at is not None:
+            payload["finished_at"] = self.finished_at
         return payload
 
 
@@ -218,6 +224,7 @@ class ValidationArtifact:
     schema_version: int = SCHEMA_VERSION
     tool: str = TOOL_NAME
     metadata: dict[str, object] = field(default_factory=dict)
+    generated_at: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -235,6 +242,8 @@ class ValidationArtifact:
             payload["core_commit"] = self.core_commit
         if self.logs_path is not None:
             payload["logs_path"] = self.logs_path
+        if self.generated_at is not None:
+            payload["generated_at"] = self.generated_at
         return payload
 
 
@@ -447,6 +456,19 @@ def _validate_check_dict(data: object, where: str) -> CheckResult:
     error_obj = check_dict.get("error")
     error = None if error_obj is None else _require_str(error_obj, f"{where}.error")
 
+    started_at_obj = check_dict.get("started_at")
+    started_at = (
+        None
+        if started_at_obj is None
+        else _require_str(started_at_obj, f"{where}.started_at")
+    )
+    finished_at_obj = check_dict.get("finished_at")
+    finished_at = (
+        None
+        if finished_at_obj is None
+        else _require_str(finished_at_obj, f"{where}.finished_at")
+    )
+
     return CheckResult(
         check_id=check_id,
         capability=capability,
@@ -457,6 +479,8 @@ def _validate_check_dict(data: object, where: str) -> CheckResult:
         failure_domain=failure_domain,
         evidence=dict(evidence_obj),
         error=error,
+        started_at=started_at,
+        finished_at=finished_at,
     )
 
 
@@ -544,6 +568,13 @@ def validate_artifact_dict(data: object) -> ValidationArtifact:
     if not isinstance(metadata_obj, dict):
         raise SchemaValidationError("artifact.metadata must be an object")
 
+    generated_at_obj = root.get("generated_at")
+    generated_at = (
+        None
+        if generated_at_obj is None
+        else _require_str(generated_at_obj, "artifact.generated_at")
+    )
+
     return ValidationArtifact(
         radio=radio,
         transport=transport,
@@ -555,6 +586,7 @@ def validate_artifact_dict(data: object) -> ValidationArtifact:
         mode=mode,
         tool=tool,
         metadata=dict(metadata_obj),
+        generated_at=generated_at,
     )
 
 

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -1,0 +1,400 @@
+"""Tests for the hardware-execution path of ``rigplane validate``.
+
+These never touch a real serial device — they exercise the in-process mock
+UDP radio (``connected_radio`` fixture) for the happy path and a
+``MagicMock(spec=Radio)`` with ``AsyncMock`` coroutines plus a real
+``RadioState`` for the edge cases.
+
+The IC-7610 mock round-trips set->get ONLY for freq, mode, attenuator, and
+preamp; rf_gain/af_level/nb/nr/notch/agc/rit/filter_width are NAKed (mapped to
+``CommandError`` -> FAIL/COMMAND_EXECUTION), so PASS for those controls is only
+asserted against a stateful ``MagicMock``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.core.radio_protocol import Radio
+from rigplane.core.radio_state import RadioState
+from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.runner import build_validation_artifact, load_template
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckStatus,
+    FailureDomain,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    TransportInfo,
+    ValidationArtifact,
+    ValidationLevel,
+    validate_artifact_dict,
+)
+
+_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "validation"
+    / "templates"
+    / "x6200.json"
+)
+
+_ISO8601_MS_Z = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+
+def _x6200_template() -> MatrixTemplate:
+    return load_template(_TEMPLATE_PATH)
+
+
+def _flatten(levels):
+    return {check.check_id: check for level in levels for check in level.checks}
+
+
+def _single_entry_template(
+    *,
+    check_id: str,
+    capability: str,
+    level: ValidationLevel = ValidationLevel.CAPABILITY_MATRIX,
+    declaration: CapabilityDeclaration = CapabilityDeclaration.SUPPORTED,
+    summary: str = "single",
+) -> MatrixTemplate:
+    return MatrixTemplate(
+        radio=RadioTarget(model="X6200", profile_id="x6200"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id=check_id,
+                capability=capability,
+                level=level,
+                declaration=declaration,
+                summary=summary,
+            )
+        ],
+    )
+
+
+def _make_mock_radio(*, freq: int = 14_074_000, state_freq: int = 14_074_000):
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"audio", "scope", "tuner", "tx"}
+    radio.get_freq = AsyncMock(return_value=freq)
+    radio.set_freq = AsyncMock(return_value=None)
+    radio.get_mode = AsyncMock(return_value=("USB", 1))
+    radio.set_mode = AsyncMock(return_value=None)
+    radio.set_ptt = AsyncMock(return_value=None)
+    state = RadioState()
+    state.main.freq = state_freq
+    radio.radio_state = state
+    return radio
+
+
+def _stateful_preamp_mock(*, start: int = 0):
+    """A MagicMock(spec=Radio) whose preamp set/get round-trips via a closure."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"preamp"}
+    store = {"value": start}
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(level: int, receiver: int = 0) -> None:
+        store["value"] = level
+
+    radio.get_preamp = AsyncMock(side_effect=_get)
+    radio.set_preamp = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_default_run_produces_artifact_with_expected_statuses(connected_radio):
+    template = _x6200_template()
+    safety = OperatorSafetyBlock()
+    levels = await execute_hardware_checks(
+        connected_radio, template, safety, allow_writes=True
+    )
+    checks = _flatten(levels)
+
+    assert checks["discovery.identify"].status is CheckStatus.PASS
+    assert checks["freq.write"].status is CheckStatus.PASS
+    assert checks["freq.write"].evidence["restored"] is True
+    assert checks["mode.set"].status is CheckStatus.PASS
+    assert checks["preamp.set"].status is CheckStatus.PASS
+    assert checks["attenuator.set"].status is CheckStatus.PASS
+    assert checks["freq.reverse_sync"].status is CheckStatus.PASS
+    assert checks["audio.rx"].status is CheckStatus.MANUAL_REQUIRED
+    assert checks["scope.capture"].status is CheckStatus.UNSUPPORTED
+    assert checks["tuner.tune"].status is CheckStatus.BLOCKED
+    assert checks["tx.ptt"].status is CheckStatus.BLOCKED
+
+    # filter_width is declared unsupported_pending_evidence on the X6200.
+    assert checks["filter_width.set"].status is CheckStatus.UNSUPPORTED
+
+    # Controls the IC-7610 mock cannot read back are NAKed (FAIL), never PASS.
+    for nak_check in ("rf_gain.set", "af_level.set", "notch.set", "agc.set"):
+        assert checks[nak_check].status in {CheckStatus.FAIL, CheckStatus.UNSUPPORTED}
+        assert checks[nak_check].status is not CheckStatus.PASS
+
+    artifact = build_validation_artifact(
+        template=template,
+        levels=levels,
+        transport=TransportInfo(backend="fixture"),
+        safety=safety,
+        core_version="test",
+        mode="hardware",
+    )
+    assert artifact.mode == "hardware"
+    # Round-trips through schema validation.
+    validate_artifact_dict(json.loads(json.dumps(artifact.to_dict())))
+
+
+async def test_rmvr_pass_on_stateful_mock():
+    radio, store = _stateful_preamp_mock(start=0)
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 0
+    assert check.evidence["changed"] == 1
+    assert check.evidence["readback"] == 1
+    assert check.evidence["restored"] is True
+    assert await radio.get_preamp() == 0
+
+
+async def test_rmvr_control_does_not_react_yields_fail_readback():
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"preamp"}
+    radio.set_preamp = AsyncMock(return_value=None)  # no-op write
+    radio.get_preamp = AsyncMock(return_value=0)  # always 0
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+    assert check.status is CheckStatus.FAIL
+    assert check.failure_domain is FailureDomain.READBACK
+    assert check.evidence["original"] == 0
+    assert check.evidence["readback"] == 0
+    assert check.evidence["restored"] is True
+    # changed=1 then restore=0 => at least two writes.
+    assert radio.set_preamp.call_count >= 2
+
+
+async def test_rmvr_restore_failure_is_recorded():
+    from rigplane.core.exceptions import CommandError
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"preamp"}
+    store = {"value": 0}
+    calls = {"set": 0}
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(level: int, receiver: int = 0) -> None:
+        calls["set"] += 1
+        if calls["set"] == 1:
+            store["value"] = level
+        else:
+            raise CommandError("restore failed")
+
+    radio.get_preamp = AsyncMock(side_effect=_get)
+    radio.set_preamp = AsyncMock(side_effect=_set)
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+    assert check.status is CheckStatus.FAIL
+    assert check.failure_domain is FailureDomain.READBACK
+    assert "restore_error" in check.evidence
+
+
+async def test_read_only_skips_write_checks():
+    radio = _make_mock_radio()
+    radio.capabilities = {"audio", "scope", "tuner", "tx", "preamp", "rf_gain"}
+    radio.set_preamp = AsyncMock(return_value=None)
+    radio.get_preamp = AsyncMock(return_value=0)
+    radio.set_rf_gain = AsyncMock(return_value=None)
+    radio.get_rf_gain = AsyncMock(return_value=0)
+    template = _x6200_template()
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=False
+    )
+    checks = _flatten(levels)
+
+    assert checks["freq.write"].status is CheckStatus.SKIP
+    radio.set_freq.assert_not_called()
+    assert checks["mode.set"].status is CheckStatus.SKIP
+    assert checks["preamp.set"].status is CheckStatus.SKIP
+    assert checks["rf_gain.set"].status is CheckStatus.SKIP
+    radio.set_preamp.assert_not_called()
+
+    # Read-only checks still run.
+    assert checks["freq.reverse_sync"].status is CheckStatus.PASS
+    assert checks["audio.rx"].status is CheckStatus.MANUAL_REQUIRED
+    assert checks["tuner.tune"].status is CheckStatus.BLOCKED
+
+
+async def test_timestamps_present_and_iso8601(connected_radio):
+    template = _x6200_template()
+    levels = await execute_hardware_checks(
+        connected_radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    for check in _flatten(levels).values():
+        assert check.started_at is not None
+        assert check.finished_at is not None
+        assert _ISO8601_MS_Z.match(check.started_at)
+        assert _ISO8601_MS_Z.match(check.finished_at)
+
+
+async def test_generated_at_round_trips():
+    artifact = ValidationArtifact(
+        radio=RadioTarget(model="X6200", profile_id="x6200"),
+        transport=TransportInfo(backend="serial", baud=115200),
+        safety=OperatorSafetyBlock(),
+        levels=[],
+        core_version="test",
+        generated_at="2026-05-28T15:42:09.123Z",
+    )
+    restored = validate_artifact_dict(json.loads(json.dumps(artifact.to_dict())))
+    assert restored.generated_at == "2026-05-28T15:42:09.123Z"
+    assert _ISO8601_MS_Z.match(restored.generated_at)
+
+
+async def test_unsupported_when_capability_absent():
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = set()
+    radio.set_preamp = AsyncMock(return_value=None)
+    radio.get_preamp = AsyncMock(return_value=0)
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+    assert check.status is CheckStatus.UNSUPPORTED
+    assert check.evidence["capability_present"] is False
+    radio.set_preamp.assert_not_called()
+
+
+async def test_tx_and_tuner_blocked_without_flags_and_manual_with():
+    radio = _make_mock_radio()
+    template = MatrixTemplate(
+        radio=RadioTarget(model="X6200", profile_id="x6200"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id="tuner.tune",
+                capability="tuner",
+                level=ValidationLevel.STRESS_RECOVERY,
+                declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+                summary="tuner tune",
+                tx_adjacent=True,
+            ),
+            CapabilityDeclarationEntry(
+                check_id="tx.ptt",
+                capability="tx",
+                level=ValidationLevel.STRESS_RECOVERY,
+                declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+                summary="ptt",
+                tx_adjacent=True,
+            ),
+        ],
+    )
+
+    # Default safety: both blocked.
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    checks = _flatten(levels)
+    assert checks["tuner.tune"].status is CheckStatus.BLOCKED
+    assert checks["tuner.tune"].failure_domain is FailureDomain.COMMAND_EXECUTION
+    assert checks["tx.ptt"].status is CheckStatus.BLOCKED
+    assert checks["tx.ptt"].failure_domain is FailureDomain.COMMAND_EXECUTION
+
+    # Authorized: both manual_required, never actuated.
+    authorized = OperatorSafetyBlock(tx_allowed=True, tuner_allowed=True)
+    levels = await execute_hardware_checks(
+        radio, template, authorized, allow_writes=True
+    )
+    checks = _flatten(levels)
+    assert checks["tuner.tune"].status is CheckStatus.MANUAL_REQUIRED
+    assert checks["tx.ptt"].status is CheckStatus.MANUAL_REQUIRED
+    radio.set_ptt.assert_not_called()
+
+
+async def test_timeout_yields_fail_command_execution():
+    radio = _make_mock_radio()
+
+    async def _slow(*_args, **_kwargs):
+        await asyncio.sleep(10)
+
+    radio.get_freq = AsyncMock(side_effect=_slow)
+    template = _single_entry_template(
+        check_id="discovery.identify",
+        capability="",
+        level=ValidationLevel.DISCOVERY,
+        summary="identify",
+    )
+    levels = await execute_hardware_checks(
+        radio,
+        template,
+        OperatorSafetyBlock(),
+        allow_writes=False,
+        per_check_timeout=0.01,
+    )
+    check = _flatten(levels)["discovery.identify"]
+    assert check.status is CheckStatus.FAIL
+    assert check.failure_domain is FailureDomain.COMMAND_EXECUTION
+    assert "timeout" in (check.error or "")
+
+
+async def test_reverse_sync_mismatch_yields_fail_state_publishing():
+    radio = _make_mock_radio(freq=14_074_000, state_freq=7_000_000)
+    template = _single_entry_template(
+        check_id="freq.reverse_sync",
+        capability="",
+        level=ValidationLevel.BASIC_CONTROL,
+        summary="reverse sync",
+    )
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=False
+    )
+    check = _flatten(levels)["freq.reverse_sync"]
+    assert check.status is CheckStatus.FAIL
+    assert check.failure_domain is FailureDomain.STATE_PUBLISHING
+    assert check.evidence["command_freq_hz"] == 14_074_000
+    assert check.evidence["state_freq_hz"] == 7_000_000
+    assert check.evidence["delta_hz"] == 14_074_000 - 7_000_000
+
+
+async def test_artifact_round_trips():
+    radio = _make_mock_radio()
+    template = _x6200_template()
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=False
+    )
+    artifact = build_validation_artifact(
+        template=template,
+        levels=levels,
+        transport=TransportInfo(backend="serial", baud=115200),
+        safety=OperatorSafetyBlock(),
+        core_version="test",
+        mode="hardware",
+    )
+    restored = validate_artifact_dict(json.loads(json.dumps(artifact.to_dict())))
+    assert restored.mode == "hardware"
+    assert restored.transport.backend == "serial"


### PR DESCRIPTION
## Summary

Implements the **hardware-execution path** of `rigplane validate` (#1647): connect a radio, run the matrix, emit a machine-readable artifact + human summary with real per-check verdicts, evidence, and timestamps. Also expands the per-radio templates (#1651) with RX-control checks. Builds on the schema/dry-run base from #1646. Part of epic #1645.

Verified end-to-end against a **real Xiegu X6200** over serial (see evidence below).

## Behavior

- **Default = read/write with automatic restore.** Each RX-safe control runs a read-modify-verify-restore cycle: read original → write a different value → read back (did it react?) → restore the original (in a `finally` that never raises) → control-read. This is the only way to detect "control doesn't react" faults.
  - no reaction → `fail` / `readback` (the headline diagnostic)
  - timeout / NAK → `fail` / `command_execution`; connect/auth → `fail` / `transport`
  - capability absent → `unsupported`; restore failure recorded as evidence
- **`--read-only`** disables all writes (every write check becomes `skip`).
- **Safety:** TX/PTT and the antenna tuner are **never auto-actuated**. `tx.ptt`/`tuner.tune` stay `blocked` without `--tx-allowed`/`--tuner-allowed` and `manual_required` (read-only observation) when authorized. Fail-closed authorization gate.
- **Timestamps:** every check carries ISO-8601 UTC `started_at`/`finished_at`; the artifact carries `generated_at`; one INFO log line per check for log correlation. Schema stays v1 (additive optional fields).

## Live X6200 evidence (read/write, default safety)

`pass 6 · fail 8 · unsupported 2 · manual_required 1 · blocked 2`

| check | verdict | corroborates field report |
|---|---|---|
| freq.write | pass (21.200→21.201→restore) | freq write works |
| nb / nr / agc | pass | NB/NR/AGC work |
| preamp / attenuator | fail/command_execution — "no cmd29 route 0x16/0x02 … 0x11" | PRE/ATT don't react (root cause surfaced) |
| notch | fail/command_execution — timeout | Notch doesn't work |
| mode | fail/readback — wrote LSB, readback USB | mode/filter don't change |
| filter_width | unsupported (not in X6200 profile) | — |
| audio / scope | manual_required / unsupported | no audio/waterfall |
| tuner / tx | blocked (not actuated) | — |
| rf_gain / af_level / rit / xit | fail (readback/timeout) | flagged for follow-up (analog-level exact-equality vs quantization) |

## Verification

- `uv run pytest tests/ -q --ignore=tests/integration` → **5968 passed**, 57 skipped, 11 xfailed.
- `uv run mypy src/` clean for new code; `ruff check` clean; `lint-imports` 4 kept / 0 broken (hardware.py imports only core+validation+stdlib; CLI keeps hardware imports deferred).
- Independent agent review: **PASS** (verified restore-in-finally, no-TX/no-tuner actuation, no-react→fail/readback, --read-only skips writes, template declarations match each rig TOML, schema back-compat).

## Known follow-up (not in this PR)

Analog level controls (rf_gain/af_level) use exact-equality on readback; the X6200 quantizes the 0–255 scale (wrote 200, read 198), so a control that *did* react reports `fail/readback`. A tolerance-based comparison for analog levels is a sensible fast-follow.

## Out of scope

TX keying, tuner tune cycle, audio/scope capture, capability bug fixes, Pro code, new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
