### PR TITLE
feat: drive RF/AF/preamp/att/NB/NR via rigctld client + tolerance-aware validation readback

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -17,6 +17,20 @@ _SUPPORTED_COMMANDS = {
     "set_ptt",
     "get_vfo_slot",
     "set_vfo_slot",
+    "get_rf_gain",
+    "set_rf_gain",
+    "get_af_level",
+    "set_af_level",
+    "get_preamp",
+    "set_preamp",
+    "get_attenuator",
+    "set_attenuator",
+    "get_attenuator_level",
+    "set_attenuator_level",
+    "get_nb",
+    "set_nb",
+    "get_nr",
+    "set_nr",
 }
 
 
@@ -77,7 +91,7 @@ class RigctldClientRadio:
 
     @property
     def capabilities(self) -> set[str]:
-        caps = {"tx"}
+        caps = {"tx", "rf_gain", "af_level", "preamp", "attenuator", "nb", "nr"}
         if self._vfo_supported:
             caps.add("vfo")
         return caps
@@ -180,6 +194,66 @@ class RigctldClientRadio:
         await self._transport.command(f"V VFO{normalized}")
         self._state.main.active_slot = normalized
 
+    async def get_rf_gain(self, receiver: int = 0) -> int:
+        self._require_main_receiver(receiver, "get_rf_gain")
+        line = (await self._transport.query("l RF", response_lines=1))[0]
+        return _parse_level_255(line, "RF gain")
+
+    async def set_rf_gain(self, level: int, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_rf_gain")
+        await self._transport.command(f"L RF {_level_255_to_float(level)}")
+
+    async def get_af_level(self, receiver: int = 0) -> int:
+        self._require_main_receiver(receiver, "get_af_level")
+        line = (await self._transport.query("l AF", response_lines=1))[0]
+        return _parse_level_255(line, "AF level")
+
+    async def set_af_level(self, level: int, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_af_level")
+        await self._transport.command(f"L AF {_level_255_to_float(level)}")
+
+    async def get_preamp(self, receiver: int = 0) -> int:
+        self._require_main_receiver(receiver, "get_preamp")
+        line = (await self._transport.query("l PREAMP", response_lines=1))[0]
+        return _preamp_db_to_level(_parse_int_level(line, "preamp"))
+
+    async def set_preamp(self, level: int, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_preamp")
+        await self._transport.command(f"L PREAMP {_preamp_level_to_db(level)}")
+
+    async def get_attenuator(self, receiver: int = 0) -> bool:
+        self._require_main_receiver(receiver, "get_attenuator")
+        return await self.get_attenuator_level(receiver) > 0
+
+    async def set_attenuator(self, on: bool, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_attenuator")
+        await self._transport.command(f"L ATT {'6' if on else '0'}")
+
+    async def get_attenuator_level(self, receiver: int = 0) -> int:
+        self._require_main_receiver(receiver, "get_attenuator_level")
+        line = (await self._transport.query("l ATT", response_lines=1))[0]
+        return _parse_int_level(line, "attenuator")
+
+    async def set_attenuator_level(self, db: int, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_attenuator_level")
+        await self._transport.command(f"L ATT {int(db)}")
+
+    async def get_nb(self) -> bool:
+        line = (await self._transport.query("u NB", response_lines=1))[0]
+        return _parse_func(line, "noise blanker")
+
+    async def set_nb(self, on: bool, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_nb")
+        await self._transport.command(f"U NB {1 if on else 0}")
+
+    async def get_nr(self) -> bool:
+        line = (await self._transport.query("u NR", response_lines=1))[0]
+        return _parse_func(line, "noise reduction")
+
+    async def set_nr(self, on: bool, receiver: int = 0) -> None:
+        self._require_main_receiver(receiver, "set_nr")
+        await self._transport.command(f"U NR {1 if on else 0}")
+
     async def _probe_vfo_support(self) -> None:
         try:
             await self.get_vfo_slot()
@@ -203,3 +277,54 @@ def _normalize_vfo_slot(value: str) -> str:
     if normalized in {"B", "VFOB"}:
         return "B"
     raise CommandError(f"External rigctld returned unsupported VFO: {value!r}.")
+
+
+def _level_255_to_float(level: int) -> str:
+    """Format a RigPlane 0..255 level as a rigctl 0.0..1.0 string (3 decimals)."""
+    clamped = max(0, min(255, int(level)))
+    return f"{clamped / 255:.3f}"
+
+
+def _float_to_level_255(value: float) -> int:
+    """Convert a rigctl 0.0..1.0 level to a clamped RigPlane 0..255 integer."""
+    return max(0, min(255, round(value * 255)))
+
+
+def _parse_level_255(line: str, name: str) -> int:
+    try:
+        value = float(line)
+    except ValueError as exc:
+        raise CommandError(
+            f"External rigctld returned malformed {name}: {line!r}."
+        ) from exc
+    return _float_to_level_255(value)
+
+
+def _parse_int_level(line: str, name: str) -> int:
+    try:
+        return int(float(line))
+    except ValueError as exc:
+        raise CommandError(
+            f"External rigctld returned malformed {name}: {line!r}."
+        ) from exc
+
+
+def _parse_func(line: str, name: str) -> bool:
+    stripped = line.strip()
+    if stripped not in {"0", "1"}:
+        raise CommandError(f"External rigctld returned malformed {name}: {line!r}.")
+    return stripped == "1"
+
+
+def _preamp_level_to_db(level: int) -> str:
+    """Map a RigPlane preamp level (0/1/2) to a rigctl dB string."""
+    return {0: "0", 1: "10", 2: "20"}.get(int(level), "0")
+
+
+def _preamp_db_to_level(db: int) -> int:
+    """Map a rigctl preamp dB reading to a RigPlane preamp level (0/1/2)."""
+    if db <= 0:
+        return 0
+    if db <= 15:
+        return 1
+    return 2

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -341,6 +341,20 @@ def _default_equal(a: T, b: T) -> bool:
     return bool(a == b)
 
 
+def _tolerant_equal(tol: int) -> Callable[[int, int], bool]:
+    """Build a comparator treating values within ``tol`` as equal.
+
+    Used for analog level controls where a real radio may quantize a written
+    value, so an exact readback is not guaranteed. Evidence still records the
+    exact original/changed/readback values.
+    """
+
+    def _eq(a: int, b: int) -> bool:
+        return abs(int(a) - int(b)) <= tol
+
+    return _eq
+
+
 async def _read_modify_verify_restore(
     radio: Radio,
     entry: CapabilityDeclarationEntry,
@@ -700,6 +714,7 @@ async def _check_filter_width_set(
         read=lambda: dsp.get_filter_width(0),
         write=lambda value: dsp.set_filter_width(value, 0),
         make_changed=lambda w: w + 200 if w <= 2600 else w - 200,
+        equal=_tolerant_equal(50),
         per_check_timeout=per_check_timeout,
     )
 
@@ -721,6 +736,7 @@ async def _check_rf_gain_set(
         read=lambda: levels.get_rf_gain(0),
         write=lambda value: levels.set_rf_gain(value, 0),
         make_changed=lambda v: 200 if v < 128 else 50,
+        equal=_tolerant_equal(3),
         per_check_timeout=per_check_timeout,
     )
 
@@ -742,6 +758,7 @@ async def _check_af_level_set(
         read=lambda: levels.get_af_level(0),
         write=lambda value: levels.set_af_level(value, 0),
         make_changed=lambda v: 200 if v < 128 else 50,
+        equal=_tolerant_equal(3),
         per_check_timeout=per_check_timeout,
     )
 
@@ -905,6 +922,7 @@ async def _check_rit_set(
         read=rit.get_rit_frequency,
         write=rit.set_rit_frequency,
         make_changed=lambda v: v + 100,
+        equal=_tolerant_equal(10),
         per_check_timeout=per_check_timeout,
     )
 

--- a/tests/fake_rigctld.py
+++ b/tests/fake_rigctld.py
@@ -16,6 +16,10 @@ _SET_PTT = {"T", r"\set_ptt"}
 _GET_VFO = {"v", r"\get_vfo"}
 _SET_VFO = {"V", r"\set_vfo"}
 _GET_INFO = {r"\get_info"}
+_GET_LEVEL = {"l", r"\get_level"}
+_SET_LEVEL = {"L", r"\set_level"}
+_GET_FUNC = {"u", r"\get_func"}
+_SET_FUNC = {"U", r"\set_func"}
 _QUIT = {"q", r"\quit"}
 
 
@@ -29,6 +33,12 @@ class FakeRigctldState:
     ptt: int = 0
     vfo: str = "VFOA"
     info: str = "Fake rigctld"
+    rf_gain: float = 0.5
+    af: float = 0.3
+    preamp_db: int = 0
+    att_db: int = 0
+    nb: int = 0
+    nr: int = 0
 
 
 @dataclass(slots=True)
@@ -227,9 +237,75 @@ class FakeRigctldServer:
             self.state.vfo = tokens[1].upper()
             return _ok()
 
+        if key in _GET_LEVEL:
+            return self._get_level(tokens)
+        if key in _SET_LEVEL:
+            return self._set_level(tokens)
+        if key in _GET_FUNC:
+            return self._get_func(tokens)
+        if key in _SET_FUNC:
+            return self._set_func(tokens)
+
         if key in _GET_INFO:
             return f"{self.state.info}\n".encode("ascii")
 
+        return _error(HamlibError.ENIMPL)
+
+    def _get_level(self, tokens: list[str]) -> bytes:
+        if len(tokens) != 2:
+            return _error(HamlibError.EINVAL)
+        name = tokens[1].upper()
+        if name == "RF":
+            return f"{self.state.rf_gain:.3f}\n".encode("ascii")
+        if name == "AF":
+            return f"{self.state.af:.3f}\n".encode("ascii")
+        if name == "PREAMP":
+            return f"{self.state.preamp_db}\n".encode("ascii")
+        if name == "ATT":
+            return f"{self.state.att_db}\n".encode("ascii")
+        return _error(HamlibError.ENIMPL)
+
+    def _set_level(self, tokens: list[str]) -> bytes:
+        if len(tokens) != 3:
+            return _error(HamlibError.EINVAL)
+        name = tokens[1].upper()
+        try:
+            if name == "RF":
+                self.state.rf_gain = float(tokens[2])
+                return _ok()
+            if name == "AF":
+                self.state.af = float(tokens[2])
+                return _ok()
+            if name == "PREAMP":
+                self.state.preamp_db = int(tokens[2])
+                return _ok()
+            if name == "ATT":
+                self.state.att_db = int(tokens[2])
+                return _ok()
+        except ValueError:
+            return _error(HamlibError.EINVAL)
+        return _error(HamlibError.ENIMPL)
+
+    def _get_func(self, tokens: list[str]) -> bytes:
+        if len(tokens) != 2:
+            return _error(HamlibError.EINVAL)
+        name = tokens[1].upper()
+        if name == "NB":
+            return f"{self.state.nb}\n".encode("ascii")
+        if name == "NR":
+            return f"{self.state.nr}\n".encode("ascii")
+        return _error(HamlibError.ENIMPL)
+
+    def _set_func(self, tokens: list[str]) -> bytes:
+        if len(tokens) != 3 or tokens[2] not in {"0", "1"}:
+            return _error(HamlibError.EINVAL)
+        name = tokens[1].upper()
+        if name == "NB":
+            self.state.nb = int(tokens[2])
+            return _ok()
+        if name == "NR":
+            self.state.nr = int(tokens[2])
+            return _ok()
         return _error(HamlibError.ENIMPL)
 
 

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -10,6 +10,10 @@ from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer
 from rigplane.backends.config import RigctldBackendConfig
 from rigplane.backends.factory import create_radio
 from rigplane.backends.rigctld_client import RigctldClientRadio, RigctldTransport
+from rigplane.backends.rigctld_client.radio import (
+    _float_to_level_255,
+    _level_255_to_float,
+)
 from rigplane.exceptions import CommandError
 from rigplane.exceptions import ConnectionError as RadioConnectionError
 from rigplane.exceptions import TimeoutError as RadioTimeoutError
@@ -112,7 +116,16 @@ async def test_radio_core_frequency_mode_ptt_and_vfo() -> None:
             assert radio.radio_ready
             assert radio.backend_id == "rigctld"
             assert radio.model == "External rigctld"
-            assert radio.capabilities == {"tx", "vfo"}
+            assert radio.capabilities == {
+                "tx",
+                "vfo",
+                "rf_gain",
+                "af_level",
+                "preamp",
+                "attenuator",
+                "nb",
+                "nr",
+            }
             assert radio.supports_command("set_freq")
             assert radio.supports_command("get_vfo_slot")
             assert not radio.supports_command("start_audio_rx_opus")
@@ -174,3 +187,101 @@ def test_config_validates_rigctld_client_backend() -> None:
         RigctldBackendConfig(host="localhost", port=0)
     with pytest.raises(ValueError, match="timeout"):
         RigctldBackendConfig(host="localhost", timeout=0)
+
+
+async def test_rigctld_levels_roundtrip() -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            await radio.set_rf_gain(200)
+            assert abs(await radio.get_rf_gain() - 200) <= 2
+
+            await radio.set_af_level(120)
+            assert abs(await radio.get_af_level() - 120) <= 2
+        finally:
+            await radio.disconnect()
+
+
+async def test_rigctld_preamp_attenuator_nb_nr() -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            assert await radio.get_preamp() == 0
+            await radio.set_preamp(1)
+            assert await radio.get_preamp() == 1
+
+            assert await radio.get_attenuator() is False
+            await radio.set_attenuator(True)
+            assert await radio.get_attenuator() is True
+            assert await radio.get_attenuator_level() == 6
+
+            assert await radio.get_nb() is False
+            await radio.set_nb(True)
+            assert await radio.get_nb() is True
+
+            assert await radio.get_nr() is False
+            await radio.set_nr(True)
+            assert await radio.get_nr() is True
+        finally:
+            await radio.disconnect()
+
+
+async def test_rigctld_unsupported_level_raises_command_error() -> None:
+    behavior = FakeRigctldBehavior(unsupported_commands={"l RF"})
+    async with FakeRigctldServer(behavior=behavior) as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            with pytest.raises(CommandError):
+                await radio.get_rf_gain()
+        finally:
+            await radio.disconnect()
+
+
+async def test_rigctld_capabilities_include_levels() -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            assert {
+                "rf_gain",
+                "af_level",
+                "preamp",
+                "attenuator",
+                "nb",
+                "nr",
+            } <= radio.capabilities
+            for command in (
+                "get_rf_gain",
+                "set_rf_gain",
+                "get_af_level",
+                "set_af_level",
+                "get_preamp",
+                "set_preamp",
+                "get_attenuator",
+                "set_attenuator",
+                "get_nb",
+                "set_nb",
+                "get_nr",
+                "set_nr",
+            ):
+                assert radio.supports_command(command)
+        finally:
+            await radio.disconnect()
+
+
+def test_level_scale_conversions_roundtrip_and_clamp() -> None:
+    # Round-trip: a 0..255 level survives encode->decode within rounding.
+    for level in (0, 50, 128, 200, 255):
+        encoded = _level_255_to_float(level)
+        assert abs(_float_to_level_255(float(encoded)) - level) <= 1
+
+    # Clamp at boundaries.
+    assert _level_255_to_float(-10) == "0.000"
+    assert _level_255_to_float(999) == "1.000"
+    assert _float_to_level_255(-1.0) == 0
+    assert _float_to_level_255(2.0) == 255
+    assert _float_to_level_255(0.0) == 0
+    assert _float_to_level_255(1.0) == 255

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -381,6 +381,57 @@ async def test_reverse_sync_mismatch_yields_fail_state_publishing():
     assert check.evidence["delta_hz"] == 14_074_000 - 7_000_000
 
 
+def test_tolerant_equal_within_and_beyond_tolerance():
+    from rigplane.validation.hardware import _tolerant_equal
+
+    eq = _tolerant_equal(3)
+    assert eq(200, 198) is True
+    assert eq(200, 203) is True
+    assert eq(200, 196) is False
+    assert eq(50, 50) is True
+
+
+class _OffByTwoRfGainRadio:
+    """Dataclass-style fake whose rf_gain readback lags the write by 2.
+
+    Mirrors a real radio that quantizes an analog level: the tolerance-aware
+    comparator must still treat the readback as a successful reaction/restore
+    while evidence records the exact written/read values.
+    """
+
+    def __init__(self) -> None:
+        self.connected = True
+        self.model = "OffByTwo"
+        self.capabilities = {"rf_gain"}
+        self.radio_state = RadioState()
+        self._value = 100
+
+    async def get_rf_gain(self, receiver: int = 0) -> int:
+        # Reads back 2 below whatever was last written.
+        return max(0, self._value - 2)
+
+    async def set_rf_gain(self, level: int, receiver: int = 0) -> None:
+        self._value = level
+
+
+async def test_rf_gain_tolerance_passes_with_off_by_two_readback():
+    radio = _OffByTwoRfGainRadio()
+    template = _single_entry_template(check_id="rf_gain.set", capability="rf_gain")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["rf_gain.set"]
+
+    assert check.status is CheckStatus.PASS
+    # original read: 100 -> 98; make_changed(98) -> 200; readback 200 -> 198.
+    assert check.evidence["original"] == 98
+    assert check.evidence["changed"] == 200
+    assert check.evidence["readback"] == 198
+    assert check.evidence["restored"] is True
+    # Restore wrote back the exact original (98); readback is 96.
+    assert check.evidence["restore_readback"] == 96
+
+
 async def test_artifact_round_trips():
     radio = _make_mock_radio()
     template = _x6200_template()


### PR DESCRIPTION
## Summary

Extends the shared `RigctldClientRadio` backend to drive **RF gain, AF, preamp, attenuator, noise blanker, noise reduction** via the rigctl level/func protocol (`l/L`, `u/U`), and adds **tolerance-aware readback** to the validation RMVR engine for analog controls. Foundation for `rigplane validate --provider hamlib` (follow-up PR) and a fix for the analog-level false-fail seen in native runs.

## Changes

- **`RigctldClientRadio`** (additive): `get/set` for `rf_gain`, `af_level`, `preamp`, `attenuator` (+level), `nb`, `nr`. Scale conversion 0–255 ↔ Hamlib 0.0–1.0 float (rounded, clamped 0–255); preamp 0/1/2 and attenuator bool map to representative dB. Six new capability tags + registered commands. Unsupported level/func on a given Hamlib model surfaces as `CommandError` (honest fail, not crash). `freq/mode/ptt/vfo` untouched.
- **`fake_rigctld.py`**: simulates `l/L/u/U` statefully (unknown name → ENIMPL) so the backend is testable without hardware.
- **Tolerance-aware RMVR** (`validation/hardware.py`): analog controls compare within a tolerance (rf_gain/af ±3 on the 0–255 scale, filter_width ±50 Hz, rit ±10 Hz) instead of exact equality, so scale quantization isn't a false "did not react". Bool/enum/mode and **frequency stay exact**. Evidence still records exact original/changed/readback.

## Verification

- `uv run pytest tests/ -q --ignore=tests/integration` → **5975 passed**, 57 skipped, 11 xfailed.
- ruff clean; mypy clean for changed files; `lint-imports` 4 kept / 0 broken.
- Independent agent review: **PASS** (additive-only backend confirmed; rigctl verbs match the repo's own handler; scale clamp safe at bounds; freq stays exact; KNOWN_CAPABILITIES contains all six tags).

## Known follow-up (out of scope)

The expanded capability set now flows into the web layer when a station runs `rigplane web --radio-backend rigctld`. The on/off controls work, but UI sub-controls `set_nb_level/nr_level/nb_depth/nb_width` are not implemented by the rigctld client and would raise `AttributeError` reachable from the UI — caught by the poller's broad handler (degraded per-command, not a crash). Gate those sub-controls on method presence in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
