### PR TITLE
feat: rigplane validate --provider hamlib (native-vs-Hamlib comparison)

### DIFF
--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -24,6 +24,8 @@
 id = "xiegu_x6200"
 model = "X6200"
 civ_addr = 0xA4
+# Hamlib RIG_MODEL_X6200 (rigs_list.h) — used by validate --provider hamlib.
+hamlib_model_id = 3091
 receiver_count = 1
 has_lan = false
 has_wifi = true

--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -30,9 +30,10 @@ import datetime
 import json
 import os
 import sys
+import tempfile
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from rigplane import __version__
 from rigplane.validation import (
@@ -123,6 +124,24 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--provider",
+        choices=["native", "hamlib"],
+        default="native",
+        help=(
+            "Validation provider: native (default) drives the radio directly; "
+            "hamlib drives it through an internally-spawned Hamlib rigctld and "
+            "compares results. Model is auto-detected (or use --model)."
+        ),
+    )
+    p.add_argument(
+        "--compare",
+        default=None,
+        help=(
+            "Path to a prior validation artifact JSON to diff this run against "
+            "(per-check status)."
+        ),
+    )
+    p.add_argument(
         "--operator-id",
         dest="operator_id",
         default=None,
@@ -165,6 +184,8 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 3
+        if getattr(args, "provider", "native") == "hamlib":
+            return asyncio.run(_run_hardware_hamlib(args, template, safety))
         return asyncio.run(_run_hardware(args, template, safety))
 
     levels = dry_run_results(template, safety)
@@ -178,7 +199,13 @@ def run(args: argparse.Namespace) -> int:
         core_commit=None,
         mode="dry-run",
     )
-    artifact = dataclasses.replace(artifact, generated_at=_utcnow_iso())
+    artifact = dataclasses.replace(
+        artifact,
+        metadata={**artifact.metadata, "provider": "native"},
+        generated_at=_utcnow_iso(),
+    )
+    if getattr(args, "compare", None):
+        artifact = _attach_comparison(artifact, args.compare)
     _emit_artifact(artifact, args)
     return 0
 
@@ -276,6 +303,271 @@ async def _run_hardware(
         core_commit=None,
         mode="hardware",
     )
-    artifact = dataclasses.replace(artifact, generated_at=_utcnow_iso())
+    artifact = dataclasses.replace(
+        artifact,
+        metadata={**artifact.metadata, "provider": "native"},
+        generated_at=_utcnow_iso(),
+    )
+    if getattr(args, "compare", None):
+        artifact = _attach_comparison(artifact, args.compare)
     _emit_artifact(artifact, args)
     return exit_code
+
+
+async def _await_tcp_ready(host: str, port: int, *, timeout: float = 10.0) -> bool:
+    """Poll until a TCP listener accepts connections or *timeout* seconds elapse.
+
+    Returns ``True`` if the port accepted a connection, ``False`` on timeout.
+    Used to wait for stock ``rigctld`` to finish its ``rig_open`` sequence and
+    bind its front-side TCP port before we attempt to connect the rigctld client.
+    """
+    deadline = time.monotonic() + timeout
+    delay = 0.1
+    while time.monotonic() < deadline:
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(host, port), timeout=1.0
+            )
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:  # noqa: BLE001
+                pass
+            return True
+        except (OSError, asyncio.TimeoutError):
+            await asyncio.sleep(delay)
+            delay = min(delay * 1.5, 1.0)
+    return False
+
+
+def _free_tcp_port() -> int:
+    """Return an ephemeral free TCP port on the loopback interface."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+async def _run_hardware_hamlib(
+    args: argparse.Namespace,
+    template: MatrixTemplate,
+    safety: OperatorSafetyBlock,
+) -> int:
+    """Drive the radio through an internally-spawned Hamlib ``rigctld``.
+
+    A :class:`HamlibBridge` owns the real (RigPlane-controlled) radio and
+    proxies raw CI-V to a stock ``rigctld``; the rigctld client backend then
+    runs the same hardware checks through Hamlib, so results can be compared to
+    the native provider. Imports are deferred to function scope to avoid a
+    circular import with ``rigplane.cli`` and to keep ``hamlib_bridge`` /
+    backend assembly off this module's import graph (matching ``_run_hardware``).
+    """
+    from rigplane.backends.config import RigctldBackendConfig
+    from rigplane.backends.factory import create_radio
+    from rigplane.cli import _build_backend_config
+    from rigplane.core.exceptions import (
+        AuthenticationError,
+        ConnectionError as RigConnectionError,
+        RigplaneError,
+    )
+    from rigplane.hamlib_bridge import HamlibBridge, RawCivPipe
+    from rigplane.profiles import get_radio_profile
+    from rigplane.validation.hardware import execute_hardware_checks
+
+    try:
+        config = await _build_backend_config(args)
+    except ValueError as exc:
+        print(f"Error: cannot build backend config: {exc}", file=sys.stderr)
+        return 3
+
+    transport = _transport_info_from_config(config)
+    levels: list[LevelResult]
+
+    # Resolve the radio profile (model is required for the hamlib provider).
+    profile = None
+    if config.model:
+        try:
+            profile = get_radio_profile(config.model)
+        except KeyError:
+            profile = None
+    if profile is None:
+        levels = _transport_failure_levels(
+            template,
+            ValueError("Hamlib provider requires a known radio model; use --model"),
+        )
+        artifact = _build_hamlib_artifact(
+            template, levels, transport, safety, profile, None
+        )
+        if getattr(args, "compare", None):
+            artifact = _attach_comparison(artifact, args.compare)
+        _emit_artifact(artifact, args)
+        return 3
+
+    # The bridge speaks raw CI-V; non-CI-V rigs (Yaesu/Kenwood) cannot be driven.
+    if profile.protocol_type != "civ":
+        levels = _transport_failure_levels(
+            template,
+            ValueError(
+                f"Hamlib provider supports only CI-V radios; "
+                f"{config.model} is {profile.protocol_type}"
+            ),
+        )
+        artifact = _build_hamlib_artifact(
+            template, levels, transport, safety, profile, profile.hamlib_model_id
+        )
+        if getattr(args, "compare", None):
+            artifact = _attach_comparison(artifact, args.compare)
+        _emit_artifact(artifact, args)
+        return 3
+
+    hamlib_model = profile.hamlib_model_id
+    civaddr = getattr(config, "radio_addr", None) or profile.civ_addr
+    front_port = _free_tcp_port()
+    timeout = getattr(args, "timeout", 5.0) or 5.0
+
+    stderr_fd, stderr_path = tempfile.mkstemp(prefix="rigplane-rigctld-", suffix=".log")
+    os.close(stderr_fd)
+
+    native_radio = create_radio(config)
+    exit_code = 0
+    try:
+        async with native_radio:
+            # CoreRadio-derived Icom backends structurally satisfy the raw
+            # CI-V pipe the bridge needs; the Radio protocol doesn't declare it.
+            bridge = HamlibBridge(
+                cast(RawCivPipe, native_radio),
+                model=str(hamlib_model),
+                civaddr=civaddr,
+                front_port=front_port,
+                stderr_path=stderr_path,
+            )
+            try:
+                # start() is inside the try so a partial start (e.g. rigctld
+                # missing → spawn_rigctld raises after open_transport bound the
+                # listener and began the CAT session) is still torn down by stop().
+                await bridge.start()
+                ready = await _await_tcp_ready("127.0.0.1", front_port, timeout=10.0)
+                if not ready:
+                    # Read stderr tail for diagnostics (best-effort).
+                    stderr_tail = ""
+                    try:
+                        raw = Path(stderr_path).read_bytes()
+                        if raw:
+                            stderr_tail = "\nrigctld stderr tail:\n" + raw[
+                                -2048:
+                            ].decode(errors="replace")
+                    except OSError:
+                        pass
+                    raise RigConnectionError(
+                        f"Hamlib rigctld did not become ready on "
+                        f"127.0.0.1:{front_port} within 10s "
+                        f"(rig_open may have failed; see {stderr_path})" + stderr_tail
+                    )
+                hamlib_cfg = RigctldBackendConfig(
+                    host="127.0.0.1",
+                    port=front_port,
+                    timeout=timeout,
+                    model=config.model,
+                )
+                hamlib_radio = create_radio(hamlib_cfg)
+                async with hamlib_radio:
+                    levels = await execute_hardware_checks(
+                        hamlib_radio,
+                        template,
+                        safety,
+                        allow_writes=not bool(getattr(args, "read_only", False)),
+                        per_check_timeout=timeout,
+                    )
+            finally:
+                await bridge.stop()
+    except (RigConnectionError, AuthenticationError, OSError, RigplaneError) as exc:
+        levels = _transport_failure_levels(template, exc)
+        exit_code = 3
+    else:
+        # Clean up the stderr log only on success (leave it for debugging on failure).
+        try:
+            os.unlink(stderr_path)
+        except OSError:
+            pass
+
+    artifact = _build_hamlib_artifact(
+        template, levels, transport, safety, profile, hamlib_model
+    )
+    if getattr(args, "compare", None):
+        artifact = _attach_comparison(artifact, args.compare)
+    _emit_artifact(artifact, args)
+    return exit_code
+
+
+def _build_hamlib_artifact(
+    template: MatrixTemplate,
+    levels: list[LevelResult],
+    transport: TransportInfo,
+    safety: OperatorSafetyBlock,
+    profile: Any,
+    hamlib_model: int | None,
+) -> ValidationArtifact:
+    """Assemble a hardware artifact stamped with hamlib-provider metadata."""
+    artifact = build_validation_artifact(
+        template=template,
+        levels=levels,
+        transport=transport,
+        safety=safety,
+        core_version=__version__,
+        core_commit=None,
+        mode="hardware",
+    )
+    metadata: dict[str, Any] = {**artifact.metadata, "provider": "hamlib"}
+    if hamlib_model is not None:
+        metadata["hamlib_model_id"] = hamlib_model
+    if profile is not None:
+        metadata["profile_id"] = profile.id
+    return dataclasses.replace(artifact, metadata=metadata, generated_at=_utcnow_iso())
+
+
+def _check_status_map(artifact: ValidationArtifact) -> dict[str, str]:
+    """Map ``check_id`` → status value across all levels of *artifact*."""
+    statuses: dict[str, str] = {}
+    for level in artifact.levels:
+        for check in level.checks:
+            statuses[check.check_id] = check.status.value
+    return statuses
+
+
+def _compare_artifacts(this: ValidationArtifact, other_path: str) -> dict[str, Any]:
+    """Diff per-check status between *this* artifact and one loaded from disk."""
+    from rigplane.validation.schema import validate_artifact_dict
+
+    other = validate_artifact_dict(
+        json.loads(Path(other_path).read_text(encoding="utf-8"))
+    )
+    a = _check_status_map(this)
+    b = _check_status_map(other)
+    rows = [
+        {
+            "check_id": k,
+            "this": a.get(k),
+            "other": b.get(k),
+            "agree": a.get(k) == b.get(k),
+        }
+        for k in sorted(set(a) | set(b))
+    ]
+    return {"other_provider": other.metadata.get("provider"), "rows": rows}
+
+
+def _attach_comparison(
+    artifact: ValidationArtifact, other_path: str
+) -> ValidationArtifact:
+    """Fold a per-check comparison into metadata and print a compact table."""
+    comp = _compare_artifacts(artifact, other_path)
+    print("check_id | this | other | verdict", file=sys.stderr)
+    for row in comp["rows"]:
+        verdict = "AGREE" if row["agree"] else "DIFFER"
+        print(
+            f"{row['check_id']} | {row['this']} | {row['other']} | {verdict}",
+            file=sys.stderr,
+        )
+    return dataclasses.replace(
+        artifact, metadata={**artifact.metadata, "comparison": comp}
+    )

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -169,6 +169,9 @@ class RadioProfile:
     data_mode_count: int = 0
     data_mode_labels: dict[str, str] | None = None
     protocol_type: str = "civ"
+    # Hamlib rig_model integer (from rigs_list.h). Used by the validate
+    # ``--provider hamlib`` path to launch stock rigctld with ``-m <id>``.
+    hamlib_model_id: int = 2028
     controls: dict[str, ControlSpec] | None = None
     meter_calibrations: dict[str, list[MeterCalibrationPoint]] | None = None
     meter_redlines: dict[str, int] | None = None

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -174,6 +174,7 @@ class RigConfig:
             data_mode_count=self.data_mode_count,
             data_mode_labels=self.data_mode_labels,
             protocol_type=self.protocol_type,
+            hamlib_model_id=self.hamlib_model_id,
             controls=self.controls,
             meter_calibrations=self.meter_calibrations,
             meter_redlines=self.meter_redlines,

--- a/tests/test_validate_hamlib_provider.py
+++ b/tests/test_validate_hamlib_provider.py
@@ -1,0 +1,364 @@
+"""Tests for ``rigplane validate --provider hamlib`` plumbing (PR-B).
+
+No real ``rigctld`` and no real hardware: ``HamlibBridge`` is replaced with a
+small async-context fake, and the rigctld-client side is pointed at an
+in-process :class:`FakeRigctldServer`. The native side uses a minimal
+dataclass-style fake CI-V radio (per CLAUDE.md: no MagicMock radios).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import socket
+from typing import Any
+
+from fake_rigctld import FakeRigctldServer
+
+from rigplane.backends.config import RigctldBackendConfig
+from rigplane.backends.rigctld_client import RigctldClientRadio
+from rigplane.cli import _validate
+from rigplane.profiles import get_radio_profile
+from rigplane.validation import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    ValidationLevel,
+)
+from rigplane.validation.schema import (
+    SCHEMA_VERSION,
+    TOOL_NAME,
+)
+
+
+def _identify_template(profile_id: str = "xiegu_x6200") -> MatrixTemplate:
+    """In-memory template with a single read-only ``discovery.identify`` check."""
+    entry = CapabilityDeclarationEntry(
+        check_id="discovery.identify",
+        capability="",
+        level=ValidationLevel.DISCOVERY,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="Identify the radio",
+    )
+    return MatrixTemplate(
+        radio=RadioTarget(model="X6200", profile_id=profile_id),
+        entries=[entry],
+    )
+
+
+class _FakeNativeRadio:
+    """Minimal async-context fake CI-V native radio (raw-pipe surface stubbed)."""
+
+    def __init__(self) -> None:
+        self.entered = False
+
+    async def __aenter__(self) -> _FakeNativeRadio:
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        self.entered = False
+
+
+class _FakeBridge:
+    """Async-context stand-in for :class:`HamlibBridge` — start/stop no-ops."""
+
+    instances: list[_FakeBridge] = []
+
+    def __init__(self, radio: Any, **kwargs: Any) -> None:
+        self.radio = radio
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        _FakeBridge.instances.append(self)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _PartialStartBridge(_FakeBridge):
+    """Bridge whose start() fails after a partial resource acquire.
+
+    Mirrors HamlibBridge.start() binding the listener / beginning the CAT
+    session in open_transport() and then raising in spawn_rigctld() when
+    rigctld is missing — stop() must still run to release everything.
+    """
+
+    async def start(self) -> None:
+        self.started = True  # partial acquire happened before the failure
+        raise OSError("rigctld not found on PATH")
+
+
+def _base_args(**overrides: Any) -> argparse.Namespace:
+    ns = argparse.Namespace(
+        provider="hamlib",
+        model="X6200",
+        read_only=True,
+        compare=None,
+        output=None,
+        json=False,
+    )
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def test_provider_flag_defaults_native() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    _validate.add_subparser(sub)
+    args = parser.parse_args(["validate", "--template", "x.json"])
+    assert args.provider == "native"
+    assert args.compare is None
+
+
+def test_to_profile_carries_hamlib_model_id() -> None:
+    profile = get_radio_profile("X6200")
+    assert profile.hamlib_model_id == 3091
+
+
+async def test_run_hardware_hamlib_orchestration(monkeypatch: Any) -> None:
+    _FakeBridge.instances.clear()
+    template = _identify_template()
+    safety = OperatorSafetyBlock()
+
+    async with FakeRigctldServer() as server:
+        # Native config: model="X6200" with radio_addr so the hamlib path can
+        # read both. Using a rigctld config here only as a typed carrier of
+        # .model/.host/.port — create_radio is monkeypatched, so the backend
+        # kind is irrelevant; the fake returns a CI-V native radio for it.
+        native_config = RigctldBackendConfig(
+            host="127.0.0.1", port=server.port, model="X6200"
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def fake_build_backend_config(_args: Any) -> Any:
+            return native_config
+
+        def fake_create_radio(config: Any) -> Any:
+            if (
+                isinstance(config, RigctldBackendConfig)
+                and config.host == "127.0.0.1"
+                and config.port != server.port
+            ):
+                # The hamlib-side config points at the bridge front port; route
+                # it instead at the in-process fake rigctld server.
+                captured["front_port"] = config.port
+                return RigctldClientRadio(host=server.host, port=server.port)
+            return _FakeNativeRadio()
+
+        monkeypatch.setattr(
+            _validate,
+            "_emit_artifact",
+            lambda artifact, args: captured.setdefault("artifact", artifact),
+        )
+        monkeypatch.setattr(
+            "rigplane.cli._build_backend_config", fake_build_backend_config
+        )
+        monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+        monkeypatch.setattr("rigplane.hamlib_bridge.HamlibBridge", _FakeBridge)
+
+        # The fake bridge never actually binds the front port, so skip the
+        # real TCP poll and return True immediately.
+        async def fake_await_tcp_ready(
+            host: str, port: int, *, timeout: float = 10.0
+        ) -> bool:
+            return True
+
+        monkeypatch.setattr(_validate, "_await_tcp_ready", fake_await_tcp_ready)
+
+        exit_code = await _validate._run_hardware_hamlib(_base_args(), template, safety)
+
+    assert exit_code == 0
+    assert len(_FakeBridge.instances) == 1
+    bridge = _FakeBridge.instances[0]
+    assert bridge.started is True
+    assert bridge.stopped is True
+    assert bridge.kwargs["model"] == "3091"  # hamlib_model_id for X6200
+    artifact = captured["artifact"]
+    assert artifact.metadata["provider"] == "hamlib"
+    assert artifact.metadata["hamlib_model_id"] == 3091
+
+
+async def test_hamlib_provider_partial_start_is_torn_down(monkeypatch: Any) -> None:
+    """A bridge.start() that fails mid-way must still be stopped, exit 3."""
+    _FakeBridge.instances.clear()
+    template = _identify_template()
+    safety = OperatorSafetyBlock()
+
+    native_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="X6200")
+    captured: dict[str, Any] = {}
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return native_config
+
+    def fake_create_radio(config: Any) -> Any:
+        return _FakeNativeRadio()
+
+    monkeypatch.setattr(
+        _validate,
+        "_emit_artifact",
+        lambda artifact, args: captured.setdefault("artifact", artifact),
+    )
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+    monkeypatch.setattr("rigplane.hamlib_bridge.HamlibBridge", _PartialStartBridge)
+
+    exit_code = await _validate._run_hardware_hamlib(_base_args(), template, safety)
+
+    assert exit_code == 3
+    assert len(_FakeBridge.instances) == 1
+    bridge = _FakeBridge.instances[0]
+    assert bridge.started is True  # partial start happened
+    assert bridge.stopped is True  # ...and was still torn down
+    # The failure is recorded as a transport-domain artifact.
+    artifact = captured["artifact"]
+    checks = [c for lvl in artifact.levels for c in lvl.checks]
+    assert any(c.failure_domain is not None for c in checks)
+    assert artifact.metadata["profile_id"] == "xiegu_x6200"
+
+
+async def test_hamlib_provider_rejects_non_civ(monkeypatch: Any) -> None:
+    _FakeBridge.instances.clear()
+    template = _identify_template(profile_id="ftx1")
+    safety = OperatorSafetyBlock()
+
+    # A non-CI-V config (Yaesu). _build_backend_config returns it; profile
+    # resolves to protocol_type != "civ".
+    yaesu_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="FTX-1")
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return yaesu_config
+
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.hamlib_bridge.HamlibBridge", _FakeBridge)
+    monkeypatch.setattr(
+        _validate,
+        "_emit_artifact",
+        lambda artifact, args: captured.setdefault("artifact", artifact),
+    )
+
+    exit_code = await _validate._run_hardware_hamlib(
+        _base_args(model="FTX-1"), template, safety
+    )
+
+    assert exit_code == 3
+    assert _FakeBridge.instances == []  # bridge never constructed/started
+    artifact = captured["artifact"]
+    assert artifact.metadata["provider"] == "hamlib"
+    checks = [c for level in artifact.levels for c in level.checks]
+    assert any(
+        c.status.value == "fail"
+        and c.failure_domain is not None
+        and c.failure_domain.value == "transport"
+        and c.level == ValidationLevel.DISCOVERY
+        for c in checks
+    )
+
+
+def test_compare_artifacts_diffs_status() -> None:
+    def _artifact_dict(freq_status: str, mode_status: str) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "tool": TOOL_NAME,
+            "mode": "hardware",
+            "core_version": "0",
+            "radio": {"model": "X6200", "profile_id": "xiegu_x6200"},
+            "transport": {"backend": "rigctld"},
+            "safety": {"tx_allowed": False, "tuner_allowed": False},
+            "levels": [
+                {
+                    "level": 1,
+                    "checks": [
+                        {
+                            "check_id": "freq.write",
+                            "capability": "",
+                            "level": 1,
+                            "status": freq_status,
+                            "declaration": "supported",
+                            "summary": "freq",
+                            **(
+                                {"failure_domain": "transport"}
+                                if freq_status in {"fail", "blocked"}
+                                else {}
+                            ),
+                        },
+                        {
+                            "check_id": "mode.set",
+                            "capability": "",
+                            "level": 1,
+                            "status": mode_status,
+                            "declaration": "supported",
+                            "summary": "mode",
+                            **(
+                                {"failure_domain": "transport"}
+                                if mode_status in {"fail", "blocked"}
+                                else {}
+                            ),
+                        },
+                    ],
+                }
+            ],
+            "metadata": {"provider": "native"},
+        }
+
+    from rigplane.validation.schema import validate_artifact_dict
+
+    this = validate_artifact_dict(_artifact_dict("pass", "pass"))
+
+    import json
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        other_file = Path(tmp) / "other.json"
+        other_file.write_text(
+            json.dumps(_artifact_dict("pass", "fail")), encoding="utf-8"
+        )
+        comp = _validate._compare_artifacts(this, str(other_file))
+
+    assert comp["other_provider"] == "native"
+    rows = {row["check_id"]: row for row in comp["rows"]}
+    assert rows["freq.write"]["agree"] is True
+    assert rows["mode.set"]["agree"] is False
+    assert rows["mode.set"]["this"] == "pass"
+    assert rows["mode.set"]["other"] == "fail"
+
+
+async def test_await_tcp_ready_true() -> None:
+    """_await_tcp_ready returns True when a listener is up on the target port."""
+    from rigplane.cli._validate import _await_tcp_ready
+
+    # Start a throwaway server on an ephemeral port.
+    server = await asyncio.start_server(
+        lambda r, w: w.close(), host="127.0.0.1", port=0
+    )
+    port = server.sockets[0].getsockname()[1]
+    try:
+        result = await _await_tcp_ready("127.0.0.1", port, timeout=5.0)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert result is True
+
+
+async def test_await_tcp_ready_timeout() -> None:
+    """_await_tcp_ready returns False when nothing is listening on the port."""
+    from rigplane.cli._validate import _await_tcp_ready
+
+    # Bind a socket to obtain a free port, then close it immediately (not listening).
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        closed_port = s.getsockname()[1]
+    # Port is now closed; _await_tcp_ready should time out quickly.
+    result = await _await_tcp_ready("127.0.0.1", closed_port, timeout=1.0)
+    assert result is False


### PR DESCRIPTION
## Summary

Adds `rigplane validate --provider native|hamlib`. The **hamlib** provider drives the radio through an internally-spawned Hamlib `rigctld` (via the existing `HamlibBridge`) and the rigctld client, so the same validation matrix runs through Hamlib and can be compared to the native rigplane provider. Builds on #1654 (extended rigctld client + tolerance-aware readback). Aligned with the Linear "Hamlib Provider and Assisted Discovery" boundary (Hamlib behind a managed `rigctld` process, not direct libhamlib).

## Changes

- **`--provider native|hamlib`** (default native). Model auto-detected (or `--model` override). hamlib resolves the Hamlib model from `RadioProfile.hamlib_model_id`.
- **`RadioProfile.hamlib_model_id`** plumbed from the rig TOML; `rigs/x6200.toml` → `3091` (verified `rigctl --list`).
- **hamlib orchestration**: native CoreRadio (transport owner) + `HamlibBridge` (spawns `rigctld -m <id> -c <civaddr>`) + rigctld client running the matrix. Waits for rigctld to bind its front port before connecting (with stderr capture for diagnostics); the bridge is started inside the `try` so a partial start is always torn down; non-CI-V rigs (Yaesu/Kenwood) are rejected cleanly (transport artifact + exit 3, bridge never started).
- **Artifact metadata**: `provider`, `hamlib_model_id`, `profile_id` stamped (no schema churn).
- **`--compare PATH`**: diffs this run against a prior artifact per check (agree/differ), prints a table and folds the result into metadata.

## Live X6200 evidence (native vs hamlib, read/write)

The hamlib provider ran the full matrix end-to-end (rigctld spawned + connected). `--compare` table highlights:

- **AGREE**: discovery, freq.write, freq.reverse_sync (pass/pass); mode.set, preamp.set, attenuator.set (fail/fail); tuner/tx (blocked).
- **DIFFER**: rf_gain/af_level/nb/nr native=pass vs hamlib=fail; agc/rit/xit native=fail vs hamlib=unsupported.

Note: through the bridge, Hamlib level SETs on the X6200 returned desynchronized/`RPRT -11` responses (`l RF` unsupported by the Hamlib X6200 model; `L AF/PREAMP/ATT/NB/NR` came back with a value where `RPRT 0` was expected) — a real observation about response alignment over the async CI-V bridge on this radio, surfaced as `fail/command_execution` (not a crash). Hardening the rigctld-client/bridge response pairing is a sensible follow-up.

## Verification

- `uv run pytest tests/ -q --ignore=tests/integration` → **5983 passed**, 57 skipped, 11 xfailed.
- ruff clean; mypy clean for changed files; `lint-imports` 4 kept / 0 broken (hamlib-path imports are function-local/deferred).
- Independent agent review: initial BLOCKED on a partial-start teardown leak → fixed (bridge.start() moved inside the try/finally) + regression test; readiness race found on live hardware → fixed (rigctld front-port readiness wait) + tests.

## Out of scope

Direct libhamlib; fixing other rigs' hamlib ids; bridge/rigctld response-alignment hardening; audio/scope comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
