### PR TITLE
fix(MOR-178): plain ATT/PREAMP commands on single-RX radios (X6200)

### DIFF
--- a/src/rigplane/commands/dsp.py
+++ b/src/rigplane/commands/dsp.py
@@ -48,6 +48,8 @@ def get_attenuator(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to read attenuator level (Command29-aware)."""
     if cmd_map is not None:
@@ -59,7 +61,9 @@ def get_attenuator(
             receiver=receiver,
             command29=True,
         )
-    return build_cmd29_frame(to_addr, from_addr, _CMD_ATT, receiver=receiver)
+    if command29:
+        return build_cmd29_frame(to_addr, from_addr, _CMD_ATT, receiver=receiver)
+    return build_civ_frame(to_addr, from_addr, _CMD_ATT)
 
 
 def set_attenuator_level(
@@ -68,6 +72,8 @@ def set_attenuator_level(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Set attenuator level in dB (IC-7610 supports 0..45 in 3 dB steps)."""
     if cmd_map is not None:
@@ -80,9 +86,11 @@ def set_attenuator_level(
             receiver=receiver,
             command29=True,
         )
-    return build_cmd29_frame(
-        to_addr, from_addr, _CMD_ATT, data=bytes([_bcd_byte(db)]), receiver=receiver
-    )
+    if command29:
+        return build_cmd29_frame(
+            to_addr, from_addr, _CMD_ATT, data=bytes([_bcd_byte(db)]), receiver=receiver
+        )
+    return build_civ_frame(to_addr, from_addr, _CMD_ATT, data=bytes([_bcd_byte(db)]))
 
 
 def set_attenuator(
@@ -91,6 +99,8 @@ def set_attenuator(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Compatibility wrapper for attenuator toggle (False->0dB, True->18dB)."""
     return set_attenuator_level(
@@ -99,6 +109,7 @@ def set_attenuator(
         from_addr=from_addr,
         receiver=receiver,
         cmd_map=cmd_map,
+        command29=command29,
     )
 
 
@@ -107,6 +118,8 @@ def get_preamp(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to read preamp status (Command29-aware)."""
     if cmd_map is not None:
@@ -118,9 +131,11 @@ def get_preamp(
             receiver=receiver,
             command29=True,
         )
-    return build_cmd29_frame(
-        to_addr, from_addr, _CMD_PREAMP, sub=_SUB_PREAMP_STATUS, receiver=receiver
-    )
+    if command29:
+        return build_cmd29_frame(
+            to_addr, from_addr, _CMD_PREAMP, sub=_SUB_PREAMP_STATUS, receiver=receiver
+        )
+    return build_civ_frame(to_addr, from_addr, _CMD_PREAMP, sub=_SUB_PREAMP_STATUS)
 
 
 def set_preamp(
@@ -130,6 +145,7 @@ def set_preamp(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    command29: bool = True,
 ) -> bytes:
     """Set preamp level (0=off, 1=PREAMP1, 2=PREAMP2)."""
     if cmd_map is not None:
@@ -142,13 +158,21 @@ def set_preamp(
             receiver=receiver,
             command29=True,
         )
-    return build_cmd29_frame(
+    if command29:
+        return build_cmd29_frame(
+            to_addr,
+            from_addr,
+            _CMD_PREAMP,
+            sub=_SUB_PREAMP_STATUS,
+            data=bytes([_bcd_byte(level)]),
+            receiver=receiver,
+        )
+    return build_civ_frame(
         to_addr,
         from_addr,
         _CMD_PREAMP,
         sub=_SUB_PREAMP_STATUS,
         data=bytes([_bcd_byte(level)]),
-        receiver=receiver,
     )
 
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3029,12 +3029,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._check_connected()
         self._require_capability("attenuator", operation="get_attenuator_level")
         self._require_receiver(receiver, operation="get_attenuator_level")
-        if not self._profile.supports_cmd29(0x11):
-            raise CommandError(
-                f"get_attenuator_level is unsupported by profile {self._profile.model}: "
-                "no cmd29 route for command 0x11"
-            )
-        civ = get_attenuator_cmd(to_addr=self._radio_addr, receiver=receiver)
+        self._require_cmd29_route(
+            0x11, None, receiver=receiver, operation="get_attenuator_level"
+        )
+        cmd29 = self._profile.supports_cmd29(0x11)
+        civ = get_attenuator_cmd(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         try:
             resp = await self._send_civ_expect(civ, label="get_attenuator_level")
             if resp.data:
@@ -3068,14 +3069,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._check_connected()
         self._require_capability("attenuator", operation="set_attenuator_level")
         self._require_receiver(receiver, operation="set_attenuator_level")
-        if not self._profile.supports_cmd29(0x11):
-            raise CommandError(
-                f"set_attenuator_level is unsupported by profile {self._profile.model}: "
-                "no cmd29 route for command 0x11"
-            )
+        self._require_cmd29_route(
+            0x11, None, receiver=receiver, operation="set_attenuator_level"
+        )
         if db < 0 or db > 45 or db % 3 != 0:
             raise ValueError(f"Attenuator level must be 0..45 in 3 dB steps, got {db}")
-        civ = set_attenuator_level(db, to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x11)
+        civ = set_attenuator_level(
+            db, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         await self._send_civ_raw(civ, wait_response=False)
         self._attenuator_state = db > 0
         logger.debug("set_attenuator(%d dB) sent (fire-and-forget)", db)
@@ -3085,12 +3087,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._check_connected()
         self._require_capability("attenuator", operation="set_attenuator")
         self._require_receiver(receiver, operation="set_attenuator")
-        if not self._profile.supports_cmd29(0x11):
-            raise CommandError(
-                f"set_attenuator is unsupported by profile {self._profile.model}: "
-                "no cmd29 route for command 0x11"
-            )
-        civ = set_attenuator(on, to_addr=self._radio_addr, receiver=receiver)
+        self._require_cmd29_route(
+            0x11, None, receiver=receiver, operation="set_attenuator"
+        )
+        cmd29 = self._profile.supports_cmd29(0x11)
+        civ = set_attenuator(
+            on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         await self._send_civ_raw(civ, wait_response=False)
         self._attenuator_state = on
 
@@ -3103,12 +3106,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._check_connected()
         self._require_capability("preamp", operation="get_preamp")
         self._require_receiver(receiver, operation="get_preamp")
-        if not self._profile.supports_cmd29(0x16, 0x02):
-            raise CommandError(
-                f"get_preamp is unsupported by profile {self._profile.model}: "
-                "no cmd29 route for command 0x16/0x02"
-            )
-        civ = get_preamp_cmd(to_addr=self._radio_addr, receiver=receiver)
+        self._require_cmd29_route(0x16, 0x02, receiver=receiver, operation="get_preamp")
+        cmd29 = self._profile.supports_cmd29(0x16, 0x02)
+        civ = get_preamp_cmd(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         try:
             resp = await self._send_civ_expect(civ, label="get_preamp")
             if resp.data:
@@ -3161,7 +3163,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                     exc_info=True,
                 )
 
-        civ = set_preamp(level, to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x02)
+        civ = set_preamp(
+            level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         await self._send_civ_raw(civ, wait_response=False)
         self._preamp_level = level
 

--- a/tests/test_single_rx_plain_routing.py
+++ b/tests/test_single_rx_plain_routing.py
@@ -1,0 +1,245 @@
+"""MOR-178: single-RX plain CAT routing for ATT + PREAMP.
+
+Single-RX radios (e.g. Xiegu X6200, receiver_count=1, no cmd29 routes)
+must emit plain CI-V frames for attenuator (0x11) and preamp (0x16/0x02),
+because they answer the plain command — not a cmd29-wrapped one.
+
+Dual-RX radios (e.g. IC-7610) declare cmd29 routes for 0x11 and 0x16/0x02
+and MUST keep emitting byte-identical cmd29 frames (zero regression).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rigplane.commands import (
+    build_cmd29_frame,
+    get_attenuator,
+    get_preamp,
+    set_attenuator,
+    set_preamp,
+)
+from rigplane.commands._frame import _CMD_ATT, _CMD_PREAMP, _SUB_PREAMP_STATUS
+from rigplane.exceptions import CommandError
+from rigplane.profiles import get_radio_profile
+from rigplane.radio import IcomRadio
+from rigplane.types import CivFrame
+
+X6200_PROFILE_ID = "xiegu_x6200"
+IC7610_PROFILE_ID = "icom_ic7610"
+IC7610_ADDR = 0x98
+X6200_ADDR = 0xA4  # arbitrary radio addr for builder byte assertions
+
+
+# ---------------------------------------------------------------------------
+# (a) Builder byte assertions
+# ---------------------------------------------------------------------------
+
+
+class TestBuildersPlain:
+    """Single-RX plain form (command29=False) — no 0x29 wrapper."""
+
+    def test_get_attenuator_plain(self) -> None:
+        frame = get_attenuator(to_addr=X6200_ADDR, command29=False)
+        assert frame == bytes([0xFE, 0xFE, X6200_ADDR, 0xE0, _CMD_ATT, 0xFD])
+        assert frame[4] == _CMD_ATT
+        assert 0x29 not in (frame[4],)
+
+    def test_set_attenuator_plain(self) -> None:
+        frame = set_attenuator(True, to_addr=X6200_ADDR, command29=False)
+        assert frame[4] == _CMD_ATT
+        assert frame[4] != 0x29
+        # True -> 18 dB, BCD 0x18
+        assert frame == bytes([0xFE, 0xFE, X6200_ADDR, 0xE0, _CMD_ATT, 0x18, 0xFD])
+
+    def test_set_attenuator_off_plain(self) -> None:
+        frame = set_attenuator(False, to_addr=X6200_ADDR, command29=False)
+        assert frame == bytes([0xFE, 0xFE, X6200_ADDR, 0xE0, _CMD_ATT, 0x00, 0xFD])
+
+    def test_get_preamp_plain(self) -> None:
+        frame = get_preamp(to_addr=X6200_ADDR, command29=False)
+        assert frame[4] == _CMD_PREAMP
+        assert frame[5] == _SUB_PREAMP_STATUS
+        assert frame == bytes(
+            [0xFE, 0xFE, X6200_ADDR, 0xE0, _CMD_PREAMP, _SUB_PREAMP_STATUS, 0xFD]
+        )
+
+    def test_set_preamp_plain(self) -> None:
+        frame = set_preamp(1, to_addr=X6200_ADDR, command29=False)
+        assert frame[4] == _CMD_PREAMP
+        assert frame[5] == _SUB_PREAMP_STATUS
+        assert frame == bytes(
+            [
+                0xFE,
+                0xFE,
+                X6200_ADDR,
+                0xE0,
+                _CMD_PREAMP,
+                _SUB_PREAMP_STATUS,
+                0x01,
+                0xFD,
+            ]
+        )
+
+
+class TestBuildersCmd29Regression:
+    """Dual-RX regression lock: default (command29=True) == cmd29 frame, byte-identical."""
+
+    def test_get_attenuator_cmd29_default(self) -> None:
+        frame = get_attenuator(to_addr=IC7610_ADDR)
+        assert frame[4] == 0x29
+        assert frame == build_cmd29_frame(IC7610_ADDR, 0xE0, _CMD_ATT)
+
+    def test_set_attenuator_cmd29_default(self) -> None:
+        frame = set_attenuator(True, to_addr=IC7610_ADDR)
+        assert frame[4] == 0x29
+        assert frame == build_cmd29_frame(
+            IC7610_ADDR, 0xE0, _CMD_ATT, data=bytes([0x18])
+        )
+
+    def test_get_preamp_cmd29_default(self) -> None:
+        frame = get_preamp(to_addr=IC7610_ADDR)
+        assert frame[4] == 0x29
+        assert frame == build_cmd29_frame(
+            IC7610_ADDR, 0xE0, _CMD_PREAMP, sub=_SUB_PREAMP_STATUS
+        )
+
+    def test_set_preamp_cmd29_default(self) -> None:
+        frame = set_preamp(1, to_addr=IC7610_ADDR)
+        assert frame[4] == 0x29
+        assert frame == build_cmd29_frame(
+            IC7610_ADDR, 0xE0, _CMD_PREAMP, sub=_SUB_PREAMP_STATUS, data=bytes([0x01])
+        )
+
+
+# ---------------------------------------------------------------------------
+# (b) Runtime routing — real IcomRadio with real profiles, captured frames
+# ---------------------------------------------------------------------------
+
+
+def _make_radio(profile_id: str) -> tuple[IcomRadio, list[bytes]]:
+    """Build a connected radio with real profile; capture emitted CI-V bytes."""
+    radio = IcomRadio("192.168.0.1", profile=profile_id, timeout=0.05)
+    radio._connected = True
+    # _check_connected delegates to the CI-V runtime, which requires a live
+    # _civ_transport; a sentinel suffices because we stub the send methods.
+    radio._civ_transport = object()  # type: ignore[assignment]
+    captured: list[bytes] = []
+
+    async def _capture_raw(civ_frame: bytes, **kwargs: object) -> None:
+        captured.append(civ_frame)
+        return None
+
+    radio._send_civ_raw = _capture_raw  # type: ignore[method-assign]
+    return radio, captured
+
+
+def _expect_factory(captured: list[bytes], response: CivFrame):
+    async def _capture_expect(civ_frame: bytes, **kwargs: object) -> CivFrame:
+        captured.append(civ_frame)
+        return response
+
+    return _capture_expect
+
+
+@pytest.mark.asyncio
+class TestX6200RuntimePlain:
+    async def test_set_attenuator_emits_plain(self) -> None:
+        radio, captured = _make_radio(X6200_PROFILE_ID)
+        await radio.set_attenuator(True)
+        assert len(captured) == 1
+        frame = captured[0]
+        assert frame[4] in (_CMD_ATT, _CMD_PREAMP)
+        assert frame[4] == _CMD_ATT
+        assert frame[4] != 0x29
+
+    async def test_set_preamp_emits_plain(self) -> None:
+        radio, captured = _make_radio(X6200_PROFILE_ID)
+        await radio.set_preamp(1)
+        assert len(captured) == 1
+        frame = captured[0]
+        assert frame[4] == _CMD_PREAMP
+        assert frame[5] == _SUB_PREAMP_STATUS
+        assert frame[4] != 0x29
+
+    async def test_get_attenuator_level_plain_and_decodes(self) -> None:
+        radio, captured = _make_radio(X6200_PROFILE_ID)
+        # Plain response: FE FE E0 A4 11 00 FD -> data 0x00 (off)
+        response = CivFrame(
+            to_addr=0xE0, from_addr=radio._radio_addr, command=_CMD_ATT, data=b"\x00"
+        )
+        radio._send_civ_expect = _expect_factory(captured, response)  # type: ignore[method-assign]
+        value = await radio.get_attenuator_level()
+        assert value == 0
+        frame = captured[0]
+        assert frame[4] == _CMD_ATT
+        assert frame[4] != 0x29
+
+    async def test_get_preamp_plain_and_decodes(self) -> None:
+        radio, captured = _make_radio(X6200_PROFILE_ID)
+        # Plain response: FE FE E0 A4 16 02 00 FD -> data 0x00 (off)
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=radio._radio_addr,
+            command=_CMD_PREAMP,
+            sub=_SUB_PREAMP_STATUS,
+            data=b"\x00",
+        )
+        radio._send_civ_expect = _expect_factory(captured, response)  # type: ignore[method-assign]
+        value = await radio.get_preamp()
+        assert value == 0
+        frame = captured[0]
+        assert frame[4] == _CMD_PREAMP
+        assert frame[5] == _SUB_PREAMP_STATUS
+        assert frame[4] != 0x29
+
+
+@pytest.mark.asyncio
+class TestX6200SubReceiverRejected:
+    async def test_set_attenuator_sub_raises(self) -> None:
+        radio, _captured = _make_radio(X6200_PROFILE_ID)
+        # receiver_count == 1 -> SUB unsupported
+        assert get_radio_profile(X6200_PROFILE_ID).receiver_count == 1
+        with pytest.raises(CommandError):
+            await radio.set_attenuator(True, receiver=1)
+
+
+@pytest.mark.asyncio
+class TestIC7610RuntimeRegression:
+    async def test_set_attenuator_main_emits_cmd29(self) -> None:
+        radio, captured = _make_radio(IC7610_PROFILE_ID)
+        await radio.set_attenuator(True)
+        assert len(captured) == 1
+        frame = captured[0]
+        assert frame[4] == 0x29
+        # byte-identical to pre-fix cmd29 frame
+        assert frame == build_cmd29_frame(
+            radio._radio_addr, 0xE0, _CMD_ATT, data=bytes([0x18])
+        )
+
+    async def test_set_preamp_main_emits_cmd29(self) -> None:
+        radio, captured = _make_radio(IC7610_PROFILE_ID)
+        # set_preamp(level>0) pre-checks DIGI-SEL via _send_civ_expect; return OFF.
+        digisel_off = CivFrame(
+            to_addr=0xE0,
+            from_addr=radio._radio_addr,
+            command=_CMD_PREAMP,
+            sub=0x4E,
+            data=b"\x00",
+        )
+
+        async def _expect(civ_frame: bytes, **kwargs: object) -> CivFrame:
+            return digisel_off
+
+        radio._send_civ_expect = _expect  # type: ignore[method-assign]
+        await radio.set_preamp(1)
+        assert len(captured) == 1
+        frame = captured[0]
+        assert frame[4] == 0x29
+        assert frame == build_cmd29_frame(
+            radio._radio_addr,
+            0xE0,
+            _CMD_PREAMP,
+            sub=_SUB_PREAMP_STATUS,
+            data=bytes([0x01]),
+        )


### PR DESCRIPTION
## Summary

Fixes **MOR-178**: single-receiver radios (Xiegu X6200) could not drive **attenuator** or **preamp** — the root cause behind the field reports "PRE/ATT don't react".

The att/preamp command builders always cmd29-wrapped (unlike freq/mode, which already branch on receiver), and the runtime getters/setters hard-raised `"no cmd29 route"` when the profile declared no cmd29 route. The X6200 profile correctly declares `receiver_count = 1`, no cmd29 routes, and the plain command bytes (`0x11`, `0x16/0x02`) — the runtime just never fell back to them.

## Fix (data-driven, mirrors freq/mode)

- `commands/dsp.py`: the 4 att/preamp builders take `command29: bool = True`; when `False` they emit the plain `build_civ_frame` (no cmd29 prefix, no receiver byte).
- `runtime/radio.py`: the 5 att/preamp sites drop the bespoke raise, use `_require_cmd29_route(...)` (raises only for a SUB receiver without a route) and pass `command29 = profile.supports_cmd29(cmd, sub)`. MAIN on a no-cmd29 profile → plain; IC-7610 → cmd29 as before.

## Evidence

**Hardware-confirmed.** A raw CI-V trace (MOR-177) showed the X6200 answers plain `0x11` (att) and `0x16 0x02` (preamp). After this fix, live `rigplane validate --hardware --provider native` on the X6200:

- `preamp.set` → **pass** (0 → 1 → readback 1 → restored 0)
- `attenuator.set` → **pass** (off → on → readback on → restored off)

IC-7610 (dual-RX) output is byte-identical (regression-locked by tests).

## Scope

ATT + PREAMP only. Mode is already plain at the command layer; its live `validate` failure is a separate `get_mode` stale-readback issue (follow-up). RIT/XIT/notch = MOR-179.

## Verification

- New `tests/test_single_rx_plain_routing.py` (16 tests): X6200 plain-frame byte assertions, IC-7610 cmd29 byte-equality regression lock, runtime routing (incl. SUB-receiver rejection).
- `uv run pytest tests/ -q --ignore=tests/integration` → **5999 passed**. ruff/mypy clean for changed files; lint-imports 4 kept / 0 broken.
- Independent agent review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
