### PR TITLE
fix(MOR-184): set mode via CI-V 0x26 selected-mode (X6200); IC-7610 unchanged

### DIFF
--- a/src/rigplane/commands/__init__.py
+++ b/src/rigplane/commands/__init__.py
@@ -78,6 +78,7 @@ from .freq import (
     parse_selected_mode_response,
     set_freq,
     set_frequency,
+    set_selected_mode,
 )
 
 # --- mode.py ---
@@ -563,6 +564,7 @@ __all__ = [
     "parse_selected_freq_response",
     "get_selected_mode",
     "get_unselected_mode",
+    "set_selected_mode",
     "parse_selected_mode_response",
     "_CMD_SELECTED_FREQ",
     "_CMD_SELECTED_MODE",

--- a/src/rigplane/commands/freq.py
+++ b/src/rigplane/commands/freq.py
@@ -146,6 +146,29 @@ def get_unselected_mode(
     return build_civ_frame(to_addr, from_addr, _CMD_SELECTED_MODE, data=bytes([0x01]))
 
 
+def set_selected_mode(
+    mode: Mode,
+    data_mode: int,
+    filter_index: int,
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+) -> bytes:
+    """Build a "set selected receiver mode" CI-V command (0x26 0x00).
+
+    Frame layout: ``FE FE <to> <from> 26 00 <mode> <data_mode> <filter> FD``.
+    The leading ``0x00`` data byte selects the active receiver (mirroring
+    :func:`get_selected_mode`); ``mode`` / ``data_mode`` / ``filter`` set the
+    full tuple so a mode-only change preserves the radio's current data-mode
+    and filter.
+    """
+    return build_civ_frame(
+        to_addr,
+        from_addr,
+        _CMD_SELECTED_MODE,
+        data=bytes([0x00, int(Mode(mode)), int(data_mode), int(filter_index)]),
+    )
+
+
 def parse_selected_mode_response(
     frame: CivFrame,
 ) -> tuple[int, Mode, int | None, int | None]:

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -168,6 +168,12 @@ class RadioProfile:
     agc_labels: dict[str, str] | None = None
     data_mode_count: int = 0
     data_mode_labels: dict[str, str] | None = None
+    # When True, MAIN set_mode routes through CI-V 0x26 0x00 (set selected
+    # receiver mode) instead of the bare 0x06. Data-driven: derived from the
+    # profile declaring a ``set_selected_mode`` command (e.g. Xiegu X6200,
+    # whose 0x06 mode-set is a hardware-confirmed no-op). Default False keeps
+    # the unchanged 0x06 path for every rig that does not declare it.
+    set_mode_via_selected: bool = False
     protocol_type: str = "civ"
     # Hamlib rig_model integer (from rigs_list.h). Used by the validate
     # ``--provider hamlib`` path to launch stock rigctld with ``-m <id>``.

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -173,6 +173,7 @@ class RigConfig:
             agc_labels=self.agc_labels,
             data_mode_count=self.data_mode_count,
             data_mode_labels=self.data_mode_labels,
+            set_mode_via_selected="set_selected_mode" in self.commands,
             protocol_type=self.protocol_type,
             hamlib_model_id=self.hamlib_model_id,
             controls=self.controls,

--- a/src/rigplane/runtime/_dual_rx_runtime.py
+++ b/src/rigplane/runtime/_dual_rx_runtime.py
@@ -29,6 +29,7 @@ from rigplane.commands import (
 )
 from rigplane.commands import get_selected_freq as _get_selected_freq_cmd
 from rigplane.commands import get_selected_mode as _get_selected_mode_cmd
+from rigplane.commands import set_selected_mode as _set_selected_mode_cmd
 from rigplane.commands import get_unselected_freq as _get_unselected_freq_cmd
 from rigplane.commands import get_unselected_mode as _get_unselected_mode_cmd
 from rigplane.commands import (
@@ -214,12 +215,28 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         update_cache: bool = True,
     ) -> None:
         """Set MAIN receiver mode/filter with optional cache updates."""
-        civ = set_mode(
-            mode,
-            filter_width=filter_width,
-            to_addr=self._radio_addr,
-            receiver=RECEIVER_MAIN,
-        )
+        if self._profile.set_mode_via_selected:
+            # Rigs declaring ``set_selected_mode`` (e.g. X6200) ignore the bare
+            # 0x06 mode-set; route through CI-V 0x26 0x00 with the full
+            # (mode, data_mode, filter) tuple so a mode-only change preserves
+            # the radio's current data-mode and filter.
+            target = self._radio_state.receiver("MAIN")
+            data_mode = int(getattr(target, "data_mode", 0) or 0)
+            resolved_filter = (
+                filter_width
+                if filter_width is not None
+                else (self._filter_width if self._filter_width is not None else 1)
+            )
+            civ = _set_selected_mode_cmd(
+                mode, data_mode, resolved_filter, to_addr=self._radio_addr
+            )
+        else:
+            civ = set_mode(
+                mode,
+                filter_width=filter_width,
+                to_addr=self._radio_addr,
+                receiver=RECEIVER_MAIN,
+            )
         await self._send_civ_raw(civ, wait_response=False)
         self._last_mode = mode
         if update_cache:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -396,6 +396,73 @@ class TestMode:
         assert len(mock_transport.sent_packets) > 0
 
 
+class TestSetModeSelected0x26:
+    """MAIN set_mode routes through CI-V 0x26 0x00 for rigs declaring
+    ``set_selected_mode`` (X6200), and stays on the bare 0x06 for rigs that
+    do not (IC-7610).
+
+    Note:
+        mock_server does not handle 0x26; the emitted bytes are asserted via
+        ``sent_packets[-1]``. Live IC-7610 + X6200 verification is done
+        separately by the orchestrator.
+    """
+
+    def _make_radio(self, model: str, mock_transport: MockTransport) -> IcomRadio:
+        r = IcomRadio("192.168.1.100", model=model, timeout=0.05)
+        r._civ_transport = mock_transport
+        r._ctrl_transport = mock_transport
+        r._connected = True
+        return r
+
+    @pytest.mark.asyncio
+    async def test_x6200_routes_via_0x26(self, mock_transport: MockTransport) -> None:
+        # X6200: civ_addr 0xA4, declares set_selected_mode → 0x26 path.
+        # Frame tail: 26 00 <receiver=00> <mode=LSB=00> <data_mode=00>
+        #             <filter=default 1> FD.
+        radio = self._make_radio("X6200", mock_transport)
+        try:
+            assert radio._profile.set_mode_via_selected is True
+            await radio.set_mode(Mode.LSB)
+            assert mock_transport.sent_packets[-1].endswith(
+                b"\xfe\xfe\xa4\xe0\x26\x00\x00\x00\x01\xfd"
+            )
+        finally:
+            radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_ic7610_stays_on_0x06_regression_lock(
+        self, mock_transport: MockTransport
+    ) -> None:
+        # IC-7610 must NOT declare set_selected_mode → unchanged 0x06 path.
+        # This locks zero flagship regression.
+        radio = self._make_radio("IC-7610", mock_transport)
+        try:
+            assert radio._profile.set_mode_via_selected is False
+            await radio.set_mode(Mode.LSB)
+            sent = mock_transport.sent_packets[-1]
+            assert sent.endswith(b"\xfe\xfe\x98\xe0\x06\x00\xfd")
+            assert b"\x26\x00" not in sent
+        finally:
+            radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_x6200_fills_data_mode_and_filter(
+        self, mock_transport: MockTransport
+    ) -> None:
+        # A mode-only change preserves the radio's current data_mode/filter:
+        # data_mode 1 (from MAIN state), filter 2 (from _filter_width cache).
+        # Frame tail: 26 <receiver=00> <mode=USB=01> <data_mode=01>
+        #             <filter=02> FD.
+        radio = self._make_radio("X6200", mock_transport)
+        try:
+            radio._radio_state.main.data_mode = 1
+            radio._filter_width = 2
+            await radio.set_mode(Mode.USB)
+            assert mock_transport.sent_packets[-1].endswith(b"\x26\x00\x01\x01\x02\xfd")
+        finally:
+            radio._connected = False
+
+
 class TestMeters:
     """Test meter readings."""
 

--- a/tests/test_selected_freq_mode.py
+++ b/tests/test_selected_freq_mode.py
@@ -14,6 +14,7 @@ from rigplane.commands import (
     get_unselected_mode,
     parse_selected_freq_response,
     parse_selected_mode_response,
+    set_selected_mode,
 )
 from rigplane.radio import IcomRadio
 from rigplane.types import CivFrame, Mode, bcd_encode
@@ -73,6 +74,13 @@ class TestCommandBuilders:
     def test_get_unselected_mode_frame(self) -> None:
         frame = get_unselected_mode(to_addr=0x98)
         assert b"\x26\x01" in frame
+
+    def test_set_selected_mode_frame(self) -> None:
+        # X6200 CI-V address is 0xA4; controller 0xE0; Mode.LSB == 0x00.
+        # Frame: FE FE A4 E0 26 00 <receiver=00> <mode=LSB=00> <data_mode=00>
+        #        <filter=01> FD.
+        frame = set_selected_mode(Mode.LSB, 0, 1, to_addr=0xA4)
+        assert frame == b"\xfe\xfe\xa4\xe0\x26\x00\x00\x00\x01\xfd"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes **MOR-184**: on the single-RX Xiegu X6200, setting mode did nothing. The runtime emitted a bare `0x06 <mode>` mode-set, which the X6200 **ignores** (no-op); it requires the full mode tuple. Routes MAIN `set_mode` through CI-V **0x26** selected-mode (`26 00 <mode> <data_mode> <filter>`) for rigs whose profile declares the command.

This is also the *correct* command for data modes (FT8 = USB-D), and it's exactly what Hamlib and rigplane's own state poller already use — confirmed by a live CI-V trace (Hamlib drives the X6200 via `26 00 …`).

## Design — data-driven, no per-rig code

- New builder `commands.set_selected_mode` (0x26 0x00 + mode/data_mode/filter).
- `_set_mode_main` routes via 0x26 **iff** `RadioProfile.set_mode_via_selected` is true; that field is **derived** from the profile's `[commands]` table (`"set_selected_mode" in commands`) — not a hand-authored quirk flag. data_mode/filter are filled from current state so only the mode changes.
- Rigs that don't declare the command (incl. **IC-7610**) keep the **byte-identical** `0x06` path — zero flagship behavior change.

## Hardware-verified (both radios, live)

- **X6200 (serial):** `validate --provider native` → `mode.set` **pass** (USB→LSB, readback LSB, restored). Previously fail/readback "did not react".
- **IC-7610 (LAN):** `set_mode_via_selected=False` (gate off); `set_mode` USB→LSB→readback LSB→restored — **unchanged 0x06 path, no regression**.

## Verification

- New tests: `set_selected_mode` builder byte-lock; X6200 emits the 0x26 frame; **IC-7610 regression-lock** (emits unchanged 0x06, gate off); data_mode/filter fill (mode-only change).
- `uv run pytest tests/ -q --ignore=tests/integration` → **6003 passed**. ruff/mypy clean for changed files; lint-imports 4 kept / 0 broken.
- Independent agent review pending.

## Scope / out of scope

MAIN `set_mode` only. `get_mode` (0x04) untouched (works on both radios). RIT/XIT readback = MOR-179 (write-only, → MOR-180). att/preamp = MOR-178 (merged). No rig TOML changes; mock_server untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
