### PR TITLE
feat(MOR-197): capability→check-spec registry core

### DIFF
--- a/src/rigplane/validation/registry.py
+++ b/src/rigplane/validation/registry.py
@@ -1,0 +1,497 @@
+"""Capability→check-spec registry for the universal validation matrix.
+
+Defines the closed set of check kinds and value-mutation rules, the
+``CheckSpec`` dataclass (pure data, no hardware dependencies), and
+``REGISTRY`` — the canonical 21-entry tuple that drives every validation
+run regardless of radio model or backend.
+
+Layer rule: imports only stdlib, ``rigplane.core.capabilities``, and
+``rigplane.validation.schema``.  No backends, profiles, transports, or
+hardware protocols.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from rigplane.core.capabilities import KNOWN_CAPABILITIES
+from rigplane.validation.schema import FailureDomain, ValidationLevel
+
+
+# ---------------------------------------------------------------------------
+# 2. CheckKind
+# ---------------------------------------------------------------------------
+
+
+class CheckKind(StrEnum):
+    """How a check exercises the radio under test."""
+
+    READ_ONLY = "read_only"
+    RMVR_SAFE_WRITE = "rmvr_safe_write"
+    WRITE_ONLY_OBSERVE = "write_only_observe"
+    TX_ADJACENT_BLOCKED = "tx_adjacent_blocked"
+    MANUAL = "manual"
+
+
+# ---------------------------------------------------------------------------
+# 3. ValueRule
+# ---------------------------------------------------------------------------
+
+
+class ValueRule(StrEnum):
+    """How the runner mutates a value for the write-then-read-back cycle."""
+
+    TOGGLE_BOOL = "toggle_bool"
+    STEP_LEVEL_255 = "step_level_255"
+    BUMP_HZ = "bump_hz"
+    NUDGE_FILTER = "nudge_filter"
+    PREAMP_CYCLE = "preamp_cycle"
+    AGC_FLIP = "agc_flip"
+    MODE_CYCLE = "mode_cycle"
+
+
+# ---------------------------------------------------------------------------
+# 4. VALUE_RULES
+# ---------------------------------------------------------------------------
+
+VALUE_RULES: frozenset[str] = frozenset(ValueRule)
+
+
+# ---------------------------------------------------------------------------
+# 5. CheckSpec
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CheckSpec:
+    """Immutable specification for a single validation check."""
+
+    check_id: str
+    capability: str
+    kind: CheckKind
+    level: ValidationLevel
+    failure_domain: FailureDomain
+    summary: str
+    protocol: str | None = None
+    get_op: str | None = None
+    set_op: str | None = None
+    value_rule: str = ValueRule.TOGGLE_BOOL
+    tolerance: int = 0
+    hamlib_token: str | None = None
+    tx_adjacent: bool = False
+
+
+# ---------------------------------------------------------------------------
+# 6. REGISTRY
+# ---------------------------------------------------------------------------
+
+REGISTRY: tuple[CheckSpec, ...] = (
+    # 1 — discovery.identify
+    CheckSpec(
+        check_id="discovery.identify",
+        capability="",
+        kind=CheckKind.READ_ONLY,
+        level=ValidationLevel.DISCOVERY,
+        failure_domain=FailureDomain.DISCOVERY,
+        summary="Confirm the radio responds to a frequency query at connect time.",
+        protocol=None,
+        get_op="get_freq",
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # 2 — freq.write
+    CheckSpec(
+        check_id="freq.write",
+        capability="",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.BASIC_CONTROL,
+        failure_domain=FailureDomain.READBACK,
+        summary="Write a frequency offset and read it back; restore original.",
+        protocol=None,
+        get_op="get_freq",
+        set_op="set_freq",
+        value_rule=ValueRule.BUMP_HZ,
+        tolerance=0,
+        hamlib_token="f",
+        tx_adjacent=False,
+    ),
+    # 3 — freq.reverse_sync
+    CheckSpec(
+        check_id="freq.reverse_sync",
+        capability="",
+        kind=CheckKind.READ_ONLY,
+        level=ValidationLevel.BASIC_CONTROL,
+        failure_domain=FailureDomain.STATE_PUBLISHING,
+        summary="Verify the radio state matches the frequency reported by the command layer.",
+        protocol=None,
+        get_op="get_freq",
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # 4 — mode.set
+    CheckSpec(
+        check_id="mode.set",
+        capability="",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.BASIC_CONTROL,
+        failure_domain=FailureDomain.READBACK,
+        summary="Cycle through at least two modes and confirm readback matches.",
+        protocol=None,
+        get_op="get_mode",
+        set_op="set_mode",
+        value_rule=ValueRule.MODE_CYCLE,
+        tolerance=0,
+        hamlib_token="m",
+        tx_adjacent=False,
+    ),
+    # 5 — filter_width.set
+    CheckSpec(
+        check_id="filter_width.set",
+        capability="filter_width",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Nudge the IF filter width and verify the radio accepts the change.",
+        protocol="filter_width",
+        get_op="get_filter_width",
+        set_op="set_filter_width",
+        value_rule=ValueRule.NUDGE_FILTER,
+        tolerance=50,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # 6 — rf_gain.set
+    CheckSpec(
+        check_id="rf_gain.set",
+        capability="rf_gain",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Step the RF gain level and confirm readback within tolerance.",
+        protocol="rf_gain",
+        get_op="get_rf_gain",
+        set_op="set_rf_gain",
+        value_rule=ValueRule.STEP_LEVEL_255,
+        tolerance=3,
+        hamlib_token="RF",
+        tx_adjacent=False,
+    ),
+    # 7 — af_level.set
+    CheckSpec(
+        check_id="af_level.set",
+        capability="af_level",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Step the AF volume level and confirm readback within tolerance.",
+        protocol="af_level",
+        get_op="get_af_level",
+        set_op="set_af_level",
+        value_rule=ValueRule.STEP_LEVEL_255,
+        tolerance=3,
+        hamlib_token="AF",
+        tx_adjacent=False,
+    ),
+    # 8 — preamp.set
+    CheckSpec(
+        check_id="preamp.set",
+        capability="preamp",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Cycle the preamplifier to the next level and verify readback.",
+        protocol="preamp",
+        get_op="get_preamp",
+        set_op="set_preamp",
+        value_rule=ValueRule.PREAMP_CYCLE,
+        tolerance=0,
+        hamlib_token="PREAMP",
+        tx_adjacent=False,
+    ),
+    # 9 — attenuator.set
+    CheckSpec(
+        check_id="attenuator.set",
+        capability="attenuator",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle the attenuator on then off and confirm both readbacks.",
+        protocol="attenuator",
+        get_op="get_attenuator",
+        set_op="set_attenuator",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token="ATT",
+        tx_adjacent=False,
+    ),
+    # 10 — notch.set
+    CheckSpec(
+        check_id="notch.set",
+        capability="notch",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle the manual notch filter and verify readback.",
+        protocol="notch",
+        get_op="get_manual_notch",
+        set_op="set_manual_notch",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # 11 — nb.set
+    CheckSpec(
+        check_id="nb.set",
+        capability="nb",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle the noise blanker and confirm the readback matches.",
+        protocol="nb",
+        get_op="get_nb",
+        set_op="set_nb",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token="NB",
+        tx_adjacent=False,
+    ),
+    # 12 — nr.set
+    CheckSpec(
+        check_id="nr.set",
+        capability="nr",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle the noise reduction function and confirm the readback matches.",
+        protocol="nr",
+        get_op="get_nr",
+        set_op="set_nr",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token="NR",
+        tx_adjacent=False,
+    ),
+    # 13 — agc.set
+    CheckSpec(
+        check_id="agc.set",
+        capability="agc",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Flip the AGC speed setting and verify the readback differs.",
+        protocol="agc",
+        get_op="get_agc",
+        set_op="set_agc",
+        value_rule=ValueRule.AGC_FLIP,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # 14 — rit.set
+    CheckSpec(
+        check_id="rit.set",
+        capability="rit",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Bump the RIT offset and confirm readback is within tolerance.",
+        protocol="rit",
+        get_op="get_rit_frequency",
+        set_op="set_rit_frequency",
+        value_rule=ValueRule.BUMP_HZ,
+        tolerance=10,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # 15 — xit.set
+    CheckSpec(
+        check_id="xit.set",
+        capability="xit",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle the XIT transmit offset and verify readback.",
+        protocol="xit",
+        get_op="get_rit_tx_status",
+        set_op="set_rit_tx_status",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # 16 — squelch.set
+    CheckSpec(
+        check_id="squelch.set",
+        capability="squelch",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Step the squelch threshold and confirm readback within tolerance.",
+        protocol="squelch",
+        get_op="get_squelch",
+        set_op="set_squelch",
+        value_rule=ValueRule.STEP_LEVEL_255,
+        tolerance=3,
+        hamlib_token="SQL",
+        tx_adjacent=False,
+    ),
+    # 17 — audio.rx
+    CheckSpec(
+        check_id="audio.rx",
+        capability="audio",
+        kind=CheckKind.MANUAL,
+        level=ValidationLevel.COMPATIBILITY_SURFACES,
+        failure_domain=FailureDomain.AUDIO,
+        summary="Operator confirms receive audio is present and artifact-free.",
+        protocol="audio",
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # 18 — scope.capture
+    CheckSpec(
+        check_id="scope.capture",
+        capability="scope",
+        kind=CheckKind.MANUAL,
+        level=ValidationLevel.COMPATIBILITY_SURFACES,
+        failure_domain=FailureDomain.SCOPE_WATERFALL,
+        summary="Operator confirms the scope/waterfall renders a live spectrum trace.",
+        protocol="scope",
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # 19 — meters.read
+    CheckSpec(
+        check_id="meters.read",
+        capability="meters",
+        kind=CheckKind.READ_ONLY,
+        level=ValidationLevel.COMPATIBILITY_SURFACES,
+        failure_domain=FailureDomain.READBACK,
+        summary="Read the S-meter value and verify a plausible numeric result.",
+        protocol=None,
+        get_op="get_s_meter",
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token="STRENGTH",
+        tx_adjacent=False,
+    ),
+    # 20 — tuner.tune
+    CheckSpec(
+        check_id="tuner.tune",
+        capability="tuner",
+        kind=CheckKind.TX_ADJACENT_BLOCKED,
+        level=ValidationLevel.STRESS_RECOVERY,
+        failure_domain=FailureDomain.COMMAND_EXECUTION,
+        summary="Trigger the antenna tuner; requires explicit operator authorization.",
+        protocol="tuner",
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=True,
+    ),
+    # 21 — tx.ptt
+    CheckSpec(
+        check_id="tx.ptt",
+        capability="tx",
+        kind=CheckKind.TX_ADJACENT_BLOCKED,
+        level=ValidationLevel.STRESS_RECOVERY,
+        failure_domain=FailureDomain.COMMAND_EXECUTION,
+        summary="Key the transmitter via PTT; requires explicit operator authorization.",
+        protocol=None,
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token="t",
+        tx_adjacent=True,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# 7. REGISTRY_BY_ID
+# ---------------------------------------------------------------------------
+
+REGISTRY_BY_ID: dict[str, CheckSpec] = {spec.check_id: spec for spec in REGISTRY}
+
+
+# ---------------------------------------------------------------------------
+# 8. get_spec
+# ---------------------------------------------------------------------------
+
+
+def get_spec(check_id: str) -> CheckSpec | None:
+    """Return the ``CheckSpec`` for *check_id*, or ``None`` if not found."""
+    return REGISTRY_BY_ID.get(check_id)
+
+
+# ---------------------------------------------------------------------------
+# 9. Import-time guard
+# ---------------------------------------------------------------------------
+
+
+def _validate_registry() -> None:
+    """Raise ``ValueError`` if any registry invariant is violated."""
+    ids = [spec.check_id for spec in REGISTRY]
+    if len(set(ids)) != len(ids):
+        raise ValueError("REGISTRY contains duplicate check_ids")
+
+    blocked_kinds = {CheckKind.MANUAL, CheckKind.TX_ADJACENT_BLOCKED}
+
+    for spec in REGISTRY:
+        if spec.capability and spec.capability not in KNOWN_CAPABILITIES:
+            raise ValueError(
+                f"check_id {spec.check_id!r}: capability {spec.capability!r} "
+                "is not in KNOWN_CAPABILITIES"
+            )
+        if spec.value_rule not in VALUE_RULES:
+            raise ValueError(
+                f"check_id {spec.check_id!r}: value_rule {spec.value_rule!r} "
+                "is not in VALUE_RULES"
+            )
+        if spec.kind is CheckKind.TX_ADJACENT_BLOCKED and not spec.tx_adjacent:
+            raise ValueError(
+                f"check_id {spec.check_id!r}: kind is TX_ADJACENT_BLOCKED "
+                "but tx_adjacent is False"
+            )
+        if spec.kind in blocked_kinds and spec.set_op is not None:
+            raise ValueError(
+                f"check_id {spec.check_id!r}: kind={spec.kind} "
+                f"but set_op={spec.set_op!r} (must be None)"
+            )
+
+
+_validate_registry()
+
+
+# ---------------------------------------------------------------------------
+# 10. __all__
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "CheckKind",
+    "ValueRule",
+    "VALUE_RULES",
+    "CheckSpec",
+    "REGISTRY",
+    "REGISTRY_BY_ID",
+    "get_spec",
+]

--- a/tests/validation/test_registry.py
+++ b/tests/validation/test_registry.py
@@ -1,0 +1,320 @@
+"""Tests for the capability→check-spec registry (MOR-197).
+
+Plain pytest functions — no class wrapper needed.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+
+import pytest
+
+from rigplane.core.capabilities import KNOWN_CAPABILITIES
+from rigplane.validation.registry import (
+    REGISTRY,
+    REGISTRY_BY_ID,
+    VALUE_RULES,
+    CheckKind,
+    CheckSpec,
+    ValueRule,
+    get_spec,
+)
+from rigplane.validation.schema import FailureDomain, ValidationLevel
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_21_entries():
+    assert len(REGISTRY) == 21
+
+
+def test_check_ids_unique():
+    ids = [spec.check_id for spec in REGISTRY]
+    assert len(ids) == len(set(ids))
+
+
+def test_all_capabilities_known():
+    allowed = {"", *KNOWN_CAPABILITIES}
+    for spec in REGISTRY:
+        assert spec.capability in allowed, (
+            f"{spec.check_id!r}: capability {spec.capability!r} not in KNOWN_CAPABILITIES"
+        )
+
+
+def test_all_value_rules_in_closed_set():
+    for spec in REGISTRY:
+        assert spec.value_rule in VALUE_RULES, (
+            f"{spec.check_id!r}: value_rule {spec.value_rule!r} not in VALUE_RULES"
+        )
+
+
+def test_tx_adjacent_blocked_implies_tx_adjacent():
+    # Every TX_ADJACENT_BLOCKED must have tx_adjacent=True
+    for spec in REGISTRY:
+        if spec.kind is CheckKind.TX_ADJACENT_BLOCKED:
+            assert spec.tx_adjacent is True, (
+                f"{spec.check_id!r}: TX_ADJACENT_BLOCKED but tx_adjacent is False"
+            )
+    # ONLY tuner.tune and tx.ptt should have tx_adjacent=True
+    tx_adjacent_ids = {spec.check_id for spec in REGISTRY if spec.tx_adjacent}
+    assert tx_adjacent_ids == {"tuner.tune", "tx.ptt"}
+
+
+def test_manual_and_blocked_have_no_set_op():
+    blocked_kinds = {CheckKind.MANUAL, CheckKind.TX_ADJACENT_BLOCKED}
+    for spec in REGISTRY:
+        if spec.kind in blocked_kinds:
+            assert spec.set_op is None, (
+                f"{spec.check_id!r}: kind={spec.kind} but set_op={spec.set_op!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
+
+
+def test_get_spec_known_and_unknown():
+    result = get_spec("freq.write")
+    assert isinstance(result, CheckSpec)
+    assert result.check_id == "freq.write"
+
+    assert get_spec("nope") is None
+
+
+def test_registry_by_id_contains_all():
+    assert set(REGISTRY_BY_ID.keys()) == {spec.check_id for spec in REGISTRY}
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+def test_checkspec_frozen():
+    spec = get_spec("freq.write")
+    assert spec is not None
+    with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+        spec.check_id = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+def test_registry_order():
+    first_four = [spec.check_id for spec in REGISTRY[:4]]
+    assert first_four == [
+        "discovery.identify",
+        "freq.write",
+        "freq.reverse_sync",
+        "mode.set",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Type correctness
+# ---------------------------------------------------------------------------
+
+
+def test_levels_and_domains_typed():
+    for spec in REGISTRY:
+        assert isinstance(spec.level, ValidationLevel), (
+            f"{spec.check_id!r}: level is {type(spec.level)}"
+        )
+        assert isinstance(spec.failure_domain, FailureDomain), (
+            f"{spec.check_id!r}: failure_domain is {type(spec.failure_domain)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Import guard
+# ---------------------------------------------------------------------------
+
+
+def test_import_guard_runs():
+    import rigplane.validation.registry as registry_mod
+
+    # Re-importing must not raise.
+    importlib.reload(registry_mod)
+    # Calling _validate_registry() directly must not raise.
+    registry_mod._validate_registry()  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Spot-checks (table-driven)
+# ---------------------------------------------------------------------------
+
+_EXPECTED: list[tuple[str, dict]] = [
+    (
+        "freq.write",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.BASIC_CONTROL,
+            "get_op": "get_freq",
+            "set_op": "set_freq",
+            "value_rule": ValueRule.BUMP_HZ,
+            "tolerance": 0,
+            "hamlib_token": "f",
+            "protocol": None,
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "filter_width.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "get_op": "get_filter_width",
+            "set_op": "set_filter_width",
+            "value_rule": ValueRule.NUDGE_FILTER,
+            "tolerance": 50,
+            "hamlib_token": None,
+            "protocol": "filter_width",
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "rf_gain.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "get_op": "get_rf_gain",
+            "set_op": "set_rf_gain",
+            "value_rule": ValueRule.STEP_LEVEL_255,
+            "tolerance": 3,
+            "hamlib_token": "RF",
+            "protocol": "rf_gain",
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "af_level.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "get_op": "get_af_level",
+            "set_op": "set_af_level",
+            "value_rule": ValueRule.STEP_LEVEL_255,
+            "tolerance": 3,
+            "hamlib_token": "AF",
+            "protocol": "af_level",
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "squelch.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "get_op": "get_squelch",
+            "set_op": "set_squelch",
+            "value_rule": ValueRule.STEP_LEVEL_255,
+            "tolerance": 3,
+            "hamlib_token": "SQL",
+            "protocol": "squelch",
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "rit.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "get_op": "get_rit_frequency",
+            "set_op": "set_rit_frequency",
+            "value_rule": ValueRule.BUMP_HZ,
+            "tolerance": 10,
+            "hamlib_token": None,
+            "protocol": "rit",
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "meters.read",
+        {
+            "kind": CheckKind.READ_ONLY,
+            "level": ValidationLevel.COMPATIBILITY_SURFACES,
+            "get_op": "get_s_meter",
+            "set_op": None,
+            "value_rule": ValueRule.TOGGLE_BOOL,
+            "tolerance": 0,
+            "hamlib_token": "STRENGTH",
+            "protocol": None,
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "tuner.tune",
+        {
+            "kind": CheckKind.TX_ADJACENT_BLOCKED,
+            "level": ValidationLevel.STRESS_RECOVERY,
+            "get_op": None,
+            "set_op": None,
+            "value_rule": ValueRule.TOGGLE_BOOL,
+            "tolerance": 0,
+            "hamlib_token": None,
+            "protocol": "tuner",
+            "failure_domain": FailureDomain.COMMAND_EXECUTION,
+            "tx_adjacent": True,
+        },
+    ),
+    (
+        "tx.ptt",
+        {
+            "kind": CheckKind.TX_ADJACENT_BLOCKED,
+            "level": ValidationLevel.STRESS_RECOVERY,
+            "get_op": None,
+            "set_op": None,
+            "value_rule": ValueRule.TOGGLE_BOOL,
+            "tolerance": 0,
+            "hamlib_token": "t",
+            "protocol": None,
+            "failure_domain": FailureDomain.COMMAND_EXECUTION,
+            "tx_adjacent": True,
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("check_id,expected", _EXPECTED)
+def test_spot_check_values(check_id: str, expected: dict):
+    spec = get_spec(check_id)
+    assert spec is not None, f"{check_id!r} not found in REGISTRY"
+    for field_name, expected_value in expected.items():
+        actual = getattr(spec, field_name)
+        assert actual == expected_value, (
+            f"{check_id!r}.{field_name}: expected {expected_value!r}, got {actual!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ValueRule string round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_value_rule_str_roundtrip():
+    assert ValueRule.TOGGLE_BOOL == "toggle_bool"
+    # Default value_rule on a minimal CheckSpec is TOGGLE_BOOL
+    spec = CheckSpec(
+        check_id="x",
+        capability="",
+        kind=CheckKind.READ_ONLY,
+        level=ValidationLevel.DISCOVERY,
+        failure_domain=FailureDomain.DISCOVERY,
+        summary="test",
+    )
+    assert spec.value_rule == ValueRule.TOGGLE_BOOL
+    assert spec.value_rule == "toggle_bool"


### PR DESCRIPTION
## MOR-197 — capability→check-spec registry (core)

Implements **§2** of the accepted ADR `docs/plans/2026-05-28-universal-validation-matrix.md`: the single data-only registry both validation-matrix generators (native Gen-A, Hamlib Gen-B) will consume. This is the foundation ticket of the universal-matrix epic; it adds **data + types only** — no generator, no `hardware.py` dispatch, no CLI (those are MOR-198/199/201).

### What landed
- `src/rigplane/validation/registry.py` (new):
  - `CheckKind` / `ValueRule` closed `StrEnum` vocabularies (§2.2, §2.3) + `VALUE_RULES` frozenset.
  - `CheckSpec` (`frozen=True, slots=True`): operation references (`protocol`/`get_op`/`set_op`) stored as **strings**, resolved at runtime by later tickets — keeps the module a pure data artifact and honours the `validation`-layer charter (imports only `core.capabilities` + `validation.schema` + stdlib).
  - `REGISTRY`: the 21 §2.6 entries in declaration order; `REGISTRY_BY_ID` + `get_spec()`.
  - Import-time `_validate_registry()` guard enforcing the safety invariants so generation can never emit an unsafe check (**ADR D4**): `capability ∈ KNOWN_CAPABILITIES`, `value_rule ∈ VALUE_RULES`, unique `check_id`, `TX_ADJACENT_BLOCKED ⇒ tx_adjacent`, `MANUAL`/blocked ⇒ `set_op is None`.
- `tests/validation/test_registry.py` (new): 22 tests — structural invariants + frozen behaviour + compact spot-checks of exact field values.

### Decisions (owner-confirmed)
- **Invariant enforcement:** import-time guard **and** test (not test-only) — makes D4's "data cannot encode an unsafe check" a structural guarantee.
- **`validation/__init__.py`:** re-export **deferred to MOR-198**, where Generator A makes the registry load-bearing (no dead public surface under TDD).
- **`hamlib_token`:** follows the **§5.2 grounded token map** (the code-grounded correction). Notably `filter_width = None` — §2.6's draft "M passband" note is superseded because the rigctld client does not drive filter width. `meters="STRENGTH"`/`squelch="SQL"` carried as the contract even though the client doesn't implement them yet (Gen-B treats absent client support as N/A).
- **LOC:** ~250 (registry data + first-class test) over the ≤200 heuristic — accepted; the 21 data rows are irreducible, file count is 2/3.

### Gates
- `pytest tests/` → **6075 passed, 7 skipped, 11 xfailed** (no regressions)
- `ruff check` / `ruff format` → clean
- `mypy src/rigplane/validation/registry.py` → no issues
- `lint-imports` → 4 contracts kept, 0 broken

Linear: MOR-197. Epic: Universal Profile-Driven Radio Validation Matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)