### PR TITLE
feat(MOR-198): Generator A — profile capabilities → MatrixTemplate

### DIFF
--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -11,11 +11,16 @@ reads the original value, writes a different one, verifies the readback, then
 restores the original. ``--read-only`` disables all writes (write checks SKIP).
 TX and tuner are never auto-actuated.
 
+Template resolution: ``--template`` is optional.  If omitted, ``--model`` is
+required and the template is generated in-memory from the radio profile's
+declared capabilities via ``build_template_from_capabilities``.
+
 Exit codes:
 
 * ``0`` — success (dry-run or hardware artifact emitted). Failed/blocked checks
   do NOT change the exit code.
-* ``2`` — template missing, unreadable, or schema-invalid.
+* ``2`` — template missing, unreadable, or schema-invalid; or ``--template``
+  and ``--model`` both absent; or model name is unknown.
 * ``3`` — hardware run requested but blocked (gates closed), or the radio could
   not connect / authenticate / build a backend config (artifact still emitted
   on connect failure).
@@ -83,8 +88,13 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--template",
-        required=True,
-        help="Path to a validation matrix template JSON file.",
+        required=False,
+        default=None,
+        help=(
+            "Path to a validation matrix template JSON file.  Optional: "
+            "if omitted, supply --model to generate the template from the "
+            "radio profile's declared capabilities."
+        ),
     )
     p.add_argument(
         "--dry-run",
@@ -161,11 +171,29 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
 
 
 def run(args: argparse.Namespace) -> int:
-    try:
-        template = load_template(Path(args.template))
-    except (SchemaValidationError, OSError) as exc:
-        print(f"Error: cannot load template: {exc}", file=sys.stderr)
-        return 2
+    if args.template:
+        try:
+            template = load_template(Path(args.template))
+        except (SchemaValidationError, OSError) as exc:
+            print(f"Error: cannot load template: {exc}", file=sys.stderr)
+            return 2
+    else:
+        if not getattr(args, "model", None):
+            print("Error: provide --template or --model", file=sys.stderr)
+            return 2
+        from rigplane.profiles import get_radio_profile
+        from rigplane.validation.registry import build_template_from_capabilities
+
+        try:
+            profile = get_radio_profile(args.model)
+        except KeyError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+        template = build_template_from_capabilities(
+            profile.capabilities,
+            model=profile.model,
+            profile_id=profile.id,
+        )
 
     authorized = bool(args.tx_allowed or args.tuner_allowed)
     safety = OperatorSafetyBlock(

--- a/src/rigplane/validation/registry.py
+++ b/src/rigplane/validation/registry.py
@@ -12,11 +12,19 @@ hardware protocols.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 
 from rigplane.core.capabilities import KNOWN_CAPABILITIES
-from rigplane.validation.schema import FailureDomain, ValidationLevel
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    FailureDomain,
+    MatrixTemplate,
+    RadioTarget,
+    ValidationLevel,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -483,7 +491,104 @@ _validate_registry()
 
 
 # ---------------------------------------------------------------------------
-# 10. __all__
+# 10. build_template_from_capabilities
+# ---------------------------------------------------------------------------
+
+# Maps each CheckKind to the CapabilityDeclaration used when the capability
+# is present in the profile's declared capability set.
+_KIND_TO_DECLARATION: dict[CheckKind, CapabilityDeclaration] = {
+    CheckKind.READ_ONLY: CapabilityDeclaration.SUPPORTED,
+    CheckKind.RMVR_SAFE_WRITE: CapabilityDeclaration.SUPPORTED,
+    CheckKind.WRITE_ONLY_OBSERVE: CapabilityDeclaration.SUPPORTED,
+    CheckKind.MANUAL: CapabilityDeclaration.MANUAL_REQUIRED,
+    CheckKind.TX_ADJACENT_BLOCKED: CapabilityDeclaration.MANUAL_REQUIRED,
+}
+
+
+def build_template_from_capabilities(
+    capabilities: frozenset[str],
+    *,
+    model: str,
+    profile_id: str,
+    probe: Callable[[str], bool] | None = None,
+) -> MatrixTemplate:
+    """Generate a ``MatrixTemplate`` from a set of declared capability strings.
+
+    Algorithm (ADR §3.1):
+
+    1. ``probe`` is accepted but **unused** in v1 — it is reserved for a future
+       hardware-probe integration pass that can upgrade UNSUPPORTED_PENDING_EVIDENCE
+       entries to SUPPORTED without a full hardware run.  The parameter is kept in
+       the signature for forward-compatibility; do not branch on it.
+    2. Every registry entry with ``capability == ""`` (structural) is always emitted
+       with ``CapabilityDeclaration.SUPPORTED``.
+    3. Functional entries are emitted with a declaration derived from
+       ``_KIND_TO_DECLARATION`` when the capability is declared, or
+       ``UNSUPPORTED_PENDING_EVIDENCE`` otherwise.
+    4. Capabilities that appear in *capabilities* but have no registry check receive
+       a synthetic ``<cap>.presence`` entry at ``ValidationLevel.STATIC_PROFILE`` with
+       ``UNSUPPORTED_PENDING_EVIDENCE`` (they are declared but not yet exercised).
+    5. The final list is stable-sorted by level (ascending) so that presence entries
+       (level 0) appear first.
+
+    Layer rule: this function takes a plain ``frozenset[str]`` — it does **not** import
+    ``rigplane.profiles``.  The caller is responsible for resolving the profile and
+    extracting its capabilities.
+    """
+    entries: list[CapabilityDeclarationEntry] = []
+    functional_caps: set[str] = set()
+
+    for spec in REGISTRY:
+        if spec.capability == "":
+            # Structural check — always supported.
+            declaration = CapabilityDeclaration.SUPPORTED
+        else:
+            functional_caps.add(spec.capability)
+            if spec.capability in capabilities:
+                declaration = _KIND_TO_DECLARATION[spec.kind]
+            else:
+                declaration = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+
+        entries.append(
+            CapabilityDeclarationEntry(
+                check_id=spec.check_id,
+                capability=spec.capability,
+                level=spec.level,
+                declaration=declaration,
+                summary=spec.summary,
+                tx_adjacent=spec.tx_adjacent,
+            )
+        )
+
+    # Presence entries: declared capabilities not covered by any registry check.
+    for cap in sorted(capabilities):
+        if cap not in functional_caps:
+            entries.append(
+                CapabilityDeclarationEntry(
+                    check_id=f"{cap}.presence",
+                    capability=cap,
+                    level=ValidationLevel.STATIC_PROFILE,
+                    declaration=CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE,
+                    summary=(
+                        f"Capability {cap!r} is declared by the profile but has "
+                        "no functional check yet."
+                    ),
+                    tx_adjacent=False,
+                )
+            )
+
+    # Stable sort by level — preserves registry order within each level;
+    # presence entries are level 0 so they sort before DISCOVERY (level 1).
+    entries.sort(key=lambda e: int(e.level))
+
+    return MatrixTemplate(
+        radio=RadioTarget(model=model, profile_id=profile_id),
+        entries=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 11. __all__
 # ---------------------------------------------------------------------------
 
 __all__ = [
@@ -494,4 +599,5 @@ __all__ = [
     "REGISTRY",
     "REGISTRY_BY_ID",
     "get_spec",
+    "build_template_from_capabilities",
 ]

--- a/tests/validation/test_generator.py
+++ b/tests/validation/test_generator.py
@@ -1,0 +1,292 @@
+"""Tests for the profile-driven template generator (MOR-198).
+
+Plain pytest functions — no class wrapper needed.
+Mirrors the style of tests/validation/test_registry.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from rigplane.cli import _validate
+from rigplane.profiles import get_radio_profile
+from rigplane.validation.registry import build_template_from_capabilities
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    ValidationLevel,
+    validate_template_dict,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIXTURE_TEMPLATE = (
+    Path(__file__).parent.parent / "fixtures" / "validation_template_ic7300.json"
+)
+
+
+def _make_args(**kwargs) -> argparse.Namespace:
+    """Build a Namespace with safe defaults for _validate.run()."""
+    defaults = dict(
+        template=None,
+        model=None,
+        hardware=False,
+        allow_hardware=False,
+        tx_allowed=False,
+        tuner_allowed=False,
+        read_only=False,
+        provider="native",
+        compare=None,
+        operator_id=None,
+        output=None,
+        json=True,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Generator unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_generated_template_validates():
+    """build_template_from_capabilities returns a schema-valid MatrixTemplate."""
+    tpl = build_template_from_capabilities(
+        frozenset({"rf_gain", "scope"}),
+        model="IC-7300",
+        profile_id="ic7300",
+    )
+    # validate_template_dict must not raise SchemaValidationError
+    validate_template_dict(tpl.to_dict())
+
+
+def test_structural_always_supported():
+    """Structural checks (capability == '') are always SUPPORTED regardless of caps."""
+    tpl = build_template_from_capabilities(
+        frozenset(),
+        model="IC-7300",
+        profile_id="ic7300",
+    )
+    structural_ids = {
+        "discovery.identify",
+        "freq.write",
+        "freq.reverse_sync",
+        "mode.set",
+    }
+    entries_by_id = {e.check_id: e for e in tpl.entries}
+    for cid in structural_ids:
+        assert cid in entries_by_id, f"Structural check {cid!r} missing from template"
+        entry = entries_by_id[cid]
+        assert entry.capability == "", (
+            f"{cid!r}: expected capability='', got {entry.capability!r}"
+        )
+        assert entry.declaration == CapabilityDeclaration.SUPPORTED, (
+            f"{cid!r}: expected SUPPORTED, got {entry.declaration!r}"
+        )
+
+
+def test_declared_functional_supported():
+    """A declared capability maps to SUPPORTED."""
+    tpl = build_template_from_capabilities(
+        frozenset({"rf_gain"}),
+        model="IC-7300",
+        profile_id="ic7300",
+    )
+    entries_by_id = {e.check_id: e for e in tpl.entries}
+    assert "rf_gain.set" in entries_by_id
+    assert entries_by_id["rf_gain.set"].declaration == CapabilityDeclaration.SUPPORTED
+
+
+def test_undeclared_functional_pending():
+    """A functional check whose capability is absent maps to UNSUPPORTED_PENDING_EVIDENCE."""
+    tpl = build_template_from_capabilities(
+        frozenset(),
+        model="IC-7300",
+        profile_id="ic7300",
+    )
+    entries_by_id = {e.check_id: e for e in tpl.entries}
+    assert "rf_gain.set" in entries_by_id
+    assert (
+        entries_by_id["rf_gain.set"].declaration
+        == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+    )
+
+
+def test_manual_kind_manual_required():
+    """MANUAL checks map to CapabilityDeclaration.MANUAL_REQUIRED when capability declared.
+
+    Note: the generated baseline intentionally differs from the shipped ic7300 template
+    (where scope=supported). Override reconciliation is handled in MOR-202.
+    """
+    tpl = build_template_from_capabilities(
+        frozenset({"audio", "scope"}),
+        model="IC-7300",
+        profile_id="ic7300",
+    )
+    entries_by_id = {e.check_id: e for e in tpl.entries}
+    assert (
+        entries_by_id["audio.rx"].declaration == CapabilityDeclaration.MANUAL_REQUIRED
+    )
+    assert (
+        entries_by_id["scope.capture"].declaration
+        == CapabilityDeclaration.MANUAL_REQUIRED
+    )
+
+
+def test_tx_adjacent_blocked():
+    """TX_ADJACENT_BLOCKED checks map to MANUAL_REQUIRED and preserve tx_adjacent=True."""
+    tpl = build_template_from_capabilities(
+        frozenset({"tuner", "tx"}),
+        model="IC-7300",
+        profile_id="ic7300",
+    )
+    entries_by_id = {e.check_id: e for e in tpl.entries}
+    tuner = entries_by_id["tuner.tune"]
+    ptt = entries_by_id["tx.ptt"]
+    assert tuner.declaration == CapabilityDeclaration.MANUAL_REQUIRED
+    assert tuner.tx_adjacent is True
+    assert ptt.declaration == CapabilityDeclaration.MANUAL_REQUIRED
+    assert ptt.tx_adjacent is True
+
+
+def test_presence_entries():
+    """Capabilities with no registry check get a <cap>.presence entry at STATIC_PROFILE."""
+    tpl = build_template_from_capabilities(
+        frozenset({"split", "vox", "cw"}),
+        model="IC-7300",
+        profile_id="ic7300",
+    )
+    entries_by_id = {e.check_id: e for e in tpl.entries}
+    for cap in ("split", "vox", "cw"):
+        cid = f"{cap}.presence"
+        assert cid in entries_by_id, f"Expected {cid!r} in template entries"
+        entry = entries_by_id[cid]
+        assert entry.level == ValidationLevel.STATIC_PROFILE
+        assert entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+
+
+def test_entries_sorted_by_level():
+    """Level sequence is non-decreasing; presence entries (level 0) sort first."""
+    tpl = build_template_from_capabilities(
+        frozenset({"split", "rf_gain"}),
+        model="IC-7300",
+        profile_id="ic7300",
+    )
+    levels = [int(e.level) for e in tpl.entries]
+    assert levels == sorted(levels), "Entries are not sorted by level"
+    # Presence entries are level 0 — should appear before DISCOVERY (level 1)
+    first = tpl.entries[0]
+    assert first.level == ValidationLevel.STATIC_PROFILE
+
+
+def test_check_ids_unique():
+    """No duplicate check_ids in the generated template."""
+    tpl = build_template_from_capabilities(
+        frozenset({"rf_gain", "scope", "tuner", "tx"}),
+        model="IC-7300",
+        profile_id="ic7300",
+    )
+    ids = [e.check_id for e in tpl.entries]
+    assert len(ids) == len(set(ids)), "Duplicate check_ids found"
+
+
+def test_probe_unused():
+    """probe parameter does not affect output (v1 — probe is accepted but unused)."""
+    caps = frozenset({"rf_gain", "scope"})
+    tpl_none = build_template_from_capabilities(
+        caps, model="IC-7300", profile_id="ic7300", probe=None
+    )
+    tpl_probe = build_template_from_capabilities(
+        caps,
+        model="IC-7300",
+        profile_id="ic7300",
+        probe=lambda _: True,
+    )
+    assert tpl_none.to_dict() == tpl_probe.to_dict()
+
+
+def test_realistic_ic7300():
+    """End-to-end: IC-7300 profile builds a schema-valid template."""
+    profile = get_radio_profile("IC-7300")
+    tpl = build_template_from_capabilities(
+        profile.capabilities,
+        model=profile.model,
+        profile_id=profile.id,
+    )
+    # Schema validation must pass
+    validate_template_dict(tpl.to_dict())
+    # filter_width.set declaration depends on whether filter_width is in capabilities
+    entries_by_id = {e.check_id: e for e in tpl.entries}
+    if "filter_width" in profile.capabilities:
+        assert entries_by_id["filter_width.set"].declaration in (
+            CapabilityDeclaration.SUPPORTED,
+            CapabilityDeclaration.MANUAL_REQUIRED,
+        )
+    else:
+        assert (
+            entries_by_id["filter_width.set"].declaration
+            == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI tests (dry-run, no hardware)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_template_optional_in_parser():
+    """--template must NOT be required (i.e. parse_args(['validate']) must not raise)."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd")
+    _validate.add_subparser(sub)
+    # parse_args(['validate']) must not raise SystemExit
+    args = parser.parse_args(["validate"])
+    # If we got here, --template was not required
+    assert args.template is None
+
+
+def test_cli_generates_from_model():
+    """Namespace(model='IC-7300', template=None) → rc==0, stdout is valid JSON with 'radio'."""
+    args = _make_args(model="IC-7300")
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = _validate.run(args)
+    assert rc == 0, f"Expected rc=0, got {rc}"
+    payload = json.loads(buf.getvalue())
+    assert "radio" in payload, (
+        f"'radio' key missing from artifact: {list(payload.keys())}"
+    )
+
+
+def test_cli_error_no_template_no_model():
+    """Both template and model absent → rc==2."""
+    args = _make_args(template=None, model=None)
+    rc = _validate.run(args)
+    assert rc == 2
+
+
+def test_cli_error_unknown_model():
+    """Unknown model → rc==2."""
+    args = _make_args(template=None, model="NOPE-9000")
+    rc = _validate.run(args)
+    assert rc == 2
+
+
+def test_cli_template_path_still_works():
+    """Existing --template path still works (regression guard)."""
+    if not _FIXTURE_TEMPLATE.exists():
+        pytest.skip(f"Fixture {_FIXTURE_TEMPLATE} not found")
+    args = _make_args(template=str(_FIXTURE_TEMPLATE))
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = _validate.run(args)
+    assert rc == 0


### PR DESCRIPTION
## MOR-198 — Generator A (native): profile capabilities → MatrixTemplate

Implements **§2.4 / §3 / §9** of the ADR `docs/plans/2026-05-28-universal-validation-matrix.md`. Second ticket of the universal-matrix epic (builds on MOR-197 #1659). Turns a radio profile's declared capabilities into an in-memory `MatrixTemplate` and lets `rigplane validate` generate it when `--template` is omitted — no hand-authored template required.

### What landed (3 files)
- **`src/rigplane/validation/registry.py`** — new `build_template_from_capabilities(capabilities: frozenset[str], *, model, profile_id, probe=None) -> MatrixTemplate`. Pure validation-layer data: takes a `frozenset[str]`, **never** a `RadioProfile` (no `profiles` import). Algorithm (§3.1):
  - 4 structural `""` checks emitted unconditionally as `SUPPORTED`.
  - functional checks → `SUPPORTED` (READ_ONLY/RMVR_SAFE_WRITE/WRITE_ONLY_OBSERVE) or `MANUAL_REQUIRED` (MANUAL/TX_ADJACENT_BLOCKED) when the cap is declared, else `UNSUPPORTED_PENDING_EVIDENCE` (exhaustive matrix).
  - declared caps with no registry check → `<cap>.presence` entries at `STATIC_PROFILE` (level 0) so gaps are visible, never silently dropped.
  - stable-sorted by level; passes `validate_template_dict` by construction.
- **`src/rigplane/cli/_validate.py`** — `--template` now optional; when omitted, `--model` is required and the template is generated from `get_radio_profile(model).capabilities` (the profile read lives in `cli/` per the §2.4 layer split). The generated template flows through the **unchanged** `_run_hardware` / `_run_hardware_hamlib` / `dry_run_results` path (D7). Exit `2` when neither `--template` nor `--model` is supplied, or the model is unknown.
- **`tests/validation/test_generator.py`** (new) — 16 tests: generator unit (validates, structural-supported, declared/undeclared, MANUAL→MANUAL_REQUIRED, TX-adjacent, presence entries, level sort, unique ids, probe-unused, realistic IC-7300) + CLI (parser optionality, generate-from-model dry-run exit 0, error paths, `--template` regression).

### Decisions (pinned in PLAN)
- **kind→declaration:** TX_ADJACENT_BLOCKED → `MANUAL_REQUIRED` (matches shipped tuner.tune/tx.ptt; generator never declares an auto-actuated TX check SUPPORTED).
- **Generated ≠ shipped by design:** e.g. `scope.capture` → `manual_required` (shipped ic7300 has `supported`); the override layer (MOR-202) reconciles. No special-casing.
- **Explicit `get_radio_profile(args.model)`** (fail-loud) rather than `resolve_radio_profile` auto-detect, which silently falls back to a default rig — auto-detect is ADR-scoped to the future `radio-validate` subcommand.
- `validation/__init__.py` re-export skipped (CLI imports the submodule directly); `--write-template` deferred to MOR-203/204. File count held at 3.
- `probe` param reserved/unused in v1 (§2.4 API note).

### Gates
- `pytest tests/validation/test_generator.py` → **16 passed**
- `pytest tests/` (no integration) → **6091 passed, 7 skipped, 11 xfailed** (no regressions)
- `ruff check` / `ruff format` → clean
- `mypy registry.py _validate.py` → no issues
- `lint-imports` → 4 contracts kept, 0 broken · registry.py imports only `core.capabilities` + `validation.schema` + stdlib (verified by grep — `profiles` appears only in docstrings)

Linear: MOR-198. Epic: Universal Profile-Driven Radio Validation Matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)