### PR TITLE
feat(MOR-199): generic _check_from_spec dispatch for registry-driven checks

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -28,7 +28,7 @@ import dataclasses
 import datetime
 import logging
 from collections.abc import Awaitable, Callable
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from rigplane.core.exceptions import (
     AuthenticationError,
@@ -49,6 +49,7 @@ from rigplane.core.radio_protocol import (
     UsbAudioCapable,
 )
 from rigplane.core.types import AgcMode
+from rigplane.validation.registry import CheckKind, CheckSpec, ValueRule, get_spec
 from rigplane.validation.runner import _is_authorized
 from rigplane.validation.schema import (
     CapabilityDeclaration,
@@ -234,6 +235,15 @@ async def _run_one_check(
     # Pre-gate 4: SUPPORTED -> check-specific logic.
     handler = _SUPPORTED_HANDLERS.get(entry.check_id)
     if handler is None:
+        spec = get_spec(entry.check_id)
+        if spec is not None:
+            return await _check_from_spec(
+                radio,
+                entry,
+                spec,
+                allow_writes=allow_writes,
+                per_check_timeout=per_check_timeout,
+            )
         return _base_result(
             entry,
             CheckStatus.SKIP,
@@ -945,6 +955,128 @@ async def _check_xit_set(
         write=rit.set_rit_tx_status,
         make_changed=lambda b: not b,
         per_check_timeout=per_check_timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generic dispatch: value-rule map + _check_from_spec
+# ---------------------------------------------------------------------------
+
+# Maps each scalar ValueRule to a mutation lambda.
+# MODE_CYCLE is deliberately absent: it is tuple-valued and handled exclusively
+# by the bespoke _check_mode_set named handler.
+_VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
+    ValueRule.TOGGLE_BOOL: lambda b: not b,
+    ValueRule.STEP_LEVEL_255: lambda v: 200 if v < 128 else 50,
+    ValueRule.NUDGE_FILTER: lambda w: w + 200 if w <= 2600 else w - 200,
+    ValueRule.PREAMP_CYCLE: lambda v: 1 if v == 0 else 0,
+    ValueRule.AGC_FLIP: lambda m: (
+        int(AgcMode.SLOW) if m != AgcMode.SLOW else int(AgcMode.FAST)
+    ),
+    ValueRule.BUMP_HZ: lambda v: v + 100,
+}
+
+
+async def _check_from_spec(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    spec: CheckSpec,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    """Execute a check using a registry CheckSpec when no named handler exists."""
+    if spec.kind is CheckKind.READ_ONLY:
+        if spec.get_op is None:
+            return _base_result(
+                entry,
+                CheckStatus.UNSUPPORTED,
+                evidence={"reason": f"radio has no readable op {spec.get_op!r}"},
+            )
+        read_fn = getattr(radio, spec.get_op, None)
+        if not callable(read_fn):
+            return _base_result(
+                entry,
+                CheckStatus.UNSUPPORTED,
+                evidence={"reason": f"radio has no readable op {spec.get_op!r}"},
+            )
+        value, fail = await _guard(
+            cast(Awaitable[Any], read_fn()),
+            entry,
+            per_check_timeout=per_check_timeout,
+        )
+        if fail is not None:
+            return fail
+        return _base_result(
+            entry,
+            CheckStatus.PASS,
+            evidence={
+                "value": value,
+                "op": spec.get_op,
+                "handler": "generic",
+                "kind": str(spec.kind),
+            },
+        )
+
+    if spec.kind is CheckKind.RMVR_SAFE_WRITE:
+        gate = _write_gate(radio, entry, allow_writes=allow_writes)
+        if gate is not None:
+            return gate
+        read_fn = getattr(radio, spec.get_op, None) if spec.get_op else None
+        write_fn = getattr(radio, spec.set_op, None) if spec.set_op else None
+        if not callable(read_fn) or not callable(write_fn):
+            return _base_result(
+                entry,
+                CheckStatus.UNSUPPORTED,
+                evidence={
+                    "reason": f"radio is missing get/set op for {entry.check_id}"
+                },
+            )
+        make_changed = _VALUE_RULE_FNS.get(spec.value_rule)
+        if make_changed is None:
+            return _base_result(
+                entry,
+                CheckStatus.UNSUPPORTED,
+                evidence={
+                    "reason": f"value_rule {spec.value_rule!r} not supported by generic handler"
+                },
+            )
+        equal: Callable[[Any, Any], bool] = (
+            _tolerant_equal(spec.tolerance) if spec.tolerance else _default_equal
+        )
+        _read_fn = read_fn
+        _write_fn = write_fn
+        return await _read_modify_verify_restore(
+            radio,
+            entry,
+            read=lambda: cast(Awaitable[Any], _read_fn()),
+            write=lambda v: cast(Awaitable[None], _write_fn(v)),
+            make_changed=make_changed,
+            equal=equal,
+            per_check_timeout=per_check_timeout,
+            extra_evidence={
+                "handler": "generic",
+                "value_rule": str(spec.value_rule),
+                "kind": str(spec.kind),
+            },
+        )
+
+    if spec.kind is CheckKind.WRITE_ONLY_OBSERVE:
+        return _base_result(
+            entry,
+            CheckStatus.UNSUPPORTED,
+            evidence={"reason": "write_only_observe not yet implemented (MOR-180)"},
+        )
+
+    if spec.kind is CheckKind.MANUAL:
+        return _manual_required_result(radio, entry)
+
+    # CheckKind.TX_ADJACENT_BLOCKED (defensive)
+    return _base_result(
+        entry,
+        CheckStatus.BLOCKED,
+        failure_domain=FailureDomain.COMMAND_EXECUTION,
+        evidence={"reason": "tx-adjacent blocked"},
     )
 
 

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -21,7 +21,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 from rigplane.core.radio_protocol import Radio
 from rigplane.core.radio_state import RadioState
+from rigplane.core.types import AgcMode
 from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.registry import CheckKind, CheckSpec, ValueRule
 from rigplane.validation.runner import build_validation_artifact, load_template
 from rigplane.validation.schema import (
     CapabilityDeclaration,
@@ -449,3 +451,301 @@ async def test_artifact_round_trips():
     restored = validate_artifact_dict(json.loads(json.dumps(artifact.to_dict())))
     assert restored.mode == "hardware"
     assert restored.transport.backend == "serial"
+
+
+# ---------------------------------------------------------------------------
+# MOR-199: generic _check_from_spec dispatch tests
+# ---------------------------------------------------------------------------
+
+
+def _stateful_squelch_mock(*, start: int = 0):
+    """A MagicMock(spec=Radio) whose squelch set/get round-trips via a closure."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"squelch"}
+    store = {"value": start}
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(level: int, receiver: int = 0) -> None:
+        store["value"] = level
+
+    radio.get_squelch = AsyncMock(side_effect=_get)
+    radio.set_squelch = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_generic_squelch_set_rmvr_pass():
+    """squelch.set dispatches via generic handler and round-trips (PASS)."""
+    radio, store = _stateful_squelch_mock(start=0)
+    template = _single_entry_template(check_id="squelch.set", capability="squelch")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["squelch.set"]
+    assert check.status is CheckStatus.PASS
+    # step_level_255(0) -> 200
+    assert check.evidence["original"] == 0
+    assert check.evidence["changed"] == 200
+    assert check.evidence["readback"] == 200
+    assert check.evidence["restored"] is True
+    assert check.evidence["handler"] == "generic"
+    assert check.evidence["value_rule"] == "step_level_255"
+
+
+async def test_generic_squelch_set_fail_no_react():
+    """set_squelch no-op (value never changes) -> FAIL with READBACK domain."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"squelch"}
+    radio.set_squelch = AsyncMock(return_value=None)  # no-op write
+    radio.get_squelch = AsyncMock(return_value=100)  # always 100
+    template = _single_entry_template(check_id="squelch.set", capability="squelch")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["squelch.set"]
+    assert check.status is CheckStatus.FAIL
+    assert check.failure_domain is FailureDomain.READBACK
+    # write + restore => at least 2 set_squelch calls
+    assert radio.set_squelch.call_count >= 2
+
+
+class _OffByTwoSquelchRadio:
+    """Squelch fake that reads back 2 below whatever was last written."""
+
+    def __init__(self) -> None:
+        self.connected = True
+        self.model = "OffByTwo"
+        self.capabilities = {"squelch"}
+        self.radio_state = RadioState()
+        self._value = 100
+
+    async def get_squelch(self, receiver: int = 0) -> int:
+        return max(0, self._value - 2)
+
+    async def set_squelch(self, level: int, receiver: int = 0) -> None:
+        self._value = level
+
+
+async def test_generic_squelch_set_tolerance():
+    """Tolerance=3 on squelch.set allows an off-by-two fake to PASS."""
+    radio = _OffByTwoSquelchRadio()
+    template = _single_entry_template(check_id="squelch.set", capability="squelch")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["squelch.set"]
+    assert check.status is CheckStatus.PASS
+
+
+async def test_generic_squelch_set_unsupported_no_setter():
+    """squelch capability present but set_squelch absent -> UNSUPPORTED."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"squelch"}
+    radio.get_squelch = AsyncMock(return_value=50)
+    # Deliberately omit set_squelch from the mock spec attribute access
+    # so getattr returns the MagicMock attribute but we override to None.
+    del radio.set_squelch
+    template = _single_entry_template(check_id="squelch.set", capability="squelch")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["squelch.set"]
+    assert check.status is CheckStatus.UNSUPPORTED
+
+
+async def test_generic_squelch_set_skip_read_only():
+    """allow_writes=False -> SKIP, set_squelch never called."""
+    radio, _store = _stateful_squelch_mock(start=50)
+    template = _single_entry_template(check_id="squelch.set", capability="squelch")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=False
+    )
+    check = _flatten(levels)["squelch.set"]
+    assert check.status is CheckStatus.SKIP
+    radio.set_squelch.assert_not_called()
+
+
+async def test_generic_squelch_set_unsupported_capability_absent():
+    """capability 'squelch' absent from radio.capabilities -> UNSUPPORTED."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = set()
+    radio.get_squelch = AsyncMock(return_value=50)
+    radio.set_squelch = AsyncMock(return_value=None)
+    template = _single_entry_template(check_id="squelch.set", capability="squelch")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["squelch.set"]
+    assert check.status is CheckStatus.UNSUPPORTED
+    assert check.evidence.get("capability_present") is False
+    radio.set_squelch.assert_not_called()
+
+
+async def test_generic_meters_read_pass():
+    """meters.read (READ_ONLY) dispatches via generic handler -> PASS."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"meters"}
+    radio.get_s_meter = AsyncMock(return_value=-73)
+    template = _single_entry_template(
+        check_id="meters.read",
+        capability="meters",
+        level=ValidationLevel.COMPATIBILITY_SURFACES,
+    )
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=False
+    )
+    check = _flatten(levels)["meters.read"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["value"] == -73
+    assert check.evidence["op"] == "get_s_meter"
+    assert check.evidence["handler"] == "generic"
+
+
+async def test_generic_meters_read_unsupported_no_getter():
+    """meters.read with no get_s_meter on radio -> UNSUPPORTED."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"meters"}
+    del radio.get_s_meter
+    template = _single_entry_template(
+        check_id="meters.read",
+        capability="meters",
+        level=ValidationLevel.COMPATIBILITY_SURFACES,
+    )
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=False
+    )
+    check = _flatten(levels)["meters.read"]
+    assert check.status is CheckStatus.UNSUPPORTED
+
+
+async def test_named_handler_wins_over_generic():
+    """preamp.set has a named handler; it must NOT produce handler=='generic'."""
+    radio, _store = _stateful_preamp_mock(start=0)
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence.get("handler") != "generic"
+
+
+async def test_generic_write_only_observe_unsupported():
+    """WRITE_ONLY_OBSERVE kind -> UNSUPPORTED with MOR-180 note."""
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"squelch"}
+    entry = CapabilityDeclarationEntry(
+        check_id="squelch.set",
+        capability="squelch",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="write only observe stub",
+    )
+    spec = CheckSpec(
+        check_id="squelch.set",
+        capability="squelch",
+        kind=CheckKind.WRITE_ONLY_OBSERVE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="write only observe stub",
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.UNSUPPORTED
+    assert "MOR-180" in str(result.evidence.get("reason", ""))
+
+
+async def test_generic_mode_cycle_unsupported():
+    """MODE_CYCLE value_rule -> UNSUPPORTED (handled by named _check_mode_set)."""
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"mode_x"}
+    radio.get_x = AsyncMock(return_value="USB")
+    radio.set_x = AsyncMock(return_value=None)
+    entry = CapabilityDeclarationEntry(
+        check_id="mode_x.set",
+        capability="mode_x",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="mode cycle stub",
+    )
+    spec = CheckSpec(
+        check_id="mode_x.set",
+        capability="mode_x",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="mode cycle stub",
+        get_op="get_x",
+        set_op="set_x",
+        value_rule=ValueRule.MODE_CYCLE,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.UNSUPPORTED
+    assert "mode_cycle" in str(result.evidence.get("reason", ""))
+
+
+def test_value_rule_map_correctness():
+    """All 6 scalar closures produce expected outputs; MODE_CYCLE is absent."""
+    from rigplane.validation.hardware import _VALUE_RULE_FNS
+
+    assert _VALUE_RULE_FNS[ValueRule.TOGGLE_BOOL](False) is True
+    assert _VALUE_RULE_FNS[ValueRule.TOGGLE_BOOL](True) is False
+
+    assert _VALUE_RULE_FNS[ValueRule.STEP_LEVEL_255](0) == 200
+    assert _VALUE_RULE_FNS[ValueRule.STEP_LEVEL_255](200) == 50
+
+    assert _VALUE_RULE_FNS[ValueRule.NUDGE_FILTER](2600) == 2800
+    assert _VALUE_RULE_FNS[ValueRule.NUDGE_FILTER](2601) == 2401
+
+    assert _VALUE_RULE_FNS[ValueRule.PREAMP_CYCLE](0) == 1
+    assert _VALUE_RULE_FNS[ValueRule.PREAMP_CYCLE](1) == 0
+
+    assert _VALUE_RULE_FNS[ValueRule.AGC_FLIP](AgcMode.FAST) == int(AgcMode.SLOW)
+    assert _VALUE_RULE_FNS[ValueRule.AGC_FLIP](AgcMode.SLOW) == int(AgcMode.FAST)
+
+    assert _VALUE_RULE_FNS[ValueRule.BUMP_HZ](14_000_000) == 14_000_100
+
+    assert ValueRule.MODE_CYCLE not in _VALUE_RULE_FNS
+
+
+async def test_unknown_check_id_still_skips():
+    """A SUPPORTED entry with an unknown check_id (no spec) -> SKIP."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = set()
+    template = _single_entry_template(
+        check_id="bogus.thing",
+        capability="",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+    )
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["bogus.thing"]
+    assert check.status is CheckStatus.SKIP
+    assert "no hardware handler" in str(check.evidence.get("reason", ""))


### PR DESCRIPTION
## MOR-199 — generic `_check_from_spec` dispatch (the single additive engine change)

Implements **§2.5** of the ADR `docs/plans/2026-05-28-universal-validation-matrix.md`. Third ticket of the universal-matrix epic (builds on MOR-197 #1659 registry + MOR-198 #1660 Generator A). Makes registry CheckSpecs that have **no hand-written named handler** execute on hardware — so the exhaustive, profile-driven matrix actually runs, and every capability MOR-200 adds works with zero further engine changes.

### What landed (2 files)
- **`src/rigplane/validation/hardware.py`**
  - `_run_one_check`: the `handler is None` branch now looks up `get_spec(entry.check_id)` and dispatches to `_check_from_spec`; unknown ids still `SKIP` (fallback preserved). The 15 named handlers keep precedence — only the no-handler branch changed.
  - `_check_from_spec` branches on `CheckKind`:
    - `READ_ONLY` → `getattr(get_op)()` read, `PASS` on value — covers **meters.read**
    - `RMVR_SAFE_WRITE` → `_write_gate` then the existing `_read_modify_verify_restore` with a `value_rule`→`make_changed` closure + `tolerance`→`equal` — covers **squelch.set**
    - `WRITE_ONLY_OBSERVE` → `UNSUPPORTED` (MOR-180 mechanism pending)
    - `MANUAL` / `TX_ADJACENT_BLOCKED` → defensive manual/blocked (normally caught by the earlier `MANUAL_REQUIRED`/tx-adjacent pre-gates; present for hand-authored overrides)
  - `_VALUE_RULE_FNS` reproduces the 6 **scalar** closures from the named handlers exactly; `mode_cycle` is deliberately excluded (tuple-valued → stays in the bespoke `_check_mode_set`). Generic results carry `evidence {handler:"generic", value_rule, kind}` so artifacts distinguish generic vs named execution.
- **`tests/validation/test_hardware.py`** — 13 new tests: squelch RMVR pass/fail/tolerance/missing-setter/read-only-skip/cap-absent, meters.read pass/missing-getter, named-handler-wins, WRITE_ONLY_OBSERVE + mode_cycle unsupported (direct calls), `_VALUE_RULE_FNS` correctness, unknown-id SKIP.

### Key facts / decisions
- `get_op`/`set_op` are called with **no receiver arg**, relying on the `receiver=0` protocol defaults (`get_squelch(receiver=0)`, `get_s_meter(receiver=0)`, …) — the nb/nr pattern. Uniform and safe.
- **`bump_hz` = +100** in the generic map (smaller RX-safe nudge). `freq.write` (+1000) and `rit.set` (+100) keep their named handlers unchanged, so the generic delta only ever affects future caps.
- No existing test expectations changed (the X6200 fixture template doesn't include squelch.set/meters.read).
- `hardware.py → registry` import is intra-`validation`-layer — `lint-imports` clean, no contract edit.

### Gates
- `pytest tests/validation/test_hardware.py` → **27 passed**
- `pytest tests/` (no integration) → **6104 passed, 7 skipped, 11 xfailed** (no regressions)
- `ruff check` / `ruff format` → clean · `mypy hardware.py` → no issues · `lint-imports` → 4 kept, 0 broken

Live X6200 re-verify (squelch.set RMVR + meters.read actually executing) is run by the orchestrator before merge. Known X6200 rit/xit write-only limitation belongs to MOR-180.

Linear: MOR-199. Epic: Universal Profile-Driven Radio Validation Matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)