### PR TITLE
feat(MOR-180): set-and-observe engine path for write-only controls

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -962,6 +962,24 @@ async def _check_xit_set(
 # Generic dispatch: value-rule map + _check_from_spec
 # ---------------------------------------------------------------------------
 
+# Standalone test value to SET for a write-only control (no original is readable).
+_WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
+    ValueRule.TOGGLE_BOOL: True,
+    ValueRule.BUMP_HZ: 100,
+    ValueRule.STEP_LEVEL_255: 100,
+    ValueRule.NUDGE_FILTER: 2800,
+    ValueRule.PREAMP_CYCLE: 1,
+    ValueRule.AGC_FLIP: int(AgcMode.FAST),
+}
+
+# Benign value to restore a write-only control to afterwards (best-effort).
+# Only defined where a clear neutral exists; absence => skip restore honestly.
+_WRITE_ONLY_RESTORE: dict[str, Any] = {
+    ValueRule.TOGGLE_BOOL: False,
+    ValueRule.BUMP_HZ: 0,
+}
+
+
 # Maps each scalar ValueRule to a mutation lambda.
 # MODE_CYCLE is deliberately absent: it is tuple-valued and handled exclusively
 # by the bespoke _check_mode_set named handler.
@@ -975,6 +993,81 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     ),
     ValueRule.BUMP_HZ: lambda v: v + 100,
 }
+
+
+async def _set_and_observe(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    spec: CheckSpec,
+    *,
+    per_check_timeout: float,
+) -> CheckResult:
+    """Verify a write-only control: SET a test value (no read-first), treat a
+    NAK/timeout-free SET as success, best-effort restore to a benign default."""
+    set_fn = getattr(radio, spec.set_op, None) if spec.set_op else None
+    if not callable(set_fn):
+        return _base_result(
+            entry,
+            CheckStatus.UNSUPPORTED,
+            evidence={
+                "reason": f"radio has no set op {spec.set_op!r} for write-only check"
+            },
+        )
+
+    test_value = _WRITE_ONLY_TEST_VALUES.get(spec.value_rule)
+    if test_value is None:
+        return _base_result(
+            entry,
+            CheckStatus.UNSUPPORTED,
+            evidence={
+                "reason": f"no write-only test value for value_rule {spec.value_rule!r}"
+            },
+        )
+
+    evidence: dict[str, object] = {
+        "verification": "set_observe",
+        "readback": "unavailable",
+        "test_value": test_value,
+        "handler": "set_and_observe",
+        "value_rule": str(spec.value_rule),
+    }
+
+    _, fail = await _guard(
+        cast(Awaitable[None], set_fn(test_value)),
+        entry,
+        per_check_timeout=per_check_timeout,
+    )
+    if fail is not None:
+        evidence["set_error"] = fail.error
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=fail.failure_domain,
+            evidence=evidence,
+            error=fail.error,
+        )
+
+    evidence["set_accepted"] = True
+
+    restore_value = _WRITE_ONLY_RESTORE.get(spec.value_rule)
+    if restore_value is not None:
+        _, r_fail = await _guard(
+            cast(Awaitable[None], set_fn(restore_value)),
+            entry,
+            per_check_timeout=per_check_timeout,
+        )
+        evidence["restored"] = r_fail is None
+        if r_fail is not None:
+            evidence["restore_error"] = r_fail.error
+        else:
+            evidence["restore_value"] = restore_value
+    else:
+        evidence["restored"] = False
+        evidence["restore_skipped"] = (
+            f"no benign default for value_rule {spec.value_rule!r}"
+        )
+
+    return _base_result(entry, CheckStatus.PASS, evidence=evidence)
 
 
 async def _check_from_spec(
@@ -1062,10 +1155,11 @@ async def _check_from_spec(
         )
 
     if spec.kind is CheckKind.WRITE_ONLY_OBSERVE:
-        return _base_result(
-            entry,
-            CheckStatus.UNSUPPORTED,
-            evidence={"reason": "write_only_observe not yet implemented (MOR-180)"},
+        gate = _write_gate(radio, entry, allow_writes=allow_writes)
+        if gate is not None:
+            return gate
+        return await _set_and_observe(
+            radio, entry, spec, per_check_timeout=per_check_timeout
         )
 
     if spec.kind is CheckKind.MANUAL:

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -643,20 +643,244 @@ async def test_named_handler_wins_over_generic():
     assert check.evidence.get("handler") != "generic"
 
 
-async def test_generic_write_only_observe_unsupported():
-    """WRITE_ONLY_OBSERVE kind -> UNSUPPORTED with MOR-180 note."""
+async def test_set_and_observe_pass():
+    """WRITE_ONLY_OBSERVE + TOGGLE_BOOL: SET accepted -> PASS; restore writes False."""
+    from rigplane.core.exceptions import TimeoutError as RigTimeoutError  # noqa: F401
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"xit"}
+    radio.set_rit_tx_status = AsyncMock(return_value=None)
+
+    entry = CapabilityDeclarationEntry(
+        check_id="xit.set",
+        capability="xit",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="write only xit",
+    )
+    spec = CheckSpec(
+        check_id="xit.set",
+        capability="xit",
+        kind=CheckKind.WRITE_ONLY_OBSERVE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="write only xit",
+        set_op="set_rit_tx_status",
+        value_rule=ValueRule.TOGGLE_BOOL,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["verification"] == "set_observe"
+    assert result.evidence["set_accepted"] is True
+    assert result.evidence["handler"] == "set_and_observe"
+    # restore: False is the benign default for TOGGLE_BOOL
+    assert radio.set_rit_tx_status.call_count == 2
+    calls = radio.set_rit_tx_status.call_args_list
+    assert calls[0].args[0] is True  # test value
+    assert calls[1].args[0] is False  # restore value
+    assert result.evidence["restored"] is True
+    assert result.evidence["restore_value"] is False
+
+
+async def test_set_and_observe_bump_hz_restores_zero():
+    """WRITE_ONLY_OBSERVE + BUMP_HZ: second call uses restore value 0."""
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"rit"}
+    radio.set_rit_frequency = AsyncMock(return_value=None)
+
+    entry = CapabilityDeclarationEntry(
+        check_id="rit.set",
+        capability="rit",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="write only rit freq",
+    )
+    spec = CheckSpec(
+        check_id="rit.set",
+        capability="rit",
+        kind=CheckKind.WRITE_ONLY_OBSERVE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="write only rit freq",
+        set_op="set_rit_frequency",
+        value_rule=ValueRule.BUMP_HZ,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.PASS
+    calls = radio.set_rit_frequency.call_args_list
+    assert radio.set_rit_frequency.call_count == 2
+    assert calls[0].args[0] == 100  # BUMP_HZ test value
+    assert calls[1].args[0] == 0  # restore value
+    assert result.evidence["restore_value"] == 0
+
+
+async def test_set_and_observe_set_timeout_fails():
+    """SET raises RigTimeoutError -> FAIL with COMMAND_EXECUTION domain."""
+    from rigplane.core.exceptions import TimeoutError as RigTimeoutError
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"xit"}
+    radio.set_rit_tx_status = AsyncMock(side_effect=RigTimeoutError("timed out"))
+
+    entry = CapabilityDeclarationEntry(
+        check_id="xit.set",
+        capability="xit",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="write only xit timeout",
+    )
+    spec = CheckSpec(
+        check_id="xit.set",
+        capability="xit",
+        kind=CheckKind.WRITE_ONLY_OBSERVE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="write only xit timeout",
+        set_op="set_rit_tx_status",
+        value_rule=ValueRule.TOGGLE_BOOL,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.FAIL
+    assert result.failure_domain is FailureDomain.COMMAND_EXECUTION
+    assert "set_error" in result.evidence
+    assert result.evidence.get("set_accepted") is not True
+
+
+async def test_set_and_observe_skip_read_only():
+    """allow_writes=False -> SKIP via _write_gate; set_op never called."""
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"xit"}
+    radio.set_rit_tx_status = AsyncMock(return_value=None)
+
+    entry = CapabilityDeclarationEntry(
+        check_id="xit.set",
+        capability="xit",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="write only xit skip",
+    )
+    spec = CheckSpec(
+        check_id="xit.set",
+        capability="xit",
+        kind=CheckKind.WRITE_ONLY_OBSERVE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="write only xit skip",
+        set_op="set_rit_tx_status",
+        value_rule=ValueRule.TOGGLE_BOOL,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=False, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.SKIP
+    radio.set_rit_tx_status.assert_not_called()
+
+
+async def test_set_and_observe_unsupported_capability_absent():
+    """Capability absent -> UNSUPPORTED via _write_gate; set_op never called."""
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = set()
+    radio.set_rit_tx_status = AsyncMock(return_value=None)
+
+    entry = CapabilityDeclarationEntry(
+        check_id="xit.set",
+        capability="xit",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="write only xit cap absent",
+    )
+    spec = CheckSpec(
+        check_id="xit.set",
+        capability="xit",
+        kind=CheckKind.WRITE_ONLY_OBSERVE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="write only xit cap absent",
+        set_op="set_rit_tx_status",
+        value_rule=ValueRule.TOGGLE_BOOL,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.UNSUPPORTED
+    radio.set_rit_tx_status.assert_not_called()
+
+
+async def test_set_and_observe_unsupported_no_set_op():
+    """Capability present but radio lacks set_op attribute -> UNSUPPORTED."""
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"xit"}
+    # Deliberately omit set_rit_tx_status so getattr falls back to None/missing.
+    del radio.set_rit_tx_status
+
+    entry = CapabilityDeclarationEntry(
+        check_id="xit.set",
+        capability="xit",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="write only no set op",
+    )
+    spec = CheckSpec(
+        check_id="xit.set",
+        capability="xit",
+        kind=CheckKind.WRITE_ONLY_OBSERVE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="write only no set op",
+        set_op="set_rit_tx_status",
+        value_rule=ValueRule.TOGGLE_BOOL,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.UNSUPPORTED
+    assert "set_rit_tx_status" in str(result.evidence.get("reason", ""))
+
+
+async def test_set_and_observe_no_restore_default():
+    """STEP_LEVEL_255 has no benign restore default -> PASS, set called once."""
     from rigplane.validation.hardware import _check_from_spec
 
     radio = MagicMock(spec=Radio)
     radio.connected = True
     radio.model = "X6200"
     radio.capabilities = {"squelch"}
+    radio.set_squelch = AsyncMock(return_value=None)
+
     entry = CapabilityDeclarationEntry(
         check_id="squelch.set",
         capability="squelch",
         level=ValidationLevel.CAPABILITY_MATRIX,
         declaration=CapabilityDeclaration.SUPPORTED,
-        summary="write only observe stub",
+        summary="write only squelch no restore",
     )
     spec = CheckSpec(
         check_id="squelch.set",
@@ -664,13 +888,56 @@ async def test_generic_write_only_observe_unsupported():
         kind=CheckKind.WRITE_ONLY_OBSERVE,
         level=ValidationLevel.CAPABILITY_MATRIX,
         failure_domain=FailureDomain.READBACK,
-        summary="write only observe stub",
+        summary="write only squelch no restore",
+        set_op="set_squelch",
+        value_rule=ValueRule.STEP_LEVEL_255,
     )
     result = await _check_from_spec(
         radio, entry, spec, allow_writes=True, per_check_timeout=5.0
     )
-    assert result.status is CheckStatus.UNSUPPORTED
-    assert "MOR-180" in str(result.evidence.get("reason", ""))
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["restored"] is False
+    assert "restore_skipped" in result.evidence
+    radio.set_squelch.assert_called_once()
+
+
+async def test_set_and_observe_restore_error_swallowed():
+    """Restore raises RigTimeoutError -> still PASS, evidence records restore_error."""
+    from rigplane.core.exceptions import TimeoutError as RigTimeoutError
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"xit"}
+    radio.set_rit_tx_status = AsyncMock(
+        side_effect=[None, RigTimeoutError("restore timed out")]
+    )
+
+    entry = CapabilityDeclarationEntry(
+        check_id="xit.set",
+        capability="xit",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="write only xit restore error",
+    )
+    spec = CheckSpec(
+        check_id="xit.set",
+        capability="xit",
+        kind=CheckKind.WRITE_ONLY_OBSERVE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="write only xit restore error",
+        set_op="set_rit_tx_status",
+        value_rule=ValueRule.TOGGLE_BOOL,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["set_accepted"] is True
+    assert result.evidence["restored"] is False
+    assert "restore_error" in result.evidence
 
 
 async def test_generic_mode_cycle_unsupported():


### PR DESCRIPTION
## MOR-180 — set-and-observe engine path for write-only controls (mechanism)

Engine MECHANISM (180a) for verifying controls that accept a SET but have no usable readback — a read-first RMVR times out and FAILs even though the control works (X6200 RIT/XIT per MOR-179, manual notch per MOR-207). Decomposed from the original MOR-180; **per-radio classification** (which controls are write-only on which rig — profile `write_only_controls` from TOML) is the sibling ticket **MOR-208**.

### What landed (2 files)
- **`src/rigplane/validation/hardware.py`**
  - `_set_and_observe(radio, entry, spec, *, per_check_timeout)`: SET a standalone test value (NO read-first), treat a NAK/timeout-free SET as success → `PASS` with evidence `{verification: set_observe, readback: unavailable, set_accepted: true, …}`. SET timeout/NAK → `FAIL` (command_execution). Best-effort restore to a benign default, recorded in evidence; never raises.
  - `_WRITE_ONLY_TEST_VALUES` / `_WRITE_ONLY_RESTORE`: per-`value_rule` test + benign-restore values (`toggle_bool`→True/False, `bump_hz`→100/0, …). Rules with no clear neutral skip restore **honestly** (`evidence.restore_skipped`).
  - `_check_from_spec` `WRITE_ONLY_OBSERVE` branch: replaces the MOR-199 `UNSUPPORTED` stub with `_write_gate` (SKIP on `--read-only`, UNSUPPORTED when capability absent) then `_set_and_observe`.
- **`tests/validation/test_hardware.py`**: replaced the old "unsupported stub" test with 8 set-and-observe tests (pass, bump_hz→0 restore, set-timeout FAIL, read-only SKIP, capability-absent UNSUPPORTED, missing set_op UNSUPPORTED, no-restore-default PASS, restore-error swallowed).

### Decisions
- **Status = `PASS` + distinct evidence**, not a new `CheckStatus` — no v1 schema/contract change, no ripple to summarize/compare/human-summary.
- **Restore** = best-effort SET to a `value_rule`-derived benign default (since the original is unreadable); honest evidence when no default exists or restore fails. RMVR's "always restore" intent preserved as far as a write-only control allows.
- **Mechanism only**: exercised via synthetic `WRITE_ONLY_OBSERVE` specs. No real radio is classified write-only yet → zero behaviour change for any shipped profile until MOR-208 lands the per-radio classification (then X6200 rit/xit/notch validate honestly on hardware, closing the false-FAIL part of MOR-179/MOR-207).
- Safety: RX-only; the authorization/tx-adjacent pre-gates are unchanged; TX/tuner never actuated.

### Gates
- `pytest tests/validation/test_hardware.py` → **34 passed**
- `pytest tests/` (no integration) → **6111 passed, 7 skipped, 11 xfailed** (no regressions)
- `ruff` / `mypy hardware.py` / `lint-imports` → clean

Linear: MOR-180 (mechanism). Sibling MOR-208 (classification). ADR MOR-196 §2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)