### PR TITLE
feat(MOR-208): per-radio write-only classification → set-and-observe

### DIFF
--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -102,6 +102,13 @@ values = [0, 1]
 modes = [0, 1, 2, 3]
 labels = { "0" = "OFF", "1" = "FAST", "2" = "SLOW", "3" = "AUTO" }
 
+# Per-radio validation classification (MOR-208). Controls whose capability
+# names appear here route through the validate set-and-observe engine path
+# (no read-first), so SET-but-no-GET controls report honest PASS instead of a
+# read-first-timeout FAIL. Each entry must be a declared [capabilities] feature.
+[validation]
+write_only_controls = ["rit", "xit"]  # X6200 RIT/XIT accept SET but GET times out (MOR-179)
+
 [controls.attenuator]
 style = "toggle"
 

--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -306,6 +306,19 @@ async def _run_hardware(
         print(f"Error: cannot build backend config: {exc}", file=sys.stderr)
         return 3
 
+    # Resolve the radio profile for per-radio validation classification
+    # (write-only controls, MOR-208). Best-effort: unknown model → no profile.
+    write_only_capabilities: frozenset[str] = frozenset()
+    if config.model:
+        from rigplane.profiles import get_radio_profile
+
+        try:
+            profile = get_radio_profile(config.model)
+        except KeyError:
+            profile = None
+        if profile is not None:
+            write_only_capabilities = profile.write_only_controls
+
     transport = _transport_info_from_config(config)
     radio = create_radio(config)
     exit_code = 0
@@ -317,6 +330,7 @@ async def _run_hardware(
                 safety,
                 allow_writes=not bool(getattr(args, "read_only", False)),
                 per_check_timeout=getattr(args, "timeout", 5.0) or 5.0,
+                write_only_capabilities=write_only_capabilities,
             )
     except (RigConnectionError, AuthenticationError, OSError, RigplaneError) as exc:
         levels = _transport_failure_levels(template, exc)
@@ -506,6 +520,9 @@ async def _run_hardware_hamlib(
                         safety,
                         allow_writes=not bool(getattr(args, "read_only", False)),
                         per_check_timeout=timeout,
+                        write_only_capabilities=(
+                            profile.write_only_controls if profile else frozenset()
+                        ),
                     )
             finally:
                 await bridge.stop()

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -199,6 +199,11 @@ class RadioProfile:
     sample_rate_by_codec: dict[str, int] | None = None
     browser_rx_transport: str | None = None
     browser_rx_transcode_to_opus: bool | None = None
+    # Capability names whose validate checks route through the set-and-observe
+    # engine path (no read-first) instead of read-modify-verify-restore. Data-
+    # driven from ``[validation].write_only_controls`` in the rig TOML (MOR-208).
+    # Empty by default: every control uses the standard RMVR path.
+    write_only_controls: frozenset[str] = frozenset()
 
     @property
     def vfo_swap_code(self) -> int | None:

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -114,6 +114,7 @@ class RigConfig:
     sample_rate_by_codec: dict[str, int] | None = None
     browser_rx_transport: str | None = None
     browser_rx_transcode_to_opus: bool | None = None
+    write_only_controls: tuple[str, ...] = ()
 
     def to_profile(self) -> RadioProfile:
         """Build a ``RadioProfile`` from this config."""
@@ -193,6 +194,7 @@ class RigConfig:
             sample_rate_by_codec=self.sample_rate_by_codec,
             browser_rx_transport=self.browser_rx_transport,
             browser_rx_transcode_to_opus=self.browser_rx_transcode_to_opus,
+            write_only_controls=frozenset(self.write_only_controls),
         )
 
     def to_command_map(self) -> CommandMap:
@@ -547,6 +549,19 @@ def load_rig(path: Path) -> RigConfig:
                 f"{filename}: unknown capability {cap!r}. "
                 f"Known: {sorted(KNOWN_CAPABILITIES)}"
             )
+
+    # Validate [validation].write_only_controls — each entry must be a declared
+    # capability. These route through the validate set-and-observe engine path
+    # (MOR-208) instead of read-modify-verify-restore.
+    feature_set = set(features)
+    write_only_raw = data.get("validation", {}).get("write_only_controls", [])
+    for c in write_only_raw:
+        if c not in feature_set:
+            raise RigLoadError(
+                f"{filename}: [validation].write_only_controls entry {c!r} "
+                f"is not a declared capability"
+            )
+    write_only_controls = tuple(write_only_raw)
 
     # Validate [vfo]
     vfo = data["vfo"]
@@ -934,6 +949,7 @@ def load_rig(path: Path) -> RigConfig:
         sample_rate_by_codec=sample_rate_by_codec,
         browser_rx_transport=browser_rx_transport,
         browser_rx_transcode_to_opus=browser_rx_transcode_to_opus,
+        write_only_controls=write_only_controls,
     )
 
 

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -125,6 +125,7 @@ async def execute_hardware_checks(
     *,
     allow_writes: bool,
     per_check_timeout: float = DEFAULT_PER_CHECK_TIMEOUT,
+    write_only_capabilities: frozenset[str] = frozenset(),
 ) -> list[LevelResult]:
     """Run a template's checks against an already-connected ``radio``.
 
@@ -144,6 +145,7 @@ async def execute_hardware_checks(
             safety,
             allow_writes=allow_writes,
             per_check_timeout=per_check_timeout,
+            write_only_capabilities=write_only_capabilities,
         )
         finished = _utcnow_iso()
         result = dataclasses.replace(result, started_at=started, finished_at=finished)
@@ -207,6 +209,7 @@ async def _run_one_check(
     *,
     allow_writes: bool,
     per_check_timeout: float,
+    write_only_capabilities: frozenset[str] = frozenset(),
 ) -> CheckResult:
     """Execute a single template entry, applying universal pre-gates first."""
     # Pre-gate 1: authorization for TX-adjacent checks.
@@ -231,6 +234,19 @@ async def _run_one_check(
         elif present is not None:
             evidence["capability_present"] = present
         return _base_result(entry, CheckStatus.UNSUPPORTED, evidence=evidence)
+
+    # Per-radio write-only classification (MOR-208): controls whose capability
+    # is declared write-only route through set-and-observe (no read-first),
+    # overriding any named RMVR handler. Falls through if the check has no spec.
+    if entry.capability and entry.capability in write_only_capabilities:
+        spec = get_spec(entry.check_id)
+        if spec is not None:
+            gate = _write_gate(radio, entry, allow_writes=allow_writes)
+            if gate is not None:
+                return gate
+            return await _set_and_observe(
+                radio, entry, spec, per_check_timeout=per_check_timeout
+            )
 
     # Pre-gate 4: SUPPORTED -> check-specific logic.
     handler = _SUPPORTED_HANDLERS.get(entry.check_id)

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from rigplane.command_map import CommandMap
-from rigplane.profiles import BandInfo, FreqRangeInfo, RadioProfile
+from rigplane.profiles import BandInfo, FreqRangeInfo, RadioProfile, get_radio_profile
 from rigplane.rig_loader import RigConfig, RigLoadError, discover_rigs, load_rig
 
 RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
@@ -765,3 +765,29 @@ browser_rx_transcode_to_opus = true
         toml = _MINIMAL_TOML + '\n[audio]\nbrowser_rx_transport = "rtmp"\n'
         with pytest.raises(RigLoadError, match="browser_rx_transport"):
             load_rig(_write_toml(tmp_path, toml))
+
+
+class TestWriteOnlyControls:
+    """[validation].write_only_controls parsing and propagation (MOR-208)."""
+
+    def test_write_only_controls_parsed(self, tmp_path):
+        # "scope" is declared in _MINIMAL_TOML's features; mark it write-only.
+        toml = _MINIMAL_TOML + '\n[validation]\nwrite_only_controls = ["scope"]\n'
+        rig = load_rig(_write_toml(tmp_path, toml))
+        assert rig.write_only_controls == ("scope",)
+        assert rig.to_profile().write_only_controls == frozenset({"scope"})
+
+    def test_write_only_controls_defaults_empty(self, tmp_path):
+        rig = load_rig(_write_toml(tmp_path, _MINIMAL_TOML))
+        assert rig.write_only_controls == ()
+        assert rig.to_profile().write_only_controls == frozenset()
+
+    def test_write_only_controls_must_be_declared_capability(self, tmp_path):
+        # "rit" is NOT in _MINIMAL_TOML's features.
+        toml = _MINIMAL_TOML + '\n[validation]\nwrite_only_controls = ["rit"]\n'
+        with pytest.raises(RigLoadError, match="rit"):
+            load_rig(_write_toml(tmp_path, toml))
+
+    def test_x6200_declares_rit_xit_write_only(self):
+        profile = get_radio_profile("X6200")
+        assert profile.write_only_controls >= {"rit", "xit"}

--- a/tests/test_validate_hamlib_provider.py
+++ b/tests/test_validate_hamlib_provider.py
@@ -362,3 +362,74 @@ async def test_await_tcp_ready_timeout() -> None:
     # Port is now closed; _await_tcp_ready should time out quickly.
     result = await _await_tcp_ready("127.0.0.1", closed_port, timeout=1.0)
     assert result is False
+
+
+async def test_run_hardware_forwards_write_only_capabilities(
+    monkeypatch: Any,
+) -> None:
+    """_run_hardware (native) forwards profile.write_only_controls to the
+    hardware runner as write_only_capabilities (MOR-208)."""
+    template = _identify_template()
+    safety = OperatorSafetyBlock()
+    native_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="X6200")
+    captured: dict[str, Any] = {}
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return native_config
+
+    def fake_create_radio(config: Any) -> Any:
+        return _FakeNativeRadio()
+
+    async def fake_execute(*args: Any, **kwargs: Any) -> Any:
+        captured["write_only_capabilities"] = kwargs.get("write_only_capabilities")
+        return []
+
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+    monkeypatch.setattr(
+        "rigplane.validation.hardware.execute_hardware_checks", fake_execute
+    )
+    monkeypatch.setattr(_validate, "_emit_artifact", lambda artifact, args: None)
+
+    await _validate._run_hardware(_base_args(read_only=False), template, safety)
+
+    assert captured["write_only_capabilities"] == frozenset({"rit", "xit"})
+
+
+async def test_run_hardware_hamlib_forwards_write_only_capabilities(
+    monkeypatch: Any,
+) -> None:
+    """_run_hardware_hamlib forwards profile.write_only_controls too."""
+    _FakeBridge.instances.clear()
+    template = _identify_template()
+    safety = OperatorSafetyBlock()
+    native_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="X6200")
+    captured: dict[str, Any] = {}
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return native_config
+
+    def fake_create_radio(config: Any) -> Any:
+        return _FakeNativeRadio()
+
+    async def fake_execute(*args: Any, **kwargs: Any) -> Any:
+        captured["write_only_capabilities"] = kwargs.get("write_only_capabilities")
+        return []
+
+    async def fake_await_tcp_ready(
+        host: str, port: int, *, timeout: float = 10.0
+    ) -> bool:
+        return True
+
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+    monkeypatch.setattr("rigplane.hamlib_bridge.HamlibBridge", _FakeBridge)
+    monkeypatch.setattr(
+        "rigplane.validation.hardware.execute_hardware_checks", fake_execute
+    )
+    monkeypatch.setattr(_validate, "_await_tcp_ready", fake_await_tcp_ready)
+    monkeypatch.setattr(_validate, "_emit_artifact", lambda artifact, args: None)
+
+    await _validate._run_hardware_hamlib(_base_args(), template, safety)
+
+    assert captured["write_only_capabilities"] == frozenset({"rit", "xit"})

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -19,6 +19,7 @@ import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+from rigplane.core.exceptions import TimeoutError as RigTimeoutError
 from rigplane.core.radio_protocol import Radio
 from rigplane.core.radio_state import RadioState
 from rigplane.core.types import AgcMode
@@ -154,6 +155,107 @@ async def test_default_run_produces_artifact_with_expected_statuses(connected_ra
     assert artifact.mode == "hardware"
     # Round-trips through schema validation.
     validate_artifact_dict(json.loads(json.dumps(artifact.to_dict())))
+
+
+def _write_only_rit_mock():
+    """A rit radio whose SET succeeds but GET times out (X6200 behaviour)."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"rit"}
+    radio.set_rit_frequency = AsyncMock(return_value=None)
+    radio.get_rit_frequency = AsyncMock(side_effect=RigTimeoutError("readback timeout"))
+    return radio
+
+
+async def test_write_only_cap_routes_to_set_observe():
+    """THE FIX: a write-only-classified cap routes through set-and-observe,
+    so a SET-only radio reports PASS instead of read-first-timeout FAIL."""
+    radio = _write_only_rit_mock()
+    template = _single_entry_template(check_id="rit.set", capability="rit")
+
+    # WITHOUT the write-only classification: the RMVR handler reads first and
+    # the readback timeout produces a FAIL.
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["rit.set"]
+    assert check.status is CheckStatus.FAIL
+    assert check.failure_domain is FailureDomain.COMMAND_EXECUTION
+
+    # WITH the classification: route through set-and-observe → honest PASS.
+    radio = _write_only_rit_mock()
+    levels = await execute_hardware_checks(
+        radio,
+        template,
+        OperatorSafetyBlock(),
+        allow_writes=True,
+        write_only_capabilities=frozenset({"rit"}),
+    )
+    check = _flatten(levels)["rit.set"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["verification"] == "set_observe"
+    assert check.evidence["handler"] == "set_and_observe"
+    radio.get_rit_frequency.assert_not_called()
+    # SET test value (100) then restore (0).
+    assert radio.set_rit_frequency.call_count == 2
+
+
+async def test_non_write_only_cap_still_uses_rmvr():
+    """A cap NOT in write_only_capabilities keeps the RMVR read-modify-verify
+    path even when other caps are classified write-only."""
+    radio, store = _stateful_preamp_mock(start=0)
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio,
+        template,
+        OperatorSafetyBlock(),
+        allow_writes=True,
+        write_only_capabilities=frozenset({"rit"}),
+    )
+    check = _flatten(levels)["preamp.set"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 0
+    assert check.evidence["changed"] == 1
+    assert check.evidence["restored"] is True
+    assert check.evidence.get("verification") != "set_observe"
+
+
+async def test_write_only_read_only_skips():
+    """Write-only cap under --read-only skips without touching the radio."""
+    radio = _write_only_rit_mock()
+    template = _single_entry_template(check_id="rit.set", capability="rit")
+    levels = await execute_hardware_checks(
+        radio,
+        template,
+        OperatorSafetyBlock(),
+        allow_writes=False,
+        write_only_capabilities=frozenset({"rit"}),
+    )
+    check = _flatten(levels)["rit.set"]
+    assert check.status is CheckStatus.SKIP
+    radio.set_rit_frequency.assert_not_called()
+
+
+async def test_write_only_cap_no_spec_falls_through():
+    """A cap in write_only_capabilities whose check_id has no registry spec
+    falls through to the named/SKIP path without crashing."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"madeup"}
+    template = _single_entry_template(
+        check_id="madeup.nonexistent", capability="madeup"
+    )
+    levels = await execute_hardware_checks(
+        radio,
+        template,
+        OperatorSafetyBlock(),
+        allow_writes=True,
+        write_only_capabilities=frozenset({"madeup"}),
+    )
+    check = _flatten(levels)["madeup.nonexistent"]
+    assert check.status is CheckStatus.SKIP
 
 
 async def test_rmvr_pass_on_stateful_mock():


### PR DESCRIPTION
## MOR-208 — per-radio write-only classification (the X6200 honest-validation fix)

Makes a radio's intrinsically write-only CI-V controls validate **honestly**: they route through the set-and-observe engine path (mechanism from MOR-180) instead of a read-first RMVR that times out and FAILs even though the control works (X6200 RIT/XIT — MOR-179). Sibling of MOR-180 (180b). Data-driven (Option B): write-only-ness is a **radio-firmware fact** declared in the rig profile, not the validation override layer.

After this, `validate --model X6200 --hardware --allow-hardware` is a trustworthy debugging report — every remaining FAIL is a **real** bug, not a false write-only timeout.

### What landed (8 files: 5 source + 3 test)
- **`rigs/x6200.toml`** — `[validation] write_only_controls = ["rit", "xit"]` (notch deferred pending a raw-CIV confirmation, MOR-207).
- **`profiles/rig_loader.py`** — parse `[validation].write_only_controls` → `RigConfig`; reject any entry not in the declared `[capabilities].features` (`RigLoadError`); thread into `RadioProfile`.
- **`profiles/__init__.py`** — `RadioProfile.write_only_controls: frozenset[str] = frozenset()`.
- **`validation/hardware.py`** — `execute_hardware_checks`/`_run_one_check` gain a keyword-only `write_only_capabilities: frozenset[str]`. A SUPPORTED check whose capability is in the set routes through `_write_gate` + `_set_and_observe` (overriding the named RMVR handler), inserted after the UNSUPPORTED_PENDING_EVIDENCE pre-gate and before the named-handler dispatch; falls through if the check has no registry spec. **No `profiles` import** — the set arrives as a plain frozenset param.
- **`cli/_validate.py`** — `_run_hardware` + `_run_hardware_hamlib` forward `profile.write_only_controls` (function-local `get_radio_profile`, guarded).

### Decisions (pinned in PLAN)
- **Engine-param / capability-based wiring** — no v1 template-schema change, no Generator A change, `validation` stays profile-free. (Override layer MOR-206 can add a template flag later, independently.)
- **rit + xit now; notch gated** on a live raw-CIV confirmation (MOR-207) — not committed blind.
- **Strict subset validation:** a `write_only_controls` entry must be a declared capability, else load error.
- Restore is RX-safe (rit→0, xit→off) via the MOR-180 `_WRITE_ONLY_RESTORE` map. Radios without the field are unaffected (full RMVR).

### Gates
- targeted `pytest` (rig_loader + hardware + cli) → **118 passed**
- `pytest tests/` (no integration) → **6121 passed, 7 skipped, 11 xfailed** (no regressions)
- `ruff` / `mypy` (4 source files) / `lint-imports` → clean · `hardware.py` confirmed free of any `rigplane.profiles` import

The regression-proof test: a fake radio whose `get_rit_frequency` times out but `set_rit_frequency` works → **FAIL (timeout) without** the param, **PASS (set_observe) with** `write_only_capabilities={"rit"}`.

Live X6200 write-enabled verification run by the orchestrator before merge.

Linear: MOR-208 (blocked-by MOR-180). Closes false-FAIL of MOR-179; MOR-207 (notch) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)