### PR TITLE
fix(MOR-207): classify X6200 manual notch as write-only

### DIFF
--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -107,7 +107,7 @@ labels = { "0" = "OFF", "1" = "FAST", "2" = "SLOW", "3" = "AUTO" }
 # (no read-first), so SET-but-no-GET controls report honest PASS instead of a
 # read-first-timeout FAIL. Each entry must be a declared [capabilities] feature.
 [validation]
-write_only_controls = ["rit", "xit"]  # X6200 RIT/XIT accept SET but GET times out (MOR-179)
+write_only_controls = ["rit", "xit", "notch"]  # SET accepted but GET times out / no echo (MOR-179 rit/xit, MOR-207 notch; raw-CIV confirmed)
 
 [controls.attenuator]
 style = "toggle"

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -788,6 +788,6 @@ class TestWriteOnlyControls:
         with pytest.raises(RigLoadError, match="rit"):
             load_rig(_write_toml(tmp_path, toml))
 
-    def test_x6200_declares_rit_xit_write_only(self):
+    def test_x6200_declares_rit_xit_notch_write_only(self):
         profile = get_radio_profile("X6200")
-        assert profile.write_only_controls >= {"rit", "xit"}
+        assert profile.write_only_controls >= {"rit", "xit", "notch"}


### PR DESCRIPTION
## MOR-207 — X6200 manual notch is write-only

Follow-up to MOR-180/MOR-208. A raw-CIV probe on live X6200 confirmed manual notch is **write-only**:

```
get_manual_notch → TimeoutError, 0 inbound frames (baseline ×2 + after set)
set_manual_notch(True/False) → accepted, no exception
```

Identical to RIT/XIT. So `notch.set`'s read-first RMVR was producing a false timeout-FAIL.

### Change (2 files)
- **`rigs/x6200.toml`** — add `"notch"` to `[validation].write_only_controls` → `["rit", "xit", "notch"]`.
- **`tests/test_rig_loader.py`** — assert X6200 declares all three.

### Live-verify (write-enabled, X6200)
`notch.set → pass` via `verification: set_observe`, `set_accepted: true`, restored to off. With this, **all three** X6200 write-only controls (rit/xit/notch) validate honestly — the X6200 `validate --model X6200 --hardware` report is now fully clean (no false FAILs).

Gates: `pytest tests/test_rig_loader.py` 70 passed; ruff clean. (Pure data + test; engine mechanism shipped in MOR-180/208.)

Closes MOR-207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)