### PR TITLE
fix(test): include notch in X6200 write_only_capabilities assertions

### DIFF
--- a/tests/test_validate_hamlib_provider.py
+++ b/tests/test_validate_hamlib_provider.py
@@ -393,7 +393,7 @@ async def test_run_hardware_forwards_write_only_capabilities(
 
     await _validate._run_hardware(_base_args(read_only=False), template, safety)
 
-    assert captured["write_only_capabilities"] == frozenset({"rit", "xit"})
+    assert captured["write_only_capabilities"] == frozenset({"rit", "xit", "notch"})
 
 
 async def test_run_hardware_hamlib_forwards_write_only_capabilities(
@@ -432,4 +432,4 @@ async def test_run_hardware_hamlib_forwards_write_only_capabilities(
 
     await _validate._run_hardware_hamlib(_base_args(), template, safety)
 
-    assert captured["write_only_capabilities"] == frozenset({"rit", "xit"})
+    assert captured["write_only_capabilities"] == frozenset({"rit", "xit", "notch"})


### PR DESCRIPTION
**Repairs red `main`.** MOR-207 (#1665) added `"notch"` to `rigs/x6200.toml` `[validation].write_only_controls`, so the X6200 profile now exposes `{rit, xit, notch}`. Two CLI-forwarding tests in `test_validate_hamlib_provider.py` still asserted the old `{rit, xit}` set and have been failing on `main` since #1665 merged — that PR's review ran only `tests/test_rig_loader.py`, not the full suite, so the cross-file assertion break was missed.

Fix: update both assertions (`test_run_hardware_forwards_write_only_capabilities`, `test_run_hardware_hamlib_forwards_write_only_capabilities`) to `frozenset({"rit", "xit", "notch"})`.

Test-only, 1 file. `pytest tests/test_validate_hamlib_provider.py` → 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)