### PR TITLE
feat(MOR-200): Hamlib dump_caps ingestion → normalized HamlibCaps

### DIFF
--- a/src/rigplane/backends/hamlib_models.py
+++ b/src/rigplane/backends/hamlib_models.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 __all__ = [
+    "HamlibCaps",
     "HamlibModelCatalog",
     "HamlibModelMetadata",
+    "load_hamlib_caps",
     "load_hamlib_model_catalog",
+    "parse_hamlib_dump_caps",
     "parse_hamlib_model_list",
 ]
 
@@ -136,3 +140,170 @@ def _load_from_tool(
         return None, "hamlib model list unavailable: no parseable models"
 
     return HamlibModelCatalog(models=models, source_tool=tool), ""
+
+
+# ---------------------------------------------------------------------------
+# HamlibCaps — normalized dump_caps view
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HamlibCaps:
+    """Normalized view of a Hamlib ``dump_caps`` output."""
+
+    get_funcs: frozenset[str] = frozenset()
+    set_funcs: frozenset[str] = frozenset()
+    get_levels: frozenset[str] = frozenset()
+    set_levels: frozenset[str] = frozenset()
+    modes: frozenset[str] = frozenset()
+    vfo_ops: frozenset[str] = frozenset()
+    ptt_type: str | None = None
+    has_set_freq: bool = False
+    model_id: int | None = None
+    degraded_reason: str | None = None
+
+
+def _parse_token(raw: str) -> str:
+    """Strip granularity annotation: ``RF(0..1/0.003922)`` → ``RF``."""
+    paren = raw.find("(")
+    return raw[:paren] if paren != -1 else raw
+
+
+def _parse_token_list(value: str) -> frozenset[str]:
+    """Parse a space-separated token list, stripping granularity annotations."""
+    return frozenset(t for raw in value.split() if (t := _parse_token(raw)))
+
+
+def parse_hamlib_dump_caps(text: str) -> HamlibCaps:
+    """Parse ``rigctl -m <id> --dump-caps`` stdout into a :class:`HamlibCaps`.
+
+    Only lines starting at column 0 (not indented) are dispatched, which
+    excludes ``Extra functions:``/``Extra levels:`` indented sub-blocks.
+    Never raises; returns a degraded :class:`HamlibCaps` on any error or
+    when no recognized sections are found.
+    """
+    try:
+        get_funcs: frozenset[str] = frozenset()
+        set_funcs: frozenset[str] = frozenset()
+        get_levels: frozenset[str] = frozenset()
+        set_levels: frozenset[str] = frozenset()
+        modes: frozenset[str] = frozenset()
+        vfo_ops: frozenset[str] = frozenset()
+        ptt_type: str | None = None
+        has_set_freq: bool = False
+        recognized = 0
+
+        for line in text.splitlines():
+            # Only dispatch column-0 lines; skip indented sub-blocks entirely.
+            if not line or line[0] in (" ", "\t"):
+                continue
+
+            if line.startswith("Get functions:"):
+                get_funcs = _parse_token_list(line[len("Get functions:") :])
+                recognized += 1
+            elif line.startswith("Set functions:"):
+                set_funcs = _parse_token_list(line[len("Set functions:") :])
+                recognized += 1
+            elif line.startswith("Get level gran:"):
+                get_levels = _parse_token_list(line[len("Get level gran:") :])
+                recognized += 1
+            elif line.startswith("Get level:"):
+                get_levels = _parse_token_list(line[len("Get level:") :])
+                recognized += 1
+            elif line.startswith("Set level gran:"):
+                set_levels = _parse_token_list(line[len("Set level gran:") :])
+                recognized += 1
+            elif line.startswith("Set level:"):
+                set_levels = _parse_token_list(line[len("Set level:") :])
+                recognized += 1
+            elif line.startswith("Mode list:"):
+                modes = _parse_token_list(line[len("Mode list:") :])
+                recognized += 1
+            elif line.startswith("VFO Ops:"):
+                vfo_ops = _parse_token_list(line[len("VFO Ops:") :])
+                recognized += 1
+            elif line.startswith("PTT type:"):
+                raw_val = line[len("PTT type:") :].strip()
+                ptt_type = None if raw_val == "None" else (raw_val or None)
+                recognized += 1
+            elif line.startswith("Can set Frequency:"):
+                raw_val = line[len("Can set Frequency:") :].strip()
+                has_set_freq = raw_val == "Y"
+                recognized += 1
+
+        if recognized == 0:
+            return HamlibCaps(
+                degraded_reason="dump_caps parse produced no recognized sections"
+            )
+
+        return HamlibCaps(
+            get_funcs=get_funcs,
+            set_funcs=set_funcs,
+            get_levels=get_levels,
+            set_levels=set_levels,
+            modes=modes,
+            vfo_ops=vfo_ops,
+            ptt_type=ptt_type,
+            has_set_freq=has_set_freq,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("dump_caps parse failed", exc_info=True)
+        return HamlibCaps(
+            degraded_reason="dump_caps parse produced no recognized sections"
+        )
+
+
+def load_hamlib_caps(
+    model_id: int,
+    tool: str = "rigctl",
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> HamlibCaps:
+    """Shell out to ``rigctl -m <model_id> --dump-caps`` and parse the result.
+
+    Mirrors ``_load_from_tool`` error-handling: missing tool, timeout, OS
+    errors, and nonzero exit codes all degrade to an empty :class:`HamlibCaps`
+    with a fixed ``degraded_reason``. Raw subprocess output is NEVER
+    interpolated into ``degraded_reason``.
+    """
+    try:
+        completed = subprocess.run(
+            [tool, "-m", str(model_id), "--dump-caps"],
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        logger.debug("dump_caps tool not found: %s", tool)
+        return HamlibCaps(
+            degraded_reason="dump_caps unavailable: tool not found",
+            model_id=model_id,
+        )
+    except subprocess.TimeoutExpired:
+        logger.debug("dump_caps command timed out: %s model=%d", tool, model_id)
+        return HamlibCaps(
+            degraded_reason="dump_caps unavailable: command timed out",
+            model_id=model_id,
+        )
+    except OSError as exc:
+        logger.debug("dump_caps command failed to start: %s: %s", tool, exc)
+        return HamlibCaps(
+            degraded_reason="dump_caps unavailable: command failed",
+            model_id=model_id,
+        )
+
+    if completed.returncode != 0:
+        logger.debug(
+            "dump_caps command failed: %s model=%d rc=%d",
+            tool,
+            model_id,
+            completed.returncode,
+        )
+        return HamlibCaps(
+            degraded_reason="dump_caps unavailable: command failed",
+            model_id=model_id,
+        )
+
+    caps = parse_hamlib_dump_caps(completed.stdout or "")
+    return dataclasses.replace(caps, model_id=model_id)

--- a/tests/fixtures/hamlib_dump_caps_ts480.txt
+++ b/tests/fixtures/hamlib_dump_caps_ts480.txt
@@ -1,0 +1,476 @@
+Caps dump for model: 2028
+Model name:	TS-480
+Mfg name:	Kenwood
+Hamlib version:	Hamlib 4.7.1 2026-04-15T20:20:01Z SHA=d042479a9 64-bit
+Backend version:	20250515.3
+Backend copyright:	LGPL
+Backend status:	Stable
+Rig type:	Other Receiver Transmitter Transceiver 
+PTT type:	None
+DCD type:	Rig capable
+Port type:	RS-232
+Serial speed: 4800..115200 baud, 8N1, ctrl=NONE
+Write delay: 0ms, timeout 500ms, 3 retry
+Post write delay: 0ms
+Has targetable VFO: Y
+Targetable features: FREQ
+Has async data support: N
+Announce: 0x0
+Max RIT: -9.990kHz/+9.990kHz
+Max XIT: -9.990kHz/+9.990kHz
+Max IF-SHIFT: -0.0kHz/+0.0kHz
+Preamp: 12dB
+Attenuator: 12dB
+AGC levels: 0=OFF 2=FAST 3=SLOW
+CTCSS: None
+DCS: None
+Get functions: NB COMP VOX FBKIN NR MON LOCK BC RIT TUNER XIT BC2 
+Set functions: NB COMP VOX FBKIN NR MON LOCK BC RIT TUNER XIT BC2 
+Extra functions:
+	NR2
+		Type: CHECKBUTTON
+		Default: 
+		Label: Noise reduction 2
+		Tooltip: Noise reduction 2
+	CW_IF_FOR_SSB_RX
+		Type: CHECKBUTTON
+		Default: 
+		Label: CW IF filter for SSB
+		Tooltip: Use CW IF filter for SSB reception
+	FILTER_WIDTH_DATA
+		Type: CHECKBUTTON
+		Default: 
+		Label: Filter bandwidth for data
+		Tooltip: Filter bandwidth for data communications
+	TX_AUDIO_FROM_DATA_INPUT
+		Type: CHECKBUTTON
+		Default: 
+		Label: TX audio from data input
+		Tooltip: Transmit with audio input from the data terminal
+Get level: PREAMP(0..20/10) ATT(0..12/0) VOXDELAY(0..30/1) AF(0.000000..1.000000/0.003922) RF(0.000000..1.000000/0.003922) SQL(0.000000..1.000000/0.010000) NR(0.000000..1.000000/0.100000) CWPITCH(400..1000/50) RFPOWER(0.050000..1.000000/0.010000) MICGAIN(0.000000..1.000000/0.010000) KEYSPD(10..60/1) COMP(0.000000..1.000000/0.010000) AGC(0..0/0) VOXGAIN(0.000000..1.000000/0.010000) SLOPE_LOW(0..2400/10) SLOPE_HIGH(0..5000/10) BKIN_DLYMS(0..1000/50) SWR(0.000000..5.000000/0.003922) ALC(0.000000..1.000000/0.010000) STRENGTH(0..60/0) RFPOWER_METER(0.000000..1.000000/0.003922) COMP_METER(0.000000..1.000000/0.003922) MONITOR_GAIN(0.000000..1.000000/0.010000) NB(0.000000..1.000000/0.100000) 
+Set level: PREAMP(0..20/10) ATT(0..12/0) VOXDELAY(0..30/1) AF(0.000000..1.000000/0.003922) RF(0.000000..1.000000/0.003922) SQL(0.000000..1.000000/0.010000) NR(0.000000..1.000000/0.100000) CWPITCH(400..1000/50) RFPOWER(0.050000..1.000000/0.010000) MICGAIN(0.000000..1.000000/0.010000) KEYSPD(10..60/1) COMP(0.000000..1.000000/0.010000) AGC(0..0/0) METER(0..0/0) VOXGAIN(0.000000..1.000000/0.010000) SLOPE_LOW(0..2400/10) SLOPE_HIGH(0..5000/10) BKIN_DLYMS(0..1000/50) MONITOR_GAIN(0.000000..1.000000/0.010000) NB(0.000000..1.000000/0.100000) 
+Extra levels:
+	DIGITAL_NOISE_LIMITER
+		Type: COMBO
+		Default: 
+		Label: Digital Noise Limiter
+		Tooltip: Digital Noise Limiter
+		Values: 0="OFF" 1="DNL Level 1" 2="DNL Level 2" 3="DNL Level 3"
+	DSP_RX_EQUALIZER
+		Type: COMBO
+		Default: 
+		Label: DSP RX equalizer
+		Tooltip: DSP RX equalizer type
+		Values: 0="OFF" 1="Hb1" 2="Hb2" 3="FP" 4="bb1" 5="bb2" 6="c" 7="U"
+	DSP_TX_EQUALIZER
+		Type: COMBO
+		Default: 
+		Label: DSP TX equalizer
+		Tooltip: DSP TX equalizer type
+		Values: 0="OFF" 1="Hb1" 2="Hb2" 3="FP" 4="bb1" 5="bb2" 6="c" 7="U"
+	DSP_TX_BANDWIDTH
+		Type: COMBO
+		Default: 
+		Label: DSP TX bandwidth
+		Tooltip: DSP TX bandwidth for SSB and AM
+		Values: 0="2.0 kHz" 1="2.4 kHz"
+	BEEP_VOLUME
+		Type: NUMERIC
+		Default: 
+		Label: Beep volume
+		Tooltip: Beep volume
+		Range: 0.000000..9.000000/1.000000
+	TX_SIDETONE_VOLUME
+		Type: NUMERIC
+		Default: 
+		Label: TX sidetone volume
+		Tooltip: TX sidetone volume
+		Range: 0.000000..9.000000/1.000000
+	AF_INPUT_LEVEL
+		Type: NUMERIC
+		Default: 
+		Label: AF input level
+		Tooltip: AF input level for data communications
+		Range: 0.000000..9.000000/1.000000
+	AF_OUTPUT_LEVEL
+		Type: NUMERIC
+		Default: 
+		Label: AF output level
+		Tooltip: AF output level for data communications
+		Range: 0.000000..9.000000/1.000000
+Get parameters: 
+Set parameters: 
+Extra parameters:
+Mode list: AM CW USB LSB RTTY FM CWR RTTYR
+VFO list: VFOA VFOB 
+VFO Ops: CPY UP DOWN BAND_UP BAND_DOWN TUNE 
+Scan Ops: 
+Number of banks:	0
+Memory name desc size:	0
+Memories:
+	1..3:   	VOICE
+	  Mem caps: 
+	1..3:   	MORSE
+	  Mem caps: 
+TX ranges #1 for TBD:
+	1810000 Hz - 1850000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	1810000 Hz - 1850000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	3500000 Hz - 3800000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	3500000 Hz - 3800000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	7000000 Hz - 7200000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	7000000 Hz - 7200000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	10100000 Hz - 10150000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	10100000 Hz - 10150000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	14000000 Hz - 14350000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	14000000 Hz - 14350000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	18068000 Hz - 18168000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	18068000 Hz - 18168000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	21000000 Hz - 21450000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	21000000 Hz - 21450000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	24890000 Hz - 24990000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	24890000 Hz - 24990000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	28000000 Hz - 29700000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	28000000 Hz - 29700000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	50000000 Hz - 52000000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	50000000 Hz - 52000000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+RX ranges #1 for TBD:
+	100000 Hz - 59999999 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM CW USB LSB RTTY FM CWR RTTYR
+		Antenna list: ANT_NONE
+TX ranges #2 for TBD:
+	1800000 Hz - 1999999 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	1800000 Hz - 1999999 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	3500000 Hz - 3999999 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	3500000 Hz - 3999999 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	5250000 Hz - 5450000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	5250000 Hz - 5450000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	7000000 Hz - 7300000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	7000000 Hz - 7300000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	10100000 Hz - 10150000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	10100000 Hz - 10150000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	14000000 Hz - 14350000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	14000000 Hz - 14350000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	18068000 Hz - 18168000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	18068000 Hz - 18168000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	21000000 Hz - 21450000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	21000000 Hz - 21450000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	24890000 Hz - 24990000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	24890000 Hz - 24990000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	28000000 Hz - 29700000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	28000000 Hz - 29700000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+	50000000 Hz - 52000000 Hz
+		VFO list: VFOA VFOB 
+		Mode list:  CW USB LSB RTTY FM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 100 W
+	50000000 Hz - 52000000 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM
+		Antenna list: ANT_NONE
+		Low power: 5 W, High power: 25 W
+RX ranges #2 for TBD:
+	100000 Hz - 59999999 Hz
+		VFO list: VFOA VFOB 
+		Mode list: AM CW USB LSB RTTY FM CWR RTTYR
+		Antenna list: ANT_NONE
+TX ranges #3 for TBD:
+RX ranges #3 for TBD:
+TX ranges #4 for TBD:
+RX ranges #4 for TBD:
+TX ranges #5 for TBD:
+RX ranges #5 for TBD:
+TX ranges #1 status for TBD:	OK (0)
+RX ranges #1 status for TBD:	OK (0)
+TX ranges #2 status for TBD:	OK (0)
+RX ranges #2 status for TBD:	OK (0)
+TX ranges #3 status for TBD:	OK (0)
+RX ranges #3 status for TBD:	OK (0)
+TX ranges #4 status for TBD:	OK (0)
+RX ranges #4 status for TBD:	OK (0)
+TX ranges #5 status for TBD:	OK (0)
+RX ranges #5 status for TBD:	OK (0)
+Tuning steps:
+	1.0000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	2.5000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	5.0000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	6.2500 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	10.0000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	12.5000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	15.0000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	20.0000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	25.0000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	30.0000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	100.0000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	500.0000 kHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	1.0000000 MHz:   	AM CW USB LSB RTTY FM CWR RTTYR
+	ANY:   	AM CW USB LSB RTTY FM CWR RTTYR
+Tuning steps status:	OK (0)
+Filters:
+	2.4000 kHz:   	 USB LSB
+	270.0 Hz:   	 USB LSB
+	500.0 Hz:   	 USB LSB
+	200.0 Hz:   	 CW CWR
+	50.0 Hz:   	 CW CWR
+	1.0000 kHz:   	 CW CWR
+	80.0 Hz:   	 CW CWR
+	100.0 Hz:   	 CW CWR
+	150.0 Hz:   	 CW CWR
+	300.0 Hz:   	 CW CWR
+	400.0 Hz:   	 CW CWR
+	500.0 Hz:   	 CW CWR
+	600.0 Hz:   	 CW CWR
+	2.0000 kHz:   	 CW CWR
+	500.0 Hz:   	 RTTY RTTYR
+	250.0 Hz:   	 RTTY RTTYR
+	1.0000 kHz:   	 RTTY RTTYR
+	1.5000 kHz:   	 RTTY RTTYR
+	6.0000 kHz:   	AM
+	2.4000 kHz:   	AM
+	12.0000 kHz:   	 FM
+Bandwidths:
+	AM	Normal: 6.0000 kHz,	Narrow: 2.4000 kHz,	Wide: 0.0 Hz
+	CW	Normal: 200.0 Hz,	Narrow: 50.0 Hz,	Wide: 1.0000 kHz
+	USB	Normal: 2.4000 kHz,	Narrow: 270.0 Hz,	Wide: 0.0 Hz
+	LSB	Normal: 2.4000 kHz,	Narrow: 270.0 Hz,	Wide: 0.0 Hz
+	RTTY	Normal: 500.0 Hz,	Narrow: 250.0 Hz,	Wide: 1.0000 kHz
+	FM	Normal: 12.0000 kHz,	Narrow: 0.0 Hz,	Wide: 0.0 Hz
+	CWR	Normal: 200.0 Hz,	Narrow: 50.0 Hz,	Wide: 1.0000 kHz
+	RTTYR	Normal: 500.0 Hz,	Narrow: 250.0 Hz,	Wide: 1.0000 kHz
+Spectrum scopes: None
+Spectrum modes: 
+Spectrum spans: 
+Spectrum averaging modes: 
+Spectrum attenuator: None
+Has priv data:	Y
+Has Init:	Y
+Has Cleanup:	Y
+Has Open:	Y
+Has Close:	N
+Can set Conf:	N
+Can get Conf:	N
+Can set Frequency:	Y
+Can get Frequency:	Y
+Can set Mode:	Y
+Can get Mode:	Y
+Can set VFO:	Y
+Can get VFO:	Y
+Can set PTT:	Y
+Can get PTT:	Y
+Can get DCD:	Y
+Can set Repeater Duplex:	N
+Can get Repeater Duplex:	N
+Can set Repeater Offset:	N
+Can get Repeater Offset:	N
+Can set Split Freq:	E
+Can get Split Freq:	E
+Can set Split Mode:	E
+Can get Split Mode:	E
+Can set Split VFO:	Y
+Can get Split VFO:	Y
+Can set Tuning Step:	N
+Can get Tuning Step:	N
+Can set RIT:	Y
+Can get RIT:	Y
+Can set XIT:	Y
+Can get XIT:	Y
+Can set CTCSS:	N
+Can get CTCSS:	N
+Can set DCS:	N
+Can get DCS:	N
+Can set CTCSS Squelch:	N
+Can get CTCSS Squelch:	N
+Can set DCS Squelch:	N
+Can get DCS Squelch:	N
+Can set Power Stat:	Y
+Can get Power Stat:	Y
+Can Reset:	Y
+Can get Ant:	Y
+Can set Ant:	Y
+Can set Transceive:	E
+Can get Transceive:	N
+Can set Func:	Y
+Can get Func:	Y
+Can set Level:	Y
+Can get Level:	Y
+Can set Param:	N
+Can get Param:	N
+Can send DTMF:	N
+Can recv DTMF:	N
+Can send Morse:	Y
+Can stop Morse:	N
+Can wait Morse:	Y
+Can send Voice:	Y
+Can decode Events:	N
+Can set Bank:	N
+Can set Mem:	N
+Can get Mem:	N
+Can set Channel:	N
+Can get Channel:	N
+Can ctl Mem/VFO:	Y
+Can Scan:	Y
+Can get Info:	Y
+Can get power2mW:	N
+Can get mW2power:	N
+
+Overall backend warnings: 0   

--- a/tests/test_hamlib_dump_caps.py
+++ b/tests/test_hamlib_dump_caps.py
@@ -1,0 +1,289 @@
+"""Tests for Hamlib dump_caps parsing and subprocess loading."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from rigplane.backends.hamlib_models import (
+    HamlibCaps,  # noqa: F401 — exported symbol; validated by isinstance checks below
+    load_hamlib_caps,
+    parse_hamlib_dump_caps,
+)
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "hamlib_dump_caps_ts480.txt"
+
+
+# ---------------------------------------------------------------------------
+# 1. Parse fixture — real TS-480 dump
+# ---------------------------------------------------------------------------
+
+
+def test_parse_fixture_funcs_and_levels() -> None:
+    caps = parse_hamlib_dump_caps(_FIXTURE.read_text(encoding="utf-8"))
+
+    # get_funcs populated from "Get functions:" line
+    assert "NB" in caps.get_funcs
+    assert "COMP" in caps.get_funcs
+
+    # set_funcs populated
+    assert "NB" in caps.set_funcs
+
+    # get_levels from "Get level:" line — granularity stripped
+    assert "AF" in caps.get_levels
+    assert "STRENGTH" in caps.get_levels
+    assert "RF" in caps.get_levels
+
+    # set_levels from "Set level:" line
+    assert "AF" in caps.set_levels
+
+    # modes from "Mode list:"
+    assert {"USB", "LSB", "CW", "AM"} <= caps.modes
+
+    # VFO ops
+    assert "TUNE" in caps.vfo_ops
+    assert "CPY" in caps.vfo_ops
+
+    # has_set_freq
+    assert caps.has_set_freq is True
+
+    # PTT type: None  →  ptt_type=None
+    assert caps.ptt_type is None
+
+    # no degradation
+    assert caps.degraded_reason is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Level granularity stripped: FOO(0..1/…) → "FOO"
+# ---------------------------------------------------------------------------
+
+
+def test_level_granularity_stripped() -> None:
+    text = "Get level: RF(0.000000..1.000000/0.003922) AF(0..100/1)\n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.get_levels == frozenset({"RF", "AF"})
+
+
+def test_level_granularity_stripped_parens_and_dots() -> None:
+    text = "Set level: CWPITCH(400..1000/50) NR(0.000000..1.000000/0.100000)\n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.set_levels == frozenset({"CWPITCH", "NR"})
+
+
+# ---------------------------------------------------------------------------
+# 3. Missing section → empty set
+# ---------------------------------------------------------------------------
+
+
+def test_missing_vfo_ops_is_empty() -> None:
+    text = "Get functions: NB\nMode list: USB LSB\nCan set Frequency:\tY\n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.vfo_ops == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# 4. Empty section (trailing space) → empty set, no empty string token
+# ---------------------------------------------------------------------------
+
+
+def test_empty_get_functions_line() -> None:
+    text = "Get functions: \n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.get_funcs == frozenset()
+    assert "" not in caps.get_funcs
+
+
+def test_empty_mode_list() -> None:
+    text = "Mode list:  \n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.modes == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# 5. Extra whitespace tolerated
+# ---------------------------------------------------------------------------
+
+
+def test_extra_whitespace_in_token_list() -> None:
+    text = "Get functions:  NB   COMP   VOX  \n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.get_funcs == frozenset({"NB", "COMP", "VOX"})
+
+
+# ---------------------------------------------------------------------------
+# 6. Extra functions/levels indented block NOT swallowed
+# ---------------------------------------------------------------------------
+
+
+def test_extra_functions_indented_block_not_swallowed() -> None:
+    text = (
+        "Get functions: NB\n"
+        "Extra functions:\n"
+        "\tNR2\n"
+        "\t\tType: CHECKBUTTON\n"
+        "\tCW_IF_FOR_SSB_RX\n"
+    )
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.get_funcs == frozenset({"NB"})
+    assert "NR2" not in caps.get_funcs
+    assert "CW_IF_FOR_SSB_RX" not in caps.get_funcs
+
+
+def test_extra_levels_indented_block_not_swallowed() -> None:
+    text = (
+        "Get level: AF(0..1/0.003922)\n"
+        "Extra levels:\n"
+        "\tDIGITAL_NOISE_LIMITER\n"
+        "\t\tType: COMBO\n"
+    )
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.get_levels == frozenset({"AF"})
+    assert "DIGITAL_NOISE_LIMITER" not in caps.get_levels
+
+
+# ---------------------------------------------------------------------------
+# 7. Malformed/garbage input → degraded, no raise
+# ---------------------------------------------------------------------------
+
+
+def test_garbage_input_does_not_raise() -> None:
+    caps = parse_hamlib_dump_caps(
+        "!!!totally garbage\x00\x01 binary\nno sections here\n"
+    )
+    assert caps.degraded_reason is not None
+    assert caps.get_funcs == frozenset()
+    assert caps.modes == frozenset()
+
+
+def test_empty_string_input_degrades() -> None:
+    caps = parse_hamlib_dump_caps("")
+    assert caps.degraded_reason is not None
+
+
+# ---------------------------------------------------------------------------
+# 8. PTT type variants
+# ---------------------------------------------------------------------------
+
+
+def test_ptt_type_rts() -> None:
+    text = "PTT type:\tRTS\n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.ptt_type == "RTS"
+
+
+def test_ptt_type_none_string() -> None:
+    text = "PTT type:\tNone\n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.ptt_type is None
+
+
+def test_ptt_type_rig() -> None:
+    text = "PTT type:\tRig capable\n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.ptt_type == "Rig capable"
+
+
+# ---------------------------------------------------------------------------
+# 9. Can set Frequency: N → has_set_freq False
+# ---------------------------------------------------------------------------
+
+
+def test_can_set_frequency_n() -> None:
+    text = "Can set Frequency:\tN\n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.has_set_freq is False
+
+
+def test_can_set_frequency_y() -> None:
+    text = "Can set Frequency:\tY\n"
+    caps = parse_hamlib_dump_caps(text)
+    assert caps.has_set_freq is True
+
+
+# ---------------------------------------------------------------------------
+# 10. load_hamlib_caps monkeypatch — success path
+# ---------------------------------------------------------------------------
+
+
+def test_load_hamlib_caps_success(monkeypatch) -> None:
+    fixture_text = _FIXTURE.read_text(encoding="utf-8")
+    captured_args: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured_args.append(list(args))
+        assert kwargs.get("shell") is False
+        return subprocess.CompletedProcess(args, 0, stdout=fixture_text, stderr="")
+
+    monkeypatch.setattr("rigplane.backends.hamlib_models.subprocess.run", fake_run)
+
+    caps = load_hamlib_caps(2028)
+
+    assert captured_args == [["rigctl", "-m", "2028", "--dump-caps"]]
+    assert caps.model_id == 2028
+    assert caps.degraded_reason is None
+    assert "NB" in caps.get_funcs
+    assert caps.has_set_freq is True
+
+
+# ---------------------------------------------------------------------------
+# 11. load_hamlib_caps FileNotFoundError → empty degraded, no raise
+# ---------------------------------------------------------------------------
+
+
+def test_load_hamlib_caps_tool_not_found(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "rigplane.backends.hamlib_models.subprocess.run",
+        lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError("rigctl")),
+    )
+
+    caps = load_hamlib_caps(2028)
+
+    assert caps.degraded_reason is not None
+    assert caps.model_id == 2028
+    assert caps.get_funcs == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# 12. Timeout doesn't leak secrets
+# ---------------------------------------------------------------------------
+
+
+def test_load_hamlib_caps_timeout_does_not_leak(monkeypatch) -> None:
+    def fake_run(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(
+            args, timeout=0.1, output="SECRET=xyz", stderr="token=topsecret"
+        )
+
+    monkeypatch.setattr("rigplane.backends.hamlib_models.subprocess.run", fake_run)
+
+    caps = load_hamlib_caps(2028)
+
+    assert caps.degraded_reason is not None
+    assert "SECRET" not in str(caps)
+    assert "SECRET" not in (caps.degraded_reason or "")
+    assert "topsecret" not in str(caps)
+
+
+# ---------------------------------------------------------------------------
+# 13. Nonzero return code → empty degraded
+# ---------------------------------------------------------------------------
+
+
+def test_load_hamlib_caps_nonzero_rc(monkeypatch) -> None:
+    def fake_run(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args, 1, stdout="", stderr="some error on stderr"
+        )
+
+    monkeypatch.setattr("rigplane.backends.hamlib_models.subprocess.run", fake_run)
+
+    caps = load_hamlib_caps(2028)
+
+    assert caps.degraded_reason is not None
+    assert caps.get_funcs == frozenset()
+    assert "some error" not in (caps.degraded_reason or "")


### PR DESCRIPTION
## MOR-200 — Hamlib `dump_caps` ingestion + normalized `HamlibCaps`

Parses `rigctl -m <id> --dump-caps` into a clean `HamlibCaps` view so **Generator B** (MOR-201) and the **profile converter** (MOR-203) consume a normalized capability set instead of raw text. **Parser + dataclass only** — the rigplane-capability↔hamlib-token map already lives on `CheckSpec.hamlib_token` (MOR-197); the consumption (token ∈ caps?) is Generator B. ADR §5.1.

### What landed (3 files)
- **`src/rigplane/backends/hamlib_models.py`** (off the `validation` import graph; mirrors the catalog loader's shell-out + graceful-degrade + no-stdout-leak pattern):
  - `HamlibCaps` frozen dataclass: `get/set_funcs`, `get/set_levels`, `modes`, `vfo_ops`, `ptt_type`, `has_set_freq`, `model_id`, `degraded_reason`.
  - `parse_hamlib_dump_caps(text)`: column-0 prefix dispatch; strips level granularity `TOKEN(min..max/step)` → `TOKEN`; ignores tab-indented `Extra functions/levels` blocks; tolerates version-variant headers (`Get level` vs `Get level gran`); **never raises** — degrades to an empty `HamlibCaps` with a fixed `degraded_reason` (no raw-input echo).
  - `load_hamlib_caps(model_id)`: shells `rigctl -m <id> --dump-caps`, degrades to empty on missing tool / timeout / nonzero rc, never leaking stdout/stderr.
- **`tests/test_hamlib_dump_caps.py`** — 20 tests (parse real fixture, granularity strip, missing/empty section, whitespace, Extra-block exclusion, malformed→empty-no-raise, ptt/freq, `load_hamlib_caps` monkeypatched subprocess incl. missing-tool/timeout-no-secret-leak/nonzero-rc).
- **`tests/fixtures/hamlib_dump_caps_ts480.txt`** — verbatim captured `rigctl -m 2028 --dump-caps`.

### Gates
- `pytest tests/test_hamlib_dump_caps.py tests/test_hamlib_models.py` → 28 passed
- full suite (no integration) → **6141 passed** (rebased on the #1667 main fix)
- ruff / mypy (`hamlib_models.py`) / lint-imports → clean · no `validation` import

Linear: MOR-200. Next: MOR-201 (Generator B) consumes this + the registry token map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)