### PR TITLE
fix(MOR-182): harden rigctld-client response alignment over the bridge

### DIFF
--- a/src/rigplane/backends/rigctld_client/transport.py
+++ b/src/rigplane/backends/rigctld_client/transport.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from ...exceptions import CommandError
 from ...exceptions import ConnectionError as RadioConnectionError
 from ...exceptions import TimeoutError as RadioTimeoutError
+
+_LOGGER = logging.getLogger(__name__)
 
 _ERROR_HINTS = {
     -1: "invalid parameter",
@@ -64,12 +67,29 @@ class RigctldTransport:
         except OSError:
             pass
 
+    async def _drain_stale(self) -> None:
+        """Discard any unread bytes left in the socket buffer from a prior
+        transaction (e.g. a late/out-of-band frame the bridge injected) so the
+        next command reads only its own reply."""
+        reader = self._reader
+        if reader is None:
+            return
+        while True:
+            try:
+                chunk = await asyncio.wait_for(reader.read(4096), timeout=0.001)
+            except (asyncio.TimeoutError, TimeoutError):
+                return
+            if not chunk:
+                return  # EOF
+            _LOGGER.debug("rigctld transport: drained %d stale bytes", len(chunk))
+
     async def query(self, command: str, *, response_lines: int) -> list[str]:
         """Send a command and read a fixed number of response lines."""
         if response_lines <= 0:
             raise ValueError("response_lines must be > 0")
 
         async with self._lock:
+            await self._drain_stale()
             await self._write_line(command)
             lines: list[str] = []
             for _ in range(response_lines):
@@ -88,8 +108,37 @@ class RigctldTransport:
     async def command(self, command: str) -> None:
         """Send a write command and require ``RPRT 0`` success."""
         async with self._lock:
+            await self._drain_stale()
             await self._write_line(command)
+            # Re-sync: do ONE blocking read for the server's response.
+            # If it is not RPRT-shaped (stray value line that arrived in the
+            # same transaction window), attempt non-blocking reads to find the
+            # real RPRT that should be buffered right behind it.  We only skip
+            # lines that have an immediately-buffered successor — a lone
+            # malformed response (nothing else buffered) is left in `line` so
+            # that _parse_rprt can raise its normal "malformed" CommandError.
+            _MAX_RESYNC = 4
             line = await self._read_line(command)
+            reader = self._reader
+            for _ in range(_MAX_RESYNC - 1):
+                if line.startswith("RPRT ") or reader is None:
+                    break
+                try:
+                    raw = await asyncio.wait_for(reader.readline(), timeout=0.001)
+                except (asyncio.TimeoutError, TimeoutError):
+                    # Nothing else buffered — `line` is the actual response.
+                    break
+                if not raw:
+                    break  # EOF
+                _LOGGER.debug(
+                    "rigctld transport: skipping non-RPRT line for %r: %r",
+                    command,
+                    line,
+                )
+                try:
+                    line = raw.decode("ascii").rstrip("\r\n")
+                except UnicodeDecodeError:
+                    line = raw.decode("latin-1").rstrip("\r\n")
 
         code = _parse_rprt(line, command)
         if code < 0:

--- a/tests/fake_rigctld.py
+++ b/tests/fake_rigctld.py
@@ -54,6 +54,7 @@ class FakeRigctldBehavior:
     disconnect_commands: set[str] = field(default_factory=set)
     malformed_responses: dict[str, bytes] = field(default_factory=dict)
     unsupported_commands: set[str] = field(default_factory=set)
+    extra_lines: dict[str, bytes] = field(default_factory=dict)
 
 
 class FakeRigctldServer:
@@ -181,6 +182,10 @@ class FakeRigctldServer:
 
                 if key in _QUIT:
                     break
+
+                extra = _lookup(self.behavior.extra_lines, line, key)
+                if extra is not None:
+                    await _write_response(writer, extra)
 
                 await _write_response(writer, self._response_for(line, key))
         except (ConnectionError, OSError):

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -285,3 +285,77 @@ def test_level_scale_conversions_roundtrip_and_clamp() -> None:
     assert _float_to_level_255(2.0) == 255
     assert _float_to_level_255(0.0) == 0
     assert _float_to_level_255(1.0) == 255
+
+
+# ---------------------------------------------------------------------------
+# Stale-buffer / re-sync hardening tests (MOR-182)
+# ---------------------------------------------------------------------------
+
+
+async def test_command_drains_stray_preceding_line() -> None:
+    """SET command must succeed even when a stray value line precedes RPRT 0.
+
+    Regression: L AF 0.784 → server sends "0.0392157\\nRPRT 0\\n"; transport
+    used to read only one line, consuming the stray value and then
+    _parse_rprt("0.0392157") raised CommandError.
+    """
+    behavior = FakeRigctldBehavior(extra_lines={"L AF 0.784": b"0.0392157\n"})
+    async with FakeRigctldServer(behavior=behavior) as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            # Must NOT raise; real RPRT 0 follows the stray line.
+            await transport.command("L AF 0.784")
+        finally:
+            await transport.close()
+
+
+async def test_leftover_line_discarded_between_transactions() -> None:
+    """A leftover line in the buffer from transaction A must not corrupt B.
+
+    Simulates the U NB 1 → "0\\nRPRT 0\\n" scenario: if transaction A
+    somehow leaves a line in the reader, the pre-drain in transaction B
+    eats it so B reads its own RPRT 0.
+    """
+    behavior = FakeRigctldBehavior(extra_lines={"U NB 1": b"0\n"})
+    async with FakeRigctldServer(behavior=behavior) as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            # First call: server sends "0\nRPRT 0\n".  With the re-sync loop
+            # inside command() this should succeed.
+            await transport.command("U NB 1")
+            # Second call with a normal command must still work (no leftover
+            # from the first lingering in the buffer).
+            await transport.command("U NB 0")
+        finally:
+            await transport.close()
+
+
+async def test_get_reads_value_after_drain() -> None:
+    """GET (query) path is unaffected by the pre-drain (no leftover → no-op)."""
+    async with FakeRigctldServer() as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            result = await transport.query("l AF", response_lines=1)
+        finally:
+            await transport.close()
+    assert result == ["0.300"]
+
+
+async def test_negative_rprt_still_raises() -> None:
+    """l RF → RPRT -11 (unsupported) must still raise CommandError.
+
+    The re-sync loop must not discard RPRT-shaped lines — it must accept
+    them immediately so _raise_rprt can fire.
+    """
+    behavior = FakeRigctldBehavior(unsupported_commands={"l RF"})
+    async with FakeRigctldServer(behavior=behavior) as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            with pytest.raises(CommandError, match="command failed|unsupported"):
+                await transport.command("l RF")
+        finally:
+            await transport.close()


### PR DESCRIPTION
## MOR-182 — harden Hamlib bridge response alignment for level/func SETs

`validate --provider hamlib` runs the matrix through `HamlibBridge` + the rigctld client. On a flaky X6200, level/func SET acks came back **desynchronized** — a stray GET-shaped value line left in the socket buffer by a late/out-of-band frame was consumed as the next command's reply (`L AF 0.784` read `0.0392157`; `U NB 1` read `0`), surfacing as noisy `command_execution` fails.

### Root cause
At the **rigctld-client ↔ socket layer** (`RigctldTransport`), not the bridge (which is an intentional transparent byte pipe). Commands are already lock-serialized, so it's not interleave: each transaction read exactly its expected lines and left extras in the `StreamReader` buffer, where the **next** transaction consumed them.

### Fix (3 files, all inside the existing per-connection lock)
- **`backends/rigctld_client/transport.py`**:
  - `_drain_stale()` — before each `query()`/`command()`, non-blockingly discard any bytes already buffered from a prior transaction, so a leftover line can't be read as this command's reply.
  - `command()` **RPRT re-sync** — if the read line isn't `RPRT`-shaped, bounded non-blocking re-read for the real `RPRT <n>` (handles a stray line arriving within the transaction window). A legitimate negative RPRT (`l RF` → `RPRT -11`) is RPRT-shaped → still raises via `_raise_rprt`.
  - `query()` gains only the pre-drain (its replies are value-shaped).
- **`tests/fake_rigctld.py`** — `extra_lines` knob to inject a stray preceding line, deterministically reproducing the desync.
- **`tests/test_rigctld_client_backend.py`** — regression tests: stray-preceding-line drained (`L AF`→`0.0392157`), leftover-between-transactions discarded (`U NB 1`→`0`), GET still reads value after drain (no hang), negative RPRT still raises; existing serialization test stays green.

Implementation note: `asyncio.wait_for(reader.read(), timeout=0)` fires before reading buffered data on this event loop, so the drain uses `timeout=0.001`.

No bridge or production-radio change.

### Gates
- `pytest tests/test_rigctld_client_backend.py` → all pass (incl. `test_transport_serializes_requests`)
- full suite (no integration) → **6125 passed** (rebased on the #1667 main fix)
- ruff / mypy (`transport.py`) / lint-imports → clean

Final confidence needs a live X6200 native-vs-hamlib re-run (orchestrator, post-merge, serial port free); the unit tests prove the desync fix deterministically without hardware.

Linear: MOR-182. Unblocks reliable MOR-201 (Generator B) execution + MOR-202 comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)