### PR TITLE
feat(MOR-201): Generator B core — registry → Hamlib-filtered MatrixTemplate

### DIFF
--- a/src/rigplane/validation/registry.py
+++ b/src/rigplane/validation/registry.py
@@ -505,6 +505,36 @@ _KIND_TO_DECLARATION: dict[CheckKind, CapabilityDeclaration] = {
 }
 
 
+def _presence_entries(
+    capabilities: frozenset[str],
+    functional_caps: set[str],
+) -> list[CapabilityDeclarationEntry]:
+    """Return synthetic ``<cap>.presence`` entries for undiscovered capabilities.
+
+    For every capability in *capabilities* that is not covered by any registry
+    check (i.e. not in *functional_caps*), emit a ``CapabilityDeclarationEntry``
+    at ``ValidationLevel.STATIC_PROFILE`` with ``UNSUPPORTED_PENDING_EVIDENCE``.
+    The list is sorted alphabetically by capability name so output is stable.
+    """
+    result: list[CapabilityDeclarationEntry] = []
+    for cap in sorted(capabilities):
+        if cap not in functional_caps:
+            result.append(
+                CapabilityDeclarationEntry(
+                    check_id=f"{cap}.presence",
+                    capability=cap,
+                    level=ValidationLevel.STATIC_PROFILE,
+                    declaration=CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE,
+                    summary=(
+                        f"Capability {cap!r} is declared by the profile but has "
+                        "no functional check yet."
+                    ),
+                    tx_adjacent=False,
+                )
+            )
+    return result
+
+
 def build_template_from_capabilities(
     capabilities: frozenset[str],
     *,
@@ -561,21 +591,96 @@ def build_template_from_capabilities(
         )
 
     # Presence entries: declared capabilities not covered by any registry check.
-    for cap in sorted(capabilities):
-        if cap not in functional_caps:
-            entries.append(
-                CapabilityDeclarationEntry(
-                    check_id=f"{cap}.presence",
-                    capability=cap,
-                    level=ValidationLevel.STATIC_PROFILE,
-                    declaration=CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE,
-                    summary=(
-                        f"Capability {cap!r} is declared by the profile but has "
-                        "no functional check yet."
-                    ),
-                    tx_adjacent=False,
-                )
+    entries.extend(_presence_entries(capabilities, functional_caps))
+
+    # Stable sort by level — preserves registry order within each level;
+    # presence entries are level 0 so they sort before DISCOVERY (level 1).
+    entries.sort(key=lambda e: int(e.level))
+
+    return MatrixTemplate(
+        radio=RadioTarget(model=model, profile_id=profile_id),
+        entries=entries,
+    )
+
+
+def build_hamlib_template_from_capabilities(
+    capabilities: frozenset[str],
+    available_hamlib_tokens: frozenset[str],
+    *,
+    model: str,
+    profile_id: str,
+) -> MatrixTemplate:
+    """Generate a ``MatrixTemplate`` gated on available Hamlib tokens.
+
+    This is Generator B (ADR §6): it mirrors ``build_template_from_capabilities``
+    (Generator A) but gates each check on whether its ``CheckSpec.hamlib_token``
+    is present in *available_hamlib_tokens*.
+
+    Parameters
+    ----------
+    capabilities:
+        The set of capability strings declared by the radio profile.
+    available_hamlib_tokens:
+        A plain ``frozenset[str]`` of Hamlib token names reported by the
+        Hamlib backend (e.g. ``{"f", "m", "RF", "AF", "PREAMP", "ATT", "t"}``).
+        This function takes a plain frozenset — it does **not** import
+        ``rigplane.backends``.  The caller (CLI, MOR-211) is responsible for
+        flattening a ``HamlibCaps`` object into tokens before calling here.
+    model:
+        Radio model string for ``RadioTarget``.
+    profile_id:
+        Profile identifier for ``RadioTarget``.
+
+    Algorithm (ADR §6):
+
+    1. Walk REGISTRY in order.  For each ``CheckSpec``:
+       - If ``spec.hamlib_token is None`` → ``UNSUPPORTED_PENDING_EVIDENCE``.
+       - elif ``spec.hamlib_token not in available_hamlib_tokens`` →
+         ``UNSUPPORTED_PENDING_EVIDENCE``.
+       - else (token present):
+         - If ``spec.capability == ""`` (structural) → ``SUPPORTED``.
+         - elif ``spec.capability in capabilities`` →
+           ``_KIND_TO_DECLARATION[spec.kind]``.
+         - else (token present but cap not declared) →
+           ``UNSUPPORTED_PENDING_EVIDENCE``.
+    2. Track functional caps (non-empty capability) for presence-entry exclusion.
+    3. Append ``_presence_entries(capabilities, functional_caps)``.
+    4. Stable-sort by level; return ``MatrixTemplate``.
+    """
+    entries: list[CapabilityDeclarationEntry] = []
+    functional_caps: set[str] = set()
+
+    for spec in REGISTRY:
+        # Track all functional capabilities regardless of token/cap status.
+        if spec.capability:
+            functional_caps.add(spec.capability)
+
+        if spec.hamlib_token is None:
+            declaration = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+        elif spec.hamlib_token not in available_hamlib_tokens:
+            declaration = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+        else:
+            # Token is present — now check structural vs functional.
+            if spec.capability == "":
+                declaration = CapabilityDeclaration.SUPPORTED
+            elif spec.capability in capabilities:
+                declaration = _KIND_TO_DECLARATION[spec.kind]
+            else:
+                declaration = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+
+        entries.append(
+            CapabilityDeclarationEntry(
+                check_id=spec.check_id,
+                capability=spec.capability,
+                level=spec.level,
+                declaration=declaration,
+                summary=spec.summary,
+                tx_adjacent=spec.tx_adjacent,
             )
+        )
+
+    # Presence entries: declared capabilities not covered by any registry check.
+    entries.extend(_presence_entries(capabilities, functional_caps))
 
     # Stable sort by level — preserves registry order within each level;
     # presence entries are level 0 so they sort before DISCOVERY (level 1).
@@ -600,4 +705,5 @@ __all__ = [
     "REGISTRY_BY_ID",
     "get_spec",
     "build_template_from_capabilities",
+    "build_hamlib_template_from_capabilities",
 ]

--- a/tests/validation/test_generator_hamlib.py
+++ b/tests/validation/test_generator_hamlib.py
@@ -1,0 +1,190 @@
+"""Tests for Generator B: build_hamlib_template_from_capabilities (MOR-201a).
+
+Plain pytest functions — mirrors the style of test_generator.py.
+All cases use frozensets of tokens/capabilities, never HamlibCaps.
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.registry import build_hamlib_template_from_capabilities
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    ValidationLevel,
+    validate_template_dict,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _entry(tpl, check_id):
+    """Return the CapabilityDeclarationEntry with the given check_id, or raise."""
+    by_id = {e.check_id: e for e in tpl.entries}
+    assert check_id in by_id, f"check_id {check_id!r} not found in template"
+    return by_id[check_id]
+
+
+def _build(caps=frozenset(), tokens=frozenset()):
+    return build_hamlib_template_from_capabilities(
+        frozenset(caps),
+        frozenset(tokens),
+        model="IC-TEST",
+        profile_id="ic_test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core token-gating tests
+# ---------------------------------------------------------------------------
+
+
+def test_token_present_and_declared_supported():
+    """caps={'rf_gain'}, tokens={'RF'} → rf_gain.set == SUPPORTED."""
+    tpl = _build(caps={"rf_gain"}, tokens={"RF"})
+    entry = _entry(tpl, "rf_gain.set")
+    assert entry.declaration == CapabilityDeclaration.SUPPORTED
+
+
+def test_token_none_unsupported():
+    """agc.hamlib_token is None → agc.set == UNSUPPORTED_PENDING_EVIDENCE regardless of caps."""
+    tpl = _build(caps={"agc"}, tokens=frozenset())
+    entry = _entry(tpl, "agc.set")
+    assert entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+
+
+def test_token_absent_from_available_unsupported():
+    """caps={'rf_gain'} but 'RF' not in tokens → rf_gain.set == UNSUPPORTED_PENDING_EVIDENCE."""
+    tpl = _build(caps={"rf_gain"}, tokens=frozenset())
+    entry = _entry(tpl, "rf_gain.set")
+    assert entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+
+
+def test_undeclared_but_token_present_unsupported():
+    """'RF' token present but rf_gain not in caps → rf_gain.set == UNSUPPORTED_PENDING_EVIDENCE."""
+    tpl = _build(caps=frozenset(), tokens={"RF"})
+    entry = _entry(tpl, "rf_gain.set")
+    assert entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+
+
+# ---------------------------------------------------------------------------
+# Structural (capability == '') checks gated by their hamlib_token
+# ---------------------------------------------------------------------------
+
+
+def test_structural_freq_mode_gated_by_token():
+    """freq.write and mode.set are SUPPORTED only when their tokens are present.
+
+    discovery.identify and freq.reverse_sync have hamlib_token=None so they
+    are always UNSUPPORTED_PENDING_EVIDENCE.
+    """
+    # tokens present → structural freq/mode SUPPORTED
+    tpl_with = _build(tokens={"f", "m"})
+    assert _entry(tpl_with, "freq.write").declaration == CapabilityDeclaration.SUPPORTED
+    assert _entry(tpl_with, "mode.set").declaration == CapabilityDeclaration.SUPPORTED
+
+    # no tokens → freq.write and mode.set UNSUPPORTED_PENDING_EVIDENCE
+    tpl_without = _build(tokens=frozenset())
+    assert (
+        _entry(tpl_without, "freq.write").declaration
+        == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+    )
+    assert (
+        _entry(tpl_without, "mode.set").declaration
+        == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+    )
+
+    # discovery.identify and freq.reverse_sync are always UNSUPPORTED_PENDING_EVIDENCE
+    # because hamlib_token is None for both
+    for check_id in ("discovery.identify", "freq.reverse_sync"):
+        assert (
+            _entry(tpl_with, check_id).declaration
+            == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+        ), f"{check_id} should be UNSUPPORTED_PENDING_EVIDENCE (hamlib_token=None)"
+
+
+# ---------------------------------------------------------------------------
+# TX-adjacent checks
+# ---------------------------------------------------------------------------
+
+
+def test_tx_manual_required_tuner_unsupported_both_tx_adjacent():
+    """tx.ptt: token='t' present + cap declared → MANUAL_REQUIRED, tx_adjacent=True.
+    tuner.tune: hamlib_token=None → UNSUPPORTED_PENDING_EVIDENCE, tx_adjacent=True.
+    """
+    tpl = _build(caps={"tx", "tuner"}, tokens={"t"})
+    ptt = _entry(tpl, "tx.ptt")
+    tuner = _entry(tpl, "tuner.tune")
+
+    assert ptt.declaration == CapabilityDeclaration.MANUAL_REQUIRED
+    assert ptt.tx_adjacent is True
+
+    assert tuner.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+    assert tuner.tx_adjacent is True
+
+
+# ---------------------------------------------------------------------------
+# MANUAL checks
+# ---------------------------------------------------------------------------
+
+
+def test_manual_audio_scope():
+    """audio.rx and scope.capture have hamlib_token=None → always UNSUPPORTED_PENDING_EVIDENCE."""
+    tpl = _build(caps={"audio", "scope"}, tokens=frozenset())
+    assert (
+        _entry(tpl, "audio.rx").declaration
+        == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+    )
+    assert (
+        _entry(tpl, "scope.capture").declaration
+        == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_template_validates():
+    """build_hamlib_template_from_capabilities returns a schema-valid MatrixTemplate."""
+    tpl = _build(
+        caps={"rf_gain", "af_level", "preamp", "attenuator", "tx"},
+        tokens={"RF", "AF", "PREAMP", "ATT", "t", "f", "m"},
+    )
+    # Must not raise SchemaValidationError
+    validate_template_dict(tpl.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Sort / structural invariants
+# ---------------------------------------------------------------------------
+
+
+def test_entries_sorted_by_level():
+    """Level sequence is non-decreasing; presence entries (level 0) sort first."""
+    tpl = _build(caps={"split", "rf_gain"}, tokens={"RF"})
+    levels = [int(e.level) for e in tpl.entries]
+    assert levels == sorted(levels), "Entries are not sorted by level"
+    # 'split' has no registry check → presence entry at STATIC_PROFILE (0)
+    first = tpl.entries[0]
+    assert first.level == ValidationLevel.STATIC_PROFILE
+
+
+def test_presence_entries():
+    """A declared capability with no registry check gets a <cap>.presence entry."""
+    tpl = _build(caps={"split"}, tokens=frozenset())
+    entry = _entry(tpl, "split.presence")
+    assert entry.level == ValidationLevel.STATIC_PROFILE
+    assert entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+
+
+def test_check_ids_unique():
+    """No duplicate check_ids in the generated template."""
+    tpl = _build(
+        caps={"rf_gain", "scope", "tuner", "tx", "split"},
+        tokens={"RF", "t"},
+    )
+    ids = [e.check_id for e in tpl.entries]
+    assert len(ids) == len(set(ids)), "Duplicate check_ids found"


### PR DESCRIPTION
## MOR-201 (201a) — Generator B core

`build_hamlib_template_from_capabilities(capabilities, available_hamlib_tokens, *, model, profile_id)` in `validation/registry.py` — Generator B's pure core (ADR §6), mirroring Generator A but gating each check on whether its `CheckSpec.hamlib_token` is in the model's available tokens:
- token `None` → `UNSUPPORTED_PENDING_EVIDENCE` (D6: N/A, never FAIL)
- token set but absent from the available set → `UNSUPPORTED_PENDING_EVIDENCE`
- token present + structural (`freq.write`/`mode.set`) → `SUPPORTED`; + capability declared → `_KIND_TO_DECLARATION` (MANUAL_REQUIRED for MANUAL/TX_ADJACENT_BLOCKED); + token present but cap **undeclared** → `UNSUPPORTED_PENDING_EVIDENCE`
- `discovery.identify`/`freq.reverse_sync` (token None) → `UNSUPPORTED_PENDING_EVIDENCE`; `tx.ptt`("t",declared)→MANUAL_REQUIRED+tx_adjacent; `tuner.tune`(None)→UNSUPPORTED but tx_adjacent True
- presence entries via a shared `_presence_entries` helper refactored out of Gen-A (behaviour-preserving)

**Layering:** takes a plain `frozenset[str]` of tokens, NOT a `HamlibCaps` — keeps `validation/` free of any `backends` import (the CLI flattens `HamlibCaps`→tokens in **MOR-211**). registry.py still imports only `core.capabilities` + `validation.schema` + stdlib (grep-confirmed).

Decomposed from the original MOR-201 (owner-approved): CLI wiring + X6200 live-verify = **MOR-211**; rigctld client squelch/S-meter widening = **MOR-212**.

### Gates
- `pytest test_generator_hamlib.py + test_generator.py` → 27 passed (11 new + 16 Gen-A regression)
- full suite (no integration) → **6156 passed**
- ruff / mypy (`registry.py`) / lint-imports → clean; no backends import

🤖 Generated with [Claude Code](https://claude.com/claude-code)