### PR TITLE
feat(MOR-211): wire Generator B into the CLI for --provider hamlib

### DIFF
--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -38,7 +38,10 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from rigplane.backends.hamlib_models import HamlibCaps
 
 from rigplane import __version__
 from rigplane.validation import (
@@ -61,6 +64,20 @@ from rigplane.validation.schema import (
     SchemaValidationError,
     ValidationLevel,
 )
+
+
+def _hamlib_caps_to_tokens(caps: HamlibCaps) -> frozenset[str]:
+    """Flatten a HamlibCaps into the set of registry hamlib_token strings the
+    model supports, for Generator B."""
+    tokens: set[str] = set()
+    tokens |= caps.get_levels | caps.set_levels | caps.get_funcs | caps.set_funcs
+    if caps.has_set_freq:
+        tokens.add("f")
+    if caps.modes:
+        tokens.add("m")
+    if caps.ptt_type is not None:
+        tokens.add("t")
+    return frozenset(tokens)
 
 
 def _utcnow_iso() -> str:
@@ -182,18 +199,41 @@ def run(args: argparse.Namespace) -> int:
             print("Error: provide --template or --model", file=sys.stderr)
             return 2
         from rigplane.profiles import get_radio_profile
-        from rigplane.validation.registry import build_template_from_capabilities
 
         try:
             profile = get_radio_profile(args.model)
         except KeyError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 2
-        template = build_template_from_capabilities(
-            profile.capabilities,
-            model=profile.model,
-            profile_id=profile.id,
-        )
+        if getattr(args, "provider", "native") == "hamlib":
+            from rigplane.backends.hamlib_models import load_hamlib_caps
+            from rigplane.validation.registry import (
+                build_hamlib_template_from_capabilities,
+            )
+
+            caps = load_hamlib_caps(profile.hamlib_model_id)
+            if caps.degraded_reason:
+                print(
+                    f"Warning: Hamlib dump_caps unavailable for model "
+                    f"{profile.hamlib_model_id} ({caps.degraded_reason}); "
+                    f"all checks will be N/A.",
+                    file=sys.stderr,
+                )
+            tokens = _hamlib_caps_to_tokens(caps)
+            template = build_hamlib_template_from_capabilities(
+                profile.capabilities,
+                tokens,
+                model=profile.model,
+                profile_id=profile.id,
+            )
+        else:
+            from rigplane.validation.registry import build_template_from_capabilities
+
+            template = build_template_from_capabilities(
+                profile.capabilities,
+                model=profile.model,
+                profile_id=profile.id,
+            )
 
     authorized = bool(args.tx_allowed or args.tuner_allowed)
     safety = OperatorSafetyBlock(

--- a/tests/test_validate_hamlib_provider.py
+++ b/tests/test_validate_hamlib_provider.py
@@ -16,6 +16,7 @@ from typing import Any
 from fake_rigctld import FakeRigctldServer
 
 from rigplane.backends.config import RigctldBackendConfig
+from rigplane.backends.hamlib_models import HamlibCaps
 from rigplane.backends.rigctld_client import RigctldClientRadio
 from rigplane.cli import _validate
 from rigplane.profiles import get_radio_profile
@@ -433,3 +434,207 @@ async def test_run_hardware_hamlib_forwards_write_only_capabilities(
     await _validate._run_hardware_hamlib(_base_args(), template, safety)
 
     assert captured["write_only_capabilities"] == frozenset({"rit", "xit", "notch"})
+
+
+# ---------------------------------------------------------------------------
+# Generator B (_hamlib_caps_to_tokens) unit tests (MOR-211)
+# ---------------------------------------------------------------------------
+
+
+def test_hamlib_caps_to_tokens_levels_and_funcs() -> None:
+    """Levels and funcs sets are all unioned into the token set."""
+    caps = HamlibCaps(
+        get_levels=frozenset({"RF", "STRENGTH"}),
+        set_levels=frozenset({"AF"}),
+        get_funcs=frozenset({"NB"}),
+        set_funcs=frozenset({"NR"}),
+    )
+    tokens = _validate._hamlib_caps_to_tokens(caps)
+    assert {"RF", "STRENGTH", "AF", "NB", "NR"}.issubset(tokens)
+
+
+def test_hamlib_caps_to_tokens_has_set_freq_true() -> None:
+    """has_set_freq=True adds 'f' token."""
+    caps = HamlibCaps(has_set_freq=True)
+    tokens = _validate._hamlib_caps_to_tokens(caps)
+    assert "f" in tokens
+
+
+def test_hamlib_caps_to_tokens_has_set_freq_false() -> None:
+    """has_set_freq=False does NOT add 'f' token."""
+    caps = HamlibCaps(has_set_freq=False)
+    tokens = _validate._hamlib_caps_to_tokens(caps)
+    assert "f" not in tokens
+
+
+def test_hamlib_caps_to_tokens_modes_nonempty() -> None:
+    """Non-empty modes adds 'm' token."""
+    caps = HamlibCaps(modes=frozenset({"USB", "LSB"}))
+    tokens = _validate._hamlib_caps_to_tokens(caps)
+    assert "m" in tokens
+
+
+def test_hamlib_caps_to_tokens_modes_empty() -> None:
+    """Empty modes does NOT add 'm' token."""
+    caps = HamlibCaps(modes=frozenset())
+    tokens = _validate._hamlib_caps_to_tokens(caps)
+    assert "m" not in tokens
+
+
+def test_hamlib_caps_to_tokens_ptt_type_present() -> None:
+    """ptt_type != None adds 't' token."""
+    caps = HamlibCaps(ptt_type="RIG")
+    tokens = _validate._hamlib_caps_to_tokens(caps)
+    assert "t" in tokens
+
+
+def test_hamlib_caps_to_tokens_ptt_type_none() -> None:
+    """ptt_type=None does NOT add 't' token."""
+    caps = HamlibCaps(ptt_type=None)
+    tokens = _validate._hamlib_caps_to_tokens(caps)
+    assert "t" not in tokens
+
+
+def test_hamlib_caps_to_tokens_empty_caps() -> None:
+    """All-default (degraded) HamlibCaps yields an empty frozenset."""
+    caps = HamlibCaps()
+    tokens = _validate._hamlib_caps_to_tokens(caps)
+    assert tokens == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# CLI Gen-B generation — dry-run, no hardware (MOR-211)
+# ---------------------------------------------------------------------------
+
+
+def _make_dry_run_args(**kwargs: Any) -> argparse.Namespace:
+    """Namespace with safe defaults for _validate.run() dry-run."""
+    defaults = dict(
+        template=None,
+        model="X6200",
+        hardware=False,
+        allow_hardware=False,
+        tx_allowed=False,
+        tuner_allowed=False,
+        read_only=False,
+        provider="hamlib",
+        compare=None,
+        operator_id=None,
+        output=None,
+        json=True,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_cli_genb_dry_run_hamlib_provider(monkeypatch: Any) -> None:
+    """validate --model X6200 --provider hamlib (no --template) calls Generator B.
+
+    With the supplied HamlibCaps providing RF/AF/PREAMP/ATT/NB/NR/f/m/t tokens,
+    the expected SUPPORTED checks are:
+      rf_gain.set, af_level.set, preamp.set, attenuator.set, nb.set, nr.set,
+      freq.write, mode.set.
+    Checks with hamlib_token=None (discovery.identify, agc.set, rit.set) must
+    be UNSUPPORTED_PENDING_EVIDENCE.
+    """
+    fake_caps = HamlibCaps(
+        get_levels=frozenset({"RF", "AF", "PREAMP", "ATT"}),
+        set_levels=frozenset({"RF", "AF", "PREAMP", "ATT"}),
+        get_funcs=frozenset({"NB", "NR"}),
+        set_funcs=frozenset({"NB", "NR"}),
+        modes=frozenset({"USB"}),
+        has_set_freq=True,
+        ptt_type="RIG",
+    )
+    monkeypatch.setattr(
+        "rigplane.backends.hamlib_models.load_hamlib_caps",
+        lambda model_id: fake_caps,
+    )
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        _validate,
+        "_emit_artifact",
+        lambda artifact, args: captured.setdefault("artifact", artifact),
+    )
+
+    args = _make_dry_run_args()
+    rc = _validate.run(args)
+
+    assert rc == 0
+    artifact = captured["artifact"]
+    entries_by_id = {c.check_id: c for level in artifact.levels for c in level.checks}
+
+    # Checks that should be SUPPORTED (token present + cap declared on X6200)
+    expected_supported = {
+        "rf_gain.set",
+        "af_level.set",
+        "preamp.set",
+        "attenuator.set",
+        "nb.set",
+        "nr.set",
+        "freq.write",
+        "mode.set",
+    }
+    for cid in expected_supported:
+        assert cid in entries_by_id, f"Missing check_id {cid!r}"
+        assert entries_by_id[cid].declaration == CapabilityDeclaration.SUPPORTED, (
+            f"{cid!r}: expected SUPPORTED, got {entries_by_id[cid].declaration!r}"
+        )
+
+    # Checks with hamlib_token=None → always UNSUPPORTED_PENDING_EVIDENCE in Gen-B
+    expected_pending = {"discovery.identify", "agc.set", "rit.set"}
+    for cid in expected_pending:
+        assert cid in entries_by_id, f"Missing check_id {cid!r}"
+        assert (
+            entries_by_id[cid].declaration
+            == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+        ), (
+            f"{cid!r}: expected UNSUPPORTED_PENDING_EVIDENCE, got {entries_by_id[cid].declaration!r}"
+        )
+
+
+def test_cli_genb_dry_run_degraded_caps_warns(monkeypatch: Any, capsys: Any) -> None:
+    """When HamlibCaps is degraded, a warning is printed to stderr."""
+    degraded_caps = HamlibCaps(
+        degraded_reason="dump_caps unavailable: tool not found",
+    )
+    monkeypatch.setattr(
+        "rigplane.backends.hamlib_models.load_hamlib_caps",
+        lambda model_id: degraded_caps,
+    )
+    monkeypatch.setattr(
+        _validate,
+        "_emit_artifact",
+        lambda artifact, args: None,
+    )
+
+    args = _make_dry_run_args()
+    rc = _validate.run(args)
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+    assert "dump_caps unavailable" in captured.err or "N/A" in captured.err
+
+
+def test_cli_genb_native_provider_unchanged(monkeypatch: Any) -> None:
+    """--provider native (no --template) still uses Gen-A; discovery.identify SUPPORTED."""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        _validate,
+        "_emit_artifact",
+        lambda artifact, args: captured.setdefault("artifact", artifact),
+    )
+
+    args = _make_dry_run_args(provider="native")
+    rc = _validate.run(args)
+
+    assert rc == 0
+    artifact = captured["artifact"]
+    entries_by_id = {c.check_id: c for level in artifact.levels for c in level.checks}
+    # Gen-A: discovery.identify is SUPPORTED (structural, no hamlib_token gating)
+    assert (
+        entries_by_id["discovery.identify"].declaration
+        == CapabilityDeclaration.SUPPORTED
+    )


### PR DESCRIPTION
## MOR-211 (201b) — Generator B CLI wiring

`validate --model <X> --provider hamlib` (no `--template`) now builds the matrix from the Hamlib model's `dump_caps` via **Generator B** (MOR-201), instead of Gen-A. ADR §6/§9. The existing `_run_hardware_hamlib` runs the generated template unchanged.

### Changes (2 files)
- **`cli/_validate.py`**:
  - `_hamlib_caps_to_tokens(HamlibCaps) -> frozenset[str]`: flattens `get/set_levels | get/set_funcs`, plus `"f"` (has_set_freq), `"m"` (modes), `"t"` (ptt_type). The **CLI** owns this `HamlibCaps`→tokens bridge so `validation/` stays backends-free.
  - `run()` template-absent branch splits on provider: `hamlib` → `load_hamlib_caps(profile.hamlib_model_id)` → tokens → `build_hamlib_template_from_capabilities(...)`; degraded caps → stderr warning + honest all-N/A. `native` → Gen-A (unchanged).
- **`tests/test_validate_hamlib_provider.py`**: `_hamlib_caps_to_tokens` units; CLI Gen-B dry-run (monkeypatched `load_hamlib_caps`) asserting the SUPPORTED set (rf_gain/af_level/preamp/attenuator/nb/nr/freq.write/mode.set) and UNSUPPORTED for token-None (discovery.identify/agc/rit); degraded-caps warning; native-provider regression guard.

### Gates
- `pytest test_validate_hamlib_provider.py + test_generator.py` → 37 passed
- full suite (no integration) → **6167 passed**
- ruff / mypy (`_validate.py`) / lint-imports → clean

Live X6200 `--provider hamlib` verify run by the orchestrator before merge. Known findings to expect (candidates for MOR-202, not bugs here): squelch/meters SUPPORTED-but-fail (client gap → MOR-212); mode.set hamlib timeout on X6200.

Decomposed from MOR-201. Blocked-by MOR-201✅ + MOR-200✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)