### PR TITLE
feat(MOR-202): comparison dimensions helper (native-vs-hamlib + profile-vs-reality)

### DIFF
--- a/src/rigplane/validation/__init__.py
+++ b/src/rigplane/validation/__init__.py
@@ -8,6 +8,7 @@ path that plans checks from a template without touching hardware.
 
 from __future__ import annotations
 
+from rigplane.validation.comparison import compute_comparison_dimensions
 from rigplane.validation.hardware import execute_hardware_checks
 from rigplane.validation.runner import (
     HARDWARE_OPT_IN_ENV,
@@ -64,4 +65,5 @@ __all__ = [
     "build_validation_artifact",
     "human_summary",
     "execute_hardware_checks",
+    "compute_comparison_dimensions",
 ]

--- a/src/rigplane/validation/comparison.py
+++ b/src/rigplane/validation/comparison.py
@@ -1,0 +1,234 @@
+"""Comparison dimensions helper for native vs Hamlib validation artifacts.
+
+Operates entirely on plain ``dict`` objects (the output of
+``ValidationArtifact.to_dict()`` or a JSON-loaded equivalent).  Imports only
+``rigplane.validation.schema`` enums and stdlib — no backends, no CLI.
+
+ADR reference: docs/plans/2026-04-29-modularization-plan.md §7 (or the
+validation-matrix ADR that defines the three comparison dimensions).
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.schema import CapabilityDeclaration, CheckStatus
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+# Cache .value references once to avoid repeated attribute access in loops.
+_PASS = CheckStatus.PASS.value
+_FAIL = CheckStatus.FAIL.value
+_SKIP = CheckStatus.SKIP.value
+_UNSUPPORTED = CheckStatus.UNSUPPORTED.value
+_MANUAL_REQUIRED_STATUS = CheckStatus.MANUAL_REQUIRED.value
+_BLOCKED = CheckStatus.BLOCKED.value
+
+_SUPPORTED = CapabilityDeclaration.SUPPORTED.value
+_UNSUPPORTED_PENDING = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE.value
+_MANUAL_REQUIRED_DECL = CapabilityDeclaration.MANUAL_REQUIRED.value
+
+# Statuses that are never PASS/FAIL for cross-impl comparison.
+_OPAQUE_STATUSES: frozenset[str] = frozenset(
+    {_UNSUPPORTED, _SKIP, _MANUAL_REQUIRED_STATUS, _BLOCKED}
+)
+
+
+def _index(artifact: dict[str, object]) -> dict[str, tuple[str, str]]:
+    """Return ``{check_id: (declaration, status)}`` from an artifact dict.
+
+    Walks ``artifact["levels"][*]["checks"][*]``.  Missing or malformed entries
+    are skipped defensively so callers always get a plain mapping without
+    raising on partial data.
+    """
+    result: dict[str, tuple[str, str]] = {}
+    levels_obj = artifact.get("levels", [])
+    if not isinstance(levels_obj, list):
+        return result
+    for level in levels_obj:
+        if not isinstance(level, dict):
+            continue
+        checks_obj = level.get("checks", [])
+        if not isinstance(checks_obj, list):
+            continue
+        for check in checks_obj:
+            if not isinstance(check, dict):
+                continue
+            check_id = check.get("check_id")
+            declaration = check.get("declaration")
+            status = check.get("status")
+            if (
+                isinstance(check_id, str)
+                and check_id
+                and isinstance(declaration, str)
+                and isinstance(status, str)
+            ):
+                result[check_id] = (declaration, status)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Shared decl × status classification used by both profile_vs_reality and
+# hamlib_vs_reality.  Returns "agree", "differ", or "na".
+# ---------------------------------------------------------------------------
+
+
+def _classify_pvr(declaration: str, status: str) -> str:
+    """Classify one (declaration, status) pair for the profile-vs-reality dim.
+
+    Rules (ADR §7.1):
+    - SUPPORTED + pass          → agree
+    - SUPPORTED + {fail|unsupported} → differ
+    - UNSUPPORTED_PENDING + unsupported → agree
+    - UNSUPPORTED_PENDING + pass        → differ
+    - everything else (manual_required decl, manual_required/skip/blocked
+      status, UNSUPPORTED_PENDING+fail) → na
+    """
+    if declaration == _SUPPORTED:
+        if status == _PASS:
+            return "agree"
+        if status in (_FAIL, _UNSUPPORTED):
+            return "differ"
+        # skip / manual_required / blocked → na
+        return "na"
+    if declaration == _UNSUPPORTED_PENDING:
+        if status == _UNSUPPORTED:
+            return "agree"
+        if status == _PASS:
+            return "differ"
+        # fail / skip / manual_required / blocked → na
+        return "na"
+    # MANUAL_REQUIRED declaration (or any unknown value) → na
+    return "na"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_comparison_dimensions(
+    native_artifact: dict[str, object],
+    hamlib_artifact: dict[str, object],
+) -> dict[str, object]:
+    """Roll up a native and a Hamlib ``ValidationArtifact`` dict into three
+    comparison dimensions.
+
+    Parameters
+    ----------
+    native_artifact:
+        ``ValidationArtifact.to_dict()`` (or equivalent loaded JSON) from the
+        native rigplane backend validation run.
+    hamlib_artifact:
+        Same shape from the Hamlib/rigctld backend validation run.
+
+    Returns
+    -------
+    A dict with three keys:
+
+    ``profile_vs_reality``
+        How well the native backend's declared support matches observed outcomes.
+        Keys: ``agree`` (int), ``differ`` (int), ``differing`` (sorted list of
+        check_ids where declaration and outcome disagreed).  No ``na`` key.
+
+    ``hamlib_vs_reality``
+        Same classification applied to the Hamlib artifact.
+        Keys: ``agree`` (int), ``differ`` (int), ``na`` (int).  No ``differing``
+        list.
+
+    ``cross_impl``
+        Per-check status comparison between native and Hamlib (aligned on
+        check_id).  Only PASS/FAIL checks on both sides are classified as
+        agree/differ; everything else (opaque status, missing in one artifact)
+        is na.
+        Keys: ``agree`` (int), ``differ`` (int), ``na`` (int).
+    """
+    native_idx = _index(native_artifact)
+    hamlib_idx = _index(hamlib_artifact)
+
+    # ------------------------------------------------------------------
+    # (a) profile_vs_reality — from native index
+    # ------------------------------------------------------------------
+    pvr_agree = 0
+    pvr_differ = 0
+    pvr_differing: list[str] = []
+
+    for check_id, (declaration, status) in native_idx.items():
+        verdict = _classify_pvr(declaration, status)
+        if verdict == "agree":
+            pvr_agree += 1
+        elif verdict == "differ":
+            pvr_differ += 1
+            pvr_differing.append(check_id)
+
+    pvr_differing.sort()
+
+    profile_vs_reality: dict[str, object] = {
+        "agree": pvr_agree,
+        "differ": pvr_differ,
+        "differing": pvr_differing,
+    }
+
+    # ------------------------------------------------------------------
+    # (b) hamlib_vs_reality — from hamlib index (same classification)
+    # ------------------------------------------------------------------
+    hvr_agree = 0
+    hvr_differ = 0
+    hvr_na = 0
+
+    for _check_id, (declaration, status) in hamlib_idx.items():
+        verdict = _classify_pvr(declaration, status)
+        if verdict == "agree":
+            hvr_agree += 1
+        elif verdict == "differ":
+            hvr_differ += 1
+        else:
+            hvr_na += 1
+
+    hamlib_vs_reality: dict[str, object] = {
+        "agree": hvr_agree,
+        "differ": hvr_differ,
+        "na": hvr_na,
+    }
+
+    # ------------------------------------------------------------------
+    # (c) cross_impl — aligned on check_id present in EITHER index
+    # ------------------------------------------------------------------
+    ci_agree = 0
+    ci_differ = 0
+    ci_na = 0
+
+    all_ids = set(native_idx) | set(hamlib_idx)
+    for check_id in all_ids:
+        if check_id not in native_idx or check_id not in hamlib_idx:
+            # Present in only one artifact → na
+            ci_na += 1
+            continue
+
+        native_status = native_idx[check_id][1]
+        hamlib_status = hamlib_idx[check_id][1]
+
+        if native_status in _OPAQUE_STATUSES or hamlib_status in _OPAQUE_STATUSES:
+            ci_na += 1
+            continue
+
+        # Both are in {pass, fail}
+        if native_status == hamlib_status:
+            ci_agree += 1
+        else:
+            ci_differ += 1
+
+    cross_impl: dict[str, object] = {
+        "agree": ci_agree,
+        "differ": ci_differ,
+        "na": ci_na,
+    }
+
+    return {
+        "profile_vs_reality": profile_vs_reality,
+        "hamlib_vs_reality": hamlib_vs_reality,
+        "cross_impl": cross_impl,
+    }
+
+
+__all__ = ["compute_comparison_dimensions"]

--- a/tests/test_validation_comparison.py
+++ b/tests/test_validation_comparison.py
@@ -1,0 +1,386 @@
+"""Tests for rigplane.validation.comparison.compute_comparison_dimensions.
+
+TDD: tests written first, confirmed red, then implementation added.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rigplane.validation.schema import CapabilityDeclaration, CheckStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SUPPORTED = CapabilityDeclaration.SUPPORTED.value
+_UNSUPPORTED_PENDING = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE.value
+_MANUAL_REQUIRED_DECL = CapabilityDeclaration.MANUAL_REQUIRED.value
+
+_PASS = CheckStatus.PASS.value
+_FAIL = CheckStatus.FAIL.value
+_SKIP = CheckStatus.SKIP.value
+_UNSUPPORTED = CheckStatus.UNSUPPORTED.value
+_MANUAL_REQUIRED_STATUS = CheckStatus.MANUAL_REQUIRED.value
+_BLOCKED = CheckStatus.BLOCKED.value
+
+
+def _artifact(checks: list[tuple[str, str, str]]) -> dict:
+    """Build a minimal artifact dict from (check_id, declaration, status) triples."""
+    return {
+        "levels": [
+            {
+                "checks": [
+                    {"check_id": cid, "declaration": decl, "status": status}
+                    for cid, decl, status in checks
+                ]
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Import smoke
+# ---------------------------------------------------------------------------
+
+
+def test_import():
+    import rigplane.validation as _val
+    import rigplane.validation.comparison as _comp
+
+    assert hasattr(_val, "compute_comparison_dimensions")
+    assert hasattr(_comp, "compute_comparison_dimensions")
+
+
+# ---------------------------------------------------------------------------
+# profile_vs_reality
+# ---------------------------------------------------------------------------
+
+
+class TestProfileVsReality:
+    def _get(self, checks_native: list[tuple[str, str, str]]) -> dict:
+        from rigplane.validation.comparison import compute_comparison_dimensions
+
+        result = compute_comparison_dimensions(_artifact(checks_native), _artifact([]))
+        return result["profile_vs_reality"]
+
+    def test_supported_pass_counts_agree(self):
+        dim = self._get([("rf_gain", _SUPPORTED, _PASS)])
+        assert dim["agree"] == 1
+        assert dim["differ"] == 0
+        assert dim["differing"] == []
+
+    def test_supported_fail_counts_differ(self):
+        dim = self._get([("mode.set", _SUPPORTED, _FAIL)])
+        assert dim["agree"] == 0
+        assert dim["differ"] == 1
+        assert "mode.set" in dim["differing"]
+
+    def test_supported_unsupported_counts_differ(self):
+        dim = self._get([("att", _SUPPORTED, _UNSUPPORTED)])
+        assert dim["differ"] == 1
+        assert "att" in dim["differing"]
+
+    def test_unsupported_pending_unsupported_counts_agree(self):
+        dim = self._get([("ext.feature", _UNSUPPORTED_PENDING, _UNSUPPORTED)])
+        assert dim["agree"] == 1
+        assert dim["differ"] == 0
+        assert dim["differing"] == []
+
+    def test_unsupported_pending_pass_counts_differ(self):
+        dim = self._get([("ext.feature", _UNSUPPORTED_PENDING, _PASS)])
+        assert dim["differ"] == 1
+        assert "ext.feature" in dim["differing"]
+
+    def test_manual_required_status_is_na(self):
+        """manual_required status → na (not counted in agree/differ)."""
+        dim = self._get([("tx.power", _SUPPORTED, _MANUAL_REQUIRED_STATUS)])
+        assert dim["agree"] == 0
+        assert dim["differ"] == 0
+        assert dim["differing"] == []
+
+    def test_skip_status_is_na(self):
+        dim = self._get([("rf_gain", _SUPPORTED, _SKIP)])
+        assert dim["agree"] == 0
+        assert dim["differ"] == 0
+
+    def test_blocked_status_is_na(self):
+        dim = self._get([("rf_gain", _SUPPORTED, _BLOCKED)])
+        assert dim["agree"] == 0
+        assert dim["differ"] == 0
+
+    def test_manual_required_decl_is_na(self):
+        dim = self._get([("tx.power", _MANUAL_REQUIRED_DECL, _PASS)])
+        assert dim["agree"] == 0
+        assert dim["differ"] == 0
+
+    def test_unsupported_pending_fail_is_na(self):
+        """UNSUPPORTED_PENDING + fail is undefined per ADR → na."""
+        dim = self._get([("ext.feature", _UNSUPPORTED_PENDING, _FAIL)])
+        assert dim["agree"] == 0
+        assert dim["differ"] == 0
+
+    def test_differing_is_sorted(self):
+        checks = [
+            ("zzz.last", _SUPPORTED, _FAIL),
+            ("aaa.first", _SUPPORTED, _FAIL),
+            ("mmm.mid", _SUPPORTED, _FAIL),
+        ]
+        dim = self._get(checks)
+        assert dim["differing"] == sorted(dim["differing"])
+        assert dim["differing"] == ["aaa.first", "mmm.mid", "zzz.last"]
+
+    def test_no_na_key_in_output(self):
+        """profile_vs_reality must NOT emit an 'na' key (ADR §7.2)."""
+        dim = self._get([("rf_gain", _SUPPORTED, _PASS)])
+        assert "na" not in dim
+
+    def test_output_keys(self):
+        dim = self._get([])
+        assert set(dim.keys()) == {"agree", "differ", "differing"}
+
+    def test_multiple_checks_combined(self):
+        checks = [
+            ("rf_gain", _SUPPORTED, _PASS),  # agree
+            ("mode.set", _SUPPORTED, _FAIL),  # differ
+            ("att", _SUPPORTED, _UNSUPPORTED),  # differ
+            ("ext.f", _UNSUPPORTED_PENDING, _UNSUPPORTED),  # agree
+            ("ext.g", _UNSUPPORTED_PENDING, _PASS),  # differ
+            ("tx.p", _SUPPORTED, _SKIP),  # na
+        ]
+        dim = self._get(checks)
+        assert dim["agree"] == 2
+        assert dim["differ"] == 3
+        assert sorted(dim["differing"]) == ["att", "ext.g", "mode.set"]
+
+
+# ---------------------------------------------------------------------------
+# hamlib_vs_reality
+# ---------------------------------------------------------------------------
+
+
+class TestHamlibVsReality:
+    def _get(self, checks_hamlib: list[tuple[str, str, str]]) -> dict:
+        from rigplane.validation.comparison import compute_comparison_dimensions
+
+        result = compute_comparison_dimensions(_artifact([]), _artifact(checks_hamlib))
+        return result["hamlib_vs_reality"]
+
+    def test_unsupported_pending_unsupported_counts_agree(self):
+        dim = self._get([("discovery", _UNSUPPORTED_PENDING, _UNSUPPORTED)])
+        assert dim["agree"] == 1
+        assert dim["differ"] == 0
+
+    def test_supported_pass_counts_agree(self):
+        dim = self._get([("rf_gain", _SUPPORTED, _PASS)])
+        assert dim["agree"] == 1
+        assert dim["differ"] == 0
+
+    def test_supported_fail_counts_differ(self):
+        dim = self._get([("mode.set", _SUPPORTED, _FAIL)])
+        assert dim["differ"] == 1
+
+    def test_skip_counts_na(self):
+        dim = self._get([("rf_gain", _SUPPORTED, _SKIP)])
+        assert dim["na"] == 1
+        assert dim["agree"] == 0
+        assert dim["differ"] == 0
+
+    def test_na_key_present(self):
+        """hamlib_vs_reality MUST emit an 'na' key."""
+        dim = self._get([("rf_gain", _SUPPORTED, _PASS)])
+        assert "na" in dim
+
+    def test_output_keys(self):
+        dim = self._get([])
+        assert set(dim.keys()) == {"agree", "differ", "na"}
+
+    def test_na_count_accumulates(self):
+        checks = [
+            ("a", _SUPPORTED, _SKIP),
+            ("b", _SUPPORTED, _BLOCKED),
+            ("c", _SUPPORTED, _MANUAL_REQUIRED_STATUS),
+            ("d", _SUPPORTED, _PASS),  # agree
+        ]
+        dim = self._get(checks)
+        assert dim["na"] == 3
+        assert dim["agree"] == 1
+
+    def test_no_differing_list_key(self):
+        """hamlib_vs_reality must NOT emit a 'differing' list key."""
+        dim = self._get([("mode.set", _SUPPORTED, _FAIL)])
+        assert "differing" not in dim
+
+
+# ---------------------------------------------------------------------------
+# cross_impl
+# ---------------------------------------------------------------------------
+
+
+class TestCrossImpl:
+    def _get(
+        self,
+        native_checks: list[tuple[str, str, str]],
+        hamlib_checks: list[tuple[str, str, str]],
+    ) -> dict:
+        from rigplane.validation.comparison import compute_comparison_dimensions
+
+        result = compute_comparison_dimensions(
+            _artifact(native_checks), _artifact(hamlib_checks)
+        )
+        return result["cross_impl"]
+
+    def test_native_pass_hamlib_fail_counts_differ(self):
+        dim = self._get(
+            [("mode.set", _SUPPORTED, _PASS)],
+            [("mode.set", _SUPPORTED, _FAIL)],
+        )
+        assert dim["differ"] == 1
+        assert dim["agree"] == 0
+
+    def test_both_pass_counts_agree(self):
+        dim = self._get(
+            [("rf_gain", _SUPPORTED, _PASS)],
+            [("rf_gain", _SUPPORTED, _PASS)],
+        )
+        assert dim["agree"] == 1
+        assert dim["differ"] == 0
+
+    def test_hamlib_unsupported_is_na(self):
+        """If either status is unsupported/skip/manual_required/blocked → na."""
+        dim = self._get(
+            [("rf_gain", _SUPPORTED, _PASS)],
+            [("rf_gain", _SUPPORTED, _UNSUPPORTED)],
+        )
+        assert dim["na"] >= 1
+        assert dim["differ"] == 0
+
+    def test_check_id_only_in_native_is_na(self):
+        dim = self._get(
+            [("native.only", _SUPPORTED, _PASS)],
+            [],
+        )
+        assert dim["na"] >= 1
+
+    def test_check_id_only_in_hamlib_is_na(self):
+        dim = self._get(
+            [],
+            [("hamlib.only", _SUPPORTED, _PASS)],
+        )
+        assert dim["na"] >= 1
+
+    def test_output_keys(self):
+        dim = self._get([], [])
+        assert set(dim.keys()) == {"agree", "differ", "na"}
+
+    def test_no_differing_list_key(self):
+        """cross_impl must NOT emit a 'differing' key in v1."""
+        dim = self._get(
+            [("mode.set", _SUPPORTED, _PASS)],
+            [("mode.set", _SUPPORTED, _FAIL)],
+        )
+        assert "differing" not in dim
+
+    def test_native_fail_hamlib_fail_counts_agree(self):
+        dim = self._get(
+            [("rf_gain", _SUPPORTED, _FAIL)],
+            [("rf_gain", _SUPPORTED, _FAIL)],
+        )
+        assert dim["agree"] == 1
+
+    def test_skip_in_native_is_na(self):
+        dim = self._get(
+            [("rf_gain", _SUPPORTED, _SKIP)],
+            [("rf_gain", _SUPPORTED, _PASS)],
+        )
+        assert dim["na"] >= 1
+        assert dim["differ"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Combined realistic case
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedRealistic:
+    """
+    native:  rf_gain pass, mode.set pass, discovery SUPPORTED+pass
+    hamlib:  rf_gain pass, mode.set fail, discovery UNSUPPORTED_PENDING+unsupported
+    """
+
+    @pytest.fixture
+    def result(self):
+        from rigplane.validation.comparison import compute_comparison_dimensions
+
+        native = _artifact(
+            [
+                ("rf_gain", _SUPPORTED, _PASS),
+                ("mode.set", _SUPPORTED, _PASS),
+                ("discovery", _SUPPORTED, _PASS),
+            ]
+        )
+        hamlib = _artifact(
+            [
+                ("rf_gain", _SUPPORTED, _PASS),
+                ("mode.set", _SUPPORTED, _FAIL),
+                ("discovery", _UNSUPPORTED_PENDING, _UNSUPPORTED),
+            ]
+        )
+        return compute_comparison_dimensions(native, hamlib)
+
+    def test_cross_impl_differ_includes_mode_set(self, result):
+        # mode.set: native pass vs hamlib fail → differ
+        assert result["cross_impl"]["differ"] >= 1
+
+    def test_profile_vs_reality_native_clean(self, result):
+        # native: rf_gain+mode.set+discovery all SUPPORTED+pass → all agree, no differ
+        pvr = result["profile_vs_reality"]
+        assert pvr["differ"] == 0
+        assert pvr["agree"] == 3
+
+    def test_hamlib_vs_reality_discovery_agree(self, result):
+        # hamlib discovery UNSUPPORTED_PENDING+unsupported → agree
+        hvr = result["hamlib_vs_reality"]
+        assert hvr["agree"] >= 1
+
+    def test_hamlib_vs_reality_mode_set_differ(self, result):
+        # hamlib mode.set SUPPORTED+fail → differ
+        hvr = result["hamlib_vs_reality"]
+        assert hvr["differ"] >= 1
+
+    def test_cross_impl_rf_gain_agree(self, result):
+        # rf_gain: both pass → agree
+        assert result["cross_impl"]["agree"] >= 1
+
+    def test_cross_impl_discovery_na(self, result):
+        # discovery: hamlib unsupported → na
+        assert result["cross_impl"]["na"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Empty artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyArtifacts:
+    def test_all_zeros_on_empty(self):
+        from rigplane.validation.comparison import compute_comparison_dimensions
+
+        result = compute_comparison_dimensions(_artifact([]), _artifact([]))
+        assert result["profile_vs_reality"] == {
+            "agree": 0,
+            "differ": 0,
+            "differing": [],
+        }
+        assert result["hamlib_vs_reality"] == {"agree": 0, "differ": 0, "na": 0}
+        assert result["cross_impl"] == {"agree": 0, "differ": 0, "na": 0}
+
+    def test_missing_levels_key(self):
+        """Artifacts missing 'levels' key should not raise — return zeros."""
+        from rigplane.validation.comparison import compute_comparison_dimensions
+
+        result = compute_comparison_dimensions({}, {})
+        assert result["profile_vs_reality"]["agree"] == 0
+        assert result["hamlib_vs_reality"]["agree"] == 0
+        assert result["cross_impl"]["agree"] == 0


### PR DESCRIPTION
## MOR-202 (202a) — comparison dimensions helper

`compute_comparison_dimensions(native_artifact, hamlib_artifact) -> dict` in new `validation/comparison.py` — pure dict-walk rolling two ValidationArtifacts into the three ADR §7 dimensions, aligned on `check_id` (the registry guarantees the same id universe; declarations differ per provider):
- **profile_vs_reality** (native): `{agree, differ, differing[]}` — SUPPORTED+pass=agree; SUPPORTED+fail/unsupported=differ (declared-but-unresponsive / engine-gap); UNSUPPORTED_PENDING+unsupported=agree; UNSUPPORTED_PENDING+pass=differ (supported-but-undeclared).
- **hamlib_vs_reality** (hamlib): `{agree, differ, na}` — same table; na for skip/manual/blocked.
- **cross_impl** (native.status vs hamlib.status per check_id): `{agree, differ, na}` — either side unsupported/skip/manual/blocked → na; both terminal & equal → agree; both terminal & unequal (e.g. native pass / hamlib fail) → differ.

**Layering:** imports only `validation.schema` enums + stdlib (no backends/cli) — re-exported from `validation/__init__`. Operates on plain `to_dict()` dicts so it's trivially unit-testable and reusable by `radio-validate` (MOR-204).

Decomposed from MOR-202 (owner-approved). CLI `--provider both` wiring + X6200 live-verify = **MOR-213**.

### Gates
- `pytest test_validation_comparison.py` → 40 passed (all agree/differ/na cells incl. mode.set cross_impl differ)
- full suite (no integration) → **6207 passed**
- ruff / mypy / lint-imports → clean; import-pure

🤖 Generated with [Claude Code](https://claude.com/claude-code)