### PR TITLE
feat(MOR-213): validate --provider both — native+hamlib comparison dimensions

### DIFF
--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -51,6 +51,7 @@ from rigplane.validation import (
     TransportInfo,
     ValidationArtifact,
     build_validation_artifact,
+    compute_comparison_dimensions,
     dry_run_results,
     human_summary,
     load_template,
@@ -152,12 +153,14 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--provider",
-        choices=["native", "hamlib"],
+        choices=["native", "hamlib", "both"],
         default="native",
         help=(
             "Validation provider: native (default) drives the radio directly; "
             "hamlib drives it through an internally-spawned Hamlib rigctld and "
-            "compares results. Model is auto-detected (or use --model)."
+            "compares results; both runs native then hamlib sequentially and "
+            "attaches cross-implementation comparison dimensions to the primary "
+            "(native) artifact. Model is auto-detected (or use --model)."
         ),
     )
     p.add_argument(
@@ -187,13 +190,53 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
     return p
 
 
+def _generate_template(
+    args: argparse.Namespace, profile: Any, provider: str
+) -> MatrixTemplate:
+    """Build a per-provider in-memory template from *profile*.
+
+    *provider* must be ``"native"`` (Gen-A) or ``"hamlib"`` (Gen-B).
+    The caller is responsible for resolving the profile before calling this.
+    """
+    if provider == "hamlib":
+        from rigplane.backends.hamlib_models import load_hamlib_caps
+        from rigplane.validation.registry import build_hamlib_template_from_capabilities
+
+        caps = load_hamlib_caps(profile.hamlib_model_id)
+        if caps.degraded_reason:
+            print(
+                f"Warning: Hamlib dump_caps unavailable for model "
+                f"{profile.hamlib_model_id} ({caps.degraded_reason}); "
+                f"all checks will be N/A.",
+                file=sys.stderr,
+            )
+        tokens = _hamlib_caps_to_tokens(caps)
+        return build_hamlib_template_from_capabilities(
+            profile.capabilities,
+            tokens,
+            model=profile.model,
+            profile_id=profile.id,
+        )
+    # native (Gen-A)
+    from rigplane.validation.registry import build_template_from_capabilities
+
+    return build_template_from_capabilities(
+        profile.capabilities,
+        model=profile.model,
+        profile_id=profile.id,
+    )
+
+
 def run(args: argparse.Namespace) -> int:
+    provider = getattr(args, "provider", "native")
+
     if args.template:
         try:
             template = load_template(Path(args.template))
         except (SchemaValidationError, OSError) as exc:
             print(f"Error: cannot load template: {exc}", file=sys.stderr)
             return 2
+        profile = None
     else:
         if not getattr(args, "model", None):
             print("Error: provide --template or --model", file=sys.stderr)
@@ -205,35 +248,12 @@ def run(args: argparse.Namespace) -> int:
         except KeyError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 2
-        if getattr(args, "provider", "native") == "hamlib":
-            from rigplane.backends.hamlib_models import load_hamlib_caps
-            from rigplane.validation.registry import (
-                build_hamlib_template_from_capabilities,
-            )
-
-            caps = load_hamlib_caps(profile.hamlib_model_id)
-            if caps.degraded_reason:
-                print(
-                    f"Warning: Hamlib dump_caps unavailable for model "
-                    f"{profile.hamlib_model_id} ({caps.degraded_reason}); "
-                    f"all checks will be N/A.",
-                    file=sys.stderr,
-                )
-            tokens = _hamlib_caps_to_tokens(caps)
-            template = build_hamlib_template_from_capabilities(
-                profile.capabilities,
-                tokens,
-                model=profile.model,
-                profile_id=profile.id,
-            )
+        if provider in ("hamlib", "native"):
+            template = _generate_template(args, profile, provider)
         else:
-            from rigplane.validation.registry import build_template_from_capabilities
-
-            template = build_template_from_capabilities(
-                profile.capabilities,
-                model=profile.model,
-                profile_id=profile.id,
-            )
+            # "both": will build per-provider templates below; use native for
+            # dry-run / safety-block path.
+            template = _generate_template(args, profile, "native")
 
     authorized = bool(args.tx_allowed or args.tuner_allowed)
     safety = OperatorSafetyBlock(
@@ -252,9 +272,18 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 3
-        if getattr(args, "provider", "native") == "hamlib":
-            return asyncio.run(_run_hardware_hamlib(args, template, safety))
-        return asyncio.run(_run_hardware(args, template, safety))
+
+        if provider == "both":
+            return asyncio.run(_run_hardware_both(args, profile, safety))
+
+        if provider == "hamlib":
+            rc, artifact = asyncio.run(_run_hardware_hamlib(args, template, safety))
+        else:
+            rc, artifact = asyncio.run(_run_hardware(args, template, safety))
+        if getattr(args, "compare", None):
+            artifact = _attach_comparison(artifact, args.compare)
+        _emit_artifact(artifact, args)
+        return rc
 
     levels = dry_run_results(template, safety)
     transport = TransportInfo(backend="fixture")
@@ -276,6 +305,58 @@ def run(args: argparse.Namespace) -> int:
         artifact = _attach_comparison(artifact, args.compare)
     _emit_artifact(artifact, args)
     return 0
+
+
+async def _run_hardware_both(
+    args: argparse.Namespace,
+    profile: Any,
+    safety: OperatorSafetyBlock,
+) -> int:
+    """Run native then hamlib sequentially, attach comparison dims to native artifact."""
+    if getattr(args, "compare", None):
+        print(
+            "Warning: --compare is ignored under --provider both",
+            file=sys.stderr,
+        )
+
+    tmpl_native = _generate_template(args, profile, "native")
+    tmpl_hamlib = _generate_template(args, profile, "hamlib")
+
+    # Sequential: native first, then hamlib (serial port must release between).
+    rc_n, art_n = await _run_hardware(args, tmpl_native, safety)
+    rc_h, art_h = await _run_hardware_hamlib(args, tmpl_hamlib, safety)
+
+    dims = compute_comparison_dimensions(art_n.to_dict(), art_h.to_dict())
+
+    # Build per-check rows from both status maps.
+    map_n = _check_status_map(art_n)
+    map_h = _check_status_map(art_h)
+    all_ids = sorted(set(map_n) | set(map_h))
+    rows = [
+        {
+            "check_id": cid,
+            "this": map_n.get(cid),
+            "other": map_h.get(cid),
+            "agree": map_n.get(cid) == map_h.get(cid),
+        }
+        for cid in all_ids
+    ]
+
+    comparison: dict[str, Any] = {
+        "other_provider": "hamlib",
+        "rows": rows,
+        "dimensions": dims,
+    }
+    art_n = dataclasses.replace(
+        art_n,
+        metadata={
+            **art_n.metadata,
+            "generated_from": "profile",
+            "comparison": comparison,
+        },
+    )
+    _emit_artifact(art_n, args)
+    return rc_n if rc_n else rc_h
 
 
 def _emit_artifact(artifact: ValidationArtifact, args: argparse.Namespace) -> None:
@@ -324,12 +405,14 @@ async def _run_hardware(
     args: argparse.Namespace,
     template: MatrixTemplate,
     safety: OperatorSafetyBlock,
-) -> int:
+) -> tuple[int, ValidationArtifact]:
     """Connect to the configured radio and execute the validation checks.
 
-    Imports of the CLI backend-config builder, the backend factory, and the
-    hardware runner are deferred to function scope to avoid a circular import
-    between this module and ``rigplane.cli``.
+    Returns ``(exit_code, artifact)``; the caller is responsible for attaching
+    comparison metadata and emitting the artifact.  Imports of the CLI
+    backend-config builder, the backend factory, and the hardware runner are
+    deferred to function scope to avoid a circular import between this module
+    and ``rigplane.cli``.
     """
     from rigplane.backends.factory import create_radio
     from rigplane.cli import _build_backend_config
@@ -344,7 +427,24 @@ async def _run_hardware(
         config = await _build_backend_config(args)
     except ValueError as exc:
         print(f"Error: cannot build backend config: {exc}", file=sys.stderr)
-        return 3
+        # Build a minimal failure artifact so callers always get a tuple.
+        transport = TransportInfo(backend="fixture")
+        levels = _transport_failure_levels(template, exc)
+        artifact = build_validation_artifact(
+            template=template,
+            levels=levels,
+            transport=transport,
+            safety=safety,
+            core_version=__version__,
+            core_commit=None,
+            mode="hardware",
+        )
+        artifact = dataclasses.replace(
+            artifact,
+            metadata={**artifact.metadata, "provider": "native"},
+            generated_at=_utcnow_iso(),
+        )
+        return 3, artifact
 
     # Resolve the radio profile for per-radio validation classification
     # (write-only controls, MOR-208). Best-effort: unknown model → no profile.
@@ -390,10 +490,7 @@ async def _run_hardware(
         metadata={**artifact.metadata, "provider": "native"},
         generated_at=_utcnow_iso(),
     )
-    if getattr(args, "compare", None):
-        artifact = _attach_comparison(artifact, args.compare)
-    _emit_artifact(artifact, args)
-    return exit_code
+    return exit_code, artifact
 
 
 async def _await_tcp_ready(host: str, port: int, *, timeout: float = 10.0) -> bool:
@@ -435,15 +532,17 @@ async def _run_hardware_hamlib(
     args: argparse.Namespace,
     template: MatrixTemplate,
     safety: OperatorSafetyBlock,
-) -> int:
+) -> tuple[int, ValidationArtifact]:
     """Drive the radio through an internally-spawned Hamlib ``rigctld``.
 
-    A :class:`HamlibBridge` owns the real (RigPlane-controlled) radio and
-    proxies raw CI-V to a stock ``rigctld``; the rigctld client backend then
-    runs the same hardware checks through Hamlib, so results can be compared to
-    the native provider. Imports are deferred to function scope to avoid a
-    circular import with ``rigplane.cli`` and to keep ``hamlib_bridge`` /
-    backend assembly off this module's import graph (matching ``_run_hardware``).
+    Returns ``(exit_code, artifact)``; the caller is responsible for attaching
+    comparison metadata and emitting the artifact.  A :class:`HamlibBridge`
+    owns the real (RigPlane-controlled) radio and proxies raw CI-V to a stock
+    ``rigctld``; the rigctld client backend then runs the same hardware checks
+    through Hamlib, so results can be compared to the native provider. Imports
+    are deferred to function scope to avoid a circular import with
+    ``rigplane.cli`` and to keep ``hamlib_bridge`` / backend assembly off this
+    module's import graph (matching ``_run_hardware``).
     """
     from rigplane.backends.config import RigctldBackendConfig
     from rigplane.backends.factory import create_radio
@@ -461,10 +560,14 @@ async def _run_hardware_hamlib(
         config = await _build_backend_config(args)
     except ValueError as exc:
         print(f"Error: cannot build backend config: {exc}", file=sys.stderr)
-        return 3
+        transport = TransportInfo(backend="fixture")
+        levels = _transport_failure_levels(template, exc)
+        artifact = _build_hamlib_artifact(
+            template, levels, transport, safety, None, None
+        )
+        return 3, artifact
 
     transport = _transport_info_from_config(config)
-    levels: list[LevelResult]
 
     # Resolve the radio profile (model is required for the hamlib provider).
     profile = None
@@ -481,10 +584,7 @@ async def _run_hardware_hamlib(
         artifact = _build_hamlib_artifact(
             template, levels, transport, safety, profile, None
         )
-        if getattr(args, "compare", None):
-            artifact = _attach_comparison(artifact, args.compare)
-        _emit_artifact(artifact, args)
-        return 3
+        return 3, artifact
 
     # The bridge speaks raw CI-V; non-CI-V rigs (Yaesu/Kenwood) cannot be driven.
     if profile.protocol_type != "civ":
@@ -498,10 +598,7 @@ async def _run_hardware_hamlib(
         artifact = _build_hamlib_artifact(
             template, levels, transport, safety, profile, profile.hamlib_model_id
         )
-        if getattr(args, "compare", None):
-            artifact = _attach_comparison(artifact, args.compare)
-        _emit_artifact(artifact, args)
-        return 3
+        return 3, artifact
 
     hamlib_model = profile.hamlib_model_id
     civaddr = getattr(config, "radio_addr", None) or profile.civ_addr
@@ -579,10 +676,7 @@ async def _run_hardware_hamlib(
     artifact = _build_hamlib_artifact(
         template, levels, transport, safety, profile, hamlib_model
     )
-    if getattr(args, "compare", None):
-        artifact = _attach_comparison(artifact, args.compare)
-    _emit_artifact(artifact, args)
-    return exit_code
+    return exit_code, artifact
 
 
 def _build_hamlib_artifact(

--- a/tests/test_validate_hamlib_provider.py
+++ b/tests/test_validate_hamlib_provider.py
@@ -174,7 +174,9 @@ async def test_run_hardware_hamlib_orchestration(monkeypatch: Any) -> None:
 
         monkeypatch.setattr(_validate, "_await_tcp_ready", fake_await_tcp_ready)
 
-        exit_code = await _validate._run_hardware_hamlib(_base_args(), template, safety)
+        exit_code, artifact = await _validate._run_hardware_hamlib(
+            _base_args(), template, safety
+        )
 
     assert exit_code == 0
     assert len(_FakeBridge.instances) == 1
@@ -182,7 +184,6 @@ async def test_run_hardware_hamlib_orchestration(monkeypatch: Any) -> None:
     assert bridge.started is True
     assert bridge.stopped is True
     assert bridge.kwargs["model"] == "3091"  # hamlib_model_id for X6200
-    artifact = captured["artifact"]
     assert artifact.metadata["provider"] == "hamlib"
     assert artifact.metadata["hamlib_model_id"] == 3091
 
@@ -211,7 +212,9 @@ async def test_hamlib_provider_partial_start_is_torn_down(monkeypatch: Any) -> N
     monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
     monkeypatch.setattr("rigplane.hamlib_bridge.HamlibBridge", _PartialStartBridge)
 
-    exit_code = await _validate._run_hardware_hamlib(_base_args(), template, safety)
+    exit_code, artifact = await _validate._run_hardware_hamlib(
+        _base_args(), template, safety
+    )
 
     assert exit_code == 3
     assert len(_FakeBridge.instances) == 1
@@ -219,7 +222,6 @@ async def test_hamlib_provider_partial_start_is_torn_down(monkeypatch: Any) -> N
     assert bridge.started is True  # partial start happened
     assert bridge.stopped is True  # ...and was still torn down
     # The failure is recorded as a transport-domain artifact.
-    artifact = captured["artifact"]
     checks = [c for lvl in artifact.levels for c in lvl.checks]
     assert any(c.failure_domain is not None for c in checks)
     assert artifact.metadata["profile_id"] == "xiegu_x6200"
@@ -247,13 +249,12 @@ async def test_hamlib_provider_rejects_non_civ(monkeypatch: Any) -> None:
         lambda artifact, args: captured.setdefault("artifact", artifact),
     )
 
-    exit_code = await _validate._run_hardware_hamlib(
+    exit_code, artifact = await _validate._run_hardware_hamlib(
         _base_args(model="FTX-1"), template, safety
     )
 
     assert exit_code == 3
     assert _FakeBridge.instances == []  # bridge never constructed/started
-    artifact = captured["artifact"]
     assert artifact.metadata["provider"] == "hamlib"
     checks = [c for level in artifact.levels for c in level.checks]
     assert any(
@@ -638,3 +639,371 @@ def test_cli_genb_native_provider_unchanged(monkeypatch: Any) -> None:
         entries_by_id["discovery.identify"].declaration
         == CapabilityDeclaration.SUPPORTED
     )
+
+
+# ---------------------------------------------------------------------------
+# --provider both tests (MOR-213)
+# ---------------------------------------------------------------------------
+
+
+def _make_hardware_args(**kwargs: Any) -> argparse.Namespace:
+    """Namespace with hardware-run defaults for _validate.run() with both."""
+    import os
+
+    defaults = dict(
+        template=None,
+        model="X6200",
+        hardware=True,
+        allow_hardware=True,
+        tx_allowed=False,
+        tuner_allowed=False,
+        read_only=True,
+        provider="both",
+        compare=None,
+        operator_id=None,
+        output=None,
+        json=True,
+    )
+    defaults.update(kwargs)
+    # Set the env gate so the hardware guard passes
+    os.environ["RIGPLANE_VALIDATION_ALLOW_HARDWARE"] = "1"
+    return argparse.Namespace(**defaults)
+
+
+def test_provider_both_parses() -> None:
+    """add_subparser accepts --provider both."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    _validate.add_subparser(sub)
+    args = parser.parse_args(["validate", "--template", "x.json", "--provider", "both"])
+    assert args.provider == "both"
+
+
+def test_provider_both_attaches_dimensions(monkeypatch: Any) -> None:
+    """--provider both runs native then hamlib, attaches comparison dims to native artifact.
+
+    Native: mode.set=pass, rf_gain.set=pass, discovery.identify=SUPPORTED+pass
+    Hamlib: mode.set=fail, rf_gain.set=pass, discovery.identify=UNSUPPORTED_PENDING+unsupported
+    Expected: cross_impl differ >= 1 (mode.set disagrees); exactly ONE artifact emitted.
+    """
+    import os
+
+    os.environ["RIGPLANE_VALIDATION_ALLOW_HARDWARE"] = "1"
+
+    from rigplane.backends.config import RigctldBackendConfig
+    from rigplane.backends.hamlib_models import HamlibCaps
+
+    native_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="X6200")
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return native_config
+
+    def fake_create_radio(config: Any) -> Any:
+        return _FakeNativeRadio()
+
+    # Side-effect list: first call → native levels, second call → hamlib levels
+    call_count = {"n": 0}
+
+    async def fake_execute_hardware_checks(
+        radio: Any, template: Any, safety: Any, **kwargs: Any
+    ) -> Any:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Native: mode.set pass, rf_gain pass, discovery pass
+            return _build_level_results(
+                [
+                    ("mode.set", "supported", "pass"),
+                    ("rf_gain.set", "supported", "pass"),
+                    ("discovery.identify", "supported", "pass"),
+                ]
+            )
+        else:
+            # Hamlib: mode.set fail, rf_gain pass, discovery unsupported_pending→unsupported
+            return _build_level_results(
+                [
+                    ("mode.set", "supported", "fail"),
+                    ("rf_gain.set", "supported", "pass"),
+                    (
+                        "discovery.identify",
+                        "unsupported_pending_evidence",
+                        "unsupported",
+                    ),  # noqa: E501
+                ]
+            )
+
+    emitted: list[Any] = []
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+    monkeypatch.setattr(
+        "rigplane.validation.hardware.execute_hardware_checks",
+        fake_execute_hardware_checks,
+    )
+    monkeypatch.setattr(
+        "rigplane.hamlib_bridge.HamlibBridge",
+        _FakeBridge,
+    )
+
+    async def fake_await_tcp_ready(
+        host: str, port: int, *, timeout: float = 10.0
+    ) -> bool:
+        return True
+
+    monkeypatch.setattr(_validate, "_await_tcp_ready", fake_await_tcp_ready)
+    monkeypatch.setattr(
+        _validate,
+        "_emit_artifact",
+        lambda artifact, args: emitted.append(artifact),
+    )
+
+    # Also patch load_hamlib_caps so the Gen-B template build doesn't fail
+    fake_caps = HamlibCaps(
+        get_levels=frozenset({"RF"}),
+        set_levels=frozenset({"RF"}),
+        modes=frozenset({"USB"}),
+        has_set_freq=True,
+    )
+    monkeypatch.setattr(
+        "rigplane.backends.hamlib_models.load_hamlib_caps",
+        lambda model_id: fake_caps,
+    )
+
+    _FakeBridge.instances.clear()
+    args = _make_hardware_args()
+    rc = _validate.run(args)
+
+    # Exactly one artifact emitted (the native primary)
+    assert len(emitted) == 1, f"Expected 1 artifact, got {len(emitted)}"
+    artifact = emitted[0]
+
+    # It is the native artifact (provider=native)
+    assert artifact.metadata.get("provider") == "native"
+
+    # generated_from is set to "profile"
+    assert artifact.metadata.get("generated_from") == "profile"
+
+    # comparison block exists
+    comp = artifact.metadata.get("comparison")
+    assert comp is not None, "No comparison in metadata"
+    assert comp["other_provider"] == "hamlib"
+
+    # cross_impl must have at least 1 differ (mode.set: native=pass, hamlib=fail)
+    dims = comp["dimensions"]
+    assert dims["cross_impl"]["differ"] >= 1, (
+        f"Expected cross_impl differ >= 1, got {dims['cross_impl']}"
+    )
+
+    # rc is non-zero only if either run returned non-zero; both succeeded here
+    assert rc == 0
+
+    # execute_hardware_checks was called exactly twice (native + hamlib)
+    assert call_count["n"] == 2
+
+
+def test_provider_both_compare_warns(monkeypatch: Any, capsys: Any) -> None:
+    """--provider both + --compare path emits warning to stderr, still emits primary."""
+    import os
+
+    os.environ["RIGPLANE_VALIDATION_ALLOW_HARDWARE"] = "1"
+
+    from rigplane.backends.config import RigctldBackendConfig
+    from rigplane.backends.hamlib_models import HamlibCaps
+
+    native_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="X6200")
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return native_config
+
+    def fake_create_radio(config: Any) -> Any:
+        return _FakeNativeRadio()
+
+    async def fake_execute_hardware_checks(
+        radio: Any, template: Any, safety: Any, **kwargs: Any
+    ) -> Any:
+        return _build_level_results([("discovery.identify", "supported", "pass")])
+
+    emitted: list[Any] = []
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+    monkeypatch.setattr(
+        "rigplane.validation.hardware.execute_hardware_checks",
+        fake_execute_hardware_checks,
+    )
+    monkeypatch.setattr("rigplane.hamlib_bridge.HamlibBridge", _FakeBridge)
+
+    async def fake_await_tcp_ready(
+        host: str, port: int, *, timeout: float = 10.0
+    ) -> bool:
+        return True
+
+    monkeypatch.setattr(_validate, "_await_tcp_ready", fake_await_tcp_ready)
+    monkeypatch.setattr(
+        _validate,
+        "_emit_artifact",
+        lambda artifact, args: emitted.append(artifact),
+    )
+
+    fake_caps = HamlibCaps(
+        get_levels=frozenset({"RF"}),
+        set_levels=frozenset({"RF"}),
+    )
+    monkeypatch.setattr(
+        "rigplane.backends.hamlib_models.load_hamlib_caps",
+        lambda model_id: fake_caps,
+    )
+
+    _FakeBridge.instances.clear()
+    args = _make_hardware_args(compare="/some/nonexistent/path.json")
+    _validate.run(args)
+
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err and "--compare" in captured.err, (
+        f"Expected --compare warning in stderr, got: {captured.err!r}"
+    )
+    # Still emits primary artifact
+    assert len(emitted) == 1
+
+
+def test_single_provider_native_unchanged(monkeypatch: Any) -> None:
+    """Single-provider native hardware run emits exactly one artifact (regression)."""
+    import os
+
+    os.environ["RIGPLANE_VALIDATION_ALLOW_HARDWARE"] = "1"
+
+    from rigplane.backends.config import RigctldBackendConfig
+
+    native_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="X6200")
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return native_config
+
+    def fake_create_radio(config: Any) -> Any:
+        return _FakeNativeRadio()
+
+    async def fake_execute_hardware_checks(
+        radio: Any, template: Any, safety: Any, **kwargs: Any
+    ) -> Any:
+        return _build_level_results([("discovery.identify", "supported", "pass")])
+
+    emitted: list[Any] = []
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+    monkeypatch.setattr(
+        "rigplane.validation.hardware.execute_hardware_checks",
+        fake_execute_hardware_checks,
+    )
+    monkeypatch.setattr(
+        _validate,
+        "_emit_artifact",
+        lambda artifact, args: emitted.append(artifact),
+    )
+
+    args = _make_hardware_args(provider="native")
+    rc = _validate.run(args)
+
+    assert len(emitted) == 1, f"Expected exactly 1 artifact, got {len(emitted)}"
+    assert emitted[0].metadata["provider"] == "native"
+    assert rc == 0
+
+
+def test_single_provider_hamlib_unchanged(monkeypatch: Any) -> None:
+    """Single-provider hamlib hardware run still emits exactly one artifact (regression)."""
+    import os
+
+    os.environ["RIGPLANE_VALIDATION_ALLOW_HARDWARE"] = "1"
+    _FakeBridge.instances.clear()
+
+    from rigplane.backends.config import RigctldBackendConfig
+
+    native_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="X6200")
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return native_config
+
+    def fake_create_radio(config: Any) -> Any:
+        return _FakeNativeRadio()
+
+    async def fake_execute_hardware_checks(
+        radio: Any, template: Any, safety: Any, **kwargs: Any
+    ) -> Any:
+        return _build_level_results([("discovery.identify", "supported", "pass")])
+
+    async def fake_await_tcp_ready(
+        host: str, port: int, *, timeout: float = 10.0
+    ) -> bool:
+        return True
+
+    emitted: list[Any] = []
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+    monkeypatch.setattr(
+        "rigplane.validation.hardware.execute_hardware_checks",
+        fake_execute_hardware_checks,
+    )
+    monkeypatch.setattr("rigplane.hamlib_bridge.HamlibBridge", _FakeBridge)
+    monkeypatch.setattr(_validate, "_await_tcp_ready", fake_await_tcp_ready)
+    monkeypatch.setattr(
+        _validate,
+        "_emit_artifact",
+        lambda artifact, args: emitted.append(artifact),
+    )
+
+    args = _make_hardware_args(provider="hamlib")
+    rc = _validate.run(args)
+
+    assert len(emitted) == 1, f"Expected exactly 1 artifact, got {len(emitted)}"
+    assert emitted[0].metadata["provider"] == "hamlib"
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Helper to build LevelResult lists from plain tuples
+# ---------------------------------------------------------------------------
+
+
+def _build_level_results(
+    checks: list[tuple[str, str, str]],
+) -> list[Any]:
+    """Build a list of LevelResult from (check_id, declaration, status) tuples.
+
+    declaration strings: "supported", "unsupported_pending_evidence", "manual_required"
+    status strings: "pass", "fail", "skip", "unsupported", "blocked", "manual_required"
+    """
+    from rigplane.validation.schema import (
+        CapabilityDeclaration,
+        CheckResult,
+        CheckStatus,
+        FailureDomain,
+        LevelResult,
+        ValidationLevel,
+    )
+
+    decl_map = {
+        "supported": CapabilityDeclaration.SUPPORTED,
+        "unsupported_pending_evidence": CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE,
+        "manual_required": CapabilityDeclaration.MANUAL_REQUIRED,
+    }
+    status_map = {
+        "pass": CheckStatus.PASS,
+        "fail": CheckStatus.FAIL,
+        "skip": CheckStatus.SKIP,
+        "unsupported": CheckStatus.UNSUPPORTED,
+        "blocked": CheckStatus.BLOCKED,
+        "manual_required": CheckStatus.MANUAL_REQUIRED,
+    }
+    results = []
+    for check_id, decl_str, status_str in checks:
+        decl = decl_map[decl_str]
+        status = status_map[status_str]
+        failure_domain = FailureDomain.TRANSPORT if status == CheckStatus.FAIL else None
+        results.append(
+            CheckResult(
+                check_id=check_id,
+                capability="",
+                level=ValidationLevel.DISCOVERY,
+                status=status,
+                declaration=decl,
+                summary=f"{check_id} synthetic",
+                failure_domain=failure_domain,
+            )
+        )
+    return [LevelResult(level=ValidationLevel.DISCOVERY, checks=results)]


### PR DESCRIPTION
## MOR-213 (202b) — `validate --provider both`

Turns two validation runs into one comparison report. `validate --model <X> --provider both --hardware` runs native (Gen-A) then hamlib (Gen-B) **sequentially** (serial port released between — never concurrent), computes the three ADR §7 dimensions via `compute_comparison_dimensions` (MOR-202), attaches them to the **primary (native)** artifact's `metadata.comparison` (alongside per-check `rows`) + sets `metadata.generated_from="profile"`, and emits the primary only.

### Changes (2 files)
- **`cli/_validate.py`**:
  - `--provider` gains `both`.
  - **Behaviour-preserving refactor:** `_run_hardware` / `_run_hardware_hamlib` now return `(exit_code, ValidationArtifact)`; `_emit_artifact` + `--compare` attach moved to `run()` so single-provider emits **exactly once** as before.
  - `_generate_template(args, profile, provider)` extracts the per-provider Gen-A/Gen-B template build (reused by single + both paths).
  - `_run_hardware_both`: sequential native→hamlib, dimensions roll-up, attach to native metadata, emit primary, return `rc_n or rc_h`.
  - `--compare` + `--provider both` → stderr warning (both self-computes).
- **`tests/test_validate_hamlib_provider.py`**: `--provider both` parses; both-run attaches dimensions (canned native mode.set=pass / hamlib mode.set=fail → cross_impl differ flags mode.set; one artifact emitted; generated_from=profile); `--compare` warning; single-provider native + hamlib unchanged (regression).

### Gates
- `pytest test_validate_hamlib_provider.py` → 26 passed
- full suite (no integration) → **6212 passed**
- ruff / mypy (`_validate.py`) / lint-imports → clean

Live X6200 `--provider both` verify run by the orchestrator before merge: expect `cross_impl` to flag `mode.set` (native pass / hamlib timeout), `profile_vs_reality` clean.

Decomposed from MOR-202. Blocked-by MOR-202✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)