### PR TITLE
feat(MOR-203): pure Hamlib dump_caps → draft TOML converter + cross-check

### DIFF
--- a/src/rigplane/cli/_convert.py
+++ b/src/rigplane/cli/_convert.py
@@ -1,0 +1,194 @@
+"""Pure Hamlib ``dump_caps`` → draft rigplane TOML + cross-check (MOR-203).
+
+This module is a *pure* data transform: ``str``/dataclass in, ``str``/dataclass
+out. It performs NO subprocess calls, NO disk I/O, and registers NO CLI verb —
+those belong to MOR-204. It lives in ``cli/`` because only the top layer may
+import BOTH ``rigplane.backends.hamlib_models`` (``HamlibCaps``) AND
+``rigplane.validation.registry`` (the token map). ``validation/`` must not import
+``backends/``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from rigplane.backends.hamlib_models import HamlibCaps
+from rigplane.validation.registry import REGISTRY
+
+__all__ = [
+    "CrossCheckReport",
+    "build_draft_toml",
+    "caps_to_capabilities",
+    "cross_check",
+]
+
+
+# Hamlib mode token -> rigplane mode string. Unknown tokens pass through.
+_MODE_MAP: dict[str, str] = {
+    "CWR": "CW-R",
+    "RTTYR": "RTTY-R",
+    "PKTUSB": "USB-D",
+    "PKTLSB": "LSB-D",
+    "PKTFM": "FM",
+}
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _token_to_capability() -> dict[str, str]:
+    """Reverse map ``hamlib_token -> rigplane capability`` from REGISTRY.
+
+    Only specs with a non-None ``hamlib_token`` AND a non-empty ``capability``
+    contribute, except the structural transmit token ``t`` which maps to the
+    real ``tx`` capability and is included here. Structural ``f``/``m`` (empty
+    capability) are skipped.
+    """
+    mapping: dict[str, str] = {}
+    for spec in REGISTRY:
+        if spec.hamlib_token is None:
+            continue
+        if spec.capability:
+            mapping[spec.hamlib_token] = spec.capability
+    return mapping
+
+
+def caps_to_capabilities(caps: HamlibCaps) -> frozenset[str]:
+    """Union of present Hamlib tokens mapped through :func:`_token_to_capability`.
+
+    Considers ``get_funcs | set_funcs | get_levels | set_levels`` plus the
+    transmit token ``t`` when ``caps.ptt_type`` is set. Tokens with no mapping
+    are dropped.
+    """
+    token_map = _token_to_capability()
+    present: set[str] = set(
+        caps.get_funcs | caps.set_funcs | caps.get_levels | caps.set_levels
+    )
+    if caps.ptt_type:
+        present.add("t")
+    return frozenset(token_map[token] for token in present if token in token_map)
+
+
+def _normalize_modes(modes: frozenset[str]) -> list[str]:
+    """Map Hamlib mode tokens to rigplane mode strings, sorted, deduplicated."""
+    return sorted({_MODE_MAP.get(m, m) for m in modes})
+
+
+def _slug(model: str) -> str:
+    """Lowercase *model*, replacing runs of non-alphanumerics with ``_``."""
+    return _SLUG_RE.sub("_", model.lower()).strip("_")
+
+
+@dataclass(frozen=True, slots=True)
+class CrossCheckReport:
+    """Result of comparing a profile's declared capabilities against Hamlib."""
+
+    profile_id: str
+    agreed: tuple[str, ...]
+    rigplane_only: tuple[str, ...]
+    hamlib_only: tuple[str, ...]
+    mode_only_profile: tuple[str, ...]
+    mode_only_hamlib: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly dict; bucket fields are lists, not tuples."""
+        return {
+            "profile_id": self.profile_id,
+            "agreed": list(self.agreed),
+            "rigplane_only": list(self.rigplane_only),
+            "hamlib_only": list(self.hamlib_only),
+            "mode_only_profile": list(self.mode_only_profile),
+            "mode_only_hamlib": list(self.mode_only_hamlib),
+        }
+
+    def human_table(self) -> str:
+        """Render a readable multi-line summary of every bucket."""
+        lines = [f"Cross-check report for profile: {self.profile_id or '(none)'}"]
+        buckets = (
+            ("agreed", self.agreed),
+            ("rigplane_only", self.rigplane_only),
+            ("hamlib_only", self.hamlib_only),
+            ("mode_only_profile", self.mode_only_profile),
+            ("mode_only_hamlib", self.mode_only_hamlib),
+        )
+        for name, values in buckets:
+            rendered = ", ".join(values) if values else "(none)"
+            lines.append(f"  {name}: {rendered}")
+        return "\n".join(lines)
+
+
+def cross_check(
+    caps: HamlibCaps,
+    profile_capabilities: frozenset[str],
+    *,
+    profile_id: str = "",
+) -> CrossCheckReport:
+    """Compare declared profile capabilities against Hamlib-derived ones (ADR §8.2).
+
+    ``agreed`` = intersection; ``rigplane_only`` = declared but no Hamlib token;
+    ``hamlib_only`` = Hamlib token present but profile omits it. Mode buckets are
+    empty in v1 (cross_check receives no profile modes). All tuples are sorted
+    for determinism.
+    """
+    hamlib_caps = caps_to_capabilities(caps)
+    return CrossCheckReport(
+        profile_id=profile_id,
+        agreed=tuple(sorted(profile_capabilities & hamlib_caps)),
+        rigplane_only=tuple(sorted(profile_capabilities - hamlib_caps)),
+        hamlib_only=tuple(sorted(hamlib_caps - profile_capabilities)),
+        mode_only_profile=(),
+        mode_only_hamlib=(),
+    )
+
+
+def build_draft_toml(caps: HamlibCaps, *, model: str, profile_id: str) -> str:
+    """Return draft TOML text (valid per ``tomllib``) from *caps* (ADR §8.1).
+
+    Auto-fills the loader-required sections/fields, normalizes modes and maps
+    capability tokens, and marks every non-auto field with ``TODO(human):``.
+    Deterministic: all lists are sorted. The string is hand-rolled — no TOML
+    writer dependency.
+    """
+    features = sorted(caps_to_capabilities(caps))
+    modes = _normalize_modes(caps.modes) or ["USB"]
+
+    lines: list[str] = [
+        "# REVIEW: auto-generated draft from Hamlib dump_caps. Human review required",
+        "#         before this becomes a real profile. Do NOT auto-commit.",
+        "",
+        "[radio]",
+        f'id = "{_slug(model)}"',
+        f'model = "{model}"',
+    ]
+    if caps.model_id is not None:
+        lines.append(f"hamlib_model_id = {caps.model_id}")
+    lines.extend(
+        [
+            "receiver_count = 1  # TODO(human): confirm receiver count",
+            "has_lan = false  # TODO(human): RigPlane-specific, not in dump_caps",
+            "has_wifi = false  # TODO(human): RigPlane-specific, not in dump_caps",
+            "# TODO(human): civ_addr — per-unit, not exposed by dump_caps",
+            "",
+            "[protocol]",
+            'type = "civ"  # TODO(human): civ|kenwood_cat|yaesu_cat',
+            "",
+            "[capabilities]",
+            "features = [" + ", ".join(f'"{f}"' for f in features) + "]",
+            "",
+            "[modes]",
+            "list = ["
+            + ", ".join(f'"{m}"' for m in modes)
+            + ("]" if caps.modes else "]  # TODO(human): no modes in dump_caps"),
+            "",
+            "[filters]",
+            'list = ["FIL1"]  # TODO(human): dump_caps exposes no filter passbands',
+            "",
+            "[vfo]",
+            'scheme = "ab"  # TODO(human): ab|main_sub|single',
+            "",
+            "[commands]",
+            "# TODO(human): CI-V/CAT byte maps not in dump_caps",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,193 @@
+"""Unit tests for the pure Hamlib dump_caps → draft TOML converter (MOR-203)."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from rigplane.backends.hamlib_models import HamlibCaps, parse_hamlib_dump_caps
+from rigplane.cli._convert import (
+    CrossCheckReport,
+    build_draft_toml,
+    caps_to_capabilities,
+    cross_check,
+)
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "hamlib_dump_caps_ts480.txt"
+
+
+def _ts480_caps() -> HamlibCaps:
+    return parse_hamlib_dump_caps(_FIXTURE.read_text())
+
+
+# ---------------------------------------------------------------------------
+# build_draft_toml
+# ---------------------------------------------------------------------------
+
+
+def test_build_draft_toml_parses_and_has_required_sections() -> None:
+    caps = _ts480_caps()
+    # model_id is not set by parse_hamlib_dump_caps; inject it like load_hamlib_caps.
+    import dataclasses
+
+    caps = dataclasses.replace(caps, model_id=2028)
+
+    text = build_draft_toml(caps, model="TS-480", profile_id="ts480")
+
+    # (#2) Generated draft is valid TOML.
+    data = tomllib.loads(text)
+
+    # Required sections present (rig_loader._REQUIRED_SECTIONS).
+    for section in ("radio", "capabilities", "modes", "filters", "vfo"):
+        assert section in data, f"missing section {section!r}"
+
+    # Required radio fields (rig_loader._REQUIRED_RADIO_FIELDS).
+    radio = data["radio"]
+    for f in ("id", "model", "receiver_count", "has_lan", "has_wifi"):
+        assert f in radio, f"missing [radio].{f}"
+
+    assert radio["model"] == "TS-480"
+    assert radio["id"] == "ts_480"
+    assert radio["hamlib_model_id"] == 2028
+
+    # Features mapped from tokens.
+    features = set(data["capabilities"]["features"])
+    assert {
+        "nb",
+        "nr",
+        "rf_gain",
+        "af_level",
+        "attenuator",
+        "preamp",
+        "squelch",
+        "meters",
+    } <= features
+
+    # Modes normalized: CWR -> CW-R, original token gone.
+    modes = data["modes"]["list"]
+    assert "CW-R" in modes
+    assert "CWR" not in modes
+    assert "RTTY-R" in modes
+    assert "RTTYR" not in modes
+
+    # Review banner + TODO markers present in raw text.
+    assert "# REVIEW:" in text
+    assert "TODO(human)" in text
+
+    # hamlib_model_id line present when model_id set.
+    assert "hamlib_model_id = 2028" in text
+
+
+def test_build_draft_toml_omits_hamlib_model_id_when_none() -> None:
+    caps = _ts480_caps()  # model_id is None from parse.
+    text = build_draft_toml(caps, model="TS-480", profile_id="ts480")
+    assert "hamlib_model_id" not in text
+    tomllib.loads(text)
+
+
+# ---------------------------------------------------------------------------
+# caps_to_capabilities / cross_check
+# ---------------------------------------------------------------------------
+
+
+def test_caps_to_capabilities_maps_tokens() -> None:
+    caps = HamlibCaps(
+        get_levels=frozenset({"RF", "AF"}),
+        get_funcs=frozenset({"NB"}),
+    )
+    assert caps_to_capabilities(caps) == frozenset({"rf_gain", "af_level", "nb"})
+
+
+def test_caps_to_capabilities_maps_ptt_to_tx() -> None:
+    caps = HamlibCaps(ptt_type="RIG")
+    assert caps_to_capabilities(caps) == frozenset({"tx"})
+
+
+def test_cross_check_buckets() -> None:
+    caps = HamlibCaps(
+        get_levels=frozenset({"RF", "AF"}),
+        get_funcs=frozenset({"NB"}),
+    )
+    profile_caps = frozenset({"rf_gain", "agc", "rit"})
+    report = cross_check(caps, profile_caps, profile_id="ts480")
+
+    assert isinstance(report, CrossCheckReport)
+    assert report.profile_id == "ts480"
+
+    assert report.agreed == ("rf_gain",)
+    # Declared by profile, no Hamlib token.
+    assert "agc" in report.rigplane_only
+    assert "rit" in report.rigplane_only
+    # Token present, profile omits.
+    assert "af_level" in report.hamlib_only
+    assert "nb" in report.hamlib_only
+
+    # All tuple fields sorted.
+    assert list(report.rigplane_only) == sorted(report.rigplane_only)
+    assert list(report.hamlib_only) == sorted(report.hamlib_only)
+    assert list(report.agreed) == sorted(report.agreed)
+
+    # Mode buckets empty in v1.
+    assert report.mode_only_profile == ()
+    assert report.mode_only_hamlib == ()
+
+
+def test_cross_check_report_to_dict_and_table() -> None:
+    caps = HamlibCaps(
+        get_levels=frozenset({"RF", "AF"}),
+        get_funcs=frozenset({"NB"}),
+    )
+    report = cross_check(caps, frozenset({"rf_gain", "agc"}), profile_id="ts480")
+
+    d = report.to_dict()
+    for key in (
+        "agreed",
+        "rigplane_only",
+        "hamlib_only",
+        "mode_only_profile",
+        "mode_only_hamlib",
+        "profile_id",
+    ):
+        assert key in d
+    # List values (not tuples) for the bucket fields.
+    for key in (
+        "agreed",
+        "rigplane_only",
+        "hamlib_only",
+        "mode_only_profile",
+        "mode_only_hamlib",
+    ):
+        assert isinstance(d[key], list)
+
+    table = report.human_table()
+    assert isinstance(table, str)
+    assert table
+    assert "agreed" in table
+    assert "rigplane_only" in table
+    assert "hamlib_only" in table
+
+
+# ---------------------------------------------------------------------------
+# Degraded caps
+# ---------------------------------------------------------------------------
+
+
+def test_build_draft_toml_degraded_caps() -> None:
+    caps = HamlibCaps(degraded_reason="x")
+    text = build_draft_toml(caps, model="Mystery Rig", profile_id="mystery")
+
+    data = tomllib.loads(text)
+    for section in ("radio", "capabilities", "modes", "filters", "vfo"):
+        assert section in data
+
+    # Empty features, mode fallback to ["USB"].
+    assert data["capabilities"]["features"] == []
+    assert data["modes"]["list"] == ["USB"]
+
+
+def test_cross_check_degraded_caps() -> None:
+    caps = HamlibCaps(degraded_reason="x")
+    report = cross_check(caps, frozenset({"rf_gain"}))
+    assert report.rigplane_only == ("rf_gain",)
+    assert report.agreed == ()
+    assert report.hamlib_only == ()


### PR DESCRIPTION
## MOR-203 — Profile converter (pure data transform)

Bootstraps a **draft** rigplane TOML profile from Hamlib `dump_caps` and cross-checks an existing profile's capabilities against `dump_caps`. Implements ADR `docs/plans/2026-05-28-universal-validation-matrix.md` §8.

**Scope (owner-confirmed): PURE LIBRARY ONLY.** No argparse verb, no subprocess, no disk write — the `radio-validate convert` CLI verb + file write + `load_hamlib_caps` driver are MOR-204.

### Why `cli/`
`validation/` may not import `backends/` (charter + ruff TID251), and `HamlibCaps` lives in `backends/hamlib_models.py` while the capability↔token map lives in `validation/registry.py`. Only the top-layer `cli/` package sees both — matching ADR D5 (impure resolution lives in `cli/`). The functions stay pure (str/dataclass in → str/dataclass out), so they're directly unit-testable per the ticket acceptance.

### Public API (`src/rigplane/cli/_convert.py`)
- `caps_to_capabilities(caps) -> frozenset[str]` — present Hamlib tokens mapped through a REGISTRY-derived reverse token map (RF→rf_gain, AF→af_level, SQL→squelch, PREAMP→preamp, ATT→attenuator, NB→nb, NR→nr, STRENGTH→meters, t→tx).
- `build_draft_toml(caps, *, model, profile_id) -> str` — deterministic TOML text with a `# REVIEW:` banner and `TODO(human):` markers on every non-auto field. Emits all loader-required sections (`radio/capabilities/modes/filters/vfo`) and radio fields (`id/model/receiver_count/has_lan/has_wifi`); modes normalized (CWR→CW-R, …); `dump_caps` has no filter/CI-V data → those are `TODO(human)`.
- `cross_check(caps, profile_capabilities, *, profile_id="") -> CrossCheckReport` — ADR §8.2 set algebra: `agreed` / `rigplane_only` / `hamlib_only` (+ `to_dict()`, `human_table()`).

### Tests
`tests/test_convert.py` — 8 tests over the existing `hamlib_dump_caps_ts480.txt` fixture (a model not yet profiled) + inline `HamlibCaps` for cross-check; covers draft sections/features/mode-normalization, valid-TOML round-trip, the three cross-check buckets, report rendering, and the degraded/empty-caps path.

### Gates
- `uv run pytest tests/ -q` — 6450 passed, 0 failures (full suite incl. integration)
- `uv run ruff check` / `ruff format` — clean
- `uv run mypy src/rigplane/cli/_convert.py` — clean
- `uv run lint-imports` — 4 contracts kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)