### PR TITLE
feat(MOR-204): radio-validate verb — thin profile-driven wrapper over validate run path

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -90,6 +90,10 @@ from rigplane.cli._validate import (  # noqa: E402
     add_subparser as _add_validate_subparser,
     run as _run_validate,
 )
+from rigplane.cli._radio_validate import (  # noqa: E402
+    add_subparser as _add_radio_validate_subparser,
+    run as _run_radio_validate,
+)
 from rigplane.core.radio_protocol import Radio  # noqa: E402
 from rigplane.core.types import Mode, get_audio_capabilities  # noqa: E402
 
@@ -332,6 +336,7 @@ _COMMAND_NAMES = {
     "scope",
     "diagnose",
     "validate",
+    "radio-validate",
 }
 
 _GLOBAL_CONNECTION_OPTIONS = {
@@ -1488,6 +1493,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # validate — run the real-radio validation matrix (dry-run by default)
     _add_validate_subparser(sub)
+
+    # radio-validate — profile-driven entrypoint; thin wrapper over validate
+    _add_radio_validate_subparser(sub)
 
     return p
 
@@ -3723,6 +3731,8 @@ def main() -> None:
         sys.exit(_run_diagnose(args))
     elif args.command == "validate":
         sys.exit(_run_validate(args))
+    elif args.command == "radio-validate":
+        sys.exit(_run_radio_validate(args))
     elif args.command is None:
         parser.print_help()
         sys.exit(0)

--- a/src/rigplane/cli/_radio_validate.py
+++ b/src/rigplane/cli/_radio_validate.py
@@ -1,0 +1,185 @@
+"""``rigplane radio-validate <model>`` — profile-driven validation entrypoint.
+
+This is the first-class, profile-driven form of the universal validation
+matrix. It is a THIN WRAPPER (ADR D7,
+``docs/plans/2026-05-28-universal-validation-matrix.md`` §9) over the existing
+``validate`` run path in :mod:`rigplane.cli._validate` — NOT a fork. The
+``validate`` subcommand already performs profile-driven Gen-A/Gen-B template
+generation, ``--provider native|hamlib|both``, comparison, and safety gating;
+``radio-validate`` simply makes the profile-driven form ergonomic with a
+positional ``model`` and adds ``--write-template`` to dump the generated
+in-memory matrix.
+
+``run`` normalises the parsed namespace (maps the positional model onto
+``args.model``, forces ``args.template = None`` so the shared path generates
+from the profile) and then delegates to :func:`rigplane.cli._validate.run`.
+The only logic that lives here is argument normalisation and the small
+``--write-template`` dump.
+
+.. note::
+   MOR-220 (slice 204b) will add a ``convert`` subcommand to this verb. The
+   positional-model form here is forward-compatible: 204b may restructure the
+   parser into subparsers (``radio-validate <model>`` vs
+   ``radio-validate convert ...``) without changing this delegation contract.
+
+Exit codes mirror ``validate``: ``0`` success (artifact or template emitted),
+``2`` model missing/unknown, ``3`` hardware blocked / connect failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import rigplane.cli._validate as _validate
+
+
+def add_subparser(sub: Any) -> argparse.ArgumentParser:
+    """Register the ``radio-validate`` subparser on ``sub``.
+
+    Typed as ``Any`` because ``argparse._SubParsersAction`` is private and the
+    surrounding parser code in ``cli/__init__.py`` follows the same convention.
+    """
+    p: argparse.ArgumentParser = sub.add_parser(
+        "radio-validate",
+        help=(
+            "Validate a radio against the universal matrix, generated from its "
+            "profile (dry-run by default). Thin wrapper over 'validate'."
+        ),
+    )
+    # Distinct dest so the positional does not shadow the global --model option
+    # (which lives on the root parser). run() reconciles the two.
+    p.add_argument(
+        "radio_validate_model",
+        nargs="?",
+        default=None,
+        metavar="MODEL",
+        help=(
+            "Radio model (e.g. X6200, IC-7610). If omitted, the global --model "
+            "is used; if neither is given the command errors."
+        ),
+    )
+    p.add_argument(
+        "--provider",
+        choices=["native", "hamlib", "both"],
+        default="native",
+        help=(
+            "Validation provider: native (default) drives the radio directly; "
+            "hamlib drives it through an internally-spawned Hamlib rigctld and "
+            "compares results; both runs native then hamlib sequentially."
+        ),
+    )
+    p.add_argument(
+        "--read-only",
+        dest="read_only",
+        action="store_true",
+        help=(
+            "Disable all writes (write checks SKIP). Default is read/write "
+            "with automatic restore."
+        ),
+    )
+    p.add_argument(
+        "--tx-allowed",
+        dest="tx_allowed",
+        action="store_true",
+        help="Authorize TX-adjacent checks (PTT/TX).",
+    )
+    p.add_argument(
+        "--tuner-allowed",
+        dest="tuner_allowed",
+        action="store_true",
+        help="Authorize tuner tune-cycle checks.",
+    )
+    p.add_argument(
+        "--hardware",
+        action="store_true",
+        help=(
+            "Run against a real connected radio (double-gated; read/write with "
+            "restore by default)."
+        ),
+    )
+    p.add_argument(
+        "--allow-hardware",
+        action="store_true",
+        help="First hardware gate; also requires RIGPLANE_VALIDATION_ALLOW_HARDWARE=1.",
+    )
+    p.add_argument(
+        "--compare",
+        default=None,
+        help=(
+            "Path to a prior validation artifact JSON to diff this run against "
+            "(per-check status)."
+        ),
+    )
+    p.add_argument(
+        "--operator-id",
+        dest="operator_id",
+        default=None,
+        help="Operator identifier recorded in the safety block.",
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        help="Write the JSON artifact to this path instead of stdout.",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the artifact as JSON (default: human summary).",
+    )
+    p.add_argument(
+        "--write-template",
+        dest="write_template",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Dump the generated in-memory validation matrix to PATH as JSON "
+            "and exit (no hardware). Useful for inspecting or hand-editing the "
+            "template before a hardware run."
+        ),
+    )
+    return p
+
+
+def run(args: argparse.Namespace) -> int:
+    # Reconcile the positional model with the global --model: positional wins,
+    # else fall back to the global option.
+    positional = getattr(args, "radio_validate_model", None)
+    if positional:
+        args.model = positional
+    if not getattr(args, "model", None):
+        print(
+            "Error: no radio model given. Pass a positional model "
+            "(e.g. 'rigplane radio-validate X6200') or the global --model.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # This verb is always profile-driven: the shared run path generates the
+    # template in-memory from the profile when --template is None.
+    args.template = None
+
+    provider = getattr(args, "provider", "native")
+
+    # --write-template: build the in-memory matrix and dump it, no hardware.
+    if getattr(args, "write_template", None):
+        from rigplane.profiles import get_radio_profile
+
+        try:
+            profile = get_radio_profile(args.model)
+        except KeyError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+        gen_provider = "native" if provider == "both" else provider
+        template = _validate._generate_template(args, profile, gen_provider)
+        text = json.dumps(template.to_dict(), indent=2)
+        Path(args.write_template).write_text(text + "\n", encoding="utf-8")
+        print(f"Template written to: {args.write_template}", file=sys.stderr)
+        return 0
+
+    # Delegate to the existing validate run path — single source of truth for
+    # generation, hardware orchestration, comparison, and artifact emission.
+    return _validate.run(args)

--- a/tests/test_radio_validate.py
+++ b/tests/test_radio_validate.py
@@ -1,0 +1,115 @@
+"""Tests for the ``rigplane radio-validate <model>`` CLI verb (MOR-204, 204a).
+
+``radio-validate`` is a thin, profile-driven wrapper over the existing
+``validate`` run path (ADR D7): it adds a positional ``model``, reuses the
+same flags, and adds ``--write-template`` to dump the generated in-memory
+matrix as JSON. All tests here are dry-run / no-hardware: the generation
+path runs entirely in-process.
+
+The tests drive the *real* registered parser via ``_build_parser`` so the
+wiring (dispatch routing + ``_COMMAND_NAMES`` + subparser registration) is
+exercised, not just the module in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from rigplane.cli import _build_parser, _radio_validate, _validate
+from rigplane.validation import load_template
+
+
+def _parse(argv: list[str]) -> Any:
+    """Parse argv through the real top-level parser."""
+    parser = _build_parser()
+    return parser.parse_args(argv)
+
+
+def test_radio_validate_dry_run_native_emits_artifact(capsys: Any) -> None:
+    """``radio-validate X6200`` (dry-run, --json) exits 0, native artifact."""
+    args = _parse(["radio-validate", "X6200", "--json"])
+    rc = _radio_validate.run(args)
+    assert rc == 0
+    out = capsys.readouterr().out
+    artifact = json.loads(out)
+    assert artifact["metadata"]["provider"] == "native"
+    # At least one check entry present across the levels.
+    entries = [c for level in artifact["levels"] for c in level["checks"]]
+    assert entries
+
+
+def test_radio_validate_dry_run_hamlib_provider(capsys: Any) -> None:
+    """``radio-validate X6200 --provider hamlib`` dry-run exits 0.
+
+    Hamlib dump_caps may be unavailable in this environment (degraded); the
+    generation path must still succeed and exit 0.
+    """
+    args = _parse(["radio-validate", "X6200", "--provider", "hamlib", "--json"])
+    rc = _radio_validate.run(args)
+    assert rc == 0
+
+
+def test_radio_validate_missing_model_errors(capsys: Any) -> None:
+    """No positional model and no global --model → exit 2 with a helpful error."""
+    args = _parse(["radio-validate", "--json"])
+    rc = _radio_validate.run(args)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "model" in err.lower()
+
+
+def test_radio_validate_global_model_fallback(capsys: Any) -> None:
+    """A global --model (before the subcommand) is used when the positional is omitted."""
+    args = _parse(["--model", "X6200", "radio-validate", "--json"])
+    rc = _radio_validate.run(args)
+    assert rc == 0
+    artifact = json.loads(capsys.readouterr().out)
+    assert artifact["metadata"]["provider"] == "native"
+
+
+def test_radio_validate_write_template(tmp_path: Path) -> None:
+    """``--write-template PATH`` writes a valid MatrixTemplate JSON, exit 0, no hardware."""
+    out = tmp_path / "m.json"
+    args = _parse(["radio-validate", "X6200", "--write-template", str(out)])
+    rc = _radio_validate.run(args)
+    assert rc == 0
+    assert out.exists()
+    template = load_template(out)
+    assert template.entries
+
+
+def test_radio_validate_unknown_model_errors(capsys: Any) -> None:
+    """An unknown model name → exit 2."""
+    args = _parse(["radio-validate", "BOGUS_MODEL", "--json"])
+    rc = _radio_validate.run(args)
+    assert rc == 2
+
+
+def test_radio_validate_delegates_to_validate(monkeypatch: Any) -> None:
+    """The wrapper delegates to ``_validate.run`` with model set and template None."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(args: Any) -> int:
+        captured["model"] = getattr(args, "model", None)
+        captured["template"] = getattr(args, "template", "MISSING")
+        captured["provider"] = getattr(args, "provider", None)
+        return 0
+
+    monkeypatch.setattr(_validate, "run", fake_run)
+
+    args = _parse(["radio-validate", "X6200"])
+    rc = _radio_validate.run(args)
+
+    assert rc == 0
+    assert captured["model"] == "X6200"
+    assert captured["template"] is None
+    assert captured["provider"] == "native"
+
+
+def test_radio_validate_command_registered() -> None:
+    """The verb is wired into the parser and routes its own namespace."""
+    args = _parse(["radio-validate", "X6200"])
+    assert args.command == "radio-validate"
+    assert args.provider == "native"


### PR DESCRIPTION
## MOR-204 (slice 204a) — `radio-validate` CLI verb

Adds `rigplane radio-validate <model>` — the profile-driven entry point to the universal validation matrix. Implements ADR `docs/plans/2026-05-28-universal-validation-matrix.md` §9.

**Thin wrapper (D7):** the existing `validate` run path (`cli/_validate.py:run`) already does profile-driven Gen-A/B generation, `--provider native|hamlib|both`, comparison, and safety gating. This verb only normalizes args (positional `model` → `args.model`, forces `--template` off so the profile generates the matrix) and then **delegates** to `_validate.run(args)` — no forked execution/artifact/comparison logic.

**Scope:** 204a only. The `convert` subcommand (MOR-220) and OSS docs (MOR-221) are separate slices.

### Surface
`rigplane radio-validate [MODEL] [--provider native|hamlib|both] [--read-only] [--tx-allowed] [--tuner-allowed] [--hardware --allow-hardware] [--compare PATH] [--operator-id ID] [--output PATH] [--json] [--write-template PATH]`
- Positional `MODEL` (`nargs="?"`, falls back to global `--model`; neither → exit 2).
- New `--write-template PATH`: dump the generated in-memory matrix as JSON and exit 0 (no hardware).

### Files
- `src/rigplane/cli/_radio_validate.py` (new, 185 LOC)
- `src/rigplane/cli/__init__.py` (+10: import, `_COMMAND_NAMES`, `_build_parser`, dispatch)
- `tests/test_radio_validate.py` (new, 8 tests)

### Gates
- `uv run pytest tests/ -q` — 6458 passed, 0 failures (full suite)
- ruff / lint-imports — clean; mypy — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)