### PR TITLE
fix(MOR-219): resolve X6200 USB audio via CDC-ACM topology

### DIFF
--- a/src/rigplane/audio/_usb_resolve.py
+++ b/src/rigplane/audio/_usb_resolve.py
@@ -1,26 +1,40 @@
 """Resolve USB Audio devices associated with a serial CI-V port.
 
-When multiple Icom radios are connected via USB, each exposes identical
-"USB Audio CODEC" devices (Burr-Brown/TI USB Audio Class 1.0).  This module
-maps a serial port (e.g. ``/dev/cu.usbserial-201410``) to the correct
-audio input/output device indices by correlating USB topology information.
+When multiple USB radios are connected, each exposes a USB Audio Class
+device (Icom: "USB Audio CODEC"; Yaesu: "USB Audio Device"; Xiegu X6200:
+a C-Media "USB Audio Device"). This module maps a serial CI-V port
+(e.g. ``/dev/cu.usbserial-201410`` or the X6200's ``/dev/cu.usbmodemXXXXX``)
+to the correct audio input/output device indices by correlating USB
+topology information — anchoring on the physical hub the port sits on
+rather than fragile, collision-prone device-name strings.
 
 **Algorithm (macOS — IORegistry)**:
 
 1. Parse the serial port's TTY suffix → find its ``locationID`` in IORegistry.
+   Both ``usbserial-XXXX`` (FTDI/CP210x) and ``usbmodemXXXX`` (CDC-ACM, e.g.
+   the X6200's WCH CH342 bridge) suffixes are recognised.
 2. Extract the upper 16 bits of ``locationID`` as the USB hub prefix.
 3. Find all USB audio devices (``USB Audio CODEC``, ``USB Audio Device``) in
    IORegistry with their ``locationID``.
 4. Match audio devices sharing the same hub prefix as the serial port.
 5. Map matched locations to ``sounddevice`` device indices by positional order.
 
-**Fallback**: When IORegistry is unavailable (Linux, or ``ioreg`` missing),
-falls back to name-based matching (existing ``UsbAudioDriver`` behavior).
+**Fallback**: When IORegistry is unavailable, ``ioreg`` is missing, or the
+platform is not macOS, falls back to name-based matching (see
+:func:`_is_usb_audio_codec` and ``usb_driver._USB_NAME_PATTERNS``). Name
+matching recognises the C-Media identity used by the X6200 so single-device
+setups resolve even without topology.
 
 Platform support:
-- **macOS**: Full topology-based resolution via ``/usr/sbin/ioreg``.
-- **Linux**: Future — ``/sys/bus/usb/devices/`` sysfs traversal (not yet implemented).
-- **Windows**: Not supported (no USB topology introspection planned).
+- **macOS**: Full topology-based resolution via ``/usr/sbin/ioreg`` for both
+  FTDI/CP210x and CDC-ACM (``usbmodem``) serial ports.
+- **Linux**: Topology resolution not yet implemented (``/sys`` sysfs traversal
+  is future work); relies on name-based / robust-identity fallback and the
+  optional ``[usb] rx_device``/``tx_device`` override escape hatch.
+- **Windows**: Topology resolution not implemented; same fallback path.
+
+For Linux/Windows multi-radio disambiguation, capture the exact audio device
+names on hardware and set the ``[usb]`` override in ``audio.toml`` (MOR-219).
 """
 
 from __future__ import annotations
@@ -208,17 +222,30 @@ def _resolve_macos(
 
 
 def _extract_tty_suffix(serial_port: str) -> str | None:
-    """Extract TTY suffix from a serial port path.
+    """Extract TTY suffix from a macOS serial port path.
 
-    Handles macOS (``/dev/cu.usbserial-XXXXXX``) and Linux
-    (``/dev/ttyUSBX``) formats.
+    Handles both macOS USB serial enumeration schemes:
+
+    - **FTDI / CP210x bridges** (``/dev/cu.usbserial-XXXXXX``) — the suffix
+      follows a dash and is the chip serial number. Used by Icom CI-V
+      cables (CP2102), Yaesu HRI, etc.
+    - **CDC-ACM composite bridges** (``/dev/cu.usbmodemXXXXX``) — the suffix
+      follows ``usbmodem`` directly (no dash) and is a location-derived id.
+      Used by the WCH CH342 dual-serial bridge in the Xiegu X6200 (MOR-219).
+
+    The matched suffix corresponds to the IORegistry ``IOTTYSuffix`` value,
+    which is what :func:`_find_serial_location` correlates against.
 
     >>> _extract_tty_suffix("/dev/cu.usbserial-201410")
     '201410'
     >>> _extract_tty_suffix("/dev/tty.usbserial-201410")
     '201410'
+    >>> _extract_tty_suffix("/dev/cu.usbmodem14201")
+    '14201'
+    >>> _extract_tty_suffix("/dev/tty.usbmodem1434203")
+    '1434203'
     """
-    m = re.search(r"usbserial-(\w+)", serial_port)
+    m = re.search(r"usb(?:serial-|modem)(\w+)", serial_port)
     if m:
         return m.group(1)
     return None
@@ -276,13 +303,26 @@ def _find_audio_codec_locations(ioreg_text: str) -> list[int]:
 def _is_usb_audio_codec(name: str) -> bool:
     """Check if a device name matches a USB audio device pattern.
 
-    Uses a broad match to support Icom, Yaesu, and Kenwood radios that
-    expose USB Audio Class devices.
+    Uses a broad match to support radios that expose a USB Audio Class
+    device under a vendor-specific or commodity name:
+
+    - Icom (``USB Audio CODEC`` — Burr-Brown/TI),
+    - Yaesu / Kenwood (vendor name in the device string),
+    - Xiegu X6200 (``USB Audio Device`` — C-Media Electronics codec; the
+      generic CMedia name is also matched as a robust-identity fallback on
+      platforms without topology resolution, MOR-219).
     """
     lowered = name.lower()
     return any(
         p in lowered
-        for p in ("usb audio codec", "usb audio device", "yaesu", "kenwood")
+        for p in (
+            "usb audio codec",
+            "usb audio device",
+            "yaesu",
+            "kenwood",
+            "c-media",
+            "cmedia",
+        )
     )
 
 

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -32,12 +32,19 @@ _DEPENDENCY_HINT = (
     "USB audio backend requires optional dependencies sounddevice and numpy. "
     "Install with: pip install rigplane[bridge]"
 )
+# Ordered by selection preference (lower index = stronger match). The
+# C-Media identity ranks the Xiegu X6200's audio codec ahead of an unknown
+# commodity device on platforms without topology resolution (MOR-219). It is
+# placed after the explicit "usb audio" names so a vendor CODEC still wins
+# when both are present.
 _USB_NAME_PATTERNS: tuple[str, ...] = (
     "usb audio codec",
     "usb audio",
     "icom",
     "yaesu",
     "kenwood",
+    "c-media",
+    "cmedia",
     "ftdi",
 )
 

--- a/tests/test_usb_audio_resolve.py
+++ b/tests/test_usb_audio_resolve.py
@@ -501,3 +501,177 @@ class TestAudioDeviceMapping:
         )
         with pytest.raises(AttributeError):
             m.rx_device_index = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# MOR-219 — Xiegu X6200 (CDC-ACM usbmodem + C-Media USB Audio)
+# ---------------------------------------------------------------------------
+
+# Xiegu X6200: WCH CH342 dual-serial CDC-ACM bridge (/dev/cu.usbmodem…) plus a
+# C-Media "USB Audio Device", both on hub prefix 0x1423. The CAT port is the
+# second ACM interface (SERIAL-B → /dev/cu.usbmodem14203). Before MOR-219,
+# _extract_tty_suffix matched only "usbserial-…", so the X6200's usbmodem port
+# never reached topology resolution and the browser RX stream stayed silent.
+IOREG_XIEGU_X6200 = textwrap.dedent("""\
+    | +-o USB Audio Device@14232200  <class IOUSBHostDevice, id 0x1000c0de1>
+    | |   "locationID" = 337846784
+    | |   "USB Product Name" = "USB Audio Device"
+    | |   "USB Vendor Name" = "C-Media Electronics Inc.      "
+    | +-o USB Dual_Serial@14231000  <class IOUSBHostDevice, id 0x1000c0de0>
+    | |   "locationID" = 337842176
+    | |   "USB Vendor Name" = "Nanjing QinHeng Electronics Co."
+    | | +-o AppleUSBACMData
+    | |   | "IOTTYSuffix" = "14203"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbmodem14203"
+""")
+
+# X6200 (usbmodem) alongside an Icom IC-7610 (usbserial) — proves the usbmodem
+# port still resolves its own hub prefix when a CP2102-based radio is present.
+IOREG_XIEGU_AND_ICOM = textwrap.dedent("""\
+    | +-o USB Audio Device@14232200  <class IOUSBHostDevice, id 0x1000c0de1>
+    | |   "locationID" = 337846784
+    | |   "USB Product Name" = "USB Audio Device"
+    | +-o USB Dual_Serial@14231000  <class IOUSBHostDevice, id 0x1000c0de0>
+    | |   "locationID" = 337842176
+    | | +-o AppleUSBACMData
+    | |   | "IOTTYSuffix" = "14203"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbmodem14203"
+    | +-o USB Audio CODEC@01111400  <class IOUSBHostDevice, id 0x1000a9ab5>
+    | |   "locationID" = 17895424
+    | |   "USB Product Name" = "USB Audio CODEC"
+    | +-o CP2102 USB to UART Bridge Controller@01112000
+    | |   "locationID" = 17895936
+    | | +-o AppleUSBSLCOM
+    | |   | "IOTTYSuffix" = "111120"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbserial-111120"
+""")
+
+
+def _make_mock_sd_xiegu() -> MagicMock:
+    """Mock sounddevice for an X6200: one built-in + one C-Media duplex device.
+
+    The C-Media codec enumerates on macOS CoreAudio as a single "USB Audio
+    Device" with both capture (1ch) and playback (2ch) channels.
+    """
+    devices: list[dict[str, Any]] = [
+        {
+            "name": "Built-in Speaker",
+            "index": 0,
+            "max_input_channels": 0,
+            "max_output_channels": 2,
+            "default_samplerate": 48000.0,
+        },
+        {
+            "name": "USB Audio Device",
+            "index": 1,
+            "max_input_channels": 1,
+            "max_output_channels": 2,
+            "default_samplerate": 48000.0,
+        },
+    ]
+    sd = MagicMock()
+    sd.query_devices.return_value = devices
+    sd.default.device = [-1, -1]
+    return sd
+
+
+class TestExtractTtySuffixCdcAcm:
+    """MOR-219: usbmodem (CDC-ACM) ports must yield a TTY suffix."""
+
+    def test_usbmodem_cu(self) -> None:
+        assert _extract_tty_suffix("/dev/cu.usbmodem14201") == "14201"
+
+    def test_usbmodem_tty(self) -> None:
+        assert _extract_tty_suffix("/dev/tty.usbmodem1434203") == "1434203"
+
+    def test_usbmodem_composite_acm_index(self) -> None:
+        # CH342 dual-serial exposes …1 and …3; CAT is on SERIAL-B (…3).
+        assert _extract_tty_suffix("/dev/cu.usbmodem14203") == "14203"
+
+    def test_usbserial_unchanged(self) -> None:
+        # Existing FTDI/CP210x extraction must not regress.
+        assert _extract_tty_suffix("/dev/cu.usbserial-201410") == "201410"
+
+
+class TestIsUsbAudioCodecXiegu:
+    """MOR-219: recognise the C-Media / generic 'USB Audio Device' identity."""
+
+    def test_usb_audio_device(self) -> None:
+        assert _is_usb_audio_codec("USB Audio Device") is True
+
+    def test_cmedia_vendor_dashed(self) -> None:
+        assert _is_usb_audio_codec("C-Media USB Headphone Set") is True
+
+    def test_cmedia_vendor_plain(self) -> None:
+        assert _is_usb_audio_codec("CMedia Audio") is True
+
+    def test_unrelated_still_false(self) -> None:
+        assert _is_usb_audio_codec("Built-in Microphone") is False
+
+
+class TestResolveXieguX6200:
+    """Full macOS topology resolution for the X6200."""
+
+    def test_audio_codec_locations_include_cmedia(self) -> None:
+        assert _find_audio_codec_locations(IOREG_XIEGU_X6200) == [0x14232200]
+
+    def test_single_x6200_usbmodem_resolves_to_cmedia(self) -> None:
+        sd = _make_mock_sd_xiegu()
+        result = _resolve_macos(
+            "/dev/cu.usbmodem14203",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_XIEGU_X6200,
+        )
+        assert result is not None
+        assert result.serial_port == "/dev/cu.usbmodem14203"
+        assert result.location_prefix == 0x1423
+        # The duplex C-Media device serves both RX and TX.
+        assert result.rx_device_index == 1
+        assert result.tx_device_index == 1
+
+    def test_x6200_serial_location_found_alongside_icom(self) -> None:
+        # Root-cause regression: the usbmodem suffix must extract AND its
+        # locationID must be found even when a usbserial Icom is also present.
+        loc = _find_serial_location(IOREG_XIEGU_AND_ICOM, "14203")
+        assert loc == 0x14231000
+        assert (loc >> 16) == 0x1423
+
+    def test_icom_unaffected_by_xiegu_presence(self) -> None:
+        loc = _find_serial_location(IOREG_XIEGU_AND_ICOM, "111120")
+        assert loc == 17895936  # matches the IC-7610 fixture literal
+        assert (loc >> 16) == 0x0111
+
+    def test_audio_locations_mixed(self) -> None:
+        assert _find_audio_codec_locations(IOREG_XIEGU_AND_ICOM) == [
+            0x01111400,
+            0x14232200,
+        ]
+
+
+class TestNameFallbackXiegu:
+    """MOR-219: name-based fallback (Linux/Windows) prefers the C-Media codec
+    over an unknown commodity device when topology is unavailable."""
+
+    def test_cmedia_preferred_over_unknown_duplex(self) -> None:
+        from rigplane.audio.usb_driver import (
+            UsbAudioDevice,
+            select_usb_audio_devices,
+        )
+
+        devices = [
+            UsbAudioDevice(
+                index=0,
+                name="Some Cheap Headset",
+                input_channels=1,
+                output_channels=2,
+            ),
+            UsbAudioDevice(
+                index=1,
+                name="C-Media Electronics",
+                input_channels=1,
+                output_channels=2,
+            ),
+        ]
+        rx, tx = select_usb_audio_devices(devices)
+        assert rx.index == 1
+        assert tx.index == 1


### PR DESCRIPTION
## Summary

Fixes **MOR-219** — the browser RX "LIVE" stream was **silent for the Xiegu X6200**. Root cause: the macOS USB-audio topology resolver could not link the X6200's CDC-ACM serial port to its USB audio input.

`_extract_tty_suffix()` matched only `usbserial-…` (FTDI/CP210x), not the `usbmodem…` (CDC-ACM) ports used by the X6200's WCH CH342 dual-serial bridge. With no TTY suffix, IORegistry lookup never ran → topology resolution returned `None` → audio fell back to silence.

## Change (generic, topology-anchored — no per-profile audio field)

- **`_extract_tty_suffix()`** now matches both `usbserial-XXXX` and `usbmodemXXXX`, so CDC-ACM ports reach IORegistry hub-prefix matching. The X6200's C-Media `USB Audio Device` already matches the existing `USB Audio (?:CODEC|Device)@` node scan, so it links by physical hub.
- **`_is_usb_audio_codec()`** and **`usb_driver._USB_NAME_PATTERNS`** recognise the C-Media identity (`c-media`/`cmedia`) as a robust-identity fallback for Linux/Windows, where topology resolution is not yet implemented (tracked in **MOR-222**).
- Module docstring updated: macOS covers FTDI/CP210x + CDC-ACM; Linux/Windows use name/identity fallback + the existing optional `[usb]` override escape hatch (no new per-profile field).

## Tests

Added regression tests in `tests/test_usb_audio_resolve.py`: `usbmodem` suffix extraction, single-X6200 topology resolution to the C-Media device, X6200-alongside-Icom serial-location lookup, C-Media name recognition, and name-fallback preference. Existing IC-7610/IC-7300/FTX-1 resolution unchanged.

## Gate

- `pytest` (non-integration): **6226 passed**, 7 skipped, 11 xfailed
- `ruff check` + `ruff format --check`: clean
- doctests in `_usb_resolve.py`: pass
- mypy: no new errors (pre-existing baseline only)

## Hardware verification (real X6200, macOS, 2026-05-29)

- TTY suffix now extracts `58910181093` (previously `None`).
- Topology confirmed: audio `locationID 0x01122000` ↔ serial CH342 `0x01124000` → both hub prefix `0x0112`.
- Resolver picks `[0] USB Audio Device` (C-Media, VID:PID `0x0D8C:0x0012`, in 1 / out 2) — not the MacBook mic or BlackHole present in the same enumeration.
- Live capture from the resolved device: RMS ≈ 322, peak ≈ 2397 (full-scale 32767) = real RX audio flowing.

## Scope / follow-up

- Linux & Windows topology linking remains unimplemented (name/identity fallback only) — tracked in **MOR-222** with per-OS recommendations.
- Open-core boundary; Pro pins core, so this needs a core release + re-pin to unblock the rigplane-pro beta.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)