### PR TITLE
feat(MOR-206): wire override files into the validate generate path + metadata audit

### DIFF
--- a/src/rigplane/cli/_radio_validate.py
+++ b/src/rigplane/cli/_radio_validate.py
@@ -115,6 +115,16 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--no-overrides",
+        dest="no_overrides",
+        action="store_true",
+        help=(
+            "Skip auto-applying the per-profile override file "
+            "(docs/validation/templates/<profile_id>.json). Escape hatch for "
+            "deterministic CI runs. No effect when --template is given."
+        ),
+    )
+    p.add_argument(
         "--operator-id",
         dest="operator_id",
         default=None,

--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -67,6 +67,77 @@ from rigplane.validation.schema import (
 )
 
 
+def _overrides_dir() -> Path:
+    """Return the path to the per-profile override directory (ADR §4.1).
+
+    Override files live at ``docs/validation/templates/<profile_id>.json``.
+    Mirrors the dev/installed resolution used by ``cli.__init__._rigs_dir``:
+    prefer a copy shipped next to the package, else resolve relative to the
+    repo root in a development checkout.
+    """
+    # Installed layout: rigplane/docs/validation/templates/ next to the package.
+    # (this file is rigplane/cli/_validate.py → up two levels to rigplane/)
+    pkg_dir = (
+        Path(__file__).resolve().parent.parent / "docs" / "validation" / "templates"
+    )
+    if pkg_dir.is_dir():
+        return pkg_dir
+    # Development layout: repo_root/docs/validation/templates/
+    # (parents[3] from src/rigplane/cli/_validate.py = repo root)
+    return Path(__file__).resolve().parents[3] / "docs" / "validation" / "templates"
+
+
+def _apply_overrides(
+    template: MatrixTemplate, profile_id: str
+) -> tuple[MatrixTemplate, dict[str, Any] | None]:
+    """Auto-apply a per-profile override FILE onto a generated *template*.
+
+    Returns ``(possibly-merged template, audit dict or None)``. The audit dict,
+    when present, mirrors the :class:`~rigplane.validation.MergeReport`:
+    ``{"applied": [...], "appended": [...], "excluded": [...], "rejected": [...]}``.
+
+    Resolution and policy (ADR §4.1):
+
+    * No ``<profile_id>.json`` in the override dir → ``(template, None)``: a rig
+      with no override file still gets the full generated matrix.
+    * The file lacks a top-level ``"override": true`` → ``(template, None)``: it
+      is a FULL legacy template, not a sparse patch, and is not auto-applied.
+    * Otherwise the file is parsed and merged via the pure override layer.
+
+    Never raises: a malformed or unreadable override file degrades to a stderr
+    warning and ``(template, None)`` so a broken override can never block
+    validation. The pure :func:`merge_overrides` enforces the tx/tuner safety
+    invariant, so unsafe relaxations are refused and recorded in ``rejected``.
+    """
+    path = _overrides_dir() / f"{profile_id}.json"
+    if not path.is_file():
+        return template, None
+
+    try:
+        from rigplane.validation import merge_overrides, parse_override_dict
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("override") is not True:
+            # Full template, not a sparse patch — do not auto-apply.
+            return template, None
+        patch = parse_override_dict(data)
+        merged, report = merge_overrides(template, patch)
+    except (OSError, ValueError, SchemaValidationError) as exc:
+        print(
+            f"Warning: ignoring override file {path}: {exc}",
+            file=sys.stderr,
+        )
+        return template, None
+
+    audit = {
+        "applied": list(report.applied),
+        "appended": list(report.appended),
+        "excluded": list(report.excluded),
+        "rejected": list(report.rejected),
+    }
+    return merged, audit
+
+
 def _hamlib_caps_to_tokens(caps: HamlibCaps) -> frozenset[str]:
     """Flatten a HamlibCaps into the set of registry hamlib_token strings the
     model supports, for Generator B."""
@@ -172,6 +243,16 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--no-overrides",
+        dest="no_overrides",
+        action="store_true",
+        help=(
+            "Skip auto-applying the per-profile override file "
+            "(docs/validation/templates/<profile_id>.json). Escape hatch for "
+            "deterministic CI runs. No effect when --template is given."
+        ),
+    )
+    p.add_argument(
         "--operator-id",
         dest="operator_id",
         default=None,
@@ -254,6 +335,13 @@ def run(args: argparse.Namespace) -> int:
             # "both": will build per-provider templates below; use native for
             # dry-run / safety-block path.
             template = _generate_template(args, profile, "native")
+        # Auto-apply the per-profile override file (single chokepoint). The
+        # "both" path re-merges per provider inside _run_hardware_both; for the
+        # single-provider + dry-run paths this is the merge that executes.
+        overrides_audit: dict[str, Any] | None = None
+        if not getattr(args, "no_overrides", False):
+            template, overrides_audit = _apply_overrides(template, profile.id)
+        args._overrides_audit = overrides_audit
 
     authorized = bool(args.tx_allowed or args.tuner_allowed)
     safety = OperatorSafetyBlock(
@@ -280,6 +368,7 @@ def run(args: argparse.Namespace) -> int:
             rc, artifact = asyncio.run(_run_hardware_hamlib(args, template, safety))
         else:
             rc, artifact = asyncio.run(_run_hardware(args, template, safety))
+        artifact = _stamp_overrides(artifact, getattr(args, "_overrides_audit", None))
         if getattr(args, "compare", None):
             artifact = _attach_comparison(artifact, args.compare)
         _emit_artifact(artifact, args)
@@ -301,6 +390,7 @@ def run(args: argparse.Namespace) -> int:
         metadata={**artifact.metadata, "provider": "native"},
         generated_at=_utcnow_iso(),
     )
+    artifact = _stamp_overrides(artifact, getattr(args, "_overrides_audit", None))
     if getattr(args, "compare", None):
         artifact = _attach_comparison(artifact, args.compare)
     _emit_artifact(artifact, args)
@@ -321,6 +411,13 @@ async def _run_hardware_both(
 
     tmpl_native = _generate_template(args, profile, "native")
     tmpl_hamlib = _generate_template(args, profile, "hamlib")
+
+    # Auto-apply the per-profile override file to BOTH provider templates so
+    # the merged matrices execute and the (native) audit reaches the artifact.
+    overrides_audit: dict[str, Any] | None = None
+    if not getattr(args, "no_overrides", False):
+        tmpl_native, overrides_audit = _apply_overrides(tmpl_native, profile.id)
+        tmpl_hamlib, _ = _apply_overrides(tmpl_hamlib, profile.id)
 
     # Sequential: native first, then hamlib (serial port must release between).
     rc_n, art_n = await _run_hardware(args, tmpl_native, safety)
@@ -347,16 +444,27 @@ async def _run_hardware_both(
         "rows": rows,
         "dimensions": dims,
     }
-    art_n = dataclasses.replace(
-        art_n,
-        metadata={
-            **art_n.metadata,
-            "generated_from": "profile",
-            "comparison": comparison,
-        },
-    )
+    metadata: dict[str, Any] = {
+        **art_n.metadata,
+        "generated_from": "profile",
+        "comparison": comparison,
+    }
+    if overrides_audit is not None:
+        metadata["overrides"] = overrides_audit
+    art_n = dataclasses.replace(art_n, metadata=metadata)
     _emit_artifact(art_n, args)
     return rc_n if rc_n else rc_h
+
+
+def _stamp_overrides(
+    artifact: ValidationArtifact, audit: dict[str, Any] | None
+) -> ValidationArtifact:
+    """Fold the override audit into ``metadata["overrides"]`` when non-None."""
+    if audit is None:
+        return artifact
+    return dataclasses.replace(
+        artifact, metadata={**artifact.metadata, "overrides": audit}
+    )
 
 
 def _emit_artifact(artifact: ValidationArtifact, args: argparse.Namespace) -> None:

--- a/tests/test_validate_overrides.py
+++ b/tests/test_validate_overrides.py
@@ -215,3 +215,45 @@ def test_radio_validate_path_applies_overrides(
     assert "filter_width.set" in overrides["applied"]
     checks = {c["check_id"]: c for level in artifact["levels"] for c in level["checks"]}
     assert checks["filter_width.set"]["summary"] == "VIA RADIO-VALIDATE"
+
+
+def test_radio_validate_no_overrides_flag_parses_and_skips_merge(
+    tmp_path: Any, monkeypatch: Any, capsys: Any
+) -> None:
+    """``radio-validate <model> --no-overrides`` parses and skips the merge.
+
+    Regression for the review gap: the ``--no-overrides`` escape hatch existed
+    only on the ``validate`` parser, so ``radio-validate`` rejected it at argparse
+    time (SystemExit 2). This asserts the flag parses through the real
+    ``_build_parser()`` AND that the override merge is skipped — while the same
+    override file IS applied when the flag is absent.
+    """
+    _write_override(
+        tmp_path / f"{PROFILE_ID}.json",
+        entries=[{"check_id": "rf_gain.set", "declaration": "excluded"}],
+    )
+    monkeypatch.setattr(_validate, "_overrides_dir", lambda: tmp_path)
+
+    # Without the flag: the override file IS applied (rf_gain.set excluded).
+    args_on = _parse(["radio-validate", MODEL, "--json"])
+    rc_on = _radio_validate.run(args_on)
+    assert rc_on == 0
+    artifact_on = json.loads(capsys.readouterr().out)
+    assert artifact_on["metadata"].get("overrides") is not None
+    checks_on = {
+        c["check_id"] for level in artifact_on["levels"] for c in level["checks"]
+    }
+    assert "rf_gain.set" not in checks_on
+
+    # With the flag: it PARSES (no SystemExit) and the merge is skipped.
+    args_off = _parse(["radio-validate", MODEL, "--json", "--no-overrides"])
+    assert args_off.no_overrides is True
+    rc_off = _radio_validate.run(args_off)
+    assert rc_off == 0
+    artifact_off = json.loads(capsys.readouterr().out)
+    assert artifact_off["metadata"].get("overrides") is None
+    checks_off = {
+        c["check_id"] for level in artifact_off["levels"] for c in level["checks"]
+    }
+    # Not excluded — the override was skipped.
+    assert "rf_gain.set" in checks_off

--- a/tests/test_validate_overrides.py
+++ b/tests/test_validate_overrides.py
@@ -1,0 +1,217 @@
+"""Tests for override-file wiring into the validate generate path (MOR-206).
+
+The PURE merge core (``rigplane.validation.overrides``) is tested elsewhere;
+these tests exercise the CLI WIRING in :mod:`rigplane.cli._validate`:
+
+* ``_overrides_dir`` resolves the shipped override directory;
+* ``_apply_overrides`` auto-applies a per-profile override FILE when it carries
+  ``"override": true``, threading a ``metadata.overrides`` audit;
+* a profile with no override file is unchanged;
+* a full template (no ``override`` flag) is NOT auto-applied;
+* the safety invariant survives wiring (an unsafe tx.ptt relax is rejected and
+  surfaced in ``metadata.overrides.rejected``);
+* ``--no-overrides`` skips the merge;
+* a malformed override file degrades (stderr warning) without raising.
+
+All tests are dry-run / no-hardware and monkeypatch ``_overrides_dir`` to a
+``tmp_path`` so they never depend on shipped files.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from rigplane.cli import _build_parser, _radio_validate, _validate
+
+# The profile-driven model used across these tests; its generated matrix
+# contains a gated ``tx.ptt`` entry (level 5, manual_required) and a
+# ``filter_width.set`` entry (level 3, supported).
+MODEL = "IC-7610"
+PROFILE_ID = "icom_ic7610"
+
+
+def _parse(argv: list[str]) -> Any:
+    parser = _build_parser()
+    return parser.parse_args(argv)
+
+
+def _write_override(
+    path: Path, entries: list[dict[str, Any]], *, flag: bool = True
+) -> None:
+    """Write a sparse override file (the v1 template shape + ``override`` flag)."""
+    doc: dict[str, Any] = {
+        "schema_version": 1,
+        "radio": {"model": MODEL, "profile_id": PROFILE_ID},
+        "entries": entries,
+    }
+    if flag:
+        doc["override"] = True
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def test_override_file_is_merged_and_audited(
+    tmp_path: Any, monkeypatch: Any, capsys: Any
+) -> None:
+    """A profile WITH an override file: a replace + an exclude both take effect.
+
+    The merged template drives the artifact, and ``metadata.overrides`` records
+    the applied/excluded check_ids.
+    """
+    _write_override(
+        tmp_path / f"{PROFILE_ID}.json",
+        entries=[
+            {"check_id": "filter_width.set", "summary": "PATCHED summary"},
+            {"check_id": "rf_gain.set", "declaration": "excluded"},
+        ],
+    )
+    monkeypatch.setattr(_validate, "_overrides_dir", lambda: tmp_path)
+
+    args = _parse(["--model", MODEL, "validate", "--json"])
+    rc = _validate.run(args)
+    assert rc == 0
+    artifact = json.loads(capsys.readouterr().out)
+
+    overrides = artifact["metadata"].get("overrides")
+    assert overrides is not None
+    assert "filter_width.set" in overrides["applied"]
+    assert "rf_gain.set" in overrides["excluded"]
+
+    checks = {c["check_id"]: c for level in artifact["levels"] for c in level["checks"]}
+    # Replaced summary reached the executed matrix.
+    assert checks["filter_width.set"]["summary"] == "PATCHED summary"
+    # Excluded entry is gone from the executed matrix.
+    assert "rf_gain.set" not in checks
+
+
+def test_no_override_file_leaves_matrix_unchanged(
+    tmp_path: Any, monkeypatch: Any, capsys: Any
+) -> None:
+    """No override file for the profile → full generated matrix; no audit."""
+    monkeypatch.setattr(_validate, "_overrides_dir", lambda: tmp_path)
+
+    args = _parse(["--model", MODEL, "validate", "--json"])
+    rc = _validate.run(args)
+    assert rc == 0
+    artifact = json.loads(capsys.readouterr().out)
+
+    assert artifact["metadata"].get("overrides") is None
+    checks = {c["check_id"] for level in artifact["levels"] for c in level["checks"]}
+    # filter_width.set is part of the full generated IC-7610 matrix.
+    assert "filter_width.set" in checks
+
+
+def test_full_template_without_flag_is_not_applied(
+    tmp_path: Any, monkeypatch: Any, capsys: Any
+) -> None:
+    """A file lacking ``"override": true`` is a full template, not a patch."""
+    _write_override(
+        tmp_path / f"{PROFILE_ID}.json",
+        entries=[{"check_id": "filter_width.set", "summary": "SHOULD NOT APPLY"}],
+        flag=False,
+    )
+    monkeypatch.setattr(_validate, "_overrides_dir", lambda: tmp_path)
+
+    args = _parse(["--model", MODEL, "validate", "--json"])
+    rc = _validate.run(args)
+    assert rc == 0
+    artifact = json.loads(capsys.readouterr().out)
+
+    assert artifact["metadata"].get("overrides") is None
+    checks = {c["check_id"]: c for level in artifact["levels"] for c in level["checks"]}
+    assert checks["filter_width.set"]["summary"] != "SHOULD NOT APPLY"
+
+
+def test_safety_invariant_rejects_tx_relax(
+    tmp_path: Any, monkeypatch: Any, capsys: Any
+) -> None:
+    """An override that tries to relax tx.ptt is refused and surfaced."""
+    _write_override(
+        tmp_path / f"{PROFILE_ID}.json",
+        entries=[
+            {
+                "check_id": "tx.ptt",
+                "declaration": "supported",
+                "tx_adjacent": False,
+                "summary": "attempted relax",
+            }
+        ],
+    )
+    monkeypatch.setattr(_validate, "_overrides_dir", lambda: tmp_path)
+
+    args = _parse(["--model", MODEL, "validate", "--json"])
+    rc = _validate.run(args)
+    assert rc == 0
+    artifact = json.loads(capsys.readouterr().out)
+
+    overrides = artifact["metadata"].get("overrides")
+    assert overrides is not None
+    assert "tx.ptt" in overrides["rejected"]
+
+    checks = {c["check_id"]: c for level in artifact["levels"] for c in level["checks"]}
+    # tx.ptt stays gated: the declaration was not relaxed to "supported".
+    assert checks["tx.ptt"]["declaration"] != "supported"
+
+
+def test_no_overrides_flag_skips_merge(
+    tmp_path: Any, monkeypatch: Any, capsys: Any
+) -> None:
+    """``--no-overrides`` skips the merge even when a file exists."""
+    _write_override(
+        tmp_path / f"{PROFILE_ID}.json",
+        entries=[{"check_id": "rf_gain.set", "declaration": "excluded"}],
+    )
+    monkeypatch.setattr(_validate, "_overrides_dir", lambda: tmp_path)
+
+    args = _parse(["--model", MODEL, "validate", "--json", "--no-overrides"])
+    rc = _validate.run(args)
+    assert rc == 0
+    artifact = json.loads(capsys.readouterr().out)
+
+    assert artifact["metadata"].get("overrides") is None
+    checks = {c["check_id"] for level in artifact["levels"] for c in level["checks"]}
+    # Not excluded — the override was skipped.
+    assert "rf_gain.set" in checks
+
+
+def test_malformed_override_degrades_without_raising(
+    tmp_path: Any, monkeypatch: Any, capsys: Any
+) -> None:
+    """A malformed override file → stderr warning, validation still succeeds."""
+    (tmp_path / f"{PROFILE_ID}.json").write_text("{ not valid json ", encoding="utf-8")
+    monkeypatch.setattr(_validate, "_overrides_dir", lambda: tmp_path)
+
+    args = _parse(["--model", MODEL, "validate", "--json"])
+    rc = _validate.run(args)
+    assert rc == 0
+    captured = capsys.readouterr()
+    artifact = json.loads(captured.out)
+
+    assert artifact["metadata"].get("overrides") is None
+    assert "override" in captured.err.lower()
+    # The un-merged full matrix is intact.
+    checks = {c["check_id"] for level in artifact["levels"] for c in level["checks"]}
+    assert "filter_width.set" in checks
+
+
+def test_radio_validate_path_applies_overrides(
+    tmp_path: Any, monkeypatch: Any, capsys: Any
+) -> None:
+    """The ``radio-validate <model>`` delegation also applies overrides."""
+    _write_override(
+        tmp_path / f"{PROFILE_ID}.json",
+        entries=[{"check_id": "filter_width.set", "summary": "VIA RADIO-VALIDATE"}],
+    )
+    monkeypatch.setattr(_validate, "_overrides_dir", lambda: tmp_path)
+
+    args = _parse(["radio-validate", MODEL, "--json"])
+    rc = _radio_validate.run(args)
+    assert rc == 0
+    artifact = json.loads(capsys.readouterr().out)
+
+    overrides = artifact["metadata"].get("overrides")
+    assert overrides is not None
+    assert "filter_width.set" in overrides["applied"]
+    checks = {c["check_id"]: c for level in artifact["levels"] for c in level["checks"]}
+    assert checks["filter_width.set"]["summary"] == "VIA RADIO-VALIDATE"


### PR DESCRIPTION
## MOR-206 (wiring slice) — completes the override layer

Wires the pure override-merge core (PR #1676) into the CLI generate path. A per-rig override file `docs/validation/templates/<profile_id>.json` carrying top-level `"override": true` is auto-merged onto the profile-generated matrix; the audit lands in `metadata.overrides`. ADR `docs/plans/2026-05-28-universal-validation-matrix.md` §4.1 + §7.2. Completes MOR-206 together with #1676.

### Single chokepoint (covers both verbs)
`radio-validate` delegates to `_validate.run`, and `validate --model` uses the same path, so wiring lives entirely in `cli/_validate.py`:
- `_overrides_dir()` resolves `docs/validation/templates/` (dev + installed).
- `_apply_overrides(template, profile_id) -> (MatrixTemplate, audit|None)`: finds `<profile_id>.json`, merges via the pure `parse_override_dict` + `merge_overrides`. Applied after every profile-driven generation (native/hamlib/dry-run + both `tmpl_native`/`tmpl_hamlib` in `_run_hardware_both`); `_stamp_overrides` folds the audit into `metadata["overrides"]` at every emit point.

### `metadata.overrides`
`{"applied":[...],"appended":[...],"excluded":[...],"rejected":[...]}` — absent/null when no patch applied.

### Policy
- Explicit `--template <path>`: UNCHANGED (overrides never auto-applied).
- No override file → full generated matrix (acceptance: a rig with no file still gets the full matrix).
- File without `"override": true` → treated as a full legacy template, not auto-applied.
- Malformed/unreadable → stderr warning, validation still succeeds (degrade, never raise).
- `--no-overrides` escape hatch on BOTH `validate` and `radio-validate` parsers.

### Safety
`merge_overrides` is only wired, not weakened: an override relaxing `tx.ptt`/`tuner.tune` is refused and surfaced in `metadata.overrides.rejected` (tested).

### Files
`cli/_validate.py` (+124/-8), `cli/_radio_validate.py` (+10, `--no-overrides`), `tests/test_validate_overrides.py` (new, 8 tests).

### Gates
- `uv run pytest tests/ -q` — 6476 passed, 0 failures (full suite)
- ruff / lint-imports — clean; mypy — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)