### PR TITLE
feat(MOR-220): rigplane convert verb — bootstrap draft TOML from Hamlib dump_caps + cross-check

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -94,6 +94,10 @@ from rigplane.cli._radio_validate import (  # noqa: E402
     add_subparser as _add_radio_validate_subparser,
     run as _run_radio_validate,
 )
+from rigplane.cli._convert import (  # noqa: E402
+    add_subparser as _add_convert_subparser,
+    run as _run_convert,
+)
 from rigplane.core.radio_protocol import Radio  # noqa: E402
 from rigplane.core.types import Mode, get_audio_capabilities  # noqa: E402
 
@@ -337,6 +341,7 @@ _COMMAND_NAMES = {
     "diagnose",
     "validate",
     "radio-validate",
+    "convert",
 }
 
 _GLOBAL_CONNECTION_OPTIONS = {
@@ -1496,6 +1501,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # radio-validate — profile-driven entrypoint; thin wrapper over validate
     _add_radio_validate_subparser(sub)
+
+    # convert — bootstrap a draft TOML from Hamlib dump_caps + cross-check
+    _add_convert_subparser(sub)
 
     return p
 
@@ -3733,6 +3741,8 @@ def main() -> None:
         sys.exit(_run_validate(args))
     elif args.command == "radio-validate":
         sys.exit(_run_radio_validate(args))
+    elif args.command == "convert":
+        sys.exit(_run_convert(args))
     elif args.command is None:
         parser.print_help()
         sys.exit(0)

--- a/src/rigplane/cli/_convert.py
+++ b/src/rigplane/cli/_convert.py
@@ -1,11 +1,13 @@
-"""Pure Hamlib ``dump_caps`` → draft rigplane TOML + cross-check (MOR-203).
+"""Hamlib ``dump_caps`` → draft rigplane TOML + cross-check (MOR-203 / MOR-220).
 
-This module is a *pure* data transform: ``str``/dataclass in, ``str``/dataclass
-out. It performs NO subprocess calls, NO disk I/O, and registers NO CLI verb —
-those belong to MOR-204. It lives in ``cli/`` because only the top layer may
-import BOTH ``rigplane.backends.hamlib_models`` (``HamlibCaps``) AND
-``rigplane.validation.registry`` (the token map). ``validation/`` must not import
-``backends/``.
+The core (``build_draft_toml`` / ``cross_check`` / ``caps_to_capabilities``) is a
+*pure* data transform: ``str``/dataclass in, ``str``/dataclass out, with NO
+subprocess calls and NO disk I/O (MOR-203). The ``rigplane convert`` CLI verb
+(``add_subparser`` / ``run``, MOR-220) is the thin I/O driver around it: it shells
+out via ``load_hamlib_caps`` and writes the draft to disk. Both live in ``cli/``
+because only the top layer may import BOTH ``rigplane.backends.hamlib_models``
+(``HamlibCaps``) AND ``rigplane.validation.registry`` (the token map);
+``validation/`` must not import ``backends/``.
 """
 
 from __future__ import annotations

--- a/src/rigplane/cli/_convert.py
+++ b/src/rigplane/cli/_convert.py
@@ -10,17 +10,24 @@ import BOTH ``rigplane.backends.hamlib_models`` (``HamlibCaps``) AND
 
 from __future__ import annotations
 
+import argparse
+import json
 import re
+import sys
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
-from rigplane.backends.hamlib_models import HamlibCaps
+from rigplane.backends.hamlib_models import HamlibCaps, load_hamlib_caps
 from rigplane.validation.registry import REGISTRY
 
 __all__ = [
     "CrossCheckReport",
+    "add_subparser",
     "build_draft_toml",
     "caps_to_capabilities",
     "cross_check",
+    "run",
 ]
 
 
@@ -192,3 +199,133 @@ def build_draft_toml(caps: HamlibCaps, *, model: str, profile_id: str) -> str:
         ]
     )
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI verb: ``rigplane convert <model>`` (MOR-220 / ADR §8) — I/O driver.
+#
+# This is the thin driver wrapping the pure functions above. It shells out via
+# ``load_hamlib_caps`` (the only I/O), writes the draft TOML to disk, and
+# optionally runs the cross-check against an existing profile. It lives in the
+# same module to keep the pure converter + its driver cohesive.
+# ---------------------------------------------------------------------------
+
+
+def add_subparser(sub: Any) -> argparse.ArgumentParser:
+    """Register the top-level ``convert`` subparser on ``sub``.
+
+    Typed as ``Any`` because ``argparse._SubParsersAction`` is private and the
+    surrounding parser code in ``cli/__init__.py`` follows the same convention.
+    """
+    p: argparse.ArgumentParser = sub.add_parser(
+        "convert",
+        help=(
+            "Bootstrap a draft rigplane TOML profile from a Hamlib model's "
+            "dump_caps (and optionally cross-check it against an existing "
+            "profile). Human review required before the draft becomes real."
+        ),
+    )
+    p.add_argument(
+        "convert_model",
+        metavar="MODEL",
+        help=(
+            "Hamlib numeric model id (e.g. 3091) or a known rigplane model "
+            "name (e.g. X6200)."
+        ),
+    )
+    p.add_argument(
+        "--draft-out",
+        dest="draft_out",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Where to write the draft TOML. Default: <slug>.draft.toml in the "
+            "current directory (NOT rigs/, to avoid auto-load)."
+        ),
+    )
+    p.add_argument(
+        "--compare-profile",
+        dest="compare_profile",
+        default=None,
+        metavar="MODEL",
+        help=(
+            "Cross-check the Hamlib-derived capabilities against this existing "
+            "profile and print the report."
+        ),
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON (cross-check report) instead of human text.",
+    )
+    return p
+
+
+def _resolve_model_id(model: str) -> tuple[int, str]:
+    """Resolve *model* to ``(hamlib_model_id, display_name)``.
+
+    Tries ``int(model)`` first; on ``ValueError`` resolves a rigplane profile
+    by name via :func:`rigplane.profiles.get_radio_profile`. Raises ``KeyError``
+    when the name is unknown.
+    """
+    try:
+        model_id = int(model)
+    except ValueError:
+        from rigplane.profiles import get_radio_profile
+
+        profile = get_radio_profile(model)  # may raise KeyError
+        return profile.hamlib_model_id, profile.model
+    return model_id, str(model_id)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Driver for ``rigplane convert``. Returns a process exit code.
+
+    Exit codes: ``0`` success; ``2`` unknown model name; ``3`` Hamlib
+    ``dump_caps`` unavailable / degraded (cannot bootstrap a draft).
+    """
+    model_arg = str(getattr(args, "convert_model"))
+
+    try:
+        model_id, display_name = _resolve_model_id(model_arg)
+    except KeyError as exc:
+        print(f"Error: unknown model {model_arg!r}: {exc}", file=sys.stderr)
+        return 2
+
+    caps = load_hamlib_caps(model_id)
+    if caps.degraded_reason:
+        print(
+            f"Error: cannot bootstrap draft for {model_arg!r}: "
+            f"{caps.degraded_reason}.\n"
+            "  dump_caps is required (check that Hamlib `rigctl` is installed "
+            "and the model id is valid).",
+            file=sys.stderr,
+        )
+        return 3
+
+    profile_id = _slug(display_name)
+    text = build_draft_toml(caps, model=display_name, profile_id=profile_id)
+
+    draft_out = getattr(args, "draft_out", None) or f"{profile_id}.draft.toml"
+    out_path = Path(draft_out)
+    out_path.write_text(text + "\n", encoding="utf-8")
+    print(f"Draft written to: {out_path}", file=sys.stderr)
+
+    compare = getattr(args, "compare_profile", None)
+    if compare:
+        from rigplane.profiles import get_radio_profile
+
+        try:
+            other = get_radio_profile(compare)
+        except KeyError as exc:
+            print(
+                f"Error: unknown --compare-profile {compare!r}: {exc}", file=sys.stderr
+            )
+            return 2
+        report = cross_check(caps, other.capabilities, profile_id=other.id)
+        if getattr(args, "json", False):
+            print(json.dumps(report.to_dict(), indent=2))
+        else:
+            print(report.human_table())
+
+    return 0

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -957,7 +957,9 @@ def discover_rigs(directory: Path) -> dict[str, RigConfig]:
     """Discover and load all rig TOML files in a directory.
 
     Files starting with underscore are ignored (e.g. ``_schema.md``,
-    ``_template.toml``).
+    ``_template.toml``). ``*.draft.toml`` files (emitted by ``rigplane
+    convert``) are also ignored so an unreviewed bootstrap draft is never
+    auto-loaded as a real profile.
 
     Returns:
         Dict mapping model name to ``RigConfig``.
@@ -967,7 +969,7 @@ def discover_rigs(directory: Path) -> dict[str, RigConfig]:
         return rigs
 
     for path in sorted(directory.glob("*.toml")):
-        if path.name.startswith("_"):
+        if path.name.startswith("_") or path.name.endswith(".draft.toml"):
             continue
         rig = load_rig(path)
         rigs[rig.model] = rig

--- a/tests/test_convert_cli.py
+++ b/tests/test_convert_cli.py
@@ -1,0 +1,231 @@
+"""CLI driver tests for the ``rigplane convert`` verb (MOR-220, slice 204b).
+
+These cover the I/O driver and wiring around the pure MOR-203 converter:
+model resolution (numeric id + name), draft TOML emission, degraded-caps
+handling, the ``--compare-profile`` cross-check, and the ``discover_rigs``
+``*.draft.toml`` auto-load skip.
+
+Argv is driven through the real ``rigplane.cli._build_parser()`` so the
+dispatch wiring (``_COMMAND_NAMES`` + the ``elif`` branch) is exercised.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import rigplane.cli as cli
+import rigplane.cli._convert as convert_mod
+from rigplane.backends.hamlib_models import HamlibCaps
+
+
+def _run_convert(argv: list[str]) -> int:
+    """Parse *argv* through the real parser and dispatch to the convert run()."""
+    parser = cli._build_parser()
+    args = parser.parse_args(argv)
+    assert args.command == "convert"
+    return convert_mod.run(args)
+
+
+def _good_caps() -> HamlibCaps:
+    """A non-degraded caps view: RF/AF levels, NB func, USB/CWR modes, set freq."""
+    return HamlibCaps(
+        get_levels=frozenset({"RF", "AF"}),
+        get_funcs=frozenset({"NB"}),
+        modes=frozenset({"USB", "CWR"}),
+        has_set_freq=True,
+        model_id=3091,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. convert <numeric id> --draft-out
+# ---------------------------------------------------------------------------
+
+
+def test_convert_numeric_id_writes_draft(tmp_path, monkeypatch, capsys) -> None:
+    out = tmp_path / "x.draft.toml"
+    monkeypatch.setattr(
+        convert_mod, "load_hamlib_caps", lambda model_id, **kw: _good_caps()
+    )
+
+    rc = _run_convert(["convert", "3091", "--draft-out", str(out)])
+
+    assert rc == 0
+    assert out.exists()
+    data = tomllib.loads(out.read_text())
+    # Required loader sections present.
+    for section in ("radio", "protocol", "capabilities", "modes", "filters", "vfo"):
+        assert section in data
+    # Features mapped from Hamlib tokens.
+    features = set(data["capabilities"]["features"])
+    assert {"rf_gain", "af_level", "nb"} <= features
+    # Modes normalized: CWR -> CW-R, USB passthrough.
+    assert "CW-R" in data["modes"]["list"]
+    assert "USB" in data["modes"]["list"]
+    # Driver reports the written path on stderr.
+    assert str(out) in capsys.readouterr().err
+
+
+def test_convert_default_draft_out_is_cwd_slug(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        convert_mod, "load_hamlib_caps", lambda model_id, **kw: _good_caps()
+    )
+
+    rc = _run_convert(["convert", "3091"])
+
+    assert rc == 0
+    expected = tmp_path / "3091.draft.toml"
+    assert expected.exists()
+
+
+# ---------------------------------------------------------------------------
+# 2. name resolution + unknown name
+# ---------------------------------------------------------------------------
+
+
+def test_convert_name_resolves_to_hamlib_model_id(tmp_path, monkeypatch) -> None:
+    out = tmp_path / "x6200.draft.toml"
+    seen: dict[str, int] = {}
+
+    def _fake_load(model_id: int, **kw: object) -> HamlibCaps:
+        seen["model_id"] = model_id
+        return _good_caps()
+
+    monkeypatch.setattr(convert_mod, "load_hamlib_caps", _fake_load)
+
+    rc = _run_convert(["convert", "X6200", "--draft-out", str(out)])
+
+    assert rc == 0
+    # X6200 profile carries hamlib_model_id 3091.
+    assert seen["model_id"] == 3091
+
+
+def test_convert_unknown_name_exits_2(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        convert_mod,
+        "load_hamlib_caps",
+        lambda model_id, **kw: pytest.fail("should not load caps for unknown model"),
+    )
+
+    rc = _run_convert(["convert", "NO-SUCH-RADIO", "--draft-out", str(tmp_path / "x")])
+
+    assert rc == 2
+    assert "unknown model" in capsys.readouterr().err.lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. degraded caps -> exit 3, no file written
+# ---------------------------------------------------------------------------
+
+
+def test_convert_degraded_caps_exits_3_no_file(tmp_path, monkeypatch, capsys) -> None:
+    out = tmp_path / "x.draft.toml"
+    monkeypatch.setattr(
+        convert_mod,
+        "load_hamlib_caps",
+        lambda model_id, **kw: HamlibCaps(degraded_reason="rigctl not found"),
+    )
+
+    rc = _run_convert(["convert", "3091", "--draft-out", str(out)])
+
+    assert rc == 3
+    assert not out.exists()
+    assert capsys.readouterr().err.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# 4. --compare-profile --json
+# ---------------------------------------------------------------------------
+
+
+def test_convert_compare_profile_json(tmp_path, monkeypatch, capsys) -> None:
+    import json
+
+    out = tmp_path / "x.draft.toml"
+    monkeypatch.setattr(
+        convert_mod, "load_hamlib_caps", lambda model_id, **kw: _good_caps()
+    )
+
+    rc = _run_convert(
+        [
+            "convert",
+            "3091",
+            "--draft-out",
+            str(out),
+            "--compare-profile",
+            "X6200",
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert "agreed" in report
+    assert "rigplane_only" in report
+    assert "hamlib_only" in report
+
+
+def test_convert_compare_profile_human(tmp_path, monkeypatch, capsys) -> None:
+    out = tmp_path / "x.draft.toml"
+    monkeypatch.setattr(
+        convert_mod, "load_hamlib_caps", lambda model_id, **kw: _good_caps()
+    )
+
+    rc = _run_convert(
+        ["convert", "3091", "--draft-out", str(out), "--compare-profile", "X6200"]
+    )
+
+    assert rc == 0
+    assert "Cross-check report" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# 5. discover_rigs skips *.draft.toml
+# ---------------------------------------------------------------------------
+
+_REAL_TOML = """\
+[radio]
+id = "icom_ic7300"
+model = "IC-7300"
+civ_addr = 0x94
+receiver_count = 1
+has_lan = true
+has_wifi = false
+
+[capabilities]
+features = ["audio", "tx"]
+
+[modes]
+list = ["USB", "LSB"]
+
+[filters]
+list = ["FIL1"]
+
+[vfo]
+scheme = "ab"
+
+[commands]
+get_freq = [0x03]
+"""
+
+
+def test_discover_rigs_skips_draft_toml(tmp_path) -> None:
+    from rigplane.profiles.rig_loader import discover_rigs
+
+    (tmp_path / "real.toml").write_text(textwrap.dedent(_REAL_TOML))
+    # A stray draft that must NOT be auto-loaded (it would fail validation anyway,
+    # but more importantly it must be skipped silently like _-prefixed files).
+    (tmp_path / "x6200.draft.toml").write_text(
+        textwrap.dedent(_REAL_TOML).replace('model = "IC-7300"', 'model = "DRAFT"')
+    )
+
+    rigs = discover_rigs(Path(tmp_path))
+
+    assert "IC-7300" in rigs
+    assert "DRAFT" not in rigs
+    assert len(rigs) == 1


### PR DESCRIPTION
## MOR-220 (slice 204b) — `rigplane convert` verb

The runnable I/O driver around the pure MOR-203 converter: bootstrap a draft rigplane TOML profile from a Hamlib model's `dump_caps`, optionally cross-checking against an existing profile. ADR `docs/plans/2026-05-28-universal-validation-matrix.md` §8.

### CLI surface (top-level verb)
`rigplane convert <model> [--draft-out PATH] [--compare-profile MODEL] [--json]`

Chosen as a **top-level** verb rather than `radio-validate convert` (ADR §8/§9 phrasing): argparse can't cleanly combine the `radio-validate <model>` positional with a `convert` subcommand, and `convert` is semantically a distinct "bootstrap a profile" operation. Matches the existing flat-subcommand CLI; no argparse hacks; no regression to the shipped `radio-validate <model>` UX.

### Driver flow
1. Resolve model: `int(model)` first; else `get_radio_profile(model).hamlib_model_id` (unknown → exit 2).
2. `load_hamlib_caps(model_id)`; degraded → clear stderr error, exit 3, no file written.
3. `build_draft_toml(...)` → write to `--draft-out` (default `<slug>.draft.toml` in CWD, **not** rigs/).
4. `--compare-profile X` → `cross_check` human table (or JSON dict with agreed/rigplane_only/hamlib_only under `--json`).

### Draft safety
`discover_rigs` now skips `*.draft.toml` (one line, alongside the `_`-prefix skip) so a stray draft in rigs/ can never auto-load. ADR §11.2 open question #2 resolved.

### Files
`cli/_convert.py` (+driver, alongside the pure funcs), `cli/__init__.py` (wiring), `profiles/rig_loader.py` (1-line draft skip), `tests/test_convert_cli.py` (new, 8 tests).

### Gates
- `uv run pytest tests/ -q` — 6476 passed, 0 failures (full suite)
- ruff / lint-imports — clean; mypy — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)