### PR TITLE
fix(MOR-224): accept CDC-ACM serial ports in discovery (X6200 / CH342)

### DIFF
--- a/src/rigplane/backends/discovery.py
+++ b/src/rigplane/backends/discovery.py
@@ -821,14 +821,25 @@ def _normalize_usb_audio_metadata(value: object) -> dict[str, object] | None:
 
 
 def _is_candidate(port: object) -> bool:
-    """Return True if *port* is a plausible Icom serial connection.
+    """Return True if *port* is a plausible USB-connected radio serial port.
 
-    Inclusion criteria:
-    - Device path contains ``"usb"`` (case-insensitive)
+    Inclusion criteria (any one is sufficient):
+    - The OS reports a USB vendor id for the port (``port.vid`` is set), or
+    - The hardware id string contains ``"usb"`` (e.g. ``USB VID:PID=...``), or
+    - The device path contains ``"usb"`` (case-insensitive).
 
-    Exclusion criteria:
+    Exclusion criteria (checked first, take precedence):
     - Device path contains ``"bluetooth"`` (case-insensitive)
     - Device path contains ``"debug"``, ``"wlan"``, or ``"spi"`` (virtual ports)
+
+    Anchoring on the USB *identity* rather than only the device-path substring
+    matters cross-platform: USB serial radios do not all carry ``"usb"`` in
+    their OS device name. macOS uses ``/dev/cu.usbserial-*`` / ``usbmodem*``
+    (has ``"usb"``) and Linux ``/dev/ttyUSB*`` for FTDI/CP210x bridges, but
+    CDC-ACM composite bridges enumerate as ``/dev/ttyACM*`` on Linux and
+    ``COMx`` on Windows — neither contains ``"usb"``. The Xiegu X6200's WCH
+    CH342 is exactly such a CDC-ACM device, so the old device-name-only filter
+    hard-skipped it on Linux/Windows before any CI-V probe could run (MOR-224).
 
     Args:
         port: A ``serial.tools.list_ports_common.ListPortInfo`` object.
@@ -847,4 +858,9 @@ def _is_candidate(port: object) -> bool:
         if kw in device_lower:
             return False
 
+    if getattr(port, "vid", None) is not None:
+        return True
+    hwid_lower = str(getattr(port, "hwid", "") or "").lower()
+    if "usb" in hwid_lower:
+        return True
     return "usb" in device_lower

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -309,6 +309,49 @@ class TestIsCandidate:
         port = _make_port("/dev/ttyS0", "Standard Serial")
         assert _is_candidate(port) is False
 
+    # MOR-224: CDC-ACM bridges (e.g. the X6200's WCH CH342) enumerate under
+    # device names that do NOT contain "usb" on Linux (/dev/ttyACM*) and
+    # Windows (COMx). They must still be accepted via their USB identity.
+    def test_x6200_linux_ttyacm_included_by_vid(self) -> None:
+        port = _make_port(
+            "/dev/ttyACM0",
+            "USB Dual_Serial",
+            "USB VID:PID=1A86:55D2 LOCATION=1-1.2.4",
+            vid=0x1A86,
+            pid=0x55D2,
+            product="USB Dual_Serial",
+        )
+        assert _is_candidate(port) is True
+
+    def test_x6200_windows_com_included_by_vid(self) -> None:
+        port = _make_port(
+            "COM3",
+            "USB Dual_Serial",
+            "USB VID:PID=1A86:55D2",
+            vid=0x1A86,
+            pid=0x55D2,
+            product="USB Dual_Serial",
+        )
+        assert _is_candidate(port) is True
+
+    def test_generic_usb_radio_windows_com_included_by_vid(self) -> None:
+        # Any USB serial radio on Windows surfaces as COMx (no "usb" in name).
+        port = _make_port(
+            "COM4", "Silicon Labs CP210x", "USB VID:PID=10C4:EA60", vid=0x10C4
+        )
+        assert _is_candidate(port) is True
+
+    def test_cdc_acm_included_by_hwid_when_vid_absent(self) -> None:
+        # Some OS/permission setups don't surface vid via pyserial; the
+        # "USB VID:PID=" hwid string is the robust-identity fallback.
+        port = _make_port("/dev/ttyACM0", "", "USB VID:PID=1A86:55D2")
+        assert _is_candidate(port) is True
+
+    def test_bluetooth_with_vid_still_excluded(self) -> None:
+        # Name-based exclusions take precedence over the USB-identity accept.
+        port = _make_port("/dev/tty.Bluetooth-Incoming-Port", "Bluetooth", vid=0x1234)
+        assert _is_candidate(port) is False
+
 
 class TestEnumerateSerialPorts:
     def test_usb_port_returned(self) -> None:
@@ -382,6 +425,26 @@ class TestEnumerateSerialPorts:
         with patch("serial.tools.list_ports.comports", return_value=[]):
             result = enumerate_serial_ports()
         assert isinstance(result, list)
+
+    def test_x6200_cdc_acm_returned_as_candidate(self) -> None:
+        # MOR-224: the X6200's CH342 on Linux (/dev/ttyACM*) must enumerate
+        # as a candidate even though its device name has no "usb".
+        port = _make_port(
+            "/dev/ttyACM0",
+            "USB Dual_Serial",
+            "USB VID:PID=1A86:55D2 LOCATION=1-1.2.4",
+            vid=0x1A86,
+            pid=0x55D2,
+            product="USB Dual_Serial",
+            manufacturer=None,
+            serial_number="5891018109",
+        )
+        with patch("serial.tools.list_ports.comports", return_value=[port]):
+            result = enumerate_serial_ports()
+        assert len(result) == 1
+        assert result[0].device == "/dev/ttyACM0"
+        assert result[0].vid == 0x1A86
+        assert result[0].pid == 0x55D2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes **MOR-224** — the Xiegu X6200 was **not detected** during serial discovery on Linux and Windows; its port was hard-skipped before any CI-V probe ran. Same release vehicle as the X6200 audio fix #1677 (MOR-219). **Blocks rigplane-pro beta.7.**

## Root cause (confirmed, corrects the issue hypothesis)

`_is_candidate()` accepted a port only when the OS **device path** contained the substring `"usb"`. USB serial radios don't all carry `"usb"` in their device name:
- macOS: `/dev/cu.usbserial-*` / `usbmodem*` — has `"usb"` ✅
- Linux FTDI/CP210x: `/dev/ttyUSB*` — has `"usb"` ✅
- **CDC-ACM bridges: `/dev/ttyACM*` (Linux) and `COMx` (Windows) — no `"usb"`** ❌

The X6200's WCH CH342 is a CDC-ACM device, so it (and in fact **any** USB serial radio on Windows COMx) was filtered out at enumeration. macOS was unaffected only because `usbmodem` happens to contain `"usb"`.

This is **not** the MOR-170 hwid-disambiguation override: that helper runs only *after* a successful CI-V probe and never skips a port. The skip is the long-standing device-name-substring filter (present since the filter's first commit); the X6200 is simply the first CDC-ACM radio to expose it.

## Change

`_is_candidate()` now anchors on USB **identity**: accept when pyserial surfaces a USB vendor id, or the hwid string contains `"USB VID:PID="`, falling back to the device-name substring. Bluetooth/virtual exclusions still take precedence; IC-705 vs X6200 disambiguation untouched. Generic, cross-platform, no per-radio special-casing.

## Tests

X6200 on Linux `ttyACM*` and Windows `COMx` accepted by vid; generic USB radio on Windows COM accepted; CDC-ACM accepted by hwid when vid absent; bluetooth-with-vid still excluded (name precedence); `ttyACM` enumerates as a candidate. Existing exclusions / `"usb"`-name cases unchanged.

## Gate

- `pytest` (non-integration): **6208 passed**, 57 skipped, 11 xfailed
- `ruff check` + `ruff format --check`: clean

## Hardware verification

- Real X6200 (macOS): discovery still resolves to `xiegu_x6200` (count=1, addr 0xA4 @ 19200) — no regression.
- Linux/Windows verified via mock ports through the real `_is_candidate` (I have only macOS hardware). Manual checklist: plug X6200 into Linux (`ttyACM*`) and Windows (`COMx`), run discovery, confirm model `X6200`; confirm other USB radios still found; confirm a genuine IC-705 is not mislabeled.

## Scope / follow-up

- Override still keys on USB hwid fingerprint (`1A86:55D2` / `"USB Dual_Serial"`) — robustness via CI-V model-ID probe tracked in **MOR-226** (was MOR-170 "out of scope").
- Open-core; Pro pins core → needs a core release + re-pin to unblock beta.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)