### PR TITLE
feat(MOR-226): disambiguate X6200 vs IC-705 by CI-V model ID

### DIFF
--- a/src/rigplane/backends/discovery.py
+++ b/src/rigplane/backends/discovery.py
@@ -40,6 +40,7 @@ __all__ = [
     "probe_serial_civ",
     "probe_serial_kenwood_cat",
     "probe_serial_yaesu_cat",
+    "probe_xiegu_model_id",
     "rank_hamlib_probe",
 ]
 
@@ -286,6 +287,114 @@ def _parse_probe_response(port: str, baud: int, data: bytes) -> CivProbeResult |
         model_id.hex(),
     )
     return CivProbeResult(port=port, baud=baud, address=address, model_id=model_id)
+
+
+# ---------------------------------------------------------------------------
+# Xiegu model-ID probe (X6200 vs IC-705 disambiguation at CI-V address 0xA4)
+# ---------------------------------------------------------------------------
+
+#: CI-V *get Xiegu model ID* command (``0x1D 0x19``), addressed to a radio at
+#: 0xA4 from the controller (0xE0). Documented for the X6200 (Radioddity
+#: *X6200 CI-V implementation V1.0.6*, PDF page 9); Icom radios at the same
+#: address (IC-705) have no such opcode and answer with a NAK.
+_XIEGU_MODEL_ID_CMD = bytes([0xFE, 0xFE, 0xA4, 0xE0, 0x1D, 0x19, 0xFD])
+
+
+async def probe_xiegu_model_id(
+    port: str,
+    baud: int,
+    timeout: float = 0.5,
+    *,
+    _open_serial: _OpenSerial | None = None,
+) -> bool:
+    """Return ``True`` if *port* answers the Xiegu model-ID query (0x1D 0x19).
+
+    Disambiguates the Xiegu X6200 from the Icom IC-705: both default to CI-V
+    address 0xA4, but only the Xiegu implements ``0x1D 0x19`` (Radioddity
+    X6200 CI-V V1.0.6, PDF page 9). A valid (non-NAK) reply positively
+    identifies a Xiegu, regardless of the USB bridge it enumerates behind —
+    so it survives USB-chip changes that the hwid fingerprint would miss
+    (MOR-226). Safe to send to an IC-705: standard Icom CI-V NAKs unknown
+    commands rather than wedging.
+
+    Args:
+        port: Serial device path.
+        baud: Baud rate to use (the rate the CI-V probe already succeeded at).
+        timeout: Read timeout in seconds.
+        _open_serial: Override for ``serial_asyncio.open_serial_connection``
+            (used in tests).
+
+    Returns:
+        ``True`` on a valid ``0x1D 0x19`` reply, ``False`` on NAK, timeout,
+        unexpected data, or open failure.
+    """
+    open_fn = _open_serial or _default_open_serial()
+    try:
+        reader, writer = await open_fn(url=port, baudrate=baud)
+    except Exception:
+        logger.debug("probe_xiegu_model_id: cannot open %s @ %d", port, baud)
+        return False
+
+    try:
+        writer.write(_XIEGU_MODEL_ID_CMD)
+        await writer.drain()
+
+        buf = bytearray()
+        response_preamble = bytes([0xFE, 0xFE, 0xE0])
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                break
+            try:
+                chunk = await asyncio.wait_for(reader.read(64), timeout=remaining)
+                buf.extend(chunk)
+            except asyncio.TimeoutError:
+                break
+            if buf.find(response_preamble) != -1:
+                break
+
+        return _is_xiegu_model_id_reply(port, bytes(buf))
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+def _is_xiegu_model_id_reply(port: str, data: bytes) -> bool:
+    """Return ``True`` if *data* holds a valid CI-V ``0x1D 0x19`` reply.
+
+    Expected frame: ``FE FE E0 <addr> 1D 19 <model...> FD``. A NAK collision
+    (``FE FE E0 <addr> FA FD``) or any other command echo means the radio does
+    not implement the Xiegu opcode (i.e. it is an IC-705, not an X6200).
+    """
+    search = bytes([0xFE, 0xFE, 0xE0])
+    idx = data.find(search)
+    if idx == -1:
+        logger.debug("probe_xiegu_model_id: no reply from %s (not a Xiegu)", port)
+        return False
+
+    frame = data[idx:]
+    if len(frame) < 6:
+        logger.debug("probe_xiegu_model_id: reply too short from %s", port)
+        return False
+
+    if frame[4] == 0xFA:
+        logger.debug("probe_xiegu_model_id: %s NAKed 0x1D 0x19 (not a Xiegu)", port)
+        return False
+    if frame[4] != 0x1D or frame[5] != 0x19:
+        logger.debug(
+            "probe_xiegu_model_id: unexpected reply from %s: %s",
+            port,
+            frame[:8].hex(),
+        )
+        return False
+
+    end_idx = frame.find(0xFD, 6)
+    model = bytes(frame[6:end_idx]) if end_idx != -1 else b""
+    logger.info(
+        "probe_xiegu_model_id: %s is a Xiegu (model id %s)", port, model.hex() or "?"
+    )
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -605,6 +714,15 @@ async def discover_serial_radios(
             # Hardware-fingerprint override for the IC-705 / X6200 CI-V
             # address collision (both default to 0xA4). MOR-170.
             xiegu_override = _resolve_xiegu_x6200_override(civ.address, port)
+            # When the USB hwid is inconclusive at the shared 0xA4 address,
+            # confirm via the Xiegu-only CI-V model-ID opcode (0x1D 0x19) —
+            # survives future USB-chip changes the hwid fingerprint misses
+            # and never mislabels an IC-705 (which NAKs the opcode). MOR-226.
+            if xiegu_override is None and civ.address == 0xA4:
+                if await probe_xiegu_model_id(
+                    civ.port, civ.baud, _open_serial=_open_serial
+                ):
+                    xiegu_override = ("X6200", "xiegu_x6200")
             if xiegu_override is not None:
                 model, profile_id = xiegu_override
             results.append(

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -15,6 +15,7 @@ from rigplane.discovery import (
     RadioDiscoveryResult,
     SerialPortCandidate,
     _is_candidate,
+    _is_xiegu_model_id_reply,
     _parse_probe_response,
     build_setup_discovery_payload,
     _parse_yaesu_id_response,
@@ -23,6 +24,7 @@ from rigplane.discovery import (
     enumerate_serial_ports,
     probe_serial_civ,
     probe_serial_yaesu_cat,
+    probe_xiegu_model_id,
 )
 from rigplane.usb_audio_resolve import AudioDeviceMapping
 
@@ -46,6 +48,12 @@ def _fast_probes():
             patch(
                 "rigplane.discovery.probe_serial_yaesu_cat",
                 partial(probe_serial_yaesu_cat, baud_rates=[38400], timeout=0.01),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "rigplane.discovery.probe_xiegu_model_id",
+                partial(probe_xiegu_model_id, timeout=0.01),
             )
         )
         yield
@@ -96,6 +104,12 @@ _IC7610_RESPONSE = bytes([0xFE, 0xFE, 0xE0, 0x98, 0x19, 0x00, 0x01, 0x06, 0xFD])
 # at the address level — disambiguation is by USB hwid, not CI-V payload.
 _IC705_RESPONSE = bytes([0xFE, 0xFE, 0xE0, 0xA4, 0x19, 0x00, 0x01, 0x05, 0xFD])
 _PROBE_CMD = bytes([0xFE, 0xFE, 0x00, 0xE0, 0x19, 0x00, 0xFD])
+
+# Xiegu model-ID (0x1D 0x19) replies (MOR-226). The X6200 echoes the command
+# and returns its model id (0x62 0x00); the IC-705 has no such opcode and NAKs.
+_XIEGU_MODEL_ID_CMD = bytes([0xFE, 0xFE, 0xA4, 0xE0, 0x1D, 0x19, 0xFD])
+_XIEGU_MODEL_ID_REPLY = bytes([0xFE, 0xFE, 0xE0, 0xA4, 0x1D, 0x19, 0x62, 0x00, 0xFD])
+_XIEGU_NAK_REPLY = bytes([0xFE, 0xFE, 0xE0, 0xA4, 0xFA, 0xFD])
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +267,85 @@ class TestParseProbeResponse:
     def test_no_terminator_returns_none(self) -> None:
         data = bytes([0xFE, 0xFE, 0xE0, 0x98, 0x19, 0x00, 0x01, 0x06])
         assert _parse_probe_response("/dev/x", 19200, data) is None
+
+
+# ---------------------------------------------------------------------------
+# Xiegu model-ID probe tests (MOR-226)
+# ---------------------------------------------------------------------------
+
+
+class TestIsXieguModelIdReply:
+    def test_valid_reply_is_xiegu(self) -> None:
+        assert _is_xiegu_model_id_reply("/dev/x", _XIEGU_MODEL_ID_REPLY) is True
+
+    def test_nak_is_not_xiegu(self) -> None:
+        # IC-705 has no 0x1D 0x19 opcode → NAK collision FE FE E0 A4 FA FD.
+        assert _is_xiegu_model_id_reply("/dev/x", _XIEGU_NAK_REPLY) is False
+
+    def test_wrong_command_echo_is_not_xiegu(self) -> None:
+        # A 0x19 0x00 transceiver-ID frame must not be mistaken for 0x1D 0x19.
+        assert _is_xiegu_model_id_reply("/dev/x", _IC705_RESPONSE) is False
+
+    def test_no_preamble_is_not_xiegu(self) -> None:
+        assert _is_xiegu_model_id_reply("/dev/x", bytes(8)) is False
+
+    def test_short_reply_is_not_xiegu(self) -> None:
+        assert _is_xiegu_model_id_reply("/dev/x", bytes([0xFE, 0xFE, 0xE0])) is False
+
+    def test_command_echo_before_reply_is_ignored(self) -> None:
+        # The radio's echo of our command (dest 0xA4) lacks the FE FE E0
+        # controller preamble, so only the real reply is matched.
+        data = _XIEGU_MODEL_ID_CMD + _XIEGU_MODEL_ID_REPLY
+        assert _is_xiegu_model_id_reply("/dev/x", data) is True
+
+
+class TestProbeXieguModelId:
+    @pytest.mark.asyncio
+    async def test_valid_reply_returns_true(self) -> None:
+        reader = _FakeReader([_XIEGU_MODEL_ID_REPLY])
+        writer = _FakeWriter()
+        result = await probe_xiegu_model_id(
+            "/dev/x", 19200, timeout=0.1, _open_serial=_make_open(reader, writer)
+        )
+        assert result is True
+        assert writer.written[0] == _XIEGU_MODEL_ID_CMD
+
+    @pytest.mark.asyncio
+    async def test_nak_returns_false(self) -> None:
+        reader = _FakeReader([_XIEGU_NAK_REPLY])
+        writer = _FakeWriter()
+        result = await probe_xiegu_model_id(
+            "/dev/x", 19200, timeout=0.1, _open_serial=_make_open(reader, writer)
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_false(self) -> None:
+        reader = _FakeReader([])  # nothing to read
+        writer = _FakeWriter()
+        result = await probe_xiegu_model_id(
+            "/dev/x", 19200, timeout=0.05, _open_serial=_make_open(reader, writer)
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_open_failure_returns_false(self) -> None:
+        async def _open(*, url: str, baudrate: int, **_kw: object):
+            raise OSError("Resource busy")
+
+        result = await probe_xiegu_model_id(
+            "/dev/x", 19200, timeout=0.1, _open_serial=_open
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_closes_writer(self) -> None:
+        reader = _FakeReader([_XIEGU_MODEL_ID_REPLY])
+        writer = _FakeWriter()
+        await probe_xiegu_model_id(
+            "/dev/x", 19200, timeout=0.1, _open_serial=_make_open(reader, writer)
+        )
+        assert writer.closed is True
 
 
 def _make_port(
@@ -1026,6 +1119,69 @@ class TestDiscoverSerialRadios:
 
         assert results[0].model == "X6200"
         assert results[0].profile_id == "xiegu_x6200"
+
+    @pytest.mark.asyncio
+    async def test_civ_addr_0xA4_civ_model_id_resolves_to_x6200(self) -> None:
+        """MOR-226: an X6200 whose USB hwid does NOT match the CH342
+        fingerprint (e.g. a different/future USB bridge, or VID/PID not
+        surfaced and no ``USB Dual_Serial`` product) is still classified as
+        X6200 via the Xiegu-only CI-V model-ID opcode (0x1D 0x19).
+        """
+        # First read → CI-V transceiver-ID probe response (addr 0xA4);
+        # second read → the Xiegu model-ID reply to 0x1D 0x19.
+        reader = _FakeReader([_IC705_RESPONSE, _XIEGU_MODEL_ID_REPLY])
+        writer = _FakeWriter()
+
+        port = _make_port(
+            "/dev/ttyACM0",
+            "Some Generic CDC-ACM",
+            "USB VID:PID=DEAD:BEEF",
+            vid=0xDEAD,
+            pid=0xBEEF,
+            product="Generic Serial",
+        )
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+        ):
+            results = await discover_serial_radios(
+                _open_serial=_make_open(reader, writer),
+            )
+
+        assert len(results) == 1
+        assert results[0].address == 0xA4
+        assert results[0].model == "X6200"
+        assert results[0].profile_id == "xiegu_x6200"
+
+    @pytest.mark.asyncio
+    async def test_civ_addr_0xA4_civ_nak_stays_ic705(self) -> None:
+        """MOR-226: a genuine IC-705 (non-Xiegu hwid) that NAKs 0x1D 0x19
+        must remain classified as IC-705 — no false X6200 promotion.
+        """
+        reader = _FakeReader([_IC705_RESPONSE, _XIEGU_NAK_REPLY])
+        writer = _FakeWriter()
+
+        port = _make_port(
+            "/dev/ttyUSB0",
+            "USB Serial",
+            "USB VID:PID=0C26:0036",
+            vid=0x0C26,
+            pid=0x0036,
+            manufacturer="Icom Inc.",
+            product="IC-705",
+        )
+        with (
+            _fast_probes(),
+            patch("serial.tools.list_ports.comports", return_value=[port]),
+        ):
+            results = await discover_serial_radios(
+                _open_serial=_make_open(reader, writer),
+            )
+
+        assert len(results) == 1
+        assert results[0].address == 0xA4
+        assert results[0].model == "IC-705"
+        assert results[0].profile_id == "icom_ic705"
 
     @pytest.mark.asyncio
     async def test_civ_radio_preserves_usb_audio_resolution_metadata(self) -> None:


### PR DESCRIPTION
## Summary

Resolves **MOR-226** — makes the Xiegu X6200 vs Icom IC-705 disambiguation (shared CI-V address 0xA4) robust at the **protocol level**, instead of relying solely on the exact USB hwid fingerprint introduced in MOR-170.

## Why

MOR-170 distinguished the two radios only by `vid==0x1A86 && pid==0x55D2` / product `"USB Dual_Serial"` (WCH CH342). That is fragile: an X6200 behind a different/future USB bridge — or one whose VID/PID the OS doesn't surface and whose product string differs — was **misclassified as IC-705** and driven with the wrong CI-V envelope (the exact display-wedge MOR-170 was filed to prevent). The `rigs/x6200.toml` TODO already flagged this: *"probe this in discovery rather than relying on hwid fingerprint."*

## Change

When the USB hwid is **inconclusive** at 0xA4, probe the Xiegu-only opcode **`0x1D 0x19`** (documented for the X6200 — Radioddity CI-V V1.0.6 PDF p.9; already declared in `rigs/x6200.toml` as `get_xiegu_model_id`). A valid reply positively identifies a Xiegu; an IC-705 has no such opcode and NAKs → stays IC-705.

- hwid fingerprint remains the **fast path** (no extra serial I/O when it matches).
- The extra `0x1D 0x19` is sent only to 0xA4 ports that don't match the X6200 fingerprint. Safe — standard Icom CI-V NAKs unknown commands rather than wedging.
- New `probe_xiegu_model_id()` + `_is_xiegu_model_id_reply()` mirror the existing CI-V probe/parse style; wired into `discover_serial_radios` only at 0xA4 when the hwid override is inconclusive. MOR-170 hwid/product-name paths unchanged.

## Tests

Reply-parsing (valid / NAK / wrong-echo / short / no-preamble / command-echo-skip), the probe (valid→True, NAK→False, timeout, open-failure, writer-close), and discover-level X6200-via-CI-V promotion + IC-705-NAK-stays-IC-705.

## Gate

- `pytest` (non-integration): **6237 passed**, 57 skipped, 11 xfailed
- `ruff check` + `ruff format --check`: clean
- `mypy src/rigplane/backends/discovery.py`: clean

## Hardware verification

- **Real X6200 (macOS):** `0x1D 0x19` returns model id `0x6200`; `probe_xiegu_model_id` → True; discovery resolves `xiegu_x6200`. ✅
- **IC-705 negative path (NAK → stays IC-705):** unit-tested; not validated on hardware (no IC-705 available). Manual checklist: connect an IC-705, run discovery, confirm it is still classified IC-705 (and that the radio NAKs `0x1D 0x19` cleanly, no wedge). Also confirm an X6200 behind a non-CH342 bridge promotes to X6200.

## Scope

Completes the X6200 follow-ups alongside MOR-219 (#1677) and MOR-224 (#1680). Open-core; needs a core release + re-pin for rigplane-pro beta.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)