### PR TITLE
fix(MOR-223): derive TX/tuner authorization from the registry, not the mutable template flag

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -50,7 +50,7 @@ from rigplane.core.radio_protocol import (
 )
 from rigplane.core.types import AgcMode
 from rigplane.validation.registry import CheckKind, CheckSpec, ValueRule, get_spec
-from rigplane.validation.runner import _is_authorized
+from rigplane.validation.runner import _is_authorized, _is_safety_gated
 from rigplane.validation.schema import (
     CapabilityDeclaration,
     CapabilityDeclarationEntry,
@@ -213,7 +213,7 @@ async def _run_one_check(
 ) -> CheckResult:
     """Execute a single template entry, applying universal pre-gates first."""
     # Pre-gate 1: authorization for TX-adjacent checks.
-    if entry.tx_adjacent and not _is_authorized(entry, safety):
+    if _is_safety_gated(entry) and not _is_authorized(entry, safety):
         return _base_result(
             entry,
             CheckStatus.BLOCKED,

--- a/src/rigplane/validation/runner.py
+++ b/src/rigplane/validation/runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from rigplane.validation.registry import CheckKind, get_spec
 from rigplane.validation.schema import (
     CapabilityDeclaration,
     CapabilityDeclarationEntry,
@@ -55,23 +56,47 @@ def load_template(path: Path) -> MatrixTemplate:
     return validate_template_dict(data)
 
 
+def _registry_gated_capability(entry: CapabilityDeclarationEntry) -> str | None:
+    """Return the IMMUTABLE registry capability for ``entry.check_id`` when its
+    registry ``CheckSpec`` is ``TX_ADJACENT_BLOCKED``; else ``None``. This is the
+    authoritative safety class — it cannot be relaxed by mutating the template's
+    ``tx_adjacent`` flag."""
+    spec = get_spec(entry.check_id)
+    if spec is not None and spec.kind == CheckKind.TX_ADJACENT_BLOCKED:
+        return spec.capability
+    return None
+
+
+def _is_safety_gated(entry: CapabilityDeclarationEntry) -> bool:
+    """True if the entry requires operator authorization — by the template flag
+    OR (defense-in-depth) by the registry safety class."""
+    return entry.tx_adjacent or _registry_gated_capability(entry) is not None
+
+
 def _is_authorized(
     entry: CapabilityDeclarationEntry, safety: OperatorSafetyBlock
 ) -> bool:
     """Return True when the operator is authorized to run ``entry``.
 
-    Fail-closed: any tx_adjacent entry is blocked by default.
+    Fail-closed: any safety-gated entry is blocked by default.
 
-    - Non-TX-adjacent entries are always authorized.
+    - Entries that are neither ``tx_adjacent`` nor registry-gated are always
+      authorized.
+    - The capability used for the tuner/tx split is the IMMUTABLE registry
+      capability whenever the check is registry-gated (``TX_ADJACENT_BLOCKED``);
+      a mutated ``entry.capability`` cannot dodge the split. Only when the entry
+      is gated solely by the template flag do we fall back to ``entry.capability``.
     - Tuner capability is gated solely by ``tuner_allowed`` (independent of
       ``tx_allowed``), because the tuner keys TX into the ATU and has its own
       operator gate.
-    - ALL other tx_adjacent entries — regardless of capability or check_id —
-      require ``tx_allowed``. There is no residual fail-open path.
+    - ALL other safety-gated entries require ``tx_allowed``. There is no
+      residual fail-open path.
     """
-    if not entry.tx_adjacent:
+    gated_cap = _registry_gated_capability(entry)
+    if not entry.tx_adjacent and gated_cap is None:
         return True
-    if entry.capability == _TUNER_CAPABILITY:
+    capability = gated_cap if gated_cap is not None else entry.capability
+    if capability == _TUNER_CAPABILITY:
         return safety.tuner_allowed
     return safety.tx_allowed
 
@@ -90,7 +115,7 @@ def dry_run_results(
     for entry in template.entries:
         status = _DECLARATION_TO_STATUS[entry.declaration]
         failure_domain: FailureDomain | None = None
-        if entry.tx_adjacent and not _is_authorized(entry, safety):
+        if _is_safety_gated(entry) and not _is_authorized(entry, safety):
             status = CheckStatus.BLOCKED
             failure_domain = FailureDomain.COMMAND_EXECUTION
         result = CheckResult(
@@ -176,6 +201,7 @@ def human_summary(artifact: ValidationArtifact) -> str:
 __all__ = [
     "HARDWARE_OPT_IN_ENV",
     "HardwareExecutionBlocked",
+    "_is_safety_gated",
     "load_template",
     "dry_run_results",
     "summarize_results",

--- a/tests/test_authz_registry_gated.py
+++ b/tests/test_authz_registry_gated.py
@@ -1,0 +1,207 @@
+"""Defense-in-depth: TX/tuner authorization derives from the IMMUTABLE registry.
+
+These tests prove that a template whose ``tx.ptt`` / ``tuner.tune`` entry has
+been mutated to ``tx_adjacent=False`` (e.g. a hand-edited template) still cannot
+BYPASS the operator authorization gate, because the gate consults the registry's
+``CheckKind.TX_ADJACENT_BLOCKED`` safety class — which is not part of the
+mutable template — rather than trusting ``entry.tx_adjacent`` alone. They also
+verify that a mutated ``entry.capability`` cannot dodge the tuner/tx split.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.core.radio_protocol import Radio
+from rigplane.core.radio_state import RadioState
+from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.runner import (
+    _is_authorized,
+    _is_safety_gated,
+    dry_run_results,
+)
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckStatus,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    ValidationLevel,
+)
+
+
+def _entry(
+    *,
+    check_id: str,
+    capability: str,
+    tx_adjacent: bool,
+    declaration: CapabilityDeclaration = CapabilityDeclaration.SUPPORTED,
+) -> CapabilityDeclarationEntry:
+    return CapabilityDeclarationEntry(
+        check_id=check_id,
+        capability=capability,
+        level=ValidationLevel.STRESS_RECOVERY,
+        declaration=declaration,
+        summary="single",
+        tx_adjacent=tx_adjacent,
+    )
+
+
+def _template(entry: CapabilityDeclarationEntry) -> MatrixTemplate:
+    return MatrixTemplate(
+        radio=RadioTarget(model="X6200", profile_id="x6200"),
+        entries=[entry],
+    )
+
+
+def _flatten(levels):
+    return {check.check_id: check for level in levels for check in level.checks}
+
+
+# ---------------------------------------------------------------------------
+# 1. dry-run bypass closed: mutated tx.ptt (tx_adjacent=False) still BLOCKED
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_mutated_tx_ptt_still_blocked_without_authorization():
+    entry = _entry(check_id="tx.ptt", capability="tx", tx_adjacent=False)
+    template = _template(entry)
+
+    blocked = dry_run_results(
+        template, OperatorSafetyBlock(tx_allowed=False, tuner_allowed=False)
+    )
+    check = _flatten(blocked)["tx.ptt"]
+    assert check.status is CheckStatus.BLOCKED
+    assert check.status is not CheckStatus.SKIP
+
+    authorized = dry_run_results(
+        template, OperatorSafetyBlock(tx_allowed=True, tuner_allowed=False)
+    )
+    assert _flatten(authorized)["tx.ptt"].status is not CheckStatus.BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# 2. tuner mutated: tx_adjacent=False still gated by tuner_allowed (own gate)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_mutated_tuner_uses_tuner_gate_not_tx():
+    entry = _entry(check_id="tuner.tune", capability="tuner", tx_adjacent=False)
+    template = _template(entry)
+
+    # Neither flag -> blocked.
+    none = dry_run_results(template, OperatorSafetyBlock())
+    assert _flatten(none)["tuner.tune"].status is CheckStatus.BLOCKED
+
+    # tx_allowed alone does NOT authorize the tuner -> still blocked.
+    tx_only = dry_run_results(
+        template, OperatorSafetyBlock(tx_allowed=True, tuner_allowed=False)
+    )
+    assert _flatten(tx_only)["tuner.tune"].status is CheckStatus.BLOCKED
+
+    # tuner_allowed authorizes it -> not blocked.
+    tuner_ok = dry_run_results(
+        template, OperatorSafetyBlock(tx_allowed=False, tuner_allowed=True)
+    )
+    assert _flatten(tuner_ok)["tuner.tune"].status is not CheckStatus.BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# 3. mutated capability can't dodge the split: tuner.tune + capability="tx"
+# ---------------------------------------------------------------------------
+
+
+def test_mutated_capability_cannot_dodge_tuner_tx_split():
+    # Both flags mutated: tx_adjacent=False AND capability="tx" (wrong).
+    entry = _entry(check_id="tuner.tune", capability="tx", tx_adjacent=False)
+
+    # Registry capability ("tuner") wins: tx_allowed alone must NOT authorize.
+    assert (
+        _is_authorized(entry, OperatorSafetyBlock(tx_allowed=True, tuner_allowed=False))
+        is False
+    )
+    # tuner_allowed authorizes it.
+    assert (
+        _is_authorized(entry, OperatorSafetyBlock(tx_allowed=False, tuner_allowed=True))
+        is True
+    )
+
+    template = _template(entry)
+    tx_only = dry_run_results(
+        template, OperatorSafetyBlock(tx_allowed=True, tuner_allowed=False)
+    )
+    assert _flatten(tx_only)["tuner.tune"].status is CheckStatus.BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# 4. non-gated entry unaffected: rf_gain.set is never safety-gated
+# ---------------------------------------------------------------------------
+
+
+def test_non_gated_entry_unaffected():
+    entry = _entry(check_id="rf_gain.set", capability="rf_gain", tx_adjacent=False)
+    assert _is_safety_gated(entry) is False
+    assert _is_authorized(entry, OperatorSafetyBlock()) is True
+
+    template = _template(entry)
+    levels = dry_run_results(template, OperatorSafetyBlock())
+    check = _flatten(levels)["rf_gain.set"]
+    # SUPPORTED maps to SKIP in dry-run; never BLOCKED.
+    assert check.status is CheckStatus.SKIP
+
+
+# ---------------------------------------------------------------------------
+# 5. hardware pre-gate: mutated tx.ptt is gated (no actuation) on hardware path
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_radio():
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"audio", "scope", "tuner", "tx"}
+    radio.set_ptt = AsyncMock(return_value=None)
+    radio.radio_state = RadioState()
+    return radio
+
+
+async def test_hardware_pregate_blocks_mutated_tx_ptt():
+    radio = _make_mock_radio()
+    # tx.ptt mutated to tx_adjacent=False; declared SUPPORTED to bypass the
+    # MANUAL_REQUIRED pre-gate, isolating the authorization pre-gate.
+    entry = _entry(check_id="tx.ptt", capability="tx", tx_adjacent=False)
+    template = _template(entry)
+
+    levels = await execute_hardware_checks(
+        radio,
+        template,
+        OperatorSafetyBlock(tx_allowed=False, tuner_allowed=False),
+        allow_writes=True,
+    )
+    check = _flatten(levels)["tx.ptt"]
+    assert check.status is CheckStatus.BLOCKED
+    assert check.evidence.get("reason") == "operator authorization required"
+    radio.set_ptt.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 6. regression: canonical tx_adjacent=True entries gate exactly as before
+# ---------------------------------------------------------------------------
+
+
+def test_regression_canonical_tx_adjacent_entries_gate_as_before():
+    tx_entry = _entry(check_id="tx.ptt", capability="tx", tx_adjacent=True)
+    tuner_entry = _entry(check_id="tuner.tune", capability="tuner", tx_adjacent=True)
+
+    assert _is_safety_gated(tx_entry) is True
+    assert _is_safety_gated(tuner_entry) is True
+
+    none = OperatorSafetyBlock()
+    assert _is_authorized(tx_entry, none) is False
+    assert _is_authorized(tuner_entry, none) is False
+
+    assert _is_authorized(tx_entry, OperatorSafetyBlock(tx_allowed=True)) is True
+    assert _is_authorized(tuner_entry, OperatorSafetyBlock(tuner_allowed=True)) is True
+    # tx_allowed does not authorize the tuner.
+    assert _is_authorized(tuner_entry, OperatorSafetyBlock(tx_allowed=True)) is False


### PR DESCRIPTION
## MOR-223 — registry-derived authorization (defense-in-depth)

The TX/tuner authorization gate trusted the **mutable** template flag `entry.tx_adjacent`, so a hand-edited/mutated template with `tx.ptt`/`tuner.tune` set to `tx_adjacent=False` would BYPASS the gate. This makes the gate derive its safety class from the **immutable registry** (`get_spec(check_id).kind == CheckKind.TX_ADJACENT_BLOCKED`), matching the ADR §4.2/§10 claim that authorization is re-applied "regardless of the template flag". Hardening — no current exploit path (the MOR-206 override layer already clamps the flag; novel ids are inert).

### Change
- `validation/runner.py`: new `_registry_gated_capability(entry)` (immutable registry capability for a TX_ADJACENT_BLOCKED check) + `_is_safety_gated(entry)` (template flag OR registry); `_is_authorized` uses the registry capability for the tuner-vs-tx split (a mutated `entry.capability` can't dodge it); dry-run gate uses `_is_safety_gated`.
- `validation/hardware.py`: Pre-gate 1 in `_run_one_check` uses `_is_safety_gated` (blocked-result body unchanged).
- No import cycle (registry imports only schema/core).

### Tests (`tests/test_authz_registry_gated.py`, 6)
mutated `tx.ptt`/`tuner.tune` (tx_adjacent=False) → BLOCKED without authorization; tuner uses its own gate (tx_allowed alone doesn't clear it); mutated `capability` can't shift the split; non-gated `rf_gain.set` unaffected; hardware pre-gate blocks with `set_ptt` never called; canonical tx_adjacent=True regression.

### Gates
- `uv run pytest tests/ -q` — 6523 passed, 0 failures (full suite)
- ruff / lint-imports — clean; `mypy src/` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)