### PR TITLE
refactor(MOR-230): pair USB audio by identity, not positional order

### DIFF
--- a/src/rigplane/audio/_usb_resolve.py
+++ b/src/rigplane/audio/_usb_resolve.py
@@ -17,7 +17,14 @@ rather than fragile, collision-prone device-name strings.
 3. Find all USB audio devices (``USB Audio CODEC``, ``USB Audio Device``) in
    IORegistry with their ``locationID``.
 4. Match audio devices sharing the same hub prefix as the serial port.
-5. Map matched locations to ``sounddevice`` device indices by positional order.
+5. Map the matched audio device to ``sounddevice`` indices by **identity**:
+   group the enumerated USB-audio entries into per-device clusters (a duplex
+   entry stands alone; an output-only entry adjacent to a same-named
+   input-only entry forms one split-pair cluster), then select the cluster
+   whose product name and same-name rank match the IORegistry device. This
+   survives mixed-vendor / mixed-shape sets (a single duplex C-Media device
+   next to a split-pair Icom CODEC), where a flat positional index over
+   inputs/outputs would desync (MOR-230).
 
 **Fallback**: When IORegistry is unavailable, ``ioreg`` is missing, or the
 platform is not macOS, falls back to name-based matching (see
@@ -135,14 +142,14 @@ def _resolve_macos(
 
     serial_prefix = serial_location >> 16
 
-    # 4. Find all USB Audio CODEC locationIDs
-    audio_locations = _find_audio_codec_locations(ioreg_text)
-    if not audio_locations:
+    # 4. Find all USB Audio CODEC (name, locationID) pairs
+    audio_entries = _find_audio_codec_entries(ioreg_text)
+    if not audio_entries:
         logger.warning("usb-audio-resolve: no USB Audio CODEC devices found in ioreg")
         return None
 
     # 5. Check if any audio device shares our hub prefix
-    matching = [loc for loc in audio_locations if (loc >> 16) == serial_prefix]
+    matching = [loc for _name, loc in audio_entries if (loc >> 16) == serial_prefix]
     if not matching:
         logger.warning(
             "usb-audio-resolve: no audio devices match prefix %#06x for %s",
@@ -166,39 +173,19 @@ def _resolve_macos(
 
     devices = list(sd.query_devices())
 
-    # Collect all USB Audio CODEC input/output device indices (ordered)
-    usb_inputs: list[int] = []
-    usb_outputs: list[int] = []
-    for idx, dev in enumerate(devices):
-        if _is_usb_audio_codec(dev.get("name", "")):
-            if _safe_int(dev.get("max_input_channels")) > 0:
-                usb_inputs.append(idx)
-            if _safe_int(dev.get("max_output_channels")) > 0:
-                usb_outputs.append(idx)
-
-    # 7. Determine positional index: sorted unique prefixes → pair index
-    unique_prefixes = sorted(set(loc >> 16 for loc in audio_locations))
-    try:
-        pair_idx = unique_prefixes.index(serial_prefix)
-    except ValueError:
+    # 7. Pair by identity, not positional order across flat input/output lists.
+    pair = _pair_audio_device_for_location(devices, audio_entries, serial_location)
+    if pair is None:
         logger.warning(
-            "usb-audio-resolve: prefix %#06x not in audio prefixes %s",
+            "usb-audio-resolve: could not pair an audio device for prefix %#06x "
+            "(serial loc %#010x, audio entries %s)",
             serial_prefix,
-            [f"{p:#06x}" for p in unique_prefixes],
+            serial_location,
+            [(n, f"{loc:#010x}") for n, loc in audio_entries],
         )
         return None
 
-    if pair_idx >= len(usb_inputs) or pair_idx >= len(usb_outputs):
-        logger.warning(
-            "usb-audio-resolve: pair index %d out of range (inputs=%d, outputs=%d)",
-            pair_idx,
-            len(usb_inputs),
-            len(usb_outputs),
-        )
-        return None
-
-    rx_idx = usb_inputs[pair_idx]
-    tx_idx = usb_outputs[pair_idx]
+    rx_idx, tx_idx = pair
 
     logger.info(
         "usb-audio-resolve: %s → prefix %#06x → RX device [%d], TX device [%d]",
@@ -219,6 +206,148 @@ def _resolve_macos(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _cluster_usb_audio_devices(
+    devices: list[Any],
+) -> list[tuple[str, int | None, int | None]]:
+    """Group enumerated USB-audio entries into per-physical-device clusters.
+
+    Each cluster is a ``(name, rx_index, tx_index)`` tuple describing one
+    physical USB audio device's CoreAudio product name and its
+    capture/playback ``sounddevice`` indices:
+
+    - A **duplex** entry (both input and output channels) is a self-contained
+      cluster — the X6200's C-Media codec, which CoreAudio surfaces as one
+      bidirectional device.
+    - A **split** device (Icom "USB Audio CODEC") surfaces as two adjacent
+      same-named entries — one output-only and one input-only — which are
+      merged into a single cluster. Adjacency in the ``sounddevice``
+      enumeration mirrors USB topology order, so the two halves of one
+      physical device sit next to each other.
+
+    Clusters are returned in enumeration order. The ``name`` is the identity
+    key that :func:`_pair_audio_device_for_location` matches against the
+    IORegistry product name. Identity-based, not positional across flattened
+    input/output lists.
+    """
+    clusters: list[tuple[str, int | None, int | None]] = []
+    # pending split cluster: (name, rx_index|None, tx_index|None)
+    pending: tuple[str, int | None, int | None] | None = None
+
+    for idx, dev in enumerate(devices):
+        name = dev.get("name", "")
+        if not _is_usb_audio_codec(name):
+            continue
+        has_in = _safe_int(dev.get("max_input_channels")) > 0
+        has_out = _safe_int(dev.get("max_output_channels")) > 0
+
+        if has_in and has_out:
+            # Flush any half-open split cluster before the duplex device.
+            if pending is not None:
+                clusters.append(pending)
+                pending = None
+            clusters.append((name, idx, idx))
+            continue
+
+        rx = idx if has_in else None
+        tx = idx if has_out else None
+        if pending is None:
+            pending = (name, rx, tx)
+            continue
+        # Merge with the open split cluster when it is the same device name
+        # and fills the missing half.
+        pend_name, pend_rx, pend_tx = pending
+        if pend_name == name and (
+            (rx is not None and pend_rx is None) or (tx is not None and pend_tx is None)
+        ):
+            clusters.append((pend_name, pend_rx or rx, pend_tx or tx))
+            pending = None
+        else:
+            clusters.append(pending)
+            pending = (name, rx, tx)
+
+    if pending is not None:
+        clusters.append(pending)
+
+    return clusters
+
+
+def _pair_audio_device_for_location(
+    devices: list[Any],
+    audio_entries: list[tuple[str, int]],
+    serial_location: int,
+) -> tuple[int, int] | None:
+    """Select the ``(rx_index, tx_index)`` for the matched audio device.
+
+    Pairing is by **identity**, not positional order across flattened
+    input/output lists. The serial port's hub prefix selects the matched
+    audio device (an IORegistry ``(product_name, locationID)`` entry); that
+    device's identity is its product name plus its **rank among same-named
+    audio devices** (sorted by ``locationID``). The corresponding
+    ``sounddevice`` cluster (see :func:`_cluster_usb_audio_devices`) is the
+    rank-th cluster carrying the same product name, and it yields the device
+    indices.
+
+    This is the reusable, platform-neutral pairing primitive the future
+    Linux/Windows resolvers (MOR-228/229) can call once they enumerate audio
+    ``(name, locationID)`` entries and ``sounddevice`` clusters.
+
+    Why name + same-name rank, not a global location rank: ``sounddevice``
+    exposes no ``locationID`` field, and CoreAudio does **not** enumerate USB
+    audio devices in ``locationID`` order across vendors (a C-Media device
+    may enumerate before an Icom CODEC with a lower ``locationID``). The
+    CoreAudio product name *is* the IORegistry node name, so it is the
+    strongest available identity link. Within one vendor/name the remaining
+    ambiguity (e.g. two identical Icom CODECs) is resolved by enumeration
+    order, which for same-model devices tracks ``locationID`` order — this
+    preserves the validated homogeneous-multi-radio behaviour.
+
+    Returns ``None`` when the serial port shares no audio hub prefix or when
+    no same-named cluster occupies the matched device's rank.
+    """
+    serial_prefix = serial_location >> 16
+    sorted_entries = sorted(audio_entries, key=lambda e: e[1])
+
+    # The matched audio device shares the serial port's hub prefix.
+    matched_idx = next(
+        (
+            i
+            for i, (_n, loc) in enumerate(sorted_entries)
+            if (loc >> 16) == serial_prefix
+        ),
+        None,
+    )
+    if matched_idx is None:
+        return None
+    matched_name, _matched_loc = sorted_entries[matched_idx]
+    # Rank of the matched device among same-named audio devices.
+    same_name_rank = sum(
+        1 for _n, _loc in sorted_entries[:matched_idx] if _n == matched_name
+    )
+
+    clusters = _cluster_usb_audio_devices(devices)
+    same_name_clusters = [c for c in clusters if c[0] == matched_name]
+    if same_name_rank >= len(same_name_clusters):
+        logger.warning(
+            "usb-audio-resolve: %r rank %d out of range (%d matching clusters)",
+            matched_name,
+            same_name_rank,
+            len(same_name_clusters),
+        )
+        return None
+
+    _name, rx, tx = same_name_clusters[same_name_rank]
+    if rx is None or tx is None:
+        logger.warning(
+            "usb-audio-resolve: incomplete audio cluster for %r rank %d (rx=%r, tx=%r)",
+            matched_name,
+            same_name_rank,
+            rx,
+            tx,
+        )
+        return None
+    return rx, tx
 
 
 def _extract_tty_suffix(serial_port: str) -> str | None:
@@ -294,10 +423,22 @@ def _find_audio_codec_locations(ioreg_text: str) -> list[int]:
     - ``USB Audio CODEC@...`` — Icom (Burr-Brown/TI chip)
     - ``USB Audio Device@...`` — Yaesu FTX-1 and similar
     """
-    locations: list[int] = []
-    for m in re.finditer(r"USB Audio (?:CODEC|Device)@([0-9a-fA-F]+)", ioreg_text):
-        locations.append(int(m.group(1), 16))
-    return sorted(locations)
+    return sorted(loc for _name, loc in _find_audio_codec_entries(ioreg_text))
+
+
+def _find_audio_codec_entries(ioreg_text: str) -> list[tuple[str, int]]:
+    """Find ``(product_name, locationID)`` pairs for USB audio devices.
+
+    The product name (``USB Audio CODEC`` / ``USB Audio Device``) is the same
+    string CoreAudio reports as the ``sounddevice`` device name, so it is the
+    identity key used to disambiguate mixed-vendor sets in
+    :func:`_pair_audio_device_for_location` (MOR-230). Returned in ascending
+    ``locationID`` order.
+    """
+    entries: list[tuple[str, int]] = []
+    for m in re.finditer(r"(USB Audio (?:CODEC|Device))@([0-9a-fA-F]+)", ioreg_text):
+        entries.append((m.group(1), int(m.group(2), 16)))
+    return sorted(entries, key=lambda e: e[1])
 
 
 def _is_usb_audio_codec(name: str) -> bool:

--- a/src/rigplane/audio/_usb_resolve.py
+++ b/src/rigplane/audio/_usb_resolve.py
@@ -261,7 +261,13 @@ def _cluster_usb_audio_devices(
         if pend_name == name and (
             (rx is not None and pend_rx is None) or (tx is not None and pend_tx is None)
         ):
-            clusters.append((pend_name, pend_rx or rx, pend_tx or tx))
+            # Coalesce the two halves with explicit None checks: a device
+            # index of 0 is valid and falsy, so `pend_rx or rx` would wrongly
+            # drop it (e.g. a USB codec enumerating at index 0 on a headless
+            # host with no built-in audio). MOR-230.
+            merged_rx = pend_rx if pend_rx is not None else rx
+            merged_tx = pend_tx if pend_tx is not None else tx
+            clusters.append((pend_name, merged_rx, merged_tx))
             pending = None
         else:
             clusters.append(pending)

--- a/tests/test_usb_audio_resolve.py
+++ b/tests/test_usb_audio_resolve.py
@@ -764,6 +764,48 @@ class TestResolveMixedVendorShapes:
         assert x6200.tx_device_index != icom.tx_device_index
 
 
+class TestResolveSplitPairAtIndexZero:
+    """MOR-230 regression: a split-pair USB codec whose playback device
+    enumerates at sounddevice index 0 (e.g. a headless host with no built-in
+    audio ahead of the USB codec). Index 0 is a valid but falsy index; the
+    split-cluster merge must not drop it (the `pend_tx or tx` bug)."""
+
+    def _sd_codec_split_at_zero(self) -> MagicMock:
+        # No built-in device: the USB Audio CODEC pair occupies indices 0/1,
+        # output-only at 0 (the falsy index), input-only at 1.
+        devices: list[dict[str, Any]] = [
+            {
+                "name": "USB Audio CODEC",
+                "index": 0,
+                "max_input_channels": 0,
+                "max_output_channels": 2,
+                "default_samplerate": 48000.0,
+            },
+            {
+                "name": "USB Audio CODEC",
+                "index": 1,
+                "max_input_channels": 2,
+                "max_output_channels": 0,
+                "default_samplerate": 48000.0,
+            },
+        ]
+        sd = MagicMock()
+        sd.query_devices.return_value = devices
+        sd.default.device = [-1, -1]
+        return sd
+
+    def test_index_zero_playback_not_dropped(self) -> None:
+        result = _resolve_macos(
+            "/dev/cu.usbserial-201410",
+            sounddevice_module=self._sd_codec_split_at_zero(),
+            ioreg_output=IOREG_SINGLE_RADIO,
+        )
+        assert result is not None
+        assert result.rx_device_index == 1
+        # TX is the output-only device at index 0 — must survive the merge.
+        assert result.tx_device_index == 0
+
+
 class TestNameFallbackXiegu:
     """MOR-219: name-based fallback (Linux/Windows) prefers the C-Media codec
     over an unknown commodity device when topology is unavailable."""

--- a/tests/test_usb_audio_resolve.py
+++ b/tests/test_usb_audio_resolve.py
@@ -648,6 +648,122 @@ class TestResolveXieguX6200:
         ]
 
 
+# ---------------------------------------------------------------------------
+# MOR-230 — identity-based pairing for mixed-vendor / mixed-shape sets
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_sd_cmedia_duplex_plus_icom_split() -> MagicMock:
+    """Mock the CoreAudio enumeration for an X6200 + Icom IC-7610 set.
+
+    The C-Media codec (X6200) enumerates as ONE duplex device (in=1/out=2),
+    while the Icom "USB Audio CODEC" enumerates as a split pair: an
+    output-only device followed by an input-only device.
+
+    Enumeration order here deliberately interleaves shapes so a flat
+    ``usb_inputs[i]`` / ``usb_outputs[i]`` positional index desyncs:
+
+        idx 0 -> Built-in Speaker      (skipped, not USB audio)
+        idx 1 -> C-Media duplex        in=1 out=2   (X6200, prefix 0x1423)
+        idx 2 -> Icom CODEC playback   in=0 out=2   (IC-7610, prefix 0x0111)
+        idx 3 -> Icom CODEC capture     in=2 out=0   (IC-7610, prefix 0x0111)
+    """
+    devices: list[dict[str, Any]] = [
+        {
+            "name": "Built-in Speaker",
+            "index": 0,
+            "max_input_channels": 0,
+            "max_output_channels": 2,
+            "default_samplerate": 48000.0,
+        },
+        {
+            "name": "USB Audio Device",
+            "index": 1,
+            "max_input_channels": 1,
+            "max_output_channels": 2,
+            "default_samplerate": 48000.0,
+        },
+        {
+            "name": "USB Audio CODEC",
+            "index": 2,
+            "max_input_channels": 0,
+            "max_output_channels": 2,
+            "default_samplerate": 48000.0,
+        },
+        {
+            "name": "USB Audio CODEC",
+            "index": 3,
+            "max_input_channels": 2,
+            "max_output_channels": 0,
+            "default_samplerate": 48000.0,
+        },
+    ]
+    sd = MagicMock()
+    sd.query_devices.return_value = devices
+    sd.default.device = [-1, -1]
+    return sd
+
+
+class TestResolveMixedVendorShapes:
+    """MOR-230: a duplex C-Media device next to a split-pair Icom CODEC.
+
+    The pre-MOR-230 positional logic flattens every USB-audio entry into a
+    single ``usb_inputs`` / ``usb_outputs`` list and indexes both by the
+    sorted-prefix position. With mixed device shapes those flat lists no
+    longer line up with the sorted prefixes, so each port resolves to the
+    *other* radio's device. Identity-based pairing must select each port's
+    OWN audio device.
+
+    Sorted audio locations: [0x01111400 (Icom), 0x14232200 (X6200)].
+    Correct outcome:
+        - X6200 usbmodem (prefix 0x1423) -> C-Media duplex (idx 1/1)
+        - Icom usbserial (prefix 0x0111) -> CODEC split   (rx 3 / tx 2)
+    """
+
+    def test_x6200_resolves_to_cmedia_duplex(self) -> None:
+        sd = _make_mock_sd_cmedia_duplex_plus_icom_split()
+        result = _resolve_macos(
+            "/dev/cu.usbmodem14203",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_XIEGU_AND_ICOM,
+        )
+        assert result is not None
+        assert result.location_prefix == 0x1423
+        # The C-Media duplex device serves both RX and TX.
+        assert result.rx_device_index == 1
+        assert result.tx_device_index == 1
+
+    def test_icom_resolves_to_codec_split_pair(self) -> None:
+        sd = _make_mock_sd_cmedia_duplex_plus_icom_split()
+        result = _resolve_macos(
+            "/dev/cu.usbserial-111120",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_XIEGU_AND_ICOM,
+        )
+        assert result is not None
+        assert result.location_prefix == 0x0111
+        # Icom CODEC: input-only capture (idx 3) + output-only playback (idx 2).
+        assert result.rx_device_index == 3
+        assert result.tx_device_index == 2
+
+    def test_each_port_resolves_to_its_own_device(self) -> None:
+        sd = _make_mock_sd_cmedia_duplex_plus_icom_split()
+        x6200 = _resolve_macos(
+            "/dev/cu.usbmodem14203",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_XIEGU_AND_ICOM,
+        )
+        icom = _resolve_macos(
+            "/dev/cu.usbserial-111120",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_XIEGU_AND_ICOM,
+        )
+        assert x6200 is not None and icom is not None
+        # The two radios must never share an audio device.
+        assert x6200.rx_device_index != icom.rx_device_index
+        assert x6200.tx_device_index != icom.tx_device_index
+
+
 class TestNameFallbackXiegu:
     """MOR-219: name-based fallback (Linux/Windows) prefers the C-Media codec
     over an unknown commodity device when topology is unavailable."""


### PR DESCRIPTION
## Problem

The macOS USB-audio resolver (`src/rigplane/audio/_usb_resolve.py`, `_resolve_macos` step 7) paired a serial CI-V port to its audio device by **positional index**:

- sort the ioreg audio-node `locationID`s → find the serial prefix's index (`pair_idx`)
- pick `usb_inputs[pair_idx]` / `usb_outputs[pair_idx]` from the flat sounddevice enumeration order.

This assumes the sounddevice enumeration order matches the `locationID`-sorted order **and** that every radio contributes exactly one input entry and one output entry. It **desyncs for mixed-vendor / mixed-shape sets** — e.g. a single duplex C-Media "USB Audio Device" (the Xiegu X6200: ONE device with both input + output channels) next to a split-pair Icom "USB Audio CODEC" (separate input-only + output-only entries). The flat input/output lists no longer line up with the sorted prefixes, so each port resolves to the **other** radio's device. Correct only for single-radio and homogeneous-Icom setups.

## Fix — pair by identity, not position

Select the sounddevice entry that corresponds to the matched audio **device's own identity**, not the i-th USB-audio device in enumeration order:

1. `_find_audio_codec_entries(ioreg_text)` now returns `(product_name, locationID)` pairs (the IORegistry node name is exactly the CoreAudio / sounddevice device name).
2. `_cluster_usb_audio_devices(devices)` groups the enumerated USB-audio entries into per-physical-device clusters: a **duplex** entry (in + out) stands alone; an adjacent **same-named** out-only + in-only pair merges into one split-pair cluster. Each cluster carries its product name.
3. `_pair_audio_device_for_location(...)` selects the matched audio device (the entry sharing the serial port's hub prefix) and picks the sounddevice cluster whose **product name + same-name rank** match it.

The pairing logic is factored into reusable, platform-neutral helpers the future Linux/Windows resolvers (MOR-228/229) can call once they can enumerate `(name, locationID)` audio entries + sounddevice clusters. Public entry point `resolve_audio_for_serial_port(...)` signature is unchanged.

### Design assumption

`sounddevice` exposes no `locationID` field (verified on hardware), so a direct `locationID → sounddevice index` link does not exist. CoreAudio also does **not** enumerate USB audio devices in `locationID` order across vendors (a C-Media device can enumerate before an Icom CODEC with a lower `locationID`) — so a global location-rank correlation is unsafe. The CoreAudio **product name** *is* the IORegistry node name, making it the strongest available identity link; within one vendor/name, remaining ambiguity (e.g. two identical Icom CODECs) is resolved by enumeration order, which for same-model devices tracks `locationID` order — preserving validated homogeneous-multi-radio behaviour. No radio is special-cased by name or VID.

## Tests

- New `TestResolveMixedVendorShapes`: a duplex C-Media "USB Audio Device" (in=1/out=2, prefix `0x1423`) + split-pair Icom "USB Audio CODEC" (out-only + in-only, prefix `0x0111`), enumerated in an interleaved order that desyncs the old flat positional logic. Asserts the X6200 usbmodem port → the C-Media duplex device (rx=1/tx=1) and the Icom usbserial port → the CODEC split pair (rx=3/tx=2), and that the two radios never share a device. Confirmed these fail against the old positional code (each port resolved to the other radio).
- All existing cases stay green: single-radio, two/three homogeneous Icom, Yaesu, X6200.

## Gate

- `uv run pytest tests/test_usb_audio_resolve.py -q` — 51 passed
- `uv run pytest tests/ -q -k "audio or usb or resolve"` — 870 passed, 13 skipped
- `uv run ruff check src/ tests/` — clean; `ruff format --check` on both touched files — clean
- `uv run mypy src/rigplane/audio/_usb_resolve.py` — clean
- `uv.lock` churn reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)