### PR TITLE
feat(MOR-229): Windows USB-audio topology / robust-identity resolution

### DIFF
--- a/src/rigplane/audio/_usb_resolve.py
+++ b/src/rigplane/audio/_usb_resolve.py
@@ -38,10 +38,19 @@ Platform support:
 - **Linux**: Topology resolution not yet implemented (``/sys`` sysfs traversal
   is future work); relies on name-based / robust-identity fallback and the
   optional ``[usb] rx_device``/``tx_device`` override escape hatch.
-- **Windows**: Topology resolution not implemented; same fallback path.
+- **Windows**: Topology resolution via USB PnP (MOR-229). The serial ``COMx``
+  function and the USB Audio Class function of one physical radio share a
+  parent USB composite-device instance path, which is the topology anchor
+  (the analogue of the macOS hub prefix). When the parent link is unavailable,
+  a VID:PID robust-identity fallback links serial↔audio. The OS enumeration is
+  isolated behind an injectable ``pnp_query`` callable so the resolver is
+  testable off-Windows. Audio→``sounddevice`` mapping reuses the MOR-230
+  identity primitive (product name + same-name rank).
 
-For Linux/Windows multi-radio disambiguation, capture the exact audio device
-names on hardware and set the ``[usb]`` override in ``audio.toml`` (MOR-219).
+For Linux multi-radio disambiguation, and for Windows hosts with multiple
+identical radios (same VID:PID, ambiguous parent), capture the exact audio
+device names on hardware and set the ``[usb]`` override in ``audio.toml``
+(MOR-219).
 """
 
 from __future__ import annotations
@@ -57,6 +66,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "AudioDeviceMapping",
+    "WindowsPnpDevice",
     "resolve_audio_for_serial_port",
 ]
 
@@ -79,6 +89,40 @@ class AudioDeviceMapping:
     location_prefix: int | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class WindowsPnpDevice:
+    """One USB PnP function enumerated by the Windows PnP/WMI subsystem.
+
+    Each entry models a single child function of a USB composite device — the
+    serial (CDC/COM) function or the USB Audio Class function. The
+    ``parent_pnp_id`` is the shared composite-device instance path that links
+    the two functions of one physical radio (the Windows analogue of the macOS
+    USB hub prefix).
+
+    Attributes:
+        pnp_device_id: The function's own PnP instance path
+            (e.g. ``USB\\VID_0D8C&PID_0012\\6&1a2b&0&1&0000``).
+        parent_pnp_id: The parent composite-device instance path that the
+            serial and audio functions share. May be empty if the PnP query
+            could not resolve the parent (then VID:PID is the only link).
+        vid: USB vendor id, 4-hex-digit string (e.g. ``"0D8C"``), or ``None``.
+        pid: USB product id, 4-hex-digit string (e.g. ``"0012"``), or ``None``.
+        com_port: The ``COMx`` name if this function is the serial port, else
+            ``None``.
+        audio_endpoint_name: The audio device/endpoint product name if this
+            function is the USB Audio Class device, else ``None``. This is the
+            string CoreAudio/WASAPI surfaces as the ``sounddevice`` device
+            name, so it is the identity key for pairing.
+    """
+
+    pnp_device_id: str
+    parent_pnp_id: str
+    vid: str | None
+    pid: str | None
+    com_port: str | None
+    audio_endpoint_name: str | None
+
+
 def resolve_audio_for_serial_port(
     serial_port: str,
     *,
@@ -96,6 +140,8 @@ def resolve_audio_for_serial_port(
     """
     if platform.system() == "Darwin":
         return _resolve_macos(serial_port, sounddevice_module=sounddevice_module)
+    if platform.system() == "Windows":
+        return _resolve_windows(serial_port, sounddevice_module=sounddevice_module)
     # Future: Linux sysfs resolution
     logger.info(
         "usb-audio-resolve: platform %s — topology resolution not supported, "
@@ -203,9 +249,296 @@ def _resolve_macos(
     )
 
 
+def _resolve_windows(
+    serial_port: str,
+    *,
+    sounddevice_module: object | None = None,
+    pnp_query: object | None = None,
+) -> AudioDeviceMapping | None:
+    """Windows-specific resolution via USB PnP topology.
+
+    Args:
+        serial_port: The ``COMx`` name of the radio's CI-V serial port.
+        sounddevice_module: Injected ``sounddevice`` (for testing).
+        pnp_query: Injected zero-arg callable returning a list of
+            :class:`WindowsPnpDevice` (for testing without a Windows host).
+            Defaults to :func:`_query_windows_pnp_devices`, the real
+            PowerShell/WMI enumeration. Isolating the OS call here keeps the
+            resolver body testable on non-Windows hosts.
+
+    Algorithm:
+        1. Enumerate USB PnP functions via ``pnp_query`` (behind ``try/except``;
+           headless-safe — any failure → ``None``, name-based fallback).
+        2. Locate the serial function whose ``com_port`` matches ``serial_port``.
+        3. Find the audio endpoint(s) **sharing the serial function's parent**
+           USB composite device. If the parent link is unavailable (empty
+           ``parent_pnp_id``), fall back to matching by shared **VID:PID**
+           (robust-identity).
+        4. Map the matched audio endpoint name to ``sounddevice`` indices by
+           identity, reusing the MOR-230 cluster + same-name-rank primitive.
+
+    Multi-radio caveat: when several identical radios share one host (same
+    VID:PID, ambiguous parent), the VID:PID fallback cannot disambiguate them;
+    set the ``[usb] rx_device``/``tx_device`` override in ``audio.toml``.
+    """
+    query: Any = pnp_query if pnp_query is not None else _query_windows_pnp_devices
+    try:
+        records = list(query())
+    except Exception as exc:  # noqa: BLE001 — headless-safe: any failure → fallback
+        logger.warning("usb-audio-resolve: Windows PnP query failed: %s", exc)
+        return None
+
+    if not records:
+        logger.warning("usb-audio-resolve: Windows PnP query returned no devices")
+        return None
+
+    target = serial_port.strip().upper()
+    serial_dev = next(
+        (
+            r
+            for r in records
+            if r.com_port is not None and r.com_port.strip().upper() == target
+        ),
+        None,
+    )
+    if serial_dev is None:
+        logger.warning("usb-audio-resolve: no PnP serial function for %r", serial_port)
+        return None
+
+    # 1. Topology link: audio endpoints sharing the serial function's parent.
+    audio_devs: list[WindowsPnpDevice] = []
+    if serial_dev.parent_pnp_id:
+        audio_devs = [
+            r
+            for r in records
+            if r.audio_endpoint_name is not None
+            and r.parent_pnp_id == serial_dev.parent_pnp_id
+        ]
+    # 2. Robust-identity fallback: link by shared VID:PID when topology is
+    #    ambiguous (no parent or no co-parented audio function).
+    if not audio_devs and serial_dev.vid is not None and serial_dev.pid is not None:
+        audio_devs = [
+            r
+            for r in records
+            if r.audio_endpoint_name is not None
+            and r.vid == serial_dev.vid
+            and r.pid == serial_dev.pid
+        ]
+        if audio_devs:
+            logger.info(
+                "usb-audio-resolve: %s linked to audio by VID:PID %s:%s "
+                "(topology ambiguous — multi-radio hosts may need [usb] override)",
+                serial_port,
+                serial_dev.vid,
+                serial_dev.pid,
+            )
+
+    if not audio_devs:
+        logger.warning(
+            "usb-audio-resolve: no audio endpoint shares parent/identity with %s",
+            serial_port,
+        )
+        return None
+
+    audio_dev = audio_devs[0]
+    audio_name = audio_dev.audio_endpoint_name
+    assert audio_name is not None  # narrowed by the filters above
+
+    # Same-name rank: position of the matched endpoint among all same-named
+    # audio endpoints (ordered by PnP instance path), mirroring the macOS
+    # name + same-name-rank identity used by _pair_audio_device_for_location.
+    same_name = sorted(
+        (r for r in records if r.audio_endpoint_name == audio_name),
+        key=lambda r: r.pnp_device_id,
+    )
+    same_name_rank = next(
+        (
+            i
+            for i, r in enumerate(same_name)
+            if r.pnp_device_id == audio_dev.pnp_device_id
+        ),
+        0,
+    )
+
+    # 3. Map to sounddevice indices by identity (reuses the MOR-230 cluster).
+    sd: Any = sounddevice_module
+    if sd is None:
+        try:
+            import sounddevice as sd_mod
+
+            sd = sd_mod
+        except ImportError:
+            logger.warning(
+                "usb-audio-resolve: sounddevice not available, cannot map indices"
+            )
+            return None
+
+    devices = list(sd.query_devices())
+    pair = _pair_audio_cluster_by_name_rank(devices, audio_name, same_name_rank)
+    if pair is None:
+        logger.warning(
+            "usb-audio-resolve: could not map audio endpoint %r (rank %d) to "
+            "sounddevice indices for %s",
+            audio_name,
+            same_name_rank,
+            serial_port,
+        )
+        return None
+
+    rx_idx, tx_idx = pair
+    logger.info(
+        "usb-audio-resolve: %s → audio %r → RX device [%d], TX device [%d]",
+        serial_port,
+        audio_name,
+        rx_idx,
+        tx_idx,
+    )
+    return AudioDeviceMapping(
+        rx_device_index=rx_idx,
+        tx_device_index=tx_idx,
+        serial_port=serial_port,
+        location_prefix=None,
+    )
+
+
+def _query_windows_pnp_devices() -> list[WindowsPnpDevice]:
+    """Enumerate USB PnP functions on a real Windows host (best-effort).
+
+    Runs PowerShell ``Get-PnpDevice`` and joins each device with its parent
+    instance path and VID:PID parsed from the PnP instance id, plus the COM
+    port name (for serial functions) or the friendly audio endpoint name (for
+    USB Audio Class functions). Returns ``[]`` on any failure — the caller
+    treats an empty/raised result as "topology unavailable" and falls back to
+    name-based selection. This keeps the base install free of a hard PnP/WMI
+    dependency; the heavy lifting is shelled out to PowerShell, which ships
+    with Windows.
+
+    NOTE: This function is only ever executed on Windows. It is intentionally
+    NOT exercised by the unit tests (which inject a fake ``pnp_query``); its
+    exact field shape MUST be validated against a real Windows host + X6200
+    before relying on the topology path in production (see PR checklist).
+    """
+    if platform.system() != "Windows":
+        return []
+    # PowerShell one-liner: emit one CSV-ish line per USB PnP device with the
+    # fields we need. We parse the parent and VID:PID from the InstanceId.
+    script = (
+        "Get-PnpDevice -PresentOnly | "
+        "ForEach-Object { "
+        "$id = $_.InstanceId; "
+        "$parent = (Get-PnpDeviceProperty -InstanceId $id "
+        "-KeyName 'DEVPKEY_Device_Parent' -ErrorAction SilentlyContinue).Data; "
+        "$friendly = $_.FriendlyName; "
+        "'{0}`t{1}`t{2}`t{3}' -f $id, $parent, $_.Class, $friendly }"
+    )
+    try:
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+            capture_output=True,
+            timeout=20,
+        )
+        if result.returncode != 0:
+            logger.debug(
+                "usb-audio-resolve: Get-PnpDevice exited %d", result.returncode
+            )
+            return []
+        text = result.stdout.decode("utf-8", errors="replace")
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("usb-audio-resolve: PowerShell PnP query failed: %s", exc)
+        return []
+
+    devices: list[WindowsPnpDevice] = []
+    for line in text.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 4:
+            continue
+        instance_id, parent, dev_class, friendly = (
+            parts[0].strip(),
+            parts[1].strip(),
+            parts[2].strip(),
+            parts[3].strip(),
+        )
+        vid, pid = _parse_vid_pid(instance_id)
+        com_port = _parse_com_port(friendly)
+        # Audio Class functions report Class in {AudioEndpoint, MEDIA}; the
+        # friendly name is the endpoint product name.
+        is_audio = dev_class.upper() in {
+            "AUDIOENDPOINT",
+            "MEDIA",
+        } or _is_usb_audio_codec(friendly)
+        audio_name = friendly if (is_audio and com_port is None) else None
+        if com_port is None and audio_name is None:
+            continue
+        devices.append(
+            WindowsPnpDevice(
+                pnp_device_id=instance_id,
+                parent_pnp_id=parent,
+                vid=vid,
+                pid=pid,
+                com_port=com_port,
+                audio_endpoint_name=audio_name,
+            )
+        )
+    return devices
+
+
+def _parse_vid_pid(instance_id: str) -> tuple[str | None, str | None]:
+    """Extract ``(VID, PID)`` 4-hex-digit strings from a PnP instance id."""
+    vid_m = re.search(r"VID_([0-9A-Fa-f]{4})", instance_id)
+    pid_m = re.search(r"PID_([0-9A-Fa-f]{4})", instance_id)
+    vid = vid_m.group(1).upper() if vid_m else None
+    pid = pid_m.group(1).upper() if pid_m else None
+    return vid, pid
+
+
+def _parse_com_port(friendly_name: str) -> str | None:
+    """Extract a ``COMx`` port name from a PnP friendly name (e.g. ``... (COM3)``)."""
+    m = re.search(r"\b(COM\d+)\b", friendly_name)
+    return m.group(1) if m else None
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _pair_audio_cluster_by_name_rank(
+    devices: list[Any],
+    audio_name: str,
+    same_name_rank: int,
+) -> tuple[int, int] | None:
+    """Select ``(rx_index, tx_index)`` for the rank-th same-named audio cluster.
+
+    This is the platform-neutral tail of :func:`_pair_audio_device_for_location`,
+    factored out so the Windows resolver (which derives the identity key —
+    product name + same-name rank — from PnP records rather than IORegistry
+    locationIDs) can reuse the exact cluster-and-rank selection. The macOS path
+    continues to derive the name+rank from ``locationID``-sorted entries.
+
+    Returns ``None`` when no same-named cluster occupies ``same_name_rank`` or
+    the matched cluster is missing an RX or TX index.
+    """
+    clusters = _cluster_usb_audio_devices(devices)
+    same_name_clusters = [c for c in clusters if c[0] == audio_name]
+    if same_name_rank >= len(same_name_clusters):
+        logger.warning(
+            "usb-audio-resolve: %r rank %d out of range (%d matching clusters)",
+            audio_name,
+            same_name_rank,
+            len(same_name_clusters),
+        )
+        return None
+    _name, rx, tx = same_name_clusters[same_name_rank]
+    if rx is None or tx is None:
+        logger.warning(
+            "usb-audio-resolve: incomplete audio cluster for %r rank %d (rx=%r, tx=%r)",
+            audio_name,
+            same_name_rank,
+            rx,
+            tx,
+        )
+        return None
+    return rx, tx
 
 
 def _cluster_usb_audio_devices(
@@ -331,29 +664,7 @@ def _pair_audio_device_for_location(
     same_name_rank = sum(
         1 for _n, _loc in sorted_entries[:matched_idx] if _n == matched_name
     )
-
-    clusters = _cluster_usb_audio_devices(devices)
-    same_name_clusters = [c for c in clusters if c[0] == matched_name]
-    if same_name_rank >= len(same_name_clusters):
-        logger.warning(
-            "usb-audio-resolve: %r rank %d out of range (%d matching clusters)",
-            matched_name,
-            same_name_rank,
-            len(same_name_clusters),
-        )
-        return None
-
-    _name, rx, tx = same_name_clusters[same_name_rank]
-    if rx is None or tx is None:
-        logger.warning(
-            "usb-audio-resolve: incomplete audio cluster for %r rank %d (rx=%r, tx=%r)",
-            matched_name,
-            same_name_rank,
-            rx,
-            tx,
-        )
-        return None
-    return rx, tx
+    return _pair_audio_cluster_by_name_rank(devices, matched_name, same_name_rank)
 
 
 def _extract_tty_suffix(serial_port: str) -> str | None:

--- a/tests/test_usb_audio_resolve.py
+++ b/tests/test_usb_audio_resolve.py
@@ -833,3 +833,248 @@ class TestNameFallbackXiegu:
         rx, tx = select_usb_audio_devices(devices)
         assert rx.index == 1
         assert tx.index == 1
+
+
+# ---------------------------------------------------------------------------
+# MOR-229 — Windows USB topology / robust-identity resolution
+# ---------------------------------------------------------------------------
+
+# Windows enumerates USB devices through PnP. Each USB radio is a composite
+# parent device (instance path like USB\VID_xxxx&PID_yyyy\serial) whose
+# children are the CDC/serial function (exposing a COMx name) and the USB
+# Audio Class function (exposing an audio endpoint name). The shared *parent*
+# instance path is the topology anchor, mirroring the macOS hub-prefix anchor.
+#
+# Modelled set:
+#   - Xiegu X6200: C-Media composite parent, COM3 serial + "USB Audio Device"
+#     audio endpoint, VID:PID 0D8C:0012.
+#   - A second USB radio (Icom-like) on a DIFFERENT parent: COM7 serial +
+#     "USB Audio CODEC" audio endpoint, VID:PID 10C4:EA60 (CP210x bridge).
+
+
+def _x6200_pnp_records() -> list[Any]:
+    """X6200 alone: C-Media composite parent with serial (COM3) + audio."""
+    from rigplane.usb_audio_resolve import WindowsPnpDevice
+
+    parent = r"USB\VID_0D8C&PID_0012\6&1A2B3C4D&0&1"
+    return [
+        WindowsPnpDevice(
+            pnp_device_id=parent + r"&0000",
+            parent_pnp_id=parent,
+            vid="0D8C",
+            pid="0012",
+            com_port="COM3",
+            audio_endpoint_name=None,
+        ),
+        WindowsPnpDevice(
+            pnp_device_id=parent + r"&0001",
+            parent_pnp_id=parent,
+            vid="0D8C",
+            pid="0012",
+            com_port=None,
+            audio_endpoint_name="USB Audio Device",
+        ),
+    ]
+
+
+def _x6200_and_icom_pnp_records() -> list[Any]:
+    """X6200 (COM3, C-Media) + a second radio (COM7, Icom CODEC) on a
+    different USB parent. Each radio's serial and audio share one parent."""
+    from rigplane.usb_audio_resolve import WindowsPnpDevice
+
+    x6200_parent = r"USB\VID_0D8C&PID_0012\6&1A2B3C4D&0&1"
+    icom_parent = r"USB\VID_10C4&PID_EA60\IC7610_0001"
+    return [
+        WindowsPnpDevice(
+            pnp_device_id=x6200_parent + r"&0000",
+            parent_pnp_id=x6200_parent,
+            vid="0D8C",
+            pid="0012",
+            com_port="COM3",
+            audio_endpoint_name=None,
+        ),
+        WindowsPnpDevice(
+            pnp_device_id=x6200_parent + r"&0001",
+            parent_pnp_id=x6200_parent,
+            vid="0D8C",
+            pid="0012",
+            com_port=None,
+            audio_endpoint_name="USB Audio Device",
+        ),
+        WindowsPnpDevice(
+            pnp_device_id=icom_parent + r"&0000",
+            parent_pnp_id=icom_parent,
+            vid="10C4",
+            pid="EA60",
+            com_port="COM7",
+            audio_endpoint_name=None,
+        ),
+        WindowsPnpDevice(
+            pnp_device_id=icom_parent + r"&0001",
+            parent_pnp_id=icom_parent,
+            vid="10C4",
+            pid="EA60",
+            com_port=None,
+            audio_endpoint_name="USB Audio CODEC",
+        ),
+    ]
+
+
+class TestResolveWindows:
+    """MOR-229: Windows topology resolution via an injected pnp_query."""
+
+    def test_single_x6200_resolves_to_cmedia(self) -> None:
+        from rigplane.usb_audio_resolve import _resolve_windows
+
+        sd = _make_mock_sd_xiegu()
+        result = _resolve_windows(
+            "COM3",
+            sounddevice_module=sd,
+            pnp_query=lambda: _x6200_pnp_records(),
+        )
+        assert result is not None
+        assert result.serial_port == "COM3"
+        # The C-Media duplex device serves both RX and TX.
+        assert result.rx_device_index == 1
+        assert result.tx_device_index == 1
+
+    def test_two_radios_each_resolves_to_own_audio(self) -> None:
+        from rigplane.usb_audio_resolve import _resolve_windows
+
+        sd = _make_mock_sd_cmedia_duplex_plus_icom_split()
+        records = _x6200_and_icom_pnp_records()
+        x6200 = _resolve_windows(
+            "COM3",
+            sounddevice_module=sd,
+            pnp_query=lambda: records,
+        )
+        icom = _resolve_windows(
+            "COM7",
+            sounddevice_module=sd,
+            pnp_query=lambda: records,
+        )
+        assert x6200 is not None and icom is not None
+        # X6200 → C-Media duplex (idx 1/1).
+        assert x6200.rx_device_index == 1
+        assert x6200.tx_device_index == 1
+        # Icom → CODEC split pair (rx capture idx 3 / tx playback idx 2).
+        assert icom.rx_device_index == 3
+        assert icom.tx_device_index == 2
+        # The two radios must never share an audio device.
+        assert x6200.rx_device_index != icom.rx_device_index
+        assert x6200.tx_device_index != icom.tx_device_index
+
+    def test_unknown_com_port_returns_none(self) -> None:
+        from rigplane.usb_audio_resolve import _resolve_windows
+
+        sd = _make_mock_sd_xiegu()
+        result = _resolve_windows(
+            "COM99",
+            sounddevice_module=sd,
+            pnp_query=lambda: _x6200_pnp_records(),
+        )
+        assert result is None
+
+    def test_no_sibling_audio_endpoint_returns_none(self) -> None:
+        from rigplane.usb_audio_resolve import WindowsPnpDevice, _resolve_windows
+
+        # A serial-only device with no audio function on its parent.
+        parent = r"USB\VID_10C4&PID_EA60\NOAUDIO"
+        records = [
+            WindowsPnpDevice(
+                pnp_device_id=parent + r"&0000",
+                parent_pnp_id=parent,
+                vid="10C4",
+                pid="EA60",
+                com_port="COM5",
+                audio_endpoint_name=None,
+            ),
+        ]
+        sd = _make_mock_sd_xiegu()
+        result = _resolve_windows(
+            "COM5",
+            sounddevice_module=sd,
+            pnp_query=lambda: records,
+        )
+        assert result is None
+
+    def test_pnp_query_unavailable_returns_none(self) -> None:
+        from rigplane.usb_audio_resolve import _resolve_windows
+
+        def boom() -> list[Any]:
+            raise OSError("WMI not available (headless)")
+
+        sd = _make_mock_sd_xiegu()
+        result = _resolve_windows(
+            "COM3",
+            sounddevice_module=sd,
+            pnp_query=boom,
+        )
+        assert result is None
+
+    def test_pnp_query_returns_empty_returns_none(self) -> None:
+        from rigplane.usb_audio_resolve import _resolve_windows
+
+        sd = _make_mock_sd_xiegu()
+        result = _resolve_windows(
+            "COM3",
+            sounddevice_module=sd,
+            pnp_query=lambda: [],
+        )
+        assert result is None
+
+    def test_vidpid_fallback_when_parent_ambiguous(self) -> None:
+        """Robust-identity fallback: when the serial device exposes no usable
+        parent link, fall back to matching the audio endpoint by VID:PID."""
+        from rigplane.usb_audio_resolve import WindowsPnpDevice, _resolve_windows
+
+        # Serial and audio carry the same VID:PID but report no parent
+        # (parent_pnp_id empty) — topology is ambiguous, VID:PID must link.
+        records = [
+            WindowsPnpDevice(
+                pnp_device_id=r"USB\VID_0D8C&PID_0012\SER\&0000",
+                parent_pnp_id="",
+                vid="0D8C",
+                pid="0012",
+                com_port="COM3",
+                audio_endpoint_name=None,
+            ),
+            WindowsPnpDevice(
+                pnp_device_id=r"USB\VID_0D8C&PID_0012\SER\&0001",
+                parent_pnp_id="",
+                vid="0D8C",
+                pid="0012",
+                com_port=None,
+                audio_endpoint_name="USB Audio Device",
+            ),
+        ]
+        sd = _make_mock_sd_xiegu()
+        result = _resolve_windows(
+            "COM3",
+            sounddevice_module=sd,
+            pnp_query=lambda: records,
+        )
+        assert result is not None
+        assert result.rx_device_index == 1
+        assert result.tx_device_index == 1
+
+
+class TestResolvePlatformDispatchWindows:
+    """MOR-229: resolve_audio_for_serial_port dispatches to _resolve_windows."""
+
+    @patch("rigplane.usb_audio_resolve.platform")
+    @patch("rigplane.usb_audio_resolve._resolve_windows")
+    def test_windows_delegates(
+        self, mock_resolve: MagicMock, mock_platform: MagicMock
+    ) -> None:
+        mock_platform.system.return_value = "Windows"
+        mock_resolve.return_value = AudioDeviceMapping(
+            rx_device_index=1,
+            tx_device_index=1,
+            serial_port="COM3",
+            location_prefix=None,
+        )
+        result = resolve_audio_for_serial_port("COM3")
+        assert result is not None
+        assert result.rx_device_index == 1
+        mock_resolve.assert_called_once()


### PR DESCRIPTION
## What

Adds **Windows** USB-audio topology resolution to `src/rigplane/audio/_usb_resolve.py` (MOR-229). Previously Windows had no topology resolution — only the name-based fallback in `usb_driver`, which collides on the commodity "USB Audio Device" name. Now each radio's serial `COMx` resolves to its own audio device.

## Approach

- **`WindowsPnpDevice`** — typed record for one USB PnP function (serial `COMx` or USB Audio Class endpoint): own instance path, shared parent composite-device path, VID:PID, COM port, audio endpoint name.
- **`_resolve_windows(serial_port, *, sounddevice_module=None, pnp_query=None)`** dispatched from `resolve_audio_for_serial_port` via a single surgical `elif Windows:` branch:
  1. Enumerate PnP functions via `pnp_query` (headless-safe — any raise/empty → `None`, name-based fallback).
  2. Find the serial function matching `COMx`.
  3. **Topology link**: audio endpoints sharing the serial function's **parent** USB composite device (the Windows analogue of the macOS hub prefix).
  4. **Robust-identity fallback**: when the parent link is unavailable, link serial↔audio by shared **VID:PID**. Multi-identical-radio hosts may still need the `[usb] rx_device` override (documented).
  5. Map audio endpoint → `sounddevice` indices by **identity**, reusing the MOR-230 primitive.
- **OS call isolated** behind injectable `pnp_query` (default `_query_windows_pnp_devices`, a `try/except`-guarded PowerShell `Get-PnpDevice` shell-out). **No hard PnP/WMI dependency** added to the base install.

### Reused vs new helpers
- **Reused (MOR-230):** `_cluster_usb_audio_devices` (platform-neutral clustering), and the name + same-name-rank identity logic.
- **New:** `WindowsPnpDevice`, `_resolve_windows`, `_query_windows_pnp_devices`, `_parse_vid_pid`, `_parse_com_port`, and `_pair_audio_cluster_by_name_rank` — the latter factored out of `_pair_audio_device_for_location` (which now calls it) so both macOS and Windows share the exact cluster+rank selection. Clean generalization, no behavior change to macOS.

## Tests (`tests/test_usb_audio_resolve.py`, new classes `TestResolveWindows` / `TestResolvePlatformDispatchWindows`)

Fixture-based, injecting a fake `pnp_query`:
- X6200 alone (C-Media COM3, "USB Audio Device", shared parent) → C-Media duplex device.
- X6200 (COM3) + a second radio (COM7, Icom "USB Audio CODEC") on a **different** parent → each COM resolves to its **own** audio device; never shared.
- Unknown COM port → `None`; serial-only device with no sibling audio → `None`.
- `pnp_query` raising (headless WMI) → `None`; empty result → `None`.
- VID:PID fallback when parent link is ambiguous (empty `parent_pnp_id`).
- Dispatch test: `platform.system() == "Windows"` delegates to `_resolve_windows`.

macOS path and None-on-unsupported behavior unchanged. Existing tests kept green; dispatch edit and new tests are isolated to minimize conflict with the parallel MOR-228 (Linux) work.

## Gate (all pass)
- `uv run pytest tests/test_usb_audio_resolve.py -q` — **60 passed**
- `uv run pytest tests/ -q -k "audio or usb or resolve"` — **879 passed, 13 skipped**
- Full non-integration suite — **6305 passed**
- `uv run ruff check src/ tests/` — clean; `ruff format --check` on changed files — clean
- `uv run mypy src/rigplane/audio/_usb_resolve.py` — clean
- `uv run lint-imports` — 4 contracts kept
- `uv.lock` churn reverted

## Hardware-validation checklist (real Windows + X6200 required)

Validated only via injected-`pnp_query` fixtures + unit tests. Before relying on the topology path in production, on a real Windows host with the X6200:

- [ ] Capture exact WASAPI **and** MME `sounddevice` device names for the C-Media codec — the resolver matches `audio_endpoint_name` against the `sounddevice` device name; WASAPI vs MME naming differences may break the identity match.
- [ ] Confirm the C-Media audio VID:PID is `0x0D8C:0x0012` as assumed in the VID:PID fallback fixtures.
- [ ] Confirm the audio function and the serial (CAT) function **share a USB parent** composite-device instance path under `Get-PnpDevice` / `DEVPKEY_Device_Parent` (the core topology assumption).
- [ ] Verify `_query_windows_pnp_devices` field shape: the real `Get-PnpDevice` `Class` for the audio endpoint (`AudioEndpoint` vs `MEDIA`), the `FriendlyName` format for the COM port (`... (COM3)`), and that `DEVPKEY_Device_Parent` returns the composite parent rather than the hub.
- [ ] Multi-radio-on-one-host: confirm two identical X6200s need the `[usb] rx_device`/`tx_device` override (VID:PID fallback cannot disambiguate identical devices).

## Uncertainty about the real PnP layer

`_query_windows_pnp_devices` is **not exercised by tests** (only the injected fake is) and is **unverified against real Windows**. Specific uncertainties: the exact `Get-PnpDevice` output columns/encoding, whether `DEVPKEY_Device_Parent` yields the composite parent vs the upstream hub, the audio endpoint `Class` value, and whether the COM port surfaces in `FriendlyName` vs a separate property. The `try/except`-everything guard means a wrong shape degrades gracefully to the existing name-based fallback rather than crashing, but the topology path itself needs hardware confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)