### PR TITLE
feat(MOR-228): Linux sysfs USB-audio topology resolution

### DIFF
--- a/src/rigplane/audio/_usb_resolve.py
+++ b/src/rigplane/audio/_usb_resolve.py
@@ -35,13 +35,34 @@ setups resolve even without topology.
 Platform support:
 - **macOS**: Full topology-based resolution via ``/usr/sbin/ioreg`` for both
   FTDI/CP210x and CDC-ACM (``usbmodem``) serial ports.
-- **Linux**: Topology resolution not yet implemented (``/sys`` sysfs traversal
-  is future work); relies on name-based / robust-identity fallback and the
-  optional ``[usb] rx_device``/``tx_device`` override escape hatch.
+- **Linux**: Full topology-based resolution via ``/sys`` sysfs traversal for
+  both CDC-ACM (``ttyACM*``, e.g. the X6200's WCH CH342) and FTDI/CP210x
+  (``ttyUSB*``) serial ports. The serial port and each ALSA card are resolved
+  to their USB device node; the audio card sharing the **longest common
+  USB-device path prefix** (same physical device or hub) with the serial port
+  is the link, with ``idVendor``/``idProduct`` as a robust-identity tie-break
+  (MOR-228).
 - **Windows**: Topology resolution not implemented; same fallback path.
 
-For Linux/Windows multi-radio disambiguation, capture the exact audio device
+For Windows multi-radio disambiguation, capture the exact audio device
 names on hardware and set the ``[usb]`` override in ``audio.toml`` (MOR-219).
+
+**Algorithm (Linux — sysfs)**:
+
+1. Serial port → USB device path: read ``<sysfs_root>/class/tty/<ttyXXX>/device``
+   and ``realpath`` it into the USB tree (``.../usbN/N-x[.y]/...``). The USB
+   *device* node is the deepest ancestor whose basename has no ``:`` (an
+   interface node is ``N-x:c.i``; its parent device node is ``N-x``).
+2. Each ALSA card → USB device path: enumerate
+   ``<sysfs_root>/class/sound/card*/device`` and ``realpath`` likewise.
+3. Link = the audio card whose USB device path shares the **longest common
+   USB-device path prefix** with the serial port (same physical device/hub).
+4. Map to ``sounddevice`` indices by **identity**: the ALSA card name (the USB
+   ``product`` string) is the CoreAudio/PortAudio device-name key, matched
+   against the :func:`_cluster_usb_audio_devices` clusters with same-name rank
+   (shared with the macOS path, MOR-230).
+5. Robust-identity fallback: ``idVendor``/``idProduct`` read from the USB node
+   disambiguate when the topology prefix match is ambiguous.
 """
 
 from __future__ import annotations
@@ -96,7 +117,8 @@ def resolve_audio_for_serial_port(
     """
     if platform.system() == "Darwin":
         return _resolve_macos(serial_port, sounddevice_module=sounddevice_module)
-    # Future: Linux sysfs resolution
+    elif platform.system() == "Linux":
+        return _resolve_linux(serial_port, sounddevice_module=sounddevice_module)
     logger.info(
         "usb-audio-resolve: platform %s — topology resolution not supported, "
         "falling back to name-based selection",
@@ -201,6 +223,339 @@ def _resolve_macos(
         serial_port=serial_port,
         location_prefix=serial_prefix,
     )
+
+
+# ---------------------------------------------------------------------------
+# Linux — sysfs topology resolution (MOR-228)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_linux(
+    serial_port: str,
+    *,
+    sounddevice_module: object | None = None,
+    sysfs_root: str = "/sys",
+) -> AudioDeviceMapping | None:
+    """Linux-specific resolution via the ``/sys`` (sysfs) USB topology.
+
+    Args:
+        serial_port: Serial port path (``/dev/ttyACM0``, ``/dev/ttyUSB0``).
+        sounddevice_module: Injected ``sounddevice`` module (for testing).
+        sysfs_root: Root of the sysfs tree. Injectable so tests can point at a
+            fixture directory; defaults to the real ``/sys``.
+
+    Algorithm: resolve the serial port and every ALSA card to their USB device
+    node under sysfs, pick the audio card sharing the longest common
+    USB-device path prefix with the serial port, then map that card's name to
+    ``sounddevice`` indices by identity (name + same-name rank).
+    """
+    # 1. Serial port → USB device node.
+    tty_name = _extract_linux_tty_name(serial_port)
+    if tty_name is None:
+        logger.warning(
+            "usb-audio-resolve: cannot extract Linux tty name from %r", serial_port
+        )
+        return None
+
+    serial_dev = _sysfs_usb_device_for_tty(sysfs_root, tty_name)
+    if serial_dev is None:
+        logger.warning(
+            "usb-audio-resolve: no USB device node for tty %r under %s",
+            tty_name,
+            sysfs_root,
+        )
+        return None
+
+    # 2. Each ALSA card → USB device node.
+    cards = _sysfs_usb_audio_cards(sysfs_root)
+    if not cards:
+        logger.warning(
+            "usb-audio-resolve: no USB-backed ALSA cards found under %s", sysfs_root
+        )
+        return None
+
+    # 3. Link = audio card with the longest common USB-device path prefix.
+    best: tuple[str, str] | None = None  # (card_dev, card_name)
+    best_score = -1
+    serial_ids = _read_usb_ids(serial_dev)
+    for card_dev, card_name in cards:
+        score = _common_usb_path_score(serial_dev, card_dev)
+        # Robust-identity tie-break: a card on the SAME physical device as the
+        # serial port (shared idVendor:idProduct) wins ties. This disambiguates
+        # composite radios where audio + CAT live on one USB device.
+        if serial_ids is not None and _read_usb_ids(card_dev) == serial_ids:
+            score += 1
+        if score > best_score:
+            best_score = score
+            best = (card_dev, card_name)
+
+    if best is None or best_score <= 0:
+        logger.warning(
+            "usb-audio-resolve: no ALSA card shares a USB path with %s (serial %s)",
+            serial_port,
+            serial_dev,
+        )
+        return None
+
+    matched_card_dev, matched_card_name = best
+
+    # 4. Map the matched card to sounddevice indices by identity.
+    sd: Any = sounddevice_module
+    if sd is None:
+        try:
+            import sounddevice as sd_mod
+
+            sd = sd_mod
+        except ImportError:
+            logger.warning(
+                "usb-audio-resolve: sounddevice not available, cannot map indices"
+            )
+            return None
+
+    devices = list(sd.query_devices())
+
+    # Rank the matched card among USB-backed cards carrying the same name, in
+    # sysfs card order — mirrors the macOS same-name rank semantics so
+    # _cluster_usb_audio_devices can be shared unchanged (MOR-230).
+    same_name_rank = sum(
+        1
+        for c_dev, c_name in cards
+        if c_name == matched_card_name and c_dev < matched_card_dev
+    )
+    pair = _pair_audio_cluster_by_name(devices, matched_card_name, same_name_rank)
+    if pair is None:
+        logger.warning(
+            "usb-audio-resolve: could not pair sounddevice cluster for ALSA card "
+            "%r rank %d (cards=%s)",
+            matched_card_name,
+            same_name_rank,
+            [(n, d) for d, n in cards],
+        )
+        return None
+
+    rx_idx, tx_idx = pair
+
+    vid_pid = _read_usb_ids(matched_card_dev)
+    location_prefix = _usb_path_location_prefix(matched_card_dev)
+    logger.info(
+        "usb-audio-resolve: %s → ALSA card %r (%s) → RX device [%d], TX device [%d]",
+        serial_port,
+        matched_card_name,
+        f"{vid_pid[0]}:{vid_pid[1]}" if vid_pid else "vid:pid unknown",
+        rx_idx,
+        tx_idx,
+    )
+
+    return AudioDeviceMapping(
+        rx_device_index=rx_idx,
+        tx_device_index=tx_idx,
+        serial_port=serial_port,
+        location_prefix=location_prefix,
+    )
+
+
+def _extract_linux_tty_name(serial_port: str) -> str | None:
+    """Extract the Linux tty kernel name from a serial port path.
+
+    Recognises both CDC-ACM (``ttyACM*``) and USB-serial (``ttyUSB*``) device
+    nodes. These are the two enumeration schemes Linux uses for USB CI-V
+    bridges: ``ttyACM*`` for CDC-ACM composite bridges (the X6200's WCH CH342),
+    ``ttyUSB*`` for FTDI/CP210x. This is the Linux counterpart of the macOS
+    :func:`_extract_tty_suffix`; it is deliberately separate because the sysfs
+    lookup keys on the full kernel name (``ttyACM0``), not a chip-serial suffix.
+
+    >>> _extract_linux_tty_name("/dev/ttyACM0")
+    'ttyACM0'
+    >>> _extract_linux_tty_name("/dev/ttyUSB1")
+    'ttyUSB1'
+    >>> _extract_linux_tty_name("/dev/cu.usbserial-201410") is None
+    True
+    """
+    m = re.search(r"(tty(?:ACM|USB)\d+)", serial_port)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _usb_device_node_from_realpath(real: str) -> str | None:
+    """Walk up a realpath'd sysfs path to the nearest USB *device* node.
+
+    A USB device node basename looks like ``1-1`` or ``1-1.4`` (bus-port[.port]
+    with no colon). A USB *interface* node basename looks like ``1-1:1.0``
+    (device``:``config.interface). ``<...>/device`` symlinks for tty and sound
+    classes point at an interface node, so we ascend until the basename has no
+    ``:`` and matches the device-node shape, returning that absolute path.
+
+    Returns ``None`` if no USB device node is found in the ancestry.
+    """
+    parts = real.split("/")
+    # Walk from the deepest component upward.
+    for i in range(len(parts), 0, -1):
+        base = parts[i - 1]
+        if ":" in base:
+            continue
+        if re.fullmatch(r"\d+-\d+(?:\.\d+)*", base):
+            return "/".join(parts[:i])
+    return None
+
+
+def _sysfs_usb_device_for_tty(sysfs_root: str, tty_name: str) -> str | None:
+    """Resolve ``<sysfs_root>/class/tty/<tty_name>/device`` to its USB node."""
+    import os
+
+    link = os.path.join(sysfs_root, "class", "tty", tty_name, "device")
+    try:
+        real = os.path.realpath(link)
+    except OSError:
+        return None
+    if not os.path.exists(real):
+        return None
+    return _usb_device_node_from_realpath(real)
+
+
+def _sysfs_usb_audio_cards(sysfs_root: str) -> list[tuple[str, str]]:
+    """Enumerate USB-backed ALSA cards as ``(usb_device_path, card_name)``.
+
+    For each ``<sysfs_root>/class/sound/card*`` whose ``device`` symlink lands
+    in the USB tree, return the USB device node path and the card's product
+    name (the USB ``product`` string, which is the PortAudio/ALSA device-name
+    identity key). Sorted by USB device path for deterministic same-name rank.
+    """
+    import glob
+    import os
+
+    cards: list[tuple[str, str]] = []
+    pattern = os.path.join(sysfs_root, "class", "sound", "card*")
+    for card_dir in sorted(glob.glob(pattern)):
+        if not re.fullmatch(r"card\d+", os.path.basename(card_dir)):
+            continue
+        link = os.path.join(card_dir, "device")
+        try:
+            real = os.path.realpath(link)
+        except OSError:
+            continue
+        if not os.path.exists(real):
+            continue
+        usb_dev = _usb_device_node_from_realpath(real)
+        if usb_dev is None:
+            continue
+        name = _read_sysfs_str(os.path.join(usb_dev, "product"))
+        if name is None:
+            name = os.path.basename(card_dir)
+        cards.append((usb_dev, name))
+    return sorted(cards, key=lambda c: c[0])
+
+
+def _common_usb_path_score(serial_dev: str, card_dev: str) -> int:
+    """Score the shared USB-device path prefix length of two device nodes.
+
+    Splits each device's bus-port path (e.g. ``1-1.4`` → ``["1", "1", "4"]``)
+    and counts matching leading components. A higher score means the two
+    devices sit deeper on the same physical hub branch; an equal full path
+    means they are the *same* USB device (composite radio).
+    """
+    a = _usb_path_components(serial_dev)
+    b = _usb_path_components(card_dev)
+    score = 0
+    for x, y in zip(a, b):
+        if x != y:
+            break
+        score += 1
+    return score
+
+
+def _usb_path_components(usb_dev: str) -> list[str]:
+    """Split a USB device node basename into bus/port components.
+
+    ``.../usb1/1-1.4`` → ``["1", "1", "4"]`` (bus, then each port hop).
+    """
+    import os
+
+    base = os.path.basename(usb_dev)
+    m = re.fullmatch(r"(\d+)-(\d+(?:\.\d+)*)", base)
+    if not m:
+        return []
+    bus = m.group(1)
+    ports = m.group(2).split(".")
+    return [bus, *ports]
+
+
+def _usb_path_location_prefix(usb_dev: str) -> int | None:
+    """Derive an integer ``location_prefix`` from a USB device path.
+
+    There is no macOS-style ``locationID`` on Linux; we synthesise a stable
+    small integer from the bus and root-port hops (``bus<<8 | first_port``) so
+    AudioDeviceMapping carries a sensible, comparable hub identity. Returns
+    ``None`` if the path cannot be parsed.
+    """
+    comps = _usb_path_components(usb_dev)
+    if len(comps) < 2:
+        return None
+    try:
+        bus = int(comps[0])
+        root_port = int(comps[1])
+    except ValueError:
+        return None
+    return (bus << 8) | root_port
+
+
+def _read_usb_ids(usb_dev: str) -> tuple[str, str] | None:
+    """Read ``(idVendor, idProduct)`` from a USB device node, lowercased."""
+    import os
+
+    vid = _read_sysfs_str(os.path.join(usb_dev, "idVendor"))
+    pid = _read_sysfs_str(os.path.join(usb_dev, "idProduct"))
+    if vid is None or pid is None:
+        return None
+    return vid.lower(), pid.lower()
+
+
+def _read_sysfs_str(path: str) -> str | None:
+    """Read and strip a sysfs attribute file, or ``None`` on failure/empty."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            value = fh.read().strip()
+    except OSError:
+        return None
+    return value or None
+
+
+def _pair_audio_cluster_by_name(
+    devices: list[Any],
+    card_name: str,
+    same_name_rank: int,
+) -> tuple[int, int] | None:
+    """Select ``(rx_index, tx_index)`` for a card by name + same-name rank.
+
+    Platform-neutral counterpart of :func:`_pair_audio_device_for_location`:
+    where the macOS path derives the identity (name, rank) from IORegistry
+    locationIDs, the Linux path derives it from sysfs (ALSA card name + sysfs
+    card order). Both then select the rank-th
+    :func:`_cluster_usb_audio_devices` cluster carrying ``card_name``. Kept
+    separate from the macOS selector to avoid overloading its locationID-based
+    signature (MOR-228).
+    """
+    clusters = _cluster_usb_audio_devices(devices)
+    same_name_clusters = [c for c in clusters if c[0] == card_name]
+    if same_name_rank >= len(same_name_clusters):
+        logger.warning(
+            "usb-audio-resolve: %r rank %d out of range (%d matching clusters)",
+            card_name,
+            same_name_rank,
+            len(same_name_clusters),
+        )
+        return None
+    _name, rx, tx = same_name_clusters[same_name_rank]
+    if rx is None or tx is None:
+        logger.warning(
+            "usb-audio-resolve: incomplete audio cluster for %r rank %d (rx=%r, tx=%r)",
+            card_name,
+            same_name_rank,
+            rx,
+            tx,
+        )
+        return None
+    return rx, tx
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_usb_audio_resolve.py
+++ b/tests/test_usb_audio_resolve.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import textwrap
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -10,11 +12,14 @@ import pytest
 
 from rigplane.usb_audio_resolve import (
     AudioDeviceMapping,
+    _extract_linux_tty_name,
     _extract_tty_suffix,
     _find_audio_codec_locations,
     _find_serial_location,
     _is_usb_audio_codec,
+    _resolve_linux,
     _resolve_macos,
+    _usb_device_node_from_realpath,
     resolve_audio_for_serial_port,
 )
 
@@ -447,8 +452,9 @@ class TestResolvePlatformDispatch:
     """Test that resolve_audio_for_serial_port dispatches correctly."""
 
     @patch("rigplane.usb_audio_resolve.platform")
-    def test_non_darwin_returns_none(self, mock_platform: MagicMock) -> None:
-        mock_platform.system.return_value = "Linux"
+    def test_unsupported_platform_returns_none(self, mock_platform: MagicMock) -> None:
+        # Windows (and any non-Darwin/non-Linux) has no topology resolver yet.
+        mock_platform.system.return_value = "Windows"
         result = resolve_audio_for_serial_port("/dev/ttyUSB0")
         assert result is None
 
@@ -833,3 +839,321 @@ class TestNameFallbackXiegu:
         rx, tx = select_usb_audio_devices(devices)
         assert rx.index == 1
         assert tx.index == 1
+
+
+# ---------------------------------------------------------------------------
+# MOR-228 — Linux sysfs topology resolution
+# ---------------------------------------------------------------------------
+
+
+def _mk_usb_device(
+    root: Path,
+    usb_dev_path: str,
+    *,
+    id_vendor: str | None = None,
+    id_product: str | None = None,
+    product: str | None = None,
+) -> Path:
+    """Create a fake USB *device* node directory under a fixture sysfs tree.
+
+    ``usb_dev_path`` is relative to ``<root>/devices`` and ends in a USB
+    device node name (e.g. ``usb1/1-1/1-1.1``). Writes the optional
+    ``idVendor``/``idProduct``/``product`` attribute files. Returns the
+    absolute path to the device node directory.
+    """
+    dev_dir = root / "devices" / usb_dev_path
+    dev_dir.mkdir(parents=True, exist_ok=True)
+    if id_vendor is not None:
+        (dev_dir / "idVendor").write_text(id_vendor + "\n")
+    if id_product is not None:
+        (dev_dir / "idProduct").write_text(id_product + "\n")
+    if product is not None:
+        (dev_dir / "product").write_text(product + "\n")
+    return dev_dir
+
+
+def _link_tty(root: Path, tty_name: str, usb_dev_dir: Path) -> None:
+    """Wire <root>/class/tty/<tty_name>/device → an interface under usb_dev_dir."""
+    # The kernel's `device` symlink points at the *interface* node; create one.
+    iface = usb_dev_dir / (os.path.basename(str(usb_dev_dir)) + ":1.0")
+    iface.mkdir(parents=True, exist_ok=True)
+    tty_class_dir = root / "class" / "tty" / tty_name
+    tty_class_dir.mkdir(parents=True, exist_ok=True)
+    (tty_class_dir / "device").symlink_to(iface, target_is_directory=True)
+
+
+def _link_card(root: Path, card_n: int, usb_dev_dir: Path) -> None:
+    """Wire <root>/class/sound/cardN/device → an interface under usb_dev_dir."""
+    iface = usb_dev_dir / (os.path.basename(str(usb_dev_dir)) + ":1.0")
+    iface.mkdir(parents=True, exist_ok=True)
+    card_dir = root / "class" / "sound" / f"card{card_n}"
+    card_dir.mkdir(parents=True, exist_ok=True)
+    (card_dir / "device").symlink_to(iface, target_is_directory=True)
+
+
+def _make_mock_sd_two_usb_named(name_a: str, name_b: str) -> MagicMock:
+    """Two duplex USB-audio devices with distinct names, after a built-in.
+
+    idx 0 -> Built-in Speaker (skipped)
+    idx 1 -> name_a duplex (in/out)
+    idx 2 -> name_b duplex (in/out)
+    """
+    devices: list[dict[str, Any]] = [
+        {
+            "name": "Built-in Speaker",
+            "index": 0,
+            "max_input_channels": 0,
+            "max_output_channels": 2,
+            "default_samplerate": 48000.0,
+        },
+        {
+            "name": name_a,
+            "index": 1,
+            "max_input_channels": 1,
+            "max_output_channels": 2,
+            "default_samplerate": 48000.0,
+        },
+        {
+            "name": name_b,
+            "index": 2,
+            "max_input_channels": 1,
+            "max_output_channels": 2,
+            "default_samplerate": 48000.0,
+        },
+    ]
+    sd = MagicMock()
+    sd.query_devices.return_value = devices
+    sd.default.device = [-1, -1]
+    return sd
+
+
+class TestExtractLinuxTtyName:
+    """MOR-228: Linux tty names for both CDC-ACM and USB-serial nodes."""
+
+    def test_ttyacm(self) -> None:
+        assert _extract_linux_tty_name("/dev/ttyACM0") == "ttyACM0"
+
+    def test_ttyusb(self) -> None:
+        assert _extract_linux_tty_name("/dev/ttyUSB1") == "ttyUSB1"
+
+    def test_ttyacm_high_index(self) -> None:
+        assert _extract_linux_tty_name("/dev/ttyACM12") == "ttyACM12"
+
+    def test_macos_path_is_none(self) -> None:
+        assert _extract_linux_tty_name("/dev/cu.usbserial-201410") is None
+
+    def test_unrelated_is_none(self) -> None:
+        assert _extract_linux_tty_name("/dev/ttyS0") is None
+
+
+class TestUsbDeviceNodeFromRealpath:
+    """MOR-228: ascend an interface realpath to the USB device node."""
+
+    def test_interface_to_device(self) -> None:
+        real = "/sys/devices/pci0000:00/usb1/1-1/1-1.4/1-1.4:1.0"
+        assert (
+            _usb_device_node_from_realpath(real)
+            == "/sys/devices/pci0000:00/usb1/1-1/1-1.4"
+        )
+
+    def test_root_port_device(self) -> None:
+        real = "/sys/devices/pci0000:00/usb2/2-1/2-1:1.0"
+        assert (
+            _usb_device_node_from_realpath(real) == "/sys/devices/pci0000:00/usb2/2-1"
+        )
+
+    def test_no_usb_node(self) -> None:
+        assert _usb_device_node_from_realpath("/sys/devices/platform/foo") is None
+
+
+class TestResolveLinuxSysfs:
+    """MOR-228: full Linux resolution against a fixture sysfs tree.
+
+    Topology modelled:
+      bus 1, hub 1-1: X6200 — CAT (ttyACM0) at 1-1.1, C-Media audio at 1-1.2
+      bus 1, hub 1-2: FTDI radio — serial (ttyUSB0) at 1-2.1, audio at 1-2.2
+
+    Each radio's CAT/serial port shares a deeper USB-path prefix with its OWN
+    audio device (score 2: bus + hub) than with the other radio's audio
+    (score 1: bus only), so each must resolve to its own card.
+    """
+
+    @staticmethod
+    def _build_tree(root: Path) -> None:
+        # X6200 CAT (CDC-ACM) and its C-Media audio share hub 1-1.
+        x6200_cat = _mk_usb_device(
+            root,
+            "pci0000:00/usb1/1-1/1-1.1",
+            id_vendor="1a86",
+            id_product="55d4",
+            product="USB Dual_Serial",
+        )
+        x6200_audio = _mk_usb_device(
+            root,
+            "pci0000:00/usb1/1-1/1-1.2",
+            id_vendor="0d8c",
+            id_product="0012",
+            product="USB Audio Device",
+        )
+        # FTDI radio serial and its audio share a *different* hub 1-2.
+        ftdi_serial = _mk_usb_device(
+            root,
+            "pci0000:00/usb1/1-2/1-2.1",
+            id_vendor="0403",
+            id_product="6001",
+            product="USB Serial",
+        )
+        ftdi_audio = _mk_usb_device(
+            root,
+            "pci0000:00/usb1/1-2/1-2.2",
+            id_vendor="08bb",
+            id_product="2901",
+            product="USB Audio CODEC",
+        )
+        _link_tty(root, "ttyACM0", x6200_cat)
+        _link_tty(root, "ttyUSB0", ftdi_serial)
+        _link_card(root, 0, x6200_audio)
+        _link_card(root, 1, ftdi_audio)
+
+    def test_x6200_resolves_to_cmedia(self, tmp_path: Path) -> None:
+        self._build_tree(tmp_path)
+        sd = _make_mock_sd_two_usb_named("USB Audio Device", "USB Audio CODEC")
+        result = _resolve_linux(
+            "/dev/ttyACM0",
+            sounddevice_module=sd,
+            sysfs_root=str(tmp_path),
+        )
+        assert result is not None
+        assert result.serial_port == "/dev/ttyACM0"
+        # C-Media "USB Audio Device" duplex enumerates at sounddevice index 1.
+        assert result.rx_device_index == 1
+        assert result.tx_device_index == 1
+
+    def test_ftdi_resolves_to_its_own_codec(self, tmp_path: Path) -> None:
+        self._build_tree(tmp_path)
+        sd = _make_mock_sd_two_usb_named("USB Audio Device", "USB Audio CODEC")
+        result = _resolve_linux(
+            "/dev/ttyUSB0",
+            sounddevice_module=sd,
+            sysfs_root=str(tmp_path),
+        )
+        assert result is not None
+        assert result.serial_port == "/dev/ttyUSB0"
+        # "USB Audio CODEC" enumerates at sounddevice index 2.
+        assert result.rx_device_index == 2
+        assert result.tx_device_index == 2
+
+    def test_each_port_resolves_to_its_own_device(self, tmp_path: Path) -> None:
+        self._build_tree(tmp_path)
+        sd = _make_mock_sd_two_usb_named("USB Audio Device", "USB Audio CODEC")
+        x6200 = _resolve_linux(
+            "/dev/ttyACM0", sounddevice_module=sd, sysfs_root=str(tmp_path)
+        )
+        ftdi = _resolve_linux(
+            "/dev/ttyUSB0", sounddevice_module=sd, sysfs_root=str(tmp_path)
+        )
+        assert x6200 is not None and ftdi is not None
+        assert x6200.rx_device_index != ftdi.rx_device_index
+        assert x6200.tx_device_index != ftdi.tx_device_index
+
+    def test_unknown_tty_returns_none(self, tmp_path: Path) -> None:
+        self._build_tree(tmp_path)
+        sd = _make_mock_sd_two_usb_named("USB Audio Device", "USB Audio CODEC")
+        result = _resolve_linux(
+            "/dev/ttyACM9",  # not wired into the fixture tree
+            sounddevice_module=sd,
+            sysfs_root=str(tmp_path),
+        )
+        assert result is None
+
+    def test_non_linux_serial_path_returns_none(self, tmp_path: Path) -> None:
+        self._build_tree(tmp_path)
+        sd = _make_mock_sd_two_usb_named("USB Audio Device", "USB Audio CODEC")
+        result = _resolve_linux(
+            "/dev/cu.usbserial-201410",  # macOS shape, not a Linux tty
+            sounddevice_module=sd,
+            sysfs_root=str(tmp_path),
+        )
+        assert result is None
+
+    def test_no_usb_audio_cards_returns_none(self, tmp_path: Path) -> None:
+        # Wire only the serial port; no ALSA cards under /class/sound.
+        x6200_cat = _mk_usb_device(
+            tmp_path,
+            "pci0000:00/usb1/1-1/1-1.1",
+            id_vendor="1a86",
+            id_product="55d4",
+            product="USB Dual_Serial",
+        )
+        _link_tty(tmp_path, "ttyACM0", x6200_cat)
+        sd = _make_mock_sd_two_usb_named("USB Audio Device", "USB Audio CODEC")
+        result = _resolve_linux(
+            "/dev/ttyACM0", sounddevice_module=sd, sysfs_root=str(tmp_path)
+        )
+        assert result is None
+
+
+class TestResolveLinuxCompositeIdentity:
+    """MOR-228: when two cards tie on USB-path prefix, the idVendor/idProduct
+    matching the radio's OWN USB device breaks the tie (composite radio whose
+    audio + CAT live on one physical device behind a shared hub)."""
+
+    def test_vid_pid_tiebreak(self, tmp_path: Path) -> None:
+        # Both audio cards sit one hop from the serial port (tie on prefix),
+        # but only one shares the serial port's idVendor:idProduct.
+        cat = _mk_usb_device(
+            tmp_path,
+            "pci0000:00/usb1/1-1",
+            id_vendor="0d8c",
+            id_product="0012",
+            product="USB Dual_Serial",
+        )
+        # Same physical device exposes audio too (same VID:PID, same node).
+        own_audio = _mk_usb_device(
+            tmp_path,
+            "pci0000:00/usb1/1-1",
+            id_vendor="0d8c",
+            id_product="0012",
+            product="USB Audio Device",
+        )
+        # An unrelated audio device on a sibling port (different VID:PID).
+        other_audio = _mk_usb_device(
+            tmp_path,
+            "pci0000:00/usb1/1-2",
+            id_vendor="08bb",
+            id_product="2901",
+            product="USB Audio Device",
+        )
+        _link_tty(tmp_path, "ttyACM0", cat)
+        _link_card(tmp_path, 0, own_audio)
+        _link_card(tmp_path, 1, other_audio)
+        # Two same-named "USB Audio Device" entries; rank picks card0 (own).
+        sd = _make_mock_sd_two_usb_named("USB Audio Device", "USB Audio Device")
+        result = _resolve_linux(
+            "/dev/ttyACM0", sounddevice_module=sd, sysfs_root=str(tmp_path)
+        )
+        assert result is not None
+        # card0 (own VID:PID, sysfs path 1-1) is same-name rank 0 → idx 1.
+        assert result.rx_device_index == 1
+        assert result.tx_device_index == 1
+
+
+class TestResolveLinuxDispatch:
+    """MOR-228: resolve_audio_for_serial_port dispatches to _resolve_linux."""
+
+    @patch("rigplane.usb_audio_resolve.platform")
+    @patch("rigplane.usb_audio_resolve._resolve_linux")
+    def test_linux_delegates(
+        self, mock_resolve: MagicMock, mock_platform: MagicMock
+    ) -> None:
+        mock_platform.system.return_value = "Linux"
+        mock_resolve.return_value = AudioDeviceMapping(
+            rx_device_index=1,
+            tx_device_index=1,
+            serial_port="/dev/ttyACM0",
+            location_prefix=0x0101,
+        )
+        result = resolve_audio_for_serial_port("/dev/ttyACM0")
+        assert result is not None
+        assert result.rx_device_index == 1
+        mock_resolve.assert_called_once()


### PR DESCRIPTION
## Summary

Implements Linux USB-audio topology resolution (MOR-228, 222a) in the resolver.
Until now `resolve_audio_for_serial_port` only resolved topology on macOS
(IORegistry) and returned `None` everywhere else, leaving Linux on the
name-based fallback. This adds a sysfs-anchored `_resolve_linux`, dispatched
via a single `elif platform.system() == "Linux"` branch.

## Approach (sysfs, no new deps)

1. **Serial port → USB device node.** `_extract_linux_tty_name` pulls the
   kernel tty name (`ttyACM0` / `ttyUSB0`) from the port path — a Linux-specific
   helper, deliberately separate from the macOS `usbserial-/usbmodem`-shaped
   `_extract_tty_suffix`. `realpath(<sysfs_root>/class/tty/<tty>/device)` lands
   on the USB *interface* node; `_usb_device_node_from_realpath` ascends to the
   nearest USB *device* node (basename `N-x[.y]`, no `:`). Handles both CDC-ACM
   (X6200 WCH CH342) and FTDI/CP210x bridges.
2. **ALSA card → USB device node.** `_sysfs_usb_audio_cards` enumerates
   `<sysfs_root>/class/sound/card*` and realpaths each `device` into the USB
   tree, reading the USB `product` string as the card identity name.
3. **Link.** `_common_usb_path_score` picks the audio card sharing the
   **longest common USB-device path prefix** with the serial port (same
   physical device / hub). `idVendor`/`idProduct` read from the USB node breaks
   prefix ties in favour of the radio's own physical device.
4. **Index mapping.** Reuses the MOR-230 `_cluster_usb_audio_devices` clustering
   through a new platform-neutral `_pair_audio_cluster_by_name` (name +
   same-name rank), mirroring `_pair_audio_device_for_location` without
   overloading its locationID-based signature.

`sysfs_root` is injectable (default `/sys`) so tests run on macOS against
fixture directories.

## Reused vs new helpers

- **Reused unchanged:** `_cluster_usb_audio_devices` (MOR-230),
  `_is_usb_audio_codec`, `AudioDeviceMapping`.
- **New (Linux):** `_resolve_linux`, `_extract_linux_tty_name`,
  `_usb_device_node_from_realpath`, `_sysfs_usb_device_for_tty`,
  `_sysfs_usb_audio_cards`, `_common_usb_path_score`, `_usb_path_components`,
  `_usb_path_location_prefix`, `_read_usb_ids`, `_read_sysfs_str`,
  `_pair_audio_cluster_by_name`.

The macOS path and the unsupported-platform (`None`) behaviour are unchanged.
Dispatch edit kept surgical (single `elif`) to avoid conflict with the parallel
MOR-229 (Windows) work; Linux tests live in their own clearly-named classes.

## Tests

New `TestExtractLinuxTtyName`, `TestUsbDeviceNodeFromRealpath`,
`TestResolveLinuxSysfs`, `TestResolveLinuxCompositeIdentity`,
`TestResolveLinuxDispatch`. `TestResolveLinuxSysfs` builds a temp sysfs tree
(`tty`/`sound` `device` symlink chains + `idVendor`/`idProduct`/`product`
files) modelling an **X6200** (`ttyACM0` + C-Media audio on hub `1-1`) beside an
**FTDI radio** (`ttyUSB0` + audio on hub `1-2`); asserts each port resolves to
its own audio device and they never share an index. Covers unknown-tty,
non-Linux path, no-cards, and the VID:PID tie-break. The pre-existing
`test_non_darwin_returns_none` was renamed to `test_unsupported_platform_returns_none`
and now uses `Windows` (Linux is no longer a no-op).

## Gate

- `uv run pytest tests/test_usb_audio_resolve.py -q` — 68 passed
- `uv run pytest tests/ -q -k "audio or usb or resolve"` — 887 passed, 13 skipped
- Full non-integration suite — 6313 passed, 0 failures
- `uv run ruff check src/ tests/` — clean; `ruff format --check` — clean
- `uv run mypy src/rigplane/audio/_usb_resolve.py` — clean
- `uv.lock` churn reverted

## Hardware-validation checklist (requires real Linux + X6200)

Validated only via sysfs fixtures + unit tests — **no Linux box was available**.
Before relying on this in production, on a real Linux host with the X6200:

- [ ] Confirm the X6200 audio codec and CAT (CDC-ACM) port actually share a USB
      hub branch (the longest-common-prefix assumption). If they enumerate as
      one composite device, the same-device full-prefix + VID:PID path still
      covers it, but confirm the real tree shape.
- [ ] Capture the exact ALSA card name (the USB `product` string under
      `/sys/.../product`) and confirm it equals the PortAudio/`sounddevice`
      device name used by `_cluster_usb_audio_devices`.
- [ ] Confirm the C-Media audio VID:PID is `0x0D8C:0x0012` and matches the
      `idVendor`/`idProduct` read from the USB node (the fixture assumes this).
- [ ] Verify the C-Media codec enumerates as a single duplex `sounddevice`
      entry on Linux/ALSA (as it does on macOS CoreAudio), not a split pair.
- [ ] End-to-end: browser RX stream + TX both bind to the correct device when
      the X6200 is plugged in alongside another USB radio.

## Uncertainty

The exact realpath shape (`pci…/usbN/N-x/N-x.y/N-x.y:1.0`) and whether the
X6200's two functions land on a shared hub vs one composite device are modelled
from the documented sysfs layout, not observed on hardware. The
`_common_usb_path_score` + VID:PID tie-break is robust to either, but the
same-name rank ordering (sysfs card path order) should be sanity-checked if two
identical radios are ever connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)