### PR TITLE
fix(MOR-236): feed X6200 RX USB audio capture into the broadcaster

### DIFF
--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -37,6 +37,18 @@ default_baud = 19200
 type = "civ"
 address = 0xA4
 
+[audio]
+# The Xiegu X6200 exposes a standard mono USB Audio Class CODEC (C-Media
+# based), exactly like the IC-705 / IC-7300 SERIAL-audio path. Its capture
+# device advertises a single input channel, so RX audio must be opened as
+# 1-channel PCM. Without this section the profile fell back to the global
+# default codec (``PCM_2CH_16BIT``, stereo), and ``UsbAudioDriver.start_rx``
+# asked PortAudio for a 2-channel InputStream — which the mono device
+# rejects with ``Invalid number of channels`` (PaErrorCode -9998). The
+# AudioBus then logged ``failed to start RX`` and the browser received zero
+# RX frames (MOR-236). Mirror the IC-705 / IC-7300 mono preference.
+codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
+
 [capabilities]
 # Aligned to Hamlib's ``X108G_LEVELS`` / ``X108G_FUNCS`` envelope
 # (xiegu.c lines 52, 54) intersected with what the Radioddity X6200 PDF

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -585,6 +585,24 @@ class UsbAudioDriver:
                 frame_ms=fm,
                 allow_sample_rate_fallback=allow_sample_rate_fallback,
             )
+            # Log the effective capture request before opening the
+            # InputStream. ``input_channels`` is included because a codec /
+            # device channel-count mismatch is the failure mode behind
+            # MOR-236: requesting more channels than the mono USB CODEC
+            # exposes makes PortAudio reject the stream with "Invalid number
+            # of channels" (PaErrorCode -9998), which previously surfaced
+            # only as an opaque "audio-bus: failed to start RX" with zero
+            # RX frames reaching the browser.
+            logger.info(
+                "usb-audio: opening RX capture — device=[%d] %s, %d Hz, "
+                "%d ch, %d ms (device input_channels=%d)",
+                selected_rx.index,
+                selected_rx.name,
+                contract.sample_rate_hz,
+                ch,
+                fm,
+                selected_rx.input_channels,
+            )
             self._rx_stream = self._backend.open_rx(
                 AudioDeviceId(selected_rx.index),
                 sample_rate=contract.sample_rate_hz,
@@ -593,6 +611,11 @@ class UsbAudioDriver:
             )
             await self._rx_stream.start(callback)
             self._store_stream_contract(contract)
+            logger.info(
+                "usb-audio: RX capture running — device=[%d] %s",
+                selected_rx.index,
+                selected_rx.name,
+            )
 
     async def stop_rx(self) -> None:
         """Stop capture loop and close RX stream."""

--- a/tests/test_x6200_rx_audio_mor236.py
+++ b/tests/test_x6200_rx_audio_mor236.py
@@ -1,0 +1,191 @@
+"""Regression tests for MOR-236 — Xiegu X6200 RX USB audio delivers 0 frames.
+
+Root cause: the ``rigs/x6200.toml`` profile had no ``[audio]`` section, so the
+radio's RX codec fell back to the global default ``PCM_2CH_16BIT`` (stereo).
+``UsbAudioDriver.start_rx`` then asked PortAudio for a 2-channel ``InputStream``
+on the mono Xiegu USB CODEC, which PortAudio rejects with "Invalid number of
+channels" (PaErrorCode -9998). The ``AudioBus`` caught it as "failed to start
+RX" and the browser received zero RX frames.
+
+These tests pin the mono codec resolution and exercise the
+capture -> AudioBus -> AudioBroadcaster -> client wiring with a backend that
+reproduces PortAudio's channel-count rejection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from rigplane.audio.backend import (
+    AudioDeviceId,
+    AudioDeviceInfo,
+    FakeRxStream,
+    FakeTxStream,
+)
+from rigplane.audio.usb_driver import UsbAudioDriver
+from rigplane.backends.config import SerialBackendConfig
+from rigplane.backends.factory import create_radio
+from rigplane.backends.ic705.serial import Ic705SerialRadio
+from rigplane.types import AudioCodec
+from rigplane.web.handlers import AudioBroadcaster
+from rigplane.web.protocol import AUDIO_CODEC_PCM16, AUDIO_HEADER_SIZE
+
+
+class _MonoUsbAudioBackend:
+    """Fake backend that mimics a mono USB CODEC like the Xiegu X6200.
+
+    ``open_rx`` rejects any channel count other than the single input
+    channel the device exposes, reproducing PortAudio's PaErrorCode -9998
+    ("Invalid number of channels") that is the MOR-236 failure mode.
+    """
+
+    def __init__(self, *, input_channels: int = 1) -> None:
+        self._device = AudioDeviceInfo(
+            id=AudioDeviceId(0),
+            name="USB Audio Device",
+            input_channels=input_channels,
+            output_channels=input_channels,
+            default_samplerate=48_000,
+            is_default_input=True,
+            is_default_output=True,
+        )
+        self.rx_streams: list[FakeRxStream] = []
+        self.tx_streams: list[FakeTxStream] = []
+
+    def list_devices(self) -> list[AudioDeviceInfo]:
+        return [self._device]
+
+    def check_sample_rate(
+        self, device: AudioDeviceId, sample_rate: int, *, direction: str = "rx"
+    ) -> bool:
+        return sample_rate in (48_000, 24_000, 16_000, 8_000)
+
+    def open_rx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> FakeRxStream:
+        if channels != self._device.input_channels:
+            raise RuntimeError(
+                "Error opening InputStream: Invalid number of channels "
+                f"[requested {channels}, device exposes "
+                f"{self._device.input_channels}]"
+            )
+        stream = FakeRxStream()
+        self.rx_streams.append(stream)
+        return stream
+
+    def open_tx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> FakeTxStream:
+        stream = FakeTxStream()
+        self.tx_streams.append(stream)
+        return stream
+
+
+class _FakeSerialCivLink:
+    """Minimal serial CI-V link double so the radio reports ``connected``."""
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.ready = False
+        self.healthy = False
+
+    async def connect(self) -> None:
+        self.connected = True
+        self.ready = True
+        self.healthy = True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+        self.ready = False
+        self.healthy = False
+
+    async def send(self, frame: bytes) -> None:
+        _ = frame
+
+    async def receive(self, timeout: float | None = None) -> bytes | None:
+        await asyncio.sleep(0.02 if timeout is None else min(timeout, 0.02))
+        return None
+
+
+def test_x6200_profile_resolves_mono_rx_codec() -> None:
+    """X6200 must resolve to a 1-channel RX codec (root-cause guard)."""
+    radio = create_radio(SerialBackendConfig(device="/dev/null", model="X6200"))
+    assert AudioCodec(radio.audio_codec) == AudioCodec.PCM_1CH_16BIT
+    assert radio.profile.codec_preference is not None
+    assert radio.profile.codec_preference[0] == "PCM_1CH_16BIT"
+    # The serial audio path derives RX/TX channel count from the codec; a
+    # stereo codec is what made PortAudio reject the mono Xiegu InputStream.
+    assert radio._serial_audio_channels_for_codec() == 1
+
+
+@pytest.mark.asyncio
+async def test_usb_driver_rx_rejects_stereo_on_mono_device() -> None:
+    """Opening a 2-channel capture on a mono device fails (MOR-236 mode)."""
+    driver = UsbAudioDriver(serial_port=None, backend=_MonoUsbAudioBackend())
+    with pytest.raises(RuntimeError, match="Invalid number of channels"):
+        await driver.start_rx(lambda _frame: None, channels=2)
+    assert not driver.rx_running
+
+
+@pytest.mark.asyncio
+async def test_usb_driver_rx_mono_capture_feeds_callback() -> None:
+    """A 1-channel capture opens and pushes PCM frames to the callback."""
+    backend = _MonoUsbAudioBackend()
+    driver = UsbAudioDriver(serial_port=None, backend=backend)
+    received: list[bytes] = []
+
+    await driver.start_rx(received.append, channels=1)
+    assert driver.rx_running
+    assert len(backend.rx_streams) == 1
+
+    pcm = b"\x10\x20" * 480
+    backend.rx_streams[0].inject_frame(pcm)
+    assert received == [pcm]
+
+    await driver.stop_rx()
+    assert not driver.rx_running
+
+
+@pytest.mark.asyncio
+async def test_x6200_serial_capture_feeds_broadcaster() -> None:
+    """End-to-end: X6200 mono capture reaches a broadcaster client queue.
+
+    Uses the real ``Ic705SerialRadio`` resolved against the X6200 profile so
+    the RX channel count is whatever the profile produces. With the mono
+    backend, a regression back to a stereo codec would raise inside
+    ``start_audio_rx_opus`` and the client would receive no frames.
+    """
+    backend = _MonoUsbAudioBackend()
+    audio_driver = UsbAudioDriver(serial_port=None, backend=backend)
+    radio = Ic705SerialRadio(
+        device="/dev/tty.usbmodem-X6200",
+        model="X6200",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=audio_driver,
+    )
+    await radio.connect()
+    broadcaster = AudioBroadcaster(radio)
+    queue = await broadcaster.subscribe()
+    try:
+        # The relay/bus subscription has opened the RX stream by now.
+        assert len(backend.rx_streams) == 1, "RX capture did not open"
+        pcm_frame = b"\xab\xcd" * 480
+        backend.rx_streams[0].inject_frame(pcm_frame)
+        web_frame = await asyncio.wait_for(queue.get(), timeout=1.0)
+        assert web_frame[1] == AUDIO_CODEC_PCM16
+        assert web_frame[AUDIO_HEADER_SIZE:] == pcm_frame
+    finally:
+        await broadcaster.unsubscribe(queue)
+        await radio.disconnect()


### PR DESCRIPTION
## Summary

On macOS with a Xiegu X6200, the web UI **LIVE / Browser audio stream** was silent: the MOR-219 device-resolution fix worked, but the RX broadcaster delivered **zero PCM frames** to the browser.

### Root cause (why 0 frames)

Decisive evidence from the live managed log:

```
rigplane.web.handlers.audio  audio-broadcaster: radio codec=PCM_2CH_16BIT (0x10) → web_codec=0x02 ... ch=2
rigplane.audio.bus           audio-bus: +subscriber 'web-audio' (1 total)
rigplane.audio.bus  [ERROR]  audio-bus: failed to start RX
Traceback (most recent call last):
  ...
  File "rigplane/audio/usb_driver.py", line 594, in start_rx
  ...
sounddevice.PortAudioError: Error opening InputStream: Invalid number of channels [PaErrorCode -9998]
```

The relay **did** start and the bus **did** request RX capture — but `start_audio_rx_opus` → `UsbAudioDriver.start_rx` failed.

The `rigs/x6200.toml` profile had **no `[audio]` section**, so the RX codec fell back to the global default `PCM_2CH_16BIT` (stereo). The serial audio path derives its channel count from the codec, so it asked PortAudio for a **2-channel** `InputStream` on the Xiegu's **mono** USB CODEC → `Invalid number of channels` (-9998). `AudioBus` swallowed it as `failed to start RX`, the capture never produced frames, and the browser sender exited "after 0 frames".

IC-705 / IC-7300 / IC-9700 were unaffected because their profiles declare `codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]` (mono) and resolve to a 1-channel capture.

### The fix

- **`rigs/x6200.toml`** — add `[audio] codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]`, mirroring the IC-705 / IC-7300 mono SERIAL-audio path. X6200 now resolves to `PCM_1CH_16BIT` (1 channel) and the InputStream opens successfully.
- **`audio/usb_driver.py`** — log the effective RX capture request (device, sample rate, channels, **device `input_channels`**) before opening the InputStream, and a `RX capture running` line after. A future channel mismatch is now directly observable instead of surfacing only as an opaque `audio-bus: failed to start RX`.
- **`tests/test_x6200_rx_audio_mor236.py`** — new regression coverage.

### Tests

New `tests/test_x6200_rx_audio_mor236.py`:
- `test_x6200_profile_resolves_mono_rx_codec` — pins X6200 → `PCM_1CH_16BIT`, 1 channel (root-cause guard).
- `test_usb_driver_rx_rejects_stereo_on_mono_device` — reproduces the -9998 mode (2ch on a mono device raises).
- `test_usb_driver_rx_mono_capture_feeds_callback` — 1ch capture opens and pushes PCM frames.
- `test_x6200_serial_capture_feeds_broadcaster` — end-to-end capture → `AudioBus` → `AudioBroadcaster` → client queue with the real `Ic705SerialRadio` resolved against the X6200 profile.

**Verified the tests fail without the fix**: with the `[audio]` section stripped, the profile guard and the broadcaster-wiring test fail with the exact `Invalid number of channels [requested 2, device exposes 1]` error.

### Gate results

- `uv run pytest tests/test_x6200_rx_audio_mor236.py` — 4 passed
- `uv run pytest tests/ -k "audio or broadcast or usb"` — 917 passed, 13 skipped
- `uv run pytest tests/test_profiles_runtime.py tests/test_profiles_routing.py tests/test_radio_validate.py tests/test_ic705_backend.py tests/test_convert_cli.py` — 78 passed
- `uv run ruff check` + `ruff format --check` on touched files — clean

### Hardware-validation checklist (X6200 not available to this agent)

1. Connect the Xiegu X6200 over USB on macOS; complete setup (USB audio auto-resolves per MOR-219).
2. Open the web UI, click **LIVE / Browser audio stream**.
3. Confirm audio is **audible** and frames flow — `audio: sent frame #1...` in `~/Library/Logs/rigplane-pro/rigplane-managed.log` (no longer "cancelled after 0 frames").
4. Confirm the new capture log appears: `usb-audio: opening RX capture — device=[0] ... 1 ch ... (device input_channels=1)` followed by `usb-audio: RX capture running`.
5. Confirm **no** `audio-bus: failed to start RX` / PaErrorCode -9998 in the log.

### Boundary

`open-core` — generic radio profile + USB audio capture.

### Out of scope / follow-ups

- `rigs/x6100.toml` and `rigs/tx500.toml` (other Xiegu/QRP serial profiles) similarly lack `[audio]` sections and would hit the same mono/stereo mismatch if used over the serial USB-audio path. Worth a follow-up to audit and add mono `codec_preference` where the hardware is mono.

> Independent agent review pending — the implementation agent cannot self-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)