### PR TITLE
fix(MOR-237): stabilize X6200 CH342 serial session + CI-V RX framing

### DIFF
--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -83,6 +83,12 @@ class _IcomSerialRadioBase(CoreRadio):
     _DEFAULT_MODEL: str = ""
     _SERIAL_WATCHDOG_INTERVAL_S = 0.2
     _SERIAL_WATCHDOG_RETRY_S = 0.5
+    # Cap for the exponential backoff applied after repeated reconnect failures
+    # (e.g. the USB serial device node briefly disappearing during macOS device
+    # renumbering on a CH342 bridge — MOR-237). Without a backoff the watchdog
+    # retried every _SERIAL_WATCHDOG_RETRY_S and flooded the log with full
+    # tracebacks twice a second while the port was gone.
+    _SERIAL_WATCHDOG_RETRY_MAX_S = 5.0
 
     def __init__(
         self,
@@ -534,6 +540,11 @@ class _IcomSerialRadioBase(CoreRadio):
         self._civ_data_watchdog_task = None
 
     async def _serial_civ_watchdog_loop(self) -> None:
+        # Number of consecutive failed soft-reconnect attempts. Drives a capped
+        # exponential backoff and demotes repeated, identical failures from a
+        # WARNING-with-traceback to a quiet DEBUG so a transient/vanished port
+        # does not flood the log (MOR-237).
+        consecutive_failures = 0
         try:
             while True:
                 await asyncio.sleep(self._SERIAL_WATCHDOG_INTERVAL_S)
@@ -547,20 +558,55 @@ class _IcomSerialRadioBase(CoreRadio):
                     self._civ_recovering = False
                     self._conn_state = RadioConnectionState.CONNECTED
                     self._last_civ_data_received = time.monotonic()
+                    consecutive_failures = 0
                     continue
 
                 self._civ_stream_ready = False
                 self._civ_recovering = True
                 try:
                     await self.soft_reconnect()
-                except Exception:
-                    logger.warning(
-                        "serial-civ-watchdog: soft reconnect failed",
-                        exc_info=True,
+                    consecutive_failures = 0
+                except Exception as exc:
+                    consecutive_failures += 1
+                    if consecutive_failures == 1:
+                        # First failure of a run: surface it once, with the
+                        # full traceback for diagnosis.
+                        logger.warning(
+                            "serial-civ-watchdog: soft reconnect failed (%s); "
+                            "retrying with backoff",
+                            exc,
+                            exc_info=True,
+                        )
+                    else:
+                        # Subsequent identical failures (e.g. port still gone):
+                        # keep the log quiet, just note the count.
+                        logger.debug(
+                            "serial-civ-watchdog: soft reconnect still failing "
+                            "(attempt %d): %s",
+                            consecutive_failures,
+                            exc,
+                        )
+                    await asyncio.sleep(
+                        self._serial_watchdog_retry_delay(consecutive_failures)
                     )
-                    await asyncio.sleep(self._SERIAL_WATCHDOG_RETRY_S)
         except asyncio.CancelledError:
             pass
+
+    def _serial_watchdog_retry_delay(self, consecutive_failures: int) -> float:
+        """Capped exponential backoff for repeated reconnect failures.
+
+        The first retry uses ``_SERIAL_WATCHDOG_RETRY_S``; each subsequent
+        failure doubles the delay up to ``_SERIAL_WATCHDOG_RETRY_MAX_S`` so a
+        long-absent port is retried slowly and quietly instead of twice a
+        second with a full traceback (MOR-237).
+        """
+        exponent = max(0, consecutive_failures - 1)
+        multiplier: float = float(2**exponent)
+        delay: float = float(self._SERIAL_WATCHDOG_RETRY_S) * multiplier
+        cap: float = float(self._SERIAL_WATCHDOG_RETRY_MAX_S)
+        if delay > cap:
+            return cap
+        return delay
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -49,6 +49,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 CIV_HEADER_SIZE = 0x15
+# Icom CI-V frequency payloads (cmd 0x00 unsolicited / 0x03 GET response) are
+# always exactly 5 BCD bytes. Truncated/partial frames (e.g. from a flaky USB
+# serial line such as the Xiegu X6200 CH342 bridge — MOR-237) must be skipped
+# before reaching the 5-byte BCD decoder, otherwise every malformed frame
+# raised a caught ValueError and spammed the debug log on each poll cycle.
+_FREQ_BCD_LEN = 5
 _SCOPE_BACKLOG_SHED_THRESHOLD = 256
 _SCOPE_BACKLOG_KEEP_LATEST = 64
 _RAW_RECEIVED_FRAME_BYTES_LIMIT = 256
@@ -805,9 +811,18 @@ class CivRuntime:
         try:
             if frame.command in (0x03, 0x00):
                 # Frequency: 0x03 = response to GET, 0x00 = unsolicited (e.g. VFO knob)
-                freq = parse_frequency_response(frame)
-                host._state_cache.update_freq(freq)
-                host._last_freq_hz = freq
+                if len(frame.data) != _FREQ_BCD_LEN:
+                    # Truncated/partial freq frame (flaky serial). Skip quietly
+                    # so the 5-byte BCD decoder never sees a short payload.
+                    logger.debug(
+                        "civ-rx: skipping short freq frame cmd=0x%02x len=%d",
+                        frame.command,
+                        len(frame.data),
+                    )
+                else:
+                    freq = parse_frequency_response(frame)
+                    host._state_cache.update_freq(freq)
+                    host._last_freq_hz = freq
             elif frame.command in (0x04, 0x01):
                 mode_val, filt = parse_mode_response(frame)
                 host._state_cache.update_mode(mode_val.name, filt)
@@ -1010,6 +1025,15 @@ class CivRuntime:
         slot_override: str | None,
     ) -> None:
         # cmd 0x03 (GET freq response) and 0x00 (unsolicited freq).
+        if len(frame.data) != _FREQ_BCD_LEN:
+            # Truncated/partial freq frame (flaky serial — MOR-237). Skip quietly
+            # before the 5-byte BCD decoder rather than raising/logging per poll.
+            logger.debug(
+                "civ-rx: skipping short freq frame cmd=0x%02x len=%d",
+                frame.command,
+                len(frame.data),
+            )
+            return
         freq = parse_frequency_response(frame)
         if slot_override is not None:
             from dataclasses import replace as _replace

--- a/tests/test_civ_rx_short_frame_robustness.py
+++ b/tests/test_civ_rx_short_frame_robustness.py
@@ -1,0 +1,105 @@
+"""Regression tests for CI-V RX robustness against short/partial/echo frames.
+
+MOR-237: the Xiegu X6200 (and a flaky serial line generally) can deliver
+truncated frequency frames — e.g. ``FE FE E0 98 00 FD`` (cmd 0x00, zero data
+bytes) or ``FE FE E0 98 00 00 00 FD`` (two data bytes). These reached the
+5-byte BCD decoder and raised ``ValueError: BCD data must be exactly 5 bytes``,
+which was caught but logged on every poll cycle (thousands of debug lines).
+
+These tests assert that such frames are skipped gracefully:
+- no exception escapes the dispatch path,
+- no state corruption (frequency cache/state untouched),
+- a valid 5-byte frame that follows still decodes correctly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from test_radio import MockTransport
+
+from rigplane import IC_7610_ADDR
+from rigplane.commands import CONTROLLER_ADDR
+from rigplane.radio import IcomRadio
+from rigplane.radio_state import RadioState
+from rigplane.types import CivFrame
+
+
+def _make_radio() -> IcomRadio:
+    transport = MockTransport()
+    radio = IcomRadio("192.168.1.100")
+    radio._civ_transport = transport
+    radio._ctrl_transport = transport
+    radio._connected = True
+    radio._radio_state = RadioState()
+    return radio
+
+
+def _freq_frame(data: bytes, *, command: int = 0x00) -> CivFrame:
+    return CivFrame(
+        to_addr=CONTROLLER_ADDR,
+        from_addr=IC_7610_ADDR,
+        command=command,
+        sub=None,
+        data=data,
+        receiver=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"",  # "got 0" — FE FE E0 98 00 FD
+        b"\x00\x00",  # "got 2" — FE FE E0 98 00 00 00 FD
+        b"\x00\x00\x00",  # 3 bytes
+        b"\x00\x40\x07\x14",  # 4 bytes (alternate-shape probe, still skipped)
+        b"\x00\x40\x07\x14\x00\x00",  # 6 bytes (over-long)
+    ],
+)
+@pytest.mark.parametrize("command", [0x00, 0x03])
+def test_short_freq_frame_does_not_raise_or_corrupt_state(
+    caplog: pytest.LogCaptureFixture, data: bytes, command: int
+) -> None:
+    radio = _make_radio()
+    radio._radio_state.receiver("MAIN").freq = 14_074_000
+    radio._last_freq_hz = 14_074_000
+
+    frame = _freq_frame(data, command=command)
+
+    with caplog.at_level(logging.DEBUG, logger="rigplane.runtime._civ_rx"):
+        # Both update paths must tolerate the malformed frame.
+        radio._civ_runtime._update_state_cache_from_frame(frame)
+        radio._civ_runtime._update_radio_state_from_frame(frame)
+
+    # State must be untouched by the malformed frame.
+    assert radio._radio_state.receiver("MAIN").freq == 14_074_000
+    assert radio._last_freq_hz == 14_074_000
+
+    # No error-level spam (the old code emitted "BCD data must be exactly..."
+    # exceptions caught at debug; now we skip without ever invoking the decoder).
+    for record in caplog.records:
+        assert record.levelno < logging.WARNING, (
+            f"unexpected non-debug log: {record.levelname} {record.getMessage()}"
+        )
+        assert "BCD data must be exactly" not in record.getMessage(), (
+            "short freq frame should be skipped before the BCD decoder"
+        )
+
+
+@pytest.mark.parametrize("command", [0x00, 0x03])
+def test_valid_freq_frame_still_decodes_after_short_frame(command: int) -> None:
+    from rigplane.types import bcd_encode
+
+    radio = _make_radio()
+
+    # A truncated frame first, then a valid 5-byte frame.
+    radio._civ_runtime._update_radio_state_from_frame(_freq_frame(b"", command=command))
+    radio._civ_runtime._update_state_cache_from_frame(_freq_frame(b"", command=command))
+
+    valid = _freq_frame(bcd_encode(14_074_000), command=command)
+    radio._civ_runtime._update_radio_state_from_frame(valid)
+    radio._civ_runtime._update_state_cache_from_frame(valid)
+
+    assert radio._radio_state.receiver("MAIN").freq == 14_074_000
+    assert radio._last_freq_hz == 14_074_000

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -77,9 +77,11 @@ class _FakeSerialCivLink:
         *,
         fail_connect: BaseException | None = None,
         fail_connect_calls: set[int] | None = None,
+        fail_connect_calls_exc: BaseException | None = None,
     ) -> None:
         self._fail_connect = fail_connect
         self._fail_connect_calls = set(fail_connect_calls or set())
+        self._fail_connect_calls_exc = fail_connect_calls_exc
         self.connect_calls = 0
         self.disconnect_calls = 0
         self.connected = False
@@ -92,6 +94,8 @@ class _FakeSerialCivLink:
     async def connect(self) -> None:
         self.connect_calls += 1
         if self.connect_calls in self._fail_connect_calls:
+            if self._fail_connect_calls_exc is not None:
+                raise self._fail_connect_calls_exc
             raise OSError(f"connect failed on call {self.connect_calls}")
         if self._fail_connect is not None:
             raise self._fail_connect
@@ -258,6 +262,75 @@ async def test_serial_watchdog_retries_after_transient_soft_reconnect_failure() 
     assert await _wait_until(lambda: link.connect_calls >= 3, timeout_s=2.0)
     assert await _wait_until(lambda: radio.radio_ready, timeout_s=2.0)
     assert radio.conn_state == RadioConnectionState.CONNECTED
+
+    await radio.disconnect()
+
+
+def test_serial_watchdog_retry_delay_is_capped_exponential_backoff() -> None:
+    """MOR-237: repeated reconnect failures back off, capped at the max."""
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+    )
+    base = radio._SERIAL_WATCHDOG_RETRY_S
+    cap = radio._SERIAL_WATCHDOG_RETRY_MAX_S
+
+    # First failure -> base delay; then doubling; never above the cap.
+    assert radio._serial_watchdog_retry_delay(1) == base
+    assert radio._serial_watchdog_retry_delay(2) == base * 2
+    assert radio._serial_watchdog_retry_delay(3) == base * 4
+    # A very large failure count is clamped to the cap.
+    assert radio._serial_watchdog_retry_delay(50) == cap
+    # Monotonic non-decreasing.
+    delays = [radio._serial_watchdog_retry_delay(n) for n in range(1, 12)]
+    assert delays == sorted(delays)
+
+
+@pytest.mark.asyncio
+async def test_serial_watchdog_quiet_after_transient_open_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MOR-237: a vanished port (FileNotFoundError) must not flood WARNING+traceback.
+
+    Only the first failure of a run is a WARNING (with traceback); subsequent
+    identical failures are demoted to DEBUG. Recovery resets the run.
+    """
+    import logging
+
+    # Fail soft_reconnect's connect() on calls 2..5 with a "port gone" error,
+    # then let it recover on call 6.
+    link = _FakeSerialCivLink(
+        fail_connect_calls={2, 3, 4, 5},
+        fail_connect_calls_exc=FileNotFoundError(
+            "[Errno 2] No such file or directory: '/dev/cu.usbmodem58910181093'"
+        ),
+    )
+    radio = Icom7610SerialRadio(device="/dev/ttyUSB0", civ_link=link)
+    radio._SERIAL_WATCHDOG_INTERVAL_S = 0.02  # type: ignore[attr-defined]
+    radio._SERIAL_WATCHDOG_RETRY_S = 0.01  # type: ignore[attr-defined]
+    radio._SERIAL_WATCHDOG_RETRY_MAX_S = 0.05  # type: ignore[attr-defined]
+
+    await radio.connect()
+    assert radio.radio_ready is True
+
+    with caplog.at_level(logging.DEBUG, logger="rigplane.backends._icom_serial_base"):
+        # Trip the watchdog into recovery.
+        link.ready = False
+        link.healthy = False
+        # Wait until the port "returns" and the session recovers.
+        assert await _wait_until(lambda: link.connect_calls >= 6, timeout_s=3.0)
+        assert await _wait_until(lambda: radio.radio_ready, timeout_s=2.0)
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "soft reconnect failed" in r.getMessage()
+    ]
+    # The whole multi-failure run must produce at most one WARNING line, and it
+    # must not be repeated per retry (the old behaviour logged one per 0.5s).
+    assert len(warnings) <= 1, (
+        f"expected <=1 WARNING during a transient outage, got {len(warnings)}"
+    )
 
     await radio.disconnect()
 


### PR DESCRIPTION
## MOR-237 — Xiegu X6200 over CH342 USB serial: session flapping + short-BCD CI-V errors

Two related faults observed live (`~/Library/Logs/rigplane-pro/rigplane-managed.log`) on the X6200 over the WCH CH342 dual-serial bridge (`/dev/cu.usbmodem58910181093` @ 19200). The fix also hardens the shared Icom serial path generally — no X6200 port hardcoding.

### Root causes

**1. CI-V RX framing — truncated frequency frames hit the BCD decoder.**
The X6200 / a flaky serial line delivered short frequency frames parsed as `cmd=0x00 sub=0x00 data=` (0 bytes) and `cmd=0x00 ... data=0000` (2 bytes). `cmd 0x00` (unsolicited freq) and `0x03` (GET-freq response) route into `parse_frequency_response` → `bcd_decode`, which requires exactly 5 bytes and raised `ValueError: BCD data must be exactly 5 bytes, got 0/2`. The exception was caught but logged on every poll cycle (~6980 debug lines in the captured log), once in `_update_state_cache_from_frame` and once in `_update_radio_state_from_frame`.

**2. Serial stability — spurious reconnect loop with traceback flood.**
`_serial_civ_watchdog_loop` calls `soft_reconnect()` the instant `serial_session.ready` is false. A single recoverable read hiccup flips `healthy → False`; the watchdog then disconnects the working session and tries to reopen. When the CH342 device node briefly vanished during macOS USB renumbering (`SerialException: ... No such file or directory`), `soft_reconnect` failed, logged a full-traceback `WARNING`, and retried every `_SERIAL_WATCHDOG_RETRY_S` (0.5s) — forever (`Failed to reconnect serial session ...` repeated indefinitely, interleaved with `Connected to X6200 ...`).

### Fix

- **CI-V framing (`runtime/_civ_rx.py`):** validate freq-frame payload is exactly `_FREQ_BCD_LEN` (5) bytes before decoding, in both the legacy `_update_state_cache_from_frame` cmd 0x00/0x03 branch and the `_handle_freq` dispatch handler. Short/partial/over-long freq frames are skipped with a single DEBUG line — the 5-byte BCD decoder never sees a malformed payload. No exception, no state corruption.
- **Serial stability (`backends/_icom_serial_base.py`):** the watchdog now tracks consecutive reconnect failures, applies a **capped exponential backoff** (`_SERIAL_WATCHDOG_RETRY_S` doubling up to `_SERIAL_WATCHDOG_RETRY_MAX_S = 5.0s`), and **demotes repeated identical failures from WARNING+traceback to DEBUG**. The first failure of a run is still a WARNING with traceback for diagnosis; a vanished/transient port is then retried slowly and quietly and recovers (counter resets) when the node returns. Genuine disconnects still trigger an immediate first reconnect — the existing recovery test is unchanged.

This stays within the existing layering (`runtime/` framing, `backends/` serial session) and does not touch the X6200 audio/discovery/disambiguation work from MOR-219/224/226.

### Tests
- New `tests/test_civ_rx_short_frame_robustness.py`: short (0/2/3/4/6-byte) freq frames for cmd 0x00 and 0x03 — asserts no raise, no state corruption, no `BCD data must be exactly` log, and that a valid 5-byte frame after a short one still decodes.
- `tests/test_icom7610_serial_radio.py`: added a capped-exponential-backoff unit test and a transient-open-failure (`FileNotFoundError` "port gone" on calls 2–5, recover on 6) test asserting **at most one WARNING** for the whole outage. Existing `test_serial_watchdog_retries_after_transient_soft_reconnect_failure` still passes.

### Gate
- `uv run pytest -k "serial or civ or x6200 or backend"` — pass
- `uv run pytest tests/ --ignore=tests/integration` — **6335 passed**, 0 failed
- `uv run ruff check` + `ruff format --check` on changed files — clean
- `uv run mypy src/` — no new errors in touched files (the one `_civ_rx.py:403 redundant-cast` is the pre-existing baseline, confirmed against `origin/main`)
- `uv.lock` churn reverted

### Manual hardware-validation checklist (could not run — no physical X6200)
1. Connect the X6200 via USB (CH342 dual-serial); confirm macOS enumerates `/dev/cu.usbmodem…091` (SERIAL-A) and `…093` (SERIAL-B).
2. Start the managed station against the X6200 serial backend @ 19200 baud.
3. Tail `~/Library/Logs/rigplane-pro/rigplane-managed.log` and confirm:
   - no recurring `BCD data must be exactly 5 bytes` lines,
   - no `Failed to reconnect serial session … No such file or directory` reconnect loop (at most a single WARNING if the node briefly drops, then quiet DEBUG backoff, then `CI-V data resumed` / `Connected to X6200`),
   - stable freq/mode display while spinning the VFO and changing modes.
4. Physically unplug/replug (or trigger a USB renumber) and confirm the session recovers without a traceback flood.

### Uncertainty
- The captured short frames are `cmd=0x00` with 0/2 data bytes — clearly **truncated**, not a valid alternate shape (a 4-byte X6200 freq would log as `data=00400714`, never seen). The fix treats them as partial and skips them, which is correct for truncation. If the X6200 ever emits a genuinely valid non-5-byte freq frame on real hardware, that would surface as a steady stream of `skipping short freq frame` DEBUG lines with a frozen frequency — the hardware run in the checklist will confirm freq still tracks (it should, since the valid 5-byte frames are unaffected).
- Whether the truncation originates from the flaky serial (partial reads) or an embedded `0xFD`-byte mis-frame in `SerialFrameCodec`/`iter_civ_frames` could not be confirmed without the device; the `_civ_rx` guard is robust to both. Stabilizing the serial session (fault #2) should also reduce the rate of partial frames feeding fault #1.

Independent review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)