### PR TITLE
chore(release): bump to 2.7.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] — 2026-05-29
+
+### Added
+- USB-audio topology resolution on **Linux** (`/sys` sysfs) and **Windows**
+  (USB PnP / SetupAPI), extending the macOS resolver so USB radios — notably
+  the Xiegu X6200's WCH CH342 CDC-ACM bridge (`/dev/ttyACM*`, `COMx`) — map
+  their host USB audio device by physical USB topology with a VID:PID identity
+  fallback (#1687, #1686).
+
+### Changed
+- USB audio↔serial device pairing is now by device **identity** (product name
+  + same-name rank) instead of positional enumeration order, correcting
+  selection on mixed-vendor multi-radio hosts (#1685).
+
+### Fixed
+- Xiegu X6200 browser "LIVE" RX audio now flows: the mono C-Media USB codec is
+  opened as 1-channel PCM via an `[audio] codec_preference` profile entry,
+  instead of failing the global stereo default (PortAudio `-9998`) and starving
+  the stream (#1688).
+- Xiegu X6200 CH342 serial session stabilized: the reconnect watchdog uses
+  capped exponential backoff and no longer floods the log on transient USB
+  renumbering, and CI-V RX framing tolerates short/partial frequency frames
+  instead of raising `BCD data must be exactly 5 bytes` (#1689).
+
 ## [2.6.0] — 2026-05-29
 
 ### Added
@@ -1499,7 +1523,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/rigplane/rigplane-core/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/rigplane/rigplane-core/compare/v2.5.1...v2.6.0
 [2.5.1]: https://github.com/rigplane/rigplane-core/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/rigplane/rigplane-core/compare/v2.4.0...v2.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.6.0"
+version = "2.7.0"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release 2.7.0 (minor bump from 2.6.0)

Version + CHANGELOG only — **no code changes**. The diff is exactly `pyproject.toml` (version `2.6.0` → `2.7.0`) and `docs/CHANGELOG.md`.

### Scope — 5 PRs since v2.6.0 (all on `origin/main`)
- `524dd684` refactor(MOR-230): pair USB audio by identity, not positional order (#1685)
- `04c9e065` feat(MOR-229): Windows USB-audio topology / robust-identity resolution (#1686)
- `3db3be49` feat(MOR-228): Linux sysfs USB-audio topology resolution (#1687)
- `900a53d1` fix(MOR-237): stabilize X6200 CH342 serial session + CI-V RX framing (#1689)
- `bb62a7a4` fix(MOR-236): feed X6200 RX USB audio capture into the broadcaster (#1688)

No breaking changes → minor.

### Process note (this repo)
`main` is a **protected** branch (Agent Review Gate required), so the bump cannot be pushed to `main` directly. This PR carries the bump; **the orchestrator handles tag + GitHub Release after merge** (the GitHub Release `published` event is what triggers `publish.yml` → PyPI). This branch does **not** tag, merge, or publish.

### Local pre-flight gates (matched to `publish.yml` `validate`)
- `ruff check src/ tests/` — PASS
- `ruff format --check src/ tests/` — PASS (509 files)
- `lint-imports` — PASS (4 contracts kept)
- `mypy --strict src/rigplane/web` — PASS (21 files, no issues)
- frontend: `npm ci` / `npm run check` (0 errors) / `vitest run` (1842 tests) / `npm run build` — PASS
- `pytest tests/ --ignore=tests/integration -n auto` — PASS (6337 passed; 2 known-flaky `test_web_server` tests failed under parallel load, **confirmed green re-run in isolation**: 184 passed)
- `uv build` smoke — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)