### PR TITLE
test(MOR-237): fix 3.12 GC-finalizer flake in civ-rx short-frame test

### DIFF
--- a/tests/test_civ_rx_short_frame_robustness.py
+++ b/tests/test_civ_rx_short_frame_robustness.py
@@ -78,7 +78,20 @@ def test_short_freq_frame_does_not_raise_or_corrupt_state(
 
     # No error-level spam (the old code emitted "BCD data must be exactly..."
     # exceptions caught at debug; now we skip without ever invoking the decoder).
-    for record in caplog.records:
+    #
+    # Scope the assertion to the logger under test (``rigplane.runtime._civ_rx``
+    # and its children) only. Capturing global/root logging would let unrelated
+    # warnings fail the test — e.g. the ``Radio`` finalizer's "Radio collected
+    # with active connection/tasks" warning, which the GC can emit inside this
+    # capture window (timing differs across 3.11/3.12/3.13) from a different
+    # component entirely. The test's intent is purely about ``_civ_rx``.
+    civ_rx_logger = "rigplane.runtime._civ_rx"
+    civ_rx_records = [
+        record
+        for record in caplog.records
+        if record.name == civ_rx_logger or record.name.startswith(civ_rx_logger + ".")
+    ]
+    for record in civ_rx_records:
         assert record.levelno < logging.WARNING, (
             f"unexpected non-debug log: {record.levelname} {record.getMessage()}"
         )


### PR DESCRIPTION
## Problem

The `publish.yml` full-matrix `validate (3.12)` job failed and nothing was published for v2.7.0:

```
FAILED tests/test_civ_rx_short_frame_robustness.py::test_short_freq_frame_does_not_raise_or_corrupt_state[3-]
  AssertionError: unexpected non-debug log: WARNING Radio collected with active connection/tasks; ensure disconnect() or async with is used.
```

## Root cause

`test_short_freq_frame_does_not_raise_or_corrupt_state` (added by MOR-237 #1689) asserts that handling a short CI-V freq frame produces only DEBUG-level logs. It already calls `caplog.at_level(logging.DEBUG, logger="rigplane.runtime._civ_rx")`, but the assertion loop then iterated over **all** `caplog.records` regardless of logger name.

The offending `WARNING` comes from `rigplane.runtime.radio` — the `Radio` finalizer (`__del__`), which emits `"Radio collected with active connection/tasks…"` when a `Radio` is garbage-collected without a clean `disconnect()`. The test helper `_make_radio()` constructs such a `Radio`. On Python 3.12 the GC finalized one of these objects **inside the test's log-capture window**, so the unrelated warning landed in `caplog.records` and tripped the assertion. On 3.13 the GC timing differed and the warning fell outside the window, so it stayed green. This is a test-isolation bug — the production code is correct.

## Fix

Scope the assertion to records whose logger name is `rigplane.runtime._civ_rx` (or its children), matching the `caplog.at_level` filter already present. Unrelated warnings from other components (the Radio finalizer) can no longer fail the test, and the result is deterministic across 3.11/3.12/3.13.

The test still proves its real intent: short/partial/over-long freq frames emit **no** warning/error from `_civ_rx`, no `BCD data must be exactly 5 bytes`, and no state corruption. All parametrized cases are retained.

## Verification

- Reproduced on 3.12: failed before the fix, passes after (`uv run --python 3.12 pytest tests/test_civ_rx_short_frame_robustness.py -q` → 12 passed).
- Default interpreter: 12 passed.
- 3.12 slice `-k "civ or serial or x6200"`: 615 passed, 4 skipped, 2 xfailed.
- `ruff check` + `ruff format --check` clean; `uv.lock` churn reverted.

Unblocks the v2.7.0 PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)