### PR TITLE
fix(MOR-238): clamp USB audio channels to device capability

### DIFF
--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -111,6 +111,7 @@ class UsbAudioStreamContract:
     channels: int
     frame_ms: int
     sample_rate_source: str
+    channel_source: str = "requested"
     fallback_reason: str | None = None
 
     def to_dict(self) -> dict[str, object]:
@@ -121,6 +122,7 @@ class UsbAudioStreamContract:
             "channels": self.channels,
             "frame_ms": self.frame_ms,
             "sample_rate_source": self.sample_rate_source,
+            "channel_source": self.channel_source,
         }
         if self.fallback_reason:
             payload["fallback_reason"] = self.fallback_reason
@@ -480,6 +482,35 @@ class UsbAudioDriver:
     def _sample_rate_candidates(self, requested: int) -> tuple[int, ...]:
         return tuple(dict.fromkeys((requested, *_DEFAULT_SAMPLE_RATE_CANDIDATES)))
 
+    def _clamp_channels(
+        self,
+        *,
+        direction: str,
+        device: UsbAudioDevice,
+        requested_channels: int,
+    ) -> tuple[int, str, str | None]:
+        """Clamp requested channels to the device's real capability (MOR-238).
+
+        A profile / codec may request stereo from a device that only exposes a
+        mono capture (or playback) endpoint. PortAudio rejects that open with
+        PaErrorCode -9998 ("Invalid number of channels"). Mirroring the
+        sample-rate negotiation, the effective channel count is clamped down to
+        what the device advertises so any mono/stereo USB codec self-heals
+        without a per-profile ``codec_preference`` entry. Downstream DSP is
+        48 kHz mono, so a 1-channel capture feeds the broadcaster cleanly.
+        """
+
+        device_max = (
+            device.input_channels if direction == "rx" else device.output_channels
+        )
+        # A device advertising zero channels for this direction is a selection
+        # bug, not a clamp target — leave the request untouched and let the
+        # open surface the real error.
+        if device_max >= 1 and requested_channels > device_max:
+            reason = f"channels-{requested_channels}-clamped-to-device-{device_max}"
+            return device_max, "device-clamp", reason
+        return requested_channels, "requested", None
+
     def _resolve_stream_contract(
         self,
         *,
@@ -491,6 +522,11 @@ class UsbAudioDriver:
         allow_sample_rate_fallback: bool,
     ) -> UsbAudioStreamContract:
         device_id = AudioDeviceId(device.index)
+        effective_channels, channel_source, channel_reason = self._clamp_channels(
+            direction=direction,
+            device=device,
+            requested_channels=channels,
+        )
         if self._backend.check_sample_rate(
             device_id,
             requested_sample_rate,
@@ -501,9 +537,11 @@ class UsbAudioDriver:
                 direction=direction,
                 device=device,
                 sample_rate_hz=requested_sample_rate,
-                channels=channels,
+                channels=effective_channels,
                 frame_ms=frame_ms,
                 sample_rate_source=source,
+                channel_source=channel_source,
+                fallback_reason=channel_reason,
             )
 
         if not allow_sample_rate_fallback:
@@ -521,16 +559,21 @@ class UsbAudioDriver:
                 candidate,
                 direction=direction,
             ):
+                sample_reason = f"sample-rate-{requested_sample_rate}-unsupported"
+                fallback_reason = (
+                    f"{sample_reason}; {channel_reason}"
+                    if channel_reason
+                    else sample_reason
+                )
                 return UsbAudioStreamContract(
                     direction=direction,
                     device=device,
                     sample_rate_hz=candidate,
-                    channels=channels,
+                    channels=effective_channels,
                     frame_ms=frame_ms,
                     sample_rate_source="fallback",
-                    fallback_reason=(
-                        f"sample-rate-{requested_sample_rate}-unsupported"
-                    ),
+                    channel_source=channel_source,
+                    fallback_reason=fallback_reason,
                 )
 
         raise AudioDriverLifecycleError(
@@ -595,18 +638,21 @@ class UsbAudioDriver:
             # RX frames reaching the browser.
             logger.info(
                 "usb-audio: opening RX capture — device=[%d] %s, %d Hz, "
-                "%d ch, %d ms (device input_channels=%d)",
+                "%d ch (requested %d, source=%s), %d ms "
+                "(device input_channels=%d)",
                 selected_rx.index,
                 selected_rx.name,
                 contract.sample_rate_hz,
+                contract.channels,
                 ch,
+                contract.channel_source,
                 fm,
                 selected_rx.input_channels,
             )
             self._rx_stream = self._backend.open_rx(
                 AudioDeviceId(selected_rx.index),
                 sample_rate=contract.sample_rate_hz,
-                channels=ch,
+                channels=contract.channels,
                 frame_ms=fm,
             )
             await self._rx_stream.start(callback)
@@ -657,7 +703,7 @@ class UsbAudioDriver:
             self._tx_stream = self._backend.open_tx(
                 AudioDeviceId(selected_tx.index),
                 sample_rate=contract.sample_rate_hz,
-                channels=ch,
+                channels=contract.channels,
                 frame_ms=fm,
             )
             await self._tx_stream.start()

--- a/tests/test_usb_audio_channel_clamp_mor238.py
+++ b/tests/test_usb_audio_channel_clamp_mor238.py
@@ -1,0 +1,267 @@
+"""Regression tests for MOR-238 — clamp USB audio channels to device capability.
+
+USB RX/TX channel count is derived from the codec (``_CHANNELS_BY_CODEC`` /
+``_serial_audio_channels_for_codec``), not from the device. A mono USB codec
+(1 input channel) whose profile lacks a mono ``codec_preference`` entry made the
+driver request a 2-channel ``InputStream`` → PortAudio PaErrorCode -9998
+("Invalid number of channels") → 0 RX frames / silent LIVE audio. This is the
+class of bug behind MOR-236, which was worked around per-profile.
+
+Sample rate already auto-negotiates against the device. These tests pin that the
+channel count is now device-capability-aware too: ``UsbAudioDriver`` clamps the
+open to ``device.input_channels`` (RX) / ``device.output_channels`` (TX), so any
+mono/stereo USB codec self-heals with no per-profile entry — including the X6200
+path with its ``codec_preference`` removed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from rigplane.audio.backend import (
+    AudioDeviceId,
+    AudioDeviceInfo,
+    FakeRxStream,
+    FakeTxStream,
+)
+from rigplane.audio.usb_driver import UsbAudioDriver
+from rigplane.backends.ic705.serial import Ic705SerialRadio
+from rigplane.types import AudioCodec
+
+
+class _StrictChannelBackend:
+    """Fake backend that rejects any open whose channel count ≠ device capability.
+
+    Reproduces PortAudio's -9998 ("Invalid number of channels") so a test only
+    passes if the driver clamps the requested channels to what the device
+    actually exposes before opening the stream.
+    """
+
+    def __init__(self, *, input_channels: int = 1, output_channels: int = 1) -> None:
+        self._device = AudioDeviceInfo(
+            id=AudioDeviceId(0),
+            name="USB Audio Device",
+            input_channels=input_channels,
+            output_channels=output_channels,
+            default_samplerate=48_000,
+            is_default_input=True,
+            is_default_output=True,
+        )
+        self.rx_streams: list[FakeRxStream] = []
+        self.tx_streams: list[FakeTxStream] = []
+        self.rx_open_channels: list[int] = []
+        self.tx_open_channels: list[int] = []
+
+    def list_devices(self) -> list[AudioDeviceInfo]:
+        return [self._device]
+
+    def check_sample_rate(
+        self, device: AudioDeviceId, sample_rate: int, *, direction: str = "rx"
+    ) -> bool:
+        return sample_rate in (48_000, 24_000, 16_000, 8_000)
+
+    def open_rx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> FakeRxStream:
+        self.rx_open_channels.append(channels)
+        if channels != self._device.input_channels:
+            raise RuntimeError(
+                "Error opening InputStream: Invalid number of channels "
+                f"[requested {channels}, device exposes "
+                f"{self._device.input_channels}]"
+            )
+        stream = FakeRxStream()
+        self.rx_streams.append(stream)
+        return stream
+
+    def open_tx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> FakeTxStream:
+        self.tx_open_channels.append(channels)
+        if channels != self._device.output_channels:
+            raise RuntimeError(
+                "Error opening OutputStream: Invalid number of channels "
+                f"[requested {channels}, device exposes "
+                f"{self._device.output_channels}]"
+            )
+        stream = FakeTxStream()
+        self.tx_streams.append(stream)
+        return stream
+
+
+class _FakeSerialCivLink:
+    """Minimal serial CI-V link double so the radio reports ``connected``."""
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.ready = False
+        self.healthy = False
+
+    async def connect(self) -> None:
+        self.connected = True
+        self.ready = True
+        self.healthy = True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+        self.ready = False
+        self.healthy = False
+
+    async def send(self, frame: bytes) -> None:
+        _ = frame
+
+    async def receive(self, timeout: float | None = None) -> bytes | None:
+        await asyncio.sleep(0.02 if timeout is None else min(timeout, 0.02))
+        return None
+
+
+@pytest.mark.asyncio
+async def test_rx_stereo_request_clamps_to_mono_device() -> None:
+    """A 2-channel RX request opens at 1 ch on a mono-input device."""
+    backend = _StrictChannelBackend(input_channels=1)
+    driver = UsbAudioDriver(serial_port=None, backend=backend)
+    received: list[bytes] = []
+
+    await driver.start_rx(received.append, channels=2)
+
+    assert driver.rx_running
+    assert backend.rx_open_channels == [1]
+    contract = driver.usb_audio_contract
+    assert contract is not None and contract.rx is not None
+    assert contract.rx.channels == 1
+    assert contract.rx.channel_source == "device-clamp"
+    assert contract.rx.fallback_reason == "channels-2-clamped-to-device-1"
+
+    pcm = b"\x10\x20" * 480
+    backend.rx_streams[0].inject_frame(pcm)
+    assert received == [pcm]
+    await driver.stop_rx()
+
+
+@pytest.mark.asyncio
+async def test_tx_stereo_request_clamps_to_mono_device() -> None:
+    """A 2-channel TX request opens at 1 ch on a mono-output device."""
+    backend = _StrictChannelBackend(output_channels=1)
+    driver = UsbAudioDriver(serial_port=None, backend=backend)
+
+    await driver.start_tx(channels=2)
+
+    assert driver.tx_running
+    assert backend.tx_open_channels == [1]
+    contract = driver.usb_audio_contract
+    assert contract is not None and contract.tx is not None
+    assert contract.tx.channels == 1
+    assert contract.tx.channel_source == "device-clamp"
+    await driver.stop_tx()
+
+
+@pytest.mark.asyncio
+async def test_stereo_device_request_is_unchanged() -> None:
+    """A stereo request on a stereo device is passed through verbatim."""
+    backend = _StrictChannelBackend(input_channels=2, output_channels=2)
+    driver = UsbAudioDriver(serial_port=None, backend=backend)
+
+    await driver.start_rx(lambda _frame: None, channels=2)
+
+    assert backend.rx_open_channels == [2]
+    contract = driver.usb_audio_contract
+    assert contract is not None and contract.rx is not None
+    assert contract.rx.channels == 2
+    assert contract.rx.channel_source == "requested"
+    assert contract.rx.fallback_reason is None
+    await driver.stop_rx()
+
+
+@pytest.mark.asyncio
+async def test_mono_request_on_stereo_device_not_upmixed() -> None:
+    """A mono request is never raised to the device max (clamp only narrows)."""
+    backend = _StrictChannelBackend(input_channels=2, output_channels=2)
+    backend._device = AudioDeviceInfo(  # type: ignore[attr-defined]
+        id=AudioDeviceId(0),
+        name="USB Audio Device",
+        input_channels=2,
+        output_channels=2,
+        default_samplerate=48_000,
+        is_default_input=True,
+        is_default_output=True,
+    )
+    driver = UsbAudioDriver(serial_port=None, backend=backend)
+
+    # A 1-ch request must stay 1-ch even though the device exposes 2 inputs;
+    # the strict backend would raise if the driver upmixed to 2.
+    with pytest.raises(RuntimeError, match="Invalid number of channels"):
+        await driver.start_rx(lambda _frame: None, channels=1)
+    assert backend.rx_open_channels == [1]
+
+
+@pytest.mark.asyncio
+async def test_zero_channel_device_is_not_clamped_to_zero() -> None:
+    """A device advertising 0 channels for the direction is left untouched.
+
+    Clamping to 0 would silently open an unusable stream; instead the request
+    passes through so the open surfaces the real selection error.
+    """
+    backend = _StrictChannelBackend(input_channels=0, output_channels=2)
+    driver = UsbAudioDriver(serial_port=None, backend=backend)
+
+    # Device selection picks the device; the open then requests the real
+    # requested channel count (2), which the 0-input device rejects.
+    with pytest.raises(Exception):
+        await driver.start_rx(lambda _frame: None, channels=2)
+    # The clamp must not have rewritten the request down to 0 channels.
+    assert 0 not in backend.rx_open_channels
+
+
+@pytest.mark.asyncio
+async def test_x6200_path_self_heals_without_codec_preference() -> None:
+    """The X6200 mono capture flows even when the codec asks for stereo.
+
+    Proves the clamp alone suffices: the radio is built with the *default*
+    stereo ``PCM_2CH_16BIT`` codec (i.e. as if the X6200 profile's
+    ``codec_preference`` were removed). The serial path derives 2 channels from
+    that codec, but the driver clamps the open to the mono device and RX PCM
+    still reaches the radio callback. The profile entry stays in place as
+    belt-and-suspenders; this test guards that the clamp is the load-bearing
+    fix.
+    """
+    backend = _StrictChannelBackend(input_channels=1, output_channels=1)
+    audio_driver = UsbAudioDriver(serial_port=None, backend=backend)
+    radio = Ic705SerialRadio(
+        device="/dev/tty.usbmodem-X6200",
+        model="X6200",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=audio_driver,
+    )
+    # Emulate the X6200 profile with its mono ``codec_preference`` REMOVED: the
+    # resolved codec falls back to the global stereo default. (The profile entry
+    # stays in the tree as belt-and-suspenders; we override only the resolved
+    # codec here to prove the clamp — not the profile entry — is load-bearing.)
+    radio._audio_codec = AudioCodec.PCM_2CH_16BIT
+    assert radio._serial_audio_channels_for_codec() == 2
+
+    await radio.connect()
+    packets: list[bytes] = []
+    try:
+        await radio.start_audio_rx_opus(lambda pkt: packets.append(pkt.data))
+        assert len(backend.rx_streams) == 1, "RX capture did not open"
+        assert backend.rx_open_channels == [1], "channels were not clamped to mono"
+        pcm_frame = b"\xab\xcd" * 480
+        backend.rx_streams[0].inject_frame(pcm_frame)
+        await asyncio.sleep(0.01)
+        # PCM codec → no Opus transcode → raw mono PCM forwarded verbatim.
+        assert packets == [pcm_frame]
+    finally:
+        await radio.stop_audio_rx_opus()
+        await radio.disconnect()

--- a/tests/test_x6200_rx_audio_mor236.py
+++ b/tests/test_x6200_rx_audio_mor236.py
@@ -131,12 +131,23 @@ def test_x6200_profile_resolves_mono_rx_codec() -> None:
 
 
 @pytest.mark.asyncio
-async def test_usb_driver_rx_rejects_stereo_on_mono_device() -> None:
-    """Opening a 2-channel capture on a mono device fails (MOR-236 mode)."""
-    driver = UsbAudioDriver(serial_port=None, backend=_MonoUsbAudioBackend())
-    with pytest.raises(RuntimeError, match="Invalid number of channels"):
-        await driver.start_rx(lambda _frame: None, channels=2)
-    assert not driver.rx_running
+async def test_usb_driver_rx_clamps_stereo_on_mono_device() -> None:
+    """A stereo request on a mono device clamps to 1 ch (MOR-238 self-heal).
+
+    Before MOR-238 this raised PortAudio's -9998 "Invalid number of channels"
+    (the MOR-236 failure mode). The driver now clamps the open to the device's
+    real ``input_channels`` so the capture starts regardless of the requested
+    codec's channel count.
+    """
+    backend = _MonoUsbAudioBackend()
+    driver = UsbAudioDriver(serial_port=None, backend=backend)
+    await driver.start_rx(lambda _frame: None, channels=2)
+    assert driver.rx_running
+    contract = driver.usb_audio_contract
+    assert contract is not None and contract.rx is not None
+    assert contract.rx.channels == 1
+    assert contract.rx.channel_source == "device-clamp"
+    await driver.stop_rx()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

USB audio RX/TX channel count was derived purely from the codec
(`_CHANNELS_BY_CODEC` in `audio/route.py`, `_serial_audio_channels_for_codec`
in `_icom_serial_base.py`), never from the device. The global default codec is
`PCM_2CH_16BIT` (stereo), so a mono USB codec (1 input channel) whose profile
lacks a mono `codec_preference` entry made `UsbAudioDriver` request a 2-channel
stream → PortAudio **-9998 ("Invalid number of channels")** → capture fails →
0 RX frames / silent LIVE audio. This is the class of bug behind MOR-236, which
was worked around by adding a `codec_preference` entry to the X6200 profile.

Sample rate already auto-negotiated against the device; channels did not.

## Fix

Make the open channel count device-capability-aware, mirroring the existing
sample-rate negotiation:

- New `UsbAudioDriver._clamp_channels` clamps the requested channel count to the
  device's real capability — `min(requested, device.input_channels)` for RX,
  `output_channels` for TX.
- `_resolve_stream_contract` records the effective channel count plus a
  `channel_source` (`requested` / `device-clamp`) and a `fallback_reason` on the
  `UsbAudioStreamContract` (now also surfaced in `to_dict()`), just like the
  sample-rate fallback.
- `start_rx` / `start_tx` open the stream with `contract.channels` instead of
  the raw requested `ch` (previously the contract was computed but the open
  still used the unclamped value).

The clamp only **narrows**, never upmixes (a mono request on a stereo device
stays mono), and a device advertising **0** channels for the direction is left
untouched so the open surfaces the real selection error rather than silently
opening a 0-channel stream. Downstream DSP is 48 kHz mono, so a clamped
1-channel capture feeds the broadcaster cleanly with no transcode mismatch
(PCM passes through verbatim).

After this, **any** mono/stereo USB codec self-heals with no per-profile entry.
The X6200 `codec_preference` is **kept** as belt-and-suspenders.

## Where channels are now resolved

`UsbAudioDriver._resolve_stream_contract` → `_clamp_channels` (RX/TX device-open
boundary in `src/rigplane/audio/usb_driver.py`). The profile/codec-derived count
is still the *request*; the device capability is the *ceiling*.

## Tests

- **New** `tests/test_usb_audio_channel_clamp_mor238.py`: RX clamp on a mono
  device, TX clamp on a mono device, stereo-device passthrough (unchanged),
  mono-request-not-upmixed, the 0-channel guard, and X6200 self-heal with the
  resolved codec forced to the stereo default (i.e. `codec_preference` removed —
  proving the clamp alone suffices, without touching the profile).
- **Updated** `tests/test_x6200_rx_audio_mor236.py`: the driver-level case flips
  from `test_usb_driver_rx_rejects_stereo_on_mono_device` (pinned the bug) to
  `test_usb_driver_rx_clamps_stereo_on_mono_device` (pins the self-heal). The
  root-cause profile guard and broadcaster e2e are unchanged.

## Gate results

- `uv run pytest tests/ -q --ignore=tests/integration` → **6295 passed, 57 skipped, 11 xfailed, 1 xpassed**
- `uv run pytest tests/ -k "audio or usb or route or channel"` → **955 passed, 13 skipped**
- `uv run ruff check src/ tests/` → clean; `ruff format` applied
- `uv run mypy src/` → no new errors in changed files (pre-existing errors in `scope/render.py`, `runtime/_civ_rx.py`, `yaesu_cat/radio.py` only)

## Hardware-validation checklist (could not run — no hardware access)

- [ ] **X6200 (mono USB codec)**: connect over serial/USB, open LIVE audio in the
  web UI, confirm RX frames flow (waterfall/meter moves, audio audible). Then
  temporarily remove the `codec_preference` entry from the X6200 profile and
  confirm RX still works (clamp alone) — expect log line
  `usb-audio: opening RX capture … 1 ch (requested 2, source=device-clamp) …`.
- [ ] **Stereo-capable radio** (e.g. an IC USB-audio rig with a 2-in codec):
  confirm RX/TX still open at 2 channels unchanged (`source=requested`), no
  regression in audio quality.
- [ ] Confirm TX (USB playback) path is unaffected on both mono and stereo devices.

Independent agent review pending (implementation agent cannot self-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)