### PR TITLE
chore(release): bump to 2.7.1 — clamp USB audio channels to device capability (MOR-238)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] — 2026-05-29
+
+### Fixed
+- USB audio now clamps the requested channel count to the device's real
+  capability (`input_channels` for RX, `output_channels` for TX) at stream
+  open, mirroring the existing sample-rate negotiation. Any mono USB codec
+  self-heals instead of failing the global stereo default with PortAudio
+  `-9998` ("Invalid number of channels") and starving the stream; the Xiegu
+  X6200 mono RX path no longer depends on its profile `codec_preference`
+  entry (verified on hardware). The effective channel count and its source
+  are recorded on the stream contract for diagnostics (#1692).
+
 ## [2.7.0] — 2026-05-29
 
 ### Added
@@ -1523,7 +1535,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.7.0...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.7.1...HEAD
+[2.7.1]: https://github.com/rigplane/rigplane-core/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/rigplane/rigplane-core/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/rigplane/rigplane-core/compare/v2.5.1...v2.6.0
 [2.5.1]: https://github.com/rigplane/rigplane-core/compare/v2.5.0...v2.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.7.0"
+version = "2.7.1"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release **v2.7.1** (PATCH). Version bump + CHANGELOG only — no code changes.

Bundles the single change merged since v2.7.0:
- **MOR-238 / #1692** — clamp USB audio channels to device capability. Mono USB codecs self-heal instead of failing the global stereo default with PortAudio `-9998`. HW-validated on the X6200 (stereo request → clamps to 1ch → real audio, rms≈350) and a real stereo-input device (unchanged).

## Files
- `pyproject.toml` — `2.7.0` → `2.7.1`
- `docs/CHANGELOG.md` — `[2.7.1]` Fixed entry + footer links

## Pre-flight (mirrors publish.yml validate — all green)
- ruff check + format, `lint-imports` (4 contracts kept), `mypy --strict src/rigplane/web` (0 issues)
- pytest (no integration): 6295 passed, 57 skipped, 11 xfailed, 1 xpassed
- frontend: svelte-check 0 errors/0 warnings, vitest 1842 passed, build OK
- `uv build` smoke OK

After merge, `v2.7.1` will be tagged on the squash-merge commit and `gh release create` will trigger `publish.yml` → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)