### PR TITLE
fix(MOR-239): resume AudioContext on LIVE gesture so RX audio plays

### DIFF
--- a/frontend/src/lib/audio/__tests__/rx-player.test.ts
+++ b/frontend/src/lib/audio/__tests__/rx-player.test.ts
@@ -248,3 +248,79 @@ describe('RxPlayer jitter bounds (#1363)', () => {
     p.stop();
   });
 });
+
+describe('RxPlayer suspended-context recovery (MOR-239)', () => {
+  it('start() resumes a context that is created suspended (WKWebView autoplay)', () => {
+    ctx.state = 'suspended';
+    const p = new RxPlayer();
+    p.start();
+    expect(ctx.resume).toHaveBeenCalled();
+    p.stop();
+  });
+
+  it('drops the frame while suspended but re-attempts resume and warns (not silent)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    ctx.state = 'suspended';
+    const p = new RxPlayer();
+    p.start();
+    ctx.resume.mockClear();
+
+    p.feed(pcm16(480));
+
+    // Frame can't play on a suspended ctx, but instead of a silent return
+    // we re-attempt resume() and surface a warning so it's observable.
+    expect(ctx.createBufferSource).not.toHaveBeenCalled();
+    expect(ctx.resume).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+    p.stop();
+    warn.mockRestore();
+  });
+
+  it('plays frames once the context has resumed to running', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    ctx.state = 'suspended';
+    const p = new RxPlayer();
+    p.start();
+    p.feed(pcm16(480));           // dropped — suspended
+    expect(ctx._lastSrc).toBeNull();
+
+    ctx.state = 'running';        // resume() honoured by the gesture
+    p.feed(pcm16(480));           // now audible
+    expect(ctx.createBufferSource).toHaveBeenCalled();
+    expect(ctx._lastSrc.start).toHaveBeenCalled();
+    p.stop();
+    warn.mockRestore();
+  });
+
+  it('re-attempts resume on focus/visibility regain (WKWebView re-suspend)', () => {
+    ctx.state = 'suspended';
+    const p = new RxPlayer();
+    p.start();
+    ctx.resume.mockClear();
+    window.dispatchEvent(new Event('focus'));
+    expect(ctx.resume).toHaveBeenCalled();
+    p.stop();
+    // After stop the listener must be gone — no further resume calls.
+    ctx.resume.mockClear();
+    window.dispatchEvent(new Event('focus'));
+    expect(ctx.resume).not.toHaveBeenCalled();
+  });
+});
+
+describe('RxPlayer mono routing (MOR-239)', () => {
+  it('routes a mono (1-ch) PCM16 buffer to the audible MAIN channel', () => {
+    const p = new RxPlayer();
+    p.start();                    // default focus='both' → MAIN gain audible
+    p.feed(pcm16(480));           // header marks 1 channel
+
+    // Mono buffer allocated as 1 channel...
+    expect(ctx.createBuffer).toHaveBeenCalledWith(1, 480, SAMPLE_RATE);
+    // ...fed into preGain (→ splitter[0] → mainGain → mainPanner → destination).
+    const [preGain, mainGain] = ctx._gains;
+    expect(ctx._lastSrc.connect).toHaveBeenCalledWith(preGain);
+    // MAIN channel must carry audible gain so mono lands on an output, not
+    // only on the silenced SUB (channel 1) of the splitter.
+    expect(mainGain.gain.value).toBeGreaterThan(0);
+    p.stop();
+  });
+});

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -228,6 +228,10 @@ class AudioManager {
       setAudioConnected(true);
       console.log('[audio-ws] connected');
       if (this._rxEnabled) {
+        // Idempotent resume nudge: if the AudioContext re-entered
+        // 'suspended' while the WS was down (WKWebView backgrounding), wake
+        // it as we resubscribe so streamed frames are not dropped.
+        this.rxPlayer.start();
         ws.send(JSON.stringify({
           type: 'audio_start',
           direction: 'rx',

--- a/frontend/src/lib/audio/rx-player.ts
+++ b/frontend/src/lib/audio/rx-player.ts
@@ -51,6 +51,12 @@ export class RxPlayer {
   private _floorSec = 0.05;
   private _ceilingSec = 0.30;
 
+  // Count of frames dropped because the context was suspended (autoplay
+  // policy). Surfaced via console.warn so a silent no-audio state is
+  // observable instead of invisible. Reset once the context resumes.
+  private _droppedSuspendedFrames = 0;
+  private _resumeListenersAttached = false;
+
   get volume(): number {
     return this._volume;
   }
@@ -104,9 +110,18 @@ export class RxPlayer {
     return this.ctx !== null && this.ctx.state !== 'closed';
   }
 
+  /** Start (or resume) playback.
+   *
+   * MUST be called synchronously from a user-gesture handler (e.g. the LIVE
+   * button click): WKWebView / mobile-Safari autoplay policy only honours
+   * ``AudioContext.resume()`` when it runs inside the gesture's call stack.
+   * Calling again on an existing context is a cheap idempotent resume — the
+   * AudioManager re-invokes start() on ``audio_start`` and reconnect to keep
+   * nudging a context that re-entered ``suspended``.
+   */
   start(): void {
     if (this.ctx) {
-      if (this.ctx.state === 'suspended') this.ctx.resume();
+      this._resume();
       return;
     }
     const Ctx = globalThis.AudioContext ?? (globalThis as any).webkitAudioContext;
@@ -129,9 +144,8 @@ export class RxPlayer {
     this.subPanner.connect(this.ctx.destination);
     this._applyGraphState();
     this.nextPlayTime = 0;
-    if (this.ctx.state === 'suspended') {
-      this.ctx.resume().catch(() => {});
-    }
+    this._attachResumeListeners();
+    this._resume();
   }
 
   stop(): void {
@@ -139,6 +153,7 @@ export class RxPlayer {
       try { this.decoder.close(); } catch { /* ok */ }
       this.decoder = null;
     }
+    this._detachResumeListeners();
     if (this.ctx) {
       this.ctx.close().catch(() => {});
       this.ctx = null;
@@ -151,6 +166,66 @@ export class RxPlayer {
     }
     this.nextPlayTime = 0;
     this.opusTs = 0;
+    this._droppedSuspendedFrames = 0;
+  }
+
+  /** Best-effort resume of a suspended context. Safe to call repeatedly. */
+  private _resume(): void {
+    if (this.ctx && this.ctx.state === 'suspended') {
+      this.ctx.resume().catch(() => {});
+    }
+  }
+
+  /** Resume-on-regain-focus handler: WKWebView re-suspends an AudioContext
+   *  when the webview is backgrounded; resume it when we come back. Bound as
+   *  an arrow property so add/removeEventListener see a stable reference. */
+  private _onResumeEvent = (): void => {
+    this._resume();
+  };
+
+  private _attachResumeListeners(): void {
+    if (this._resumeListenersAttached) return;
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', this._onResumeEvent);
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('focus', this._onResumeEvent);
+    }
+    this._resumeListenersAttached = true;
+  }
+
+  private _detachResumeListeners(): void {
+    if (!this._resumeListenersAttached) return;
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this._onResumeEvent);
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('focus', this._onResumeEvent);
+    }
+    this._resumeListenersAttached = false;
+  }
+
+  /** Returns true when frames can be scheduled (context running). When the
+   *  context is suspended this re-attempts resume() and warns — rather than
+   *  silently dropping every frame, which previously made a stuck-suspended
+   *  context (no sound, blank scope) impossible to diagnose. */
+  private _ensureRunning(): boolean {
+    if (!this.ctx) return false;
+    if (this.ctx.state === 'running') {
+      this._droppedSuspendedFrames = 0;
+      return true;
+    }
+    if (this.ctx.state === 'suspended') {
+      this._resume();
+      this._droppedSuspendedFrames++;
+      if (this._droppedSuspendedFrames <= 3 || this._droppedSuspendedFrames % 200 === 0) {
+        console.warn(
+          `RxPlayer: AudioContext suspended — dropped ${this._droppedSuspendedFrames} ` +
+          `frame(s), retrying resume(). Audio needs a user gesture (click LIVE).`,
+        );
+      }
+    }
+    return false;
   }
 
   /** Feed a raw binary frame from WS */
@@ -174,7 +249,7 @@ export class RxPlayer {
 
   private playPcm16(payload: Uint8Array, sr: number, ch: number): void {
     if (!this.ctx || !this.preGain) return;
-    if (this.ctx.state === 'suspended') return;
+    if (!this._ensureRunning()) return;
     const channels = ch === 2 ? 2 : 1;
     const frameCount = Math.floor(payload.byteLength / (2 * channels));
     if (frameCount <= 0) return;
@@ -194,7 +269,7 @@ export class RxPlayer {
 
   private decodeOpus(payload: Uint8Array, sr: number, ch: number): void {
     if (!this.ctx || !this.preGain) return;
-    if (this.ctx.state === 'suspended') return;
+    if (!this._ensureRunning()) return;
     if (typeof AudioDecoder === 'undefined') return;
 
     if (!this.decoder) {


### PR DESCRIPTION
## Summary

Fixes **MOR-239** — the last blocker for rigplane-pro beta.7 LIVE audio. On desktop (Tauri WKWebView) the RX AUDIO **LIVE / Browser audio stream** produced **no sound** and a **blank Audio Scope**, even though the backend was streaming real PCM16 MONO frames over the audio WS (confirmed: USB capture RMS −40.5 dBFS, server log `audio: sent frame #1 … #425`).

## Confirmed root cause

Frontend, not capture/backend. Under the WKWebView / mobile-Safari **autoplay policy** an `AudioContext` starts (and can re-enter) `suspended`. `RxPlayer.playPcm16()` / `decodeOpus()` then **silently `return`ed for every frame** when `ctx.state === 'suspended'`, so nothing was ever scheduled → no audio. The async `resume().catch(() => {})` in `start()` was the only resume attempt and was easily lost.

Mono routing was re-checked and is **not** the cause: a 1-ch buffer up-mixes to `splitter[0] → mainGain → mainPanner → destination`, and `mainGain` is audible under the default `focus='both'`.

## Fix

- **Resume inside the user gesture** — `start()` resumes synchronously in the LIVE-button click stack (`onclick → onMonitorModeChange('live') → AudioManager.startRx → RxPlayer.start`), the only place WKWebView honours `resume()`. Idempotent when re-invoked.
- **Re-nudge resume** on every `audio_start` / WS (re)connect (`AudioManager.onopen`).
- **Resume on focus/visibility regain** — WKWebView re-suspends a backgrounded webview; `visibilitychange` + window `focus` listeners re-attempt resume (attached on `start`, torn down on `stop`).
- **No more silent drops** — `_ensureRunning()` re-attempts `resume()` and emits a throttled `console.warn` when frames are dropped due to a suspended context, so the state is diagnosable. Frames flow as soon as the context reaches `running`.

## Tests / gates (in worktree, off latest `main`)

- `npm test` — **1847 passed** (4 new MOR-239 tests: suspended→resume+warn, resume-then-play, focus-regain resume + listener teardown, mono→audible-MAIN routing)
- `npm run lint` — clean
- `npm run check` (svelte-check + tsc) — **0 errors / 0 warnings**
- `npm run build` — success

## Manual hardware-validation checklist (cannot run desktop WebView here)

1. Launch rigplane-pro desktop (Tauri) build with this branch's frontend; connect the X6200 (USB audio + serial).
2. Open the web UI, click RX AUDIO **LIVE**.
3. Confirm **audible RX audio** from the host output.
4. Confirm the **Audio Scope shows a live waveform**.
5. Background the window / switch tabs, then refocus → audio resumes (no manual re-click).
6. With DevTools open, verify **no** repeating `RxPlayer: AudioContext suspended …` warnings during normal playback (a few at startup before the gesture resolves are acceptable).

> Independent agent review pending — implementation agent cannot self-review.