### PR TITLE
fix(MOR-241): dispatch audio FFT frames to /api/v1/audio-scope (fix blank scope on non-hw-scope radios)

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -413,10 +413,12 @@ class WebServer:
         _has_scope = (CAP_SCOPE in radio.capabilities) if radio is not None else False
         if radio is not None and _has_audio:
             self._audio_fft_scope = AudioFftScope(fft_size=2048, fps=20, avg_count=2)
-            self._audio_fft_scope.on_frame(self._broadcast_audio_scope)
+            # AudioFftScope.on_frame() is a single-slot setter: register one
+            # dispatch method that fans out to BOTH broadcasters. Registering
+            # twice would clobber the first callback (MOR-241).
+            self._audio_fft_scope.on_frame(self._dispatch_audio_fft_frame)
             if not _has_scope:
-                # No hardware scope — audio FFT also feeds /api/v1/scope
-                self._audio_fft_scope.on_frame(self._broadcast_scope)
+                # No hardware scope — audio FFT also feeds /api/v1/scope.
                 self._audio_broadcaster.set_pcm_tap(self._audio_fft_scope.feed_audio)
             logger.info(
                 "Audio FFT scope available (has_audio=%s, has_hw_scope=%s)",
@@ -608,6 +610,24 @@ class WebServer:
             )
             if self._radio is not None:
                 self._set_scope_data_callback(self._broadcast_scope)
+
+    def _dispatch_audio_fft_frame(self, frame: Any) -> None:
+        """Fan out an audio FFT frame to the relevant scope channels.
+
+        Single registered callback for :class:`AudioFftScope` (whose
+        ``on_frame`` is a single-slot setter). Always feeds the dedicated
+        ``/api/v1/audio-scope`` channel. For radios WITHOUT a hardware scope
+        the same frame also drives ``/api/v1/scope`` (the main panadapter),
+        since those radios derive their spectrum from RX audio. Hardware-scope
+        radios (e.g. IC-7610) keep ``/api/v1/scope`` sourced exclusively from
+        the real scope, so the audio FFT never touches it (MOR-241).
+        """
+        self._broadcast_audio_scope(frame)
+        _has_scope = (
+            CAP_SCOPE in self._radio.capabilities if self._radio is not None else False
+        )
+        if not _has_scope:
+            self._broadcast_scope(frame)
 
     def _broadcast_scope(self, frame: Any) -> None:
         """Broadcast scope frame to all registered handlers.

--- a/tests/integration/test_x6200_audio_scope_smoke.py
+++ b/tests/integration/test_x6200_audio_scope_smoke.py
@@ -1,0 +1,100 @@
+"""Hardware-gated smoke test for MOR-241 — X6200 AUDIO SCOPE delivers frames.
+
+Brings up the real ``/api/v1/audio-scope`` wiring against a physical Xiegu
+X6200 (serial CI-V + USB RX audio) and asserts that at least one FFT
+:class:`ScopeFrame` reaches the audio-scope channel within a few seconds.
+
+OFF BY DEFAULT. This test is double-gated and is skipped in a normal
+``uv run pytest tests/`` run:
+
+* it lives in ``tests/integration/`` (CLAUDE.md runs with
+  ``--ignore=tests/integration``);
+* it carries the ``serial_integration`` marker, so the integration conftest
+  skips it unless ``ICOM_SERIAL_DEVICE`` is configured;
+* it additionally requires ``RIGPLANE_HW_SMOKE=1`` (mirroring the
+  ``RIGPLANE_VALIDATION_ALLOW_HARDWARE`` opt-in style) so it never runs by
+  accident even inside a configured integration session.
+
+To run against attached hardware::
+
+    RIGPLANE_HW_SMOKE=1 \
+    ICOM_SERIAL_DEVICE=/dev/tty.usbmodemXXXX \
+    uv run pytest tests/integration/test_x6200_audio_scope_smoke.py \
+        -m serial_integration -o addopts=""
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from rigplane.backends.config import SerialBackendConfig
+from rigplane.backends.factory import create_radio
+from rigplane.capabilities import CAP_AUDIO, CAP_SCOPE
+from rigplane.scope import ScopeFrame
+from rigplane.web.server import WebConfig, WebServer
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.serial_integration,
+    pytest.mark.skipif(
+        os.getenv("RIGPLANE_HW_SMOKE") != "1",
+        reason="hardware smoke disabled (set RIGPLANE_HW_SMOKE=1 to run)",
+    ),
+]
+
+
+class _RecordingScopeHandler:
+    """Minimal audio-scope handler that records frames it is handed."""
+
+    def __init__(self) -> None:
+        self.frames: list[ScopeFrame] = []
+
+    def enqueue_frame(self, frame: ScopeFrame) -> None:
+        self.frames.append(frame)
+
+
+@pytest.mark.asyncio
+async def test_x6200_audio_scope_delivers_fft_frames_on_real_hardware(
+    serial_radio_config: dict,
+) -> None:
+    """A real X6200 with USB RX audio must relay >=1 FFT frame in a few seconds."""
+    radio = create_radio(
+        SerialBackendConfig(
+            device=serial_radio_config["device"],
+            baudrate=serial_radio_config["baudrate"],
+            radio_addr=serial_radio_config["radio_addr"],
+            model="X6200",
+        )
+    )
+    await radio.connect()
+    try:
+        assert CAP_AUDIO in radio.capabilities
+        assert CAP_SCOPE not in radio.capabilities, "X6200 must have no hardware scope"
+
+        server = WebServer(radio=radio, config=WebConfig())
+        assert server._audio_fft_scope is not None
+
+        # Make sure the FFT scope has a valid center frequency so feed_audio's
+        # center_freq>0 gate passes.
+        freq = await radio.get_frequency()
+        assert isinstance(freq, int) and freq > 0
+        server._audio_fft_scope.set_center_freq(freq)
+
+        handler = _RecordingScopeHandler()
+        # ensure_audio_scope_enabled wires the PCM tap + starts the relay so
+        # real RX audio drives the FFT, exactly like a connected browser would.
+        await server.ensure_audio_scope_enabled(handler)
+
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while not handler.frames and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.1)
+
+        assert len(handler.frames) >= 1, (
+            "no audio-scope FFT frames arrived from real X6200 within 5s"
+        )
+        assert isinstance(handler.frames[0], ScopeFrame)
+    finally:
+        await radio.disconnect()

--- a/tests/test_audio_scope_dispatch.py
+++ b/tests/test_audio_scope_dispatch.py
@@ -1,0 +1,265 @@
+"""Regression tests for MOR-241 — X6200 AUDIO SCOPE panel is blank.
+
+Root cause: ``AudioFftScope.on_frame()`` is a single-slot callback setter.
+``WebServer.__init__`` registered ``_broadcast_audio_scope`` (the
+``/api/v1/audio-scope`` relay) and then, for non-hardware-scope radios,
+*overwrote* it with ``_broadcast_scope`` (the ``/api/v1/scope`` relay). The
+second registration silently clobbered the first, so the audio-scope path
+received zero FFT frames and the AUDIO SCOPE panel rendered blank. IC-7610
+(``CAP_SCOPE`` present) skipped the second registration and was unaffected.
+
+The fix registers a single dispatch method that fans out to BOTH broadcasters
+for non-hardware-scope radios, while a hardware-scope radio drives ONLY the
+audio-scope path (so the IC-7610 main spectrum keeps coming from the real
+hardware scope, byte-identical).
+
+These tests are hardware-free: they reuse the MOR-236 mono-USB X6200 pattern
+(a real ``Ic705SerialRadio`` resolved against the X6200 profile) and a
+hardware-scope fake radio, feeding synthetic PCM16 through the broadcaster's
+PCM tap exactly as the live audio pipeline does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from rigplane.audio.backend import (
+    AudioDeviceId,
+    AudioDeviceInfo,
+    FakeRxStream,
+    FakeTxStream,
+)
+from rigplane.audio.usb_driver import UsbAudioDriver
+from rigplane.backends.ic705.serial import Ic705SerialRadio
+from rigplane.capabilities import CAP_AUDIO, CAP_SCOPE
+from rigplane.scope import ScopeFrame
+from rigplane.web.server import WebConfig, WebServer
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+
+class _MonoUsbAudioBackend:
+    """Fake mono USB CODEC backend (Xiegu X6200 shape), as used by MOR-236."""
+
+    def __init__(self, *, input_channels: int = 1) -> None:
+        self._device = AudioDeviceInfo(
+            id=AudioDeviceId(0),
+            name="USB Audio Device",
+            input_channels=input_channels,
+            output_channels=input_channels,
+            default_samplerate=48_000,
+            is_default_input=True,
+            is_default_output=True,
+        )
+        self.rx_streams: list[FakeRxStream] = []
+        self.tx_streams: list[FakeTxStream] = []
+
+    def list_devices(self) -> list[AudioDeviceInfo]:
+        return [self._device]
+
+    def check_sample_rate(
+        self, device: AudioDeviceId, sample_rate: int, *, direction: str = "rx"
+    ) -> bool:
+        return sample_rate in (48_000, 24_000, 16_000, 8_000)
+
+    def open_rx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> FakeRxStream:
+        stream = FakeRxStream()
+        self.rx_streams.append(stream)
+        return stream
+
+    def open_tx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> FakeTxStream:
+        stream = FakeTxStream()
+        self.tx_streams.append(stream)
+        return stream
+
+
+class _FakeSerialCivLink:
+    """Minimal serial CI-V link double so the radio reports ``connected``."""
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.ready = False
+        self.healthy = False
+
+    async def connect(self) -> None:
+        self.connected = True
+        self.ready = True
+        self.healthy = True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+        self.ready = False
+        self.healthy = False
+
+    async def send(self, frame: bytes) -> None:
+        _ = frame
+
+    async def receive(self, timeout: float | None = None) -> bytes | None:
+        await asyncio.sleep(0.0 if timeout is None else min(timeout, 0.0))
+        return None
+
+
+class _HardwareScopeRadio:
+    """Minimal fake radio that advertises BOTH audio and hardware scope.
+
+    Used to prove the IC-7610-class non-regression: a hardware-scope radio
+    must still receive audio-scope frames but must NOT have the audio FFT
+    drive ``/api/v1/scope`` (its main spectrum comes from the real scope).
+    """
+
+    def __init__(self) -> None:
+        from rigplane.radio_state import RadioState
+
+        self.capabilities = frozenset({CAP_AUDIO, CAP_SCOPE})
+        self.radio_state = RadioState()
+        self.audio_codec = None
+        self.audio_sample_rate = 48_000
+
+
+class _FakeScopeHandler:
+    """Records frames enqueued by the server's broadcast methods."""
+
+    def __init__(self) -> None:
+        self.frames: list[ScopeFrame] = []
+
+    def enqueue_frame(self, frame: ScopeFrame) -> None:
+        self.frames.append(frame)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_pcm_noise(num_samples: int, amplitude: int = 5000) -> bytes:
+    """Generate PCM16 mono white noise frames (radio RX shape)."""
+    rng = np.random.default_rng(241)
+    samples = (rng.uniform(-1, 1, num_samples) * amplitude).astype(np.int16)
+    return samples.tobytes()
+
+
+def _feed_pcm_through_tap(server: WebServer, total_samples: int) -> None:
+    """Push synthetic PCM16 through the broadcaster's PCM tap.
+
+    The FFT scope is rate-limited to ``fps``; reset its last-frame clock so
+    the first window emits immediately, then drive enough samples that at
+    least one FFT window is processed.
+    """
+    scope = server._audio_fft_scope
+    assert scope is not None
+    scope._last_frame_time = 0.0  # bypass the fps rate-limit for the first frame
+    # The broadcaster fans PCM out to all registered taps; the FFT scope tap
+    # is the one under test. Feed in chunks to mimic 20 ms RX frames.
+    chunk = 960  # 20 ms @ 48 kHz mono
+    fed = 0
+    while fed < total_samples:
+        pcm = _make_pcm_noise(min(chunk, total_samples - fed))
+        server._audio_broadcaster._tap_registry.feed(pcm)
+        fed += chunk
+
+
+# ── X6200 (no hardware scope) ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_x6200_audio_scope_receives_fft_frames() -> None:
+    """Non-hardware-scope X6200 must relay FFT frames to /api/v1/audio-scope.
+
+    THIS IS THE MOR-241 REGRESSION GUARD. On the unfixed code the second
+    ``on_frame`` registration clobbers ``_broadcast_audio_scope`` and this
+    assertion fails (zero audio-scope frames). After the dispatch fix it
+    passes.
+    """
+    backend = _MonoUsbAudioBackend()
+    audio_driver = UsbAudioDriver(serial_port=None, backend=backend)
+    radio = Ic705SerialRadio(
+        device="/dev/tty.usbmodem-X6200",
+        model="X6200",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=audio_driver,
+    )
+    await radio.connect()
+    try:
+        # Sanity: X6200 has audio FFT but no hardware scope.
+        assert CAP_AUDIO in radio.capabilities
+        assert CAP_SCOPE not in radio.capabilities
+
+        server = WebServer(radio=radio, config=WebConfig())
+        assert server._audio_fft_scope is not None, "audio FFT scope not wired"
+
+        # center_freq > 0 gate inside feed_audio must pass.
+        radio.radio_state.main.freq = 14_074_000
+        server._audio_fft_scope.set_center_freq(14_074_000)
+
+        audio_handler = _FakeScopeHandler()
+        main_handler = _FakeScopeHandler()
+        server._audio_scope_handlers.add(audio_handler)
+        server._scope_handlers.add(main_handler)
+
+        # Feed several FFT windows worth of PCM through the broadcaster tap.
+        _feed_pcm_through_tap(server, total_samples=2048 * 4)
+
+        assert len(audio_handler.frames) >= 1, (
+            "audio-scope handler received zero FFT frames "
+            "(MOR-241: dispatch clobbered the audio-scope callback)"
+        )
+        assert isinstance(audio_handler.frames[0], ScopeFrame)
+        # Non-hardware-scope radios also feed the MAIN spectrum (X6200 relies
+        # on /api/v1/scope for its panadapter) — must NOT be dropped.
+        assert len(main_handler.frames) >= 1, (
+            "non-hw-scope radio stopped feeding /api/v1/scope (regression)"
+        )
+    finally:
+        await radio.disconnect()
+
+
+# ── Hardware-scope radio (IC-7610 class) non-regression ──────────────────────
+
+
+def test_hardware_scope_radio_audio_fft_only_on_audio_scope() -> None:
+    """Hardware-scope radio: audio FFT drives ONLY /api/v1/audio-scope.
+
+    IC-7610 must stay byte-identical: the audio FFT must reach the
+    audio-scope path but must NEVER be pushed to /api/v1/scope (whose
+    frames come from the real hardware scope).
+    """
+    radio = _HardwareScopeRadio()
+    server = WebServer(radio=radio, config=WebConfig())
+    assert server._audio_fft_scope is not None
+
+    audio_handler = _FakeScopeHandler()
+    main_handler = _FakeScopeHandler()
+    server._audio_scope_handlers.add(audio_handler)
+    server._scope_handlers.add(main_handler)
+
+    # Drive the dispatch entry point directly with a synthetic frame.
+    frame = ScopeFrame(
+        receiver=0,
+        mode=0,
+        start_freq_hz=14_000_000,
+        end_freq_hz=14_100_000,
+        pixels=bytes(160),
+        out_of_range=False,
+    )
+    server._dispatch_audio_fft_frame(frame)
+
+    assert audio_handler.frames == [frame], "audio-scope must receive the FFT frame"
+    assert main_handler.frames == [], (
+        "hardware-scope radio must NOT route audio FFT to /api/v1/scope"
+    )


### PR DESCRIPTION
## Root cause

`AudioFftScope.on_frame()` (`src/rigplane/audio/fft_scope.py`) is a **single-slot** callback setter. `WebServer.__init__` called it twice for non-hardware-scope radios:

1. `self._audio_fft_scope.on_frame(self._broadcast_audio_scope)` → `/api/v1/audio-scope`
2. (only when `CAP_SCOPE` absent) `self._audio_fft_scope.on_frame(self._broadcast_scope)` → `/api/v1/scope`

The second call **overwrote** the first, so `_broadcast_audio_scope` became dead code and `/api/v1/audio-scope` received **zero FFT frames** → the AUDIO SCOPE panel rendered blank on the X6200. IC-7610 (`CAP_SCOPE` present) skipped step 2 and was unaffected.

## The fix

Register a single `_dispatch_audio_fft_frame(frame)` callback that fans out:

- always feeds `_broadcast_audio_scope` (`/api/v1/audio-scope`);
- only for radios **without** a hardware scope (`CAP_SCOPE not in radio.capabilities`) also feeds `_broadcast_scope` (`/api/v1/scope`), since those radios derive their main panadapter from RX audio.

The PCM tap registration (`set_pcm_tap(... feed_audio)`) is unchanged. One source file touched (`server.py`); `fft_scope.py` and the single-slot engine are untouched.

## Compatibility (IC-7610 byte-identical)

For hardware-scope radios `_dispatch_audio_fft_frame` calls **only** `_broadcast_audio_scope` and never `_broadcast_scope` — `/api/v1/scope` stays sourced exclusively from the real hardware scope. No behavior change for that class.

## Tests

- `tests/test_audio_scope_dispatch.py` (new, hardware-free):
  - `test_x6200_audio_scope_receives_fft_frames` — reuses the MOR-236 mono-USB X6200 pattern (real `Ic705SerialRadio` + `WebServer`), feeds synthetic PCM16 through the broadcaster PCM tap, asserts ≥1 `ScopeFrame` on the audio-scope handler **and** that `/api/v1/scope` is still fed. Confirmed to **FAIL on the unfixed code** (0 audio-scope frames) and **PASS after the fix**.
  - `test_hardware_scope_radio_audio_fft_only_on_audio_scope` — IC-7610-class non-regression: audio FFT reaches `/api/v1/audio-scope` but never `/api/v1/scope`.
- `tests/integration/test_x6200_audio_scope_smoke.py` (new, **OFF by default**): real X6200 serial + USB RX audio, asserts a live FFT frame arrives within 5s. Double-gated — under `tests/integration/` (ignored by the default `--ignore=tests/integration` run), `serial_integration` marker, and `RIGPLANE_HW_SMOKE=1` env opt-in. Verified skipped in a normal run.

## Gate results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **6347 passed, 7 skipped, 11 xfailed, 1 xpassed, 0 failures**
- `uv run ruff check src/ tests/` → clean; `uv run ruff format src/ tests/` → clean
- `uv run mypy src/` → no new errors in `server.py`; 6 pre-existing baseline errors remain in `backends/yaesu_cat/radio.py` and `runtime/_civ_rx.py` (unrelated)
- `uv run lint-imports` → 4 contracts kept, 0 broken

Independent review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)