### PR TITLE
fix(MOR-242): arm USB-audio TX for serial Icom backends + RX-only bridge fallback

### DIFF
--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -478,11 +478,25 @@ class AudioBridge:
 
         # --- TX path: virtual device input → radio ---
         if self._tx_enabled:
-            await self._radio.start_audio_tx_pcm(
-                sample_rate=self._sample_rate,
-                channels=self._channels,
-                frame_ms=self._frame_ms,
-            )
+            try:
+                await self._radio.start_audio_tx_pcm(
+                    sample_rate=self._sample_rate,
+                    channels=self._channels,
+                    frame_ms=self._frame_ms,
+                )
+            except (RuntimeError, NotImplementedError) as exc:
+                # The radio cannot arm a PCM TX stream (e.g. a serial backend
+                # that never set up its USB-audio TX path). Degrade to RX-only
+                # instead of spinning a _tx_loop that would reject — and log —
+                # every captured frame (MOR-242).
+                self._tx_enabled = False
+                self._tx_started = False
+                logger.warning(
+                    "%s: radio rejected TX start (%s); running RX-only",
+                    self._label,
+                    exc,
+                )
+                return
             self._tx_started = True
 
             tx_dev_id = dev_id
@@ -829,6 +843,17 @@ class AudioBridge:
 
                 try:
                     await self._radio.push_audio_tx_pcm(pcm_bytes)
+                except (RuntimeError, NotImplementedError) as exc:
+                    # The radio cannot accept PCM TX frames (TX path not armed).
+                    # Degrade to RX-only and stop the loop instead of rejecting
+                    # — and logging — every captured frame (MOR-242).
+                    self._tx_enabled = False
+                    logger.warning(
+                        "%s: radio rejected TX frame (%s); switching to RX-only",
+                        self._label,
+                        exc,
+                    )
+                    return
                 except Exception:
                     if self._tx_frames <= 5:
                         logger.warning("%s: TX push error", self._label, exc_info=True)

--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -454,7 +454,38 @@ class _IcomSerialRadioBase(CoreRadio):
         await self._serial_audio_driver.stop_rx()
 
     # ------------------------------------------------------------------
-    # Audio TX
+    # Audio TX (Opus)
+    # ------------------------------------------------------------------
+
+    async def start_audio_tx_opus(self) -> None:
+        self._check_connected()
+        await self._serial_audio_driver.start_tx(
+            sample_rate=self.audio_sample_rate,
+            channels=self._serial_audio_channels_for_codec(),
+            frame_ms=20,
+        )
+
+    async def push_audio_tx_opus(self, opus_data: bytes) -> None:
+        self._check_connected()
+        if not self._serial_audio_driver.tx_running:
+            raise RuntimeError("Audio TX not started")
+        payload = bytes(opus_data)
+        if self._serial_codec_is_opus():
+            transcoder = self._get_pcm_transcoder(
+                sample_rate=self.audio_sample_rate,
+                channels=self._serial_audio_channels_for_codec(),
+                frame_ms=20,
+            )
+            payload = transcoder.opus_to_pcm(payload)
+        await self._serial_audio_driver._push_tx_pcm(payload)
+
+    async def stop_audio_tx_opus(self) -> None:
+        await self._serial_audio_driver.stop_tx()
+        self._pcm_tx_fmt = None
+
+    # ------------------------------------------------------------------
+    # Audio TX (PCM) — arms ``_pcm_tx_fmt`` so ``push_audio_tx_pcm`` works
+    # over the serial USB CODEC path (MOR-242).
     # ------------------------------------------------------------------
 
     async def start_audio_tx_pcm(
@@ -485,15 +516,51 @@ class _IcomSerialRadioBase(CoreRadio):
                 "sample_rate * frame_ms must produce an integer frame size."
             )
 
+        # Icom USB CODEC mic input is mono-only by hardware; the LAN path
+        # enforces this by forcing txcodec to a mono value in _send_conninfo
+        # (issue #794).  For the serial path we clamp channels to 1 here so
+        # that PortAudio always opens the USB CODEC as a mono output stream.
+        # Opening with channels=2 causes the radio ALC to behave erratically
+        # for the first 5-10 seconds of TX (GH#1382 regression; consistent with
+        # the MOR-238 RX clamp).
+        tx_channels = 1
+
         self._check_connected()
         await self._serial_audio_driver.start_tx(
             sample_rate=sample_rate,
-            channels=channels,
+            channels=tx_channels,
             frame_ms=frame_ms,
         )
+        self._pcm_tx_fmt = (sample_rate, tx_channels, frame_ms)
+
+    async def push_audio_tx_pcm(
+        self,
+        pcm_bytes: bytes | bytearray | memoryview,
+    ) -> None:
+        self._check_connected()
+        if self._pcm_tx_fmt is None:
+            raise RuntimeError(
+                "PCM TX not started; call start_audio_tx_pcm() before push_audio_tx_pcm()."
+            )
+        if not isinstance(pcm_bytes, (bytes, bytearray, memoryview)):
+            raise AudioFormatError("PCM input must be bytes-like.")
+        sample_rate, channels, frame_ms = self._pcm_tx_fmt
+        if (sample_rate * frame_ms) % 1000 != 0:
+            raise AudioFormatError(
+                "sample_rate * frame_ms must produce an integer frame size."
+            )
+        frame_samples = (sample_rate * frame_ms) // 1000
+        expected = frame_samples * channels * 2
+        frame = bytes(pcm_bytes)
+        if len(frame) != expected:
+            raise AudioFormatError(
+                f"PCM frame size mismatch: expected {expected} bytes "
+                f"({frame_ms}ms at {sample_rate}Hz, {channels}ch s16le), got {len(frame)}."
+            )
+        await self._serial_audio_driver._push_tx_pcm(frame)
 
     async def stop_audio_tx_pcm(self) -> None:
-        await self._serial_audio_driver.stop_tx()
+        await self.stop_audio_tx_opus()
 
     async def _push_pcm_tx(self, frame: bytes) -> None:
         if not isinstance(frame, bytes):
@@ -613,8 +680,17 @@ class _IcomSerialRadioBase(CoreRadio):
     # ------------------------------------------------------------------
 
     async def _stop_serial_audio_driver(self) -> None:
-        await self._serial_audio_driver.stop_rx()
-        await self._serial_audio_driver.stop_tx()
+        self._pcm_tx_fmt = None
+        self._pcm_rx_user_callback = None
+        self._opus_rx_user_callback = None
+        try:
+            await self._serial_audio_driver.stop_tx()
+        except Exception:
+            logger.debug("serial-audio: failed to stop TX path", exc_info=True)
+        try:
+            await self._serial_audio_driver.stop_rx()
+        except Exception:
+            logger.debug("serial-audio: failed to stop RX path", exc_info=True)
 
     def _ensure_scope_baud_guardrail(self) -> None:
         if self._serial_baudrate >= _SERIAL_SCOPE_MIN_BAUD:

--- a/src/rigplane/backends/icom7610/serial.py
+++ b/src/rigplane/backends/icom7610/serial.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from ...exceptions import AudioFormatError, CommandError
+from ...exceptions import CommandError
 from .._icom_serial_base import _IcomSerialRadioBase, _SERIAL_SCOPE_MIN_BAUD
 
 logger = logging.getLogger(__name__)
@@ -13,7 +13,13 @@ __all__ = ["Icom7610SerialRadio"]
 
 
 class Icom7610SerialRadio(_IcomSerialRadioBase):
-    """IC-7610 backend wired to shared core over serial CI-V session driver."""
+    """IC-7610 backend wired to shared core over serial CI-V session driver.
+
+    The audio TX (Opus + PCM) path and audio-driver teardown live in
+    ``_IcomSerialRadioBase`` (lifted there in MOR-242); this subclass only
+    carries the IC-7610-specific RX-PCM delegation and the scope baud
+    guardrail that raises ``CommandError``.
+    """
 
     _DEFAULT_MODEL = ""
 
@@ -24,131 +30,6 @@ class Icom7610SerialRadio(_IcomSerialRadioBase):
     async def stop_audio_rx_pcm(self) -> None:
         self._pcm_rx_user_callback = None
         await self.stop_audio_rx_opus()
-
-    # ------------------------------------------------------------------
-    # IC-7610 specific: Opus TX path
-    # ------------------------------------------------------------------
-
-    async def start_audio_tx_opus(self) -> None:
-        self._check_connected()
-        await self._serial_audio_driver.start_tx(
-            sample_rate=self.audio_sample_rate,
-            channels=self._serial_audio_channels_for_codec(),
-            frame_ms=20,
-        )
-
-    async def push_audio_tx_opus(self, opus_data: bytes) -> None:
-        self._check_connected()
-        if not self._serial_audio_driver.tx_running:
-            raise RuntimeError("Audio TX not started")
-        payload = bytes(opus_data)
-        if self._serial_codec_is_opus():
-            transcoder = self._get_pcm_transcoder(
-                sample_rate=self.audio_sample_rate,
-                channels=self._serial_audio_channels_for_codec(),
-                frame_ms=20,
-            )
-            payload = transcoder.opus_to_pcm(payload)
-        await self._serial_audio_driver._push_tx_pcm(payload)
-
-    async def stop_audio_tx_opus(self) -> None:
-        await self._serial_audio_driver.stop_tx()
-        self._pcm_tx_fmt = None
-
-    # ------------------------------------------------------------------
-    # IC-7610 specific: PCM TX with frame-size tracking
-    # ------------------------------------------------------------------
-
-    async def start_audio_tx_pcm(
-        self,
-        *,
-        sample_rate: int | None = None,
-        channels: int | None = None,
-        frame_ms: int | None = None,
-    ) -> None:
-        # Signature mirrors the base ``AudioRuntimeMixin`` contract (``int |
-        # None``) so subclassing does not violate the Liskov substitution
-        # principle; ``None`` resolves to the serial-path defaults.
-        if sample_rate is None:
-            sample_rate = 48000
-        if channels is None:
-            channels = 1
-        if frame_ms is None:
-            frame_ms = 20
-        for name, value in (
-            ("sample_rate", sample_rate),
-            ("channels", channels),
-            ("frame_ms", frame_ms),
-        ):
-            if isinstance(value, bool) or not isinstance(value, int):
-                raise TypeError(f"{name} must be an int, got {type(value).__name__}.")
-        if (sample_rate * frame_ms) % 1000 != 0:
-            raise AudioFormatError(
-                "sample_rate * frame_ms must produce an integer frame size."
-            )
-
-        # IC-7610 USB CODEC mic input is mono-only by hardware; the LAN path
-        # enforces this by forcing txcodec to a mono value in _send_conninfo
-        # (issue #794).  For the serial path we clamp channels to 1 here so
-        # that PortAudio always opens the USB CODEC as a mono output stream.
-        # Opening with channels=2 causes the IC-7610 ALC to behave erratically
-        # for the first 5-10 seconds of TX (GH#1382 regression vs 0.16.4 where
-        # the global default was PCM_1CH_16BIT → default_channels=1).
-        tx_channels = 1
-
-        self._check_connected()
-        await self._serial_audio_driver.start_tx(
-            sample_rate=sample_rate,
-            channels=tx_channels,
-            frame_ms=frame_ms,
-        )
-        self._pcm_tx_fmt = (sample_rate, tx_channels, frame_ms)
-
-    async def push_audio_tx_pcm(
-        self,
-        pcm_bytes: bytes | bytearray | memoryview,
-    ) -> None:
-        self._check_connected()
-        if self._pcm_tx_fmt is None:
-            raise RuntimeError(
-                "PCM TX not started; call start_audio_tx_pcm() before push_audio_tx_pcm()."
-            )
-        if not isinstance(pcm_bytes, (bytes, bytearray, memoryview)):
-            raise AudioFormatError("PCM input must be bytes-like.")
-        sample_rate, channels, frame_ms = self._pcm_tx_fmt
-        if (sample_rate * frame_ms) % 1000 != 0:
-            raise AudioFormatError(
-                "sample_rate * frame_ms must produce an integer frame size."
-            )
-        frame_samples = (sample_rate * frame_ms) // 1000
-        expected = frame_samples * channels * 2
-        frame = bytes(pcm_bytes)
-        if len(frame) != expected:
-            raise AudioFormatError(
-                f"PCM frame size mismatch: expected {expected} bytes "
-                f"({frame_ms}ms at {sample_rate}Hz, {channels}ch s16le), got {len(frame)}."
-            )
-        await self._serial_audio_driver._push_tx_pcm(frame)
-
-    async def stop_audio_tx_pcm(self) -> None:
-        await self.stop_audio_tx_opus()
-
-    # ------------------------------------------------------------------
-    # IC-7610 specific: more robust audio driver stop
-    # ------------------------------------------------------------------
-
-    async def _stop_serial_audio_driver(self) -> None:
-        self._pcm_tx_fmt = None
-        self._pcm_rx_user_callback = None
-        self._opus_rx_user_callback = None
-        try:
-            await self._serial_audio_driver.stop_tx()
-        except Exception:
-            logger.debug("serial-audio: failed to stop TX path", exc_info=True)
-        try:
-            await self._serial_audio_driver.stop_rx()
-        except Exception:
-            logger.debug("serial-audio: failed to stop RX path", exc_info=True)
 
     # ------------------------------------------------------------------
     # IC-7610 specific: scope guardrail uses CommandError

--- a/tests/hardware/test_x6200_serial_tx_smoke.py
+++ b/tests/hardware/test_x6200_serial_tx_smoke.py
@@ -1,0 +1,60 @@
+"""Opt-in hardware smoke test: X6200 serial USB-audio TX path arms (MOR-242).
+
+SAFETY: this test NEVER engages PTT and NEVER transmits RF. It only verifies
+that the serial backend's PCM TX path arms (``_pcm_tx_fmt`` set) and that a few
+PCM frames are accepted by the USB-audio OUTPUT device at the driver level.
+Pushing PCM to the USB audio out device without keying PTT does not transmit.
+
+Skipped by default. Enable with ``RIGPLANE_HW_SMOKE=1`` on a machine with a
+real X6200 attached over USB CI-V. Mirrors the env-gated convention used by
+``tests/hardware/test_ic7610_audio_pipeline.py``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from rigplane.backends.ic705 import Ic705SerialRadio
+
+pytestmark = pytest.mark.hardware
+
+_ENABLE_ENV = "RIGPLANE_HW_SMOKE"
+_DEVICE_ENV = "RIGPLANE_HW_X6200_SERIAL"
+_BAUD_ENV = "RIGPLANE_HW_X6200_BAUD"
+
+# 20ms mono s16le frame at 48kHz: 960 samples * 2 bytes.
+_FRAME = (1500).to_bytes(2, "little", signed=True) * 960
+
+
+def _flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@pytest.mark.asyncio
+async def test_x6200_serial_tx_pcm_path_arms_without_transmitting() -> None:
+    if not _flag_enabled(_ENABLE_ENV):
+        pytest.skip(f"Set {_ENABLE_ENV}=1 to run the X6200 serial TX smoke test")
+
+    device = os.environ.get(_DEVICE_ENV, "").strip()
+    if not device:
+        pytest.skip(f"Set {_DEVICE_ENV}=/dev/tty... to point at the X6200 serial port")
+
+    baud = int(os.environ.get(_BAUD_ENV, "115200"))
+
+    radio = Ic705SerialRadio(device=device, baudrate=baud, model="X6200")
+    await radio.connect()
+    try:
+        # Arm the PCM TX path. This opens the USB CODEC OUTPUT stream only —
+        # no PTT, no RF.
+        await radio.start_audio_tx_pcm()
+        assert radio._pcm_tx_fmt is not None, "TX PCM path must arm _pcm_tx_fmt"
+
+        # Push a few frames to the USB audio OUTPUT device. Without PTT this
+        # does not transmit; it only proves the driver accepts frames.
+        for _ in range(5):
+            await radio.push_audio_tx_pcm(_FRAME)
+    finally:
+        await radio.stop_audio_tx_pcm()
+        await radio.disconnect()

--- a/tests/test_serial_backend_tx_mor242.py
+++ b/tests/test_serial_backend_tx_mor242.py
@@ -1,0 +1,244 @@
+"""MOR-242: serial Icom backends must arm USB-audio PCM TX.
+
+Reproduces the "PCM TX not started" spam where ``start_audio_tx_pcm`` opened
+the USB CODEC stream but never set ``_pcm_tx_fmt``, so every
+``push_audio_tx_pcm`` raised ``RuntimeError`` from the runtime mixin guard and
+no frame reached the radio.
+
+The fakes are reused from the IC-7610 serial test module so there are no
+one-off mocks (CLAUDE.md: "MagicMock hides signature bugs").
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from rigplane.audio.backend import (
+    AudioDeviceId,
+    AudioDeviceInfo,
+    FakeAudioBackend,
+)
+from rigplane.audio_bridge import AudioBridge, SAMPLES_PER_FRAME
+from rigplane.backends.ic705 import Ic705SerialRadio
+from rigplane.backends.ic7300 import Ic7300SerialRadio
+from rigplane.backends.ic9700 import Ic9700SerialRadio
+
+from test_icom7610_serial_radio import _FakeSerialCivLink, _FakeUsbAudioDriver
+
+
+# A 20ms mono s16le frame at 48kHz = 960 samples * 2 bytes = 1920 bytes.
+_FRAME = (1000).to_bytes(2, "little", signed=True) * SAMPLES_PER_FRAME
+
+
+def _serial_radio_factories():
+    """(id, factory) pairs for every non-7610 serial Icom backend.
+
+    Includes the IC-705 backend twice: once with its default model and once as
+    the X6200 (which the factory routes through the IC-705 backend).
+    """
+    return [
+        pytest.param(
+            lambda drv: Ic705SerialRadio(
+                device="/dev/ttyUSB0",
+                civ_link=_FakeSerialCivLink(),
+                audio_driver=drv,
+            ),
+            id="ic705",
+        ),
+        pytest.param(
+            lambda drv: Ic705SerialRadio(
+                device="/dev/ttyUSB0",
+                civ_link=_FakeSerialCivLink(),
+                audio_driver=drv,
+                model="X6200",
+            ),
+            id="x6200",
+        ),
+        pytest.param(
+            lambda drv: Ic7300SerialRadio(
+                device="/dev/ttyUSB0",
+                civ_link=_FakeSerialCivLink(),
+                audio_driver=drv,
+            ),
+            id="ic7300",
+        ),
+        pytest.param(
+            lambda drv: Ic9700SerialRadio(
+                device="/dev/ttyUSB0",
+                civ_link=_FakeSerialCivLink(),
+                audio_driver=drv,
+            ),
+            id="ic9700",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("make_radio", _serial_radio_factories())
+async def test_serial_backend_arms_pcm_tx_and_pushes_frame(make_radio) -> None:  # type: ignore[no-untyped-def]
+    """start_audio_tx_pcm arms _pcm_tx_fmt and push_audio_tx_pcm reaches driver.
+
+    On the unfixed base, start_audio_tx_pcm never set _pcm_tx_fmt and the base
+    had no push_audio_tx_pcm override, so the mixin guard raised
+    "PCM TX not started" on every frame.
+    """
+    usb_audio = _FakeUsbAudioDriver()
+    radio = make_radio(usb_audio)
+
+    await radio.connect()
+    await radio.start_audio_tx_pcm()
+
+    assert radio._pcm_tx_fmt is not None
+    # USB CODEC mic input is mono-only; channels must be clamped to 1.
+    assert usb_audio.tx_start_kwargs.get("channels") == 1
+
+    await radio.push_audio_tx_pcm(_FRAME)
+    assert usb_audio.tx_frames, "push_audio_tx_pcm must reach the USB audio driver"
+    assert usb_audio.tx_frames[0] == _FRAME
+
+    await radio.stop_audio_tx_pcm()
+    assert radio._pcm_tx_fmt is None
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_backend_push_before_start_raises() -> None:
+    """push_audio_tx_pcm before start raises the armed-format guard."""
+    usb_audio = _FakeUsbAudioDriver()
+    radio = Ic705SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=usb_audio,
+    )
+    await radio.connect()
+    with pytest.raises(RuntimeError, match="PCM TX not started"):
+        await radio.push_audio_tx_pcm(_FRAME)
+    await radio.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Bridge reproducer — a real AudioBridge + FakeAudioBackend against a
+# fake-driver-backed serial radio: captured frame must reach the driver and
+# raise no RuntimeError. AsyncMock-based bridge tests could not catch this.
+# ---------------------------------------------------------------------------
+
+
+def _bridge_backend() -> FakeAudioBackend:
+    return FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(0),
+                name="Built-in Output",
+                input_channels=0,
+                output_channels=2,
+            ),
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="BlackHole 2ch",
+                input_channels=2,
+                output_channels=2,
+            ),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_bridge_tx_reaches_serial_driver_without_runtime_error() -> None:
+    """MOR-242 end-to-end: bridge TX loopback frame reaches the serial driver."""
+    usb_audio = _FakeUsbAudioDriver()
+    radio = Ic705SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=usb_audio,
+    )
+    await radio.connect()
+
+    backend = _bridge_backend()
+    bridge = AudioBridge(
+        radio, device_name="BlackHole", tx_enabled=True, backend=backend
+    )
+    await bridge.start()
+
+    loud = (2000).to_bytes(2, "little", signed=True) * SAMPLES_PER_FRAME
+    backend.rx_streams[0].inject_frame(loud)
+    await asyncio.sleep(0.1)
+
+    assert bridge._tx_enabled is True
+    assert bridge._tx_frames > 0
+    assert usb_audio.tx_frames, "loopback frame must reach the serial USB driver"
+
+    await bridge.stop()
+    await radio.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Part B2 — bridge degrades to RX-only when the radio rejects TX, logging once.
+# ---------------------------------------------------------------------------
+
+
+class _TxRejectingRadio:
+    """Serial-style radio whose start_audio_tx_pcm raises RuntimeError."""
+
+    def __init__(self) -> None:
+        from rigplane.audio_bus import AudioBus
+        from rigplane.types import AudioCodec
+
+        self.audio_codec = AudioCodec.PCM_1CH_16BIT
+        self.audio_bus = AudioBus(self)
+        self.start_tx_calls = 0
+        self.push_calls = 0
+
+    async def start_audio_rx_opus(self, callback, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+    async def stop_audio_rx_opus(self) -> None:
+        return None
+
+    async def start_audio_tx_pcm(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.start_tx_calls += 1
+        raise RuntimeError("PCM TX not started")
+
+    async def stop_audio_tx_pcm(self) -> None:
+        return None
+
+    async def push_audio_tx_pcm(self, pcm_bytes) -> None:  # type: ignore[no-untyped-def]
+        self.push_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_bridge_downgrades_to_rx_only_when_tx_rejected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A radio that rejects TX start → bridge runs RX-only, logs once, no _tx_loop."""
+    import logging
+
+    radio = _TxRejectingRadio()
+    backend = _bridge_backend()
+    bridge = AudioBridge(
+        radio, device_name="BlackHole", tx_enabled=True, backend=backend
+    )
+
+    with caplog.at_level(logging.WARNING, logger="rigplane.audio.bridge"):
+        await bridge.start()
+
+    # Degraded to RX-only.
+    assert bridge._tx_enabled is False
+    assert bridge._tx_started is False
+    assert bridge._tx_task is None
+
+    # RX still works: a published packet drives the RX loop.
+    assert radio.audio_bus.subscriber_count == 1
+
+    # No per-frame spam: at most one WARNING about the TX rejection.
+    tx_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "RX-only" in r.getMessage()
+    ]
+    assert len(tx_warnings) == 1
+    assert radio.push_calls == 0
+
+    await bridge.stop()


### PR DESCRIPTION
## Root cause (corrected)

`_IcomSerialRadioBase.start_audio_tx_pcm` opened the correct USB CODEC TX stream via `self._serial_audio_driver.start_tx(...)` but **never set `self._pcm_tx_fmt`**, and the base had **no `push_audio_tx_pcm` override**. So every push fell through to `AudioRuntimeMixin.push_audio_tx_pcm`, whose guard `if self._pcm_tx_fmt is None: raise RuntimeError("PCM TX not started…")` fired on every frame. The auto-bridge enables TX by default, so `_tx_loop` pushed loopback audio and the radio rejected every frame, spamming "PCM TX not started".

The working TX path lived **only** in `Icom7610SerialRadio`, so the bug was systemic to all non-7610 serial Icom backends.

## Part A — real fix (lift the working TX path into the shared base)

`src/rigplane/backends/_icom_serial_base.py`:
- `start_audio_tx_pcm` now clamps `channels → 1` (USB CODEC mic is mono-only; GH#1382, consistent with the MOR-238 RX clamp) and arms `self._pcm_tx_fmt = (sample_rate, 1, frame_ms)`.
- added `push_audio_tx_pcm` (guards `_pcm_tx_fmt`, validates frame size against the armed format, forwards to the USB audio driver).
- added `start/push/stop_audio_tx_opus`.
- `_pcm_tx_fmt` is cleared in `stop_audio_tx_pcm` and `_stop_serial_audio_driver`.

`src/rigplane/backends/icom7610/serial.py`: deleted the now-duplicate TX/teardown overrides so IC-7610-serial **inherits** the base. Behavior is pinned identical by the **unchanged** `tests/test_icom7610_serial_radio.py` (22 tests, green).

**Systemic scope:** fixes IC-705, X6200 (routed through the IC-705 backend), IC-7300, and IC-9700 serial TX.

## Part B2 — bridge safety (RX-only fallback)

`src/rigplane/audio/bridge.py`: `_setup_streams` wraps `start_audio_tx_pcm`, and `_tx_loop` guards the first `push_audio_tx_pcm`, so a `RuntimeError`/`NotImplementedError` downgrades the bridge to RX-only (disable TX, skip/stop `_tx_loop`, log **once** at WARNING) instead of per-frame spam. Insurance so this class of bug can never spam again. LAN, 7610, and yaesu-cat TX paths are unaffected.

## Tests

- Parametrized base-backend TX test (IC-705, X6200 model, IC-7300, IC-9700): arms `_pcm_tx_fmt`, push reaches the fake USB driver. Confirmed it **fails on the unfixed base** and passes after the lift.
- Bridge reproducer: a real `AudioBridge` + `FakeAudioBackend` against a fake-driver-backed serial radio — a captured frame reaches the driver with no RuntimeError (the AsyncMock bridge tests could not catch this).
- Part-B2 test: a TX-rejecting radio → bridge runs RX-only, logs once, no `_tx_loop`.
- Hardware-gated X6200 serial TX smoke test (`tests/hardware`, `RIGPLANE_HW_SMOKE=1`), **skipped by default**: arms the PCM TX path and pushes a few frames to the USB audio OUTPUT only — never engages PTT, never transmits RF.

Fakes reused from `tests/test_icom7610_serial_radio.py` (no one-off mocks).

## Gate results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **6352 passed, 8 skipped, 11 xfailed, 1 xpassed, 0 failed**
- `tests/test_icom7610_serial_radio.py` → **22 passed, file unchanged (zero diff)**
- `uv run ruff check src/ tests/` + `ruff format` → clean
- `uv run mypy src/` → no new errors in touched files (6 pre-existing `yaesu_cat/radio.py` errors are baseline, identical on a clean tree)
- `uv run lint-imports` → 4 contracts kept, 0 broken
- X6200 hardware smoke → skipped by default (verified)

## Compatibility

- IC-7610 LAN path untouched (`_audio_runtime_mixin.py` not modified).
- IC-7610 serial behavior-identical, pinned by the unchanged existing tests.
- On-air TX validation for IC-705/IC-7300/IC-9700 remains pending real-hardware confirmation; the X6200 path is the one with an attached test rig.

Independent review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)