### PR TITLE
chore(release): bump to 2.7.2 — X6200 RX audio + audio scope + serial USB-audio TX (MOR-239/241/242)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.2] — 2026-05-30
+
+### Fixed
+
+- Desktop RX audio: resume the `AudioContext` from the LIVE user-gesture so streamed RX audio plays under WKWebView/autoplay-restricted contexts, and recover from suspended-context frame drops instead of silently dropping them (MOR-239, #1694, 921f4c88)
+- Audio scope: dispatch audio-FFT frames to `/api/v1/audio-scope` for radios without a hardware scope (e.g. Xiegu X6200), fixing the blank AUDIO SCOPE panel; hardware-scope radios (IC-7610) are unchanged (MOR-241, #1695, 4e98ab0d)
+- Serial USB-audio TX: arm the PCM TX path in the shared serial Icom base so bridge TX reaches the radio (IC-705/IC-7300/IC-9700/X6200) instead of raising "PCM TX not started" per frame; the audio bridge now degrades to RX-only on TX failure instead of spamming (MOR-242, #1696, 37fe3d0a)
+
 ## [2.7.1] — 2026-05-29
 
 ### Fixed
@@ -1535,7 +1543,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.7.1...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.7.2...HEAD
+[2.7.2]: https://github.com/rigplane/rigplane-core/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/rigplane/rigplane-core/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/rigplane/rigplane-core/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/rigplane/rigplane-core/compare/v2.5.1...v2.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.7.1"
+version = "2.7.2"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.5.0"
+version = "2.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Release v2.7.2 (PATCH)

Version bump + changelog for the three X6200/audio fixes merged since v2.7.1.

### Changelog (Fixed)
- **MOR-239** (#1694, `921f4c8`) — desktop RX audio: resume `AudioContext` from the LIVE user-gesture under WKWebView/autoplay; recover from suspended-context frame drops.
- **MOR-241** (#1695, `4e98ab0`) — audio scope: dispatch audio-FFT frames to `/api/v1/audio-scope` for non-hardware-scope radios (X6200); IC-7610 unchanged.
- **MOR-242** (#1696, `37fe3d0`) — serial USB-audio TX: arm the PCM TX path for serial Icom backends (IC-705/IC-7300/IC-9700/X6200); bridge degrades to RX-only on TX failure.

### Files
`pyproject.toml` (2.7.1 → 2.7.2), `docs/CHANGELOG.md`, `uv.lock` (rigplane pin → 2.7.2).

### Pre-flight (matches publish.yml validate — all green)
ruff check+format ✓ · lint-imports 4/0 ✓ · mypy --strict web ✓ · frontend check 0 / vitest 1847 / build ✓ · pytest (no integration) 6304 passed ✓ · build smoke (sdist+wheel) ✓

### Hardware validation
All three fixes confirmed on a real Xiegu X6200 (audio-scope RX smoke, TX-arm smoke, and a browser RX-smoke showing the live AUDIO SCOPE waveform).

After squash-merge: tag `v2.7.2` on the merge commit → `gh release create` triggers `publish.yml` → PyPI.

Independent review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)