### PR TITLE
build: build web UI during packaging so source/git installs are self-contained

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,68 @@
+"""Hatchling build hook that bundles the Svelte web UI into the package.
+
+The frontend lives in ``frontend/`` and its build output (``frontend/dist``)
+is gitignored. At runtime the SPA is served from ``src/rigplane/web/static``,
+so the package must ship the built assets at that location.
+
+This hook makes every build target (wheel *and* sdist) self-contained:
+
+* If ``frontend/dist/index.html`` is missing and a ``frontend/`` source tree is
+  present, it builds the SPA with ``npm`` (``npm ci``/``npm install`` then
+  ``npm run build``). If ``npm`` is unavailable and no prebuilt dist exists, it
+  raises a clear ``RuntimeError`` so the failure is actionable.
+* If ``frontend/dist/index.html`` already exists, the npm build is skipped — the
+  hook is idempotent, so the PyPI publish flow (which prebuilds the frontend)
+  does not rebuild it.
+* The built ``frontend/dist`` is force-included at ``src/rigplane/web/static``
+  for whichever target is building, centralizing the mapping in one place.
+
+Without this, ``pip install git+https://...`` (a direct wheel build) would not
+bundle the SPA and the desktop UI would 404.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+# Runtime location the installed package serves the SPA from. Must not change.
+_RUNTIME_STATIC = "src/rigplane/web/static"
+
+
+class FrontendBuildHook(BuildHookInterface):  # type: ignore[type-arg]
+    """Build the web UI (if needed) and bundle it into the package."""
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        root = Path(self.root)
+        frontend_dir = root / "frontend"
+        dist_index = frontend_dir / "dist" / "index.html"
+
+        if not dist_index.exists() and frontend_dir.is_dir():
+            self._build_frontend(frontend_dir)
+
+        # Inject the force-include so the SPA lands at the runtime location for
+        # whichever target (wheel or sdist) is building.
+        force_include = build_data.setdefault("force_include", {})
+        force_include["frontend/dist"] = _RUNTIME_STATIC
+
+    def _build_frontend(self, frontend_dir: Path) -> None:
+        npm = shutil.which("npm")
+        if npm is None:
+            raise RuntimeError(
+                "Building rigplane from source requires Node.js/npm to build "
+                "the web UI (frontend/dist is not present and could not be "
+                "built). Install Node.js/npm, or build a wheel/sdist on a "
+                "machine that has them (the resulting artifact is "
+                "self-contained and needs no Node.js to install)."
+            )
+
+        lockfile = frontend_dir / "package-lock.json"
+        install_cmd = [npm, "ci"] if lockfile.exists() else [npm, "install"]
+
+        self.app.display_info("Building rigplane web UI (npm)...")
+        subprocess.run(install_cmd, cwd=frontend_dir, check=True)
+        subprocess.run([npm, "run", "build"], cwd=frontend_dir, check=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,22 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rigplane", "src/icom_lan"]
+# The web UI is placed at src/rigplane/web/static exclusively via the custom
+# build hook's force-include (see hatch_build.py). When building a wheel from an
+# sdist (uv build's default sdist->wheel chain), the sdist has already
+# materialized src/rigplane/web/static on disk; exclude it from normal project
+# file selection so the force-include is the single source and the tree is not
+# bundled twice.
+exclude = ["src/rigplane/web/static"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "rigs" = "rigplane/rigs"
 
-[tool.hatch.build.targets.sdist.force-include]
-"frontend/dist" = "src/rigplane/web/static"
+# Builds the Svelte web UI during packaging (if not prebuilt) and force-includes
+# the result at src/rigplane/web/static for BOTH wheel and sdist targets, so
+# source/git installs are self-contained. See hatch_build.py.
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Why

rigplane-core gitignores `frontend/dist`, while the wheel/sdist serve the built SPA at runtime from `src/rigplane/web/static`. Previously **only** the sdist target force-included the prebuilt frontend:

```toml
[tool.hatch.build.targets.sdist.force-include]
"frontend/dist" = "src/rigplane/web/static"
```

Consequences:
- `uv build` only worked if `frontend/dist` was pre-built (it failed in CI otherwise).
- A **direct wheel build** (`pip install git+https://github.com/rigplane/rigplane-core@<rev>`) did **not** bundle the SPA at all -> the desktop UI 404s.

RigPlane Pro will pin core via a git rev and needs self-contained installs. This makes `pip install git+...` self-build and bundle the SPA, and also fixes the "uv build needs a prebuilt dist" wart.

## What

A custom hatchling build hook (`hatch_build.py`, registered via `[tool.hatch.build.hooks.custom]`) that runs for **both** wheel and sdist targets:

1. In `initialize`: if `frontend/dist/index.html` is missing and `frontend/` exists, build the SPA -> `npm ci` (or `npm install` when there is no lockfile) then `npm run build`. If `npm` is unavailable and dist is missing, raise a clear `RuntimeError`.
2. If `frontend/dist/index.html` already exists, **skip** the npm build (idempotent — the PyPI publish flow prebuilds the frontend and must not rebuild).
3. Inject `build_data["force_include"]["frontend/dist"] = "src/rigplane/web/static"` so the SPA lands at the runtime location for whichever target is building.

pyproject changes:
- Removed the redundant sdist-only `force-include` (the hook now injects it for all targets, in one place).
- Kept the unrelated wheel `"rigs"` force-include untouched.
- Added `exclude = ["src/rigplane/web/static"]` to the wheel target. `uv build` chains sdist -> wheel by default; the sdist materializes `src/rigplane/web/static` on disk, which the wheel build then picked up as a normal project file **in addition to** the force-include, bundling the tree twice (55 duplicate archive entries). Excluding the materialized dir makes the force-include the single source.

The runtime SPA location remains exactly `src/rigplane/web/static`.

## Verification (hardware-free)

- **Clean-tree build bundles the SPA (no dups):** `rm -rf frontend/dist src/rigplane/web/static && uv build` succeeds; the hook builds the frontend.
  - wheel: `[n for n in zip.namelist() if 'web/static/index.html' in n]` -> `['rigplane/web/static/index.html']` (exactly one; 55 static files, zero duplicate entries).
  - sdist: `tar tzf ... | grep web/static/index.html` -> `rigplane-2.7.2/src/rigplane/web/static/index.html`.
- **Idempotency:** with `frontend/dist` present, `uv build` reruns in ~0.35s with no "Building rigplane web UI" message (npm skipped), SPA still bundled.
- **Install + import smoke:** wheel installed into a throwaway env; `importlib.resources.files('rigplane.web')/'static'/'index.html'` exists.
- **git-source install smoke (the real use case):** `uv pip install "git+file:///.../rigplane-corehook@codex/core-frontend-build-hook"` into a fresh venv self-built the SPA; installed `rigplane/web/static/index.html` present (55 static files).
- Gates green: `pytest tests/ --ignore=tests/integration` -> 6354 passed, 8 skipped; `ruff check` clean; `ruff format --check` clean; `lint-imports` 4 kept / 0 broken; `mypy --strict src/rigplane/web` no issues.

Independent review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)