### PR TITLE
fix(MOR-250): callback blocksize=0 TX capture + 20 ms framing — restore Windows TX (open-core half)

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -242,13 +242,19 @@ class _PortAudioRxStream:
     ``blocksize=0`` opens cleanly.
 
     The PortAudio callback runs on the audio thread and must not block. It
-    copies the captured PCM (s16le) and hands it straight to the consumer
-    *callback*. Each callback delivers a device-natural, variable-size block;
-    it is forwarded verbatim so no new fixed-size re-framing seam (which would
-    re-introduce a discontinuity) is added. The consumer contract (see
-    :class:`RxStream`) is that the callback is cheap and thread-safe to invoke
-    from the audio thread; the companion bridge marshals onto its event loop
-    via ``call_soon_threadsafe``.
+    copies the captured PCM (s16le) out of the engine-native, variable-size
+    block and *re-chunks* it into fixed ``frame_ms``-sized frames before
+    handing them to the consumer *callback*. The downstream PCM-TX contract
+    requires fixed-size frames (e.g. 20 ms = 960 samples = 1920 bytes s16le
+    mono @ 48 kHz); a managed core validator rejects any frame whose byte
+    length differs. Re-chunking a *continuous* callback stream is lossless and
+    introduces no scheduling seam (the ~50 Hz comb came from the old
+    blocking-read inter-read gap, not from re-chunking), so this preserves the
+    fixed-frame contract without re-introducing the comb. Sub-frame remainders
+    are buffered across callbacks; a trailing partial frame at stop is dropped.
+    The consumer contract (see :class:`RxStream`) is that the callback is cheap
+    and thread-safe to invoke from the audio thread; the companion bridge
+    marshals onto its event loop via ``call_soon_threadsafe``.
     """
 
     def __init__(
@@ -258,6 +264,7 @@ class _PortAudioRxStream:
         sample_rate: int,
         channels: int,
         blocksize: int,
+        frame_ms: int,
     ) -> None:
         self._sd = sd
         self._device_index = device_index
@@ -268,9 +275,17 @@ class _PortAudioRxStream:
         # WDM-KS capture face (PortAudioError -9999), but companion device
         # selection now forces the WASAPI face, on which blocksize=0 opens.
         self._blocksize = blocksize
+        # Fixed delivered-frame size: frame_ms worth of audio frames, each
+        # ``channels`` interleaved s16le samples (2 bytes/sample). The PortAudio
+        # stream stays blocksize=0; only the size handed to ``cb`` is fixed.
+        frame_samples = (sample_rate * frame_ms) // 1000
+        self._frame_bytes = max(1, frame_samples * channels * 2)
         self._stream: Any = None
         self._running = False
         self._callback: Callable[[bytes], None] | None = None
+        # Sub-frame remainder carried between audio-thread callbacks. The audio
+        # thread is the only writer, so no lock is needed.
+        self._accumulator = bytearray()
 
     @property
     def running(self) -> bool:
@@ -280,6 +295,7 @@ class _PortAudioRxStream:
         if self.running:
             raise RuntimeError("RX stream already running.")
         self._callback = callback
+        self._accumulator = bytearray()
         # blocksize=0 (engine-native period) mirrors a clean sd.rec on the
         # WASAPI face. latency="low" matches the (clean) output stream.
         self._stream = self._sd.InputStream(
@@ -299,6 +315,9 @@ class _PortAudioRxStream:
         self._stream = None
         self._running = False
         self._callback = None
+        # Drop any sub-frame remainder: an incomplete trailing frame cannot
+        # satisfy the fixed-size contract and is discarded at teardown.
+        self._accumulator = bytearray()
         if stream is not None:
             try:
                 stream.stop()
@@ -317,9 +336,13 @@ class _PortAudioRxStream:
         _status: Any,
     ) -> None:
         # Runs on PortAudio's audio thread: keep it non-blocking. Copy the
-        # captured PCM out of the (reused) input buffer and deliver it to the
-        # consumer verbatim — no re-chunking, so no new discontinuity. The
-        # consumer is contractually cheap/thread-safe.
+        # captured PCM (s16le) out of the (reused, variable-size) input buffer,
+        # append it to the running accumulator, then slice off whole fixed-size
+        # frames and deliver each to the consumer. Re-chunking a continuous
+        # callback stream is lossless (every sample reaches the consumer in
+        # order) and adds no scheduling seam, so it keeps the fixed-frame
+        # contract without re-introducing the comb. The consumer is
+        # contractually cheap/thread-safe.
         cb = self._callback
         if cb is None:
             return
@@ -332,8 +355,14 @@ class _PortAudioRxStream:
             return
         if not pcm:
             return
+        acc = self._accumulator
+        acc.extend(pcm)
+        frame_bytes = self._frame_bytes
         try:
-            cb(pcm)
+            while len(acc) >= frame_bytes:
+                frame = bytes(acc[:frame_bytes])
+                del acc[:frame_bytes]
+                cb(frame)
         except Exception:
             logger.warning("portaudio-rx: consumer callback failed", exc_info=True)
 
@@ -829,13 +858,15 @@ class PortAudioBackend:
         # clean ``sd.rec`` capture. This is safe now that companion device
         # selection forces the WASAPI host-API face (the WDM-KS face that
         # rejected blocksize=0 with PortAudioError -9999 is no longer chosen).
-        del frame_ms  # capture period is engine-native (blocksize=0)
+        # The PortAudio capture period stays engine-native; frame_ms only sizes
+        # the fixed frames re-chunked out to the consumer callback.
         return _PortAudioRxStream(
             sd,
             device_index=int(device),
             sample_rate=sample_rate,
             channels=channels,
             blocksize=0,
+            frame_ms=frame_ms,
         )
 
     def open_tx(

--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -10,7 +10,6 @@ opening RX/TX audio streams, plus two concrete implementations:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import math
 import threading
@@ -228,7 +227,29 @@ def _ensure_portaudio_deps() -> tuple[Any, Any]:
 
 
 class _PortAudioRxStream:
-    """RxStream backed by a sounddevice InputStream."""
+    """RxStream backed by a callback-driven sounddevice InputStream.
+
+    Capture is clocked by PortAudio's own audio thread via an ``InputStream``
+    callback, mirroring the callback design of :class:`_PortAudioTxStream`.
+    This replaces the previous fixed-``blocksize=960`` blocking-read loop
+    (``stream.read(960)`` on a worker thread), whose 20 ms read straddled the
+    WASAPI shared-mode engine period (~10 ms) and dropped/duplicated a sample
+    run once per block, producing a ~50 Hz spectral comb on captured TX audio
+    on Windows. The stream is opened with ``blocksize=0`` (engine-native
+    period), mirroring a known-clean ``sd.rec`` capture. The earlier WDM-KS
+    capture face rejected ``blocksize=0`` (PortAudioError -9999), but companion
+    device selection now forces the WASAPI host-API face, on which
+    ``blocksize=0`` opens cleanly.
+
+    The PortAudio callback runs on the audio thread and must not block. It
+    copies the captured PCM (s16le) and hands it straight to the consumer
+    *callback*. Each callback delivers a device-natural, variable-size block;
+    it is forwarded verbatim so no new fixed-size re-framing seam (which would
+    re-introduce a discontinuity) is added. The consumer contract (see
+    :class:`RxStream`) is that the callback is cheap and thread-safe to invoke
+    from the audio thread; the companion bridge marshals onto its event loop
+    via ``call_soon_threadsafe``.
+    """
 
     def __init__(
         self,
@@ -242,19 +263,25 @@ class _PortAudioRxStream:
         self._device_index = device_index
         self._sample_rate = sample_rate
         self._channels = channels
+        # Capture is callback-driven with blocksize=0 (engine-native period),
+        # mirroring a clean sd.rec. blocksize=0 was previously rejected by the
+        # WDM-KS capture face (PortAudioError -9999), but companion device
+        # selection now forces the WASAPI face, on which blocksize=0 opens.
         self._blocksize = blocksize
         self._stream: Any = None
-        self._task: asyncio.Task[None] | None = None
+        self._running = False
         self._callback: Callable[[bytes], None] | None = None
 
     @property
     def running(self) -> bool:
-        return self._task is not None and not self._task.done()
+        return self._running
 
     async def start(self, callback: Callable[[bytes], None]) -> None:
         if self.running:
             raise RuntimeError("RX stream already running.")
         self._callback = callback
+        # blocksize=0 (engine-native period) mirrors a clean sd.rec on the
+        # WASAPI face. latency="low" matches the (clean) output stream.
         self._stream = self._sd.InputStream(
             samplerate=self._sample_rate,
             channels=self._channels,
@@ -262,17 +289,16 @@ class _PortAudioRxStream:
             device=self._device_index,
             blocksize=self._blocksize,
             latency="low",
+            callback=self._input_callback,
         )
         self._stream.start()
-        self._task = asyncio.create_task(self._loop(), name="portaudio-rx")
+        self._running = True
 
     async def stop(self) -> None:
         stream = self._stream
-        task = self._task
         self._stream = None
-        self._task = None
+        self._running = False
         self._callback = None
-        # Close stream FIRST — unblocks executor thread stuck in stream.read()
         if stream is not None:
             try:
                 stream.stop()
@@ -282,30 +308,34 @@ class _PortAudioRxStream:
                 stream.close()
             except Exception:
                 logger.debug("portaudio-rx: stream close failed", exc_info=True)
-        # Now cancel the task (thread is already unblocked)
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
 
-    async def _loop(self) -> None:
-        stream = self._stream
+    def _input_callback(
+        self,
+        indata: Any,
+        _frames: int,
+        _time_info: Any,
+        _status: Any,
+    ) -> None:
+        # Runs on PortAudio's audio thread: keep it non-blocking. Copy the
+        # captured PCM out of the (reused) input buffer and deliver it to the
+        # consumer verbatim — no re-chunking, so no new discontinuity. The
+        # consumer is contractually cheap/thread-safe.
+        cb = self._callback
+        if cb is None:
+            return
         try:
-            while True:
-                data, _overflowed = await asyncio.to_thread(
-                    stream.read, self._blocksize
-                )
-                cb = self._callback
-                if cb is None:
-                    continue
-                pcm = bytes(data.tobytes()) if hasattr(data, "tobytes") else bytes(data)
-                cb(pcm)
-        except asyncio.CancelledError:
-            pass
+            pcm = (
+                bytes(indata.tobytes()) if hasattr(indata, "tobytes") else bytes(indata)
+            )
         except Exception:
-            logger.warning("portaudio-rx: loop failed", exc_info=True)
+            logger.warning("portaudio-rx: capture copy failed", exc_info=True)
+            return
+        if not pcm:
+            return
+        try:
+            cb(pcm)
+        except Exception:
+            logger.warning("portaudio-rx: consumer callback failed", exc_info=True)
 
 
 class _PortAudioTxStream:
@@ -795,13 +825,17 @@ class PortAudioBackend:
         frame_ms: int = 20,
     ) -> RxStream:
         sd, _ = self._ensure_deps()
-        blocksize = (sample_rate * frame_ms) // 1000
+        # blocksize=0 lets PortAudio use the engine-native period, mirroring a
+        # clean ``sd.rec`` capture. This is safe now that companion device
+        # selection forces the WASAPI host-API face (the WDM-KS face that
+        # rejected blocksize=0 with PortAudioError -9999 is no longer chosen).
+        del frame_ms  # capture period is engine-native (blocksize=0)
         return _PortAudioRxStream(
             sd,
             device_index=int(device),
             sample_rate=sample_rate,
             channels=channels,
-            blocksize=blocksize,
+            blocksize=0,
         )
 
     def open_tx(

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -428,16 +428,19 @@ class TestPortAudioBackendDeps:
         assert not stream.running
 
     @pytest.mark.asyncio()
-    async def test_open_rx_callback_delivers_all_samples_in_order(self) -> None:
-        """Anti-comb invariant: the variable-size callback blocks reach the
-        consumer with every sample, in order, with no loss or duplication.
+    async def test_open_rx_callback_emits_fixed_frame_ms_frames_lossless(self) -> None:
+        """Re-chunk invariant: variable-size device blocks are losslessly
+        accumulated and re-emitted to the consumer as FIXED frame_ms-sized
+        frames (the downstream PCM-TX validator rejects any other size).
 
-        The PortAudio callback delivers device-natural blocks whose frame count
-        may vary (480, then a short/long block, etc.). The capture path must not
-        re-chunk these onto a new fixed-size seam, drop, or reorder them: the
-        concatenation of what the consumer receives must equal the concatenation
-        of what PortAudio handed in. That byte-contiguity is exactly what was
-        broken by the old fixed-blocksize blocking read.
+        The PortAudio callback delivers engine-native blocks whose frame count
+        varies (480, 480, 200, 760, 480, ...). The capture path must accumulate
+        them and hand the consumer only whole frame_ms frames (960 samples =
+        1920 bytes s16le mono @ 48 kHz / 20 ms), with every sample delivered in
+        order, byte-for-byte equal to the input concatenation truncated to a
+        whole number of frames. No loss/dup/reorder. The re-chunk is of a
+        continuous callback stream, so it adds no scheduling seam (the ~50 Hz
+        comb came from the old blocking read's inter-read gap, not re-chunking).
         """
 
         class FakeIndata:
@@ -464,7 +467,9 @@ class TestPortAudioBackendDeps:
                     pass
 
         backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
-        stream = backend.open_rx(AudioDeviceId(0))
+        stream = backend.open_rx(
+            AudioDeviceId(0), sample_rate=48_000, channels=1, frame_ms=20
+        )
 
         received: list[bytes] = []
         await stream.start(received.append)
@@ -472,33 +477,89 @@ class TestPortAudioBackendDeps:
         cb = captured_cb["cb"]
         assert callable(cb)
 
-        # A reference s16le mono stream split into VARIABLE-size callback blocks
-        # (frame counts 4, 1, 7, 2, 6 -> 2 bytes/frame each). Feeding these
-        # through the callback must reproduce the reference byte-for-byte.
+        # A reference s16le mono stream split into VARIABLE-size device blocks
+        # (480, 480, 200, 760, 480 samples = 2400). The sequence crosses frame
+        # boundaries mid-block so re-chunking is genuinely exercised.
         import struct
 
-        reference = b"".join(struct.pack("<h", v) for v in range(20))
-        frame_splits = (4, 1, 7, 2, 6)  # sums to 20 frames
+        frame_samples = 960
+        frame_bytes = frame_samples * 2  # 1920 bytes (s16le mono)
+        # 2880 samples = exactly 3 whole frames once the final block lands.
+        total_samples = 2880
+        reference = b"".join(struct.pack("<h", v % 32768) for v in range(total_samples))
+        block_splits = (480, 480, 200, 760, 480)  # samples; sums to 2400
         offset = 0
-        for n_frames in frame_splits:
+        for n_frames in block_splits:
             chunk = reference[offset : offset + n_frames * 2]
             offset += n_frames * 2
             cb(FakeIndata(chunk), n_frames, None, None)  # type: ignore[operator]
 
-        assert b"".join(received) == reference  # all samples, in order, no dup
-        assert received == [
-            reference[0:8],
-            reference[8:10],
-            reference[10:24],
-            reference[24:28],
-            reference[28:40],
-        ]
+        # 2400 buffered samples -> two whole 960-sample frames emerge; the
+        # trailing 480-sample remainder stays buffered (not yet a whole frame).
+        assert len(received) == 2
+        for frame in received:
+            assert len(frame) == frame_bytes  # 1920 bytes / 20 ms each
+        assert b"".join(received) == reference[: 2 * frame_bytes]  # in order, no dup
+
+        # A final 480-sample block completes the third frame, draining the
+        # remainder. All 2880 samples now delivered as 3 fixed frames.
+        cb(FakeIndata(reference[offset:]), 480, None, None)  # type: ignore[operator]
+        assert len(received) == 3
+        assert all(len(f) == frame_bytes for f in received)
+        assert b"".join(received) == reference  # every sample, in order
 
         await stream.stop()
-        # After stop the consumer is detached: a late callback is a no-op (the
-        # audio thread may fire once more during teardown).
-        cb(FakeIndata(b"\xff\xff"), 1, None, None)  # type: ignore[operator]
-        assert b"".join(received) == reference
+        # After stop the consumer is detached and the accumulator is cleared: a
+        # late callback is a no-op (the audio thread may fire once during
+        # teardown).
+        cb(FakeIndata(b"\xff" * frame_bytes), 960, None, None)  # type: ignore[operator]
+        assert len(received) == 3
+
+    @pytest.mark.asyncio()
+    async def test_open_rx_callback_honors_frame_ms(self) -> None:
+        """frame_ms sizes the emitted frame: 10 ms -> 480 samples -> 960 bytes."""
+
+        class FakeIndata:
+            def __init__(self, payload: bytes) -> None:
+                self._payload = payload
+
+            def tobytes(self) -> bytes:
+                return self._payload
+
+        captured_cb: dict[str, object] = {}
+
+        class FakeSd:
+            class InputStream:
+                def __init__(self, **kw: object) -> None:
+                    captured_cb["cb"] = kw["callback"]
+
+                def start(self) -> None:
+                    pass
+
+                def stop(self) -> None:
+                    pass
+
+                def close(self) -> None:
+                    pass
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        stream = backend.open_rx(
+            AudioDeviceId(0), sample_rate=48_000, channels=1, frame_ms=10
+        )
+
+        received: list[bytes] = []
+        await stream.start(received.append)
+        cb = captured_cb["cb"]
+
+        # 1000 samples in one block -> two 480-sample (960-byte) frames, 40 left.
+        block = b"\x01\x02" * 1000
+        cb(FakeIndata(block), 1000, None, None)  # type: ignore[operator]
+
+        assert len(received) == 2
+        for frame in received:
+            assert len(frame) == 480 * 2  # 960 bytes / 10 ms each
+
+        await stream.stop()
 
     def test_open_tx_returns_tx_stream(self) -> None:
         class FakeSd:

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -368,6 +368,138 @@ class TestPortAudioBackendDeps:
         stream = backend.open_rx(AudioDeviceId(0))
         assert isinstance(stream, RxStream)
 
+    @pytest.mark.asyncio()
+    async def test_open_rx_opens_callback_driven_blocksize_zero(self) -> None:
+        """Capture must be callback-driven with blocksize=0 (engine-native).
+
+        Regression guard against the ~50 Hz TX "comb": the old implementation
+        read on a fixed-``blocksize=960`` blocking loop (``stream.read(960)`` in
+        ``asyncio.to_thread``), which straddled the WASAPI shared-mode engine
+        period and dropped/duplicated a sample run once per 20 ms block. The
+        stream must now register a ``callback=`` rather than reading, and open
+        with ``blocksize=0`` (engine-native period), mirroring a clean
+        ``sd.rec``. Companion device selection forces the WASAPI face on which
+        ``blocksize=0`` opens (the WDM-KS face that rejected ``blocksize=0`` with
+        PortAudioError -9999 is no longer chosen).
+        """
+        created: list[dict[str, object]] = []
+
+        class FakeSd:
+            class InputStream:
+                def __init__(self, **kw: object) -> None:
+                    created.append(kw)
+                    self.started = False
+                    self.stopped = False
+                    self.closed = False
+
+                def start(self) -> None:
+                    self.started = True
+
+                def stop(self) -> None:
+                    self.stopped = True
+
+                def close(self) -> None:
+                    self.closed = True
+
+                def read(self, _frames: int) -> object:  # pragma: no cover
+                    raise AssertionError("capture must not use blocking read()")
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        # frame_ms is advisory only now: the capture period is engine-native.
+        stream = backend.open_rx(
+            AudioDeviceId(0), sample_rate=48_000, channels=1, frame_ms=20
+        )
+        assert isinstance(stream, RxStream)
+
+        await stream.start(lambda _pcm: None)
+        assert stream.running
+
+        assert len(created) == 1
+        kwargs = created[0]
+        assert kwargs["blocksize"] == 0
+        assert callable(kwargs["callback"])
+        assert kwargs["samplerate"] == 48_000
+        assert kwargs["channels"] == 1
+        assert kwargs["dtype"] == "int16"
+        # device is passed as the integer index, unchanged.
+        assert kwargs["device"] == 0
+
+        await stream.stop()
+        assert not stream.running
+
+    @pytest.mark.asyncio()
+    async def test_open_rx_callback_delivers_all_samples_in_order(self) -> None:
+        """Anti-comb invariant: the variable-size callback blocks reach the
+        consumer with every sample, in order, with no loss or duplication.
+
+        The PortAudio callback delivers device-natural blocks whose frame count
+        may vary (480, then a short/long block, etc.). The capture path must not
+        re-chunk these onto a new fixed-size seam, drop, or reorder them: the
+        concatenation of what the consumer receives must equal the concatenation
+        of what PortAudio handed in. That byte-contiguity is exactly what was
+        broken by the old fixed-blocksize blocking read.
+        """
+
+        class FakeIndata:
+            def __init__(self, payload: bytes) -> None:
+                self._payload = payload
+
+            def tobytes(self) -> bytes:
+                return self._payload
+
+        captured_cb: dict[str, object] = {}
+
+        class FakeSd:
+            class InputStream:
+                def __init__(self, **kw: object) -> None:
+                    captured_cb["cb"] = kw["callback"]
+
+                def start(self) -> None:
+                    pass
+
+                def stop(self) -> None:
+                    pass
+
+                def close(self) -> None:
+                    pass
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        stream = backend.open_rx(AudioDeviceId(0))
+
+        received: list[bytes] = []
+        await stream.start(received.append)
+
+        cb = captured_cb["cb"]
+        assert callable(cb)
+
+        # A reference s16le mono stream split into VARIABLE-size callback blocks
+        # (frame counts 4, 1, 7, 2, 6 -> 2 bytes/frame each). Feeding these
+        # through the callback must reproduce the reference byte-for-byte.
+        import struct
+
+        reference = b"".join(struct.pack("<h", v) for v in range(20))
+        frame_splits = (4, 1, 7, 2, 6)  # sums to 20 frames
+        offset = 0
+        for n_frames in frame_splits:
+            chunk = reference[offset : offset + n_frames * 2]
+            offset += n_frames * 2
+            cb(FakeIndata(chunk), n_frames, None, None)  # type: ignore[operator]
+
+        assert b"".join(received) == reference  # all samples, in order, no dup
+        assert received == [
+            reference[0:8],
+            reference[8:10],
+            reference[10:24],
+            reference[24:28],
+            reference[28:40],
+        ]
+
+        await stream.stop()
+        # After stop the consumer is detached: a late callback is a no-op (the
+        # audio thread may fire once more during teardown).
+        cb(FakeIndata(b"\xff\xff"), 1, None, None)  # type: ignore[operator]
+        assert b"".join(received) == reference
+
     def test_open_tx_returns_tx_stream(self) -> None:
         class FakeSd:
             class OutputStream:

--- a/tests/test_audio_capture_tx_validator_seam.py
+++ b/tests/test_audio_capture_tx_validator_seam.py
@@ -107,7 +107,7 @@ class _ValidatorHarness(AudioRuntimeMixin):
 # ---------------------------------------------------------------------------
 
 # Each entry is a format the capture path and the validator must agree on. The
-# 20 ms / 48 kHz / mono case is the production Icom-LAN PCM TX contract; 10 ms is
+# 20 ms / 48 kHz / mono case is the production RigPlane PCM TX contract; 10 ms is
 # the smaller frame, and 2-channel checks the channel multiplier on both sides.
 _SUPPORTED_FORMATS = [
     (48_000, 20, 1),

--- a/tests/test_audio_capture_tx_validator_seam.py
+++ b/tests/test_audio_capture_tx_validator_seam.py
@@ -1,0 +1,312 @@
+"""Cross-seam regression: capture output is ALWAYS accepted by core PCM TX validator.
+
+This locks the seam between two sides that previously disagreed on frame size:
+
+* **Capture (producer)** — :class:`rigplane.audio.backend._PortAudioRxStream`,
+  driven via :meth:`PortAudioBackend.open_rx`. Its PortAudio callback receives
+  *engine-native, variable-size* device blocks (``blocksize=0``) and re-chunks
+  them into fixed ``frame_ms`` frames before handing them to the consumer.
+* **Validator (consumer)** — the managed core PCM TX path
+  :meth:`AudioRuntimeMixin._push_audio_tx_pcm_internal` (reached through the
+  public :meth:`push_audio_tx_pcm`). It raises
+  :class:`AudioFormatError` unless ``len(frame) == fmt.frame_bytes``.
+
+The bug these tests guard: ``_PortAudioRxStream`` used to forward the device-native
+variable-size blocks verbatim (~960 bytes / 10 ms on a WASAPI shared-mode engine),
+while the validator hard-requires exactly ``fmt.frame_bytes`` (1920 bytes for
+48000/1ch/s16le/20 ms). Every TX frame was rejected -> radio Po=0 W. No test
+previously spanned the capture *output* and the validator *required* size, so the
+960-vs-1920 mismatch slipped through.
+
+Both sides use the REAL production code (no re-implementation of the size check):
+the capture is the real ``_PortAudioRxStream`` (only ``sounddevice`` is faked via
+``open_rx``'s ``dependency_loader``), and the validator is the real
+``AudioRuntimeMixin._push_audio_tx_pcm_internal`` (only the transport
+``_audio_stream`` is faked so no socket is needed).
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from rigplane.audio.backend import AudioDeviceId, PortAudioBackend
+from rigplane.core.exceptions import AudioFormatError
+from rigplane.core.types import AudioCodec
+from rigplane.runtime._audio_runtime_mixin import AudioRuntimeMixin
+
+# ---------------------------------------------------------------------------
+# Fakes — minimal, matching tests/test_audio_backend.py style.
+# ---------------------------------------------------------------------------
+
+
+class _FakeIndata:
+    """sounddevice indata stand-in: an ``int16`` buffer exposing ``tobytes()``."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def tobytes(self) -> bytes:
+        return self._payload
+
+
+def _make_fake_sd(captured_cb: dict[str, object]) -> type:
+    """Build a fake ``sounddevice`` module whose InputStream records the callback.
+
+    The capture path registers ``callback=`` and never calls ``read()``; the test
+    drives the recorded callback directly with adversarial variable-size blocks.
+    """
+
+    class FakeSd:
+        class InputStream:
+            def __init__(self, **kw: object) -> None:
+                captured_cb["cb"] = kw["callback"]
+
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+    return FakeSd
+
+
+class _FakeTxAudioStream:
+    """Records frames that survive the validator and reach the transport push."""
+
+    def __init__(self) -> None:
+        self.pushed: list[bytes] = []
+
+    async def push_tx(self, data: bytes) -> None:
+        self.pushed.append(bytes(data))
+
+
+class _ValidatorHarness(AudioRuntimeMixin):
+    """Minimal real ``AudioRuntimeMixin`` host that exercises the PCM TX validator.
+
+    Only the two collaborators the validator touches are stubbed: ``_check_connected``
+    (no socket) and ``_audio_stream`` (records pushed frames). The size check itself
+    (``len(frame) != fmt.frame_bytes``) is the unmodified production code.
+    """
+
+    def __init__(self, *, sample_rate: int, channels: int, frame_ms: int) -> None:
+        self._audio_stream = _FakeTxAudioStream()  # type: ignore[assignment]
+        self._audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+        self._pcm_tx_fmt = (sample_rate, channels, frame_ms)
+
+    def _check_connected(self) -> None:  # type: ignore[override]
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Supported (sample_rate, frame_ms, channels) combos exercised on both sides.
+# ---------------------------------------------------------------------------
+
+# Each entry is a format the capture path and the validator must agree on. The
+# 20 ms / 48 kHz / mono case is the production Icom-LAN PCM TX contract; 10 ms is
+# the smaller frame, and 2-channel checks the channel multiplier on both sides.
+_SUPPORTED_FORMATS = [
+    (48_000, 20, 1),
+    (48_000, 10, 1),
+    (24_000, 20, 1),
+    (48_000, 20, 2),
+]
+
+
+def _expected_frame_bytes(sample_rate: int, frame_ms: int, channels: int) -> int:
+    frame_samples = sample_rate * frame_ms // 1000
+    return frame_samples * channels * 2  # s16le
+
+
+def _open_capture(
+    sample_rate: int,
+    frame_ms: int,
+    channels: int,
+) -> tuple[object, dict[str, object]]:
+    """Open the REAL capture stream against a fake sounddevice; return (stream, cb)."""
+    captured_cb: dict[str, object] = {}
+    fake_sd = _make_fake_sd(captured_cb)
+    backend = PortAudioBackend(dependency_loader=lambda: (fake_sd(), object()))
+    stream = backend.open_rx(
+        AudioDeviceId(0),
+        sample_rate=sample_rate,
+        channels=channels,
+        frame_ms=frame_ms,
+    )
+    return stream, captured_cb
+
+
+def _tone_pcm(total_samples: int, channels: int) -> bytes:
+    """A deterministic interleaved s16le buffer (a ramp doubles as a tone here).
+
+    Distinct per-sample values let the concatenation assert catch any
+    reorder/dup/loss, not just a length match.
+    """
+    out = bytearray()
+    for n in range(total_samples * channels):
+        out += struct.pack("<h", (n * 7 + 1) % 32768)
+    return bytes(out)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Cross-seam INTEGRATION: every captured frame is validator-accepted.
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureFramesAlwaysAcceptedByTxValidator:
+    @pytest.mark.asyncio()
+    async def test_adversarial_blocks_emit_only_validator_accepted_frames(self) -> None:
+        """Drive the real capture with adversarial variable-size blocks; feed every
+        emitted frame into the real PCM TX validator. Assert ZERO ``AudioFormatError``
+        and that accepted frames reconstruct the captured samples (no loss/dup/reorder).
+
+        This is the regression guard for the 960-vs-1920 mismatch. If the capture
+        reverted to forwarding device-native variable-size blocks verbatim, the
+        validator would raise ``AudioFormatError`` on the first non-1920-byte block
+        and this test would go RED (verified by monkeypatching the capture to
+        forward verbatim — see test below).
+        """
+        sample_rate, frame_ms, channels = 48_000, 20, 1
+        frame_bytes = _expected_frame_bytes(sample_rate, frame_ms, channels)
+
+        stream, captured_cb = _open_capture(sample_rate, frame_ms, channels)
+
+        # Collect every frame the capture emits to the consumer callback.
+        emitted: list[bytes] = []
+        await stream.start(emitted.append)
+        cb = captured_cb["cb"]
+        assert callable(cb)
+
+        # Adversarial engine-native block sizes (in samples). Deliberately none is
+        # a whole 960-sample frame and many straddle frame boundaries: 480, 200,
+        # 760, 333, 480, 480, 187, ... The pattern repeats to span several seconds.
+        block_pattern = (480, 200, 760, 333, 480, 480, 187, 911, 49, 600)
+        # Several seconds of audio so the seam is hammered, not just touched once.
+        target_samples = sample_rate * 4  # ~4 s mono
+        reference = _tone_pcm(target_samples, channels)
+
+        offset = 0
+        i = 0
+        total_bytes = len(reference)
+        while offset < total_bytes:
+            n_samples = block_pattern[i % len(block_pattern)]
+            i += 1
+            nbytes = n_samples * channels * 2
+            chunk = reference[offset : offset + nbytes]
+            if not chunk:
+                break
+            offset += len(chunk)
+            cb(_FakeIndata(chunk), len(chunk) // (channels * 2), None, None)
+
+        # --- The key assertion: every emitted frame is validator-accepted. ---
+        validator = _ValidatorHarness(
+            sample_rate=sample_rate, channels=channels, frame_ms=frame_ms
+        )
+        for frame in emitted:
+            # Real production validator path; raises AudioFormatError on size
+            # mismatch. The test asserts it NEVER does for capture output.
+            await validator.push_audio_tx_pcm(frame)
+
+        # No frame was rejected: every emitted frame reached the transport push.
+        assert len(validator._audio_stream.pushed) == len(emitted)  # type: ignore[union-attr]
+        # And every emitted frame is exactly one validator frame.
+        assert emitted, "capture must emit at least one frame for a multi-second tone"
+        assert all(len(f) == frame_bytes for f in emitted)
+
+        # Sanity: accepted frames reconstruct the captured samples truncated to
+        # whole frames (no loss, no dup, no reorder).
+        whole_frames = total_bytes // frame_bytes
+        assert b"".join(emitted) == reference[: whole_frames * frame_bytes]
+
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_verbatim_forwarding_would_be_rejected(self) -> None:
+        """Document/verify the guard: pre-fix verbatim forwarding -> validator rejects.
+
+        Simulates the OLD behavior (forward each device-native variable-size block
+        straight to the consumer, no re-chunking) and feeds those blocks into the
+        SAME real validator. Asserts the validator DOES raise ``AudioFormatError``,
+        proving the integration test above is a genuine regression guard rather than
+        a tautology: the seam only passes because the capture re-chunks.
+        """
+        sample_rate, frame_ms, channels = 48_000, 20, 1
+        validator = _ValidatorHarness(
+            sample_rate=sample_rate, channels=channels, frame_ms=frame_ms
+        )
+        # A device-native block that is NOT a whole frame (480 samples = 960 bytes,
+        # the ~10 ms WASAPI engine period that triggered the original 0 W bug).
+        verbatim_block = _tone_pcm(480, channels)
+        assert len(verbatim_block) == 960  # != 1920 = fmt.frame_bytes
+
+        with pytest.raises(AudioFormatError, match="PCM frame size mismatch"):
+            await validator.push_audio_tx_pcm(verbatim_block)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — CONTRACT: capture emitted-frame size == validator required frame_bytes.
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureValidatorFrameSizeContract:
+    @pytest.mark.parametrize(
+        ("sample_rate", "frame_ms", "channels"), _SUPPORTED_FORMATS
+    )
+    @pytest.mark.asyncio()
+    async def test_emitted_frame_size_equals_validator_required_bytes(
+        self,
+        sample_rate: int,
+        frame_ms: int,
+        channels: int,
+    ) -> None:
+        """Pin both sides to one truth for each supported format.
+
+        The capture emits frames of ``frame_samples * channels * 2`` bytes; the
+        validator requires exactly ``PcmAudioFormat.frame_bytes`` for the matching
+        PCM format. They must be equal, so a future change to blocksize / rate /
+        frame_ms / channels / codec / sample width on EITHER side breaks this test.
+        """
+        expected = _expected_frame_bytes(sample_rate, frame_ms, channels)
+
+        # --- Validator side: the size the core PCM TX validator REQUIRES. ---
+        # Construct the real format object the validator builds internally and read
+        # its required frame_bytes (the exact value compared in the size check).
+        from rigplane.audio._transcoder import PcmAudioFormat
+
+        validator_required = PcmAudioFormat(
+            sample_rate=sample_rate, channels=channels, frame_ms=frame_ms
+        ).frame_bytes
+        assert validator_required == expected
+
+        # --- Capture side: the size the real capture path EMITS. ---
+        stream, captured_cb = _open_capture(sample_rate, frame_ms, channels)
+        emitted: list[bytes] = []
+        await stream.start(emitted.append)
+        cb = captured_cb["cb"]
+
+        # Feed exactly two whole frames' worth of audio in oddly-sized blocks so the
+        # emitted frame size (not the input block size) is what is asserted.
+        two_frames_samples = (sample_rate * frame_ms // 1000) * 2
+        reference = _tone_pcm(two_frames_samples, channels)
+        # Split into three uneven blocks that cross the frame boundary.
+        third = len(reference) // 3
+        for chunk in (
+            reference[:third],
+            reference[third : 2 * third],
+            reference[2 * third :],
+        ):
+            if chunk:
+                cb(_FakeIndata(chunk), len(chunk) // (channels * 2), None, None)
+
+        await stream.stop()
+
+        assert emitted, "capture must emit whole frames for two-frame input"
+        emitted_frame_size = len(emitted[0])
+        assert all(len(f) == emitted_frame_size for f in emitted)
+
+        # The load-bearing contract: capture output size == validator required size.
+        assert emitted_frame_size == validator_required == expected

--- a/tests/test_audio_tx_contract_consistency.py
+++ b/tests/test_audio_tx_contract_consistency.py
@@ -1,6 +1,6 @@
 """TX-format single-source-of-truth contract guards.
 
-These pin the boundaries where the negotiated Icom-LAN TX format (the
+These pin the boundaries where the negotiated RigPlane TX format (the
 ``AudioStreamContract`` resolved in ``IcomRadio.__init__``) must agree with the
 PCM TX validator and the codec the radio actually puts on the wire. They guard
 the *class* of the 3-day outage: a TX stage deriving its

--- a/tests/test_audio_tx_contract_consistency.py
+++ b/tests/test_audio_tx_contract_consistency.py
@@ -1,0 +1,244 @@
+"""TX-format single-source-of-truth contract guards.
+
+These pin the boundaries where the negotiated Icom-LAN TX format (the
+``AudioStreamContract`` resolved in ``IcomRadio.__init__``) must agree with the
+PCM TX validator and the codec the radio actually puts on the wire. They guard
+the *class* of the 3-day outage: a TX stage deriving its
+codec/rate/channel/frame-size assumption independently from the negotiated one.
+
+What each guard locks (all hermetic — no hardware, no sockets):
+
+* **Codec single-source-of-truth** — every ``AudioCodec`` maps to exactly one
+  channel count via ``route._CHANNELS_BY_CODEC``; a contract can never pair a
+  1-channel codec with a 2-channel count (or vice versa), so the validator's
+  ``frame_bytes`` can never silently diverge from the negotiated channel count.
+* **Negotiated PCM contract -> raw PCM on the wire** — a PCM-negotiated radio
+  resolves ``_audio_tx_codec == PCM_1CH_16BIT`` and
+  ``_push_audio_tx_pcm_internal`` forwards the PCM frame *unchanged* (the
+  "Opus-was-sent-when-PCM-expected" regression would flip this).
+* **Negotiated Opus contract -> Opus on the wire** — the divergence is genuinely
+  detectable: an Opus-negotiated radio transcodes instead of forwarding raw PCM.
+* **Contract rate/channels feed the validator's frame size** — the bytes the
+  validator requires are computed from the *same* negotiated rate/channels the
+  contract carries, for every supported PCM rate.
+
+The TX *frame-size* seam (capture output == validator required bytes) is locked
+separately in ``test_audio_capture_tx_validator_seam.py``; this module locks the
+codec/rate/channel agreement that sits next to it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rigplane.audio._transcoder import PcmAudioFormat
+from rigplane.audio.route import (
+    _CHANNELS_BY_CODEC,
+    resolve_lan_audio_stream_request,
+)
+from rigplane.core.types import AudioCodec
+from rigplane.profiles import get_radio_profile
+from rigplane.radio import IcomRadio
+from rigplane.runtime._audio_runtime_mixin import AudioRuntimeMixin
+
+
+# ---------------------------------------------------------------------------
+# Fakes — minimal, matching tests/test_audio_transcoder.py style.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingTxAudioStream:
+    """Records the exact bytes handed to the transport push (post codec branch)."""
+
+    def __init__(self) -> None:
+        self.pushed: list[bytes] = []
+
+    async def push_tx(self, data: bytes) -> None:
+        self.pushed.append(bytes(data))
+
+
+class _ContractValidatorHarness(AudioRuntimeMixin):
+    """Real ``AudioRuntimeMixin`` driven by a negotiated TX codec.
+
+    Only the transport (``_audio_stream``) and ``_check_connected`` are stubbed.
+    The codec branch in ``_push_audio_tx_pcm_internal`` and the size validation
+    are unmodified production code.
+    """
+
+    def __init__(
+        self,
+        *,
+        tx_codec: AudioCodec,
+        sample_rate: int,
+        channels: int,
+        frame_ms: int,
+    ) -> None:
+        self._audio_stream = _RecordingTxAudioStream()  # type: ignore[assignment]
+        self._audio_tx_codec = tx_codec
+        self._pcm_tx_fmt = (sample_rate, channels, frame_ms)
+        # Opus path needs a transcoder; provide a deterministic tagging fake so
+        # the test can tell raw-PCM from transcoded output without libopus.
+        self._pcm_transcoder = _TaggingTranscoder()  # type: ignore[assignment]
+        self._pcm_transcoder_fmt = (sample_rate, channels, frame_ms)
+
+    def _check_connected(self) -> None:  # type: ignore[override]
+        return None
+
+
+class _TaggingTranscoder:
+    """Marks data as transcoded instead of encoding (no libopus dependency)."""
+
+    def pcm_to_opus(self, pcm: bytes) -> bytes:
+        return b"OPUS:" + bytes(pcm)
+
+
+# Every PCM rate the transcoder/validator accepts, at the production 20 ms frame.
+_PCM_RATES = [8000, 12000, 16000, 24000, 48000]
+
+
+# ---------------------------------------------------------------------------
+# Guard 1 — codec <-> channels single source of truth.
+# ---------------------------------------------------------------------------
+
+
+class TestCodecChannelsSingleSourceOfTruth:
+    @pytest.mark.parametrize("codec", list(AudioCodec))
+    def test_every_codec_has_exactly_one_channel_count(self, codec: AudioCodec) -> None:
+        """``route._CHANNELS_BY_CODEC`` is the only place channels are derived.
+
+        If a future edit adds a codec without a channel mapping, the
+        ``resolve_lan_audio_stream_request`` ``rx_channels=_CHANNELS_BY_CODEC[...]``
+        lookup would ``KeyError`` at runtime; this catches it at test time.
+        """
+        assert codec in _CHANNELS_BY_CODEC
+        channels = _CHANNELS_BY_CODEC[codec]
+        assert channels in (1, 2)
+        # The channel count must match the "1CH"/"2CH" promise encoded in the
+        # codec name, so a contract can never pair (e.g.) a 1ch codec with a
+        # 2-sample-per-frame validator expectation.
+        if "1CH" in codec.name:
+            assert channels == 1, f"{codec.name} must be mono"
+        if "2CH" in codec.name:
+            assert channels == 2, f"{codec.name} must be stereo"
+
+    def test_resolved_request_channels_track_resolved_codec(self) -> None:
+        """The resolved request's tx/rx channels always equal the codec mapping.
+
+        A drift here is exactly the channel-count divergence class: the contract
+        would advertise a channel count the codec does not imply, and the
+        validator's ``frame_bytes`` would silently expect the wrong size.
+        """
+        request = resolve_lan_audio_stream_request(
+            profile=get_radio_profile("IC-7610"),
+            requested_rx_codec=AudioCodec.PCM_2CH_16BIT,
+            requested_sample_rate_hz=48000,
+        )
+        assert request.rx_channels == _CHANNELS_BY_CODEC[request.rx_codec]
+        assert request.tx_channels == _CHANNELS_BY_CODEC[request.tx_codec]
+
+
+# ---------------------------------------------------------------------------
+# Guard 2 — negotiated PCM contract -> raw PCM on the wire (no Opus).
+# ---------------------------------------------------------------------------
+
+
+class TestNegotiatedContractDrivesWireCodec:
+    def test_pcm_negotiated_radio_resolves_pcm_tx_codec(self) -> None:
+        """A direct-LAN PCM radio negotiates ``_audio_tx_codec == PCM_1CH_16BIT``.
+
+        This is the constructor-level source of truth: the same contract value
+        the validator/codec branch reads. If conninfo resolution ever produced
+        Opus for a PCM radio, the wire path below would transcode and the radio
+        would reject (the false-suspect "Opus vs PCM" failure mode).
+        """
+        radio = IcomRadio("192.168.1.100", model="IC-7300")
+        contract = radio.audio_stream_contract
+        assert contract.tx_codec == AudioCodec.PCM_1CH_16BIT
+        assert radio._audio_tx_codec == AudioCodec.PCM_1CH_16BIT
+        # Channels/rate the validator will size frames from come from the same
+        # contract object, not an independent default.
+        assert contract.tx_channels == _CHANNELS_BY_CODEC[contract.tx_codec]
+
+    @pytest.mark.asyncio
+    async def test_pcm_tx_codec_forwards_raw_pcm_unchanged(self) -> None:
+        """PCM-negotiated codec => frame reaches the transport byte-for-byte.
+
+        Goes RED if ``_audio_tx_codec`` is perturbed to ``OPUS_1CH`` (the wire
+        bytes would then be the ``OPUS:``-tagged transcode, not the raw frame) —
+        see the companion test below that perturbs exactly that.
+        """
+        harness = _ContractValidatorHarness(
+            tx_codec=AudioCodec.PCM_1CH_16BIT,
+            sample_rate=48000,
+            channels=1,
+            frame_ms=20,
+        )
+        frame = b"\x11\x22" * 960  # 1920 bytes == fmt.frame_bytes for 48k/1/20
+        await harness.push_audio_tx_pcm(frame)
+        pushed = harness._audio_stream.pushed  # type: ignore[union-attr]
+        assert pushed == [frame], "PCM contract must forward the frame unchanged"
+
+    @pytest.mark.asyncio
+    async def test_opus_tx_codec_transcodes_so_divergence_is_detectable(self) -> None:
+        """Opus-negotiated codec => frame is transcoded, not forwarded raw.
+
+        Proves the guard above is genuine: the same input under a different
+        negotiated codec produces *different* wire bytes, so an
+        Opus-when-PCM-expected (or vice versa) divergence is observable.
+        """
+        harness = _ContractValidatorHarness(
+            tx_codec=AudioCodec.OPUS_1CH,
+            sample_rate=48000,
+            channels=1,
+            frame_ms=20,
+        )
+        frame = b"\x11\x22" * 960
+        await harness.push_audio_tx_pcm(frame)
+        pushed = harness._audio_stream.pushed  # type: ignore[union-attr]
+        assert pushed == [b"OPUS:" + frame]
+        assert pushed != [frame], "Opus path must NOT forward raw PCM"
+
+
+# ---------------------------------------------------------------------------
+# Guard 3 — contract rate/channels feed the validator's frame size.
+# ---------------------------------------------------------------------------
+
+
+class TestContractRateChannelsFeedValidatorFrameSize:
+    @pytest.mark.parametrize("sample_rate", _PCM_RATES)
+    @pytest.mark.asyncio
+    async def test_validator_accepts_exactly_contract_sized_frame(
+        self, sample_rate: int
+    ) -> None:
+        """The validator's required bytes == bytes from the negotiated rate/ch.
+
+        For each PCM rate, the frame size the validator enforces is computed from
+        the *same* (sample_rate, channels, frame_ms) the TX format carries. A
+        frame one sample short must be rejected; the exact-size frame accepted.
+        Any future change that lets the validator size frames from a *different*
+        rate/channel source than the contract breaks this.
+        """
+        channels, frame_ms = 1, 20
+        expected = PcmAudioFormat(
+            sample_rate=sample_rate, channels=channels, frame_ms=frame_ms
+        ).frame_bytes
+
+        harness = _ContractValidatorHarness(
+            tx_codec=AudioCodec.PCM_1CH_16BIT,
+            sample_rate=sample_rate,
+            channels=channels,
+            frame_ms=frame_ms,
+        )
+
+        good = b"\x00" * expected
+        await harness.push_audio_tx_pcm(good)
+        assert harness._audio_stream.pushed == [good]  # type: ignore[union-attr]
+
+        # One sample short: the validator must reject, never forward.
+        from rigplane.core.exceptions import AudioFormatError
+
+        short = b"\x00" * (expected - 2)
+        with pytest.raises(AudioFormatError, match="PCM frame size mismatch"):
+            await harness.push_audio_tx_pcm(short)
+        # The bad frame was not forwarded.
+        assert harness._audio_stream.pushed == [good]  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

Windows TX delivery fix (open-core half). This PR makes the TX capture stream
produce frames the core PCM TX validator actually accepts, and kills the
~50 Hz read-seam comb that the previous fixed-blocksize capture introduced.

- Linear epic: **MOR-256** — audio-routing-redesign.
- Linear: **MOR-250** — Windows TX splatter / Po=0 W on TX.

This is the **open-core** half of a two-PR delivery. It ships **together** with
the proprietary companion PR (device selection + COM init); see cross-link
below.

## Root cause

On Windows, TX produced **Po = 0 W** (no carrier modulation) even though the
audio path looked connected. Two coupled defects:

1. **Read-seam comb.** Fixed-`blocksize` capture read the input stream in
   discrete chunks, and the boundary between successive reads injected a
   periodic discontinuity — a ~50 Hz comb across the TX audio. Switching to a
   callback-driven `blocksize=0` stream removes the application-side read seam
   entirely.
2. **TX frame-size rejection (the Po=0 W cause).** The callback +
   `blocksize=0` stream emitted **960-byte (10 ms)** frames, but the core PCM
   TX validator requires **1920-byte (20 ms)** frames (48 kHz, mono, S16LE).
   Result: **100 % of TX frames were rejected** at the validator, so nothing
   was ever transmitted. The capture path now re-chunks the callback stream
   into fixed `frame_ms` (1920-byte / 20 ms) frames before handoff, so the
   frames pass the validator unchanged.

## What changed

- `38663671` — **callback-driven `blocksize=0` TX capture.** Replaces the
  fixed-blocksize read loop with a callback stream so there is no
  application-side read seam, killing the ~50 Hz comb.
- `5c5f776` — **re-chunk the callback stream into fixed `frame_ms` frames.**
  Buffers callback output and emits exactly 1920-byte / 20 ms frames, fixing
  the TX frame-size rejection (960-vs-1920) that caused Po=0 W.
- `c88de19` — **regression test: capture ↔ core PCM TX validator seam.** Drives
  the capture output through the actual core validator and asserts acceptance;
  the historical 960-byte regression frame is explicitly rejected by this test.
- `3e7306a4` — **audio-path contract tests (codec/channels/rate SSOT).** Locks
  the TX format single-source-of-truth so codec, sample rate, and channel count
  cannot silently drift apart between capture and validator.

## Tests / verification

- New + seam suite: **23 passed** (`tests/test_audio_backend.py`,
  `tests/test_audio_capture_tx_validator_seam.py`,
  `tests/test_audio_tx_contract_consistency.py`).
- The new tests were **RED-verified without the fix** (they fail on the
  pre-fix capture behaviour), then green after.
- The seam test **rejects the 960-byte regression frame**, proving the
  validator boundary is enforced.

## On-air validation

After this fix, the operator completed **real FT8 QSOs** through the RigPlane
virtual audio driver on Windows. TX carrier modulation is restored end-to-end.

## Boundary

**mixed/split.** This PR is the **open-core** portion: the TX capture stream
and frame re-chunking (generic audio transport, no commercial/device logic).
The companion device-face selection and COM initialization live in the
proprietary `rigplane-pro` PR. **The two PRs must ship together** — locally the
companion consumes this core change via the editable path source; for
release/non-local consumption see the out-of-scope note in the companion PR.

## Out of scope / follow-up

- Release/version coordination (core version bump + companion re-pin) is tracked
  in the companion PR's out-of-scope section.
- **MOR-257** — comb bench harness — remains open.
- **MOR-258** — audio path tracer — remains open.

## Cross-link

Companion (proprietary) PR: https://github.com/rigplane/rigplane-pro/pull/1119
