### PR TITLE
chore(release): bump to 2.7.3 — Windows TX capture fix (MOR-256)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.3] — 2026-05-31
+
+### Fixed
+
+- Windows FT8 TX delivered no audio (Po=0 W): the callback/`blocksize=0` TX
+  capture emitted 960-byte (10 ms) frames while the PCM TX validator requires
+  1920-byte (20 ms) frames; capture now re-chunks the continuous callback stream
+  into fixed 20 ms frames (keeps the ~50 Hz comb fix; lossless) (MOR-256, #1699,
+  17492be6)
+
+### Changed
+
+- Build (packaging): build the web UI during packaging so source/git installs
+  bundle the SPA (#1698, 55a0f81f)
+
 ## [2.7.2] — 2026-05-30
 
 ### Fixed
@@ -1543,7 +1558,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.7.2...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.7.3...HEAD
+[2.7.3]: https://github.com/rigplane/rigplane-core/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/rigplane/rigplane-core/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/rigplane/rigplane-core/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/rigplane/rigplane-core/compare/v2.6.0...v2.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.7.2"
+version = "2.7.3"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.7.2"
+version = "2.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release version bump to **2.7.3**. This is the static version/changelog bump that enables the PyPI publish of the Windows FT8 TX fix. No source/logic changes — `pyproject.toml` version, `docs/CHANGELOG.md`, and the `uv.lock` self-version reference only.

Off `origin/main` HEAD `17492be6`.

## What's included (2 commits since `v2.7.2`)

- **Fixed** — Windows FT8 TX delivered no audio (Po=0 W): the callback/`blocksize=0` TX capture emitted 960-byte (10 ms) frames while the PCM TX validator requires 1920-byte (20 ms) frames; capture now re-chunks the continuous callback stream into fixed 20 ms frames (keeps the ~50 Hz comb fix; lossless). (MOR-256, #1699, `17492be6`)
- **Changed (build)** — build the web UI during packaging so source/git installs bundle the SPA. (#1698, `55a0f81f`)

## Why

This version bump is what enables the PyPI publish of the Windows TX fix (#1699). Without the static bump, the release/publish step has nothing new to ship.

## Changes

- `pyproject.toml`: `[project] version` `2.7.2` → `2.7.3`
- `docs/CHANGELOG.md`: new `## [2.7.3] — 2026-05-31` section (Fixed + Changed) + footer compare links
- `uv.lock`: rigplane self-version `2.7.2` → `2.7.3` (lockfile consistency)

## Verification

- `uv run ruff check .` — all checks passed
- `pyproject.toml` parses; `[project] version` reads `2.7.3`
- Full validate runs in PR CI (the real gate)

## Refs

- Linear: MOR-256
- Fix PR: #1699

## Out of scope

- Tagging, GitHub release, and PyPI publish are handled separately after merge by the maintainer.