### PR TITLE
refactor: introduce Connection transport protocol; handlers depend on it (MOR-274)

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -24,7 +24,8 @@ from ..protocol import (  # noqa: TID251
     encode_audio_frame,
     encode_json,
 )
-from ..websocket import WS_OP_BINARY, WS_OP_TEXT, WebSocketConnection  # noqa: TID251
+from ..transport import Connection  # noqa: TID251
+from ..websocket import WS_OP_BINARY, WS_OP_TEXT  # noqa: TID251
 
 if TYPE_CHECKING:
     from ...capabilities import CAP_AUDIO as _CAP_AUDIO_TYPE  # noqa: F401
@@ -77,7 +78,7 @@ class AudioBroadcaster:
         self.HIGH_WATERMARK = get_audio_broadcaster_high_watermark()
         self._radio = radio
         self._clients: dict[int, asyncio.Queue[bytes]] = {}
-        self._client_ws: dict[int, WebSocketConnection] = {}
+        self._client_ws: dict[int, Connection] = {}
         self._client_rx_codec: dict[int, int] = {}
         self._subscription: _AudioSubscription | None = None
         self._relay_task: asyncio.Task[None] | None = None
@@ -112,7 +113,7 @@ class AudioBroadcaster:
 
     async def subscribe(
         self,
-        ws: WebSocketConnection | None = None,
+        ws: Connection | None = None,
         *,
         preferred_rx_codec: int | None = None,
     ) -> asyncio.Queue[bytes]:
@@ -567,7 +568,7 @@ class AudioHandler:
 
     def __init__(
         self,
-        ws: WebSocketConnection,
+        ws: Connection,
         radio: "Radio | None",
         broadcaster: "AudioBroadcaster | None" = None,
     ) -> None:

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -140,7 +140,8 @@ from ..runtime_helpers import (  # noqa: TID251
     radio_ready,
     runtime_capabilities,
 )
-from ..websocket import WS_OP_TEXT, WebSocketConnection  # noqa: TID251
+from ..transport import Connection  # noqa: TID251
+from ..websocket import WS_OP_TEXT  # noqa: TID251
 
 if TYPE_CHECKING:
     from ...radio_protocol import Radio
@@ -365,7 +366,7 @@ class ControlHandler:
 
     def __init__(
         self,
-        ws: WebSocketConnection,
+        ws: Connection,
         radio: "Radio | None",
         server_version: str,
         radio_model: str,

--- a/src/rigplane/web/handlers/scope.py
+++ b/src/rigplane/web/handlers/scope.py
@@ -7,7 +7,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ..protocol import decode_json, encode_scope_frame  # noqa: TID251
-from ..websocket import WS_OP_TEXT, WebSocketConnection  # noqa: TID251
+from ..transport import Connection  # noqa: TID251
+from ..websocket import WS_OP_TEXT  # noqa: TID251
 
 if TYPE_CHECKING:
     from ...scope import ScopeFrame
@@ -33,7 +34,7 @@ class ScopeHandler:
 
     def __init__(
         self,
-        ws: WebSocketConnection,
+        ws: Connection,
         radio: Any = None,
         server: Any = None,
         audio_mode: bool = False,

--- a/src/rigplane/web/transport/__init__.py
+++ b/src/rigplane/web/transport/__init__.py
@@ -1,0 +1,14 @@
+"""Transport abstractions for the web layer.
+
+Defines the :class:`Connection` protocol — the minimal, transport-agnostic
+surface the WebSocket handlers depend on. ``WebSocketConnection`` (the
+stdlib RFC 6455 implementation) structurally satisfies it; future transports
+(e.g. WebRTC data channels) can satisfy the same protocol without touching
+the handlers.
+"""
+
+from __future__ import annotations
+
+from .connection import Connection  # noqa: TID251
+
+__all__ = ["Connection"]

--- a/src/rigplane/web/transport/connection.py
+++ b/src/rigplane/web/transport/connection.py
@@ -1,0 +1,50 @@
+"""The :class:`Connection` transport protocol.
+
+A structural (PEP 544) protocol describing the minimal full-duplex message
+surface the web WebSocket handlers (``control`` / ``scope`` / ``audio``)
+depend on. It is intentionally minimal: it declares *only* the methods the
+handlers actually call, so any concrete transport that implements these
+satisfies it with no edits.
+
+``WebSocketConnection`` (``rigplane.web.websocket``) already exposes exactly
+this surface and therefore satisfies ``Connection`` structurally, without any
+explicit subclassing or registration. This is a pure typing seam — there is
+no behaviour here.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Connection(Protocol):
+    """Transport-agnostic full-duplex message connection.
+
+    The surface mirrors ``WebSocketConnection`` exactly for the members the
+    handlers use. Signatures (including defaults) match the concrete
+    implementation so it structurally satisfies this protocol unchanged.
+    """
+
+    async def recv(self) -> tuple[int, bytes]:
+        """Receive the next complete message as ``(opcode, payload)``.
+
+        Raises ``EOFError`` on clean close.
+        """
+        ...
+
+    async def send_text(self, text: str) -> None:
+        """Send a text message."""
+        ...
+
+    async def send_binary(self, data: bytes) -> None:
+        """Send a binary message."""
+        ...
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        """Close the connection with the given status code and reason."""
+        ...
+
+    def is_alive(self) -> bool:
+        """True if the connection is open and considered healthy."""
+        ...

--- a/tests/test_web_transport_connection.py
+++ b/tests/test_web_transport_connection.py
@@ -1,0 +1,116 @@
+"""Tests for the ``Connection`` transport protocol (MOR-274).
+
+Pure-typing seam: these tests prove that
+
+1. the concrete ``WebSocketConnection`` structurally satisfies ``Connection``;
+2. a *minimal* fake implementing only the protocol surface satisfies it; and
+3. a real handler (``ScopeHandler``) drives correctly against that minimal
+   fake — i.e. the handlers truly depend only on the protocol surface.
+
+No ``MagicMock`` is used for the connection: per the project rule
+"MagicMock hides signature bugs", the fake is a real class whose method
+signatures match the protocol exactly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from rigplane.web.handlers.scope import ScopeHandler
+from rigplane.web.transport import Connection
+from rigplane.web.websocket import WS_OP_TEXT, WebSocketConnection
+
+
+class FakeConnection:
+    """Minimal in-memory connection implementing exactly the protocol.
+
+    Signatures mirror ``Connection`` precisely (including ``close`` defaults).
+    ``recv`` yields scripted ``(opcode, payload)`` tuples, then raises
+    ``EOFError`` to signal a clean close — exactly like ``WebSocketConnection``.
+    """
+
+    def __init__(self, incoming: list[tuple[int, bytes]] | None = None) -> None:
+        self._incoming = list(incoming or [])
+        self.sent_text: list[str] = []
+        self.sent_binary: list[bytes] = []
+        self.close_calls: list[tuple[int, str]] = []
+        self._alive = True
+
+    async def recv(self) -> tuple[int, bytes]:
+        if self._incoming:
+            return self._incoming.pop(0)
+        raise EOFError("connection closed")
+
+    async def send_text(self, text: str) -> None:
+        self.sent_text.append(text)
+
+    async def send_binary(self, data: bytes) -> None:
+        self.sent_binary.append(data)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.close_calls.append((code, reason))
+        self._alive = False
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+
+def _takes(conn: Connection) -> Connection:
+    """mypy-level structural check: anything passed must satisfy Connection."""
+    return conn
+
+
+def test_websocket_connection_satisfies_connection_protocol() -> None:
+    # Structural (runtime) check: the concrete impl satisfies the protocol
+    # without any subclassing or registration.
+    assert issubclass(WebSocketConnection, Connection)
+
+
+def test_fake_connection_satisfies_connection_protocol() -> None:
+    fake = FakeConnection()
+    assert isinstance(fake, Connection)
+    # And it flows through a Connection-typed callable (mypy + runtime).
+    assert _takes(fake) is fake
+
+
+@pytest.mark.asyncio
+async def test_scope_handler_recv_loop_runs_against_minimal_fake() -> None:
+    """ScopeHandler.run() drives recv() on the minimal fake and exits cleanly.
+
+    Feed one text control frame, then let ``recv`` raise ``EOFError`` to end
+    the loop — proving the receive side needs nothing beyond ``recv``.
+    """
+    fake = FakeConnection(incoming=[(WS_OP_TEXT, b'{"type":"hello"}')])
+    handler = ScopeHandler(fake, radio=None, server=None)
+
+    await asyncio.wait_for(handler.run(), timeout=2.0)
+
+    # Loop consumed the scripted frame and exited on EOFError without error.
+    assert fake._incoming == []
+
+
+@pytest.mark.asyncio
+async def test_scope_handler_sender_uses_only_send_binary() -> None:
+    """ScopeHandler._sender delivers queued frames via send_binary only.
+
+    Drive the sender coroutine directly against the minimal fake: enqueue a
+    pre-encoded frame, let it flush, then cancel. The frame must arrive via
+    ``send_binary`` — proving the send side depends only on the protocol.
+    """
+    fake = FakeConnection()
+    handler = ScopeHandler(fake, radio=None, server=None)
+    handler._frame_queue.put_nowait(b"\x00\x01scope-bytes")
+
+    sender = asyncio.create_task(handler._sender())
+    # Yield until the frame has been dequeued and sent.
+    for _ in range(100):
+        await asyncio.sleep(0)
+        if fake.sent_binary:
+            break
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert fake.sent_binary == [b"\x00\x01scope-bytes"]


### PR DESCRIPTION
## Scope

Pure-typing refactor (MOR-274 / A1). **Zero behaviour change.** Introduces a transport-abstraction seam so the WebSocket handlers no longer depend on the concrete `WebSocketConnection` — preparing for an alternate WebRTC data-channel transport (A2) without touching handler logic.

## What

- **New `src/rigplane/web/transport/` package** with a structural (PEP 544) `Connection` Protocol declaring **exactly** the surface the handlers use:
  - `async recv() -> tuple[int, bytes]`
  - `async send_text(text: str) -> None`
  - `async send_binary(data: bytes) -> None`
  - `async close(code: int = 1000, reason: str = "") -> None`
  - `is_alive() -> bool`
  - Signatures (incl. `close` defaults) mirror `WebSocketConnection` exactly, so it satisfies `Connection` **unchanged**. `runtime_checkable` so structural `isinstance` works.
- **Retyped handlers** `control.py`, `scope.py`, `audio.py`: `ws: WebSocketConnection` → `ws: Connection` (params + the audio broadcaster `_client_ws: dict[int, Connection]`). `WS_OP_TEXT`/`WS_OP_BINARY` still imported from `websocket` (protocol constants, not the connection type). No logic changed.
- `server.py` untouched: it still constructs and passes the concrete `WebSocketConnection`, which satisfies `Connection` at runtime.
- `WebSocketConnection` itself untouched.

### Design decisions
- **`closed` omitted** — handlers never reference `.closed`; only `is_alive()` is used (on the broadcaster dict values). Kept the protocol to the actual surface.
- **`peer_info` / `PeerInfo` omitted** — `WebSocketConnection` exposes no remote-address attribute today; inventing one would force changes and break the structural match. Noted here per the task; deferred.

## Verification (verbatim)

```
$ uv run mypy --strict src/rigplane/web
Success: no issues found in 23 source files

$ uv run ruff check src/ tests/
All checks passed!

$ uv run ruff format --check src/rigplane/web/transport/ tests/test_web_transport_connection.py
3 files already formatted

$ uv run lint-imports
Contracts: 4 kept, 0 broken.

$ uv run pytest tests/test_web_transport_connection.py -q
4 passed
```

Full suite (`uv run pytest tests/ -q --ignore=tests/integration`): **identical** failure profile to clean `origin/main` — 97 failed / 35 errors on both (pre-existing sandbox MagicMock-not-a-coroutine issue in `web_startup`/`server`, unrelated to this change). This branch adds **+4 passed** (the new tests) and **zero new failures**. New behaviour-bearing tests were ADDED only; no existing test was edited.

## Tests added
`tests/test_web_transport_connection.py`:
1. `WebSocketConnection` structurally satisfies `Connection` (`issubclass`).
2. A **minimal real fake** (no MagicMock — per core's "MagicMock hides signature bugs" rule) satisfies `Connection` (`isinstance` + a `Connection`-typed `_takes()` callable).
3. `ScopeHandler` drives correctly against the minimal fake — both the `recv` loop and the `send_binary` sender path — proving the handler depends only on the protocol surface.

## Open-core boundary
Respected: the seam is a generic, transport-agnostic protocol in the public `web/` layer; no telemetry, no hollowing-out, no upward imports. `import-linter` clean (the new `transport/` package sits inside `web/`). AGENTS.md-safe.

Linear: MOR-274

## Agent Review
Independent agent review required before merge — the implementation agent does not self-review. This PR is **not** to be merged by the implementer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
