### PR TITLE
fix(#1702): reset leaked external-CAT session on radio (re)connect

### DIFF
--- a/src/rigplane/hamlib_bridge.py
+++ b/src/rigplane/hamlib_bridge.py
@@ -135,10 +135,23 @@ class HamlibBridge:
         if self._server is not None:
             return self.back_port
         self._begin_session()  # take ownership: pause RigPlane's own pollers
-        self._subscription = self._radio.add_raw_civ_listener(self._on_radio_frame)
-        self._server = await asyncio.start_server(self._handle_back, self.host, 0)
-        self._back_port = self._server.sockets[0].getsockname()[1]
-        await self._server.start_serving()
+        try:
+            self._subscription = self._radio.add_raw_civ_listener(self._on_radio_frame)
+            self._server = await asyncio.start_server(self._handle_back, self.host, 0)
+            self._back_port = self._server.sockets[0].getsockname()[1]
+            await self._server.start_serving()
+        except BaseException:
+            # Never leak external-CAT ownership if setup fails after we claimed
+            # it — a leaked session pauses RigPlane's pollers forever (#1702).
+            if self._subscription is not None:
+                self._subscription.close()
+                self._subscription = None
+            if self._server is not None:
+                self._server.close()
+                self._server = None
+            self._back_port = None
+            self._end_session()
+            raise
         logger.info(
             "hamlib-bridge: back-side CI-V listener up on %s:%d",
             self.host,
@@ -227,11 +240,15 @@ class HamlibBridge:
         if callable(begin):
             begin()
 
-    async def _end_session_and_reconcile(self) -> None:
-        """Release ownership and refresh RigPlane state (both best-effort)."""
+    def _end_session(self) -> None:
+        """Release external-CAT-session ownership if the radio supports it."""
         end = getattr(self._radio, "end_external_cat_session", None)
         if callable(end):
             end()
+
+    async def _end_session_and_reconcile(self) -> None:
+        """Release ownership and refresh RigPlane state (both best-effort)."""
+        self._end_session()
         reconcile = getattr(self._radio, "reconcile_state", None)
         if callable(reconcile):
             try:

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -1056,7 +1056,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
         Delegates to the composed ControlPhaseRuntime, then fetches
         initial radio state so RadioState is populated before consumers.
+
+        A fresh (re)connection means any prior external-CAT session is over —
+        its transport is gone — so clear leaked ownership first (#1702). Without
+        this, a ``begin_external_cat_session()`` that was never matched by an
+        ``end_external_cat_session()`` (managed-runtime crash/restart, a dropped
+        Hamlib bridge) would keep cooperating pollers paused forever, freezing
+        ``radio_state`` while rigctld/web serve a stale frequency.
         """
+        self._reset_external_cat_session()
         await self._control_phase.connect()
         await self._fetch_initial_state()
 
@@ -1347,6 +1355,17 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """Release legacy external-CAT-session ownership. Idempotent."""
         if self._external_cat_session_owner not in (None, "external"):
             return
+        self._external_cat_session = False
+        self._external_cat_session_owner = None
+
+    def _reset_external_cat_session(self) -> None:
+        """Unconditionally clear external-CAT ownership (#1702).
+
+        Used on (re)connect: a new connection invalidates any prior session
+        regardless of owner, so this drops a leaked ``begin_external_cat_session``
+        that was never released. Unlike :meth:`end_external_cat_session` it does
+        not respect the current owner — the old session can no longer exist.
+        """
         self._external_cat_session = False
         self._external_cat_session_owner = None
 

--- a/tests/test_hamlib_bridge.py
+++ b/tests/test_hamlib_bridge.py
@@ -281,3 +281,18 @@ async def test_bridge_runs_against_icom_serial_backend() -> None:
     writer.close()
     await bridge.stop()  # reconcile is best-effort (radio not connected) — tolerated
     assert radio.external_cat_session_active is False
+
+
+async def test_open_transport_failure_does_not_leak_session(
+    radio: FakeRawPipeRadio,
+) -> None:
+    """Regression for #1702: if open_transport() raises *after* taking session
+    ownership, the external-CAT flag must not leak — otherwise cooperating
+    pollers pause forever and radio_state freezes."""
+    bridge = HamlibBridge(radio, model="3078")
+    boom = RuntimeError("listener setup failed")
+    with patch.object(radio, "add_raw_civ_listener", side_effect=boom):
+        with pytest.raises(RuntimeError, match="listener setup failed"):
+            await bridge.open_transport()
+    # Ownership was taken (_begin_session) then released on failure — no leak.
+    assert radio.session_active is False

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -209,9 +209,7 @@ class TestExternalCatSessionResetOnConnect:
         # Drive connect() without hardware: stub the control-phase handshake and
         # the initial-state fetch so only the reset behaviour under test runs.
         with (
-            patch.object(
-                radio._control_phase, "connect", new_callable=AsyncMock
-            ),
+            patch.object(radio._control_phase, "connect", new_callable=AsyncMock),
             patch.object(radio, "_fetch_initial_state", new_callable=AsyncMock),
         ):
             await radio.connect()
@@ -226,9 +224,7 @@ class TestExternalCatSessionResetOnConnect:
         """The reset is a no-op on a clean connect (no false-positive churn)."""
         assert radio.external_cat_session_active is False
         with (
-            patch.object(
-                radio._control_phase, "connect", new_callable=AsyncMock
-            ),
+            patch.object(radio._control_phase, "connect", new_callable=AsyncMock),
             patch.object(radio, "_fetch_initial_state", new_callable=AsyncMock),
         ):
             await radio.connect()

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -188,3 +188,48 @@ class TestReconnectPermanentErrors:
             radio._intentional_disconnect = True
             radio._control_phase._stop_reconnect()
             await asyncio.sleep(0.05)
+
+
+class TestExternalCatSessionResetOnConnect:
+    """Regression for #1702: a leaked external-CAT session must not survive a
+    (re)connect, or the cooperating pollers stay paused forever and rigctld/web
+    serve a frozen ``radio_state`` (e.g. the FT8 default freq)."""
+
+    @pytest.mark.asyncio
+    async def test_connect_resets_leaked_external_cat_session(
+        self, radio: IcomRadio
+    ) -> None:
+        """A begin_external_cat_session() that was never matched by an end()
+        (managed runtime crash/restart, dropped Hamlib bridge) leaves the flag
+        set. connect() must clear it so pollers resume after reconnect."""
+        # Simulate a leaked external-CAT session (no matching end()).
+        radio.begin_external_cat_session()
+        assert radio.external_cat_session_active is True
+
+        # Drive connect() without hardware: stub the control-phase handshake and
+        # the initial-state fetch so only the reset behaviour under test runs.
+        with (
+            patch.object(
+                radio._control_phase, "connect", new_callable=AsyncMock
+            ),
+            patch.object(radio, "_fetch_initial_state", new_callable=AsyncMock),
+        ):
+            await radio.connect()
+
+        assert radio.external_cat_session_active is False
+        assert radio._external_cat_session_owner is None
+
+    @pytest.mark.asyncio
+    async def test_connect_keeps_session_clear_when_not_leaked(
+        self, radio: IcomRadio
+    ) -> None:
+        """The reset is a no-op on a clean connect (no false-positive churn)."""
+        assert radio.external_cat_session_active is False
+        with (
+            patch.object(
+                radio._control_phase, "connect", new_callable=AsyncMock
+            ),
+            patch.object(radio, "_fetch_initial_state", new_callable=AsyncMock),
+        ):
+            await radio.connect()
+        assert radio.external_cat_session_active is False


### PR DESCRIPTION
Closes #1702

## Root cause (file:line)

After a managed LAN session restart, rigctld served a frozen frequency (`14074000`) and control writes did not refresh live state, while RX audio / spectrum / web-state kept working. Traced to a **leaked external-CAT session** that permanently pauses both pollers:

1. `runtime/radio.py:1330` `begin_external_cat_session()` sets `_external_cat_session = True`. Its only releaser at the bridge layer is `hamlib_bridge.py` `_end_session_and_reconcile()`, called **solely** from `stop()` / `__aexit__`. If `stop()` never runs — managed station runtime crash+restart (the `exit_code_1` / login-timeout in the issue), a dropped bridge object, or `open_transport()` raising **after** `_begin_session()` (was at `hamlib_bridge.py:137`, before the listener/server setup) — the flag leaks.
2. `runtime/radio.py:1054` `connect()` re-fetched initial state on (re)connect but **never reset** `_external_cat_session`, so a leaked flag survived the reconnect.
3. With the flag stuck `True`, `rigctld/poller.py:205` and `web/radio_poller.py:638` pause polling forever, so `radio_state.main.freq` is frozen at the last `_fetch_initial_state` value. `rigctld/handler.py:512-514` then serves that frozen `main.freq` indefinitely (any `freq > 0` wins over the fallback). The `14074000` value is the FT8 default the radio was last on — a stale **live** `main.freq`, not the `_FallbackRigState` default (which is `0`).

So the frozen value is "stale live state, pollers paused", not a fallback artifact.

## Fix (minimal, in-core, behaviour-preserving)

- `runtime/radio.py` — `connect()` calls a new `_reset_external_cat_session()` **before** the control-phase handshake. A fresh connection invalidates any prior external session (its transport is gone), so a leaked flag cannot survive a reconnect and the cooperating pollers resume. This is the load-bearing fix: it recovers regardless of who/how the flag leaked, and the `reconnect_loop` path already routes through `radio.connect()`.
- `hamlib_bridge.py` — `open_transport()` now releases ownership (`_end_session()`) if listener/server setup fails after `_begin_session()`, so a partial start cannot leak.

The legitimate poller-pause during an **active** external CAT session is untouched (the reset only fires on a new connect, when no live session can exist).

## Tests (TDD — added red, then fixed)

- `tests/test_reconnect.py::TestExternalCatSessionResetOnConnect` — `connect()` clears a leaked flag; no-op when already clean.
- `tests/test_hamlib_bridge.py::test_open_transport_failure_does_not_leak_session` — a failure mid-`open_transport` does not leak the session.

## Verification

- `uv run pytest tests/ -q` → 6569 passed, 112 skipped, 11 xfailed, 1 xpassed, 0 failures.
- `uv run ruff check src/ tests/` → clean.
- `uv run lint-imports` → 4 contracts kept, 0 broken.

## Confidence / hardware caveat

High confidence on the leak + no-reset-on-reconnect mechanism and that the fix restores polling after reconnect. The exact in-pro trigger that orphaned the session (managed-runtime crash vs. radio-object swap) lives in `rigplane-pro` and could not be reproduced here; the core fix is defensive and covers all leak sources at the connection boundary. The issue's secondary suggestions (rigctld surfacing "control unavailable" after N s of invalid state; confirm-or-fail control writes) are **not** included — they are larger behavioural changes beyond the minimal root-cause fix and can be tracked separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
