### PR TITLE
feat: make DiscoveryResponder fleet-aware with additive radios[] (MOR-303)

### DIFF
--- a/src/rigplane/web/discovery.py
+++ b/src/rigplane/web/discovery.py
@@ -20,7 +20,7 @@ from typing import Callable
 
 from .. import __version__
 
-__all__ = ["DiscoveryResponder", "RadioInfo"]
+__all__ = ["DiscoveryResponder", "FleetRadioInfo", "RadioInfo"]
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +46,25 @@ class RadioInfo:
     readiness: str | None = None
     message: str | None = None
     auth_required: bool = False
+
+
+@dataclass
+class FleetRadioInfo:
+    """Snapshot of a single radio endpoint in a multi-radio fleet.
+
+    A station supervisor runs N child radios on N web ports behind one
+    discovery responder. Each fleet member is described by one of these so the
+    responder can emit an additive ``radios[]`` array. ``web_port`` (and
+    optional per-radio ``tls``) let the responder build a reachable per-radio
+    URL using the same local IP it resolves for the response.
+    """
+
+    id: str
+    model: str
+    web_port: int
+    connected: bool
+    tls: bool | None = None
+    status: str | None = None
 
 
 class _DiscoveryProtocol(asyncio.DatagramProtocol):
@@ -85,6 +104,11 @@ class DiscoveryResponder:
         web_port: HTTP/HTTPS port of the web server.
         tls: Whether the web server uses TLS.
         radio_provider: Callable returning current RadioInfo, or None.
+        fleet_provider: Optional callable returning a list of FleetRadioInfo
+            for a multi-radio fleet. When it yields entries, the response gains
+            an additive ``radios[]`` array; the single-radio top-level fields
+            stay populated (from radio_provider, or from the first fleet entry)
+            for back-compatible parsers.
         name: Human-readable instance name (default: auto from radio model).
         bind_host: Address to bind UDP socket (default: 0.0.0.0).
         discovery_port: UDP port to listen on (default: 8470).
@@ -98,10 +122,12 @@ class DiscoveryResponder:
         name: str | None = None,
         bind_host: str = "0.0.0.0",
         discovery_port: int = _DEFAULT_PORT,
+        fleet_provider: Callable[[], list[FleetRadioInfo]] | None = None,
     ) -> None:
         self._web_port = web_port
         self._tls = tls
         self._radio_provider = radio_provider
+        self._fleet_provider = fleet_provider
         self._name = name
         self._bind_host = bind_host
         self._discovery_port = discovery_port
@@ -155,6 +181,18 @@ class DiscoveryResponder:
         scheme = "https" if self._tls else "http"
 
         radio_info = self._radio_provider() if self._radio_provider else None
+        fleet = self._fleet_provider() if self._fleet_provider else None
+
+        # Back-compat: keep the single-radio top-level block populated from the
+        # first/selected fleet member when no dedicated radio_provider is set,
+        # so legacy parsers still resolve a valid station_server.
+        if radio_info is None and fleet:
+            first = fleet[0]
+            radio_info = RadioInfo(
+                model=first.model,
+                connected=first.connected,
+                radio_ready=first.connected,
+            )
 
         if self._name:
             name = self._name
@@ -208,6 +246,27 @@ class DiscoveryResponder:
                 else None
             ),
         }
+
+        if fleet:
+            payload["kind"] = "station_fleet"
+            payload["radios"] = [
+                {
+                    "id": member.id,
+                    "model": member.model,
+                    "url": (
+                        f"{'https' if member.tls else 'http'}"
+                        f"://{local_ip}:{member.web_port}"
+                    ),
+                    "status": (
+                        member.status
+                        if member.status
+                        else ("connected" if member.connected else "available")
+                    ),
+                    "connected": member.connected,
+                }
+                for member in fleet
+            ]
+
         return json.dumps(payload, separators=(",", ":")).encode("utf-8")
 
 

--- a/tests/test_discovery_responder.py
+++ b/tests/test_discovery_responder.py
@@ -9,7 +9,7 @@ import socket
 import pytest
 
 from rigplane import __version__
-from rigplane.web.discovery import DiscoveryResponder, RadioInfo
+from rigplane.web.discovery import DiscoveryResponder, FleetRadioInfo, RadioInfo
 
 MAGIC = b"RIGPLANE_DISCOVER\n"
 LEGACY_MAGIC = b"ICOM_LAN_DISCOVER\n"
@@ -181,3 +181,146 @@ class TestDiscoveryResponder:
             assert result is None  # no response, but no crash
         finally:
             await r.stop()
+
+
+class TestDiscoveryResponderFleet:
+    """MOR-303: additive radios[] array for multi-radio fleets."""
+
+    async def _fleet_responder(
+        self,
+        fleet: list[FleetRadioInfo],
+        *,
+        radio_provider=None,
+    ) -> DiscoveryResponder:
+        r = DiscoveryResponder(
+            web_port=8080,
+            tls=False,
+            radio_provider=radio_provider,
+            fleet_provider=lambda: fleet,
+            bind_host="127.0.0.1",
+            discovery_port=0,
+        )
+        await r.start()
+        return r
+
+    async def test_radios_array_emitted_for_fleet(self) -> None:
+        fleet = [
+            FleetRadioInfo(
+                id="radio-a", model="IC-7610", web_port=8081, connected=True
+            ),
+            FleetRadioInfo(
+                id="radio-b", model="IC-705", web_port=8082, connected=False
+            ),
+        ]
+        r = await self._fleet_responder(fleet)
+        try:
+            raw = await _query(r.port, MAGIC)
+        finally:
+            await r.stop()
+        assert raw is not None
+        data = json.loads(raw)
+
+        assert data["kind"] == "station_fleet"
+        radios = data["radios"]
+        assert len(radios) == 2
+        first, second = radios
+        assert first["id"] == "radio-a"
+        assert first["model"] == "IC-7610"
+        assert first["url"].endswith(":8081")
+        assert first["url"].startswith("http://")
+        assert first["connected"] is True
+        assert first["status"] == "connected"
+        assert second["id"] == "radio-b"
+        assert second["url"].endswith(":8082")
+        assert second["connected"] is False
+        assert second["status"] == "available"
+
+    async def test_single_radio_fields_preserved_with_fleet(self) -> None:
+        """Back-compat: legacy single-radio top-level fields stay populated."""
+        fleet = [
+            FleetRadioInfo(
+                id="radio-a", model="IC-7610", web_port=8081, connected=True
+            ),
+            FleetRadioInfo(
+                id="radio-b", model="IC-705", web_port=8082, connected=False
+            ),
+        ]
+        # No dedicated radio_provider — top-level block must derive from first.
+        r = await self._fleet_responder(fleet)
+        try:
+            raw = await _query(r.port, MAGIC)
+        finally:
+            await r.stop()
+        assert raw is not None
+        data = json.loads(raw)
+
+        assert data["schema"] == "rigplane.station.discovery.v1"
+        assert data["radio"]["model"] == "IC-7610"
+        assert data["radio"]["connected"] is True
+        assert data["name"] == "IC-7610"
+        assert data["url"].startswith("http://")
+        assert ":8080" in data["url"]
+        assert data["station"]["radioAvailable"] is True
+        assert data["station"]["readiness"] == "ready_with_radio"
+
+    async def test_radio_provider_overrides_top_level_with_fleet(self) -> None:
+        """When both providers are set, top-level uses radio_provider."""
+        fleet = [
+            FleetRadioInfo(
+                id="radio-b", model="IC-705", web_port=8082, connected=False
+            ),
+        ]
+        r = await self._fleet_responder(
+            fleet,
+            radio_provider=lambda: RadioInfo(model="IC-7610", connected=True),
+        )
+        try:
+            raw = await _query(r.port, MAGIC)
+        finally:
+            await r.stop()
+        assert raw is not None
+        data = json.loads(raw)
+
+        assert data["radio"]["model"] == "IC-7610"
+        assert data["radios"][0]["model"] == "IC-705"
+
+    async def test_per_radio_explicit_status_and_tls(self) -> None:
+        fleet = [
+            FleetRadioInfo(
+                id="radio-a",
+                model="IC-7610",
+                web_port=8443,
+                connected=True,
+                tls=True,
+                status="in_use",
+            ),
+        ]
+        r = await self._fleet_responder(fleet)
+        try:
+            raw = await _query(r.port, MAGIC)
+        finally:
+            await r.stop()
+        assert raw is not None
+        data = json.loads(raw)
+
+        radio = data["radios"][0]
+        assert radio["status"] == "in_use"
+        assert radio["url"].startswith("https://")
+        assert radio["url"].endswith(":8443")
+
+    async def test_empty_fleet_keeps_single_radio_kind(self) -> None:
+        """An empty fleet must not flip kind or add radios[]."""
+        r = await self._fleet_responder(
+            [],
+            radio_provider=lambda: RadioInfo(model="IC-7610", connected=True),
+        )
+        try:
+            raw = await _query(r.port, MAGIC)
+        finally:
+            await r.stop()
+        assert raw is not None
+        data = json.loads(raw)
+
+        assert data["kind"] == "station_server"
+        assert "radios" not in data
+        assert data["radio"]["model"] == "IC-7610"


### PR DESCRIPTION
Closes #1704. Mirrors Linear **MOR-303** (https://linear.app/morozsm/issue/MOR-303).

## What
Make the UDP `DiscoveryResponder` fleet-aware so one responder (the station supervisor on :8470) can advertise N radios running on N child web ports, while staying fully back-compatible with today's rigplane-pro discovery parser.

## Changes
- New `FleetRadioInfo` dataclass: `id`, `model`, `web_port`, `connected`, optional `tls`/`status`.
- New optional `fleet_provider: Callable[[], list[FleetRadioInfo]]` constructor arg on `DiscoveryResponder`.
- `build_response` emits an **additive** `radios[]` array when the provider yields entries; each item: stable `id`, `model`, per-radio `url`, `status`, `connected`. `kind` becomes `station_fleet`.
- Per-radio `url` is built from the same resolved local IP plus each member's `web_port` (and optional per-radio `tls`). `status` defaults to `connected`/`available` from `connected`, or uses an explicit value.

## Back-compat (acceptance criterion)
- Schema id stays `rigplane.station.discovery.v1` (additive — no bump).
- The single-radio top-level block (`radio`/`url`/`name`/`station`) stays populated. When no dedicated `radio_provider` is set, it is derived from the first/selected fleet member, so today's rigplane-pro parser still resolves a valid `station_server`.
- Empty fleet leaves the response unchanged (`kind` stays `station_server`, no `radios` key).
- Existing discovery tests pass unchanged.

## radios[] shape
```json
"kind": "station_fleet",
"radios": [
  {"id": "radio-a", "model": "IC-7610", "url": "http://<ip>:8081", "status": "connected", "connected": true},
  {"id": "radio-b", "model": "IC-705",  "url": "http://<ip>:8082", "status": "available", "connected": false}
]
```

## Tests
New `TestDiscoveryResponderFleet`: radios[] emission, single-radio fields preserved with a fleet, `radio_provider` overriding the top level, explicit per-radio status + TLS url, and empty-fleet no-op. Existing discovery tests unchanged.

## Gates
- `pytest` (excl. integration): 6392 passed, 8 skipped, 11 xfailed.
- `ruff check` + `ruff format --check`: clean.
- `mypy src/`: `web/discovery.py` strict-clean (pre-existing unrelated errors in `runtime/_civ_rx.py` and `backends/yaesu_cat/radio.py` exist on `main`).
- `lint-imports`: 4 contracts kept.

## Blocks / unblocks
Unblocks station fleet discovery **MOR-301** (B2d) and the LAN-discovery regression fix where children run `--no-discovery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)