### PR TITLE
docs: align docs with recent audio and WebRTC releases

### DIFF
--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -121,8 +121,16 @@ await bridge.start()
 
 # Both receive the same packets independently
 # First subscriber triggers radio.start_audio_rx_opus()
-# Last .stop() schedules radio.stop_audio_rx_opus()
+# Last awaited close triggers radio.stop_audio_rx_opus()
+await web.aclose()
+await bridge.aclose()
 ```
+
+Subscriptions support `async with`, `await sub.aclose()`, and the older
+`sub.stop()` convenience path. Prefer `async with` or `await aclose()` when
+coordinating restart/teardown: the awaited close path removes the subscriber
+before the caller proceeds, so bridge or WebSocket restarts do not race a stale
+subscriber.
 
 ### Properties
 
@@ -130,6 +138,21 @@ await bridge.start()
 |----------|------|-------------|
 | `subscriber_count` | `int` | Number of active subscribers |
 | `rx_active` | `bool` | Whether radio RX is currently streaming |
+
+## Queue And Frame Semantics
+
+Audio queues are bounded to preserve real-time behavior. When a TX playback or
+bridge capture queue overflows, RigPlane drops the oldest queued audio and
+keeps the newest live frame. This intentionally favors bounded latency over
+perfect delivery of stale audio. Diagnostics count the event as an overrun and
+record dropped/overrun audio duration when that metric is available.
+
+PortAudio capture uses engine-native callback periods (`blocksize=0`) and then
+losslessly re-chunks the continuous callback stream into fixed `frame_ms`
+frames before handing it to PCM TX validators. At 48 kHz, 16-bit mono,
+`frame_ms=20` means each emitted TX frame is 1920 bytes. Consumers should still
+treat WebSocket/DataChannel `frame_ms` as an advisory label and derive actual
+duration from payload size and metadata.
 
 ## Module Constants
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -75,6 +75,8 @@ These routes are part of the Pro/supervisor compatibility surface:
 | `GET` | `/api/v1/eibi/segments?start=<hz>&end=<hz>&on_air=true` | EiBi overlay segments |
 | `GET` | `/api/v1/eibi/identify?freq=<hz>&tolerance=<hz>` | Identify probable broadcast stations |
 | `GET` | `/api/v1/eibi/bands` | EiBi frequency bands |
+| `POST` | `/api/v1/transport/webrtc/offer` | Gated WebRTC DataChannel SDP exchange |
+| `POST` | `/api/v1/transport/webrtc/ice-candidate` | Gated WebRTC ICE trickle for a negotiated session |
 
 ### Control Endpoints
 
@@ -102,6 +104,35 @@ Stable supervisor routes:
 
 WebSocket auth accepts the same bearer header as HTTP. Query token auth is also
 accepted for browser/WebSocket clients that cannot set headers.
+
+### Optional WebRTC DataChannels
+
+WebRTC is optional and requires the `rigplane[webrtc]` extra (`aiortc`). There
+are two gated HTTP signaling routes for the DataChannel transport:
+
+| Method | Path | Status | Gate | Notes |
+|-------|------|--------|------|-------|
+| `POST` | `/api/v1/transport/webrtc/offer` | experimental transport entrypoint | `WebConfig.webrtc_enabled` / CLI `--webrtc` plus `rigplane[webrtc]` | Stateless client-facing SDP exchange that keeps a live session and returns `{ "status": "ok", "sessionId": "...", "sdp": "...", "type": "answer" }`. |
+| `POST` | `/api/v1/transport/webrtc/ice-candidate` | experimental transport entrypoint | `WebConfig.webrtc_enabled` / CLI `--webrtc` plus `rigplane[webrtc]` | Adds a browser `RTCIceCandidateInit` for an existing `sessionId`; `candidate: null` marks end-of-candidates. |
+
+The gated transport path is a transport alternative for the same handlers and
+wire frames used by WebSockets:
+
+| DataChannel | Reliability | Handler contract |
+|-------------|-------------|------------------|
+| `control` | ordered, reliable | Same JSON control frames as `/api/v1/ws` |
+| `scope` | unordered, `maxRetransmits=0` | Same binary scope frames as `/api/v1/scope` |
+| `audio` | unordered, `maxRetransmits=0` | Same JSON/binary audio frames as `/api/v1/audio` |
+
+The gated transport routes are default-off. If `WebConfig.webrtc_enabled` is
+false, or `aiortc` is missing, they return HTTP `503` with
+`code: "webrtc_unavailable"`. The CLI enables the gate with `rigplane web
+--webrtc`; programmatic callers set `WebConfig(webrtc_enabled=True)`.
+
+`/api/v1/info` exposes `capabilities.hasWebrtc`, and `/api/v1/capabilities`
+includes a `webrtc` metadata block. Treat these as optional dependency/audio
+feature-detection metadata; they do not prove the gated
+`/api/v1/transport/webrtc/*` routes are enabled.
 
 ### Structured Command Surface
 
@@ -832,6 +863,57 @@ Current readiness values are:
 - `lan_radio_unsupported_or_not_found`
 - `requires_configuration_or_auth`
 
+UDP discovery responses use the same `rigplane.station.discovery.v1` schema.
+Single-station responses keep the same top-level `kind: "station_server"`,
+`url`, `urls`, `station`, and `radio` fields. Fleet-aware supervisors can add
+an additive `radios` array and set `kind: "station_fleet"` while preserving the
+legacy top-level single-radio fields for older clients:
+
+```json
+{
+  "schema": "rigplane.station.discovery.v1",
+  "kind": "station_fleet",
+  "url": "http://192.168.1.50:58421",
+  "urls": {
+    "base": "http://192.168.1.50:58421",
+    "station": "http://192.168.1.50:58421/api/v1/station"
+  },
+  "station": {
+    "readiness": "ready_with_radio",
+    "radioAvailable": true,
+    "backend": null,
+    "authRequired": false,
+    "message": null
+  },
+  "radio": {
+    "model": "IC-705",
+    "connected": true,
+    "controlConnected": false,
+    "radioReady": true
+  },
+  "radios": [
+    {
+      "id": "portable",
+      "model": "IC-705",
+      "url": "http://192.168.1.50:58421",
+      "status": "connected",
+      "connected": true
+    },
+    {
+      "id": "base",
+      "model": "IC-7610",
+      "url": "http://192.168.1.50:58422",
+      "status": "available",
+      "connected": false
+    }
+  ]
+}
+```
+
+Clients that only understand the single-station response should ignore
+unknown fields and continue using the top-level `url`/`radio` values. Fleet
+clients should prefer `radios[]` when present.
+
 Managed runtimes also emit a single machine-readable startup event to stdout
 after the web listener has bound successfully. Supervisors should use this JSON
 line as the startup contract instead of parsing the human-readable banner:
@@ -872,7 +954,8 @@ Version, model, capability summary, and connection metadata.
     "modes": ["USB", "LSB", "CW", "CW-R", "AM", "FM", "RTTY", "RTTY-R"],
     "filters": ["FIL1", "FIL2", "FIL3"],
     "vfoScheme": "ab",
-    "hasLan": false
+    "hasLan": false,
+    "hasWebrtc": false
   },
   "connection": {
     "rigConnected": true,
@@ -942,19 +1025,27 @@ Notable fields:
 | `scopeSource` | `"hardware"` \| `"audio_fft"` \| `null` | Spectrum data source |
 | `scopeConfig.defaultSpan` | `int` | Hardware scope span or audio FFT bandwidth |
 | `audioConfig` | object | Web audio transport defaults |
+| `webrtc.available` | `bool` | Whether the optional `rigplane[webrtc]` backend is importable; this does not indicate that the default-off `WebConfig.webrtc_enabled` transport gate is enabled |
 
 When radio has audio but no hardware scope support, backend enables `AudioFftScope`
-and reports `scopeSource: "audio_fft"`.
+and reports `scopeSource: "audio_fft"`. The same FFT frames are also available
+on `/api/v1/audio-scope`; hardware-scope radios keep `/api/v1/scope` sourced
+from the radio's hardware scope.
 
 ---
 
-## WebSocket Endpoints
+## WebSocket And DataChannel Endpoints
 
 | Path | Direction | Payload |
 |------|-----------|---------|
 | `/api/v1/ws` | bi-directional | JSON commands/events/state updates |
 | `/api/v1/scope` | server -> client | Binary scope frames |
 | `/api/v1/audio` | bi-directional | JSON control + binary audio frames |
+
+The optional gated WebRTC transport uses `control`, `scope`, and `audio`
+DataChannels that carry the same payloads as these WebSocket routes. WebRTC
+changes only the transport, not command names, event names, binary headers, or
+audio frame semantics.
 
 Binary audio frames use an 8-byte header followed by codec-specific payload:
 

--- a/docs/guide/audio-recipes.md
+++ b/docs/guide/audio-recipes.md
@@ -376,6 +376,13 @@ Use two separate loopback devices for bidirectional operation. Reusing one
 device for both WSJT-X input and output can feed rigplane's RX audio back into
 its TX capture path.
 
+Serial USB-audio radios use the same direction. The shared serial audio backend
+arms PCM TX for IC-705, IC-7300, IC-9700, X6200, and related USB-audio
+profiles before bridge transmit. If TX startup fails, the bridge keeps RX
+running and reports the TX failure instead of logging per-frame "PCM TX not
+started" errors. On Windows callback capture, native callback blocks are
+re-chunked into fixed 20 ms PCM frames before transmit.
+
 ---
 
 ## Heavy usage and deployment

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -804,6 +804,11 @@ backend, auth-required flag, and a readiness value such as
 `ready_with_radio`, `no_usb_radio_connected`, or
 `radio_powered_off_or_unreachable`.
 
+Fleet-aware station supervisors may also advertise multiple child radios in an
+additive `radios[]` array. Each entry includes `id`, `model`, `url`, `status`,
+and `connected`. Existing clients can keep using the top-level single-radio
+fields; clients that understand fleets should prefer `radios[]` when present.
+
 ### `audio bridge`
 
 Route radio audio to/from a virtual audio device (BlackHole, Loopback, VB-Audio).
@@ -818,6 +823,13 @@ rigplane audio bridge --device "BlackHole 2ch"
 # RX only (no TX from virtual device)
 rigplane audio bridge --device "BlackHole 2ch" --rx-only
 ```
+
+The TX capture path preserves real-time latency by dropping the oldest queued
+capture frame when its bounded queue fills, then keeping the newest live frame.
+On callback-based PortAudio hosts, including Windows, capture uses the native
+callback period and re-chunks the continuous stream into fixed PCM frames
+before transmit. For 48 kHz mono 16-bit audio and `frame_ms=20`, each TX frame
+is 1920 bytes.
 
 !!! tip "macOS Setup"
     Install BlackHole for virtual audio routing:

--- a/docs/guide/wsjtx-setup.md
+++ b/docs/guide/wsjtx-setup.md
@@ -38,6 +38,14 @@ This starts:
 - **Audio bridge** routing radio RX → BlackHole 2ch, BlackHole 16ch → radio TX
 - **Rigctld** on `:4532` (enabled by default)
 
+Serial USB-audio radios use the same bridge direction: RX audio is played to
+the WSJT-X input loopback, and WSJT-X output is captured and transmitted
+through the radio's USB-audio TX path. Current serial Icom backends arm PCM TX
+before bridge transmit; if TX startup fails, the bridge keeps RX running and
+reports the TX failure instead of logging a per-frame "PCM TX not started"
+error. On Windows callback capture, native callback blocks are re-chunked into
+fixed 20 ms PCM frames before transmit.
+
 **Alternative: rigctld only** (no Web UI or audio bridge):
 
 ```bash

--- a/docs/internals/raw-civ-transactions.md
+++ b/docs/internals/raw-civ-transactions.md
@@ -37,6 +37,16 @@ A transaction rejects overlapping ownership instead of interrupting an existing
 external CAT session; external CAT begin likewise fails cleanly while a raw
 transaction owns the guard.
 
+`CoreRadio.connect()` resets any leaked external-CAT ownership at the LAN
+runtime full-connect boundary. This covers managed-runtime restarts, partial
+bridge startup failures, and LAN `soft_reconnect()` paths that fall back to
+that full `CoreRadio.connect()` after `begin_external_cat_session()` was called
+but the matching `end_external_cat_session()` never ran. A normal soft
+reconnect is not the reset boundary, and the shared serial Icom backend
+`connect()` override does not currently perform this reset. Rigctld and web
+pollers resume ownership only after the new LAN full radio session is
+established.
+
 ## Response Matching
 
 Transactions run on `CivRuntime`, not `RadioPoller`. They reuse the existing


### PR DESCRIPTION
## Summary
- Document current WebRTC DataChannel transport endpoints after A2.3/A2.4.
- Document fleet-aware discovery radios[] compatibility.
- Refresh audio bridge, AudioBus teardown, TX queue, Windows callback framing, serial USB-audio TX, and external-CAT ownership docs.

## Validation
- `uv run pytest tests/test_docs_runtime_sync.py tests/test_web_api_contract.py tests/test_webrtc_signaling.py tests/test_webrtc_sdp_entrypoint.py tests/test_webrtc_datachannel_connection.py tests/test_discovery_responder.py -q --tb=short` -> 31 passed, 12 skipped
- `uv run pytest tests/test_audio_bus.py tests/test_audio_bridge.py::test_bridge_tx_queue_overflow_drops_oldest_and_counts_overrun tests/test_audio_backend.py::TestPortAudioBackendDeps::test_open_rx_callback_emits_fixed_frame_ms_frames_lossless tests/test_audio_scope_dispatch.py tests/test_serial_backend_tx_mor242.py tests/test_x6200_rx_audio_mor236.py tests/test_reconnect.py::TestExternalCatSessionResetOnConnect tests/test_hamlib_bridge.py::test_open_transport_failure_does_not_leak_session -q --tb=short` -> 39 passed
- `uv run mkdocs build --strict` -> passed, existing Material/MkDocs warning and excluded-link INFO only
- `git diff --check`
- Independent docs review: Agent Review: PASS