### PR TITLE
fix: derive discovery legacy url/urls from primary fleet member (MOR-380)

### DIFF
--- a/src/rigplane/web/discovery.py
+++ b/src/rigplane/web/discovery.py
@@ -178,21 +178,32 @@ class DiscoveryResponder:
     def build_response(self, remote_addr: str) -> bytes:
         """Build the JSON discovery response payload."""
         local_ip = _get_local_ip_for(remote_addr)
-        scheme = "https" if self._tls else "http"
 
         radio_info = self._radio_provider() if self._radio_provider else None
         fleet = self._fleet_provider() if self._fleet_provider else None
 
-        # Back-compat: keep the single-radio top-level block populated from the
-        # first/selected fleet member when no dedicated radio_provider is set,
-        # so legacy parsers still resolve a valid station_server.
-        if radio_info is None and fleet:
+        # Derive the effective web_port/tls for the legacy single-radio url/urls
+        # block. When a fleet is present, the primary member (fleet[0]) owns the
+        # legacy block, so its port/tls must drive these URLs — otherwise the
+        # top-level url stays stuck on the responder's static web_port even
+        # though the radio it describes lives elsewhere.
+        web_port = self._web_port
+        tls = self._tls
+        if fleet:
             first = fleet[0]
-            radio_info = RadioInfo(
-                model=first.model,
-                connected=first.connected,
-                radio_ready=first.connected,
-            )
+            web_port = first.web_port
+            tls = first.tls if first.tls is not None else self._tls
+            # Back-compat: keep the single-radio top-level block populated from
+            # the primary fleet member when no dedicated radio_provider is set,
+            # so legacy parsers still resolve a valid station_server.
+            if radio_info is None:
+                radio_info = RadioInfo(
+                    model=first.model,
+                    connected=first.connected,
+                    radio_ready=first.connected,
+                )
+
+        scheme = "https" if tls else "http"
 
         if self._name:
             name = self._name
@@ -206,13 +217,13 @@ class DiscoveryResponder:
             "service": "rigplane",
             "kind": "station_server",
             "version": __version__,
-            "url": f"{scheme}://{local_ip}:{self._web_port}",
+            "url": f"{scheme}://{local_ip}:{web_port}",
             "urls": {
-                "base": f"{scheme}://{local_ip}:{self._web_port}",
-                "health": f"{scheme}://{local_ip}:{self._web_port}/healthz",
-                "readiness": f"{scheme}://{local_ip}:{self._web_port}/readyz",
-                "runtime": (f"{scheme}://{local_ip}:{self._web_port}/api/v1/runtime"),
-                "station": (f"{scheme}://{local_ip}:{self._web_port}/api/v1/station"),
+                "base": f"{scheme}://{local_ip}:{web_port}",
+                "health": f"{scheme}://{local_ip}:{web_port}/healthz",
+                "readiness": f"{scheme}://{local_ip}:{web_port}/readyz",
+                "runtime": (f"{scheme}://{local_ip}:{web_port}/api/v1/runtime"),
+                "station": (f"{scheme}://{local_ip}:{web_port}/api/v1/station"),
             },
             "name": name,
             "displayName": name,

--- a/tests/test_discovery_responder.py
+++ b/tests/test_discovery_responder.py
@@ -259,9 +259,40 @@ class TestDiscoveryResponderFleet:
         assert data["radio"]["connected"] is True
         assert data["name"] == "IC-7610"
         assert data["url"].startswith("http://")
-        assert ":8080" in data["url"]
+        # Legacy url must reflect the primary fleet member's port (8081),
+        # not the responder's static web_port (8080).
+        assert ":8081" in data["url"]
         assert data["station"]["radioAvailable"] is True
         assert data["station"]["readiness"] == "ready_with_radio"
+
+    async def test_legacy_url_uses_fleet_member_port_and_tls(self) -> None:
+        """Legacy url/urls.* derive scheme+port from the primary fleet member."""
+        fleet = [
+            FleetRadioInfo(
+                id="radio-a",
+                model="IC-7610",
+                web_port=8443,
+                connected=True,
+                tls=True,
+            ),
+        ]
+        r = await self._fleet_responder(fleet)
+        try:
+            raw = await _query(r.port, MAGIC)
+        finally:
+            await r.stop()
+        assert raw is not None
+        data = json.loads(raw)
+
+        assert data["url"].startswith("https://")
+        assert data["url"].endswith(":8443")
+        for key in ("base", "health", "readiness", "runtime", "station"):
+            url = data["urls"][key]
+            assert url.startswith("https://")
+            assert ":8443" in url
+        # Back-compat: legacy radio block still derives from fleet[0].
+        assert data["radio"]["model"] == "IC-7610"
+        assert data["radio"]["connected"] is True
 
     async def test_radio_provider_overrides_top_level_with_fleet(self) -> None:
         """When both providers are set, top-level uses radio_provider."""
@@ -324,3 +355,6 @@ class TestDiscoveryResponderFleet:
         assert data["kind"] == "station_server"
         assert "radios" not in data
         assert data["radio"]["model"] == "IC-7610"
+        # No-fleet path: legacy url uses the responder's static web_port.
+        assert data["url"].startswith("http://")
+        assert ":8080" in data["url"]


### PR DESCRIPTION
## Problem (MOR-380)

`DiscoveryResponder.build_response()` (`src/rigplane/web/discovery.py`) built the legacy
single-radio top-level `url` and all `urls.*` entries from the static `self._web_port`
(default 8080), even when a `fleet_provider` is configured. In a multi-radio station
front door each fleet member carries its own `web_port`, and the legacy `radio` block is
already derived from `fleet[0]` — but the legacy `url`/`urls.*` were not, so legacy
single-radio consumers were pointed at a dead port (e.g. :8080) instead of the
selected/primary member's live `:808x`.

## Fix

When a fleet is present, derive the legacy `url` / `urls.*` (and scheme) from `fleet[0]`
(`web_port`, and `tls` with fallback to the responder's own `tls` when the member's is
`None`) — consistent with how the legacy `radio` block already uses `fleet[0]`, and with
how the per-member `radios[]` URLs already use `member.web_port`/`member.tls`. The
no-fleet single-radio path is unchanged (still `self._web_port`/`self._tls`); empty fleet
`[]` is treated as no-fleet. The `radios[]` block and the discovery JSON schema are
unchanged — only the legacy block's port/scheme values change.

## Tests

- Updated `test_single_radio_fields_preserved_with_fleet` (its `:8080` assertion encoded
  the bug → now expects `fleet[0]`'s port).
- Added `test_legacy_url_uses_fleet_member_port_and_tls` (fleet `web_port=8443, tls=True`
  → legacy `url`+`urls.*` are `https://…:8443`, `radio` still from `fleet[0]`).
- Locked the no-fleet path (empty fleet → legacy `url` uses static `:8080`).

## Gate (full, in an isolated worktree)

- `pytest tests/ --ignore=tests/integration`: 7205 passed, 0 failures
- `ruff check` + `ruff format --check`: clean
- `mypy src/`: 20 = unchanged baseline, 0 new (0 in `discovery.py`)
- `lint-imports`: 4 contracts kept, 0 broken

Boundary: `core`/`web` only; no protocol/transport/upper-layer change.

Linear: MOR-380

🤖 Generated with [Claude Code](https://claude.com/claude-code)