### PR TITLE
fix: correct FTX-1 set_attenuator bool coercion + set_agc AUTO mapping (MOR-498)

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -1077,8 +1077,13 @@ class YaesuCatRadio:
         return await self.read_attenuator(receiver)
 
     async def set_attenuator(self, state: int, receiver: int = 0) -> None:
-        """Set attenuator state (0 = OFF, 1 = ON)."""
-        await self._write("set_attenuator", state=str(state))
+        """Set attenuator state (0 = OFF, 1 = ON).
+
+        Callers (and the hardware validator) may pass a Python ``bool``;
+        ``str(True)`` would render the malformed ``RA0True;`` and the radio
+        silently ignores it. Coerce to ``int`` first so ``RA0{0,1};`` is sent.
+        """
+        await self._write("set_attenuator", state=str(int(state)))
 
     async def set_attenuator_level(self, db: int, receiver: int = 0) -> None:
         """Set attenuator by dB level.
@@ -2132,8 +2137,17 @@ class YaesuCatRadio:
         return await self.read_agc(receiver)
 
     async def set_agc(self, mode: int, receiver: int = 0) -> None:
-        """Set AGC mode (GT0, 0–6)."""
-        await self._write("set_agc", mode=str(mode))
+        """Set AGC mode (GT0).
+
+        The FTX-1 read side reports 0–6 (4/5/6 = the auto-selected
+        A-FAST/A-MID/A-SLOW for the current mode), but the SET side only
+        accepts 0–4 where ``4`` means AUTO; writing ``GT05;``/``GT06;`` is
+        rejected and the value sticks at the prior setting. Manual modes
+        (0–3) are sent verbatim; any AUTO request (4, 5, or 6) is collapsed
+        to ``GT04;`` (AUTO), letting the radio re-derive the auto speed.
+        """
+        wire_mode = 4 if mode >= 4 else mode
+        await self._write("set_agc", mode=str(wire_mode))
 
     # -- Key speed (KS) -------------------------------------------------------
 

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -462,6 +462,32 @@ async def test_set_attenuator_on(connected_radio):
 
 
 @pytest.mark.asyncio
+async def test_set_attenuator_off(connected_radio):
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_attenuator(0)
+    connected_radio._transport.write.assert_called_once_with("RA00;")
+
+
+@pytest.mark.asyncio
+async def test_set_attenuator_bool_true_coerced_to_int(connected_radio):
+    """MOR-498: callers/validator pass a Python bool; ``str(True)`` would
+    render the malformed ``RA0True;`` and the radio would silently ignore it.
+    The bool must be coerced to int so the CAT write is ``RA01;``."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_attenuator(True)
+    connected_radio._transport.write.assert_called_once_with("RA01;")
+
+
+@pytest.mark.asyncio
+async def test_set_attenuator_bool_false_coerced_to_int(connected_radio):
+    """MOR-498: ``set_attenuator(False)`` must render ``RA00;``, not
+    ``RA0False;``."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_attenuator(False)
+    connected_radio._transport.write.assert_called_once_with("RA00;")
+
+
+@pytest.mark.asyncio
 async def test_get_preamp(connected_radio):
     connected_radio._transport.query = AsyncMock(return_value="PA01")
     assert await connected_radio.get_preamp() == 1
@@ -1383,6 +1409,26 @@ async def test_set_agc(connected_radio):
     connected_radio._transport.write = AsyncMock()
     await connected_radio.set_agc(2)
     connected_radio._transport.write.assert_called_once_with("GT02;")
+
+
+@pytest.mark.parametrize("mode", [0, 1, 2, 3])
+@pytest.mark.asyncio
+async def test_set_agc_manual_modes_passthrough(connected_radio, mode):
+    """MOR-498: manual AGC modes 0-3 are sent verbatim as ``GT0{mode};``."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_agc(mode)
+    connected_radio._transport.write.assert_called_once_with(f"GT0{mode};")
+
+
+@pytest.mark.parametrize("mode", [4, 5, 6])
+@pytest.mark.asyncio
+async def test_set_agc_auto_modes_map_to_gt04(connected_radio, mode):
+    """MOR-498: live FTX-1 only accepts ``GT04;`` (AUTO) on SET; ``GT05;``/
+    ``GT06;`` are rejected and stick at the prior value. Any AUTO request
+    (read-side 4/5/6) must therefore be written as ``GT04;``."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_agc(mode)
+    connected_radio._transport.write.assert_called_once_with("GT04;")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem (MOR-498) — found in live FTX-1 hardware validation 2026-06-07

Two backend SET bugs in `YaesuCatRadio` (the radio supports both; raw CAT confirmed live):

1. **set_attenuator** sent a Python `bool` through `str(state)` → `str(True)`=`"True"` → CAT write `RA0True;` (malformed) → attenuator SET was a silent no-op.
2. **set_agc** wrote AUTO modes verbatim (`GT05;`/`GT06;`), which the FTX-1 SET side rejects. The radio's `GT0` SET accepts 0-4 (4=AUTO); READ returns 0-6 (4/5/6 = auto-selected A-FAST/A-MID/A-SLOW).

## Fix
- `set_attenuator`: `state=str(int(state))` → renders `RA01;`/`RA00;`.
- `set_agc`: map AUTO requests (4/5/6) → `GT04;`; manual modes 0-3 pass through. `get_agc`/`read_agc` unchanged (still return the 0-6 read).

## Tests / gate
TDD (red confirmed). FTX-1 suite 273 passed; full suite 7215 passed/0 fail; ruff check + format clean; mypy 20=baseline/0 new; lint-imports 4/0.

Boundary: `backends/yaesu_cat` only. Linear: MOR-498

🤖 Generated with [Claude Code](https://claude.com/claude-code)