### PR TITLE
fix: validate FTX-1 table-index/compound/level controls + agc/xit checks (MOR-499)

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -381,6 +381,41 @@ def _tolerant_equal(tol: int) -> Callable[[int, int], bool]:
     return _eq
 
 
+# Below this value a filter-width readback is a discrete table index (0-23 on
+# the FTX-1), not a width in Hz. The smallest realistic Hz width is 50 (Icom
+# ``filter_width_min``), so the threshold cleanly separates the two encodings.
+_FILTER_WIDTH_INDEX_MAX = 30
+
+
+def _nudge_filter(width: int) -> int:
+    """Mutate a filter width to a DIFFERENT value the radio will accept.
+
+    Two encodings share this check:
+
+    * Discrete *table index* (FTX-1, ``width <= 30``, valid range 0-23): pick a
+      different in-range index by stepping toward the middle of the range. The
+      old ``width + 200`` produced an out-of-range index (e.g. 19 -> 219) that
+      the radio silently ignored, so the check falsely reported "did not react".
+    * Width in *Hz* (Icom, ``width > 30``): keep the historical ±200 Hz nudge.
+    """
+    if width <= _FILTER_WIDTH_INDEX_MAX:
+        # Table index: a small in-range delta toward 0 (wrap up near the floor).
+        return width - 5 if width >= 5 else width + 5
+    return width + 200 if width <= 2600 else width - 200
+
+
+def _filter_width_equal(a: int, b: int) -> bool:
+    """Encoding-aware filter-width comparator.
+
+    A table index (FTX-1) reads back exactly, so require an exact match; an Hz
+    width (Icom) may be quantized by the radio, so allow a 50 Hz tolerance.
+    Both operands are small (index) only when neither exceeds the index ceiling.
+    """
+    if int(a) <= _FILTER_WIDTH_INDEX_MAX and int(b) <= _FILTER_WIDTH_INDEX_MAX:
+        return int(a) == int(b)
+    return abs(int(a) - int(b)) <= 50
+
+
 async def _read_modify_verify_restore(
     radio: Radio,
     entry: CapabilityDeclarationEntry,
@@ -739,8 +774,8 @@ async def _check_filter_width_set(
         entry,
         read=lambda: dsp.get_filter_width(0),
         write=lambda value: dsp.set_filter_width(value, 0),
-        make_changed=lambda w: w + 200 if w <= 2600 else w - 200,
-        equal=_tolerant_equal(50),
+        make_changed=_nudge_filter,
+        equal=_filter_width_equal,
         per_check_timeout=per_check_timeout,
     )
 
@@ -842,13 +877,81 @@ async def _check_notch_set(
     if gate is not None:
         return gate
     dsp = cast(DspControlCapable, radio)
+
+    async def _read_notch_bool() -> bool:
+        # The Yaesu/FTX-1 backend returns a compound ``(state, freq_index)``;
+        # the Icom backend returns a plain bool. The check only toggles the
+        # on/off state, so collapse the read to its bool component. ``freq`` is
+        # preserved because ``set_manual_notch`` writes only the on/off state.
+        value = await dsp.get_manual_notch(0)
+        if isinstance(value, tuple):
+            return bool(value[0])
+        return bool(value)
+
     return await _read_modify_verify_restore(
         radio,
         entry,
-        read=lambda: dsp.get_manual_notch(0),
+        read=_read_notch_bool,
         write=lambda value: dsp.set_manual_notch(value, 0),
         make_changed=lambda b: not b,
         per_check_timeout=per_check_timeout,
+    )
+
+
+# A representative "on" level used when toggling a level-encoded NB/NR control
+# whose original value is 0 (off). Within range for both NB (0-10) and NR (0-15).
+_NB_NR_TEST_LEVEL = 5
+
+
+async def _check_blanker_reduction_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    name: str,
+    per_check_timeout: float,
+) -> CheckResult:
+    """RMVR a noise blanker / noise reduction control.
+
+    Prefers the boolean getter/setter (``get_nb``/``set_nb`` on Icom). When the
+    radio exposes only the level variants (``get_nb_level``/``set_nb_level`` on
+    the Yaesu/FTX-1 backend), fall back to those: toggle the level between off
+    (0) and a representative on level, treating ``level > 0`` as "on" for the
+    reaction comparison. Restores the original level on the way out.
+    """
+    bool_read = getattr(radio, f"get_{name}", None)
+    bool_write = getattr(radio, f"set_{name}", None)
+    if callable(bool_read) and callable(bool_write):
+        return await _read_modify_verify_restore(
+            radio,
+            entry,
+            read=lambda: cast(Awaitable[bool], bool_read()),
+            write=cast(Callable[[bool], Awaitable[None]], bool_write),
+            make_changed=lambda b: not b,
+            per_check_timeout=per_check_timeout,
+        )
+
+    level_read = getattr(radio, f"get_{name}_level", None)
+    level_write = getattr(radio, f"set_{name}_level", None)
+    if callable(level_read) and callable(level_write):
+        return await _read_modify_verify_restore(
+            radio,
+            entry,
+            read=lambda: cast(Awaitable[int], level_read()),
+            write=cast(Callable[[int], Awaitable[None]], level_write),
+            make_changed=lambda v: 0 if v > 0 else _NB_NR_TEST_LEVEL,
+            per_check_timeout=per_check_timeout,
+            extra_evidence={"readback_via": f"get_{name}_level"},
+        )
+
+    return _base_result(
+        entry,
+        CheckStatus.UNSUPPORTED,
+        evidence={
+            "reason": (
+                f"radio exposes set_{name} but no get_{name} or "
+                f"get_{name}_level readback"
+            )
+        },
     )
 
 
@@ -862,21 +965,8 @@ async def _check_nb_set(
     gate = _write_gate(radio, entry, allow_writes=allow_writes)
     if gate is not None:
         return gate
-    read_fn = getattr(radio, "get_nb", None)
-    if not callable(read_fn):
-        return _base_result(
-            entry,
-            CheckStatus.UNSUPPORTED,
-            evidence={"reason": "radio exposes set_nb but no get_nb readback"},
-        )
-    write_fn = cast(Callable[[bool], Awaitable[None]], getattr(radio, "set_nb"))
-    return await _read_modify_verify_restore(
-        radio,
-        entry,
-        read=lambda: cast(Awaitable[bool], read_fn()),
-        write=write_fn,
-        make_changed=lambda b: not b,
-        per_check_timeout=per_check_timeout,
+    return await _check_blanker_reduction_set(
+        radio, entry, name="nb", per_check_timeout=per_check_timeout
     )
 
 
@@ -890,21 +980,8 @@ async def _check_nr_set(
     gate = _write_gate(radio, entry, allow_writes=allow_writes)
     if gate is not None:
         return gate
-    read_fn = getattr(radio, "get_nr", None)
-    if not callable(read_fn):
-        return _base_result(
-            entry,
-            CheckStatus.UNSUPPORTED,
-            evidence={"reason": "radio exposes set_nr but no get_nr readback"},
-        )
-    write_fn = cast(Callable[[bool], Awaitable[None]], getattr(radio, "set_nr"))
-    return await _read_modify_verify_restore(
-        radio,
-        entry,
-        read=lambda: cast(Awaitable[bool], read_fn()),
-        write=write_fn,
-        make_changed=lambda b: not b,
-        per_check_timeout=per_check_timeout,
+    return await _check_blanker_reduction_set(
+        radio, entry, name="nr", per_check_timeout=per_check_timeout
     )
 
 
@@ -1002,7 +1079,7 @@ _WRITE_ONLY_RESTORE: dict[str, Any] = {
 _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     ValueRule.TOGGLE_BOOL: lambda b: not b,
     ValueRule.STEP_LEVEL_255: lambda v: 200 if v < 128 else 50,
-    ValueRule.NUDGE_FILTER: lambda w: w + 200 if w <= 2600 else w - 200,
+    ValueRule.NUDGE_FILTER: _nudge_filter,
     ValueRule.PREAMP_CYCLE: lambda v: 1 if v == 0 else 0,
     ValueRule.AGC_FLIP: lambda m: (
         int(AgcMode.SLOW) if m != AgcMode.SLOW else int(AgcMode.FAST)

--- a/tests/validation/test_hardware_ftx1.py
+++ b/tests/validation/test_hardware_ftx1.py
@@ -1,0 +1,448 @@
+"""FTX-1-flavoured hardware-validator regressions (MOR-499).
+
+The FTX-1 (``YaesuCatRadio``) reacts to filter-width, manual-notch, noise
+blanker / noise reduction, AGC, and XIT changes via documented CAT commands,
+but the universal validation harness reported false FAIL / UNSUPPORTED
+verdicts because the read-modify-verify-restore (RMVR) mutations assumed
+Icom-shaped value encodings:
+
+* ``filter_width.set`` mutated a table *index* (0-23) as if it were Hz, so the
+  changed value fell out of range and the radio ignored it.
+* ``notch.set`` toggled/compared the whole ``(bool, int)`` compound returned by
+  ``get_manual_notch`` instead of the on/off bool component.
+* ``nb.set`` / ``nr.set`` looked up ``get_nb`` / ``get_nr`` (Icom bool getters)
+  that the Yaesu backend does not expose — it has ``get_nb_level`` /
+  ``get_nr_level`` — so the harness downgraded to UNSUPPORTED.
+
+These tests lock the FTX-1 encodings AND the unchanged Icom-shaped behaviour
+(bool notch, bool nb/nr, Hz filter width) so the per-encoding branching cannot
+regress the Icom radios that share the same checks.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.core.radio_protocol import Radio
+from rigplane.core.types import AgcMode
+from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckStatus,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    ValidationLevel,
+)
+
+
+def _flatten(levels):
+    return {check.check_id: check for level in levels for check in level.checks}
+
+
+def _single_entry_template(*, check_id: str, capability: str) -> MatrixTemplate:
+    return MatrixTemplate(
+        radio=RadioTarget(model="FTX-1", profile_id="ftx1"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id=check_id,
+                capability=capability,
+                level=ValidationLevel.CAPABILITY_MATRIX,
+                declaration=CapabilityDeclaration.SUPPORTED,
+                summary="single",
+            )
+        ],
+    )
+
+
+async def _run(radio, *, check_id: str, capability: str):
+    template = _single_entry_template(check_id=check_id, capability=capability)
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    return _flatten(levels)[check_id]
+
+
+# ---------------------------------------------------------------------------
+# FIX 1 — filter_width.set table-index vs Hz
+# ---------------------------------------------------------------------------
+
+
+def _stateful_filter_mock(*, start: int):
+    """A radio whose filter-width set/get round-trips, but rejects (no-op)
+    a write that falls outside the FTX-1 table-index range 0-23."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"filter_width"}
+    store = {"value": start}
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(value: int, receiver: int = 0) -> None:
+        # FTX-1 ignores an out-of-range table index (the original bug).
+        if 0 <= value <= 23:
+            store["value"] = value
+
+    radio.get_filter_width = AsyncMock(side_effect=_get)
+    radio.set_filter_width = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_filter_width_table_index_reacts():
+    """A small table index (19) must mutate to a DIFFERENT in-range index so the
+    FTX-1 accepts the change instead of ignoring an out-of-range Hz value."""
+    radio, store = _stateful_filter_mock(start=19)
+    check = await _run(radio, check_id="filter_width.set", capability="filter_width")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 19
+    assert 0 <= int(check.evidence["changed"]) <= 23
+    assert check.evidence["changed"] != 19
+    assert check.evidence["readback"] == check.evidence["changed"]
+    assert check.evidence["restored"] is True
+
+
+async def test_filter_width_table_index_low_value_reacts():
+    """A table index of 0 must still mutate to a valid in-range alternate."""
+    radio, _store = _stateful_filter_mock(start=0)
+    check = await _run(radio, check_id="filter_width.set", capability="filter_width")
+    assert check.status is CheckStatus.PASS
+    assert 0 <= int(check.evidence["changed"]) <= 23
+    assert check.evidence["changed"] != 0
+
+
+def _stateful_hz_filter_mock(*, start: int):
+    """An Icom-shaped radio whose filter width is in Hz (round-trips any value)."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "IC-7610"
+    radio.capabilities = {"filter_width"}
+    store = {"value": start}
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(value: int, receiver: int = 0) -> None:
+        store["value"] = value
+
+    radio.get_filter_width = AsyncMock(side_effect=_get)
+    radio.set_filter_width = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_filter_width_hz_icom_unchanged_low():
+    """Icom Hz width below 2600 keeps the +200 nudge (no regression)."""
+    radio, _store = _stateful_hz_filter_mock(start=2400)
+    check = await _run(radio, check_id="filter_width.set", capability="filter_width")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 2400
+    assert check.evidence["changed"] == 2600
+
+
+async def test_filter_width_hz_icom_unchanged_high():
+    """Icom Hz width above 2600 keeps the -200 nudge (no regression)."""
+    radio, _store = _stateful_hz_filter_mock(start=3000)
+    check = await _run(radio, check_id="filter_width.set", capability="filter_width")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 3000
+    assert check.evidence["changed"] == 2800
+
+
+# ---------------------------------------------------------------------------
+# FIX 2 — notch.set compound (bool, int) vs bool
+# ---------------------------------------------------------------------------
+
+
+def _stateful_compound_notch_mock(*, on: bool, freq: int = 17):
+    """FTX-1-shaped notch: get returns (bool, int); set takes a bool only."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"notch"}
+    store = {"on": on, "freq": freq}
+
+    async def _get(receiver: int = 0) -> tuple[bool, int]:
+        return store["on"], store["freq"]
+
+    async def _set(state: bool, receiver: int = 0) -> None:
+        store["on"] = state
+
+    radio.get_manual_notch = AsyncMock(side_effect=_get)
+    radio.set_manual_notch = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_notch_compound_toggles_bool_only():
+    """The compound (bool, int) notch must toggle/compare only the bool."""
+    radio, store = _stateful_compound_notch_mock(on=False, freq=17)
+    check = await _run(radio, check_id="notch.set", capability="notch")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] is False
+    assert check.evidence["changed"] is True
+    assert check.evidence["readback"] is True
+    assert check.evidence["restored"] is True
+    # The freq index must be preserved across the cycle.
+    assert store["freq"] == 17
+    # Restored back to original bool.
+    assert store["on"] is False
+
+
+async def test_notch_compound_does_not_react_fails_readback():
+    """A compound notch whose bool never changes -> FAIL (READBACK)."""
+    from rigplane.validation.schema import FailureDomain
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"notch"}
+
+    async def _get(receiver: int = 0) -> tuple[bool, int]:
+        return False, 17  # bool never moves
+
+    async def _set(state: bool, receiver: int = 0) -> None:
+        return None  # no-op
+
+    radio.get_manual_notch = AsyncMock(side_effect=_get)
+    radio.set_manual_notch = AsyncMock(side_effect=_set)
+    check = await _run(radio, check_id="notch.set", capability="notch")
+    assert check.status is CheckStatus.FAIL
+    assert check.failure_domain is FailureDomain.READBACK
+
+
+def _stateful_bool_notch_mock(*, on: bool):
+    """Icom-shaped notch: get/set are plain bool."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "IC-7610"
+    radio.capabilities = {"notch"}
+    store = {"on": on}
+
+    async def _get(receiver: int = 0) -> bool:
+        return store["on"]
+
+    async def _set(state: bool, receiver: int = 0) -> None:
+        store["on"] = state
+
+    radio.get_manual_notch = AsyncMock(side_effect=_get)
+    radio.set_manual_notch = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_notch_plain_bool_icom_unchanged():
+    """A plain-bool notch (Icom) still toggles and passes (no regression)."""
+    radio, store = _stateful_bool_notch_mock(on=False)
+    check = await _run(radio, check_id="notch.set", capability="notch")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] is False
+    assert check.evidence["changed"] is True
+    assert check.evidence["readback"] is True
+    assert check.evidence["restored"] is True
+    assert store["on"] is False
+
+
+# ---------------------------------------------------------------------------
+# FIX 3 — nb.set / nr.set level-getter fallback
+# ---------------------------------------------------------------------------
+
+
+def _level_nb_mock(*, start: int = 0):
+    """FTX-1-shaped NB: only the level getter/setter exist (no get_nb)."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"nb"}
+    store = {"value": start}
+    del radio.get_nb  # no bool getter on the Yaesu backend
+    del radio.set_nb
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(level: int, receiver: int = 0) -> None:
+        store["value"] = level
+
+    radio.get_nb_level = AsyncMock(side_effect=_get)
+    radio.set_nb_level = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+def _level_nr_mock(*, start: int = 0):
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"nr"}
+    store = {"value": start}
+    del radio.get_nr
+    del radio.set_nr
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(level: int, receiver: int = 0) -> None:
+        store["value"] = level
+
+    radio.get_nr_level = AsyncMock(side_effect=_get)
+    radio.set_nr_level = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_nb_falls_back_to_level_getter():
+    """Absent get_nb -> fall back to get_nb_level/set_nb_level (set nonzero)."""
+    radio, store = _level_nb_mock(start=0)
+    check = await _run(radio, check_id="nb.set", capability="nb")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 0
+    assert int(check.evidence["changed"]) > 0
+    assert check.evidence["readback"] == check.evidence["changed"]
+    assert check.evidence["restored"] is True
+    assert store["value"] == 0  # restored
+
+
+async def test_nr_falls_back_to_level_getter():
+    """Absent get_nr -> fall back to get_nr_level/set_nr_level (set nonzero)."""
+    radio, store = _level_nr_mock(start=0)
+    check = await _run(radio, check_id="nr.set", capability="nr")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 0
+    assert int(check.evidence["changed"]) > 0
+    assert check.evidence["readback"] == check.evidence["changed"]
+    assert check.evidence["restored"] is True
+    assert store["value"] == 0
+
+
+async def test_nb_level_already_on_still_reacts():
+    """An NB already at a nonzero level still mutates to a DIFFERENT level."""
+    radio, store = _level_nb_mock(start=5)
+    check = await _run(radio, check_id="nb.set", capability="nb")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 5
+    assert int(check.evidence["changed"]) != 5
+    assert check.evidence["readback"] == check.evidence["changed"]
+    assert store["value"] == 5  # restored
+
+
+async def test_nb_no_level_or_bool_getter_unsupported():
+    """Neither get_nb nor get_nb_level -> UNSUPPORTED (honest, not a crash)."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"nb"}
+    del radio.get_nb
+    del radio.set_nb
+    del radio.get_nb_level
+    del radio.set_nb_level
+    check = await _run(radio, check_id="nb.set", capability="nb")
+    assert check.status is CheckStatus.UNSUPPORTED
+
+
+def _bool_nb_mock(*, on: bool = False):
+    """Icom-shaped NB: bool getter present (must keep the bool path)."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "IC-7610"
+    radio.capabilities = {"nb"}
+    store = {"on": on}
+
+    async def _get(receiver: int = 0) -> bool:
+        return store["on"]
+
+    async def _set(state: bool, receiver: int = 0) -> None:
+        store["on"] = state
+
+    radio.get_nb = AsyncMock(side_effect=_get)
+    radio.set_nb = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_nb_bool_getter_icom_unchanged():
+    """Icom NB with a bool getter still uses the bool toggle path (no regression)."""
+    radio, store = _bool_nb_mock(on=False)
+    check = await _run(radio, check_id="nb.set", capability="nb")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] is False
+    assert check.evidence["changed"] is True
+    assert check.evidence["readback"] is True
+    assert store["on"] is False
+
+
+# ---------------------------------------------------------------------------
+# FIX 4 — agc.set / xit.set named handlers exercise FTX-1 correctly
+# ---------------------------------------------------------------------------
+
+
+def _stateful_agc_mock(*, start: int):
+    """FTX-1-shaped AGC: get returns 0-6, set accepts 0-4 (5/6 read-only)."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"agc"}
+    store = {"value": start}
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(mode: int, receiver: int = 0) -> None:
+        # The FTX-1 AGC SET only accepts 0-4; 5/6 are read-only reflections.
+        if 0 <= mode <= 4:
+            store["value"] = mode
+
+    radio.get_agc = AsyncMock(side_effect=_get)
+    radio.set_agc = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_agc_set_targets_settable_manual_mode():
+    """AGC mutation flips between settable manual modes (1<->3), never 5/6."""
+    radio, store = _stateful_agc_mock(start=int(AgcMode.FAST))  # 1
+    check = await _run(radio, check_id="agc.set", capability="agc")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == int(AgcMode.FAST)
+    assert check.evidence["changed"] == int(AgcMode.SLOW)
+    assert int(check.evidence["changed"]) <= 4
+    assert check.evidence["readback"] == int(AgcMode.SLOW)
+    assert check.evidence["restored"] is True
+    assert store["value"] == int(AgcMode.FAST)
+
+
+def test_agc_flip_never_targets_readonly_auto():
+    """The AGC mutation must never target a read-only auto mode (5/6),
+    regardless of the value read back from the radio."""
+    from rigplane.validation.hardware import _VALUE_RULE_FNS
+    from rigplane.validation.registry import ValueRule
+
+    flip = _VALUE_RULE_FNS[ValueRule.AGC_FLIP]
+    for current in range(0, 7):
+        assert int(flip(current)) <= 4, f"AGC flip from {current} must stay settable"
+
+
+def _stateful_xit_mock(*, on: bool):
+    """FTX-1-shaped XIT: get/set rit_tx_status are plain bool."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"xit"}
+    store = {"on": on}
+
+    async def _get() -> bool:
+        return store["on"]
+
+    async def _set(state: bool) -> None:
+        store["on"] = state
+
+    radio.get_rit_tx_status = AsyncMock(side_effect=_get)
+    radio.set_rit_tx_status = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_xit_set_toggles_bool():
+    """xit.set toggles get_rit_tx_status/set_rit_tx_status and restores."""
+    radio, store = _stateful_xit_mock(on=False)
+    check = await _run(radio, check_id="xit.set", capability="xit")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] is False
+    assert check.evidence["changed"] is True
+    assert check.evidence["readback"] is True
+    assert check.evidence["restored"] is True
+    assert store["on"] is False


### PR DESCRIPTION
## Problem (MOR-499) — found in live FTX-1 validation 2026-06-07

The radio supports these controls (raw CAT confirmed live), but the hardware validator (`src/rigplane/validation/hardware.py`) reported false negatives.

## Fix
- **filter_width**: `_nudge_filter` mutates by encoding — table-index widths (≤30, e.g. FTX-1 0-23) get a small in-range step; Hz widths (>30, Icom) keep the historic ±200. `_filter_width_equal` is exact for indices, 50 Hz tolerant for Hz. (FTX index 19→14 reacts; Icom 2400→2600 / 3000→2800 preserved + test-locked.)
- **notch**: collapse the compound `(bool,int)` read to its on/off bool, toggle/compare only the bool, preserve freq; plain-bool (Icom) passes through.
- **nb/nr**: prefer the bool getter/setter (Icom); fall back to `get_<n>_level`/`set_<n>_level` (FTX-1), level>0 ⇒ on; honest UNSUPPORTED only when neither exists.
- **agc/xit**: the existing handlers already honor FTX-1 semantics (AGC mutation provably stays ≤4, never the read-only auto values 5/6; xit toggles the rit_tx bool) — locked with tests. Dormant until MOR-500 declares them supported.

Icom no-regression is locked by dedicated tests. New test file `tests/validation/test_hardware_ftx1.py` (15 tests).

Gate: validation suite 102 passed; full suite 7220 passed/0 fail; ruff check + format clean; mypy 20=baseline/0 new; lint-imports 4/0.

Linear: MOR-499

🤖 Generated with [Claude Code](https://claude.com/claude-code)