### PR TITLE
fix: vendor-neutral wording in rigplane discover (MOR-501)

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -1006,7 +1006,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # discover
     discover_p = sub.add_parser(
-        "discover", help="Discover Icom radios on LAN and serial ports"
+        "discover", help="Discover radios on LAN and serial ports"
     )
     discover_scope = discover_p.add_mutually_exclusive_group()
     discover_scope.add_argument(
@@ -3511,7 +3511,7 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
 
 
 async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
-    """Discover Icom radios on LAN and/or serial ports."""
+    """Discover radios on LAN and/or serial ports."""
     from rigplane.discovery import (
         build_setup_discovery_payload,
         dedupe_radios,
@@ -3547,11 +3547,11 @@ async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
     if json_output:
         pass
     elif not serial_only and not lan_only:
-        print(f"Scanning for Icom radios ({timeout:.0f}s LAN + serial)...")
+        print(f"Scanning for radios ({timeout:.0f}s LAN + serial)...")
     elif serial_only:
-        print("Scanning serial ports for Icom radios...")
+        print("Scanning serial ports for radios...")
     else:
-        print(f"Scanning LAN for Icom radios ({timeout:.0f}s)...")
+        print(f"Scanning LAN for radios ({timeout:.0f}s)...")
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1385,7 +1385,8 @@ class TestBackendAwareDiscover:
                         main()
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
-        assert "Scanning for Icom radios" in captured.out
+        assert "Scanning for radios" in captured.out
+        assert "Icom radios" not in captured.out
         assert "serial" in captured.out.lower()
 
     def test_discover_serial_error_mentions_lan(self, capsys):
@@ -1401,7 +1402,8 @@ class TestBackendAwareDiscover:
                         main()
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
-        assert "Scanning for Icom radios" in captured.out
+        assert "Scanning for radios" in captured.out
+        assert "Icom radios" not in captured.out
         assert "lan" in captured.out.lower()
 
 


### PR DESCRIPTION
`rigplane discover` serial-probes Yaesu CAT and finds non-Icom radios (confirmed live: auto-detected an FTX-1 on serial), but the user-facing text said "Icom radios". Dropped "Icom" from the 5 discover-banner strings (subcommand help, `_cmd_discover` docstring, and the 3 "Scanning … for radios" prints); the `Found N radio(s)` summary was already neutral. Cosmetic only — no logic change. CLI test assertions updated + a negative `"Icom radios" not in output` lock added.

Gate: 7234 passed/0 fail; ruff check + format clean; mypy 20=baseline/0 new; lint-imports 4/0.

Linear: MOR-501

🤖 Generated with [Claude Code](https://claude.com/claude-code)