### PR TITLE
fix: render FTX-1 NB on native scale + gate NB depth/width by capability (MOR-502)

### DIFF
--- a/frontend/src/components-v2/panels/DspPanel.svelte
+++ b/frontend/src/components-v2/panels/DspPanel.svelte
@@ -23,6 +23,15 @@
   let nbLevel = $derived(p.nbLevel);
   let nbDepth = $derived(p.nbDepth ?? 0);
   let nbWidth = $derived(p.nbWidth ?? 0);
+  // MOR-502: NB level scale — IC-7610 reports a 0-255 control range (percent
+  // display); FTX-1 has none → native 0-10 raw integer (matches LCD skin).
+  let nbLevelMax = $derived(p.nbLevelMax ?? 255);
+  let nbLevelPercent = $derived(p.nbLevelPercent ?? true);
+  let hasNbDepth = $derived(p.hasNbDepth ?? false);
+  let hasNbWidth = $derived(p.hasNbWidth ?? false);
+  let nbLevelDisplayFn = $derived(
+    nbLevelPercent ? (v: number) => rawToPercentDisplay(v, 0, nbLevelMax) : (v: number) => `${v}`,
+  );
   let notchMode = $derived(p.notchMode);
   let notchFreq = $derived(p.notchFreq);
   let manualNotchWidth = $derived(p.manualNotchWidth ?? 0);
@@ -197,7 +206,7 @@
           onpointerup={endLongPressPointer}
           onpointercancel={endLongPressPointer}
           onpointerleave={endLongPressPointer}
-        >NB{nbActive ? ` ${rawToPercentDisplay(nbLevel)}` : ''}</HardwareButton>
+        >NB{nbActive ? ` ${nbLevelDisplayFn(nbLevel)}` : ''}</HardwareButton>
       </div>
     {/if}
 
@@ -315,38 +324,42 @@
       label="NB Level"
       value={nbLevel}
       min={0}
-      max={255}
+      max={nbLevelMax}
       step={1}
       renderer="hbar"
-      displayFn={rawToPercentDisplay}
+      displayFn={nbLevelDisplayFn}
       accentColor="var(--v2-accent-yellow)"
       onChange={onNbLevelChange}
       variant="hardware-illuminated"
     />
-    <ValueControl
-      label="NB Depth"
-      value={nbDepth}
-      min={1}
-      max={10}
-      step={1}
-      renderer="discrete"
-      tickStyle="notch"
-      accentColor="var(--v2-accent-orange)"
-      onChange={onNbDepthChange}
-      variant="hardware-illuminated"
-    />
-    <ValueControl
-      label="NB Width"
-      value={nbWidth}
-      min={0}
-      max={255}
-      step={1}
-      renderer="hbar"
-      displayFn={rawToPercentDisplay}
-      accentColor="var(--v2-accent-orange)"
-      onChange={onNbWidthChange}
-      variant="hardware-illuminated"
-    />
+    {#if hasNbDepth}
+      <ValueControl
+        label="NB Depth"
+        value={nbDepth}
+        min={1}
+        max={10}
+        step={1}
+        renderer="discrete"
+        tickStyle="notch"
+        accentColor="var(--v2-accent-orange)"
+        onChange={onNbDepthChange}
+        variant="hardware-illuminated"
+      />
+    {/if}
+    {#if hasNbWidth}
+      <ValueControl
+        label="NB Width"
+        value={nbWidth}
+        min={0}
+        max={255}
+        step={1}
+        renderer="hbar"
+        displayFn={rawToPercentDisplay}
+        accentColor="var(--v2-accent-orange)"
+        onChange={onNbWidthChange}
+        variant="hardware-illuminated"
+      />
+    {/if}
   </div>
 {/if}
 

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -14,6 +14,10 @@ const mockProps = {
   agcTimeConstant: 0,
   hasNr: true,
   hasNb: true,
+  hasNbDepth: true,
+  hasNbWidth: true,
+  nbLevelMax: 255,
+  nbLevelPercent: true,
 };
 
 const mockHandlers = {
@@ -55,6 +59,7 @@ beforeEach(() => {
     notchMode: 'off', notchFreq: 1000, nbDepth: 0, nbWidth: 0,
     manualNotchWidth: 0, agcTimeConstant: 0,
     hasNr: true, hasNb: true,
+    hasNbDepth: true, hasNbWidth: true, nbLevelMax: 255, nbLevelPercent: true,
   });
   mockHandlers.onNrModeChange = vi.fn();
   mockHandlers.onNrLevelChange = vi.fn();
@@ -114,5 +119,38 @@ describe('DspPanel component rendering', () => {
     const comp = components.pop()!;
     unmount(comp);
     expect(t.innerHTML).toBe('');
+  });
+});
+
+describe('DspPanel NB modal depth/width gating (MOR-502)', () => {
+  function openNbModal(t: HTMLElement): void {
+    vi.useFakeTimers();
+    try {
+      const nbBtn = Array.from(t.querySelectorAll<HTMLButtonElement>('.dsp-btn-wrap button')).find(
+        (b) => b.textContent?.trim().startsWith('NB'),
+      );
+      nbBtn?.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      vi.advanceTimersByTime(600);
+      flushSync();
+    } finally {
+      vi.useRealTimers();
+    }
+  }
+
+  it('renders NB Depth and NB Width in the modal when both capabilities are present', () => {
+    const t = mountPanel({ nbActive: true, hasNbDepth: true, hasNbWidth: true });
+    openNbModal(t);
+    const modal = t.querySelector('[aria-label="Noise blanker settings"]');
+    expect(modal?.textContent).toContain('NB Depth');
+    expect(modal?.textContent).toContain('NB Width');
+  });
+
+  it('omits NB Depth and NB Width in the modal when both capabilities are absent', () => {
+    const t = mountPanel({ nbActive: true, hasNbDepth: false, hasNbWidth: false });
+    openNbModal(t);
+    const modal = t.querySelector('[aria-label="Noise blanker settings"]');
+    expect(modal?.textContent).not.toContain('NB Depth');
+    expect(modal?.textContent).not.toContain('NB Width');
+    expect(modal?.textContent).toContain('NB Level');
   });
 });

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.test.ts
@@ -16,6 +16,10 @@ const mockProps = {
   agcTimeConstant: 0,
   hasNr: true,
   hasNb: true,
+  hasNbDepth: true,
+  hasNbWidth: true,
+  nbLevelMax: 255,
+  nbLevelPercent: true,
 };
 
 const mockHandlers = {
@@ -105,6 +109,7 @@ beforeEach(() => {
     notchMode: 'off', notchFreq: 1000, nbDepth: 0, nbWidth: 0,
     manualNotchWidth: 0, agcTimeConstant: 0,
     hasNr: true, hasNb: true,
+    hasNbDepth: true, hasNbWidth: true, nbLevelMax: 255, nbLevelPercent: true,
   });
   mockHandlers.onNrModeChange = vi.fn();
   mockHandlers.onNrLevelChange = vi.fn();
@@ -172,13 +177,63 @@ describe('NB toggle', () => {
     expect(mockHandlers.onNbToggle).toHaveBeenCalledWith(false);
   });
 
-  it('shows the NB level as the same percent the NB-Level slider uses (not raw)', () => {
-    const t = mountPanel({ nbActive: true, nbLevel: 76 });
+  it('shows the NB level as percent on a 0-255 rig (IC-7610) when nbLevelPercent is set', () => {
+    const t = mountPanel({ nbActive: true, nbLevel: 76, nbLevelPercent: true, nbLevelMax: 255 });
     const nbBtn = getFillButtons(t).find((b) => b.textContent?.trim().startsWith('NB'));
     const label = nbBtn?.textContent?.trim();
     // rawToPercentDisplay(76) === '30%'
     expect(label).toBe(`NB ${rawToPercentDisplay(76)}`);
     expect(label).not.toContain('76');
+  });
+
+  it('shows the NB level as the raw native value on a 0-10 rig (FTX-1) when nbLevelPercent is false', () => {
+    // MOR-502: FTX-1 NB is a native 0-10 level — no nb_level 0-255 control
+    // range — so the label must show the raw integer, matching the LCD skin.
+    const t = mountPanel({ nbActive: true, nbLevel: 5, nbLevelPercent: false, nbLevelMax: 10 });
+    const nbBtn = getFillButtons(t).find((b) => b.textContent?.trim().startsWith('NB'));
+    const label = nbBtn?.textContent?.trim();
+    expect(label).toBe('NB 5');
+    expect(label).not.toContain('%');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NB depth/width capability gating (MOR-502)
+// ---------------------------------------------------------------------------
+
+function openNbModal(t: HTMLElement): void {
+  vi.useFakeTimers();
+  try {
+    const nbBtn = getFillButtons(t).find((b) => b.textContent?.trim().startsWith('NB'));
+    nbBtn?.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    vi.advanceTimersByTime(600);
+    flushSync();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+describe('NB depth/width capability gating', () => {
+  it('shows NB Depth and NB Width controls when hasNbDepth/hasNbWidth are true (IC-7610)', () => {
+    const t = mountPanel({ nbActive: true, hasNbDepth: true, hasNbWidth: true });
+    openNbModal(t);
+    const modal = t.querySelector('[aria-label="Noise blanker settings"]');
+    expect(modal).not.toBeNull();
+    const text = modal?.textContent ?? '';
+    expect(text).toContain('NB Depth');
+    expect(text).toContain('NB Width');
+  });
+
+  it('hides NB Depth and NB Width controls when hasNbDepth/hasNbWidth are false (FTX-1)', () => {
+    const t = mountPanel({ nbActive: true, hasNbDepth: false, hasNbWidth: false });
+    openNbModal(t);
+    const modal = t.querySelector('[aria-label="Noise blanker settings"]');
+    expect(modal).not.toBeNull();
+    const text = modal?.textContent ?? '';
+    expect(text).not.toContain('NB Depth');
+    expect(text).not.toContain('NB Width');
+    // NB Level remains present regardless of depth/width.
+    expect(text).toContain('NB Level');
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/dsp-nb-depth.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dsp-nb-depth.test.ts
@@ -32,6 +32,8 @@ import { sendCommand } from '$lib/transport/ws-client';
 import { patchRadioState } from '$lib/stores/radio.svelte';
 import { makeDspHandlers as makeBusDspHandlers } from '../command-bus';
 import { makeDspHandlers as makeRuntimeDspHandlers } from '$lib/runtime/commands/panel-commands';
+import { toDspProps as toBusDspProps } from '../state-adapter';
+import { toDspProps as toRuntimeDspProps } from '$lib/runtime/props/panel-props';
 
 beforeEach(() => {
   vi.mocked(sendCommand).mockClear();
@@ -60,5 +62,49 @@ describe.each([
   it('stores the wire value optimistically (matches polled readback units)', () => {
     makeHandlers().onNbDepthChange(6);
     expect(patchRadioState).toHaveBeenCalledWith({ nbDepth: 5 });
+  });
+});
+
+// MOR-502: both prop adapters must gate NB depth/width on the nb_depth control
+// range and derive the NB-level scale from the nb_level control range, so the
+// FTX-1 (native 0-10 NB, no depth/width) and X6200 (nb_level only) render
+// correctly without phantom controls.
+describe.each([
+  ['command-bus', toBusDspProps],
+  ['runtime panel-props', toRuntimeDspProps],
+])('toDspProps NB capability gating (%s)', (_name, toDspProps) => {
+  const state = { active: 'MAIN', main: {} } as any;
+
+  it('shows NB depth/width only when an nb_depth control range exists (IC-7610)', () => {
+    const props = toDspProps(
+      state,
+      { capabilities: ['nb'], controls: { nb_depth: { raw_min: 0, raw_max: 9 } } } as any,
+    );
+    expect(props.hasNbDepth).toBe(true);
+    expect(props.hasNbWidth).toBe(true);
+  });
+
+  it('hides NB depth/width when no nb_depth control range exists (FTX-1, X6200)', () => {
+    const props = toDspProps(
+      state,
+      { capabilities: ['nb'], controls: { nb_level: { raw_min: 0, raw_max: 10 } } } as any,
+    );
+    expect(props.hasNbDepth).toBe(false);
+    expect(props.hasNbWidth).toBe(false);
+  });
+
+  it('uses the nb_level raw_max with percent display when a 0-255 range exists (IC-7610)', () => {
+    const props = toDspProps(
+      state,
+      { capabilities: ['nb'], controls: { nb_level: { raw_min: 0, raw_max: 255 } } } as any,
+    );
+    expect(props.nbLevelMax).toBe(255);
+    expect(props.nbLevelPercent).toBe(true);
+  });
+
+  it('falls back to the native 0-10 raw scale without an nb_level range (FTX-1)', () => {
+    const props = toDspProps(state, { capabilities: ['nb'], controls: {} } as any);
+    expect(props.nbLevelMax).toBe(10);
+    expect(props.nbLevelPercent).toBe(false);
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
@@ -238,3 +238,51 @@ describe('toDspProps NB-depth offset (MOR-498)', () => {
     expect(toDspProps({ active: 'MAIN', nbDepth: 9 } as any, null).nbDepth).toBe(10);
   });
 });
+
+describe('toDspProps NB-depth/width capability gating (MOR-502)', () => {
+  const state = { active: 'MAIN', main: {} } as any;
+
+  it('reports NB depth/width as available only when an nb_depth control range exists (IC-7610)', () => {
+    const caps = { capabilities: ['nb'], controls: { nb_depth: { raw_min: 0, raw_max: 9 } } } as any;
+    const props = toDspProps(state, caps);
+    expect(props.hasNbDepth).toBe(true);
+    expect(props.hasNbWidth).toBe(true);
+  });
+
+  it('hides NB depth/width when there is no nb_depth control range (FTX-1, X6200)', () => {
+    const caps = { capabilities: ['nb'], controls: { nb_level: { raw_min: 0, raw_max: 10 } } } as any;
+    const props = toDspProps(state, caps);
+    expect(props.hasNbDepth).toBe(false);
+    expect(props.hasNbWidth).toBe(false);
+  });
+
+  it('hides NB depth/width when capabilities are absent', () => {
+    const props = toDspProps(state, null);
+    expect(props.hasNbDepth).toBe(false);
+    expect(props.hasNbWidth).toBe(false);
+  });
+});
+
+describe('toDspProps NB-level scale (MOR-502)', () => {
+  const state = { active: 'MAIN', main: {} } as any;
+
+  it('uses the nb_level control raw_max and percent display when a 0-255 range exists (IC-7610)', () => {
+    const caps = { capabilities: ['nb'], controls: { nb_level: { raw_min: 0, raw_max: 255 } } } as any;
+    const props = toDspProps(state, caps);
+    expect(props.nbLevelMax).toBe(255);
+    expect(props.nbLevelPercent).toBe(true);
+  });
+
+  it('falls back to the native 0-10 raw scale when no nb_level control range exists (FTX-1)', () => {
+    const caps = { capabilities: ['nb'], controls: {} } as any;
+    const props = toDspProps(state, caps);
+    expect(props.nbLevelMax).toBe(10);
+    expect(props.nbLevelPercent).toBe(false);
+  });
+
+  it('falls back to the native 0-10 raw scale when capabilities are absent', () => {
+    const props = toDspProps(state, null);
+    expect(props.nbLevelMax).toBe(10);
+    expect(props.nbLevelPercent).toBe(false);
+  });
+});

--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -359,6 +359,12 @@ export interface DspProps {
   agcTimeConstant: number;
   hasNr: boolean;
   hasNb: boolean;
+  hasNbDepth: boolean;
+  hasNbWidth: boolean;
+  /** Slider/scale ceiling for NB level: 255 (IC-7610) or 10 (FTX-1 native). */
+  nbLevelMax: number;
+  /** Render NB level as a percent (IC-7610 0-255) vs. raw integer (FTX-1 0-10). */
+  nbLevelPercent: boolean;
   hasNotch: boolean;
   hasAutoNotch: boolean;
   hasAgcTime: boolean;
@@ -376,6 +382,17 @@ export function toDspProps(
   else if (rx?.manualNotch) notchMode = 'manual';
   const manualNotchAvailable = activeFieldAvailable(state, 'manualNotch');
   const autoNotchAvailable = activeFieldAvailable(state, 'autoNotch');
+  // MOR-502: NB depth/width exist only on rigs that expose an nb_depth control
+  // range (IC-7610). FTX-1 (native 0-10 NB) and X6200 (nb_level only) must not
+  // render phantom depth/width controls.
+  const nbDepthRange = caps?.controls?.nb_depth ?? null;
+  const hasNbDepth = nbDepthRange !== null;
+  // The NB-level scale follows the nb_level control range: a 0-255 range
+  // (IC-7610) renders as a percent; its absence means the native 0-10 raw
+  // scale (FTX-1) and the label shows the raw integer.
+  const nbLevelRange = caps?.controls?.nb_level ?? null;
+  const nbLevelPercent = nbLevelRange !== null;
+  const nbLevelMax = nbLevelRange?.raw_max ?? 10;
 
   return {
     nrMode: rx?.nr ? 1 : 0,
@@ -392,6 +409,10 @@ export function toDspProps(
     agcTimeConstant: rx?.agcTimeConstant ?? 0,
     hasNr: hasCap(caps, 'nr') && activeFieldAvailable(state, 'nr'),
     hasNb: hasCap(caps, 'nb') && activeFieldAvailable(state, 'nb'),
+    hasNbDepth,
+    hasNbWidth: hasNbDepth,
+    nbLevelMax,
+    nbLevelPercent,
     hasNotch: (hasCap(caps, 'notch') || caps === null) && manualNotchAvailable,
     hasAutoNotch: (hasCap(caps, 'notch') || caps === null) && autoNotchAvailable,
     hasAgcTime: activeFieldAvailable(state, 'agcTimeConstant'),

--- a/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
@@ -298,6 +298,43 @@ describe('panel prop field availability', () => {
     expect(toDspProps(makeState({ nbDepth: 5 }), null).nbDepth).toBe(6);
     expect(toDspProps(makeState({ nbDepth: 9 }), null).nbDepth).toBe(10);
   });
+
+  it('gates NB depth/width on the nb_depth control range (MOR-502)', () => {
+    const withDepth = toDspProps(
+      makeState(),
+      { capabilities: ['nb'], controls: { nb_depth: { raw_min: 0, raw_max: 9 } } } as any,
+    );
+    expect(withDepth.hasNbDepth).toBe(true);
+    expect(withDepth.hasNbWidth).toBe(true);
+
+    const withoutDepth = toDspProps(
+      makeState(),
+      { capabilities: ['nb'], controls: { nb_level: { raw_min: 0, raw_max: 10 } } } as any,
+    );
+    expect(withoutDepth.hasNbDepth).toBe(false);
+    expect(withoutDepth.hasNbWidth).toBe(false);
+
+    const noCaps = toDspProps(makeState(), null);
+    expect(noCaps.hasNbDepth).toBe(false);
+    expect(noCaps.hasNbWidth).toBe(false);
+  });
+
+  it('derives the NB-level scale from the nb_level control range (MOR-502)', () => {
+    const icom = toDspProps(
+      makeState(),
+      { capabilities: ['nb'], controls: { nb_level: { raw_min: 0, raw_max: 255 } } } as any,
+    );
+    expect(icom.nbLevelMax).toBe(255);
+    expect(icom.nbLevelPercent).toBe(true);
+
+    const ftx1 = toDspProps(makeState(), { capabilities: ['nb'], controls: {} } as any);
+    expect(ftx1.nbLevelMax).toBe(10);
+    expect(ftx1.nbLevelPercent).toBe(false);
+
+    const noCaps = toDspProps(makeState(), null);
+    expect(noCaps.nbLevelMax).toBe(10);
+    expect(noCaps.nbLevelPercent).toBe(false);
+  });
 });
 
 describe('RF front-end preamp/digisel mutex', () => {

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -429,6 +429,12 @@ export interface DspProps {
   agcTimeConstant: number;
   hasNr: boolean;
   hasNb: boolean;
+  hasNbDepth: boolean;
+  hasNbWidth: boolean;
+  /** Slider/scale ceiling for NB level: 255 (IC-7610) or 10 (FTX-1 native). */
+  nbLevelMax: number;
+  /** Render NB level as a percent (IC-7610 0-255) vs. raw integer (FTX-1 0-10). */
+  nbLevelPercent: boolean;
   hasNotch: boolean;
   hasAutoNotch: boolean;
   hasAgcTime: boolean;
@@ -448,6 +454,17 @@ export function toDspProps(
   const nrAvailable = activeFieldAvailable(state, 'nr');
   const manualNotchAvailable = activeFieldAvailable(state, 'manualNotch');
   const autoNotchAvailable = activeFieldAvailable(state, 'autoNotch');
+  // MOR-502: NB depth/width exist only on rigs that expose an nb_depth control
+  // range (IC-7610). FTX-1 (native 0-10 NB) and X6200 (nb_level only) must not
+  // render phantom depth/width controls.
+  const nbDepthRange = caps?.controls?.nb_depth ?? null;
+  const hasNbDepth = nbDepthRange !== null;
+  // The NB-level scale follows the nb_level control range: a 0-255 range
+  // (IC-7610) renders as a percent; its absence means the native 0-10 raw
+  // scale (FTX-1) and the label shows the raw integer.
+  const nbLevelRange = caps?.controls?.nb_level ?? null;
+  const nbLevelPercent = nbLevelRange !== null;
+  const nbLevelMax = nbLevelRange?.raw_max ?? 10;
   return {
     nrMode: rx?.nr ? 1 : 0,
     // MOR-490: store holds the raw 0-255 wire value; the slider is 0-15.
@@ -463,6 +480,10 @@ export function toDspProps(
     agcTimeConstant: rx?.agcTimeConstant ?? 0,
     hasNr: hasCap(caps, 'nr') && nrAvailable,
     hasNb: hasCap(caps, 'nb') && nbAvailable,
+    hasNbDepth,
+    hasNbWidth: hasNbDepth,
+    nbLevelMax,
+    nbLevelPercent,
     hasNotch: (hasCap(caps, 'notch') || caps === null) && manualNotchAvailable,
     hasAutoNotch: (hasCap(caps, 'notch') || caps === null) && autoNotchAvailable,
     hasAgcTime: activeFieldAvailable(state, 'agcTimeConstant'),


### PR DESCRIPTION
## Problem (MOR-502) — found in live FTX-1 v2 web-UI testing 2026-06-07

The DSP panel rendered the FTX-1 noise blanker as "NB 2%" (its native 0-10 level shown as %/255) and exposed NB Depth + NB Width controls the FTX-1 can't do (Icom-only).

## Fix (frontend-only)
- NB label + NB-Level slider now derive scale from capabilities: percent when the rig has a `nb_level` control range (IC-7610 → 0-255 %), raw integer when absent (FTX-1 → native 0-10, e.g. "NB 5", matching the LCD skin).
- NB Depth/Width gated on `nb_depth` capability presence (`hasNbDepth`/`hasNbWidth`) — hidden for radios without it.
- Both adapter stacks updated in sync (`lib/runtime/props/panel-props.ts` + `components-v2/wiring/state-adapter.ts`), sourced from the `caps` param (pure, no store singleton).

Also fixes **X6200** (has nb_level, no nb_depth → depth/width were phantom; now hidden). No backend/profile change.

Gate: `npm run check`/`test` (2051 passed)/`lint`/`build` all green.

Linear: MOR-502

🤖 Generated with [Claude Code](https://claude.com/claude-code)