### PR TITLE
fix: add band-stacking codes to FTX-1 bands so band-switch uses set_band (MOR-503)

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -446,60 +446,70 @@ name = "160m"
 start_hz = 1800000
 end_hz = 2000000
 default_hz = 1825000
+bsr_code = 0x00
 
 [[freq_ranges.ranges.bands]]
 name = "80m"
 start_hz = 3500000
 end_hz = 3800000
 default_hz = 3600000
+bsr_code = 0x01
 
 [[freq_ranges.ranges.bands]]
 name = "60m"
 start_hz = 5351500
 end_hz = 5366500
 default_hz = 5357000
+bsr_code = 0x02
 
 [[freq_ranges.ranges.bands]]
 name = "40m"
 start_hz = 7000000
 end_hz = 7200000
 default_hz = 7100000
+bsr_code = 0x03
 
 [[freq_ranges.ranges.bands]]
 name = "30m"
 start_hz = 10100000
 end_hz = 10150000
 default_hz = 10125000
+bsr_code = 0x04
 
 [[freq_ranges.ranges.bands]]
 name = "20m"
 start_hz = 14000000
 end_hz = 14350000
 default_hz = 14200000
+bsr_code = 0x05
 
 [[freq_ranges.ranges.bands]]
 name = "17m"
 start_hz = 18068000
 end_hz = 18168000
 default_hz = 18100000
+bsr_code = 0x06
 
 [[freq_ranges.ranges.bands]]
 name = "15m"
 start_hz = 21000000
 end_hz = 21450000
 default_hz = 21200000
+bsr_code = 0x07
 
 [[freq_ranges.ranges.bands]]
 name = "12m"
 start_hz = 24890000
 end_hz = 24990000
 default_hz = 24940000
+bsr_code = 0x08
 
 [[freq_ranges.ranges.bands]]
 name = "10m"
 start_hz = 28000000
 end_hz = 29700000
 default_hz = 28500000
+bsr_code = 0x09
 
 [[freq_ranges.ranges]]
 label = "4m"

--- a/tests/test_bsr_band_switching.py
+++ b/tests/test_bsr_band_switching.py
@@ -343,3 +343,72 @@ class TestRigProfileBSRCodes:
                     )
                     return
         pytest.fail(f"Band {band_name} not found in {model} profile")
+
+
+# ---------------------------------------------------------------------------
+# FTX-1 (Yaesu) band-stacking codes (MOR-503)
+# ---------------------------------------------------------------------------
+
+
+class TestFtx1BandStackingCodes:
+    """Verify the FTX-1 HF bands carry CI-V band codes for set_band.
+
+    Without ``bsr_code`` the v2 UI band buttons fall through to
+    ``set_freq(default_hz)`` instead of issuing ``set_band``, which loses the
+    radio's per-band last-used frequency (MOR-503).  The codes must be valid
+    keys of ``YaesuCatPoller._CIV_TO_YAESU_BAND`` so they map to a Yaesu
+    ``BS0{nn};`` band-stack recall.
+    """
+
+    # CI-V band code per HF band (Yaesu scheme: 160m=0 … 10m=9).
+    _EXPECTED_FTX1_BSR: dict[str, int] = {
+        "160m": 0,
+        "80m": 1,
+        "60m": 2,
+        "40m": 3,
+        "30m": 4,
+        "20m": 5,
+        "17m": 6,
+        "15m": 7,
+        "12m": 8,
+        "10m": 9,
+    }
+
+    def _ftx1_bands(self) -> dict[str, int | None]:
+        profile = resolve_radio_profile(model="FTX-1")
+        return {bi.name: bi.bsr_code for fr in profile.freq_ranges for bi in fr.bands}
+
+    def test_all_hf_bands_have_bsr_code(self) -> None:
+        """Every FTX-1 HF band must define a band code (none left None)."""
+        bands = self._ftx1_bands()
+        for name in self._EXPECTED_FTX1_BSR:
+            assert bands.get(name) is not None, (
+                f"FTX-1 {name} is missing bsr_code; band-switch would fall back "
+                f"to default_hz instead of set_band"
+            )
+
+    @pytest.mark.parametrize(
+        "band_name,expected_bsr",
+        list(_EXPECTED_FTX1_BSR.items()),
+    )
+    def test_specific_ftx1_bsr_codes(self, band_name: str, expected_bsr: int) -> None:
+        """FTX-1 band codes must match the Yaesu CI-V band scheme."""
+        bands = self._ftx1_bands()
+        assert band_name in bands, f"Band {band_name} not found in FTX-1 profile"
+        assert bands[band_name] == expected_bsr, (
+            f"FTX-1 {band_name}: expected bsr_code {expected_bsr}, "
+            f"got {bands[band_name]}"
+        )
+
+    def test_bsr_codes_are_valid_yaesu_band_keys(self) -> None:
+        """Each FTX-1 bsr_code must map through _CIV_TO_YAESU_BAND for set_band."""
+        from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
+
+        bands = self._ftx1_bands()
+        for name, code in bands.items():
+            if code is None:
+                continue
+            assert code in YaesuCatPoller._CIV_TO_YAESU_BAND, (  # noqa: SLF001
+                f"FTX-1 {name} bsr_code {code} is not a valid Yaesu band key; "
+                f"set_band would silently no-op"
+            )


### PR DESCRIPTION
## Problem (MOR-503) — found in live FTX-1 v2 web-UI testing 2026-06-07

Switching bands jumped to the band's fixed `default_hz` instead of the last-used freq (20m 14.074 → 40m → 20m landed on 14.200). Root cause: FTX-1 bands had no `bsr_code`, and the v2 band buttons use `bsrCode` as the sole signal to issue `set_band`; absent it, every button fell through to `set_freq(default_hz)`. The `set_band` path (CAT `BS0{nn};` → Yaesu hardware band-stack) was fully built but never reached.

## Fix
Add `bsr_code` to the 10 HF bands in `rigs/ftx1.toml` using the **Yaesu** CI-V scheme (160m=0x00 … 10m=0x09) that `_CIV_TO_YAESU_BAND` expects — NOT the Icom scheme (160m=0x01). Now the band button issues `set_band(bsrCode)` → `BS0{nn};`, and the FTX-1's hardware band-stack restores the last-used freq.

Profile + test only; the `SetBand → poller → BS` plumbing already existed. Gate: 7246 passed; ruff/format clean; mypy baseline; lint-imports 4/0; toml parses.

**Note:** relies on the FTX-1 firmware honoring `BS` to recall its band-stack — validated live on hardware after merge.

Linear: MOR-503

🤖 Generated with [Claude Code](https://claude.com/claude-code)