### PR TITLE
fix: open USB RX at device-native channels + downmix to mono (MOR-504)

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -191,6 +191,7 @@ class AudioBackend(Protocol):
         sample_rate: int = 48_000,
         channels: int = 1,
         frame_ms: int = 20,
+        deliver_channels: int | None = None,
     ) -> RxStream: ...
 
     def open_tx(
@@ -224,6 +225,38 @@ def _ensure_portaudio_deps() -> tuple[Any, Any]:
     except ImportError as exc:
         raise ImportError(_DEPENDENCY_HINT) from exc
     return sd, np
+
+
+def _downmix_stereo_to_mono_s16le(pcm: bytes) -> bytes:
+    """Downmix L+R interleaved s16le → mono s16le via the per-pair average.
+
+    Mirrors ``rigplane.audio.bridge._downmix_stereo_to_mono`` but is dependency-
+    free (stdlib ``array``) so it can run on the PortAudio audio thread without
+    importing numpy. Used by :class:`_PortAudioRxStream` when a stereo-native
+    device is opened at 2 channels but the consumer wants mono (MOR-504):
+    passing interleaved stereo straight through would halve the effective
+    sample-rate and compress the spectrum 2x — the same bug the bridge downmix
+    guards (issue #1381). Trailing bytes that do not form a whole L/R sample
+    pair are dropped (an incomplete frame cannot satisfy the fixed contract).
+    """
+    from array import array
+
+    usable = len(pcm) - (len(pcm) % 4)  # whole L/R pairs (2 ch × 2 bytes)
+    if usable <= 0:
+        return b""
+    samples = array("h")
+    samples.frombytes(pcm[:usable])
+    import sys
+
+    if sys.byteorder != "little":
+        samples.byteswap()
+    mono = array("h", bytes(len(samples)))  # len(samples)//2 mono samples
+    for i in range(0, len(samples), 2):
+        # Average in a wider int to avoid s16 overflow before truncation.
+        mono[i // 2] = (samples[i] + samples[i + 1]) // 2
+    if sys.byteorder != "little":
+        mono.byteswap()
+    return mono.tobytes()
 
 
 class _PortAudioRxStream:
@@ -265,21 +298,37 @@ class _PortAudioRxStream:
         channels: int,
         blocksize: int,
         frame_ms: int,
+        deliver_channels: int | None = None,
     ) -> None:
         self._sd = sd
         self._device_index = device_index
         self._sample_rate = sample_rate
+        # ``channels`` is the OS open count; ``_deliver_channels`` is what the
+        # consumer receives. When deliver < open (mono request on a stereo-
+        # native device, MOR-504) the callback downmixes interleaved s16le to
+        # the deliver count before chunking. Default: deliver == open.
         self._channels = channels
+        self._deliver_channels = (
+            channels if deliver_channels is None else deliver_channels
+        )
+        # Software downmix only fires for the stereo-native → mono case. Any
+        # other deliver/open relationship passes interleaved PCM through
+        # unchanged (over-request already clamps open == deliver upstream).
+        self._downmix_stereo_to_mono = (
+            self._channels == 2 and self._deliver_channels == 1
+        )
         # Capture is callback-driven with blocksize=0 (engine-native period),
         # mirroring a clean sd.rec. blocksize=0 was previously rejected by the
         # WDM-KS capture face (PortAudioError -9999), but companion device
         # selection now forces the WASAPI face, on which blocksize=0 opens.
         self._blocksize = blocksize
         # Fixed delivered-frame size: frame_ms worth of audio frames, each
-        # ``channels`` interleaved s16le samples (2 bytes/sample). The PortAudio
-        # stream stays blocksize=0; only the size handed to ``cb`` is fixed.
+        # ``_deliver_channels`` interleaved s16le samples (2 bytes/sample). The
+        # downstream PCM validator expects the DELIVER count (1920 bytes = 20 ms
+        # mono @ 48 kHz), not the native open count. The PortAudio stream stays
+        # blocksize=0; only the size handed to ``cb`` is fixed.
         frame_samples = (sample_rate * frame_ms) // 1000
-        self._frame_bytes = max(1, frame_samples * channels * 2)
+        self._frame_bytes = max(1, frame_samples * self._deliver_channels * 2)
         self._stream: Any = None
         self._running = False
         self._callback: Callable[[bytes], None] | None = None
@@ -355,6 +404,20 @@ class _PortAudioRxStream:
             return
         if not pcm:
             return
+        if self._downmix_stereo_to_mono:
+            # Device opened at 2 ch (native) but consumer wants mono (MOR-504):
+            # collapse interleaved L/R → mono average BEFORE chunking, so the
+            # accumulator/fixed-frame slicing operates on mono bytes and the
+            # FFT scope + broadcaster receive the mono contract they expect.
+            try:
+                pcm = _downmix_stereo_to_mono_s16le(pcm)
+            except Exception:
+                logger.warning(
+                    "portaudio-rx: stereo→mono downmix failed", exc_info=True
+                )
+                return
+            if not pcm:
+                return
         acc = self._accumulator
         acc.extend(pcm)
         frame_bytes = self._frame_bytes
@@ -852,6 +915,7 @@ class PortAudioBackend:
         sample_rate: int = 48_000,
         channels: int = 1,
         frame_ms: int = 20,
+        deliver_channels: int | None = None,
     ) -> RxStream:
         sd, _ = self._ensure_deps()
         # blocksize=0 lets PortAudio use the engine-native period, mirroring a
@@ -860,6 +924,12 @@ class PortAudioBackend:
         # rejected blocksize=0 with PortAudioError -9999 is no longer chosen).
         # The PortAudio capture period stays engine-native; frame_ms only sizes
         # the fixed frames re-chunked out to the consumer callback.
+        #
+        # ``channels`` is the OS open count; ``deliver_channels`` is what the
+        # consumer receives. When ``deliver_channels`` < ``channels`` (mono
+        # request on a stereo-native device, MOR-504) the stream software-
+        # downmixes before chunking, so the consumer still sees the mono
+        # fixed-frame contract while CoreAudio/AUHAL opens the device natively.
         return _PortAudioRxStream(
             sd,
             device_index=int(device),
@@ -867,6 +937,7 @@ class PortAudioBackend:
             channels=channels,
             blocksize=0,
             frame_ms=frame_ms,
+            deliver_channels=deliver_channels,
         )
 
     def open_tx(
@@ -1040,9 +1111,13 @@ class FakeAudioBackend:
         sample_rate: int = 48_000,
         channels: int = 1,
         frame_ms: int = 20,
+        deliver_channels: int | None = None,
     ) -> FakeRxStream:
         if not any(d.id == device for d in self._devices):
             raise ValueError(f"Unknown device id {device}")
+        # ``deliver_channels`` selects the software downmix in the real
+        # PortAudio stream; FakeRxStream is a verbatim pass-through, so it only
+        # records what it was opened at for assertions.
         stream = FakeRxStream()
         self.rx_streams.append(stream)
         return stream

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -113,6 +113,21 @@ class UsbAudioStreamContract:
     sample_rate_source: str
     channel_source: str = "requested"
     fallback_reason: str | None = None
+    open_channels: int | None = None
+    """Device-native channel count the OS stream is opened at.
+
+    ``None`` means the stream opens at ``channels`` (open == deliver). It is set
+    only when the device is opened at MORE channels than downstream consumes —
+    i.e. a mono (deliver=1) request on a stereo-native device (open=2): the
+    stream opens at the native count and software-downmixes back to ``channels``
+    (MOR-504). ``channels`` always stays the DELIVERED count (downstream DSP is
+    48 kHz mono), so diagnostics and the fixed-frame contract see the mono path.
+    """
+
+    @property
+    def effective_open_channels(self) -> int:
+        """Channel count to open the OS stream at (defaults to ``channels``)."""
+        return self.channels if self.open_channels is None else self.open_channels
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -126,6 +141,8 @@ class UsbAudioStreamContract:
         }
         if self.fallback_reason:
             payload["fallback_reason"] = self.fallback_reason
+        if self.open_channels is not None:
+            payload["open_channels"] = self.open_channels
         return payload
 
 
@@ -488,28 +505,50 @@ class UsbAudioDriver:
         direction: str,
         device: UsbAudioDevice,
         requested_channels: int,
-    ) -> tuple[int, str, str | None]:
-        """Clamp requested channels to the device's real capability (MOR-238).
+    ) -> tuple[int, int, str, str | None]:
+        """Reconcile requested channels with the device's real capability.
 
-        A profile / codec may request stereo from a device that only exposes a
-        mono capture (or playback) endpoint. PortAudio rejects that open with
-        PaErrorCode -9998 ("Invalid number of channels"). Mirroring the
-        sample-rate negotiation, the effective channel count is clamped down to
-        what the device advertises so any mono/stereo USB codec self-heals
-        without a per-profile ``codec_preference`` entry. Downstream DSP is
-        48 kHz mono, so a 1-channel capture feeds the broadcaster cleanly.
+        Returns ``(deliver_channels, open_channels, channel_source,
+        fallback_reason)``:
+
+        - ``deliver_channels`` — the count delivered downstream (the broadcaster
+          / FFT scope contract is 48 kHz mono).
+        - ``open_channels`` — the count the OS stream is opened at.
+
+        Two reconciliation directions, both healing a codec/device mismatch that
+        PortAudio otherwise rejects with PaErrorCode -9998 ("Invalid number of
+        channels") on Windows, or AUHAL -10863 on macOS CoreAudio:
+
+        - **Over-request (MOR-238)** — a profile / codec asks for MORE channels
+          than the device exposes (stereo request on a mono capture endpoint).
+          Both open and deliver clamp DOWN to ``device_max``; downstream is mono,
+          so a 1-channel capture feeds the broadcaster cleanly.
+        - **Under-request (MOR-504)** — a mono (deliver=1) request on a
+          stereo-NATIVE device. macOS AUHAL refuses to open a 2-channel device at
+          1 channel (err -10863), so the stream opens at the device-native count
+          and the RX stream software-downmixes back to mono before delivery. RX
+          path only (TX never up-opens — there is no mix-up direction for
+          playback).
         """
 
         device_max = (
             device.input_channels if direction == "rx" else device.output_channels
         )
         # A device advertising zero channels for this direction is a selection
-        # bug, not a clamp target — leave the request untouched and let the
+        # bug, not a reconcile target — leave the request untouched and let the
         # open surface the real error.
-        if device_max >= 1 and requested_channels > device_max:
+        if device_max < 1:
+            return requested_channels, requested_channels, "requested", None
+        if requested_channels > device_max:
             reason = f"channels-{requested_channels}-clamped-to-device-{device_max}"
-            return device_max, "device-clamp", reason
-        return requested_channels, "requested", None
+            return device_max, device_max, "device-clamp", reason
+        if direction == "rx" and requested_channels < device_max:
+            # Open native, deliver the (mono) request via software downmix.
+            reason = (
+                f"channels-{requested_channels}-opened-as-device-{device_max}-downmix"
+            )
+            return requested_channels, device_max, "device-native", reason
+        return requested_channels, requested_channels, "requested", None
 
     def _resolve_stream_contract(
         self,
@@ -522,11 +561,19 @@ class UsbAudioDriver:
         allow_sample_rate_fallback: bool,
     ) -> UsbAudioStreamContract:
         device_id = AudioDeviceId(device.index)
-        effective_channels, channel_source, channel_reason = self._clamp_channels(
+        (
+            deliver_channels,
+            open_channels,
+            channel_source,
+            channel_reason,
+        ) = self._clamp_channels(
             direction=direction,
             device=device,
             requested_channels=channels,
         )
+        # Only carry ``open_channels`` when it differs from the delivered count
+        # (under-request downmix); otherwise the OS stream opens at ``channels``.
+        open_field = open_channels if open_channels != deliver_channels else None
         if self._backend.check_sample_rate(
             device_id,
             requested_sample_rate,
@@ -537,11 +584,12 @@ class UsbAudioDriver:
                 direction=direction,
                 device=device,
                 sample_rate_hz=requested_sample_rate,
-                channels=effective_channels,
+                channels=deliver_channels,
                 frame_ms=frame_ms,
                 sample_rate_source=source,
                 channel_source=channel_source,
                 fallback_reason=channel_reason,
+                open_channels=open_field,
             )
 
         if not allow_sample_rate_fallback:
@@ -569,11 +617,12 @@ class UsbAudioDriver:
                     direction=direction,
                     device=device,
                     sample_rate_hz=candidate,
-                    channels=effective_channels,
+                    channels=deliver_channels,
                     frame_ms=frame_ms,
                     sample_rate_source="fallback",
                     channel_source=channel_source,
                     fallback_reason=fallback_reason,
+                    open_channels=open_field,
                 )
 
         raise AudioDriverLifecycleError(
@@ -638,11 +687,12 @@ class UsbAudioDriver:
             # RX frames reaching the browser.
             logger.info(
                 "usb-audio: opening RX capture — device=[%d] %s, %d Hz, "
-                "%d ch (requested %d, source=%s), %d ms "
+                "open %d ch / deliver %d ch (requested %d, source=%s), %d ms "
                 "(device input_channels=%d)",
                 selected_rx.index,
                 selected_rx.name,
                 contract.sample_rate_hz,
+                contract.effective_open_channels,
                 contract.channels,
                 ch,
                 contract.channel_source,
@@ -652,8 +702,9 @@ class UsbAudioDriver:
             self._rx_stream = self._backend.open_rx(
                 AudioDeviceId(selected_rx.index),
                 sample_rate=contract.sample_rate_hz,
-                channels=contract.channels,
+                channels=contract.effective_open_channels,
                 frame_ms=fm,
+                deliver_channels=contract.channels,
             )
             await self._rx_stream.start(callback)
             self._store_stream_contract(contract)

--- a/tests/test_usb_audio_channel_clamp_mor238.py
+++ b/tests/test_usb_audio_channel_clamp_mor238.py
@@ -53,6 +53,7 @@ class _StrictChannelBackend:
         self.tx_streams: list[FakeTxStream] = []
         self.rx_open_channels: list[int] = []
         self.tx_open_channels: list[int] = []
+        self.rx_deliver_channels: list[int | None] = []
 
     def list_devices(self) -> list[AudioDeviceInfo]:
         return [self._device]
@@ -69,8 +70,15 @@ class _StrictChannelBackend:
         sample_rate: int = 48_000,
         channels: int = 1,
         frame_ms: int = 20,
+        deliver_channels: int | None = None,
     ) -> FakeRxStream:
         self.rx_open_channels.append(channels)
+        self.rx_deliver_channels.append(deliver_channels)
+        # ``channels`` is the OS open count: the strict backend models a device
+        # that rejects any open whose channel count ≠ its capability (PortAudio
+        # -9998 / AUHAL -10863). The driver must open at the device-native count
+        # — clamping DOWN for an over-request, opening NATIVE for a mono request
+        # on a stereo device (then downmixing in software).
         if channels != self._device.input_channels:
             raise RuntimeError(
                 "Error opening InputStream: Invalid number of channels "
@@ -185,25 +193,145 @@ async def test_stereo_device_request_is_unchanged() -> None:
 
 
 @pytest.mark.asyncio
-async def test_mono_request_on_stereo_device_not_upmixed() -> None:
-    """A mono request is never raised to the device max (clamp only narrows)."""
+async def test_mono_request_on_stereo_device_opens_device_native() -> None:
+    """A mono RX request on a stereo-native device opens at the device count.
+
+    macOS CoreAudio/AUHAL refuses to open a 2-channel device at 1 channel
+    (err -10863) → no frames → blank audio scope (MOR-504). The driver must
+    reconcile UP to the device-native open count (with ``channel_source ==
+    "device-native"``) and carry the mono request as the deliver target so the
+    RX stream downmixes back to mono. This is the macOS analogue of the MOR-238
+    over-request narrowing — previously the reconcile only narrowed, so a mono
+    request on a stereo device stayed 1 ch and the open was rejected.
+    """
     backend = _StrictChannelBackend(input_channels=2, output_channels=2)
-    backend._device = AudioDeviceInfo(  # type: ignore[attr-defined]
-        id=AudioDeviceId(0),
-        name="USB Audio Device",
-        input_channels=2,
-        output_channels=2,
-        default_samplerate=48_000,
-        is_default_input=True,
-        is_default_output=True,
-    )
     driver = UsbAudioDriver(serial_port=None, backend=backend)
 
-    # A 1-ch request must stay 1-ch even though the device exposes 2 inputs;
-    # the strict backend would raise if the driver upmixed to 2.
-    with pytest.raises(RuntimeError, match="Invalid number of channels"):
-        await driver.start_rx(lambda _frame: None, channels=1)
-    assert backend.rx_open_channels == [1]
+    await driver.start_rx(lambda _frame: None, channels=1)
+
+    assert driver.rx_running
+    # Opened at the device-native 2 ch (no rejection), delivering mono.
+    assert backend.rx_open_channels == [2]
+    assert backend.rx_deliver_channels == [1]
+    contract = driver.usb_audio_contract
+    assert contract is not None and contract.rx is not None
+    # ``channels`` stays the DELIVERED (mono) count; ``open_channels`` carries
+    # the device-native open count the OS stream is actually opened at.
+    assert contract.rx.channels == 1
+    assert contract.rx.open_channels == 2
+    assert contract.rx.effective_open_channels == 2
+    assert contract.rx.channel_source == "device-native"
+    assert contract.rx.fallback_reason == "channels-1-opened-as-device-2-downmix"
+    await driver.stop_rx()
+
+
+@pytest.mark.asyncio
+async def test_mono_request_on_stereo_device_opens_native_and_downmixes() -> None:
+    """End-to-end: stereo-native open + software downmix delivers mono average.
+
+    Combines the driver-level reconciliation (open at device-native 2 ch, no
+    rejection from the strict backend) with the PortAudio-level downmix (a
+    2-ch interleaved s16le frame collapses to the per-pair mono average at the
+    correct fixed mono byte length). FakeRxStream is a verbatim pass-through, so
+    the downmix itself is pinned by ``test_portaudio_rx_stereo_native_downmix``
+    below; here we assert the driver opens native + delivers mono and that the
+    contract advertises the downmix.
+    """
+    backend = _StrictChannelBackend(input_channels=2, output_channels=2)
+    driver = UsbAudioDriver(serial_port=None, backend=backend)
+    received: list[bytes] = []
+
+    # (a) open is not rejected → reconciled to device-native 2 ch.
+    await driver.start_rx(received.append, channels=1)
+    assert backend.rx_open_channels == [2]
+    assert backend.rx_deliver_channels == [1]
+
+    # (b) FakeRxStream is a pass-through; the real downmix lives in
+    # _PortAudioRxStream (pinned separately). A frame injected here is delivered
+    # verbatim, proving the consumer wiring survives the reconcile.
+    pcm = b"\x10\x20\x30\x40" * 240  # 240 stereo s16le L/R pairs
+    backend.rx_streams[0].inject_frame(pcm)
+    assert received == [pcm]
+    await driver.stop_rx()
+
+
+@pytest.mark.asyncio
+async def test_portaudio_rx_stereo_native_downmix_delivers_mono_average() -> None:
+    """_PortAudioRxStream opened at 2 ch / deliver 1 ch downmixes to the average.
+
+    Focused unit test for the MOR-504 downmix: a 2-ch interleaved s16le block
+    is collapsed to the per-pair mono average and re-chunked to the DELIVER
+    (mono) fixed-frame byte length (1920 bytes = 960 mono samples / 20 ms /
+    48 kHz), NOT the native 2-ch length. Interleaved stereo must never reach
+    the consumer (that halves the spectrum — bridge guard, issue #1381).
+    """
+    import struct
+
+    from rigplane.audio.backend import PortAudioBackend
+
+    class FakeIndata:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+
+        def tobytes(self) -> bytes:
+            return self._payload
+
+    captured_cb: dict[str, object] = {}
+
+    class FakeSd:
+        class InputStream:
+            def __init__(self, **kw: object) -> None:
+                captured_cb["cb"] = kw["callback"]
+
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+    backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+    # Device-native open=2, deliver=1 → downmix path engaged.
+    stream = backend.open_rx(
+        AudioDeviceId(0),
+        sample_rate=48_000,
+        channels=2,
+        frame_ms=20,
+        deliver_channels=1,
+    )
+
+    received: list[bytes] = []
+    await stream.start(received.append)
+    cb = captured_cb["cb"]
+    assert callable(cb)
+
+    # 960 stereo L/R pairs (one whole 20 ms mono frame after downmix). L and R
+    # differ so a wrong (non-averaging or pass-through) downmix is caught:
+    # L = 1000, R = 2000 → mono average 1500.
+    pairs = 960
+    block = b"".join(struct.pack("<hh", 1000, 2000) for _ in range(pairs))
+    cb(FakeIndata(block), pairs, None, None)  # type: ignore[operator]
+
+    expected_frame = b"".join(struct.pack("<h", 1500) for _ in range(pairs))
+    assert len(expected_frame) == 1920  # mono fixed-frame, not 3840 (stereo)
+    assert received == [expected_frame]
+
+    await stream.stop()
+
+
+def test_portaudio_rx_stereo_native_downmix_truncates_odd_pair() -> None:
+    """Downmix drops a trailing byte run that is not a whole L/R sample pair."""
+    import struct
+
+    from rigplane.audio.backend import _downmix_stereo_to_mono_s16le
+
+    # Two whole L/R pairs + 3 dangling bytes (not a 4-byte stereo sample).
+    pcm = struct.pack("<hh", 10, 30) + struct.pack("<hh", -20, -40) + b"\x01\x02\x03"
+    mono = _downmix_stereo_to_mono_s16le(pcm)
+    # (10+30)//2 = 20 ; (-20+-40)//2 = -30 ; dangling bytes dropped.
+    assert mono == struct.pack("<h", 20) + struct.pack("<h", -30)
 
 
 @pytest.mark.asyncio

--- a/tests/test_usb_audio_stub.py
+++ b/tests/test_usb_audio_stub.py
@@ -214,7 +214,16 @@ async def test_usb_audio_driver_auto_sample_rate_falls_back_and_reports_contract
     assert contract is not None
     assert contract.rx.sample_rate_hz == 16_000
     assert contract.rx.sample_rate_source == "fallback"
-    assert contract.rx.fallback_reason == "sample-rate-48000-unsupported"
+    # The default RX device "USB Audio CODEC" exposes 2 input channels while the
+    # driver's default request is mono. The capture opens at the device-native
+    # 2 ch and software-downmixes to mono (MOR-504), so the fallback reason now
+    # carries both the sample-rate negotiation and the channel reconciliation.
+    assert (
+        contract.rx.fallback_reason
+        == "sample-rate-48000-unsupported; channels-1-opened-as-device-2-downmix"
+    )
+    assert contract.rx.channels == 1
+    assert contract.rx.open_channels == 2
     assert contract.rx.device.name == "USB Audio CODEC"
     assert contract.to_dict()["rx"]["sample_rate_hz"] == 16_000
     assert contract.to_dict()["rx"]["sample_rate_source"] == "fallback"

--- a/tests/test_x6200_rx_audio_mor236.py
+++ b/tests/test_x6200_rx_audio_mor236.py
@@ -69,7 +69,11 @@ class _MonoUsbAudioBackend:
         sample_rate: int = 48_000,
         channels: int = 1,
         frame_ms: int = 20,
+        deliver_channels: int | None = None,
     ) -> FakeRxStream:
+        # ``deliver_channels`` is the post-downmix consumer count (MOR-504); the
+        # mono Xiegu device opens at its single native channel, so it is unused
+        # here. ``channels`` is the OS open count the device validates.
         if channels != self._device.input_channels:
             raise RuntimeError(
                 "Error opening InputStream: Invalid number of channels "


### PR DESCRIPTION
## Problem (MOR-504) — found in live FTX-1 testing on macOS 2026-06-07

RX audio capture opened the C-Media "USB Audio Device" at 1 channel on a 2-channel device → CoreAudio AUHAL err -10863, no frames → blank audio scope (the browser audio/scope is fed by this USB capture → audio-bus → WS relay). `_clamp_channels` only narrowed an over-request, never reconciled an under-request (mono on a stereo-native device) — the macOS analogue of the MOR-238 class, which only fixed the over-request direction.

## Fix
- `usb_driver.py`: under-request (RX, requested < device_max) now opens at the device-native channel count and carries the requested mono as the *deliver* count (`device-native`, contract `open_channels`). Over-request (MOR-238) unchanged.
- `backend.py`: `_PortAudioRxStream` opens native, downmixes interleaved s16le L/R → mono `(L+R)//2` in `_input_callback` before chunking (mirrors `bridge._downmix_stereo_to_mono`); `_frame_bytes` on the deliver count → mono 1920-byte (20 ms @ 48 kHz) frames. TX untouched; `deliver_channels` is optional/back-compat across the protocol + fakes.

Gate: 7237 passed/0 fail; ruff check + format clean; mypy 20=baseline/0 new; lint-imports 4/0.

**Note:** AUHAL -10863 can't be reproduced without hardware — validated live on the FTX-1 after merge (also rules out the audio scope feed end-to-end). Related: MOR-222.

Linear: MOR-504

🤖 Generated with [Claude Code](https://claude.com/claude-code)