### PR TITLE
fix: sync FFT scope center freq/mode for main/sub-keyed radios (FTX-1) (MOR-505)

### DIFF
--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -24,6 +24,7 @@ __all__ = [
     "classify_radio_health",
     "build_public_state_payload",
     "build_public_state_payload_from_snapshot",
+    "primary_receiver_snapshot_ids",
 ]
 
 _RECEIVER_KEY_MAP = {"freq": "freqHz"}
@@ -683,6 +684,28 @@ def _snapshot_receiver_key(receiver_id: str | None) -> str | None:
     if receiver_id is None:
         return None
     return _SNAPSHOT_RECEIVER_IDS.get(receiver_id)
+
+
+def primary_receiver_snapshot_ids() -> tuple[str, ...]:
+    """Return the backend-native receiver-ids for the primary receiver.
+
+    Snapshots key the primary receiver under different ids depending on the
+    backend: the legacy Icom state poller uses ``"0"`` while Yaesu CAT and
+    rigctld backends use ``"main"``. Both normalize to the canonical public
+    key ``"main"`` via :data:`_SNAPSHOT_RECEIVER_IDS`.
+
+    Consumers that need a single freq/mode (e.g. the audio FFT scope center
+    frequency) should try these ids in order and use the first one present in
+    the snapshot, rather than hardcoding a scheme-specific id.
+
+    The order is significant: ``"0"`` precedes ``"main"`` to preserve the
+    historical Icom-first lookup behavior.
+    """
+    return tuple(
+        receiver_id
+        for receiver_id, canonical in _SNAPSHOT_RECEIVER_IDS.items()
+        if canonical == "main"
+    )
 
 
 def _set_receiver_value(

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -90,6 +90,7 @@ from .radio_poller import (  # noqa: TID251
 from .runtime_helpers import (  # noqa: TID251
     build_public_state_payload_from_snapshot,
     classify_radio_health,
+    primary_receiver_snapshot_ids,
     radio_ready,
     runtime_capabilities,
 )
@@ -1064,16 +1065,33 @@ class WebServer:
             len(self._audio_scope_handlers),
         )
 
+    @staticmethod
+    def _active_primary_freq_mode_value(
+        snapshot: StateSnapshot, name: str
+    ) -> Any | None:
+        """Read a primary-receiver freq/mode field, scheme-agnostic.
+
+        Snapshots key the primary receiver under ``"0"`` (legacy Icom poller)
+        or ``"main"`` (Yaesu CAT / rigctld). Try each canonical primary id in
+        order and return the first present value; return ``None`` if no
+        candidate id carries the field.
+        """
+        for receiver_id in primary_receiver_snapshot_ids():
+            try:
+                return snapshot.field(
+                    FieldPath.active(receiver_id, "freq_mode", name)
+                ).value
+            except KeyError:
+                continue
+        return None
+
     def _update_fft_scope_freq(self, snapshot: StateSnapshot | None = None) -> None:
         """Sync AudioFftScope center frequency from a StateStore snapshot."""
         if self._audio_fft_scope is None:
             return
         if snapshot is None:
             snapshot = self.command_state_store.snapshot()
-        try:
-            freq = snapshot.field(FieldPath.active("0", "freq_mode", "freq_hz")).value
-        except KeyError:
-            return
+        freq = self._active_primary_freq_mode_value(snapshot, "freq_hz")
         if isinstance(freq, int) and freq > 0:
             self._audio_fft_scope.set_center_freq(freq)
 
@@ -1083,18 +1101,10 @@ class WebServer:
             return
         if snapshot is None:
             snapshot = self.command_state_store.snapshot()
-        try:
-            mode = snapshot.field(FieldPath.active("0", "freq_mode", "mode")).value
-        except KeyError:
-            return
+        mode = self._active_primary_freq_mode_value(snapshot, "mode")
         if not isinstance(mode, str):
             return
-        try:
-            data_mode = snapshot.field(
-                FieldPath.active("0", "freq_mode", "data_mode")
-            ).value
-        except KeyError:
-            data_mode = 0
+        data_mode = self._active_primary_freq_mode_value(snapshot, "data_mode")
         if not isinstance(data_mode, int):
             data_mode = 0
         profile = self._get_profile()

--- a/tests/test_fft_scope_center_freq.py
+++ b/tests/test_fft_scope_center_freq.py
@@ -1,0 +1,189 @@
+"""Regression tests for MOR-505 — v2 AUDIO SCOPE blank on FTX-1.
+
+Root cause: ``WebServer._update_fft_scope_freq`` / ``_update_fft_scope_mode``
+read the active receiver's freq/mode from the StateStore snapshot using a
+HARDCODED receiver-id ``"0"`` (``FieldPath.active("0", "freq_mode", ...)``).
+That id is only correct for the legacy Icom state poller. Yaesu CAT and
+rigctld backends key the primary receiver under ``"main"`` (see
+``backends/yaesu_cat/observations.py`` / ``backends/rigctld_client/
+observations.py``), so the snapshot lookup raised ``KeyError`` and the method
+returned early. ``AudioFftScope._center_freq`` stayed 0, and ``feed_audio``'s
+``_center_freq <= 0`` guard then dropped every frame — a blank scope.
+
+The fix resolves the primary receiver scheme-agnostically via
+``runtime_helpers.primary_receiver_snapshot_ids`` (derived from the canonical
+``_SNAPSHOT_RECEIVER_IDS`` map used by the public-state builder), trying
+``"0"`` then ``"main"`` and using the first present id. Icom ("0") behavior is
+unchanged; Yaesu ("main") now works.
+
+These tests are hardware-free: they construct ``StateSnapshot`` objects
+directly and drive ``_update_fft_scope_freq`` / ``_update_fft_scope_mode``,
+asserting the scope's center freq / bandwidth.
+"""
+
+from __future__ import annotations
+
+from rigplane.capabilities import CAP_AUDIO
+from rigplane.core.state_pipeline_contracts import FieldPath, SourceMetadata
+from rigplane.core.state_store import FieldSnapshot, FreshnessState, StateSnapshot
+from rigplane.profiles import resolve_radio_profile
+from rigplane.radio_state import RadioState
+from rigplane.web.server import WebConfig, WebServer
+
+_SOURCE = SourceMetadata(
+    source="state_poller",
+    provider="test",
+    transport="backend",
+    native_id="test",
+)
+
+
+class _AudioOnlyRadio:
+    """Minimal fake radio: audio capability (so the FFT scope is wired), no
+    hardware scope. Carries a real profile so mode-bandwidth resolution works.
+    """
+
+    def __init__(self, *, model: str) -> None:
+        self.capabilities = frozenset({CAP_AUDIO})
+        self.radio_state = RadioState()
+        self.audio_codec = None
+        self.audio_sample_rate = 48_000
+        self.model = model
+        self.profile = resolve_radio_profile(model=model)
+
+
+def _snapshot(*fields: FieldSnapshot) -> StateSnapshot:
+    return StateSnapshot(
+        state_revision=1,
+        freshness_revision=1,
+        observation_seq=1,
+        generated_at_monotonic=0.0,
+        fields=tuple(fields),
+    )
+
+
+def _freq_field(receiver_id: str, freq_hz: int) -> FieldSnapshot:
+    return FieldSnapshot(
+        path=FieldPath.active(receiver_id, "freq_mode", "freq_hz"),
+        value=freq_hz,
+        freshness=FreshnessState.FRESH,
+        last_observed_monotonic=0.0,
+        max_age=None,
+        source=_SOURCE,
+    )
+
+
+def _mode_field(receiver_id: str, mode: str) -> FieldSnapshot:
+    return FieldSnapshot(
+        path=FieldPath.active(receiver_id, "freq_mode", "mode"),
+        value=mode,
+        freshness=FreshnessState.FRESH,
+        last_observed_monotonic=0.0,
+        max_age=None,
+        source=_SOURCE,
+    )
+
+
+def _make_server(*, model: str) -> WebServer:
+    server = WebServer(radio=_AudioOnlyRadio(model=model), config=WebConfig())
+    assert server._audio_fft_scope is not None, "audio FFT scope must be wired"
+    return server
+
+
+# ── center frequency ─────────────────────────────────────────────────────────
+
+
+def test_center_freq_set_for_main_keyed_receiver() -> None:
+    """FTX-1/Yaesu: freq keyed under receiver "main" must set center_freq.
+
+    THIS IS THE MOR-505 GUARD. On the unfixed code the hardcoded "0" lookup
+    raises KeyError, the method returns early, and center_freq stays 0 (blank
+    scope). After the fix the "main" id is resolved and center_freq is set.
+    """
+    server = _make_server(model="FTX-1")
+    scope = server._audio_fft_scope
+    assert scope is not None
+    assert scope._center_freq == 0
+
+    server._update_fft_scope_freq(_snapshot(_freq_field("main", 14_074_000)))
+
+    assert scope._center_freq == 14_074_000
+
+
+def test_center_freq_set_for_icom_zero_keyed_receiver() -> None:
+    """Icom: freq keyed under receiver "0" must still set center_freq (no regression)."""
+    server = _make_server(model="IC-7610")
+    scope = server._audio_fft_scope
+    assert scope is not None
+
+    server._update_fft_scope_freq(_snapshot(_freq_field("0", 7_074_000)))
+
+    assert scope._center_freq == 7_074_000
+
+
+def test_center_freq_unchanged_when_freq_missing() -> None:
+    """No freq field in the snapshot: no-op, no exception, center_freq stays 0."""
+    server = _make_server(model="FTX-1")
+    scope = server._audio_fft_scope
+    assert scope is not None
+
+    server._update_fft_scope_freq(_snapshot())  # empty snapshot
+
+    assert scope._center_freq == 0
+
+
+def test_center_freq_unchanged_when_freq_zero() -> None:
+    """freq == 0 must not push a bogus center_freq (would still gate frames)."""
+    server = _make_server(model="FTX-1")
+    scope = server._audio_fft_scope
+    assert scope is not None
+    scope.set_center_freq(14_074_000)
+
+    server._update_fft_scope_freq(_snapshot(_freq_field("main", 0)))
+
+    # 0 is not > 0 — center_freq must be left at its prior value.
+    assert scope._center_freq == 14_074_000
+
+
+# ── mode bandwidth ───────────────────────────────────────────────────────────
+
+
+def test_mode_bandwidth_set_for_main_keyed_receiver() -> None:
+    """Mode keyed under "main" must resolve and set the filter bandwidth.
+
+    Use an IC-7610 profile (whose USB rule has a concrete ``max_hz``) but key
+    the mode under "main" to prove receiver-id resolution is scheme-agnostic
+    for the mode path too.
+    """
+    server = _make_server(model="IC-7610")
+    scope = server._audio_fft_scope
+    assert scope is not None
+    assert scope.bandwidth_hz is None
+
+    server._update_fft_scope_mode(_snapshot(_mode_field("main", "USB")))
+
+    # IC-7610 USB rule has max_hz=3600.
+    assert scope.bandwidth_hz == 3600
+
+
+def test_mode_bandwidth_set_for_icom_zero_keyed_receiver() -> None:
+    """Mode keyed under "0" must still resolve (no regression)."""
+    server = _make_server(model="IC-7610")
+    scope = server._audio_fft_scope
+    assert scope is not None
+
+    server._update_fft_scope_mode(_snapshot(_mode_field("0", "USB")))
+
+    assert scope.bandwidth_hz == 3600
+
+
+def test_mode_bandwidth_unchanged_when_mode_missing() -> None:
+    """No mode field: no-op, no exception, bandwidth stays at prior value."""
+    server = _make_server(model="IC-7610")
+    scope = server._audio_fft_scope
+    assert scope is not None
+    scope.set_mode_bandwidth(2700)
+
+    server._update_fft_scope_mode(_snapshot())  # empty snapshot
+
+    assert scope.bandwidth_hz == 2700


### PR DESCRIPTION
## Summary
Fixes the blank **AUDIO SCOPE** on the FTX-1 (Yaesu) and any non-Icom backend that keys its primary receiver under `"main"` instead of `"0"`.

### Root cause
`WebServer._update_fft_scope_freq` / `_update_fft_scope_mode` hardcoded `FieldPath.active("0", ...)`. The state snapshot keys the primary receiver under a backend-dependent id:
- legacy Icom poller → `"0"` (`web/radio_poller.py`)
- Yaesu-CAT / rigctld backends → `"main"` (`backends/yaesu_cat/observations.py`, `backends/rigctld_client/observations.py`)

On the FTX-1 the `"0"` lookup raised `KeyError` → early return → `_center_freq` stayed `0` → `fft_scope.feed_audio`'s `_center_freq <= 0` guard dropped every frame → blank scope.

### Fix
- New `primary_receiver_snapshot_ids()` in `web/runtime_helpers.py` (the module that already owns the receiver-id canon `_SNAPSHOT_RECEIVER_IDS`) derives the candidate ids whose canonical key is `"main"`, preserving insertion order → `("0", "main")` (Icom-first, no behavior change for Icom).
- New `WebServer._active_primary_freq_mode_value(snapshot, name)` returns the first present value across those ids.
- `_update_fft_scope_freq` / `_update_fft_scope_mode` use the helper instead of the hardcoded `"0"`. The `feed_audio` `_center_freq <= 0` guard is **left intact** — the fix sets center_freq, it does not weaken the guard.

### Tests
`tests/test_fft_scope_center_freq.py` — 7 radio-free unit tests. The two `"main"`-keyed tests are genuine regression guards (verified: they FAIL on `origin/main`, PASS here); the two `"0"`-keyed tests prove no Icom regression; missing/zero freq → no-op.

### Gate
- `pytest --ignore=tests/integration` → 7256 passed, 0 failures
- `ruff check` / `ruff format --check` → clean
- `mypy src/` → 20 baseline errors, 0 new (0 in changed files)
- `lint-imports` → 4 kept, 0 broken

### Independent review
Implementer ≠ reviewer. Independent reviewer ran old-code falsification (2 `"main"` tests fail on `origin/main`, all 7 pass on the fix) + full gate → **Agent Review: PASS**.

### Out of scope / deferred
Live re-validation that the v2 AUDIO SCOPE actually renders on a connected FTX-1 is deferred until the radio is reconnected. This change is implement + unit-test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)