### PR TITLE
fix: convert FTX-1 filter_width readback SH code → Hz via current mode (MOR-507)

### DIFF
--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -192,7 +192,9 @@ class YaesuObservationRadio(Protocol):
 
     async def read_agc(self, receiver: int = 0) -> int: ...
 
-    async def read_filter_width(self, receiver: int = 0) -> int: ...
+    async def read_filter_width(
+        self, receiver: int = 0, mode: str | None = None
+    ) -> int: ...
 
     async def read_if_shift(self, receiver: int = 0) -> int: ...
 
@@ -286,9 +288,14 @@ class YaesuObservationAdapter:
                 observations.append(
                     adapter.observation(_MAIN_FREQ, value, native_id="read_freq")
                 )
+        # Capture the MAIN mode so filter_width (below) can resolve its
+        # mode-specific width table from the freshly-read mode rather than
+        # issuing a redundant CAT mode query on the hot poll path (MOR-507).
+        main_mode: str | None = None
         if self._can_poll(_MAIN_MODE):
             ok, result = await self._safe_read("main.mode", self.radio.read_mode(0))
             if ok and result is not None:
+                main_mode = result[0]
                 observations.append(
                     adapter.observation(_MAIN_MODE, result[0], native_id="read_mode")
                 )
@@ -318,7 +325,7 @@ class YaesuObservationAdapter:
             _MAIN_FILTER_WIDTH
         ):
             ok, value = await self._safe_read(
-                "main.filter_width", self.radio.read_filter_width(0)
+                "main.filter_width", self.radio.read_filter_width(0, mode=main_mode)
             )
             if ok:
                 observations.append(

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -1257,38 +1257,56 @@ class YaesuCatRadio:
 
     # -- D4: Filters --------------------------------------------------------
 
-    def _filter_width_table(self, receiver: int = 0) -> tuple[int, ...] | None:
-        """Return the filter-width table for the current mode, or None."""
+    def _filter_width_table(
+        self, receiver: int = 0, mode: str | None = None
+    ) -> tuple[int, ...] | None:
+        """Return the filter-width table for a mode, or None.
+
+        When ``mode`` is given it is used directly (the caller already knows the
+        current mode); otherwise the mode is read from the legacy ``self._state``
+        mirror. SET callers pass no mode (the mirror is updated synchronously on
+        ``set_mode``), while the read/poll path threads the freshly-read mode.
+        """
         profile = self.profile
         if profile.filter_width_encoding != "table_index":
             return None
-        target = self._state.receiver("SUB" if receiver else "MAIN")
-        mode = getattr(target, "mode", None)
+        if mode is None:
+            target = self._state.receiver("SUB" if receiver else "MAIN")
+            mode = getattr(target, "mode", None)
         rule = profile.resolve_filter_rule(mode)
         if rule and rule.table:
             return cast("tuple[int, ...]", rule.table)
         return None
 
-    async def read_filter_width(self, receiver: int = 0) -> int:
+    async def read_filter_width(
+        self, receiver: int = 0, mode: str | None = None
+    ) -> int:
         """Read filter width in Hz (SH0/SH1) without mutating legacy state.
 
         Translates the radio's table-index code to Hz using the active
-        profile's filter rule for the current mode. The current mode is READ
-        from the legacy ``self._state`` mirror to pick the right width table,
-        but the mirror is never written. When no table is defined, the raw
-        index is returned (compat fallback).
+        profile's filter rule for the radio's CURRENT mode. The width table is
+        mode-specific (SSB/CW/DATA/RTTY differ), so the table MUST be resolved
+        from the live mode, not the legacy ``self._state`` mirror — the
+        observation adapter never writes that mirror, so during polling it is
+        stale and would select the wrong table, leaking the raw SH code as the
+        "Hz" value (MOR-507).
 
         Args:
             receiver: 0=MAIN, 1=SUB.
+            mode: The radio's current mode name. When provided (the poll path
+                reads the mode immediately before this call), it is used
+                directly so no extra CAT round-trip is issued. When omitted
+                (other call sites), the mode is read fresh via ``read_mode``.
 
         Returns:
-            Filter width in Hz.
+            Filter width in Hz. When no table is defined for the encoding/mode,
+            the raw index is returned (compat fallback).
         """
+        if mode is None and self.profile.filter_width_encoding == "table_index":
+            mode, _ = await self.read_mode(receiver)
         cmd = "get_filter_width" if receiver == 0 else "get_filter_width_sub"
         result = await self._query(cmd)
         index = int(result["code"])
-        target = self._state.receiver("SUB" if receiver else "MAIN")
-        mode = getattr(target, "mode", None)
         rule = (
             self.profile.resolve_filter_rule(mode)
             if self.profile.filter_width_encoding == "table_index"
@@ -1296,7 +1314,7 @@ class YaesuCatRadio:
         )
         if rule and rule.fixed and rule.defaults:
             return int(rule.defaults[0])
-        table = self._filter_width_table(receiver)
+        table = self._filter_width_table(receiver, mode)
         if table is None:
             return index
         try:

--- a/tests/test_dsp_filter_family.py
+++ b/tests/test_dsp_filter_family.py
@@ -380,6 +380,9 @@ async def test_yaesu_get_filter_width_translates_index_to_hz(
     ftx1_radio: YaesuCatRadio,
 ) -> None:
     """FTX-1 USB table: index 12 → 2400 Hz."""
+    # The width table is resolved from the radio's CURRENT mode, read fresh via
+    # CAT (MOR-507) — not the legacy state mirror.
+    ftx1_radio.read_mode = AsyncMock(return_value=("USB", None))  # type: ignore[method-assign]
     ftx1_radio._transport.query = AsyncMock(return_value="SH0012")
     assert await ftx1_radio.get_filter_width() == 2400
 
@@ -399,6 +402,8 @@ async def test_yaesu_filter_width_round_trip(ftx1_radio: YaesuCatRadio) -> None:
     # Use the captured command's index payload as the response stub.
     # Format: "SH0{code:03d};" so payload is chars [3:6].
     code = captured["cmd"][3:6]
+    # The readback resolves its table from the current mode, read fresh (MOR-507).
+    ftx1_radio.read_mode = AsyncMock(return_value=("USB", None))  # type: ignore[method-assign]
     ftx1_radio._transport.query = AsyncMock(return_value=f"SH0{code}")
     assert await ftx1_radio.get_filter_width() == 2400
 

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -594,10 +594,17 @@ async def test_get_notch_filter_returns_freq_index(connected_radio):
 @pytest.mark.asyncio
 async def test_get_filter_width(connected_radio):
     """get_filter_width returns Hz (issue #1101): index 10 → 2100 Hz on USB."""
-    connected_radio._transport.query = AsyncMock(return_value="SH0010")
-    # Default mode is "USB"; USB table index 10 → 2100 Hz.
+
+    # The width table is resolved from the radio's CURRENT mode, read fresh via
+    # CAT (MOR-507): get_filter_width issues a mode query (MD0;) then the
+    # filter query (SH0;). Mode code "2" → USB; USB table index 10 → 2100 Hz.
+    async def fake_query(cmd: str) -> str:
+        return "MD02" if cmd.startswith("MD") else "SH0010"
+
+    connected_radio._transport.query = AsyncMock(side_effect=fake_query)
     assert await connected_radio.get_filter_width() == 2100
-    connected_radio._transport.query.assert_called_once_with("SH0;")
+    connected_radio._transport.query.assert_any_call("SH0;")
+    connected_radio._transport.query.assert_any_call("MD0;")
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -405,7 +405,9 @@ class _SideEffectingYaesuRadio:
         self.radio_state.main.agc = value
         return value
 
-    async def read_filter_width(self, receiver: int = 0) -> int:
+    async def read_filter_width(
+        self, receiver: int = 0, mode: str | None = None
+    ) -> int:
         return 500
 
     async def get_filter_width(self, receiver: int = 0) -> int:
@@ -1443,18 +1445,21 @@ async def test_public_get_data_mode_returns_flat_value_without_state_synthesis()
 
 
 @pytest.mark.asyncio
-async def test_read_filter_width_reads_mode_without_mutating_state() -> None:
-    """MOR-445: ``read_filter_width`` may READ the mode mirror for its
-    width-table decode, but it must NOT WRITE ``self._state``.
+async def test_read_filter_width_does_not_mutate_state() -> None:
+    """MOR-445/MOR-507: ``read_filter_width`` resolves its width-table from the
+    radio's CURRENT mode (read fresh, not from the stale mirror) and must NOT
+    WRITE ``self._state``.
 
-    ``get_filter_width`` (the public, mutating path) and ``read_filter_width``
-    return the same Hz value, but only ``read_filter_width`` is wired into the
-    observation adapter so that legacy state is never mutated by polling.
+    ``get_filter_width`` (the public path) and ``read_filter_width`` return the
+    same Hz value, but only ``read_filter_width`` is wired into the observation
+    adapter so that legacy state is never mutated by polling.
     """
     radio = YaesuCatRadio("/dev/null", audio_driver=MagicMock())
-    # SSB table → code 12 decodes to 2400 Hz (see rigs/ftx1.toml SSB table).
+    # Current mode read fresh via CAT (MOR-507); the legacy mirror is ignored.
+    radio.read_mode = AsyncMock(return_value=("USB", None))  # type: ignore[method-assign]
     radio.radio_state.main.mode = "USB"
     radio.radio_state.main.filter_width = 999
+    # SSB table → code 12 decodes to 2400 Hz (see rigs/ftx1.toml SSB table).
     radio._query = AsyncMock(return_value={"code": 12})  # type: ignore[method-assign]
     state_before = radio.radio_state
 
@@ -1462,10 +1467,44 @@ async def test_read_filter_width_reads_mode_without_mutating_state() -> None:
 
     assert value == 2400
     assert isinstance(value, int)
-    # Read of the mode mirror is fine; a write to legacy state is not.
+    # A write to legacy state is not permitted.
     assert radio.radio_state is state_before
     assert radio.radio_state.main.mode == "USB"
     assert radio.radio_state.main.filter_width == 999
+
+
+@pytest.mark.asyncio
+async def test_read_filter_width_uses_current_mode_not_stale_state() -> None:
+    """MOR-507: ``read_filter_width`` must resolve the width table from the
+    radio's CURRENT mode, not the stale legacy ``self._state`` mirror.
+
+    The observation adapter never writes ``self._state``, so during polling
+    the mode mirror is stale. Resolving the table from the mirror picks the
+    wrong table (or none), so the raw SH index leaks out as the "Hz" value.
+
+    Setup: the mirror says ``USB`` (where SH code 20 = 3200 Hz), but the rig's
+    ACTUAL mode is ``CW`` (where SH code 20 = 4000 Hz; see rigs/ftx1.toml).
+    A correct readback decodes against the CW table → 4000 Hz. The old code
+    decodes against the stale USB table → 3200 Hz (wrong table), and if no
+    table resolved at all it would return the raw code 20.
+    """
+    radio = YaesuCatRadio("/dev/null", audio_driver=MagicMock())
+    # Stale legacy mirror — wrong mode (and never updated by polling).
+    radio.radio_state.main.mode = "USB"
+    # The CAT layer reports the rig's true current mode.
+    radio.read_mode = AsyncMock(return_value=("CW", None))  # type: ignore[method-assign]
+    radio._query = AsyncMock(return_value={"code": 20})  # type: ignore[method-assign]
+
+    # Threaded-mode call (the poll path passes the freshly-read mode).
+    value_threaded = await radio.read_filter_width(0, mode="CW")
+    # Fallback call (no mode supplied) must read the mode fresh, not use state.
+    value_fallback = await radio.read_filter_width(0)
+
+    assert value_threaded == 4000
+    assert value_fallback == 4000
+    # Must NOT be the stale-USB-table decode (3200) nor the raw code (20).
+    assert value_threaded != 3200
+    assert value_threaded != 20
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -315,7 +315,9 @@ class _SideEffectingYaesuRadio:
         self.radio_state.main.agc = value
         return value
 
-    async def read_filter_width(self, receiver: int = 0) -> int:
+    async def read_filter_width(
+        self, receiver: int = 0, mode: str | None = None
+    ) -> int:
         return 2400
 
     async def get_filter_width(self, receiver: int = 0) -> int:


### PR DESCRIPTION
## Summary
Fixes the FTX-1 v2 web filter-width slider snapping back to ~500 Hz after the operator drags it (the rig itself held the correct width).

### Root cause
`YaesuCatRadio.read_filter_width` resolved the mode-specific width table from the legacy `self._state` mirror — which the **observation adapter never updates**. During polling that mode was stale/default, so `_filter_width_table()` picked the wrong table (or `None`) and the method fell back to returning the **raw SH code** (e.g. `20`) as if it were Hz. `/api/v1/state main.filterWidth` then carried the raw code, and the frontend `hzToTableIndex()` mis-mapped it (~500) → the slider snapped back every poll. SET was already correct (mode-aware Hz→code).

### Fix (READ-only; SET and frontend untouched)
- `read_filter_width(receiver, mode=None)` resolves the table from the radio's **current** mode; `_filter_width_table` gained an optional `mode` param so SET and READ share one resolution path.
- `observations.py poll_medium` already reads `read_mode(0)` immediately before `read_filter_width` — it now threads that result as `read_filter_width(0, mode=main_mode)`, so **zero extra CAT round-trips on the hot poll path**.
- When `mode is None` (non-poll call sites, e.g. public `get_filter_width`), it reads the mode fresh via `read_mode(receiver)`. Degrades safely under `_safe_read` (skips the field rather than raising).
- `rule.fixed → defaults[0]` (AM/FM) and the raw-index compat fallback are preserved; SUB resolves its own fresh mode.

### Tests
New `test_read_filter_width_uses_current_mode_not_stale_state`: stale mirror `USB` (SH code 20 = 3200 Hz) while the rig's actual mode read via CAT is `CW` (code 20 = 4000 Hz) → asserts the readback returns 4000, not 3200 and not the raw code 20. Verified it **fails on `origin/main`** (behaviorally: old returns 3200) and passes here. The 3 pre-existing tests touched are mechanical updates for the now-explicit `read_mode` call / honest two-query (`MD0;`+`SH0;`) assertions — no assertion weakened (independently reviewed).

### Gate
- `pytest --ignore=tests/integration` → 7258 passed, 0 failures
- `ruff check` / `ruff format --check` → clean
- `mypy src/` → 20 baseline errors, 0 new
- `lint-imports` → 4 kept, 0 broken

### Independent review
Implementer ≠ reviewer. Independent reviewer ran old-code falsification (new test fails on `origin/main`), verified each pre-existing test edit is legitimate (not coverage-weakening) with before/after quotes, confirmed no hot-path CAT traffic, safe `mode=None` fallback, correct per-mode table resolution, SUB handled → **Agent Review: PASS**.

### Deferred
Live FTX-1 re-validation (drag the web filter-width slider, confirm no snap-back, `/state main.filterWidth` in Hz) — radio is connected; orchestrator follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)