### PR TITLE
fix: capture FTX-1 left-channel RX audio at full level (no -6 dB downmix loss) (MOR-508)

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -17,6 +17,14 @@ default_baud = 38400
 [protocol]
 type = "yaesu_cat"
 
+[audio]
+# The FTX-1 USB Audio CODEC is stereo-native but presents RX audio on the
+# LEFT channel only (right channel is the silent noise floor). The default
+# stereo→mono downmix averages (L + R) // 2, which halves the live L with a
+# silent R → −6 dB (quiet audio + low FFT scope). Take L at full level instead
+# (MOR-508). Other rigs omit this and keep the default "mix" average.
+rx_audio_channel = "left"
+
 [capabilities]
 features = [
     "audio",

--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -192,6 +192,7 @@ class AudioBackend(Protocol):
         channels: int = 1,
         frame_ms: int = 20,
         deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
     ) -> RxStream: ...
 
     def open_tx(
@@ -227,8 +228,8 @@ def _ensure_portaudio_deps() -> tuple[Any, Any]:
     return sd, np
 
 
-def _downmix_stereo_to_mono_s16le(pcm: bytes) -> bytes:
-    """Downmix L+R interleaved s16le → mono s16le via the per-pair average.
+def _downmix_stereo_to_mono_s16le(pcm: bytes, *, channel: str = "mix") -> bytes:
+    """Collapse L+R interleaved s16le → mono s16le via the selected ``channel``.
 
     Mirrors ``rigplane.audio.bridge._downmix_stereo_to_mono`` but is dependency-
     free (stdlib ``array``) so it can run on the PortAudio audio thread without
@@ -238,6 +239,20 @@ def _downmix_stereo_to_mono_s16le(pcm: bytes) -> bytes:
     sample-rate and compress the spectrum 2x — the same bug the bridge downmix
     guards (issue #1381). Trailing bytes that do not form a whole L/R sample
     pair are dropped (an incomplete frame cannot satisfy the fixed contract).
+
+    ``channel`` picks how each L/R pair collapses to one mono sample (MOR-508):
+
+    - ``"mix"`` (default) — the per-pair average ``(L + R) // 2``. Correct for a
+      dual-mono source (``L == R``); the historical behavior preserved verbatim
+      for every rig that does not opt out, so IC-7610/X6200 etc. are unchanged.
+    - ``"left"`` — take L at FULL level. The FTX-1 presents its USB RX audio on
+      the LEFT channel only (R is the silent noise floor); ``mix`` averaging the
+      live L with a silent R halves the level (−6 dB → quiet audio + low FFT
+      scope). Selecting L delivers it undivided.
+    - ``"right"`` — take R at FULL level (the mirror case).
+
+    Single-channel selection cannot clip: it copies one existing s16 sample
+    per pair, so the output stays in range with no widening/averaging.
     """
     from array import array
 
@@ -251,9 +266,16 @@ def _downmix_stereo_to_mono_s16le(pcm: bytes) -> bytes:
     if sys.byteorder != "little":
         samples.byteswap()
     mono = array("h", bytes(len(samples)))  # len(samples)//2 mono samples
-    for i in range(0, len(samples), 2):
-        # Average in a wider int to avoid s16 overflow before truncation.
-        mono[i // 2] = (samples[i] + samples[i + 1]) // 2
+    if channel == "left":
+        for i in range(0, len(samples), 2):
+            mono[i // 2] = samples[i]
+    elif channel == "right":
+        for i in range(0, len(samples), 2):
+            mono[i // 2] = samples[i + 1]
+    else:  # "mix" — per-pair average (default; legacy behavior)
+        for i in range(0, len(samples), 2):
+            # Average in a wider int to avoid s16 overflow before truncation.
+            mono[i // 2] = (samples[i] + samples[i + 1]) // 2
     if sys.byteorder != "little":
         mono.byteswap()
     return mono.tobytes()
@@ -299,6 +321,7 @@ class _PortAudioRxStream:
         blocksize: int,
         frame_ms: int,
         deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
     ) -> None:
         self._sd = sd
         self._device_index = device_index
@@ -311,6 +334,11 @@ class _PortAudioRxStream:
         self._deliver_channels = (
             channels if deliver_channels is None else deliver_channels
         )
+        # How the stereo→mono downmix collapses each L/R pair (MOR-508):
+        # "mix" = (L+R)//2 (legacy default), "left"/"right" = that channel at
+        # full level. The FTX-1 carries RX audio on L only, so averaging with a
+        # silent R halves the level (−6 dB); "left" delivers it undivided.
+        self._rx_audio_channel = rx_audio_channel
         # Software downmix only fires for the stereo-native → mono case. Any
         # other deliver/open relationship passes interleaved PCM through
         # unchanged (over-request already clamps open == deliver upstream).
@@ -410,7 +438,7 @@ class _PortAudioRxStream:
             # accumulator/fixed-frame slicing operates on mono bytes and the
             # FFT scope + broadcaster receive the mono contract they expect.
             try:
-                pcm = _downmix_stereo_to_mono_s16le(pcm)
+                pcm = _downmix_stereo_to_mono_s16le(pcm, channel=self._rx_audio_channel)
             except Exception:
                 logger.warning(
                     "portaudio-rx: stereo→mono downmix failed", exc_info=True
@@ -916,6 +944,7 @@ class PortAudioBackend:
         channels: int = 1,
         frame_ms: int = 20,
         deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
     ) -> RxStream:
         sd, _ = self._ensure_deps()
         # blocksize=0 lets PortAudio use the engine-native period, mirroring a
@@ -938,6 +967,7 @@ class PortAudioBackend:
             blocksize=0,
             frame_ms=frame_ms,
             deliver_channels=deliver_channels,
+            rx_audio_channel=rx_audio_channel,
         )
 
     def open_tx(
@@ -1112,6 +1142,7 @@ class FakeAudioBackend:
         channels: int = 1,
         frame_ms: int = 20,
         deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
     ) -> FakeRxStream:
         if not any(d.id == device for d in self._devices):
             raise ValueError(f"Unknown device id {device}")

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -383,6 +383,7 @@ class UsbAudioDriver:
         channels: int = 1,
         frame_ms: int = 20,
         backend: AudioBackend | None = None,
+        rx_audio_channel: str = "mix",
     ) -> None:
         self._rx_device_override = rx_device
         self._tx_device_override = tx_device
@@ -391,6 +392,12 @@ class UsbAudioDriver:
         self._channels = channels
         self._frame_ms = frame_ms
         self._backend: AudioBackend = backend or PortAudioBackend()
+        # Stereo→mono downmix channel selection (MOR-508): "mix" = (L+R)//2
+        # (default, unchanged for every rig), "left"/"right" = that channel at
+        # full level. Only consulted when a mono request opens a stereo-native
+        # device (MOR-504 under-request downmix). The FTX-1 sets "left" because
+        # its USB RX audio is on the LEFT channel only.
+        self._rx_audio_channel = rx_audio_channel
 
         self._selected_rx: UsbAudioDevice | None = None
         self._selected_tx: UsbAudioDevice | None = None
@@ -705,6 +712,7 @@ class UsbAudioDriver:
                 channels=contract.effective_open_channels,
                 frame_ms=fm,
                 deliver_channels=contract.channels,
+                rx_audio_channel=self._rx_audio_channel,
             )
             await self._rx_stream.start(callback)
             self._store_stream_contract(contract)

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -208,6 +208,11 @@ class YaesuCatRadio:
                 sample_rate=audio_sample_rate,
                 channels=1,
                 backend=None,  # default PortAudioBackend
+                # The FTX-1 presents USB RX audio on the LEFT channel only; the
+                # profile's [audio].rx_audio_channel selects which channel the
+                # stereo→mono downmix keeps at full level (MOR-508). Defaults to
+                # "mix" (legacy (L+R)//2) for any profile that omits it.
+                rx_audio_channel=self._config.rx_audio_channel,
             )
         else:
             self._audio_driver = audio_driver

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -53,6 +53,7 @@ VALID_RULE_KINDS = {"mutex", "disables", "requires", "value_limit"}
 VALID_KEYBOARD_MODIFIERS = {"SHIFT", "CTRL", "ALT", "META"}
 VALID_AUDIO_SAMPLE_RATES_HZ = {8000, 12000, 16000, 24000, 48000}
 VALID_BROWSER_RX_TRANSPORTS = {"auto", "pcm", "opus"}
+VALID_RX_AUDIO_CHANNELS = {"mix", "left", "right"}
 DEFAULT_KEYBOARD_PROFILE_NAME = "_keyboard-default.toml"
 
 _REQUIRED_SECTIONS = ("radio", "capabilities", "modes", "filters", "vfo")
@@ -125,6 +126,11 @@ class RigConfig:
     sample_rate_by_codec: dict[str, int] | None = None
     browser_rx_transport: str | None = None
     browser_rx_transcode_to_opus: bool | None = None
+    # Stereo→mono RX downmix channel selection (MOR-508). "mix" = (L+R)//2
+    # average (default, unchanged for every rig); "left"/"right" = that channel
+    # at full level. The FTX-1 sets "left" (USB RX audio is on L only, so the
+    # average with a silent R loses 6 dB).
+    rx_audio_channel: str = "mix"
     write_only_controls: tuple[str, ...] = ()
     state_acquisition: RadioAcquisitionProfile | None = None
 
@@ -1243,6 +1249,7 @@ def load_rig(path: Path) -> RigConfig:
     sample_rate_by_codec: dict[str, int] | None = None
     browser_rx_transport: str | None = None
     browser_rx_transcode_to_opus: bool | None = None
+    rx_audio_channel: str = "mix"
     audio_section = data.get("audio")
     if audio_section is not None:
         if not isinstance(audio_section, dict):
@@ -1325,6 +1332,17 @@ def load_rig(path: Path) -> RigConfig:
                     f"{filename}: [audio].browser_rx_transcode_to_opus must be a boolean"
                 )
             browser_rx_transcode_to_opus = transcode_raw
+        if "rx_audio_channel" in audio_section:
+            rx_channel_raw = audio_section["rx_audio_channel"]
+            if (
+                not isinstance(rx_channel_raw, str)
+                or rx_channel_raw not in VALID_RX_AUDIO_CHANNELS
+            ):
+                raise RigLoadError(
+                    f"{filename}: [audio].rx_audio_channel must be one of "
+                    f"{sorted(VALID_RX_AUDIO_CHANNELS)}, got {rx_channel_raw!r}"
+                )
+            rx_audio_channel = rx_channel_raw
 
     state_acquisition = _parse_state_acquisition(
         filename,
@@ -1387,6 +1405,7 @@ def load_rig(path: Path) -> RigConfig:
         sample_rate_by_codec=sample_rate_by_codec,
         browser_rx_transport=browser_rx_transport,
         browser_rx_transcode_to_opus=browser_rx_transcode_to_opus,
+        rx_audio_channel=rx_audio_channel,
         write_only_controls=write_only_controls,
         state_acquisition=state_acquisition,
     )

--- a/tests/test_audio_scope_dispatch.py
+++ b/tests/test_audio_scope_dispatch.py
@@ -73,6 +73,8 @@ class _MonoUsbAudioBackend:
         sample_rate: int = 48_000,
         channels: int = 1,
         frame_ms: int = 20,
+        deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
     ) -> FakeRxStream:
         stream = FakeRxStream()
         self.rx_streams.append(stream)

--- a/tests/test_ftx1_audio.py
+++ b/tests/test_ftx1_audio.py
@@ -79,6 +79,9 @@ def test_audio_driver_default_construction():
             sample_rate=48000,
             channels=1,
             backend=None,
+            # FTX-1 profile selects the LEFT channel for the stereo→mono RX
+            # downmix (MOR-508); USB RX audio is on L only.
+            rx_audio_channel="left",
         )
 
 

--- a/tests/test_rx_audio_channel_select_mor508.py
+++ b/tests/test_rx_audio_channel_select_mor508.py
@@ -1,0 +1,156 @@
+"""Regression tests for MOR-508 — per-rig RX downmix channel selection.
+
+The FTX-1 presents its USB RX audio on the LEFT channel only (right channel is
+near-silence / noise floor). The MOR-504 stereo→mono reconciliation downmix
+collapses interleaved L/R via the per-pair average ``(L + R) // 2``. For a
+mono-on-one-channel source that averages the live L with a silent R, halving the
+delivered level (−6 dB) → quiet audio + low FFT scope.
+
+These tests pin a per-rig channel selector threaded into the downmix:
+
+- ``"left"``  → take L at FULL level (the FTX-1 fix),
+- ``"right"`` → take R at FULL level,
+- ``"mix"``   → the legacy ``(L + R) // 2`` average (default for every rig).
+
+The default (``"mix"``) path MUST stay byte-identical so IC-7610/X6200 and any
+unspecified rig see no behavior change.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from rigplane.audio.backend import (
+    AudioDeviceId,
+    PortAudioBackend,
+    _downmix_stereo_to_mono_s16le,
+)
+
+
+def _stereo(pairs: list[tuple[int, int]]) -> bytes:
+    return b"".join(struct.pack("<hh", left, right) for left, right in pairs)
+
+
+def _mono(samples: list[int]) -> bytes:
+    return b"".join(struct.pack("<h", s) for s in samples)
+
+
+# ---------------------------------------------------------------------------
+# Downmix function: channel selection
+# ---------------------------------------------------------------------------
+
+
+def test_left_only_source_downmixes_to_full_left_level() -> None:
+    """A left-only stereo buffer (R == 0) → L at FULL level under ``left``.
+
+    This is the MOR-508 bug: ``mix`` would deliver L/2 (−6 dB). ``left`` must
+    deliver the live L sample unchanged.
+    """
+    pcm = _stereo([(1000, 0), (-2000, 0), (32000, 0)])
+    out = _downmix_stereo_to_mono_s16le(pcm, channel="left")
+    assert out == _mono([1000, -2000, 32000])
+
+
+def test_right_only_source_downmixes_to_full_right_level() -> None:
+    """A right-only stereo buffer (L == 0) → R at FULL level under ``right``."""
+    pcm = _stereo([(0, 1500), (0, -2500), (0, 31000)])
+    out = _downmix_stereo_to_mono_s16le(pcm, channel="right")
+    assert out == _mono([1500, -2500, 31000])
+
+
+def test_mix_default_is_byte_identical_to_legacy_average() -> None:
+    """Default ``mix`` reproduces the legacy per-pair average exactly.
+
+    No-arg call and explicit ``channel="mix"`` must both equal ``(L + R) // 2``
+    so unspecified rigs (IC-7610/X6200) see zero behavior change.
+    """
+    pairs = [(1000, 2000), (-20, -40), (32000, 30000), (-32768, -32768)]
+    pcm = _stereo(pairs)
+    expected = _mono([(left + right) // 2 for left, right in pairs])
+    assert _downmix_stereo_to_mono_s16le(pcm) == expected
+    assert _downmix_stereo_to_mono_s16le(pcm, channel="mix") == expected
+
+
+def test_dual_mono_left_select_equals_mix() -> None:
+    """For a dual-mono source (L == R), ``left`` and ``mix`` agree (no doubling)."""
+    pairs = [(1234, 1234), (-5000, -5000), (32767, 32767)]
+    pcm = _stereo(pairs)
+    expected = _mono([left for left, _ in pairs])
+    assert _downmix_stereo_to_mono_s16le(pcm, channel="left") == expected
+    assert _downmix_stereo_to_mono_s16le(pcm, channel="mix") == expected
+
+
+def test_full_scale_left_select_does_not_clip_or_overflow() -> None:
+    """Selecting a full-scale L (R silent) stays in s16 range — no overflow."""
+    pcm = _stereo([(32767, 0), (-32768, 0)])
+    out = _downmix_stereo_to_mono_s16le(pcm, channel="left")
+    assert out == _mono([32767, -32768])
+    # Re-decode to confirm valid s16 (struct.unpack would raise on overflow).
+    decoded = list(struct.unpack(f"<{len(out) // 2}h", out))
+    assert decoded == [32767, -32768]
+
+
+# ---------------------------------------------------------------------------
+# Threading: _PortAudioRxStream honors the channel selector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_portaudio_rx_stream_left_select_delivers_full_left() -> None:
+    """open_rx(rx_audio_channel="left") → callback receives full-level L mono.
+
+    Pins the end-to-end backend path: a left-only stereo block opened at 2 ch /
+    deliver 1 ch with the ``left`` selector delivers the L sample at full level
+    (not L/2) at the mono fixed-frame byte length.
+    """
+
+    class FakeIndata:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+
+        def tobytes(self) -> bytes:
+            return self._payload
+
+    captured_cb: dict[str, object] = {}
+
+    class FakeSd:
+        class InputStream:
+            def __init__(self, **kw: object) -> None:
+                captured_cb["cb"] = kw["callback"]
+
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+    backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+    stream = backend.open_rx(
+        AudioDeviceId(0),
+        sample_rate=48_000,
+        channels=2,
+        frame_ms=20,
+        deliver_channels=1,
+        rx_audio_channel="left",
+    )
+
+    received: list[bytes] = []
+    await stream.start(received.append)
+    cb = captured_cb["cb"]
+    assert callable(cb)
+
+    # 960 left-only L/R pairs → one 20 ms mono frame after channel select.
+    pairs = 960
+    block = _stereo([(1000, 0)] * pairs)
+    cb(FakeIndata(block), pairs, None, None)  # type: ignore[operator]
+
+    expected = _mono([1000] * pairs)
+    assert len(expected) == 1920  # mono fixed-frame, not 3840 (stereo)
+    assert received == [expected]
+
+    await stream.stop()

--- a/tests/test_usb_audio_channel_clamp_mor238.py
+++ b/tests/test_usb_audio_channel_clamp_mor238.py
@@ -71,6 +71,7 @@ class _StrictChannelBackend:
         channels: int = 1,
         frame_ms: int = 20,
         deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
     ) -> FakeRxStream:
         self.rx_open_channels.append(channels)
         self.rx_deliver_channels.append(deliver_channels)

--- a/tests/test_x6200_rx_audio_mor236.py
+++ b/tests/test_x6200_rx_audio_mor236.py
@@ -70,6 +70,7 @@ class _MonoUsbAudioBackend:
         channels: int = 1,
         frame_ms: int = 20,
         deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
     ) -> FakeRxStream:
         # ``deliver_channels`` is the post-downmix consumer count (MOR-504); the
         # mono Xiegu device opens at its single native channel, so it is unused


### PR DESCRIPTION
## Summary
The FTX-1 outputs USB RX audio on the **LEFT channel only** (right ≈ silence; measured L/R RMS ratio 26.6). The MOR-504 downmix `_downmix_stereo_to_mono_s16le` does `(L+R)//2`, averaging the live L with a silent R → a gratuitous **−6 dB loss**, making RX audio quiet and the FFT scope low.

## Fix — per-rig RX audio channel selector
New `[audio].rx_audio_channel` profile option (`"mix"` default / `"left"` / `"right"`), threaded top-down: `rigs/ftx1.toml` (`"left"`) → `RigConfig` (`profiles/rig_loader.py`) → `YaesuCatRadio` → `UsbAudioDriver` → `PortAudioBackend.open_rx` → `_PortAudioRxStream` → `_downmix_stereo_to_mono_s16le(pcm, channel=...)`.
- `left`/`right` copy one s16 sample per stereo pair → full level, no averaging, **cannot clip**.
- `mix` is the **byte-identical** legacy `(L+R)//2`.
- Chosen explicit per-rig config over sticky-at-open detection (which mis-decides when the radio is silent at stream start).

## No regression for other radios
`mix` is the default at **every** hop; `ic7610`/`x6200` and any rig without an `[audio]` section resolve to `mix` → the existing downmix path is unchanged. `rig_loader` validates `rx_audio_channel` and rejects typos at load time.

## Tests
New `tests/test_rx_audio_channel_select_mor508.py` (6 tests): left-only stereo (R=0) under `channel="left"` yields L at FULL level (1000→1000, not 500); `mix`/no-arg are byte-identical to `(L+R)//2`; right selection; mono untouched. Verified the suite **fails on `origin/main`** (`TypeError: unexpected keyword 'channel'`). The 4 touched pre-existing test files are mechanical fake-`open_rx` signature/protocol-conformance updates (one strengthens the FTX-1 construction assertion); no assertion weakened.

## Gate
- `pytest --ignore=tests/integration` → 7264 passed, 0 failures
- `ruff check` / `ruff format --check` → clean
- `mypy src/` → 20 baseline errors, 0 new (none in touched files)
- `lint-imports` → 4 kept, 0 broken (config flows top-down)

## Independent review
Implementer ≠ reviewer. Reviewer confirmed `mix` byte-identical over 2012 pairs incl. floor-division edges, old-code falsification (6 tests fail on `origin/main`), left/right correctness + no-clip, minimal justified threading, rig_loader rejects invalid values, all 4 test-double edits legitimate → **Agent Review: PASS**.

## Deferred
Live FTX-1 re-validation (FFT/audio +6 dB) — radio connected; will re-check together with MOR-512 (scope adaptive auto-range). Note: −6 dB recovery alone does not make the FTX-1 spectrum visible on the scope; MOR-512 (dB-window auto-range) is the visual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)