### PR TITLE
fix: adaptive auto-range for FFT audio scope dB window (MOR-512)

### DIFF
--- a/src/rigplane/audio/fft_scope.py
+++ b/src/rigplane/audio/fft_scope.py
@@ -31,12 +31,43 @@ _log = logging.getLogger(__name__)
 # Scope mode: center (matches SpectrumPanel expected mode)
 _SCOPE_MODE_CENTER = 0
 
-# Amplitude mapping: FFT dB range → 0-160 pixel range (ScopeFrame convention)
-# Range tuned for typical radio RX audio levels.
-# 55 dB span ≈ 2.9 px/dB — good contrast between noise floor and signals.
+# Amplitude mapping: FFT dB range → 0-160 pixel range (ScopeFrame convention).
+#
+# The dB→pixel window is ADAPTIVE (MOR-512): a fixed window was tuned for one
+# radio's RX audio level and rendered nearly empty for radios at a different
+# level (e.g. FTX-1, whose clean in-band signal sat ~16-20 dB below a fixed
+# -70 dB floor). Instead we track the per-stream noise floor and signal ceiling
+# and slide the window to follow them, so any radio/level stays visible.
 _PIXEL_MAX = 160
-_DB_FLOOR = -70.0  # noise floor dB
-_DB_CEIL = -15.0  # clipping level dB
+
+# Robust per-frame floor/ceil estimators (percentiles of the dB array).
+# A low percentile rejects the few near-silent bins; a high percentile rejects
+# single-bin spikes (DC leakage etc.) that would otherwise inflate the ceiling.
+_FLOOR_PCT = 10.0
+_CEIL_PCT = 99.0
+
+# EMA / attack-decay smoothing of the tracked floor & ceil. The floor adapts
+# SLOWLY for a stable baseline; the ceil rises fast (attack) but falls slowly
+# (decay) so a vanishing signal does not snap the window down and re-amplify
+# noise. Values are per-frame blend factors in (0, 1].
+_FLOOR_ALPHA = 0.05
+_CEIL_ATTACK = 0.30
+_CEIL_DECAY = 0.05
+
+# Margins placed below the tracked floor / above the tracked ceil (dB).
+_FLOOR_MARGIN = 5.0
+_CEIL_MARGIN = 3.0
+
+# Minimum display-window span (dB). During silence the observed floor and ceil
+# collapse together; without a floor on the span the auto-range would stretch a
+# flat noise field across the whole screen. Enforcing a wide minimum span keeps
+# noise pinned near the bottom until a real signal rises above it.
+_MIN_SPAN_DB = 45.0
+
+# Absolute sanity clamps on the window endpoints (dB, on the /fft_size scale).
+_ABS_FLOOR_MIN = -160.0
+_ABS_FLOOR_MAX = -20.0
+_ABS_CEIL_MAX = 0.0
 
 
 def _import_numpy() -> Any:
@@ -92,6 +123,11 @@ class AudioFftScope:
 
         # Rolling average buffer
         self._avg_buf: list[object] = []  # list of numpy arrays
+
+        # Adaptive dB→pixel window state (MOR-512). None until seeded from the
+        # first processed frame, then EMA-tracked toward the live floor/ceil.
+        self._db_floor_ema: float | None = None
+        self._db_ceil_ema: float | None = None
 
         # Frame rate limiting
         self._min_interval = 1.0 / self._fps
@@ -230,10 +266,11 @@ class AudioFftScope:
         else:
             avg_db = db
 
-        # Map dB to pixel values (0-160)
-        # Linear mapping: _DB_FLOOR → 0, _DB_CEIL → _PIXEL_MAX
-        db_range = _DB_CEIL - _DB_FLOOR
-        pixels_float = (avg_db - _DB_FLOOR) / db_range * _PIXEL_MAX
+        # Map dB to pixel values (0-160) through the ADAPTIVE window.
+        # Linear mapping: db_floor → 0, db_ceil → _PIXEL_MAX.
+        db_floor, db_ceil = self._update_db_window(avg_db)
+        db_range = db_ceil - db_floor
+        pixels_float = (avg_db - db_floor) / db_range * _PIXEL_MAX
         pixels_uint8 = np.clip(pixels_float, 0, _PIXEL_MAX).astype(np.uint8)
 
         # rfft produces fft_size//2 + 1 bins from DC to Nyquist.
@@ -278,11 +315,58 @@ class AudioFftScope:
         except Exception:
             _log.exception("AudioFftScope: frame callback error")
 
+    def _update_db_window(self, avg_db: Any) -> tuple[float, float]:
+        """Adapt the dB→pixel window to the current frame and return it.
+
+        Tracks a robust noise floor (low percentile) and signal ceiling (high
+        percentile) of ``avg_db``, smooths each with an EMA / attack-decay so
+        the window neither jitters nor pumps, then applies margins, a minimum
+        span (so silence does not amplify noise) and absolute clamps.
+
+        Args:
+            avg_db: The (averaged) per-bin dB array for this frame.
+
+        Returns:
+            ``(db_floor, db_ceil)`` — the window endpoints to map to pixels.
+        """
+        np = self._np
+
+        obs_floor = float(np.percentile(avg_db, _FLOOR_PCT))
+        obs_ceil = float(np.percentile(avg_db, _CEIL_PCT))
+
+        if self._db_floor_ema is None or self._db_ceil_ema is None:
+            # Seed from the first frame so startup is immediately sane.
+            self._db_floor_ema = obs_floor
+            self._db_ceil_ema = obs_ceil
+        else:
+            # Floor: slow EMA → stable baseline.
+            self._db_floor_ema += (obs_floor - self._db_floor_ema) * _FLOOR_ALPHA
+            # Ceil: fast attack up, slow decay down → no pump when signal drops.
+            ceil_alpha = _CEIL_ATTACK if obs_ceil > self._db_ceil_ema else _CEIL_DECAY
+            self._db_ceil_ema += (obs_ceil - self._db_ceil_ema) * ceil_alpha
+
+        # Apply display margins.
+        db_floor = self._db_floor_ema - _FLOOR_MARGIN
+        db_ceil = self._db_ceil_ema + _CEIL_MARGIN
+
+        # Absolute sanity clamps.
+        db_floor = min(max(db_floor, _ABS_FLOOR_MIN), _ABS_FLOOR_MAX)
+        db_ceil = min(db_ceil, _ABS_CEIL_MAX)
+
+        # Minimum span: never let the window collapse onto a flat noise field
+        # (silence) — keep noise pinned near the bottom.
+        if db_ceil - db_floor < _MIN_SPAN_DB:
+            db_ceil = db_floor + _MIN_SPAN_DB
+
+        return db_floor, db_ceil
+
     def stop(self) -> None:
         """Stop the scope and clear buffers."""
         self._callback = None
         self._buf = self._np.zeros(0, dtype=self._np.float32)
         self._avg_buf.clear()
+        self._db_floor_ema = None
+        self._db_ceil_ema = None
         _log.info("AudioFftScope stopped")
 
     @property

--- a/tests/test_audio_fft_scope.py
+++ b/tests/test_audio_fft_scope.py
@@ -34,6 +34,54 @@ def _make_pcm_noise(num_samples: int, amplitude: int = 1000) -> bytes:
     return samples.tobytes()
 
 
+def _make_pcm_weak_band(
+    num_windows: int,
+    fft_size: int = 2048,
+    sample_rate: int = 48000,
+    sig_amp: int = 200,
+    noise_amp: float = 0.3,
+    seed: int = 7,
+) -> bytes:
+    """Generate a band-limited (100–3000 Hz) speech-like signal at FTX-1 levels.
+
+    Reproduces the live FTX-1 measurement (MOR-512): per-bin in-band dB of
+    roughly ``max -85.9 / mean -90`` sitting over a noise floor near -126 dB
+    under the exact scope FFT math. Under the OLD fixed -70 dB display floor
+    every in-band bin renders at ~0 (invisible); the adaptive window must lift
+    them well above baseline.
+
+    Args:
+        num_windows: How many ``fft_size`` windows of audio to emit.
+        fft_size: FFT window size (must match the scope's).
+        sample_rate: Audio sample rate.
+        sig_amp: Per-band signal amplitude (int16 scale).
+        noise_amp: Broadband noise stddev (int16 scale) — sets the floor.
+        seed: RNG seed for reproducibility.
+
+    Returns:
+        Raw PCM16 mono bytes covering ``num_windows`` FFT windows.
+    """
+    rng = np.random.default_rng(seed)
+    total = fft_size * num_windows
+    t = np.arange(total) / sample_rate
+    sig = np.zeros(total)
+    freqs = np.arange(100, 3001, 100)  # 30 in-band tones spanning 100–3000 Hz
+    for f in freqs:
+        sig += np.sin(2 * np.pi * f * t + rng.uniform(0, 2 * np.pi))
+    sig = sig / len(freqs) * sig_amp
+    noise = rng.standard_normal(total) * noise_amp
+    return (sig + noise).astype(np.int16).tobytes()
+
+
+def _make_pcm_lowlevel_noise(
+    num_samples: int, noise_amp: float = 0.3, seed: int = 11
+) -> bytes:
+    """Generate pure low-level broadband noise (no signal), FTX-1 floor level."""
+    rng = np.random.default_rng(seed)
+    samples = (rng.standard_normal(num_samples) * noise_amp).astype(np.int16)
+    return samples.tobytes()
+
+
 # ── Basic construction ───────────────────────────────────────────────────────
 
 
@@ -569,3 +617,161 @@ class TestAudioFftScopeModeBandwidth:
         bin_res = sample_rate / fft_size
         expected = 2 * int((3600 / 2) / bin_res) + 1
         assert len(frames[0].pixels) == expected
+
+
+# ── Adaptive auto-range (MOR-512) ─────────────────────────────────────────────
+
+_PIXEL_MAX = 160
+
+
+class TestAudioFftScopeAdaptiveAutoRange:
+    """The dB→pixel window must adapt to the actual signal level.
+
+    A fixed -70/-15 dB window left weak-but-clean signals (FTX-1 audio levels)
+    entirely below the display floor — the scope rendered nearly empty. The
+    adaptive window must track the per-stream noise floor and signal ceiling so
+    that ANY radio level is visible, without amplifying pure noise during
+    silence.
+    """
+
+    def _feed_get_last(self, scope: AudioFftScope, pcm: bytes) -> ScopeFrame:
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+        scope.feed_audio(pcm)
+        assert len(frames) >= 1, "no frames produced"
+        return frames[-1]
+
+    def test_weak_band_renders_well_above_baseline(self):
+        """FTX-1-level weak band (-86 dB/bin) must lift well above the floor.
+
+        Under the OLD fixed -70 dB floor every in-band bin renders at ~0
+        (invisible). The adaptive window must put the in-band peak above ~40%
+        of the pixel range. This test FAILS on the old fixed-window code.
+        """
+        fft_size = 2048
+        sample_rate = 48000
+        center = 14_074_000
+        scope = AudioFftScope(
+            fft_size=fft_size, fps=100, avg_count=1, sample_rate=sample_rate
+        )
+        scope.set_center_freq(center)
+
+        # Several windows so the EMA can settle on the real floor/ceil.
+        pcm = _make_pcm_weak_band(
+            num_windows=10, fft_size=fft_size, sample_rate=sample_rate
+        )
+        frame = self._feed_get_last(scope, pcm)
+        pixels = np.frombuffer(frame.pixels, dtype=np.uint8)
+
+        # In-band region around DC (the 100–3000 Hz band maps near center).
+        center_px = len(pixels) // 2
+        bin_res = sample_rate / fft_size
+        hi_bin = int(3000 / bin_res)
+        inband = pixels[center_px - hi_bin : center_px + hi_bin + 1]
+
+        assert int(np.max(inband)) > 0.40 * _PIXEL_MAX, (
+            f"weak in-band signal only reached {int(np.max(inband))}/"
+            f"{_PIXEL_MAX} px — should be lifted well above baseline"
+        )
+
+    def test_loud_input_not_permanently_saturated(self):
+        """A near-full-scale tone must not blow the whole display to max.
+
+        The ceiling adapts upward so a strong signal still shows structure
+        (peak high, surrounding bins lower) rather than clipping everything.
+        """
+        fft_size = 2048
+        sample_rate = 48000
+        scope = AudioFftScope(
+            fft_size=fft_size, fps=100, avg_count=1, sample_rate=sample_rate
+        )
+        scope.set_center_freq(14_074_000)
+
+        # Near full-scale tone (amplitude 30000 of 32767).
+        t = np.arange(fft_size * 10) / sample_rate
+        loud = (np.sin(2 * np.pi * 1500 * t) * 30000).astype(np.int16)
+        frame = self._feed_get_last(scope, loud.tobytes())
+        pixels = np.frombuffer(frame.pixels, dtype=np.uint8)
+
+        # The vast majority of bins (off the tone) must NOT be saturated.
+        saturated = int(np.sum(pixels >= _PIXEL_MAX))
+        assert saturated < 0.25 * len(pixels), (
+            f"{saturated}/{len(pixels)} bins saturated — window did not adapt "
+            "to the loud input"
+        )
+        # The tone peak should still be present and high.
+        assert int(np.max(pixels)) > 0.7 * _PIXEL_MAX
+
+    def test_lowlevel_noise_only_stays_low(self):
+        """Pure low-level noise must NOT be amplified to fill the screen.
+
+        The minimum-window-span guard keeps noise near the bottom when there
+        is no signal above it.
+        """
+        fft_size = 2048
+        sample_rate = 48000
+        scope = AudioFftScope(
+            fft_size=fft_size, fps=100, avg_count=1, sample_rate=sample_rate
+        )
+        scope.set_center_freq(7_000_000)
+
+        pcm = _make_pcm_lowlevel_noise(fft_size * 12, noise_amp=0.3)
+        frame = self._feed_get_last(scope, pcm)
+        pixels = np.frombuffer(frame.pixels, dtype=np.uint8)
+
+        # Noise-only: bulk of bins must sit low (min-span guard prevents the
+        # auto-range from stretching a flat noise floor across the screen).
+        assert int(np.median(pixels)) < 0.30 * _PIXEL_MAX, (
+            f"noise-only median {int(np.median(pixels))}/{_PIXEL_MAX} too high "
+            "— min-span guard failed, noise was amplified"
+        )
+
+    def test_adaptive_window_converges_and_is_stable(self):
+        """Under steady input the auto-range converges (no runaway/pumping).
+
+        Frames are driven through the scope's internal chunk processor with
+        monotonically increasing timestamps so the count is deterministic and
+        independent of the wall-clock frame-rate limiter (which would otherwise
+        drop windows fed back-to-back). This isolates the convergence property
+        of the adaptive dB window.
+        """
+        fft_size = 2048
+        sample_rate = 48000
+        scope = AudioFftScope(
+            fft_size=fft_size, fps=20, avg_count=1, sample_rate=sample_rate
+        )
+        scope.set_center_freq(14_074_000)
+
+        frames: list[ScopeFrame] = []
+        scope.on_frame(frames.append)
+
+        # Many identical-statistics windows of the weak band, each emitted as
+        # its own frame with a fresh timestamp past the frame-rate interval.
+        pcm = _make_pcm_weak_band(
+            num_windows=20, fft_size=fft_size, sample_rate=sample_rate
+        )
+        chunks = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
+        for i in range(20):
+            chunk = chunks[i * fft_size : (i + 1) * fft_size]
+            # Timestamps spaced by > 1/fps so every chunk emits a frame.
+            scope._process_chunk(chunk, now=float(i))
+
+        assert len(frames) == 20, f"expected 20 frames, got {len(frames)}"
+
+        # Compare the in-band peak of the last few frames — must be stable.
+        bin_res = sample_rate / fft_size
+        hi_bin = int(3000 / bin_res)
+
+        def inband_peak(fr: ScopeFrame) -> int:
+            px = np.frombuffer(fr.pixels, dtype=np.uint8)
+            c = len(px) // 2
+            return int(np.max(px[c - hi_bin : c + hi_bin + 1]))
+
+        tail = [inband_peak(f) for f in frames[-5:]]
+        spread = max(tail) - min(tail)
+        # Once converged, the rendered peak should not pump wildly.
+        assert spread < 0.20 * _PIXEL_MAX, (
+            f"in-band peak pumping across frames: {tail} (spread {spread})"
+        )
+        # And it should be a meaningful, visible level (not collapsed to 0).
+        assert min(tail) > 0.30 * _PIXEL_MAX, f"converged peak too low: {tail}"


### PR DESCRIPTION
## Summary
The v2 AUDIO SCOPE FFT rendered nearly empty for low-level radio audio (FTX-1): the fixed dB window `_DB_FLOOR=-70 / _DB_CEIL=-15` sits ~16–20 dB above the FTX-1's actual audio (measured in-band per-bin ≈ −86 dB over a −126 dB noise floor → 0/124 bins clear the −70 floor → invisible).

## Fix — per-stream adaptive auto-range
New `_update_db_window(avg_db)` (called each frame) replaces the fixed window:
- **Floor** = 10th percentile of per-bin dB → slow EMA (`α=0.05`), placed 5 dB below.
- **Ceil** = 99th percentile → attack/decay EMA (`0.30`/`0.05`), 3 dB above.
- Seeded from the first frame; **min-span guard** `_MIN_SPAN_DB=45` (so silence/noise can't be stretched to fill the screen); absolute clamps floor `[-160,-20]`, ceil `≤0`. EMA state reset in `stop()`.

Per-frame dB compute, Hann window, averaging, frame-rate limit, center-freq/bandwidth overlay, and the `_center_freq<=0` guard (MOR-505) are byte-unchanged. Frontend renderer plots `pixels/160` linearly → **backend-only**.

## Why it won't pump or amplify silence
Floor EMA is very slow (stable baseline); ceil decays slowly so a vanishing signal doesn't snap the window down and re-amplify noise; the 45 dB min-span keeps a flat noise field pinned to the bottom. Reviewer's adversarial harness: 60 frames of pure low-level noise → max 30%/median 14% (not a fake spectrum); steady weak tone → converges to 152–153/160 with 1px frame-to-frame stability; loud transient recovers via ceil decay (no permanent saturation).

## Tests
New `TestAudioFftScopeAdaptiveAutoRange` (4 tests): weak band (~−86 dB/bin) renders well above baseline; converges + stable; loud not permanently saturated; low-level noise stays low. Verified the weak-band tests **fail on `origin/main`** (0/160 px). Test diff is purely additive — no pre-existing test weakened.

## Gate
- `pytest --ignore=tests/integration` → 7262 passed, 0 failures
- `ruff check` / `ruff format --check` → clean
- `mypy src/` → 20 baseline errors, 0 new (none in fft_scope.py)
- `lint-imports` → 4 kept, 0 broken

## Independent review
Implementer ≠ reviewer. Reviewer ran old-code falsification, an adversarial pumping/silence harness (noise pinned low; tone stable; loud recovers), confirmed existing tests untouched, state-reset/no-div-by-zero, center-freq guard + overlay byte-identical → **Agent Review: PASS**. Three non-blocking cosmetic notes (ceil-clamp ordering under absurdly-hot input; `set_sample_rate` doesn't reset EMA; pre-existing frontend smoothing) — none affecting correctness.

## Deferred
Live FTX-1 re-validation (spectrum clearly visible above noise) — radio connected; will re-check together with MOR-508 (left-channel +6 dB), already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)