### PR TITLE
fix: cap FFT scope in-band noise-estimate edge at ~3500 Hz for wide-crop modes (MOR-528)

### DIFF
--- a/src/rigplane/audio/fft_scope.py
+++ b/src/rigplane/audio/fft_scope.py
@@ -344,14 +344,21 @@ class AudioFftScope:
 
         ``avg_db`` is the rfft per-bin dB array, indexed DC..Nyquist; bin ``i``
         sits at ``i * sample_rate / fft_size`` Hz of audio. The in-band region
-        is ``_INBAND_LO_HZ <= freq <= upper``, where ``upper`` is the displayed
-        passband (``_crop_max_hz / 2``) when the mode bandwidth is known and the
-        fixed ``_INBAND_FALLBACK_HI_HZ`` otherwise. Falls back to the full array
-        if the mask would be empty (degenerate fft_size / sample_rate).
+        is ``_INBAND_LO_HZ <= freq <= upper``. When the mode bandwidth is known
+        ``upper`` is the displayed passband (``_crop_max_hz / 2``) capped at
+        ``_INBAND_FALLBACK_HI_HZ`` (MOR-528): a wide-crop mode (AM) would
+        otherwise re-include the quiet out-of-band tail that MOR-512 excluded.
+        When it is unknown the fixed ``_INBAND_FALLBACK_HI_HZ`` is used. Falls
+        back to the full array if the mask would be empty (degenerate fft_size /
+        sample_rate).
         """
         bin_res = self._sample_rate / self._fft_size
         if self._crop_max_hz:
-            upper_hz = self._crop_max_hz / 2.0
+            # Cap the upper edge even when a wider crop is known (MOR-528): a
+            # wide-crop mode (IC-7610 AM, max_hz=10000 → 5000 Hz edge) would
+            # otherwise re-include the quiet out-of-band tail above ~3.2 kHz that
+            # MOR-512 excluded, latching the floor back onto it for NARROW audio.
+            upper_hz = min(self._crop_max_hz / 2.0, _INBAND_FALLBACK_HI_HZ)
         else:
             upper_hz = _INBAND_FALLBACK_HI_HZ
         lo_bin = int(_INBAND_LO_HZ / bin_res)

--- a/tests/test_audio_fft_scope.py
+++ b/tests/test_audio_fft_scope.py
@@ -873,6 +873,105 @@ class TestAudioFftScopeAdaptiveAutoRange:
             "— min-span guard failed, noise was amplified"
         )
 
+    def test_am_wide_crop_narrow_audio_band_noise_maps_low(self):
+        """Wide-crop AM with NARROW audio must not re-include the quiet tail (MOR-528).
+
+        IC-7610 AM reports ``max_hz=10000`` → the displayed passband edge is
+        5000 Hz. The in-band floor estimate (MOR-512) followed that crop edge up
+        to 5000 Hz, re-including the quiet out-of-band tail (>~3.2 kHz) that the
+        MOR-512 fix had excluded: if the real AM audio is NARROW (band-noise only
+        ~0–3.2 kHz, quiet above), ~36% of the 50 Hz…5000 Hz estimation slice is
+        that quiet tail, the 30th-percentile floor latches to ~-131 dB and the
+        ever-present band-noise renders at ~64% of screen — the original "high
+        noise floor regardless of signal" regression, on AM only.
+
+        Capping the in-band upper edge at ~3500 Hz (``_INBAND_FALLBACK_HI_HZ``)
+        even for wide crops keeps the estimate on the band-noise so it maps LOW.
+
+        Calibrated to the same live FTX-1 bimodal numbers (band-noise -102.1 dB,
+        out-of-band -126 dB) as the MOR-512 tests. FAILS on the uncapped code
+        (in-band ~64%).
+        """
+        fft_size = 2048
+        sample_rate = 48000
+        scope = AudioFftScope(
+            fft_size=fft_size, fps=100, avg_count=1, sample_rate=sample_rate
+        )
+        scope.set_center_freq(7_200_000)
+        scope.set_mode_bandwidth(10000)  # AM → crop edge 5000 Hz
+
+        # Narrow audio: band-noise only over 100–3200 Hz, quiet -126 dB above —
+        # quiet out-of-band tail (3200–5000 Hz) sits inside the 5000 Hz crop edge.
+        avg_db = _make_bimodal_db_spectrum(fft_size=fft_size, sample_rate=sample_rate)
+        for _ in range(10):
+            pixels = _db_window_to_pixels(scope, avg_db)
+
+        bin_res = sample_rate / fft_size
+        freqs = np.arange(len(avg_db)) * bin_res
+        inband = (freqs >= 100) & (freqs <= 3200)
+
+        inband_median_pct = float(np.median(pixels[inband])) / _PIXEL_MAX
+        inband_max_pct = float(np.max(pixels[inband])) / _PIXEL_MAX
+
+        assert inband_median_pct < 0.30, (
+            f"wide-crop AM narrow-audio band-noise renders at "
+            f"{inband_median_pct * 100:.0f}% of screen — the in-band estimate "
+            "followed the 5000 Hz crop edge into the quiet out-of-band "
+            "(MOR-528 regression), should be <30%"
+        )
+        assert inband_max_pct < 0.40, (
+            f"no-signal in-band max {inband_max_pct * 100:.0f}% leaves no "
+            "headroom for an actual AM signal"
+        )
+
+    def test_am_wide_crop_wide_audio_signal_still_renders(self):
+        """A genuinely WIDE AM signal (audio filling 0–5 kHz) is not broken by the cap.
+
+        The ~3500 Hz cap (MOR-528) only changes the noise-floor *estimation*
+        slice — it must not suppress an actual wide AM signal. Band-noise filling
+        the full 5000 Hz crop plus a real tone 25 dB above it should still map
+        the band-noise LOW and lift the tone clearly above it. Same live bimodal
+        levels as the MOR-512 tests.
+        """
+        fft_size = 2048
+        sample_rate = 48000
+        scope = AudioFftScope(
+            fft_size=fft_size, fps=100, avg_count=1, sample_rate=sample_rate
+        )
+        scope.set_center_freq(7_200_000)
+        scope.set_mode_bandwidth(10000)  # AM → crop edge 5000 Hz
+
+        tone_hz = 1500.0
+        # Wide audio: band-noise fills the whole 100–5000 Hz crop, plus a tone.
+        avg_db = _make_bimodal_db_spectrum(
+            fft_size=fft_size,
+            sample_rate=sample_rate,
+            inband_hi_hz=5000.0,
+            tone_hz=tone_hz,
+            tone_db=-102.1 + 25.0,
+        )
+        for _ in range(10):
+            pixels = _db_window_to_pixels(scope, avg_db)
+
+        bin_res = sample_rate / fft_size
+        tone_bin = int(tone_hz / bin_res)
+        freqs = np.arange(len(avg_db)) * bin_res
+        inband = (freqs >= 100) & (freqs <= 5000)
+        noise_mask = inband.copy()
+        noise_mask[tone_bin] = False
+
+        tone_px = float(pixels[tone_bin])
+        noise_median_px = float(np.median(pixels[noise_mask]))
+
+        assert noise_median_px < 0.30 * _PIXEL_MAX, (
+            f"wide-AM band-noise median {noise_median_px:.0f}/{_PIXEL_MAX} too "
+            "high — the cap should not lift band-noise"
+        )
+        assert tone_px > 0.60 * _PIXEL_MAX, (
+            f"wide-AM tone only reached {tone_px:.0f}/{_PIXEL_MAX} — the cap "
+            "broke a genuinely wide AM signal"
+        )
+
     def test_adaptive_window_converges_and_is_stable(self):
         """Under steady input the auto-range converges (no runaway/pumping).
 


### PR DESCRIPTION
## Summary
Follow-up hardening to MOR-512. The in-band noise-estimate region used `upper = _crop_max_hz/2`. IC-7610 **AM** (`max_hz=10000` → edge 5000 Hz) re-included the quiet out-of-band tail, re-triggering the "high noise floor" regression on narrow AM audio.

## Fix (one line)
`_inband_db()`: `upper_hz = min(_crop_max_hz/2, _INBAND_FALLBACK_HI_HZ)` (~3500 Hz cap). `min(...)` can only lower the edge, never raise it → a strict no-op for every mode whose edge is already ≤3500 (SSB/CW/data/RTTY = ≤1800; FM/FTX-1 → unknown bandwidth → unchanged 3500 fallback). Only wide-crop AM is capped. Everything else (percentiles, EMA smoothing, min-span, clamps, empty-mask guard, the `else` branch, center-freq guard, overlay) is untouched.

## Why it's safe for wide AM
The cap only changes which bins feed the floor/ceil percentile estimate; the pixel map still applies to the full spectrum, so audio content in 3500–5000 Hz renders at full resolution above the floor.

## Tests
`test_am_wide_crop_narrow_audio_band_noise_maps_low` (wide crop + narrow audio → band-noise <30%, was ~65% uncapped) and `test_am_wide_crop_wide_audio_signal_still_renders` (genuinely wide AM tone still lifts clearly). The narrow test **fails on `origin/main`** (65%, floor latches to −126). The MOR-512 bimodal tests still pass.

## Gate
- `pytest --ignore=tests/integration` → 7272 passed, 0 failures
- `ruff check` / `ruff format --check` → clean
- `mypy src/` → 20 baseline, 0 new (none in fft_scope.py)
- `lint-imports` → 4 kept, 0 broken

## Independent review
Implementer ≠ reviewer. Reviewer ran old-code falsification (22 dB floor difference, decisive), swept all rig profiles to confirm AM is the only affected mode, confirmed the cap is structurally display-safe → **Agent Review: PASS**.

## Deferred
Live IC-7610 AM re-validation (no IC-7610 connected). No FTX-1 impact (cap is a no-op there) → no re-validation needed for the FTX-1 SSB case already validated under MOR-512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)