### PR TITLE
feat: full-duplex USB audio path (single sd.Stream) for same-device RX+TX (MOR-531)

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -141,6 +141,35 @@ class TxStream(Protocol):
         ...
 
 
+@runtime_checkable
+class DuplexStream(Protocol):
+    """Bidirectional audio stream — RX capture and TX playback on ONE device.
+
+    Backed by a single PortAudio full-duplex stream so a USB-CODEC radio can
+    transmit (computer audio → radio) while RX capture keeps running on the
+    same device, without the two-separate-stream macOS CoreAudio AUHAL ``-50``
+    (MOR-531). Combines the :class:`RxStream` consumer contract (``start``
+    registers a PCM s16le frame callback) with the :class:`TxStream` producer
+    contract (``write`` queues a playback frame).
+    """
+
+    @property
+    def running(self) -> bool: ...
+
+    @property
+    def write_health(self) -> TxStreamHealth: ...
+
+    async def start(self, callback: Callable[[bytes], None]) -> None:
+        """Begin duplex I/O; deliver captured PCM frames to *callback*."""
+        ...
+
+    async def stop(self) -> None: ...
+
+    async def write(self, frame: bytes) -> None:
+        """Queue one PCM s16le frame for playback."""
+        ...
+
+
 # ---------------------------------------------------------------------------
 # Backend protocol
 # ---------------------------------------------------------------------------
@@ -203,6 +232,28 @@ class AudioBackend(Protocol):
         channels: int = 1,
         frame_ms: int = 20,
     ) -> TxStream: ...
+
+    def open_duplex(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+        deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
+        tx_channels: int | None = None,
+    ) -> DuplexStream:
+        """Open a single full-duplex RX+TX stream on one *device* (MOR-531).
+
+        Additive: ``open_rx`` / ``open_tx`` are unchanged. ``channels`` is the
+        RX-leg native open count; ``deliver_channels`` is the RX-delivered count
+        (the duplex stream software-downmixes when delivering fewer than it
+        opens, identically to ``open_rx``). ``tx_channels`` is the TX-leg channel
+        count (defaults to ``channels``) — a ``sd.Stream`` accepts an
+        ``(in, out)`` channel pair, so RX and TX legs need not match.
+        """
+        ...
 
 
 # ---------------------------------------------------------------------------
@@ -281,6 +332,87 @@ def _downmix_stereo_to_mono_s16le(pcm: bytes, *, channel: str = "mix") -> bytes:
     return mono.tobytes()
 
 
+class _RxFramer:
+    """Shared RX data-path: downmix → accumulate → re-chunk into fixed frames.
+
+    Factored out of :class:`_PortAudioRxStream` so the duplex stream
+    (:class:`_PortAudioDuplexStream`) can reuse the *exact* same capture
+    semantics — the stereo→mono ``rx_audio_channel`` downmix (MOR-504/508) plus
+    the lossless re-chunking of engine-native variable-size blocks into fixed
+    ``frame_ms`` frames (the downstream PCM-TX validator rejects any other size).
+    The owning stream is the single audio-thread writer, so no lock is needed;
+    the consumer ``callback`` is contractually cheap and thread-safe.
+    """
+
+    def __init__(
+        self,
+        *,
+        channels: int,
+        deliver_channels: int,
+        sample_rate: int,
+        frame_ms: int,
+        rx_audio_channel: str,
+    ) -> None:
+        self._rx_audio_channel = rx_audio_channel
+        # Software downmix only fires for the stereo-native → mono case. Any
+        # other deliver/open relationship passes interleaved PCM through
+        # unchanged (over-request already clamps open == deliver upstream).
+        self._downmix_stereo_to_mono = channels == 2 and deliver_channels == 1
+        frame_samples = (sample_rate * frame_ms) // 1000
+        self._frame_bytes = max(1, frame_samples * deliver_channels * 2)
+        self._accumulator = bytearray()
+
+    @property
+    def frame_bytes(self) -> int:
+        return self._frame_bytes
+
+    def reset(self) -> None:
+        self._accumulator = bytearray()
+
+    def feed(self, indata: Any, callback: Callable[[bytes], None]) -> None:
+        """Downmix + re-chunk *indata*; deliver each whole frame to *callback*.
+
+        Runs on PortAudio's audio thread: keep it non-blocking. Copies the PCM
+        out of the (reused, variable-size) input buffer, optionally downmixes
+        stereo→mono, accumulates, then slices whole fixed-size frames out and
+        hands each to the consumer. Re-chunking a continuous callback stream is
+        lossless and adds no scheduling seam.
+        """
+        try:
+            pcm = (
+                bytes(indata.tobytes()) if hasattr(indata, "tobytes") else bytes(indata)
+            )
+        except Exception:
+            logger.warning("portaudio-rx: capture copy failed", exc_info=True)
+            return
+        if not pcm:
+            return
+        if self._downmix_stereo_to_mono:
+            # Device opened at 2 ch (native) but consumer wants mono (MOR-504):
+            # collapse interleaved L/R → mono BEFORE chunking, so the
+            # accumulator/fixed-frame slicing operates on mono bytes and the
+            # FFT scope + broadcaster receive the mono contract they expect.
+            try:
+                pcm = _downmix_stereo_to_mono_s16le(pcm, channel=self._rx_audio_channel)
+            except Exception:
+                logger.warning(
+                    "portaudio-rx: stereo→mono downmix failed", exc_info=True
+                )
+                return
+            if not pcm:
+                return
+        acc = self._accumulator
+        acc.extend(pcm)
+        frame_bytes = self._frame_bytes
+        try:
+            while len(acc) >= frame_bytes:
+                frame = bytes(acc[:frame_bytes])
+                del acc[:frame_bytes]
+                callback(frame)
+        except Exception:
+            logger.warning("portaudio-rx: consumer callback failed", exc_info=True)
+
+
 class _PortAudioRxStream:
     """RxStream backed by a callback-driven sounddevice InputStream.
 
@@ -328,41 +460,30 @@ class _PortAudioRxStream:
         self._sample_rate = sample_rate
         # ``channels`` is the OS open count; ``_deliver_channels`` is what the
         # consumer receives. When deliver < open (mono request on a stereo-
-        # native device, MOR-504) the callback downmixes interleaved s16le to
+        # native device, MOR-504) the framer downmixes interleaved s16le to
         # the deliver count before chunking. Default: deliver == open.
         self._channels = channels
         self._deliver_channels = (
             channels if deliver_channels is None else deliver_channels
-        )
-        # How the stereo→mono downmix collapses each L/R pair (MOR-508):
-        # "mix" = (L+R)//2 (legacy default), "left"/"right" = that channel at
-        # full level. The FTX-1 carries RX audio on L only, so averaging with a
-        # silent R halves the level (−6 dB); "left" delivers it undivided.
-        self._rx_audio_channel = rx_audio_channel
-        # Software downmix only fires for the stereo-native → mono case. Any
-        # other deliver/open relationship passes interleaved PCM through
-        # unchanged (over-request already clamps open == deliver upstream).
-        self._downmix_stereo_to_mono = (
-            self._channels == 2 and self._deliver_channels == 1
         )
         # Capture is callback-driven with blocksize=0 (engine-native period),
         # mirroring a clean sd.rec. blocksize=0 was previously rejected by the
         # WDM-KS capture face (PortAudioError -9999), but companion device
         # selection now forces the WASAPI face, on which blocksize=0 opens.
         self._blocksize = blocksize
-        # Fixed delivered-frame size: frame_ms worth of audio frames, each
-        # ``_deliver_channels`` interleaved s16le samples (2 bytes/sample). The
-        # downstream PCM validator expects the DELIVER count (1920 bytes = 20 ms
-        # mono @ 48 kHz), not the native open count. The PortAudio stream stays
-        # blocksize=0; only the size handed to ``cb`` is fixed.
-        frame_samples = (sample_rate * frame_ms) // 1000
-        self._frame_bytes = max(1, frame_samples * self._deliver_channels * 2)
+        # The framer owns the downmix + fixed-frame re-chunking (shared with the
+        # duplex stream). It carries the sub-frame remainder between audio-thread
+        # callbacks; the audio thread is the only writer, so no lock is needed.
+        self._framer = _RxFramer(
+            channels=self._channels,
+            deliver_channels=self._deliver_channels,
+            sample_rate=sample_rate,
+            frame_ms=frame_ms,
+            rx_audio_channel=rx_audio_channel,
+        )
         self._stream: Any = None
         self._running = False
         self._callback: Callable[[bytes], None] | None = None
-        # Sub-frame remainder carried between audio-thread callbacks. The audio
-        # thread is the only writer, so no lock is needed.
-        self._accumulator = bytearray()
 
     @property
     def running(self) -> bool:
@@ -372,7 +493,7 @@ class _PortAudioRxStream:
         if self.running:
             raise RuntimeError("RX stream already running.")
         self._callback = callback
-        self._accumulator = bytearray()
+        self._framer.reset()
         # blocksize=0 (engine-native period) mirrors a clean sd.rec on the
         # WASAPI face. latency="low" matches the (clean) output stream.
         self._stream = self._sd.InputStream(
@@ -394,7 +515,7 @@ class _PortAudioRxStream:
         self._callback = None
         # Drop any sub-frame remainder: an incomplete trailing frame cannot
         # satisfy the fixed-size contract and is discarded at teardown.
-        self._accumulator = bytearray()
+        self._framer.reset()
         if stream is not None:
             try:
                 stream.stop()
@@ -412,50 +533,17 @@ class _PortAudioRxStream:
         _time_info: Any,
         _status: Any,
     ) -> None:
-        # Runs on PortAudio's audio thread: keep it non-blocking. Copy the
-        # captured PCM (s16le) out of the (reused, variable-size) input buffer,
-        # append it to the running accumulator, then slice off whole fixed-size
-        # frames and deliver each to the consumer. Re-chunking a continuous
-        # callback stream is lossless (every sample reaches the consumer in
-        # order) and adds no scheduling seam, so it keeps the fixed-frame
-        # contract without re-introducing the comb. The consumer is
-        # contractually cheap/thread-safe.
+        # Runs on PortAudio's audio thread: keep it non-blocking. The shared
+        # framer copies the captured PCM out of the (reused, variable-size) input
+        # buffer, optionally downmixes stereo→mono, accumulates, and delivers
+        # whole fixed-size frames to the consumer. Re-chunking a continuous
+        # callback stream is lossless and adds no scheduling seam, so it keeps
+        # the fixed-frame contract without re-introducing the comb. The consumer
+        # is contractually cheap/thread-safe.
         cb = self._callback
         if cb is None:
             return
-        try:
-            pcm = (
-                bytes(indata.tobytes()) if hasattr(indata, "tobytes") else bytes(indata)
-            )
-        except Exception:
-            logger.warning("portaudio-rx: capture copy failed", exc_info=True)
-            return
-        if not pcm:
-            return
-        if self._downmix_stereo_to_mono:
-            # Device opened at 2 ch (native) but consumer wants mono (MOR-504):
-            # collapse interleaved L/R → mono average BEFORE chunking, so the
-            # accumulator/fixed-frame slicing operates on mono bytes and the
-            # FFT scope + broadcaster receive the mono contract they expect.
-            try:
-                pcm = _downmix_stereo_to_mono_s16le(pcm, channel=self._rx_audio_channel)
-            except Exception:
-                logger.warning(
-                    "portaudio-rx: stereo→mono downmix failed", exc_info=True
-                )
-                return
-            if not pcm:
-                return
-        acc = self._accumulator
-        acc.extend(pcm)
-        frame_bytes = self._frame_bytes
-        try:
-            while len(acc) >= frame_bytes:
-                frame = bytes(acc[:frame_bytes])
-                del acc[:frame_bytes]
-                cb(frame)
-        except Exception:
-            logger.warning("portaudio-rx: consumer callback failed", exc_info=True)
+        self._framer.feed(indata, cb)
 
 
 class _PortAudioTxStream:
@@ -846,6 +934,155 @@ class _PortAudioTxStream:
             logger.debug("portaudio-tx: stream close failed", exc_info=True)
 
 
+class _PortAudioDuplexStream:
+    """Full-duplex stream backed by ONE callback-driven sounddevice ``Stream``.
+
+    Wraps a single ``sd.Stream(device=(idx, idx), channels=(open, open), ...)``
+    so a USB-CODEC radio can do digital-mode TX (computer audio → radio via USB
+    MOD) WHILE RX capture (browser audio + FFT scope) keeps running — without
+    the macOS CoreAudio AUHAL ``-50`` that two separate streams
+    (``sd.InputStream`` + ``sd.OutputStream``) cause on one C-Media device
+    (MOR-531).
+
+    Reuses the existing data paths rather than duplicating them:
+
+    - **RX leg** delegates to the shared :class:`_RxFramer` — the *same*
+      ``rx_audio_channel`` downmix (MOR-504/508) and lossless re-chunking into
+      fixed ``frame_ms`` frames that :class:`_PortAudioRxStream` uses. Delivered
+      frames are marshalled to the consumer exactly as the RX stream is (the
+      consumer is contractually cheap/thread-safe; the bridge marshals onto its
+      event loop via ``call_soon_threadsafe``).
+    - **TX leg** delegates to an embedded :class:`_PortAudioTxStream` — the
+      *same* bounded ring + ``write()`` producer and ring-drain consumer. The
+      duplex callback fills ``outdata`` by invoking the TX stream's output
+      callback (silence when the queue is empty), and ``write_health`` proxies
+      the embedded TX stream so diagnostics are identical to the split path.
+    """
+
+    def __init__(
+        self,
+        sd: Any,
+        np: Any,
+        device_index: int,
+        sample_rate: int,
+        channels: int,
+        blocksize: int,
+        frame_ms: int,
+        deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
+        tx_channels: int | None = None,
+    ) -> None:
+        self._sd = sd
+        self._device_index = device_index
+        self._sample_rate = sample_rate
+        # RX leg opens at the native ``channels`` count and delivers
+        # ``deliver_channels`` (downmix when fewer, MOR-504). The TX leg opens at
+        # its own ``tx_channels`` count (the mono playback the radio's USB MOD
+        # consumes); ``sd.Stream`` accepts a ``(in, out)`` channel pair so the
+        # two legs need not match.
+        self._channels = channels
+        self._deliver_channels = (
+            channels if deliver_channels is None else deliver_channels
+        )
+        self._tx_channels = channels if tx_channels is None else tx_channels
+        self._blocksize = blocksize
+        self._framer = _RxFramer(
+            channels=self._channels,
+            deliver_channels=self._deliver_channels,
+            sample_rate=sample_rate,
+            frame_ms=frame_ms,
+            rx_audio_channel=rx_audio_channel,
+        )
+        # Embed a TX stream purely for its ring + write()/output-callback; its
+        # own ``sd`` stream is never opened (we drive its ``_output_callback``
+        # from the duplex callback). It opens at ``tx_channels`` so the ring's
+        # frame accounting and ``outdata`` interleaving match the TX leg.
+        self._tx = _PortAudioTxStream(
+            sd,
+            np,
+            device_index=device_index,
+            sample_rate=sample_rate,
+            channels=self._tx_channels,
+            blocksize=blocksize,
+        )
+        self._stream: Any = None
+        self._running = False
+        self._callback: Callable[[bytes], None] | None = None
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    @property
+    def write_health(self) -> TxStreamHealth:
+        return self._tx.write_health
+
+    async def start(self, callback: Callable[[bytes], None]) -> None:
+        if self.running:
+            raise RuntimeError("Duplex stream already running.")
+        self._callback = callback
+        self._framer.reset()
+        # The embedded TX stream's ring must be marked running so ``write()``
+        # accepts frames; its OWN sounddevice stream stays unopened — the duplex
+        # callback drives playback.
+        self._tx._running = True
+        # ONE full-duplex stream: device=(idx, idx), channels=(open, open).
+        # blocksize=0 (engine-native period) mirrors a clean sd.rec/playback.
+        self._stream = self._sd.Stream(
+            samplerate=self._sample_rate,
+            channels=(self._channels, self._tx_channels),
+            dtype="int16",
+            device=(self._device_index, self._device_index),
+            blocksize=self._blocksize,
+            latency="low",
+            callback=self._duplex_callback,
+        )
+        self._stream.start()
+        self._running = True
+
+    async def stop(self) -> None:
+        stream = self._stream
+        self._stream = None
+        self._running = False
+        self._callback = None
+        self._framer.reset()
+        self._tx._running = False
+        self._tx._clear_buffer()
+        if stream is not None:
+            try:
+                stream.stop()
+            except Exception:
+                logger.debug("portaudio-duplex: stream stop failed", exc_info=True)
+            try:
+                stream.close()
+            except Exception:
+                logger.debug("portaudio-duplex: stream close failed", exc_info=True)
+
+    async def write(self, frame: bytes) -> None:
+        """Queue one PCM s16le playback frame (TX leg, via the shared ring)."""
+        if not self.running:
+            raise RuntimeError("Duplex stream is not running.")
+        await self._tx.write(frame)
+
+    def _duplex_callback(
+        self,
+        indata: Any,
+        outdata: Any,
+        frames: int,
+        _time_info: Any,
+        status: Any,
+    ) -> None:
+        # ONE audio-thread callback handles BOTH directions:
+        #  (a) RX fan — hand captured ``indata`` to the shared framer, which
+        #      downmixes + re-chunks and delivers fixed frames to the consumer;
+        #  (b) TX pull — fill ``outdata`` from the embedded TX ring (silence when
+        #      the producer is behind), reusing the TX stream's output callback.
+        cb = self._callback
+        if cb is not None:
+            self._framer.feed(indata, cb)
+        self._tx._output_callback(outdata, frames, _time_info, status)
+
+
 class PortAudioBackend:
     """AudioBackend backed by PortAudio via *sounddevice*.
 
@@ -989,6 +1226,34 @@ class PortAudioBackend:
             blocksize=blocksize,
         )
 
+    def open_duplex(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+        deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
+        tx_channels: int | None = None,
+    ) -> DuplexStream:
+        sd, np = self._ensure_deps()
+        # TX uses a fixed blocksize (frame_ms) so the duplex callback's
+        # ``outdata`` window matches a whole playback frame, mirroring open_tx.
+        blocksize = (sample_rate * frame_ms) // 1000
+        return _PortAudioDuplexStream(
+            sd,
+            np,
+            device_index=int(device),
+            sample_rate=sample_rate,
+            channels=channels,
+            blocksize=blocksize,
+            frame_ms=frame_ms,
+            deliver_channels=deliver_channels,
+            rx_audio_channel=rx_audio_channel,
+            tx_channels=tx_channels,
+        )
+
 
 # ---------------------------------------------------------------------------
 # FakeAudioBackend (for tests)
@@ -1084,6 +1349,55 @@ class FakeTxStream:
         self.written_frames.append(frame)
 
 
+class FakeDuplexStream:
+    """Test double: one full-duplex stream — RX fan + TX queue (MOR-531).
+
+    Combines :class:`FakeRxStream` (delivers injected capture frames to the
+    registered callback) and :class:`FakeTxStream` (captures written playback
+    frames) so the same-device duplex path can be exercised without PortAudio.
+    """
+
+    def __init__(self) -> None:
+        self._running = False
+        self._callback: Callable[[bytes], None] | None = None
+        self.started_count = 0
+        self.stopped_count = 0
+        self.written_frames: list[bytes] = []
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    @property
+    def write_health(self) -> TxStreamHealth:
+        return TxStreamHealth(
+            frames_queued=len(self.written_frames),
+            writes_completed=len(self.written_frames),
+        )
+
+    async def start(self, callback: Callable[[bytes], None]) -> None:
+        if self._running:
+            raise RuntimeError("FakeDuplexStream already running.")
+        self._callback = callback
+        self._running = True
+        self.started_count += 1
+
+    async def stop(self) -> None:
+        self._running = False
+        self._callback = None
+        self.stopped_count += 1
+
+    async def write(self, frame: bytes) -> None:
+        if not self._running:
+            raise RuntimeError("FakeDuplexStream is not running.")
+        self.written_frames.append(frame)
+
+    def inject_frame(self, frame: bytes) -> None:
+        """Push an RX capture frame to the registered callback (test helper)."""
+        if self._callback is not None:
+            self._callback(frame)
+
+
 class FakeAudioBackend:
     """Deterministic AudioBackend for tests — no real audio hardware.
 
@@ -1113,6 +1427,7 @@ class FakeAudioBackend:
         }
         self.rx_streams: list[FakeRxStream] = []
         self.tx_streams: list[FakeTxStream] = []
+        self.duplex_streams: list[FakeDuplexStream] = []
 
     def list_devices(self) -> list[AudioDeviceInfo]:
         return list(self._devices)
@@ -1167,12 +1482,31 @@ class FakeAudioBackend:
         self.tx_streams.append(stream)
         return stream
 
+    def open_duplex(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+        deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
+        tx_channels: int | None = None,
+    ) -> FakeDuplexStream:
+        if not any(d.id == device for d in self._devices):
+            raise ValueError(f"Unknown device id {device}")
+        stream = FakeDuplexStream()
+        self.duplex_streams.append(stream)
+        return stream
+
 
 __all__ = [
     "AudioBackend",
     "AudioDeviceId",
     "AudioDeviceInfo",
+    "DuplexStream",
     "FakeAudioBackend",
+    "FakeDuplexStream",
     "FakeRxStream",
     "FakeTxStream",
     "PortAudioBackend",

--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -48,6 +48,7 @@ from ._bridge_state import BridgeState, BridgeStateChange
 from .backend import (
     AudioBackend,
     AudioDeviceInfo,
+    DuplexStream,
     PortAudioBackend,
     RxStream,
     TxStream,
@@ -212,6 +213,18 @@ def _find_device_in_backend(
     return None
 
 
+def _is_virtual_loopback_device(dev: AudioDeviceInfo) -> bool:
+    """Whether *dev* is a virtual loopback (BlackHole/VB-Cable/PipeWire/…).
+
+    The same-device full-duplex path (MOR-531) exists to dodge the macOS
+    CoreAudio AUHAL -50 that two separate streams cause on one *real* C-Media
+    USB CODEC. Virtual loopback drivers do not have that limitation and work
+    fine as two separate streams, so they stay on the two-stream path.
+    """
+    lowered = dev.name.lower()
+    return any(candidate.lower() in lowered for candidate in _LOOPBACK_CANDIDATES)
+
+
 class AudioBridge:
     """Bidirectional PCM audio bridge between radio and a system audio device.
 
@@ -281,6 +294,12 @@ class AudioBridge:
         self._input_channels: int = 1
         self._rx_stream: TxStream | None = None  # radio → device (playback)
         self._tx_stream: RxStream | None = None  # device → radio (capture)
+        # Single full-duplex stream for the same-device CODEC case (MOR-531):
+        # opening separate playback + capture streams on one C-Media device
+        # fails with macOS CoreAudio AUHAL -50. When set, it serves BOTH the
+        # radio→device playback (``write``) and device→radio capture (``start``
+        # callback), replacing the separate ``_rx_stream`` + ``_tx_stream`` pair.
+        self._duplex_stream: DuplexStream | None = None
         self._rx_task: asyncio.Task[None] | None = None
         self._tx_task: asyncio.Task[None] | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -427,14 +446,19 @@ class AudioBridge:
         dev_id = dev.id
         logger.info("%s: using device %r (id %d)", self._label, dev.name, int(dev_id))
 
-        # --- RX path: radio → virtual device output ---
-        self._rx_stream = self._backend.open_tx(
-            dev_id,
-            sample_rate=self._sample_rate,
-            channels=self._channels,
-            frame_ms=self._frame_ms,
-        )
-        await self._rx_stream.start()
+        # Resolve the TX-capture device up front: it shares the RX-playback
+        # device unless an explicit TX device name resolves to a different one.
+        tx_dev_id = dev_id
+        if self._tx_device_name:
+            tx_dev = _find_device_in_backend(self._backend, self._tx_device_name)
+            if tx_dev is None:
+                logger.warning(
+                    "%s: TX device %r not found, using RX device",
+                    self._label,
+                    self._tx_device_name,
+                )
+            else:
+                tx_dev_id = tx_dev.id
 
         # Codec detection
         from rigplane.types import AudioCodec
@@ -470,13 +494,13 @@ class AudioBridge:
         else:
             self._decoder = None
 
-        # Subscribe to AudioBus
-        bus = self._radio.audio_bus
-        self._subscription = bus.subscribe(name="audio-bridge")
-        await self._subscription.start()
-        self._rx_task = asyncio.create_task(self._rx_loop())
-
-        # --- TX path: virtual device input → radio ---
+        # --- Arm the radio TX path BEFORE choosing the device-stream topology.
+        # The radio may reject TX (serial backend with no USB-audio TX path):
+        # degrade to RX-only and use a plain output stream, never a duplex one
+        # (MOR-242). Only when TX is armed AND the capture leg targets the SAME
+        # device as the playback leg do we open ONE full-duplex stream (MOR-531):
+        # separate playback + capture on one C-Media CODEC fails with AUHAL -50.
+        tx_armed = False
         if self._tx_enabled:
             try:
                 await self._radio.start_audio_tx_pcm(
@@ -485,10 +509,6 @@ class AudioBridge:
                     frame_ms=self._frame_ms,
                 )
             except (RuntimeError, NotImplementedError) as exc:
-                # The radio cannot arm a PCM TX stream (e.g. a serial backend
-                # that never set up its USB-audio TX path). Degrade to RX-only
-                # instead of spinning a _tx_loop that would reject — and log —
-                # every captured frame (MOR-242).
                 self._tx_enabled = False
                 self._tx_started = False
                 logger.warning(
@@ -496,30 +516,67 @@ class AudioBridge:
                     self._label,
                     exc,
                 )
-                return
-            self._tx_started = True
+            else:
+                tx_armed = True
+                self._tx_started = True
 
-            tx_dev_id = dev_id
-            if self._tx_device_name:
-                tx_dev = _find_device_in_backend(self._backend, self._tx_device_name)
-                if tx_dev is None:
-                    logger.warning(
-                        "%s: TX device %r not found, using RX device",
-                        self._label,
-                        self._tx_device_name,
-                    )
-                else:
-                    tx_dev_id = tx_dev.id
+        # Same-device duplex only for a REAL CODEC: a virtual loopback
+        # (BlackHole/VB-Cable/PipeWire) has no AUHAL -50 limitation and stays on
+        # the two-stream path (MOR-531 targets the C-Media same-device case).
+        use_duplex = (
+            tx_armed
+            and int(tx_dev_id) == int(dev_id)
+            and not _is_virtual_loopback_device(dev)
+        )
 
-            self._tx_queue = asyncio.Queue(maxsize=64)
-            self._tx_stream = self._backend.open_rx(
-                tx_dev_id,
+        # --- RX path: radio → device output (playback) ---
+        if use_duplex:
+            logger.info(
+                "%s: same-device RX+TX (id %d) — opening single full-duplex "
+                "stream (MOR-531)",
+                self._label,
+                int(dev_id),
+            )
+            self._duplex_stream = self._backend.open_duplex(
+                dev_id,
                 sample_rate=self._sample_rate,
                 channels=self._channels,
                 frame_ms=self._frame_ms,
             )
-            await self._tx_stream.start(self._on_tx_capture)
+        else:
+            self._rx_stream = self._backend.open_tx(
+                dev_id,
+                sample_rate=self._sample_rate,
+                channels=self._channels,
+                frame_ms=self._frame_ms,
+            )
+            await self._rx_stream.start()
+
+        # Subscribe to AudioBus
+        bus = self._radio.audio_bus
+        self._subscription = bus.subscribe(name="audio-bridge")
+        await self._subscription.start()
+
+        # --- TX path: device input → radio (capture) ---
+        if tx_armed:
+            self._tx_queue = asyncio.Queue(maxsize=64)
+            if use_duplex:
+                # The single duplex stream serves BOTH playback (write) and
+                # capture (start callback). Starting it arms both directions.
+                assert self._duplex_stream is not None
+                await self._duplex_stream.start(self._on_tx_capture)
+            else:
+                self._tx_stream = self._backend.open_rx(
+                    tx_dev_id,
+                    sample_rate=self._sample_rate,
+                    channels=self._channels,
+                    frame_ms=self._frame_ms,
+                )
+                await self._tx_stream.start(self._on_tx_capture)
             self._tx_task = asyncio.create_task(self._tx_loop())
+
+        # Start the RX playback loop last so the streams above are live.
+        self._rx_task = asyncio.create_task(self._rx_loop())
 
     async def _teardown_streams(self) -> None:
         """Cancel tasks and stop streams.
@@ -560,6 +617,14 @@ class AudioBridge:
             except Exception:
                 logger.debug("%s: RX stream stop error", self._label, exc_info=True)
             self._rx_stream = None
+
+        # The single duplex stream serves both directions — stop it once.
+        if self._duplex_stream is not None:
+            try:
+                await self._duplex_stream.stop()
+            except Exception:
+                logger.debug("%s: duplex stream stop error", self._label, exc_info=True)
+            self._duplex_stream = None
 
     # ------------------------------------------------------------------
     # Reconnect
@@ -743,6 +808,19 @@ class AudioBridge:
             self._tx_overruns += 1
             self._tx_queue.put_nowait(frame)
 
+    @property
+    def _playback_stream(self) -> TxStream | DuplexStream | None:
+        """Active radio→device playback stream.
+
+        The single duplex stream (same-device RX+TX, MOR-531) supplies the
+        ``write`` playback contract too, so the RX loop writes to it directly;
+        otherwise the separate output stream (``_rx_stream``) is used. Both
+        expose ``running`` and ``write``.
+        """
+        if self._duplex_stream is not None:
+            return self._duplex_stream
+        return self._rx_stream
+
     async def _rx_loop(self) -> None:
         """Read packets from AudioBus subscription, decode, write to device."""
         try:
@@ -755,8 +833,9 @@ class AudioBridge:
                         logger.debug(
                             "%s: None packet (gap) #%d", self._label, self._rx_drops
                         )
-                    if self._rx_stream and self._rx_stream.running:
-                        await self._rx_stream.write(self._silence_bytes)
+                    playback = self._playback_stream
+                    if playback and playback.running:
+                        await playback.write(self._silence_bytes)
                     continue
 
                 opus_data = getattr(packet, "data", None)
@@ -781,11 +860,12 @@ class AudioBridge:
                     self._last_rx_level_dbfs = _rms_dbfs(pcm_data)
                     if self._rx_frames % 50 == 0:
                         self._emit_metrics()
-                    if self._rx_stream and self._rx_stream.running:
+                    playback = self._playback_stream
+                    if playback and playback.running:
                         out_data = pcm_data
                         if self._input_channels == 2:
                             out_data = _downmix_stereo_to_mono(out_data)
-                        await self._rx_stream.write(out_data)
+                        await playback.write(out_data)
                 except OSError:
                     raise  # device-level error → outer handler → reconnect
                 except Exception as exc:
@@ -810,8 +890,11 @@ class AudioBridge:
 
         try:
             while self._running:
-                # Check TX capture stream health periodically
-                if self._tx_stream is not None and not self._tx_stream.running:
+                # Check TX capture stream health periodically. In the same-device
+                # duplex case (MOR-531) the capture rides the single duplex
+                # stream; otherwise it is the dedicated capture stream.
+                capture = self._duplex_stream or self._tx_stream
+                if capture is not None and not capture.running:
                     raise OSError("TX capture stream stopped unexpectedly")
 
                 try:

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -21,6 +21,7 @@ from .backend import (
     AudioBackend,
     AudioDeviceId,
     AudioDeviceInfo,
+    DuplexStream,
     PortAudioBackend,
     RxStream,
     TxStream,
@@ -404,6 +405,10 @@ class UsbAudioDriver:
 
         self._rx_stream: RxStream | None = None
         self._tx_stream: TxStream | None = None
+        # Single full-duplex stream for the same-device RX+TX case (MOR-531):
+        # opening separate InputStream + OutputStream on one C-Media CODEC fails
+        # with macOS CoreAudio AUHAL -50. When set, it drives BOTH directions.
+        self._duplex_stream: DuplexStream | None = None
         self._usb_audio_contract = UsbAudioContract()
 
         self._rx_lock = asyncio.Lock()
@@ -411,10 +416,14 @@ class UsbAudioDriver:
 
     @property
     def rx_running(self) -> bool:
+        if self._duplex_stream is not None:
+            return self._duplex_stream.running
         return self._rx_stream is not None and self._rx_stream.running
 
     @property
     def tx_running(self) -> bool:
+        if self._duplex_stream is not None:
+            return self._duplex_stream.running
         return self._tx_stream is not None and self._tx_stream.running
 
     @property
@@ -768,12 +777,117 @@ class UsbAudioDriver:
             await self._tx_stream.start()
             self._store_stream_contract(contract)
 
+    async def start_duplex(
+        self,
+        callback: Callable[[bytes], None] | None = None,
+        *,
+        sample_rate: int | None = None,
+        channels: int | None = None,
+        frame_ms: int | None = None,
+        allow_sample_rate_fallback: bool = True,
+    ) -> None:
+        """Start a single full-duplex RX+TX stream on the SAME USB CODEC.
+
+        Opens ONE ``sd.Stream`` via :meth:`AudioBackend.open_duplex` when RX and
+        TX resolve to the same device, so a USB-CODEC radio can transmit while RX
+        capture keeps running — avoiding the macOS CoreAudio AUHAL -50 that two
+        separate streams cause on one C-Media device (MOR-531). RX frames go to
+        *callback*; TX frames are pushed via :meth:`_push_tx_pcm` (routed through
+        the duplex stream's TX queue). The two-stream :meth:`start_rx` /
+        :meth:`start_tx` path is unchanged for separate-device use.
+        """
+        if callback is None:
+            raise AudioDriverLifecycleError("Audio RX callback is required.")
+        if not callable(callback):
+            raise TypeError("Audio RX callback must be callable.")
+
+        async with self._rx_lock, self._tx_lock:
+            if self.rx_running or self.tx_running:
+                raise AudioDriverLifecycleError(
+                    "Duplex stream requires both RX and TX idle."
+                )
+
+            selected_rx, selected_tx = self._ensure_selected_devices()
+            if selected_rx.index != selected_tx.index:
+                raise AudioDriverLifecycleError(
+                    "Duplex stream requires RX and TX on the SAME device "
+                    f"(got RX=[{selected_rx.index}] {selected_rx.name}, "
+                    f"TX=[{selected_tx.index}] {selected_tx.name}); "
+                    "use start_rx/start_tx for separate devices."
+                )
+
+            sr = self._sample_rate if sample_rate is None else sample_rate
+            ch = self._channels if channels is None else channels
+            fm = self._frame_ms if frame_ms is None else frame_ms
+            if (sr * fm) % 1000 != 0:
+                raise AudioDriverLifecycleError(
+                    "Invalid duplex frame format: sample_rate * frame_ms must "
+                    "be divisible by 1000."
+                )
+
+            rx_contract = self._resolve_stream_contract(
+                direction="rx",
+                device=selected_rx,
+                requested_sample_rate=sr,
+                channels=ch,
+                frame_ms=fm,
+                allow_sample_rate_fallback=allow_sample_rate_fallback,
+            )
+            tx_contract = self._resolve_stream_contract(
+                direction="tx",
+                device=selected_tx,
+                requested_sample_rate=rx_contract.sample_rate_hz,
+                channels=ch,
+                frame_ms=fm,
+                allow_sample_rate_fallback=False,
+            )
+            logger.info(
+                "usb-audio: opening DUPLEX — device=[%d] %s, %d Hz, RX open %d ch "
+                "/ deliver %d ch, TX %d ch, %d ms",
+                selected_rx.index,
+                selected_rx.name,
+                rx_contract.sample_rate_hz,
+                rx_contract.effective_open_channels,
+                rx_contract.channels,
+                tx_contract.channels,
+                fm,
+            )
+            self._duplex_stream = self._backend.open_duplex(
+                AudioDeviceId(selected_rx.index),
+                sample_rate=rx_contract.sample_rate_hz,
+                channels=rx_contract.effective_open_channels,
+                frame_ms=fm,
+                deliver_channels=rx_contract.channels,
+                rx_audio_channel=self._rx_audio_channel,
+                tx_channels=tx_contract.channels,
+            )
+            await self._duplex_stream.start(callback)
+            self._store_stream_contract(rx_contract)
+            self._store_stream_contract(tx_contract)
+            logger.info(
+                "usb-audio: DUPLEX running — device=[%d] %s",
+                selected_rx.index,
+                selected_rx.name,
+            )
+
+    async def stop_duplex(self) -> None:
+        """Stop and close the full-duplex stream."""
+        async with self._rx_lock, self._tx_lock:
+            stream = self._duplex_stream
+            self._duplex_stream = None
+            if stream is not None and stream.running:
+                await stream.stop()
+
     async def _push_tx_pcm(self, frame: bytes) -> None:
         """Queue one PCM frame for playback."""
         if not self.tx_running:
             raise AudioDriverLifecycleError("Audio TX stream is not started.")
         if not isinstance(frame, (bytes, bytearray, memoryview)):
             raise TypeError("PCM TX frame must be bytes-like.")
+        # Same-device duplex: TX rides the single stream's TX queue.
+        if self._duplex_stream is not None:
+            await self._duplex_stream.write(bytes(frame))
+            return
         assert self._tx_stream is not None
         await self._tx_stream.write(bytes(frame))
 

--- a/tests/test_audio_duplex.py
+++ b/tests/test_audio_duplex.py
@@ -1,0 +1,430 @@
+"""Tests for the full-duplex USB audio path (single ``sd.Stream``) — MOR-531.
+
+A USB-CODEC radio (FTX-1, X6200) must be able to do digital-mode TX (computer
+audio → radio via USB MOD) WHILE RX capture (browser audio + FFT scope) keeps
+running. On macOS CoreAudio, opening two separate streams (``sd.InputStream`` +
+``sd.OutputStream``) on one C-Media device fails with AUHAL ``-50``. Opening ONE
+``sd.Stream(device=(idx, idx), channels=(2, 2), ...)`` with a single duplex
+callback avoids that.
+
+These tests exercise the additive ``open_duplex`` path on the backend, the
+``UsbAudioDriver.start_duplex`` same-device path, and the bridge's duplex
+selection — radio-free, ``FakeAudioBackend`` only (no one-off mocks). The
+PortAudio-level callback semantics are exercised against a tiny in-test fake
+``sd`` module exactly as the existing RX/TX stream tests do.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from rigplane.audio.backend import (
+    AudioBackend,
+    AudioDeviceId,
+    AudioDeviceInfo,
+    DuplexStream,
+    FakeAudioBackend,
+    FakeDuplexStream,
+    PortAudioBackend,
+)
+
+DUPLEX_DEVICE = AudioDeviceInfo(
+    id=AudioDeviceId(0),
+    name="USB Audio CODEC",
+    input_channels=2,
+    output_channels=2,
+    default_samplerate=48_000,
+    is_default_input=True,
+    is_default_output=True,
+)
+
+SEPARATE_RX_DEVICE = AudioDeviceInfo(
+    id=AudioDeviceId(1),
+    name="BlackHole 2ch",
+    input_channels=2,
+    output_channels=2,
+)
+
+
+@pytest.fixture()
+def fake_backend() -> FakeAudioBackend:
+    return FakeAudioBackend(devices=[DUPLEX_DEVICE, SEPARATE_RX_DEVICE])
+
+
+# ---------------------------------------------------------------------------
+# Protocol / Fake conformance
+# ---------------------------------------------------------------------------
+
+
+class TestDuplexProtocol:
+    def test_fake_backend_exposes_open_duplex(
+        self, fake_backend: FakeAudioBackend
+    ) -> None:
+        stream = fake_backend.open_duplex(AudioDeviceId(0))
+        assert isinstance(stream, DuplexStream)
+        assert isinstance(stream, FakeDuplexStream)
+
+    def test_fake_duplex_stream_is_duplex_stream(self) -> None:
+        assert isinstance(FakeDuplexStream(), DuplexStream)
+
+    def test_portaudio_backend_has_open_duplex(self) -> None:
+        backend = PortAudioBackend(dependency_loader=lambda: (None, None))
+        assert isinstance(backend, AudioBackend)
+        assert hasattr(backend, "open_duplex")
+
+
+# ---------------------------------------------------------------------------
+# FakeDuplexStream lifecycle (RX fan + TX queue, radio-free)
+# ---------------------------------------------------------------------------
+
+
+class TestFakeDuplexStream:
+    @pytest.mark.asyncio()
+    async def test_lifecycle_and_rx_fan(self, fake_backend: FakeAudioBackend) -> None:
+        stream = fake_backend.open_duplex(AudioDeviceId(0))
+        assert not stream.running
+        received: list[bytes] = []
+        await stream.start(received.append)
+        assert stream.running
+        # RX fan: an injected capture frame reaches the registered RX callback.
+        stream.inject_frame(b"\x01\x02")
+        assert received == [b"\x01\x02"]
+        # TX queue: a written frame is captured for assertions.
+        await stream.write(b"\x03\x04")
+        assert stream.written_frames == [b"\x03\x04"]
+        await stream.stop()
+        assert not stream.running
+
+
+# ---------------------------------------------------------------------------
+# PortAudio single-callback: RX-fan AND TX-pull in ONE callback
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_sd() -> tuple[type, dict[str, object]]:
+    """A fake ``sd`` exposing a ``Stream`` that captures its duplex callback."""
+    captured: dict[str, object] = {}
+
+    class FakeSd:
+        class Stream:
+            def __init__(self, **kw: object) -> None:
+                captured["kwargs"] = kw
+                captured["callback"] = kw["callback"]
+
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+    return FakeSd, captured
+
+
+class TestPortAudioDuplexCallback:
+    @pytest.mark.asyncio()
+    async def test_open_duplex_opens_single_stream_with_pair_args(self) -> None:
+        FakeSd, captured = _make_fake_sd()
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        stream = backend.open_duplex(
+            AudioDeviceId(3),
+            sample_rate=48_000,
+            channels=2,
+            frame_ms=20,
+            deliver_channels=1,
+            rx_audio_channel="left",
+        )
+        await stream.start(lambda _pcm: None)
+        kwargs = captured["kwargs"]
+        # ONE stream, both directions targeting the SAME device index, opened at
+        # the native channel count for both legs.
+        assert kwargs["device"] == (3, 3)
+        assert kwargs["channels"] == (2, 2)
+        assert kwargs["samplerate"] == 48_000
+        assert kwargs["dtype"] == "int16"
+        assert callable(kwargs["callback"])
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_single_callback_fans_rx_and_pulls_tx(self) -> None:
+        """ONE callback must (a) deliver indata to the RX consumer AND
+        (b) fill outdata from the TX queue — both directions in one call."""
+        FakeSd, captured = _make_fake_sd()
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        # Mono deliver on a stereo-native device (FTX-1 RX on LEFT channel),
+        # mono TX leg (the radio's USB MOD consumes one channel).
+        stream = backend.open_duplex(
+            AudioDeviceId(0),
+            sample_rate=48_000,
+            channels=2,
+            frame_ms=20,
+            deliver_channels=1,
+            rx_audio_channel="left",
+            tx_channels=1,
+        )
+        received: list[bytes] = []
+        await stream.start(received.append)
+        cb = captured["callback"]
+        assert callable(cb)
+
+        # Queue one mono 20 ms TX frame (960 samples) to be pulled into outdata.
+        tx_frame = b"".join(struct.pack("<h", (v % 200) - 100) for v in range(960))
+        await stream.write(tx_frame)
+
+        # Build one duplex callback: indata = 960 stereo frames (L = signal,
+        # R = silence), outdata = 960 mono frames to fill.
+        frames = 960
+        indata = _stereo_left_signal(frames)
+        outdata = bytearray(frames * 1 * 2)  # mono out
+
+        cb(indata, outdata, frames, None, None)  # type: ignore[operator]
+
+        # (a) RX fan: one 20 ms mono frame delivered, LEFT channel at full level
+        # (the silent R was NOT mixed in — left-only downmix).
+        assert len(received) == 1
+        assert received[0] == _expected_left_mono(frames)
+        # (b) TX pull: outdata filled from the queued TX frame.
+        assert bytes(outdata) == tx_frame
+
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_callback_fills_silence_when_tx_queue_empty(self) -> None:
+        FakeSd, captured = _make_fake_sd()
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        stream = backend.open_duplex(
+            AudioDeviceId(0),
+            sample_rate=48_000,
+            channels=2,
+            frame_ms=20,
+            deliver_channels=2,
+        )
+        received: list[bytes] = []
+        await stream.start(received.append)
+        cb = captured["callback"]
+
+        frames = 960
+        indata = _stereo_left_signal(frames)
+        outdata = bytearray(frames * 2 * 2)  # stereo out
+        outdata[:] = b"\xaa" * len(outdata)  # poison: must be overwritten
+
+        cb(indata, outdata, frames, None, None)  # type: ignore[operator]
+
+        # TX queue empty → outdata zero-filled (silence), never the poison.
+        assert bytes(outdata) == b"\x00" * len(outdata)
+        # RX still fanned (stereo passthrough — deliver == open).
+        assert len(received) == 1
+        await stream.stop()
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthesize a stereo capture buffer with LEFT signal, RIGHT silence
+# ---------------------------------------------------------------------------
+
+
+class _FakeIndata:
+    """Mimics the sounddevice numpy buffer's ``tobytes()`` contract."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def tobytes(self) -> bytes:
+        return self._payload
+
+
+def _stereo_left_signal(frames: int) -> _FakeIndata:
+    out = bytearray()
+    for i in range(frames):
+        left = ((i % 200) - 100) * 3
+        out += struct.pack("<hh", left, 0)  # L = signal, R = silence
+    return _FakeIndata(bytes(out))
+
+
+def _expected_left_mono(frames: int) -> bytes:
+    out = bytearray()
+    for i in range(frames):
+        left = ((i % 200) - 100) * 3
+        out += struct.pack("<h", left)
+    return bytes(out)
+
+
+# ---------------------------------------------------------------------------
+# UsbAudioDriver.start_duplex — same-device RX+TX uses open_duplex
+# ---------------------------------------------------------------------------
+
+
+class TestUsbDriverDuplex:
+    @pytest.mark.asyncio()
+    async def test_start_duplex_uses_open_duplex_for_same_device(self) -> None:
+        from rigplane.audio.usb_driver import UsbAudioDriver
+
+        backend = FakeAudioBackend(devices=[DUPLEX_DEVICE])
+        driver = UsbAudioDriver(
+            rx_device="USB Audio CODEC",
+            tx_device="USB Audio CODEC",
+            backend=backend,
+            rx_audio_channel="left",
+        )
+        received: list[bytes] = []
+        await driver.start_duplex(received.append)
+
+        # ONE duplex stream opened; NO separate InputStream/OutputStream.
+        assert len(backend.duplex_streams) == 1
+        assert backend.rx_streams == []
+        assert backend.tx_streams == []
+        assert driver.rx_running is True
+        assert driver.tx_running is True
+
+        # RX fan reaches the supplied callback.
+        backend.duplex_streams[0].inject_frame(b"\x05\x06")
+        assert received == [b"\x05\x06"]
+
+        # TX push routes through the duplex stream's TX queue.
+        await driver._push_tx_pcm(b"\x07\x08")
+        assert backend.duplex_streams[0].written_frames == [b"\x07\x08"]
+
+        await driver.stop_duplex()
+        assert driver.rx_running is False
+        assert driver.tx_running is False
+
+    @pytest.mark.asyncio()
+    async def test_two_stream_path_unchanged_for_separate_devices(self) -> None:
+        """start_rx/start_tx keep using two separate streams (additive)."""
+        from rigplane.audio.usb_driver import UsbAudioDriver
+
+        backend = FakeAudioBackend(devices=[DUPLEX_DEVICE])
+        driver = UsbAudioDriver(backend=backend)
+        await driver.start_rx(lambda _pcm: None)
+        await driver.start_tx()
+        # Legacy two-stream path: NO duplex stream is opened.
+        assert len(backend.rx_streams) == 1
+        assert len(backend.tx_streams) == 1
+        assert backend.duplex_streams == []
+        await driver.stop_rx()
+        await driver.stop_tx()
+
+
+# ---------------------------------------------------------------------------
+# Bridge — duplex selection when RX device == TX device
+# ---------------------------------------------------------------------------
+
+
+class _FakeRadio:
+    """Minimal AudioCapable double for the bridge (no one-off mocks of streams)."""
+
+    model = "ftx1"
+    audio_codec = None
+
+    def __init__(self) -> None:
+        self.tx_started = False
+        self.pushed: list[bytes] = []
+        self.audio_bus = _FakeBus()
+
+    async def start_audio_tx_pcm(self, **_kw: object) -> None:
+        self.tx_started = True
+
+    async def push_audio_tx_pcm(self, frame: bytes) -> None:
+        self.pushed.append(frame)
+
+    async def stop_audio_tx_pcm(self) -> None:
+        self.tx_started = False
+
+
+class _FakeSubscription:
+    async def start(self) -> None:
+        pass
+
+    async def aclose(self) -> None:
+        pass
+
+    def __aiter__(self) -> "_FakeSubscription":
+        return self
+
+    async def __anext__(self) -> object:
+        import asyncio
+
+        await asyncio.sleep(3600)
+        raise StopAsyncIteration
+
+
+class _FakeBus:
+    def subscribe(self, *, name: str) -> _FakeSubscription:
+        return _FakeSubscription()
+
+
+class TestBridgeDuplexSelection:
+    @pytest.mark.asyncio()
+    async def test_bridge_uses_duplex_when_rx_device_equals_tx_device(self) -> None:
+        from rigplane.audio.bridge import AudioBridge
+
+        backend = FakeAudioBackend(devices=[DUPLEX_DEVICE])
+        radio = _FakeRadio()
+        bridge = AudioBridge(
+            radio,  # type: ignore[arg-type]
+            device_name="USB Audio CODEC",
+            backend=backend,
+            tx_enabled=True,
+        )
+        await bridge.start()
+        try:
+            # Same device for RX leg and TX leg → ONE duplex stream, no separate
+            # InputStream + OutputStream pair (which would -50 on the C-Media).
+            assert len(backend.duplex_streams) == 1
+            assert backend.rx_streams == []
+            assert backend.tx_streams == []
+        finally:
+            await bridge.stop()
+
+    @pytest.mark.asyncio()
+    async def test_bridge_two_stream_path_for_separate_devices(self) -> None:
+        from rigplane.audio.bridge import AudioBridge
+
+        backend = FakeAudioBackend(devices=[DUPLEX_DEVICE, SEPARATE_RX_DEVICE])
+        radio = _FakeRadio()
+        bridge = AudioBridge(
+            radio,  # type: ignore[arg-type]
+            device_name="USB Audio CODEC",
+            tx_device_name="BlackHole 2ch",
+            backend=backend,
+            tx_enabled=True,
+        )
+        await bridge.start()
+        try:
+            # Distinct RX/TX devices (BlackHole capture, CODEC playback) stay on
+            # the two-stream path: one OutputStream (rx leg) + one InputStream.
+            assert backend.duplex_streams == []
+            assert len(backend.tx_streams) == 1  # radio→device playback (open_tx)
+            assert len(backend.rx_streams) == 1  # device→radio capture (open_rx)
+        finally:
+            await bridge.stop()
+
+    @pytest.mark.asyncio()
+    async def test_bridge_rx_only_degrade_preserved_on_duplex(self) -> None:
+        """If the radio rejects TX start, the duplex bridge degrades to RX-only
+        playback (open_tx), not a duplex stream (MOR-242 preserved)."""
+        from rigplane.audio.bridge import AudioBridge
+
+        class _RejectsTxRadio(_FakeRadio):
+            async def start_audio_tx_pcm(self, **_kw: object) -> None:
+                raise RuntimeError("TX path not armed")
+
+        backend = FakeAudioBackend(devices=[DUPLEX_DEVICE])
+        radio = _RejectsTxRadio()
+        bridge = AudioBridge(
+            radio,  # type: ignore[arg-type]
+            device_name="USB Audio CODEC",
+            backend=backend,
+            tx_enabled=True,
+        )
+        await bridge.start()
+        try:
+            # No duplex stream — RX-only playback uses the plain output (open_tx).
+            assert backend.duplex_streams == []
+            assert len(backend.tx_streams) == 1  # radio→device playback only
+            assert backend.rx_streams == []  # no capture leg
+        finally:
+            await bridge.stop()


### PR DESCRIPTION
## Summary
Adds a **single-`sd.Stream` full-duplex** USB audio path so a USB-CODEC radio (FTX-1, X6200) can do digital-mode TX (computer audio → radio via USB MOD) **while** the browser RX stream + FFT scope keep running — without the macOS CoreAudio `AUHAL -50` that two separate streams (`InputStream`+`OutputStream`) cause on one C-Media device. Replaces the `--bridge-rx-only` workaround for the same-device case. Do-now resolution of **MOR-505 layer-2**, scoped from the 2026-06-07 unified-audio-architecture analysis; live de-risk confirmed a single duplex stream starts cleanly on the C-Media (no `-50`).

## Design (additive)
- **`_PortAudioDuplexStream`** + `AudioBackend.open_duplex` (`audio/backend.py`): wraps ONE `sd.Stream(device=(idx,idx), channels=(rx_open,tx), …)`. Its single callback does **RX-fan** (via a new shared `_RxFramer` — the SAME `rx_audio_channel` downmix + lossless fixed-`frame_ms` re-chunk that `_PortAudioRxStream` used, now extracted and used by both) and **TX-pull** (by embedding a `_PortAudioTxStream` and driving its `_output_callback`/ring; its own `sd` stream is never opened; silence on empty).
- **`UsbAudioDriver.start_duplex`** (`audio/usb_driver.py`): opens duplex when `rx.index == tx.index`, else raises (caller uses the two-stream path); forces a shared sample rate.
- **Bridge** (`audio/bridge.py`): `use_duplex = tx_armed AND tx_dev == rx_dev AND not virtual_loopback` → one duplex stream serves both legs. Virtual loopback (BlackHole/VB-Cable/PipeWire) stays two-stream; **MOR-242 RX-only degrade preserved** (and cleaner).

`open_rx`/`open_tx` signatures **unchanged**; `_PortAudioTxStream` **byte-identical**; nothing renamed/removed (rigplane-pro-stable `audio/__init__` contract intact). All within the `audio` layer.

## Tests
`tests/test_audio_duplex.py` — 12 tests (FakeAudioBackend, in-test fake `sd`): single-callback RX-fan + TX-pull, left-only downmix parity with `start_rx`, silence-on-empty TX, `(2,2)` channel-pair open, driver same-device selection + two-stream-unchanged, bridge duplex-vs-two-stream selection + RX-only degrade. Fail on `origin/main` (no `DuplexStream`/`open_duplex`). 165 existing audio tests still pass.

## Gate
- `pytest --ignore=tests/integration` → 7284 passed, 0 failures
- existing audio suite (47 + 92) → all pass
- `ruff check` / `ruff format --check` → clean
- `mypy src/` → 20 baseline, 0 new (none in the 3 touched files)
- `lint-imports` → 4 kept, 0 broken

## Independent review
Implementer ≠ reviewer. Reviewer line-by-line confirmed the `_RxFramer` extraction is byte-identical to the old RX path (downmix/lossless-rechunk/marshalling/partial-frame carryover preserved), `_PortAudioTxStream` untouched (empty diff), duplex callback correctness (always fills `outdata`, no blocking, safe stop ordering), channel pairing, same-device + virtual-loopback exclusion, MOR-242 degrade, additive contract, and old-code falsification → **Agent Review: PASS**. Non-blocking notes: a same-device-virtual-loopback exclusion test could be added later; bridge duplex RX leg uses no downmix (matches existing two-stream `open_rx`).

## Deferred
**Live FTX-1 validation** (bridge enabled, NOT `--bridge-rx-only` → no `-50`, RX+scope keep flowing, TX path works on the same C-Media) — radio connected; orchestrator follow-up. The static + fake-backend evidence proves the topology/wiring; only live hardware proves the real CoreAudio `-50` avoidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)