### PR TITLE
fix: stable USB audio device selectors (index / hw:X,Y / platform_uid) (MOR-547)

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 import threading
 import time
 from collections import deque
@@ -29,6 +30,15 @@ _TX_BUFFER_MS = 1_000
 AudioDeviceId = NewType("AudioDeviceId", int)
 """Opaque device identifier (maps to a host-API device index)."""
 
+_ALSA_HW_RE = re.compile(r"(?:plug)?(hw:\d+,\d+)")
+
+
+def _platform_uid_from_device_name(name: str) -> str:
+    match = _ALSA_HW_RE.search(name)
+    if match is None:
+        return ""
+    return match.group(1)
+
 
 @dataclass(frozen=True, slots=True)
 class AudioDeviceInfo:
@@ -41,6 +51,7 @@ class AudioDeviceInfo:
     default_samplerate: int = 48_000
     is_default_input: bool = False
     is_default_output: bool = False
+    platform_uid: str = ""
 
     @property
     def supports_rx(self) -> bool:
@@ -1150,6 +1161,9 @@ class PortAudioBackend:
                     is_default_input=(default_in is not None and dev_idx == default_in),
                     is_default_output=(
                         default_out is not None and dev_idx == default_out
+                    ),
+                    platform_uid=_platform_uid_from_device_name(
+                        str(raw.get("name", f"device-{dev_idx}"))
                     ),
                 )
             )

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -25,6 +25,7 @@ from .backend import (
     PortAudioBackend,
     RxStream,
     TxStream,
+    _platform_uid_from_device_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -178,28 +179,103 @@ def _name_score(name: str) -> int:
     return 99
 
 
+def _format_device_choices(devices: list[UsbAudioDevice]) -> str:
+    choices: list[str] = []
+    for dev in sorted(devices, key=lambda item: (item.index, item.name.lower())):
+        label = f"[{dev.index}] {dev.name}"
+        if dev.platform_uid:
+            label = f"{label} ({dev.platform_uid})"
+        choices.append(label)
+    return ", ".join(choices) or "<none>"
+
+
+def _unique_override_match(
+    matches: list[UsbAudioDevice],
+    *,
+    override: str,
+    direction: str,
+) -> UsbAudioDevice | None:
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        available = _format_device_choices(matches)
+        raise AudioDeviceSelectionError(
+            f"Ambiguous {direction.upper()} device override {override!r}. "
+            f"Matching {direction.upper()} devices: {available}"
+        )
+    return None
+
+
 def _find_by_override(
     devices: list[UsbAudioDevice],
     *,
     override: str,
     direction: str,
 ) -> UsbAudioDevice:
-    if not override.strip():
+    selector = override.strip()
+    if not selector:
         raise AudioDeviceSelectionError(
             f"{direction.upper()} device override must be a non-empty string."
         )
-    exact = [dev for dev in devices if dev.name == override]
-    if len(exact) == 1:
-        return exact[0]
-    exact_ci = [dev for dev in devices if dev.name.lower() == override.lower()]
-    if len(exact_ci) == 1:
-        return exact_ci[0]
-    partial = [dev for dev in devices if override.lower() in dev.name.lower()]
-    if len(partial) == 1:
-        return partial[0]
-    available = ", ".join(sorted(dev.name for dev in devices)) or "<none>"
+
+    index_matches = [
+        dev
+        for dev in devices
+        if selector in {str(dev.index), f"[{dev.index}]", f"index:{dev.index}"}
+    ]
+    match = _unique_override_match(
+        index_matches,
+        override=selector,
+        direction=direction,
+    )
+    if match is not None:
+        return match
+
+    exact = [
+        dev
+        for dev in devices
+        if dev.name == selector or (dev.platform_uid and dev.platform_uid == selector)
+    ]
+    match = _unique_override_match(
+        exact,
+        override=selector,
+        direction=direction,
+    )
+    if match is not None:
+        return match
+
+    selector_ci = selector.lower()
+    exact_ci = [
+        dev
+        for dev in devices
+        if dev.name.lower() == selector_ci
+        or (dev.platform_uid and dev.platform_uid.lower() == selector_ci)
+    ]
+    match = _unique_override_match(
+        exact_ci,
+        override=selector,
+        direction=direction,
+    )
+    if match is not None:
+        return match
+
+    partial = [
+        dev
+        for dev in devices
+        if selector_ci in dev.name.lower()
+        or (dev.platform_uid and selector_ci in dev.platform_uid.lower())
+    ]
+    match = _unique_override_match(
+        partial,
+        override=selector,
+        direction=direction,
+    )
+    if match is not None:
+        return match
+
+    available = _format_device_choices(devices)
     raise AudioDeviceSelectionError(
-        f"Unknown {direction.upper()} device override {override!r}. "
+        f"Unknown {direction.upper()} device override {selector!r}. "
         f"Available {direction.upper()} devices: {available}"
     )
 
@@ -306,7 +382,11 @@ def _device_info_to_usb(
         default_samplerate=info.default_samplerate,
         is_default_input=info.is_default_input,
         is_default_output=info.is_default_output,
-        platform_uid=uid_map.get(info.name, ""),
+        platform_uid=(
+            info.platform_uid
+            or uid_map.get(info.name, "")
+            or _platform_uid_from_device_name(info.name)
+        ),
     )
 
 
@@ -352,7 +432,8 @@ def list_usb_audio_devices(sounddevice_module: Any) -> list[UsbAudioDevice]:
                 is_default_output=(
                     default_output_idx is not None and index == default_output_idx
                 ),
-                platform_uid=uid_map.get(name, ""),
+                platform_uid=uid_map.get(name, "")
+                or _platform_uid_from_device_name(name),
             )
         )
     return normalized

--- a/tests/test_usb_audio_stub.py
+++ b/tests/test_usb_audio_stub.py
@@ -69,6 +69,100 @@ def test_select_usb_audio_devices_explicit_overrides_take_precedence() -> None:
     assert selected_tx.name == "A"
 
 
+def test_select_usb_audio_devices_override_accepts_device_index() -> None:
+    devices = [
+        UsbAudioDevice(
+            index=1, name="USB Audio CODEC", input_channels=2, output_channels=2
+        ),
+        UsbAudioDevice(
+            index=3, name="USB Audio CODEC", input_channels=2, output_channels=2
+        ),
+    ]
+    selected_rx, selected_tx = select_usb_audio_devices(
+        devices,
+        rx_device="3",
+        tx_device="3",
+    )
+    assert selected_rx.index == 3
+    assert selected_tx.index == 3
+
+
+def test_select_usb_audio_devices_override_accepts_hardware_identifier() -> None:
+    devices = [
+        UsbAudioDevice(
+            index=1,
+            name="USB Audio CODEC",
+            input_channels=2,
+            output_channels=2,
+            platform_uid="alsa:hw:1,0",
+        ),
+        UsbAudioDevice(
+            index=3,
+            name="USB Audio CODEC",
+            input_channels=2,
+            output_channels=2,
+            platform_uid="alsa:hw:3,0",
+        ),
+    ]
+    selected_rx, selected_tx = select_usb_audio_devices(
+        devices,
+        rx_device="hw:3,0",
+        tx_device="hw:3,0",
+    )
+    assert selected_rx.index == 3
+    assert selected_tx.index == 3
+
+
+def test_select_usb_audio_devices_duplicate_name_override_is_ambiguous() -> None:
+    devices = [
+        UsbAudioDevice(
+            index=1, name="USB Audio CODEC", input_channels=2, output_channels=2
+        ),
+        UsbAudioDevice(
+            index=3, name="USB Audio CODEC", input_channels=2, output_channels=2
+        ),
+    ]
+    with pytest.raises(AudioDeviceSelectionError, match="Ambiguous RX device override"):
+        select_usb_audio_devices(devices, rx_device="USB Audio CODEC")
+
+
+@pytest.mark.asyncio
+async def test_usb_audio_driver_override_uses_backend_hardware_identifier() -> None:
+    backend = FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="USB Audio CODEC",
+                input_channels=2,
+                output_channels=2,
+                platform_uid="alsa:hw:1,0",
+            ),
+            AudioDeviceInfo(
+                id=AudioDeviceId(3),
+                name="USB Audio CODEC",
+                input_channels=2,
+                output_channels=2,
+                platform_uid="alsa:hw:3,0",
+            ),
+        ]
+    )
+    driver = UsbAudioDriver(
+        backend=backend,
+        rx_device="hw:3,0",
+        tx_device="hw:3,0",
+    )
+
+    await driver.start_rx(lambda _: None)
+    await driver.start_tx()
+
+    assert driver.selected_rx_device is not None
+    assert driver.selected_rx_device.index == 3
+    assert driver.selected_tx_device is not None
+    assert driver.selected_tx_device.index == 3
+    await driver.stop_tx()
+    await driver.stop_rx()
+
+
 def test_select_usb_audio_devices_auto_detect_prefers_usb_audio_codec() -> None:
     # Generic "USB Audio CODEC" now ranks above vendor-specific names so the
     # driver works equally well for Icom, Yaesu and Kenwood radios (all use


### PR DESCRIPTION
## What / why

Explicit `--rx-device` / `--tx-device` overrides previously matched by device *name* only, which breaks when multiple identical USB codecs are attached (e.g. two "USB Audio CODEC" entries). This PR makes selectors stable:

- **Device index**: `3`, `[3]`, or `index:3`
- **Platform UID**: e.g. ALSA `hw:3,0` (exact, case-insensitive, or partial match against `platform_uid`)
- **Name**: exact → case-insensitive → partial fallback, now also checked against `platform_uid`
- **Ambiguity is an error**: when a selector matches multiple devices, `AudioDeviceSelectionError` lists all matching devices with `[index] name (platform_uid)` labels instead of silently failing with "Unknown device"
- `PortAudioBackend.list_devices()` / `list_usb_audio_devices()` now derive `platform_uid` from ALSA-style names (`hw:X,Y` / `plughw:X,Y`) via new `_platform_uid_from_device_name()` helper, so UIDs are available even without a sounddevice UID map

Unblocks MOR-420.

## Source

Port of the MOR-390 core hooks from stale draft PR #1717, original commit `8c5a5e72` ("fix(MOR-390): support stable USB audio selectors", branch `codex/mor-387-388-390-core-fixes`), re-based onto current `main` (`d0a15d27`).

Scope intentionally limited to the 3 core files: `src/rigplane/audio/usb_driver.py`, `src/rigplane/audio/backend.py`, `tests/test_usb_audio_stub.py`. The original commit's docs/CLI-JSON-output/`tests/test_audio_backend.py` additions were deliberately left out of this port (follow-up material; the CLI bit only adds `platform_uid` to `list-audio-devices --json` output).

## Conflict-resolution notes

Expected conflicts with MOR-531 (`start_duplex` / `open_duplex` / `_PortAudioDuplexStream`) and MOR-508 (`rx_audio_channel`) did **not** materialize — `git cherry-pick -n 8c5a5e72` auto-merged cleanly; the selector change is purely additive (new helpers + rewritten `_find_by_override()`), applied at shifted offsets. Diff vs `origin/main` was verified hunk-by-hunk against the original commit; all main-side duplex/channel code is untouched.

## Falsification evidence

With the new tests in place and `src/rigplane/audio/{usb_driver,backend}.py` temporarily restored to `origin/main`, exactly the 4 new tests failed:

```
FAILED tests/test_usb_audio_stub.py::test_select_usb_audio_devices_override_accepts_device_index
FAILED tests/test_usb_audio_stub.py::test_select_usb_audio_devices_override_accepts_hardware_identifier
FAILED tests/test_usb_audio_stub.py::test_select_usb_audio_devices_duplicate_name_override_is_ambiguous
FAILED tests/test_usb_audio_stub.py::test_usb_audio_driver_override_uses_backend_hardware_identifier
4 failed, 13 passed
```

(`Unknown RX device override '3'`, `Unknown ... 'hw:3,0'`, ambiguity regex not matched, `AudioDeviceInfo.__init__() got an unexpected keyword argument 'platform_uid'`.)

After re-applying the implementation: `17 passed`.

## Gate results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7288 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 547 files already formatted
- `uv run mypy src/` — 20 errors in 7 files (exact pre-existing baseline, **zero new**)
- `uv run lint-imports` — Contracts: 4 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)