### PR TITLE
feat: audio_tx_codec + audio_duplex_mode descriptors on the Icom LAN runtime (MOR-535, AudioTransport 2/12)

### DIFF
--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -451,6 +451,32 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         return self._audio_codec
 
     @property
+    def audio_tx_codec(self) -> AudioCodec:
+        """Effective TX codec (MOR-532 codec descriptor surface).
+
+        Prefers the negotiated ``AudioStreamContract.tx_codec`` when a
+        contract exists, falling back to the internal ``_audio_tx_codec``
+        default (``PCM_1CH_16BIT``) — the same precedence resolved in
+        ``IcomRadio.__init__``. Consumed by later MOR-532 epic steps.
+        """
+        contract = getattr(self, "_audio_stream_contract", None)
+        tx_codec = getattr(contract, "tx_codec", None)
+        if tx_codec is not None:
+            return AudioCodec(tx_codec)
+        return getattr(self, "_audio_tx_codec", AudioCodec.PCM_1CH_16BIT)
+
+    @property
+    def audio_duplex_mode(self) -> str:
+        """Duplex capability (MOR-532 duplex descriptor surface).
+
+        The Icom LAN UDP audio stream is genuinely full-duplex: RX frames
+        keep flowing while TX is active, and ``stop_tx`` reverts the stream
+        state to RECEIVING. Single source of duplex policy for later MOR-532
+        epic steps.
+        """
+        return "full"
+
+    @property
     def audio_sample_rate(self) -> int:
         """Configured audio sample rate in Hz."""
         return self._audio_sample_rate

--- a/tests/test_audio_tx_contract_consistency.py
+++ b/tests/test_audio_tx_contract_consistency.py
@@ -200,6 +200,48 @@ class TestNegotiatedContractDrivesWireCodec:
 
 
 # ---------------------------------------------------------------------------
+# Guard — MOR-535 (AudioTransport 2/12): codec/duplex descriptor surface.
+# ---------------------------------------------------------------------------
+
+
+class TestMor535AudioDescriptorSurface:
+    def test_icom_radio_exposes_descriptor_properties(self) -> None:
+        """IcomRadio carries the MOR-532 codec/duplex descriptor surface."""
+        radio = IcomRadio("192.168.1.100", model="IC-7300")
+        assert isinstance(radio.audio_tx_codec, AudioCodec)
+        assert radio.audio_duplex_mode == "full"
+
+    def test_audio_tx_codec_prefers_negotiated_contract(self) -> None:
+        """After negotiation the contract's ``tx_codec`` wins over the default."""
+        radio = IcomRadio("192.168.1.100", model="IC-7300")
+        assert radio.audio_tx_codec == radio.audio_stream_contract.tx_codec
+        # Perturb the internal default: the negotiated contract still wins,
+        # mirroring the precedence resolved in ``IcomRadio.__init__``.
+        radio._audio_tx_codec = AudioCodec.OPUS_1CH
+        assert radio.audio_tx_codec == radio.audio_stream_contract.tx_codec
+
+    def test_audio_tx_codec_falls_back_before_negotiation(self) -> None:
+        """Without a contract the internal ``_audio_tx_codec`` default applies."""
+        harness = _ContractValidatorHarness(
+            tx_codec=AudioCodec.OPUS_1CH,
+            sample_rate=48000,
+            channels=1,
+            frame_ms=20,
+        )
+        # The harness never negotiates an ``AudioStreamContract``.
+        assert harness.audio_tx_codec == AudioCodec.OPUS_1CH
+        assert harness.audio_duplex_mode == "full"
+
+    def test_audio_tx_codec_safe_on_bare_mixin_host(self) -> None:
+        """A mixin host with neither attr resolves the wire-default codec."""
+
+        class _Bare(AudioRuntimeMixin):
+            pass
+
+        assert _Bare().audio_tx_codec == AudioCodec.PCM_1CH_16BIT
+
+
+# ---------------------------------------------------------------------------
 # Guard 3 — contract rate/channels feed the validator's frame size.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Step 2/12 of the MOR-532 AudioTransport epic (Linear MOR-535): adds the read-only codec/duplex descriptor surface to the Icom LAN runtime, next to the existing `audio_codec` property in `src/rigplane/runtime/_audio_runtime_mixin.py`.

- **`audio_tx_codec`** — promotes the internal `_audio_tx_codec` attr; prefers the negotiated `AudioStreamContract.tx_codec` when a contract exists, mirroring the precedence resolved in `IcomRadio.__init__` (runtime/radio.py:842). getattr-safe on mixin hosts without those attrs (falls back to `PCM_1CH_16BIT`).
- **`audio_duplex_mode`** — returns the literal `"full"`: the LAN UDP audio stream is genuinely full-duplex (RX keeps flowing during TX; `stop_tx` reverts stream state to RECEIVING — see `audio/lan_stream.py`). Single source of duplex policy for later epic steps.

No protocol edits, no consumer edits; `AudioCapable` in `core/radio_protocol.py` untouched.

## Tests (TDD)

Extended `tests/test_audio_tx_contract_consistency.py` (reusing its existing harness/fakes) with `TestMor535AudioDescriptorSurface`:

- `IcomRadio` exposes both properties; `audio_duplex_mode == "full"`.
- `audio_tx_codec` returns the negotiated `tx_codec` after contract negotiation, even when the internal default is perturbed.
- Falls back to `_audio_tx_codec` when no contract is negotiated (harness case) and to `PCM_1CH_16BIT` on a bare mixin host.

Red→green verified: all 4 new tests failed with `AttributeError` before the implementation, all pass after.

## Gate results (worktree)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7292 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 547 files already formatted
- `uv run mypy src/` — 20 errors in 7 files (baseline; zero new)
- `uv run lint-imports` — 4 kept / 0 broken

Diff: 2 files, +68 LOC (26 src / 42 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)