### PR TITLE
feat: USB duplex-policy resolver on UsbAudioDriver (MOR-534, AudioTransport 1/12)

### DIFF
--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -15,7 +15,7 @@ import asyncio
 import logging
 import sys
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from .backend import (
     AudioBackend,
@@ -446,6 +446,44 @@ def _extract_sounddevice_module(backend: AudioBackend) -> Any | None:
     return None
 
 
+def resolve_usb_duplex_mode(
+    rx_dev: UsbAudioDevice,
+    tx_dev: UsbAudioDevice,
+) -> Literal["full", "exclusive"]:
+    """Resolve the USB duplex policy for a selected RX/TX device pair.
+
+    Returns ``"exclusive"`` iff the platform is macOS AND RX and TX resolve
+    to the same device index AND the device is a real CODEC (not a virtual
+    loopback such as BlackHole/VB-Cable). On macOS CoreAudio, two separate
+    streams on one real C-Media USB CODEC fail with AUHAL -50 (MOR-531), so
+    such a device must be owned exclusively by ONE full-duplex stream.
+    Everything else — separate devices, virtual loopbacks, non-macOS
+    platforms — supports the two-stream path: ``"full"``.
+
+    Pure read-only policy (MOR-534, AudioTransport 1/12): nothing consumes
+    it yet; later epic steps route stream setup through it.
+    """
+    if sys.platform != "darwin":
+        return "full"
+    if rx_dev.index != tx_dev.index:
+        return "full"
+    # Single source of truth with the bridge path: reuse (not move) the
+    # virtual-loopback predicate. Imported lazily and called via the module
+    # attribute so existing monkeypatch targets on ``rigplane.audio.bridge``
+    # keep steering both consumers.
+    from rigplane.audio import bridge
+
+    info = AudioDeviceInfo(
+        id=AudioDeviceId(rx_dev.index),
+        name=rx_dev.name,
+        input_channels=rx_dev.input_channels,
+        output_channels=rx_dev.output_channels,
+    )
+    if bridge._is_virtual_loopback_device(info):
+        return "full"
+    return "exclusive"
+
+
 class UsbAudioDriver:
     """Stateful USB audio driver with deterministic device selection.
 
@@ -514,6 +552,18 @@ class UsbAudioDriver:
     @property
     def selected_tx_device(self) -> UsbAudioDevice | None:
         return self._selected_tx
+
+    @property
+    def duplex_mode(self) -> Literal["full", "exclusive"]:
+        """USB duplex policy for the resolved RX/TX pair (lazy, read-only).
+
+        Resolves devices via the normal selection path on first access; see
+        :func:`resolve_usb_duplex_mode` for the policy itself.
+        """
+        rx, tx = self._selected_rx, self._selected_tx
+        if rx is None or tx is None:
+            rx, tx = self._ensure_selected_devices()
+        return resolve_usb_duplex_mode(rx, tx)
 
     @property
     def usb_audio_contract(self) -> UsbAudioContract | None:
@@ -989,5 +1039,6 @@ __all__ = [
     "UsbAudioDriver",
     "UsbAudioStreamContract",
     "list_usb_audio_devices",
+    "resolve_usb_duplex_mode",
     "select_usb_audio_devices",
 ]

--- a/tests/test_usb_duplex_mode.py
+++ b/tests/test_usb_duplex_mode.py
@@ -1,0 +1,121 @@
+"""Tests for the USB duplex-policy resolver (MOR-534, AudioTransport 1/12).
+
+Pure read-only policy: ``resolve_usb_duplex_mode`` plus the lazy
+``UsbAudioDriver.duplex_mode`` property. ``"exclusive"`` iff macOS AND
+RX/TX resolve to the same device index AND the device is a real CODEC
+(not a virtual loopback). Nothing consumes the policy yet.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from rigplane.audio import bridge
+from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.audio.usb_driver import (
+    UsbAudioDevice,
+    UsbAudioDriver,
+    resolve_usb_duplex_mode,
+)
+
+
+def _codec(index: int = 1, name: str = "USB Audio CODEC") -> UsbAudioDevice:
+    return UsbAudioDevice(
+        index=index,
+        name=name,
+        input_channels=2,
+        output_channels=2,
+    )
+
+
+def _darwin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+
+def test_same_codec_device_on_macos_is_exclusive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _darwin(monkeypatch)
+    dev = _codec()
+    assert resolve_usb_duplex_mode(dev, dev) == "exclusive"
+
+
+def test_separate_devices_on_macos_are_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _darwin(monkeypatch)
+    assert resolve_usb_duplex_mode(_codec(index=1), _codec(index=2)) == "full"
+
+
+def test_virtual_loopback_on_macos_is_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _darwin(monkeypatch)
+    dev = _codec(name="BlackHole 2ch")
+    assert resolve_usb_duplex_mode(dev, dev) == "full"
+
+
+def test_same_codec_device_on_non_darwin_is_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    dev = _codec()
+    assert resolve_usb_duplex_mode(dev, dev) == "full"
+
+
+def test_resolver_shares_bridge_loopback_predicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Monkeypatching the bridge predicate must steer the resolver too."""
+    _darwin(monkeypatch)
+    seen: list[str] = []
+
+    def fake_predicate(dev: AudioDeviceInfo) -> bool:
+        seen.append(dev.name)
+        return True
+
+    monkeypatch.setattr(bridge, "_is_virtual_loopback_device", fake_predicate)
+    dev = _codec()
+    assert resolve_usb_duplex_mode(dev, dev) == "full"
+    assert seen == [dev.name]
+
+
+def test_driver_duplex_mode_property_same_codec_macos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _darwin(monkeypatch)
+    backend = FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="USB Audio CODEC",
+                input_channels=2,
+                output_channels=2,
+            ),
+        ]
+    )
+    driver = UsbAudioDriver(backend=backend)
+    assert driver.duplex_mode == "exclusive"
+    # The lazy property resolves devices via the normal selection path.
+    assert driver.selected_rx_device is not None
+    assert driver.selected_tx_device is not None
+
+
+def test_driver_duplex_mode_property_loopback_macos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _darwin(monkeypatch)
+    backend = FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="BlackHole 2ch",
+                input_channels=2,
+                output_channels=2,
+            ),
+        ]
+    )
+    driver = UsbAudioDriver(backend=backend)
+    assert driver.duplex_mode == "full"


### PR DESCRIPTION
## Summary

Step 1/12 of the MOR-532 AudioTransport epic (Linear MOR-534).

Adds a pure read-only USB duplex policy to `src/rigplane/audio/usb_driver.py`:

- Module-level `resolve_usb_duplex_mode(rx_dev, tx_dev) -> Literal["full", "exclusive"]` — returns `"exclusive"` iff the platform is macOS AND RX and TX resolve to the same device index AND the device is a real CODEC (not a virtual loopback); `"full"` otherwise (separate devices, virtual loopbacks like BlackHole/VB-Cable, non-macOS).
- Lazy `UsbAudioDriver.duplex_mode` property — resolves devices via the normal `_ensure_selected_devices` selection path on first access.

Rationale: single source of truth for the macOS CoreAudio AUHAL -50 same-device reality (MOR-531 context). Pure policy — nothing consumes it yet; later epic steps route stream setup through it. Zero behavior change anywhere.

The virtual-loopback predicate `_is_virtual_loopback_device` stays in `audio/bridge.py` (shared via late module-attribute lookup, not moved), so existing monkeypatch targets in bridge tests keep working — verified by a dedicated test.

## Tests (TDD, falsification-first)

New `tests/test_usb_duplex_mode.py` (7 tests, confirmed FAILING before implementation, PASSING after):

- same CODEC device on macOS → `"exclusive"`
- separate devices on macOS → `"full"`
- virtual loopback (BlackHole) same-device on macOS → `"full"`
- same device on non-Darwin (monkeypatched platform) → `"full"`
- monkeypatching `bridge._is_virtual_loopback_device` steers the resolver (shared predicate, late binding)
- `UsbAudioDriver.duplex_mode` lazy property: CODEC → `"exclusive"`, loopback → `"full"` (using `FakeAudioBackend`, no one-off mocks)

## Gate results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 7295 passed, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures (incl. `tests/test_audio_duplex.py` and bridge tests unchanged and green)
- `uv run ruff check src/ tests/` — all checks passed; `uv run ruff format --check` — 548 files already formatted
- `uv run mypy src/` — 20 errors in 7 files (baseline, zero new)
- `uv run lint-imports` — 4 kept, 0 broken

## Scope

2 files, +173/-1 (52 LOC in `usb_driver.py`, rest is the test module). Within guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)