### PR TITLE
feat: expose platform_uid in list-audio-devices --json (MOR-548)

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -143,6 +143,8 @@ If `--serial-baud` and `ICOM_SERIAL_BAUDRATE` are both unset:
 ### Audio device selection (serial backend)
 
 The serial backend uses USB audio devices exported by the radio. By default, devices are auto-detected.
+When display names are duplicated, pass a PortAudio device index or a unique
+hardware identifier such as `hw:3,0` instead of the shared display name.
 
 ```bash
 # List all available audio devices
@@ -153,6 +155,12 @@ rigplane --list-audio-devices --json
 rigplane --backend serial --serial-port /dev/tty.usbmodem-IC7610 \
     --rx-device "IC-7610 USB Audio" \
     --tx-device "IC-7610 USB Audio" \
+    audio rx --out rx.wav --seconds 10
+
+# Specify an ALSA hardware id from --list-audio-devices --json
+rigplane --backend serial --serial-port /dev/ttyACM0 \
+    --rx-device "hw:3,0" \
+    --tx-device "hw:3,0" \
     audio rx --out rx.wav --seconds 10
 ```
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -31,8 +31,8 @@ rigplane supports two backends selected via `--backend`:
 | Device | `device` | `--serial-port` | `ICOM_SERIAL_DEVICE` | — | Serial device path (required) |
 | Baud rate | `baudrate` | `--serial-baud` | `ICOM_SERIAL_BAUDRATE` | `115200` | CI-V baud rate |
 | PTT mode | `ptt_mode` | `--serial-ptt-mode` | `ICOM_SERIAL_PTT_MODE` | `civ` | Serial PTT control mode (`civ` supported) |
-| RX device | `rx_device` | `--rx-device` | `ICOM_USB_RX_DEVICE` | auto | USB audio RX device name |
-| TX device | `tx_device` | `--tx-device` | `ICOM_USB_TX_DEVICE` | auto | USB audio TX device name |
+| RX device | `rx_device` | `--rx-device` | `ICOM_USB_RX_DEVICE` | auto | USB audio RX device selector (name, index, or hardware id) |
+| TX device | `tx_device` | `--tx-device` | `ICOM_USB_TX_DEVICE` | auto | USB audio TX device selector (name, index, or hardware id) |
 | CI-V Address | `radio_addr` | — | — | `0x98` (IC-7610) | Radio's CI-V address |
 | Timeout | `timeout` | `--timeout` | — | `5.0` | Operation timeout (seconds) |
 

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -1751,6 +1751,7 @@ async def _cmd_list_audio_devices(args: argparse.Namespace) -> int:
                         "default_samplerate": d.default_samplerate,
                         "is_default_input": d.is_default_input,
                         "is_default_output": d.is_default_output,
+                        "platform_uid": d.platform_uid,
                     }
                     for d in devices
                 ]

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -358,6 +358,27 @@ class TestPortAudioBackendDeps:
         assert devices[1].is_default_output is True
         assert devices[1].output_channels == 2
 
+    def test_list_devices_extracts_alsa_hardware_identifier(self) -> None:
+        class FakeSd:
+            class default:
+                device = [-1, -1]
+
+            @staticmethod
+            def query_devices() -> list[dict]:
+                return [
+                    {
+                        "index": 3,
+                        "name": "USB Audio CODEC: Audio (hw:3,0)",
+                        "max_input_channels": 2,
+                        "max_output_channels": 2,
+                        "default_samplerate": 48000,
+                    },
+                ]
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        devices = backend.list_devices()
+        assert devices[0].platform_uid == "hw:3,0"
+
     def test_open_rx_returns_rx_stream(self) -> None:
         class FakeSd:
             class InputStream:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1465,7 +1465,7 @@ class TestListAudioDevices:
         mock_sd.query_devices.return_value = [
             {
                 "index": 0,
-                "name": "IC-7610 USB Audio",
+                "name": "IC-7610 USB Audio (hw:3,0)",
                 "max_input_channels": 1,
                 "max_output_channels": 1,
                 "default_samplerate": 48000,
@@ -1482,8 +1482,9 @@ class TestListAudioDevices:
         assert result == 0
         captured = capsys.readouterr()
         data = json_module.loads(captured.out.strip())
-        assert data[0]["name"] == "IC-7610 USB Audio"
+        assert data[0]["name"] == "IC-7610 USB Audio (hw:3,0)"
         assert data[0]["index"] == 0
+        assert data[0]["platform_uid"] == "hw:3,0"
 
 
 class TestCheckPortsAvailable:


### PR DESCRIPTION
## What

Finishes the MOR-390 port (original commit `8c5a5e72` on `codex/mor-387-388-390-core-fixes`): brings over the pieces that PR #1736 (merged as `b09d0a4c`) deliberately dropped.

- `src/rigplane/cli/__init__.py` — `platform_uid` field in `list-audio-devices --json` output (+1 LOC; `UsbAudioDevice.platform_uid` already exists on main from #1736)
- `docs/guide/cli.md` — duplicate-display-name note + `hw:3,0` selector example for `--rx-device`/`--tx-device`
- `docs/guide/configuration.md` — RX/TX device table rows updated from "device name" to "device selector (name, index, or hardware id)"
- `tests/test_audio_backend.py` — `test_list_devices_extracts_alsa_hardware_identifier`: direct unit test that `PortAudioBackend.list_devices()` extracts `hw:3,0` from an ALSA-style device name via `_platform_uid_from_device_name`
- `tests/test_cli.py` — `test_list_audio_devices_json_output` now asserts `platform_uid` is present in the JSON output

## Why

MOR-547 (#1736) ported the backend/driver selector machinery but left the CLI JSON surface, docs, and these two tests behind. Without `platform_uid` in `--json` output, users cannot discover the stable hardware id to pass as a selector.

## Red/green evidence

With the `cli/__init__.py` change stashed (everything else in place):

```
FAILED tests/test_cli.py::TestListAudioDevices::test_list_audio_devices_json_output
E   KeyError: 'platform_uid'   (tests/test_cli.py:1487)
```

With the change restored: both new tests pass.

## Gate results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 7289 passed, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, **0 failed**
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 547 files already formatted
- `uv run mypy src/` — 20 errors in 7 files (baseline, zero new)
- `uv run lint-imports` — 4 contracts kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)