### PR TITLE
feat: audio descriptors on YaesuCatRadio (MOR-537, AudioTransport 4/12)

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -319,6 +319,37 @@ class YaesuCatRadio:
         return AudioCodec.PCM_1CH_16BIT
 
     @property
+    def audio_tx_codec(self) -> AudioCodec:
+        """Effective TX codec (MOR-532 codec descriptor surface).
+
+        The FTX-1 TX path pushes raw PCM straight to the OS USB audio
+        device — there is no in-band Opus framing — so this is always
+        ``PCM_1CH_16BIT``. Consumed by later MOR-532 epic steps.
+        """
+        return AudioCodec.PCM_1CH_16BIT
+
+    @property
+    def audio_duplex_mode(self) -> str:
+        """Duplex capability (MOR-532 duplex descriptor surface).
+
+        Delegates to ``UsbAudioDriver.duplex_mode`` (MOR-534):
+        ``"exclusive"`` when macOS AUHAL would reject concurrent RX+TX
+        streams against the same physical USB CODEC (paramErr -50 — the
+        same-device reality previously encoded only in the
+        ``--bridge-rx-only`` flag), ``"full"`` otherwise. Falls back to
+        ``"full"`` when the driver does not expose the policy or device
+        resolution fails (offline / test doubles). Single source of duplex
+        policy for later MOR-532 epic steps.
+        """
+        try:
+            mode = getattr(self._audio_driver, "duplex_mode", None)
+        except Exception:
+            return "full"
+        if isinstance(mode, str):
+            return mode
+        return "full"
+
+    @property
     def audio_sample_rate(self) -> int:
         """Configured audio sample rate in Hz (default 48000)."""
         return self._audio_sample_rate

--- a/tests/test_yaesu_audio.py
+++ b/tests/test_yaesu_audio.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from typing import Callable
 from unittest.mock import AsyncMock
 
 import pytest
 
 from rigplane.audio import AudioPacket
+from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.audio.usb_driver import UsbAudioDriver
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.exceptions import AudioFormatError
 from rigplane.types import AudioCodec
@@ -137,6 +140,60 @@ class TestAudioCodecProperty:
 
     def test_is_not_opus(self, radio: YaesuCatRadio) -> None:
         assert radio.audio_codec not in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH)
+
+
+# ---------------------------------------------------------------------------
+# Audio descriptors — MOR-537 (AudioTransport epic step 4/12)
+# ---------------------------------------------------------------------------
+
+
+class TestAudioDescriptors:
+    """MOR-532 descriptor surface: ``audio_tx_codec`` + ``audio_duplex_mode``."""
+
+    def test_descriptors_present(self, radio: YaesuCatRadio) -> None:
+        assert hasattr(radio, "audio_tx_codec")
+        assert hasattr(radio, "audio_duplex_mode")
+
+    def test_audio_tx_codec_is_raw_pcm(self, radio: YaesuCatRadio) -> None:
+        assert radio.audio_tx_codec == AudioCodec.PCM_1CH_16BIT
+
+    def test_duplex_mode_same_device_macos_is_exclusive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "platform", "darwin")
+        backend = FakeAudioBackend(
+            [
+                AudioDeviceInfo(
+                    id=AudioDeviceId(1),
+                    name="USB Audio CODEC",
+                    input_channels=2,
+                    output_channels=2,
+                ),
+            ]
+        )
+        r = YaesuCatRadio(
+            device="/dev/fake0",
+            audio_driver=UsbAudioDriver(backend=backend),
+        )
+        assert r.audio_duplex_mode == "exclusive"
+
+    def test_duplex_mode_falls_back_to_full_without_driver_support(
+        self, radio: YaesuCatRadio
+    ) -> None:
+        # FakeAudioDriver has no ``duplex_mode`` — descriptor must not blow up.
+        assert radio.audio_duplex_mode == "full"
+
+    def test_duplex_mode_falls_back_to_full_when_driver_raises(self) -> None:
+        class RaisingDriver(FakeAudioDriver):
+            @property
+            def duplex_mode(self) -> str:
+                raise RuntimeError("no devices resolvable offline")
+
+        r = YaesuCatRadio(
+            device="/dev/fake0",
+            audio_driver=RaisingDriver(),  # type: ignore[arg-type]
+        )
+        assert r.audio_duplex_mode == "full"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Linear MOR-537 — step 4/12 of the MOR-532 AudioTransport epic: read-only audio descriptors on `YaesuCatRadio` (FTX-1), mirroring the MOR-535 LAN descriptors on `IcomRadio` (`runtime/_audio_runtime_mixin.py`).

- `audio_tx_codec` → `AudioCodec.PCM_1CH_16BIT`. The FTX-1 TX path pushes raw PCM straight to the OS USB audio device (no in-band Opus framing); this finally gives consumers' `getattr` chains a real source.
- `audio_duplex_mode` → delegates to `UsbAudioDriver.duplex_mode` (MOR-534, merged in `aa1c4852`) with `"full"` fallback when the driver doesn't expose the property or resolution raises (offline / test doubles). getattr-based, no protocol widening. Single-source-of-truth carrier for the macOS same-device AUHAL paramErr -50 reality, previously encoded nowhere but the `--bridge-rx-only` flag.

`usb_audio_contract` and all existing methods untouched. 2 files, +88 LOC.

## Tests (TDD, falsification-first)

New `TestAudioDescriptors` in `tests/test_yaesu_audio.py` (5 tests), confirmed RED (AttributeError) before implementation, GREEN after:

- both descriptors present
- `audio_tx_codec == AudioCodec.PCM_1CH_16BIT`
- same-device macOS (real `UsbAudioDriver` + `FakeAudioBackend` single "USB Audio CODEC" device, `sys.platform` monkeypatched to `darwin`, per the MOR-534 `tests/test_usb_duplex_mode.py` pattern) → `"exclusive"`
- stub driver lacking `duplex_mode` → `"full"`
- driver whose `duplex_mode` raises → `"full"`

No one-off MagicMocks of dataclasses.

## Gate results (worktree)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7305 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 548 files already formatted
- `uv run mypy src/` — 20 errors in 7 files (exact baseline, zero new)
- `uv run lint-imports` — 4 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)