### PR TITLE
feat: audio descriptors on the Icom serial base (MOR-536, AudioTransport 3/12)

### DIFF
--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -178,6 +178,35 @@ class _IcomSerialRadioBase(CoreRadio):
 
         return getattr(self._serial_audio_driver, "usb_audio_contract", None)
 
+    @property
+    def audio_tx_codec(self) -> AudioCodec:
+        """Effective TX codec (MOR-532 codec descriptor surface).
+
+        The serial USB CODEC mic input is mono-only by hardware:
+        ``start_audio_tx_pcm`` clamps the PortAudio output stream to one
+        channel (GH#1382), so the TX payload is always mono 16-bit PCM
+        regardless of the configured RX codec. Consumed by later MOR-532
+        epic steps.
+        """
+        return AudioCodec.PCM_1CH_16BIT
+
+    @property
+    def audio_duplex_mode(self) -> str:
+        """Duplex capability (MOR-532 duplex descriptor surface).
+
+        Delegates to the USB audio driver's ``duplex_mode`` policy (MOR-534)
+        via ``getattr`` so the internal ``_SerialAudioDriver`` protocol stays
+        narrow. Falls back to ``"full"`` when the driver does not expose the
+        property or when resolving it raises (device enumeration may fail on
+        offline hosts and test doubles). Single source of duplex policy for
+        later MOR-532 epic steps.
+        """
+        try:
+            mode = getattr(self._serial_audio_driver, "duplex_mode", None)
+        except Exception:
+            return "full"
+        return mode if isinstance(mode, str) else "full"
+
     # ------------------------------------------------------------------
     # Connection properties
     # ------------------------------------------------------------------

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -7,6 +7,7 @@ import asyncio
 import pytest
 
 from rigplane import IcomRadio, RadioConnectionState
+from rigplane.backends.ic705 import Ic705SerialRadio
 from rigplane.backends.icom7610 import Icom7610SerialRadio
 from rigplane import IC_7610_ADDR
 from rigplane.commands import (
@@ -631,3 +632,73 @@ async def test_serial_tx_accepts_none_args_resolving_to_defaults() -> None:
     assert usb_audio.tx_start_kwargs.get("channels") == 1
     await radio.stop_audio_tx_pcm()
     await radio.disconnect()
+
+
+class _DuplexAwareUsbAudioDriver(_FakeUsbAudioDriver):
+    """Fake USB driver that exposes the MOR-534 ``duplex_mode`` property."""
+
+    def __init__(self, mode: str = "exclusive") -> None:
+        super().__init__()
+        self._duplex_mode = mode
+
+    @property
+    def duplex_mode(self) -> str:
+        return self._duplex_mode
+
+
+class _RaisingDuplexUsbAudioDriver(_FakeUsbAudioDriver):
+    """Fake USB driver whose ``duplex_mode`` raises (offline enumeration)."""
+
+    @property
+    def duplex_mode(self) -> str:
+        raise RuntimeError("PortAudio device enumeration failed")
+
+
+def test_serial_audio_descriptors_present_on_serial_backends() -> None:
+    """MOR-536: both MOR-532 descriptors exist on the Icom serial backends."""
+    for radio_cls in (Icom7610SerialRadio, Ic705SerialRadio):
+        radio = radio_cls(
+            device="/dev/ttyUSB0",
+            civ_link=_FakeSerialCivLink(),
+            audio_driver=_FakeUsbAudioDriver(),
+        )
+        assert radio.audio_tx_codec == AudioCodec.PCM_1CH_16BIT
+        assert radio.audio_duplex_mode == "full"
+
+
+def test_serial_audio_tx_codec_is_mono_pcm_regardless_of_rx_codec() -> None:
+    """The serial USB CODEC TX path is always mono PCM (GH#1382 clamp)."""
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=_FakeUsbAudioDriver(),
+        audio_codec=AudioCodec.PCM_2CH_16BIT,
+    )
+    assert radio.audio_tx_codec == AudioCodec.PCM_1CH_16BIT
+
+
+def test_serial_audio_duplex_mode_delegates_to_driver() -> None:
+    """``audio_duplex_mode`` returns the driver's MOR-534 duplex policy."""
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=_DuplexAwareUsbAudioDriver("exclusive"),
+    )
+    assert radio.audio_duplex_mode == "exclusive"
+
+    radio_full = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=_DuplexAwareUsbAudioDriver("full"),
+    )
+    assert radio_full.audio_duplex_mode == "full"
+
+
+def test_serial_audio_duplex_mode_defaults_to_full_when_driver_raises() -> None:
+    """Device enumeration failures (offline hosts) fall back to ``"full"``."""
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=_RaisingDuplexUsbAudioDriver(),
+    )
+    assert radio.audio_duplex_mode == "full"


### PR DESCRIPTION
## Summary

Step 3/12 of the MOR-532 AudioTransport epic (Linear MOR-536): add the audio descriptor surface to `_IcomSerialRadioBase`, covering X6200 and the other Icom serial (USB CI-V) backends.

- `audio_tx_codec` → always `AudioCodec.PCM_1CH_16BIT`. The serial USB CODEC mic input is mono-only by hardware; `start_audio_tx_pcm` clamps the PortAudio output stream to one channel (GH#1382), so the TX payload is mono 16-bit PCM regardless of the configured RX codec.
- `audio_duplex_mode` → delegates to the USB audio driver's `duplex_mode` policy (MOR-534, merged in aa1c4852) via `getattr`, so the internal `_SerialAudioDriver` protocol stays narrow. Falls back to `"full"` when the driver does not expose the property or when resolving it raises (device enumeration may fail on offline hosts and test doubles).

Docstrings mirror the MOR-535 LAN descriptor wording in `runtime/_audio_runtime_mixin.py`. No `AudioCapable`/protocol changes, no consumers wired yet.

## Tests (TDD, falsification-first)

New tests in `tests/test_icom7610_serial_radio.py`, using the existing `_FakeUsbAudioDriver` stub pattern (no one-off MagicMocks):

- both descriptors present on `Icom7610SerialRadio` and `Ic705SerialRadio`
- `audio_tx_codec == AudioCodec.PCM_1CH_16BIT`, including with a stereo RX codec configured
- `audio_duplex_mode` returns the driver's value (`"exclusive"` / `"full"`) when the driver exposes `duplex_mode`
- `"full"` fallback for stubs without the property and for a driver whose property raises

Red→green: the delegation test failed before implementation (`assert 'full' == 'exclusive'` — the inherited LAN mixin descriptor returned `"full"` unconditionally); all 26 tests in the file pass after.

## Gate results (worktree)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7304 passed**, 9 skipped, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — All checks passed; `ruff format --check` — 548 files already formatted
- `uv run mypy src/` — 20 errors in 7 files (= baseline, zero new)
- `uv run lint-imports` — 4 kept, 0 broken

## Scope

2 files, +100 LOC (29 src / 71 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)