### PR TITLE
feat: AudioTransport neutral methods on the Icom LAN runtime (MOR-539, AudioTransport 6/12)

### DIFF
--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -49,23 +49,26 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     _audio_stream_contract: AudioStreamContract
 
     # ------------------------------------------------------------------
-    # Audio streaming
+    # Neutral AudioTransport surface (MOR-532 epic, MOR-539)
     # ------------------------------------------------------------------
 
-    async def start_audio_rx_opus(
+    async def start_rx(
         self,
         callback: Callable[[AudioPacket | None], None],
         *,
         jitter_depth: int = 5,
     ) -> None:
-        """Start receiving Opus audio from the radio.
+        """Start receiving audio from the radio (codec-neutral).
 
-        Connects the audio transport if not already connected,
-        then begins streaming RX audio to the callback.
+        Connects the audio transport if not already connected, then begins
+        streaming RX audio to the callback. Packets carry ``data`` encoded
+        per :attr:`audio_codec`.
 
         Args:
             callback: Called with each :class:`AudioPacket`.
             jitter_depth: Jitter buffer depth (0 to disable, default 5).
+                Implementation-specific widening of the minimal
+                ``AudioTransport.start_rx(callback)`` signature.
 
         Raises:
             ConnectionError: If not connected or audio port unavailable.
@@ -76,6 +79,79 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         self._opus_rx_user_callback = callback
         self._opus_rx_jitter_depth = jitter_depth
         await self._audio_stream.start_rx(callback, jitter_depth=jitter_depth)
+
+    async def stop_rx(self) -> None:
+        """Stop receiving audio from the radio (codec-neutral)."""
+        self._opus_rx_user_callback = None
+        if self._audio_stream is not None:
+            await self._audio_stream.stop_rx()
+
+    async def start_tx(self) -> None:
+        """Open the TX path, resolving format from the negotiated contract.
+
+        Codec-neutral (no format arguments): when the negotiated TX codec is
+        ``PCM_1CH_16BIT`` (direct Icom LAN conninfo) this follows the
+        contract-driven :meth:`start_audio_tx_pcm` path; otherwise the raw
+        stream-start (legacy opus) path.
+
+        Raises:
+            ConnectionError: If not connected or audio port unavailable.
+        """
+        if self.audio_tx_codec == AudioCodec.PCM_1CH_16BIT:
+            await self.start_audio_tx_pcm()
+        else:
+            await self._start_tx_stream()
+
+    async def push_tx(self, data: bytes) -> None:
+        """Send one audio frame encoded per :attr:`audio_tx_codec`.
+
+        Args:
+            data: Wire-codec audio frame bytes.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If audio TX not started.
+        """
+        self._check_connected()
+        if self._audio_stream is None:
+            raise RuntimeError("Audio TX not started")
+        await self._audio_stream.push_tx(data)
+
+    async def stop_tx(self) -> None:
+        """Close the TX path (codec-neutral)."""
+        if self._audio_stream is not None:
+            await self._audio_stream.stop_tx()
+        self._pcm_tx_fmt = None
+
+    async def _start_tx_stream(self) -> None:
+        """Raw TX stream start (the legacy ``start_audio_tx_opus`` body).
+
+        Deliberately does NOT touch ``_pcm_tx_fmt``: recovery snapshots rely
+        on it staying ``None`` for opus-only TX users.
+
+        Raises:
+            ConnectionError: If not connected or audio port unavailable.
+        """
+        self._check_connected()
+        await self._ensure_audio_transport()
+        assert self._audio_stream is not None
+        await self._audio_stream.start_tx()
+
+    # ------------------------------------------------------------------
+    # Audio streaming (legacy opus-family delegates + PCM conveniences)
+    # ------------------------------------------------------------------
+
+    async def start_audio_rx_opus(
+        self,
+        callback: Callable[[AudioPacket | None], None],
+        *,
+        jitter_depth: int = 5,
+    ) -> None:
+        """Start receiving Opus audio from the radio.
+
+        Back-compat delegate for :meth:`start_rx` (MOR-539).
+        """
+        await self.start_rx(callback, jitter_depth=jitter_depth)
 
     async def start_audio_rx_pcm(
         self,
@@ -146,10 +222,11 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         await self.stop_audio_rx_opus()
 
     async def stop_audio_rx_opus(self) -> None:
-        """Stop receiving Opus audio from the radio."""
-        self._opus_rx_user_callback = None
-        if self._audio_stream is not None:
-            await self._audio_stream.stop_rx()
+        """Stop receiving Opus audio from the radio.
+
+        Back-compat delegate for :meth:`stop_rx` (MOR-539).
+        """
+        await self.stop_rx()
 
     def _add_opus_rx_tap(
         self,
@@ -170,15 +247,11 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def start_audio_tx_opus(self) -> None:
         """Start transmitting Opus audio to the radio.
 
-        Connects the audio transport if not already connected.
-
-        Raises:
-            ConnectionError: If not connected or audio port unavailable.
+        Back-compat delegate for the raw stream start (MOR-539). Unlike the
+        neutral :meth:`start_tx`, this never routes through the PCM path —
+        it must not set ``_pcm_tx_fmt`` (recovery snapshot semantics).
         """
-        self._check_connected()
-        await self._ensure_audio_transport()
-        assert self._audio_stream is not None
-        await self._audio_stream.start_tx()
+        await self._start_tx_stream()
 
     async def start_audio_tx_pcm(
         self,
@@ -251,19 +324,11 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         self._pcm_tx_fmt = (sample_rate, channels, frame_ms)
 
     async def push_audio_tx_opus(self, opus_data: bytes) -> None:
-        """Send an Opus-encoded audio frame to the radio.
+        """Send one wire-codec audio frame to the radio.
 
-        Args:
-            opus_data: Opus-encoded audio data.
-
-        Raises:
-            ConnectionError: If not connected.
-            RuntimeError: If audio TX not started.
+        Back-compat delegate for :meth:`push_tx` (MOR-539).
         """
-        self._check_connected()
-        if self._audio_stream is None:
-            raise RuntimeError("Audio TX not started")
-        await self._audio_stream.push_tx(opus_data)
+        await self.push_tx(opus_data)
 
     async def push_audio_tx_pcm(
         self,
@@ -298,10 +363,11 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         await self.stop_audio_tx_opus()
 
     async def stop_audio_tx_opus(self) -> None:
-        """Stop transmitting Opus audio to the radio."""
-        if self._audio_stream is not None:
-            await self._audio_stream.stop_tx()
-        self._pcm_tx_fmt = None
+        """Stop transmitting Opus audio to the radio.
+
+        Back-compat delegate for :meth:`stop_tx` (MOR-539).
+        """
+        await self.stop_tx()
 
     async def start_audio_opus(
         self,

--- a/tests/test_audio_transport_lan.py
+++ b/tests/test_audio_transport_lan.py
@@ -1,0 +1,172 @@
+"""AudioTransport neutral methods on the Icom LAN runtime (MOR-539).
+
+Step 6/12 of the MOR-532 epic: ``IcomRadio`` gains the codec-neutral
+``start_rx``/``stop_rx``/``start_tx``/``push_tx``/``stop_tx`` methods and the
+legacy opus-family methods become one-line delegates onto them.
+
+Uses :class:`FakeAudioStream` (same harness as ``test_audio_recovery``) —
+no MagicMock dataclasses. All radio I/O is faked; no hardware needed.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import MagicMock
+
+import pytest
+
+from _audio_stream_fake import FakeAudioStream
+
+from rigplane.core.radio_protocol import AudioTransport
+from rigplane.core.types import AudioCodec
+from rigplane.radio import IcomRadio
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_radio() -> tuple[IcomRadio, FakeAudioStream]:
+    """Build a 'connected' IcomRadio with a FakeAudioStream installed."""
+    radio = IcomRadio("192.168.1.100")
+    radio._connected = True
+    radio._civ_transport = MagicMock()
+    stream = FakeAudioStream()
+    radio._audio_stream = stream
+    return radio, stream
+
+
+def _use_opus_tx_contract(radio: IcomRadio) -> None:
+    """Re-pin the negotiated contract to an Opus TX codec."""
+    radio._audio_stream_contract = dataclasses.replace(
+        radio.audio_stream_contract, tx_codec=AudioCodec.OPUS_1CH
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestAudioTransportConformance:
+    def test_icom_radio_satisfies_audio_transport(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        assert isinstance(radio, AudioTransport)
+
+    def test_neutral_methods_present(self) -> None:
+        radio = IcomRadio("192.168.1.100")
+        for name in ("start_rx", "stop_rx", "start_tx", "push_tx", "stop_tx"):
+            assert callable(getattr(radio, name))
+
+
+# ---------------------------------------------------------------------------
+# Delegation equivalence: legacy opus methods == neutral methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestRxDelegation:
+    async def test_start_rx_effects(self) -> None:
+        radio, stream = _make_radio()
+        cb = lambda pkt: None  # noqa: E731
+
+        await radio.start_rx(cb, jitter_depth=7)
+
+        assert stream.start_rx_count == 1
+        assert stream.last_start_rx_callback is cb
+        assert stream.last_start_rx_jitter_depth == 7
+        # Recovery-critical bookkeeping (read by _audio_recovery.capture_snapshot).
+        assert radio._opus_rx_user_callback is cb
+        assert radio._opus_rx_jitter_depth == 7
+
+    async def test_legacy_start_matches_neutral(self) -> None:
+        cb = lambda pkt: None  # noqa: E731
+        legacy, legacy_stream = _make_radio()
+        neutral, neutral_stream = _make_radio()
+
+        await legacy.start_audio_rx_opus(cb, jitter_depth=3)
+        await neutral.start_rx(cb, jitter_depth=3)
+
+        for stream in (legacy_stream, neutral_stream):
+            assert stream.start_rx_count == 1
+            assert stream.last_start_rx_callback is cb
+            assert stream.last_start_rx_jitter_depth == 3
+        for radio in (legacy, neutral):
+            assert radio._opus_rx_user_callback is cb
+            assert radio._opus_rx_jitter_depth == 3
+
+    async def test_stop_matches(self) -> None:
+        for method in ("stop_rx", "stop_audio_rx_opus"):
+            radio, stream = _make_radio()
+            radio._opus_rx_user_callback = lambda pkt: None
+            await getattr(radio, method)()
+            assert stream.stop_rx_count == 1
+            assert radio._opus_rx_user_callback is None
+
+
+@pytest.mark.asyncio
+class TestTxDelegation:
+    async def test_push_matches(self) -> None:
+        for method in ("push_tx", "push_audio_tx_opus"):
+            radio, stream = _make_radio()
+            await getattr(radio, method)(b"\x01\x02\x03")
+            assert stream.tx_frames == [b"\x01\x02\x03"]
+
+    async def test_push_raises_without_stream(self) -> None:
+        for method in ("push_tx", "push_audio_tx_opus"):
+            radio, _ = _make_radio()
+            radio._audio_stream = None
+            with pytest.raises(RuntimeError, match="Audio TX not started"):
+                await getattr(radio, method)(b"\x00")
+
+    async def test_stop_matches(self) -> None:
+        for method in ("stop_tx", "stop_audio_tx_opus"):
+            radio, stream = _make_radio()
+            radio._pcm_tx_fmt = (48000, 1, 20)
+            await getattr(radio, method)()
+            assert stream.stop_tx_count == 1
+            assert radio._pcm_tx_fmt is None
+
+
+# ---------------------------------------------------------------------------
+# start_tx routes per audio_tx_codec
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestStartTxRouting:
+    async def test_pcm_contract_routes_via_pcm_path(self) -> None:
+        radio, stream = _make_radio()
+        assert radio.audio_tx_codec == AudioCodec.PCM_1CH_16BIT
+
+        await radio.start_tx()
+
+        assert stream.start_tx_count == 1
+        contract = radio.audio_stream_contract
+        assert radio._pcm_tx_fmt == (
+            contract.tx_sample_rate_hz,
+            contract.tx_channels,
+            20,
+        )
+
+    async def test_opus_contract_routes_via_opus_path(self) -> None:
+        radio, stream = _make_radio()
+        _use_opus_tx_contract(radio)
+        assert radio.audio_tx_codec == AudioCodec.OPUS_1CH
+
+        await radio.start_tx()
+
+        assert stream.start_tx_count == 1
+        assert radio._pcm_tx_fmt is None
+
+    async def test_legacy_opus_start_never_sets_pcm_fmt(self) -> None:
+        """Recovery-critical: start_audio_tx_opus must keep _pcm_tx_fmt None
+        even when the negotiated TX codec is PCM (the Icom LAN default), so
+        AudioRecoveryRuntime snapshots keep pcm_mode=False for opus users."""
+        radio, stream = _make_radio()
+        assert radio.audio_tx_codec == AudioCodec.PCM_1CH_16BIT
+
+        await radio.start_audio_tx_opus()
+
+        assert stream.start_tx_count == 1
+        assert radio._pcm_tx_fmt is None


### PR DESCRIPTION
## Summary

Step 6/12 of the MOR-532 AudioTransport epic (Linear MOR-539). `IcomRadio` (via `AudioRuntimeMixin`) now implements the codec-neutral `AudioTransport` surface defined in MOR-538, so `isinstance(radio, AudioTransport)` is `True` for the Icom LAN backend.

- `start_rx(cb, *, jitter_depth=5)` / `stop_rx()` / `push_tx(data)` / `stop_tx()` own the former opus-family method bodies verbatim. `jitter_depth` is a deliberate keyword-only widening of the minimal protocol signature.
- `start_tx()` routes per the negotiated `audio_tx_codec`: `PCM_1CH_16BIT` (direct Icom LAN conninfo) → the contract-driven no-arg `start_audio_tx_pcm()` path; otherwise the raw stream-start (legacy opus) path.
- Legacy opus-family methods (`start_audio_rx_opus`, `stop_audio_rx_opus`, `start_audio_tx_opus`, `push_audio_tx_opus`, `stop_audio_tx_opus`) are now one-line delegates.
- PCM-family conveniences (`*_pcm`) are unchanged — they are format-parameterized helpers, not impersonation.

## Risk handling (recovery/sync bookkeeping)

`runtime/_audio_recovery.py` snapshots and `runtime/sync.py` call the legacy names and read `_opus_rx_user_callback`, `_opus_rx_jitter_depth`, and `_pcm_tx_fmt`. The bodies moved without modification, so every attribute is set/cleared at exactly the same points:

- `start_rx` sets `_opus_rx_user_callback` + `_opus_rx_jitter_depth` before `stream.start_rx`; `stop_rx` clears the callback before `stream.stop_rx`; `stop_tx` clears `_pcm_tx_fmt` after `stream.stop_tx` — identical to the previous opus bodies.
- One deliberate structural choice: `start_audio_tx_opus` delegates to a private neutral helper `_start_tx_stream()` (the verbatim old body) rather than to `start_tx()`. Delegating to `start_tx()` would (a) recurse infinitely when the TX codec is PCM (`start_tx` → `start_audio_tx_pcm` → `start_audio_tx_opus` → `start_tx`) and (b) set `_pcm_tx_fmt` where the legacy opus path leaves it `None`, flipping `pcm_mode` in recovery snapshots. The helper keeps every legacy caller byte-identical; a dedicated regression test pins this (`test_legacy_opus_start_never_sets_pcm_fmt`).

## Tests (TDD)

New `tests/test_audio_transport_lan.py` (11 tests, `FakeAudioStream` harness — no MagicMock dataclasses): protocol conformance via `isinstance`, legacy↔neutral delegation equivalence (stream calls + bookkeeping attrs), `start_tx` codec routing (PCM contract → pcm path with `_pcm_tx_fmt` from contract; Opus contract → raw path, `_pcm_tx_fmt` stays `None`), and the recovery-critical `start_audio_tx_opus` invariant. Confirmed red (10 failed) before implementation, green after. `test_pcm_e2e`, `test_audio_transcoder`, `test_audio_recovery`, `test_sync` pass unmodified.

## Gate results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 7325 passed, 9 skipped, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — All checks passed; `ruff format --check` — 550 files already formatted
- `uv run mypy src/` — 20 errors in 7 files (baseline, zero new)
- `uv run lint-imports` — Contracts: 4 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)