### PR TITLE
feat: AudioTransport neutral methods on the Icom serial base (MOR-540, AudioTransport 7/12)

### DIFF
--- a/src/rigplane/audio/lan_stream.py
+++ b/src/rigplane/audio/lan_stream.py
@@ -24,6 +24,7 @@ __all__ = [
     "AUDIO_HEADER_SIZE",
     "TX_IDENT",
     "RX_IDENT_0xA0",
+    "SYNTHETIC_RX_IDENT",
 ]
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,17 @@ MAX_AUDIO_PAYLOAD = 1364
 
 # RX ident for 0xa0-length frames
 RX_IDENT_0xA0 = 0x9781
+
+#: Ident marking locally-framed (synthetic, non-LAN-wire) AudioPackets.
+#:
+#: USB-codec backends (Icom serial base, Yaesu CAT) capture PCM from the OS
+#: audio device — there is no Icom LAN UDP header to parse — and fabricate
+#: :class:`AudioPacket` instances to feed the same audio bus as LAN RX.
+#: They stamp this ident on every synthetic packet (with a locally counted
+#: wrapping uint16 ``send_seq``). The value intentionally equals
+#: ``RX_IDENT_0xA0`` so downstream consumers treat synthetic frames exactly
+#: like ordinary LAN RX audio (MOR-540).
+SYNTHETIC_RX_IDENT = 0x9781
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Callable, Protocol
 
 from .._connection_state import RadioConnectionState
 from ..audio import AudioPacket
+from ..audio.lan_stream import SYNTHETIC_RX_IDENT
 from ..commands import parse_ack_nak, scope_off as _scope_off_cmd
 from ..exceptions import AudioFormatError, CommandError, ConnectionError
 from ..radio import CoreRadio
@@ -373,27 +374,25 @@ class _IcomSerialRadioBase(CoreRadio):
             raise CommandError("Radio rejected scope disable")
 
     # ------------------------------------------------------------------
-    # Audio RX
+    # Neutral AudioTransport surface (MOR-532 epic, MOR-540)
     # ------------------------------------------------------------------
 
-    async def start_audio_rx_opus(
+    async def start_rx(
         self,
         callback: Callable[[AudioPacket | None], None],
-        *,
-        jitter_depth: int = 5,
     ) -> None:
+        """Start RX capture from the USB CODEC (``AudioTransport.start_rx``).
+
+        Locally captured PCM (transcoded to Opus when the negotiated codec
+        is an Opus variant) is framed into synthetic :class:`AudioPacket`
+        instances marked with ``SYNTHETIC_RX_IDENT`` — there is no LAN wire
+        header on this path.
+        """
         if not callable(callback):
             raise TypeError("callback must be callable and accept AudioPacket | None.")
-        if isinstance(jitter_depth, bool) or not isinstance(jitter_depth, int):
-            raise TypeError(
-                f"jitter_depth must be an int, got {type(jitter_depth).__name__}."
-            )
-        if jitter_depth < 0:
-            raise ValueError(f"jitter_depth must be >= 0, got {jitter_depth}.")
         self._check_connected()
 
         self._opus_rx_user_callback = callback
-        self._opus_rx_jitter_depth = jitter_depth
 
         sample_rate = self.audio_sample_rate
         channels = self._serial_audio_channels_for_codec()
@@ -420,7 +419,7 @@ class _IcomSerialRadioBase(CoreRadio):
                     )
                     return
             packet = AudioPacket(
-                ident=0x9781,
+                ident=SYNTHETIC_RX_IDENT,
                 send_seq=self._serial_audio_seq,
                 data=payload,
             )
@@ -434,9 +433,65 @@ class _IcomSerialRadioBase(CoreRadio):
             frame_ms=frame_ms,
         )
 
-    async def stop_audio_rx_opus(self) -> None:
+    async def stop_rx(self) -> None:
+        """Stop RX capture (``AudioTransport.stop_rx``)."""
         self._opus_rx_user_callback = None
         await self._serial_audio_driver.stop_rx()
+
+    async def start_tx(self) -> None:
+        """Arm the USB CODEC TX path (``AudioTransport.start_tx``)."""
+        self._check_connected()
+        await self._serial_audio_driver.start_tx(
+            sample_rate=self.audio_sample_rate,
+            channels=self._serial_audio_channels_for_codec(),
+            frame_ms=20,
+        )
+
+    async def push_tx(self, data: bytes) -> None:
+        """Push one TX frame (``AudioTransport.push_tx``).
+
+        Opus input is transcoded to PCM when the negotiated codec is an
+        Opus variant; the USB CODEC driver always consumes PCM.
+        """
+        self._check_connected()
+        if not self._serial_audio_driver.tx_running:
+            raise RuntimeError("Audio TX not started")
+        payload = bytes(data)
+        if self._serial_codec_is_opus():
+            transcoder = self._get_pcm_transcoder(
+                sample_rate=self.audio_sample_rate,
+                channels=self._serial_audio_channels_for_codec(),
+                frame_ms=20,
+            )
+            payload = transcoder.opus_to_pcm(payload)
+        await self._serial_audio_driver._push_tx_pcm(payload)
+
+    async def stop_tx(self) -> None:
+        """Close the TX path (``AudioTransport.stop_tx``)."""
+        await self._serial_audio_driver.stop_tx()
+        self._pcm_tx_fmt = None
+
+    # ------------------------------------------------------------------
+    # Audio RX (legacy opus-family shims -> neutral AudioTransport)
+    # ------------------------------------------------------------------
+
+    async def start_audio_rx_opus(
+        self,
+        callback: Callable[[AudioPacket | None], None],
+        *,
+        jitter_depth: int = 5,
+    ) -> None:
+        if isinstance(jitter_depth, bool) or not isinstance(jitter_depth, int):
+            raise TypeError(
+                f"jitter_depth must be an int, got {type(jitter_depth).__name__}."
+            )
+        if jitter_depth < 0:
+            raise ValueError(f"jitter_depth must be >= 0, got {jitter_depth}.")
+        self._opus_rx_jitter_depth = jitter_depth
+        await self.start_rx(callback)
+
+    async def stop_audio_rx_opus(self) -> None:
+        await self.stop_rx()
 
     async def start_audio_rx_pcm(
         self,
@@ -483,34 +538,17 @@ class _IcomSerialRadioBase(CoreRadio):
         await self._serial_audio_driver.stop_rx()
 
     # ------------------------------------------------------------------
-    # Audio TX (Opus)
+    # Audio TX (legacy opus-family shims -> neutral AudioTransport)
     # ------------------------------------------------------------------
 
     async def start_audio_tx_opus(self) -> None:
-        self._check_connected()
-        await self._serial_audio_driver.start_tx(
-            sample_rate=self.audio_sample_rate,
-            channels=self._serial_audio_channels_for_codec(),
-            frame_ms=20,
-        )
+        await self.start_tx()
 
     async def push_audio_tx_opus(self, opus_data: bytes) -> None:
-        self._check_connected()
-        if not self._serial_audio_driver.tx_running:
-            raise RuntimeError("Audio TX not started")
-        payload = bytes(opus_data)
-        if self._serial_codec_is_opus():
-            transcoder = self._get_pcm_transcoder(
-                sample_rate=self.audio_sample_rate,
-                channels=self._serial_audio_channels_for_codec(),
-                frame_ms=20,
-            )
-            payload = transcoder.opus_to_pcm(payload)
-        await self._serial_audio_driver._push_tx_pcm(payload)
+        await self.push_tx(opus_data)
 
     async def stop_audio_tx_opus(self) -> None:
-        await self._serial_audio_driver.stop_tx()
-        self._pcm_tx_fmt = None
+        await self.stop_tx()
 
     # ------------------------------------------------------------------
     # Audio TX (PCM) — arms ``_pcm_tx_fmt`` so ``push_audio_tx_pcm`` works

--- a/tests/test_audio_transport_serial.py
+++ b/tests/test_audio_transport_serial.py
@@ -1,0 +1,130 @@
+"""AudioTransport neutral methods on the Icom serial base (MOR-540).
+
+Step 7/12 of the MOR-532 AudioTransport epic: the Icom serial backends
+gain the codec/transport-neutral ``start_rx`` / ``stop_rx`` /
+``start_tx`` / ``push_tx`` / ``stop_tx`` methods over the USB audio
+driver, the legacy ``*_opus`` family delegates onto them, and the
+synthetic RX packet ident is documented as
+``rigplane.audio.lan_stream.SYNTHETIC_RX_IDENT``.
+
+Packet bytes must be identical to the legacy path: same ident value
+(0x9781), same wrapping uint16 sequence, same payload (MOR-242/MOR-238
+pin the TX clamp and RX channel behaviour elsewhere).
+"""
+
+from __future__ import annotations
+
+import pytest
+from test_icom7610_serial_radio import _FakeSerialCivLink, _FakeUsbAudioDriver
+
+from rigplane.audio import AudioPacket
+from rigplane.audio.lan_stream import SYNTHETIC_RX_IDENT
+from rigplane.backends.ic705 import Ic705SerialRadio
+from rigplane.backends.icom7610 import Icom7610SerialRadio
+from rigplane.core.radio_protocol import AudioTransport
+
+_PCM_FRAMES = [b"\x01\x02" * 960, b"\x03\x04" * 960]
+_TX_FRAME = b"\x11\x22" * 960
+
+
+def _make_radio(radio_cls=Icom7610SerialRadio):  # type: ignore[no-untyped-def]
+    usb_audio = _FakeUsbAudioDriver()
+    radio = radio_cls(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=usb_audio,
+    )
+    return radio, usb_audio
+
+
+def test_serial_backends_satisfy_audio_transport_protocol() -> None:
+    """Both Icom serial backends are runtime instances of AudioTransport."""
+    for radio_cls in (Icom7610SerialRadio, Ic705SerialRadio):
+        radio, _ = _make_radio(radio_cls)
+        assert isinstance(radio, AudioTransport), radio_cls.__name__
+
+
+@pytest.mark.asyncio
+async def test_start_rx_packets_carry_synthetic_ident() -> None:
+    """Byte-compat lock: start_rx frames carry ident 0x9781 and wrap seq."""
+    assert SYNTHETIC_RX_IDENT == 0x9781
+
+    radio, usb_audio = _make_radio()
+    await radio.connect()
+    packets: list[AudioPacket] = []
+    await radio.start_rx(packets.append)
+    for frame in _PCM_FRAMES:
+        usb_audio.emit_rx_pcm(frame)
+    await radio.stop_rx()
+    await radio.disconnect()
+
+    assert [p.ident for p in packets] == [SYNTHETIC_RX_IDENT, SYNTHETIC_RX_IDENT]
+    assert [p.send_seq for p in packets] == [0, 1]
+    assert [p.data for p in packets] == _PCM_FRAMES
+    assert usb_audio.rx_running is False
+
+
+async def _run_rx_session(*, neutral: bool) -> tuple[list[AudioPacket], int]:
+    radio, usb_audio = _make_radio()
+    await radio.connect()
+    packets: list[AudioPacket] = []
+    if neutral:
+        await radio.start_rx(packets.append)
+    else:
+        await radio.start_audio_rx_opus(packets.append)
+    for frame in _PCM_FRAMES:
+        usb_audio.emit_rx_pcm(frame)
+    if neutral:
+        await radio.stop_rx()
+    else:
+        await radio.stop_audio_rx_opus()
+    await radio.disconnect()
+    return packets, usb_audio.rx_starts
+
+
+@pytest.mark.asyncio
+async def test_neutral_rx_matches_legacy_packet_framing() -> None:
+    """Legacy and neutral RX produce identical AudioPackets and driver calls."""
+    legacy_packets, legacy_starts = await _run_rx_session(neutral=False)
+    neutral_packets, neutral_starts = await _run_rx_session(neutral=True)
+
+    assert neutral_packets == legacy_packets
+    assert legacy_starts == neutral_starts == 1
+    assert legacy_packets, "expected RX packets in both sessions"
+
+
+async def _run_tx_session(*, neutral: bool) -> _FakeUsbAudioDriver:
+    radio, usb_audio = _make_radio()
+    await radio.connect()
+    if neutral:
+        await radio.start_tx()
+        await radio.push_tx(_TX_FRAME)
+        await radio.stop_tx()
+    else:
+        await radio.start_audio_tx_opus()
+        await radio.push_audio_tx_opus(_TX_FRAME)
+        await radio.stop_audio_tx_opus()
+    await radio.disconnect()
+    return usb_audio
+
+
+@pytest.mark.asyncio
+async def test_neutral_tx_matches_legacy_driver_calls() -> None:
+    """Legacy and neutral TX arm the driver identically and push same bytes."""
+    legacy_driver = await _run_tx_session(neutral=False)
+    neutral_driver = await _run_tx_session(neutral=True)
+
+    assert neutral_driver.tx_start_kwargs == legacy_driver.tx_start_kwargs
+    assert neutral_driver.tx_frames == legacy_driver.tx_frames == [_TX_FRAME]
+    assert legacy_driver.tx_running is False
+    assert neutral_driver.tx_running is False
+
+
+@pytest.mark.asyncio
+async def test_push_tx_requires_start_tx() -> None:
+    """push_tx keeps the legacy 'Audio TX not started' guard."""
+    radio, _ = _make_radio()
+    await radio.connect()
+    with pytest.raises(RuntimeError, match="Audio TX not started"):
+        await radio.push_tx(_TX_FRAME)
+    await radio.disconnect()


### PR DESCRIPTION
## Summary

Step 7/12 of the MOR-532 AudioTransport epic (Linear MOR-540): the Icom serial base gains the codec/transport-neutral `AudioTransport` methods, and the synthetic packet ident gets a documented name.

- **`src/rigplane/audio/lan_stream.py`** — new module constant `SYNTHETIC_RX_IDENT = 0x9781` next to the existing LAN RX ident constants, documenting that it marks locally-framed (non-LAN-wire) AudioPackets produced by USB-codec backends. Purely additive; intentionally NOT exported from `rigplane.audio.__init__` (the step-12 conformance/export step handles that — `tests/test_exports.py` untouched).
- **`src/rigplane/backends/_icom_serial_base.py`** — five neutral methods over `_serial_audio_driver`:
  - `start_rx(cb)` = body of the former `start_audio_rx_opus` (AudioPacket framing now via `SYNTHETIC_RX_IDENT`, PCM→Opus transcode branch kept inside, keyed on the existing codec check)
  - `stop_rx()`, `start_tx()` (no-arg TX arming), `push_tx(data)` (incl. Opus→PCM transcode + "Audio TX not started" guard), `stop_tx()` (clears `_pcm_tx_fmt`)
  - Legacy opus-family methods re-pointed to one-line delegates onto the neutral ones (`start_audio_rx_opus` keeps its `jitter_depth` validation/assignment — the neutral surface has no jitter knob). PCM-family methods unchanged.
- Packet bytes are **identical** to before: ident value unchanged (0x9781), wrapping uint16 `send_seq` unchanged, payload unchanged. MOR-242 TX clamp and MOR-238/MOR-236 RX channel tests pass unmodified.

## Tests (TDD)

New `tests/test_audio_transport_serial.py` (reuses the existing serial fakes from `test_icom7610_serial_radio.py`), confirmed red before implementation (5 failed), green after:
- `isinstance(Icom7610SerialRadio/Ic705SerialRadio, AudioTransport)` is True
- legacy↔neutral RX equivalence: identical `AudioPacket` sequences + identical driver start counts
- legacy↔neutral TX equivalence: identical `start_tx` kwargs + identical pushed frames
- byte-compat lock: `start_rx` packets carry `ident == 0x9781 == SYNTHETIC_RX_IDENT`, seq 0,1
- `push_tx` keeps the legacy "Audio TX not started" guard

## Gate results (worktree)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7319 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — clean; `uv run ruff format --check` — 550 files already formatted
- `uv run mypy src/` — 20 errors in 7 files (exact baseline, zero new)
- `uv run lint-imports` — 4 kept / 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)