### PR TITLE
feat: AudioTransport on YaesuCatRadio — un-impersonate FTX-1 (MOR-541, AudioTransport 8/12)

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, cast
 
 from ...audio import AudioPacket
+from ...audio.lan_stream import SYNTHETIC_RX_IDENT
 from ...command_spec import CatCommandSpec
 from ...commands import hz_to_table_index, table_index_to_hz
 from ...types import AudioCodec, BreakInMode
@@ -369,29 +370,30 @@ class YaesuCatRadio:
             self._audio_bus = AudioBus(self)
         return self._audio_bus
 
-    # -- AudioCapable methods -----------------------------------------------
+    # -- Neutral AudioTransport surface (MOR-532 epic, MOR-541) --------------
 
-    async def start_audio_rx_opus(
+    async def start_rx(
         self,
         callback: Callable[[AudioPacket | None], None],
-        *,
-        jitter_depth: int = 5,
     ) -> None:
+        """Start RX capture from the USB audio device (``AudioTransport.start_rx``).
+
+        Frames carry raw PCM encoded per :attr:`audio_codec`
+        (``PCM_1CH_16BIT``) — the FTX-1 USB path has no Opus framing.
+        Each captured frame is wrapped in a synthetic
+        :class:`AudioPacket` marked with ``SYNTHETIC_RX_IDENT`` and a
+        locally counted wrapping uint16 ``send_seq`` — there is no LAN
+        wire header on this path.
+        """
         if not callable(callback):
             raise TypeError("callback must be callable and accept AudioPacket | None.")
-        if isinstance(jitter_depth, bool) or not isinstance(jitter_depth, int):
-            raise TypeError(
-                f"jitter_depth must be an int, got {type(jitter_depth).__name__}."
-            )
-        if jitter_depth < 0:
-            raise ValueError(f"jitter_depth must be >= 0, got {jitter_depth}.")
         self._require_connected()
 
         self._opus_rx_user_callback = callback
 
         def _on_pcm_frame(pcm_frame: bytes) -> None:
             packet = AudioPacket(
-                ident=0x9781,
+                ident=SYNTHETIC_RX_IDENT,
                 send_seq=self._audio_seq,
                 data=pcm_frame,
             )
@@ -400,9 +402,64 @@ class YaesuCatRadio:
 
         await self._audio_driver.start_rx(_on_pcm_frame)
 
-    async def stop_audio_rx_opus(self) -> None:
+    async def stop_rx(self) -> None:
+        """Stop RX capture (``AudioTransport.stop_rx``)."""
         self._opus_rx_user_callback = None
         await self._audio_driver.stop_rx()
+
+    async def start_tx(self) -> None:
+        """Arm the USB audio TX path (``AudioTransport.start_tx``).
+
+        Resolves the TX format from the backend contract — mono PCM at
+        :attr:`audio_sample_rate`, 20 ms frames — exactly what the legacy
+        ``start_audio_tx_pcm()`` defaults open today. On double start the
+        driver raises ``AudioDriverLifecycleError`` (a ``RuntimeError``
+        subclass), the same exception the legacy PCM path raises.
+        """
+        self._require_connected()
+        await self._audio_driver.start_tx(
+            sample_rate=self._audio_sample_rate,
+            channels=1,
+            frame_ms=20,
+        )
+
+    async def push_tx(self, data: bytes) -> None:
+        """Push one TX frame (``AudioTransport.push_tx``).
+
+        The payload must be raw PCM per :attr:`audio_tx_codec`; the USB
+        audio driver consumes PCM directly (no transcoding on this path).
+        """
+        await self._push_pcm_tx(data)
+
+    async def stop_tx(self) -> None:
+        """Close the TX path (``AudioTransport.stop_tx``)."""
+        await self._audio_driver.stop_tx()
+
+    # -- AudioCapable methods (legacy shims -> neutral AudioTransport) -------
+
+    async def start_audio_rx_opus(
+        self,
+        callback: Callable[[AudioPacket | None], None],
+        *,
+        jitter_depth: int = 5,
+    ) -> None:
+        """Deprecated shim — delegates to :meth:`start_rx`.
+
+        Despite the historical name, packets carry raw PCM per
+        :attr:`audio_codec` (no Opus framing exists on the USB path).
+        *jitter_depth* is validated for back-compat but unused.
+        """
+        if isinstance(jitter_depth, bool) or not isinstance(jitter_depth, int):
+            raise TypeError(
+                f"jitter_depth must be an int, got {type(jitter_depth).__name__}."
+            )
+        if jitter_depth < 0:
+            raise ValueError(f"jitter_depth must be >= 0, got {jitter_depth}.")
+        await self.start_rx(callback)
+
+    async def stop_audio_rx_opus(self) -> None:
+        """Deprecated shim — delegates to :meth:`stop_rx`."""
+        await self.stop_rx()
 
     async def start_audio_rx_pcm(
         self,
@@ -471,9 +528,13 @@ class YaesuCatRadio:
         )
 
     async def stop_audio_tx_pcm(self) -> None:
-        await self._audio_driver.stop_tx()
+        """Deprecated shim — delegates to :meth:`stop_tx`."""
+        await self.stop_tx()
 
     async def _push_pcm_tx(self, frame: bytes) -> None:
+        # Private terminal helper (MOR-539 pattern): every push path —
+        # neutral push_tx and both legacy shims — funnels here, so the
+        # delegation chain cannot recurse.
         if not isinstance(frame, bytes):
             raise TypeError(f"frame must be bytes, got {type(frame).__name__}.")
         if len(frame) == 0:
@@ -482,25 +543,33 @@ class YaesuCatRadio:
         self._require_connected()
         await self._audio_driver._push_tx_pcm(frame)
 
-    # -- AudioCapable TX methods --------------------------------------------
+    # -- AudioCapable TX methods (legacy shims) -------------------------------
 
     async def push_audio_tx_opus(self, data: bytes) -> None:
-        """Forward Opus TX data as PCM (USB audio is always PCM)."""
-        # Browser sends Opus; AudioBroadcaster transcodes to PCM before calling.
-        # If raw Opus arrives here, just push as-is (driver handles it).
-        await self._push_pcm_tx(data)
+        """Legacy shim — pushes the payload as PCM via :meth:`push_tx`.
+
+        Historical oddity kept on purpose: despite the name, the bytes are
+        forwarded unchanged. AudioBroadcaster transcodes browser Opus to PCM
+        before calling; if raw Opus ever arrives here it is pushed as-is.
+        """
+        await self.push_tx(data)
 
     async def push_audio_tx_pcm(self, data: bytes) -> None:
-        """Push raw PCM TX data."""
-        await self._push_pcm_tx(data)
+        """Deprecated shim — delegates to :meth:`push_tx` (raw PCM)."""
+        await self.push_tx(data)
 
     async def start_audio_tx_opus(self) -> None:
-        """No-op: USB audio TX is started via start_audio_tx_pcm."""
-        pass
+        """Deprecated shim — delegates to :meth:`start_tx`.
+
+        BEHAVIOR CHANGE (MOR-541): this was a silent no-op (``pass``),
+        so the web handler's opus TX branch never armed the driver TX
+        path on Yaesu backends. It now arms TX like the PCM path.
+        """
+        await self.start_tx()
 
     async def stop_audio_tx_opus(self) -> None:
-        """Stop TX audio."""
-        await self.stop_audio_tx_pcm()
+        """Deprecated shim — delegates to :meth:`stop_tx`."""
+        await self.stop_tx()
 
     async def get_audio_stats(self) -> dict[str, Any]:
         """Return basic audio stats."""

--- a/tests/test_yaesu_audio.py
+++ b/tests/test_yaesu_audio.py
@@ -11,6 +11,7 @@ import pytest
 
 from rigplane.audio import AudioPacket
 from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.audio.lan_stream import SYNTHETIC_RX_IDENT
 from rigplane.audio.usb_driver import UsbAudioDriver
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.exceptions import AudioFormatError
@@ -498,3 +499,192 @@ class TestMetersCapableProtocol:
         assert isinstance(radio, MetersCapable)
         for name in ("get_power_meter", "get_alc_meter", "get_swr_meter"):
             assert callable(getattr(radio, name)), f"{name} missing"
+
+
+# ---------------------------------------------------------------------------
+# Neutral AudioTransport surface — MOR-541 (AudioTransport epic step 8/12)
+# ---------------------------------------------------------------------------
+
+_RX_FRAMES = [b"\x01\x02" * 480, b"\x03\x04" * 480]
+_TX_FRAME = b"\x11\x22" * 480
+
+
+class TracingAudioDriver(FakeAudioDriver):
+    """FakeAudioDriver that records the driver-call trace.
+
+    Used to prove the legacy ``*_opus`` family and the neutral
+    AudioTransport methods drive the USB audio driver identically
+    (delegates only — no divergent framing/format logic).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.rx_start_calls: list[dict[str, int | None]] = []
+        self.tx_start_calls: list[dict[str, int | None]] = []
+        self.tx_frames: list[bytes] = []
+
+    async def start_rx(
+        self,
+        callback: Callable[[bytes], None] | None = None,
+        *,
+        sample_rate: int | None = None,
+        channels: int | None = None,
+        frame_ms: int | None = None,
+    ) -> None:
+        self.rx_start_calls.append(
+            {"sample_rate": sample_rate, "channels": channels, "frame_ms": frame_ms}
+        )
+        await super().start_rx(
+            callback, sample_rate=sample_rate, channels=channels, frame_ms=frame_ms
+        )
+
+    async def start_tx(
+        self,
+        *,
+        sample_rate: int | None = None,
+        channels: int | None = None,
+        frame_ms: int | None = None,
+    ) -> None:
+        self.tx_start_calls.append(
+            {"sample_rate": sample_rate, "channels": channels, "frame_ms": frame_ms}
+        )
+        await super().start_tx(
+            sample_rate=sample_rate, channels=channels, frame_ms=frame_ms
+        )
+
+    async def _push_tx_pcm(self, frame: bytes) -> None:
+        await super()._push_tx_pcm(frame)
+        self.tx_frames.append(frame)
+
+
+def _make_traced_radio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[YaesuCatRadio, TracingAudioDriver]:
+    """Build a YaesuCatRadio over a TracingAudioDriver (transport faked)."""
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.transport.YaesuCatTransport.connect",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.transport.YaesuCatTransport.close",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.transport.YaesuCatTransport.connected",
+        True,
+    )
+    driver = TracingAudioDriver()
+    r = YaesuCatRadio(device="/dev/fake0", audio_driver=driver)  # type: ignore[arg-type]
+    return r, driver
+
+
+class TestAudioTransportNeutral:
+    """YaesuCatRadio implements the neutral AudioTransport surface."""
+
+    def test_satisfies_audio_transport_protocol(self, radio: YaesuCatRadio) -> None:
+        from rigplane.core.radio_protocol import AudioTransport
+
+        assert isinstance(radio, AudioTransport)
+
+    @pytest.mark.asyncio
+    async def test_start_rx_packets_carry_synthetic_ident(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Byte-compat lock: start_rx frames keep ident 0x9781 + wrapping seq."""
+        assert SYNTHETIC_RX_IDENT == 0x9781
+
+        r, driver = _make_traced_radio(monkeypatch)
+        await r.connect()
+        packets: list[AudioPacket] = []
+        await r.start_rx(packets.append)
+        for frame in _RX_FRAMES:
+            driver.inject_rx_frame(frame)
+        await r.stop_rx()
+
+        assert [p.ident for p in packets] == [SYNTHETIC_RX_IDENT, SYNTHETIC_RX_IDENT]
+        assert [p.send_seq for p in packets] == [0, 1]
+        assert [p.data for p in packets] == _RX_FRAMES
+        assert driver.rx_running is False
+
+    async def _run_rx_session(
+        self, monkeypatch: pytest.MonkeyPatch, *, neutral: bool
+    ) -> tuple[list[AudioPacket], TracingAudioDriver]:
+        r, driver = _make_traced_radio(monkeypatch)
+        await r.connect()
+        packets: list[AudioPacket] = []
+        if neutral:
+            await r.start_rx(packets.append)
+        else:
+            await r.start_audio_rx_opus(packets.append)
+        for frame in _RX_FRAMES:
+            driver.inject_rx_frame(frame)
+        if neutral:
+            await r.stop_rx()
+        else:
+            await r.stop_audio_rx_opus()
+        return packets, driver
+
+    @pytest.mark.asyncio
+    async def test_neutral_rx_matches_legacy_packet_framing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Legacy and neutral RX produce identical AudioPackets + driver calls."""
+        legacy_packets, legacy_driver = await self._run_rx_session(
+            monkeypatch, neutral=False
+        )
+        neutral_packets, neutral_driver = await self._run_rx_session(
+            monkeypatch, neutral=True
+        )
+
+        assert neutral_packets == legacy_packets
+        assert legacy_packets, "expected RX packets in both sessions"
+        assert neutral_driver.rx_start_calls == legacy_driver.rx_start_calls
+
+    async def _run_tx_session(
+        self, monkeypatch: pytest.MonkeyPatch, *, neutral: bool
+    ) -> TracingAudioDriver:
+        r, driver = _make_traced_radio(monkeypatch)
+        await r.connect()
+        if neutral:
+            await r.start_tx()
+            await r.push_tx(_TX_FRAME)
+            await r.stop_tx()
+        else:
+            await r.start_audio_tx_opus()
+            await r.push_audio_tx_opus(_TX_FRAME)
+            await r.stop_audio_tx_opus()
+        return driver
+
+    @pytest.mark.asyncio
+    async def test_neutral_tx_matches_legacy_driver_calls(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Legacy opus family and neutral TX arm the driver identically."""
+        legacy_driver = await self._run_tx_session(monkeypatch, neutral=False)
+        neutral_driver = await self._run_tx_session(monkeypatch, neutral=True)
+
+        assert neutral_driver.tx_start_calls == legacy_driver.tx_start_calls
+        assert len(legacy_driver.tx_start_calls) == 1
+        assert neutral_driver.tx_frames == legacy_driver.tx_frames == [_TX_FRAME]
+        assert legacy_driver.tx_running is False
+        assert neutral_driver.tx_running is False
+
+    @pytest.mark.asyncio
+    async def test_start_audio_tx_opus_arms_tx(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression (MOR-541): start_audio_tx_opus was a silent no-op.
+
+        The web handler's opus TX branch calls ``start_audio_tx_opus()``;
+        before MOR-541 that silently did nothing on YaesuCatRadio, leaving
+        the driver TX path unarmed. It must now delegate to ``start_tx()``.
+        """
+        r, driver = _make_traced_radio(monkeypatch)
+        await r.connect()
+        await r.start_audio_tx_opus()
+
+        assert driver.tx_running is True
+        assert len(driver.tx_start_calls) == 1
+
+        await r.stop_audio_tx_opus()
+        assert driver.tx_running is False


### PR DESCRIPTION
## Summary

Step 8/12 of the MOR-532 AudioTransport epic (Linear MOR-541). `YaesuCatRadio` now implements the codec/transport-neutral `AudioTransport` surface (`start_rx` / `stop_rx` / `start_tx` / `push_tx` / `stop_tx`) over the USB audio driver, and the legacy `*_opus`/`*_pcm` family becomes back-compat delegates — mirroring the merged LAN (MOR-539) and Icom-serial (MOR-540) implementations.

## Spec mapping

- `start_rx(cb)` carries the body of the old `start_audio_rx_opus`: the `_on_pcm_frame` wrapper fabricating synthetic `AudioPacket`s, with the ident sourced from `rigplane.audio.lan_stream.SYNTHETIC_RX_IDENT` instead of the hardcoded `0x9781` literal. Packet bytes are **identical** to before: same ident value (0x9781), same wrapping uint16 `send_seq`, same PCM payload. Docstring states frames carry PCM per `audio_codec` — no Opus claim.
- `start_tx()` = legacy `start_audio_tx_pcm()` defaults (mono PCM at `audio_sample_rate`, 20 ms frames); `push_tx(data)` = the `_push_pcm_tx` path; `stop_rx()`/`stop_tx()` close the driver streams.
- Recursion safety (MOR-539 case): `_push_pcm_tx` stays the private terminal push helper — `push_tx` and both legacy push shims funnel into it; `start_tx`/`stop_tx` call the driver directly. Verified against the real call graph: no `pcm↔opus` cycle exists.

## Behavior change (deliberate)

`start_audio_tx_opus` changes from a **silent no-op** (`pass`) to delegating to `start_tx()`. This fixes the bug class where the web handler's opus TX branch (`web/handlers/audio.py` `_handle_control`) silently did nothing on Yaesu backends, leaving the driver TX path unarmed. On double start it now raises `AudioDriverLifecycleError` ("TX stream already started.", a `RuntimeError` subclass) — the exact same exception `start_audio_tx_pcm` raises today, so the handler's existing `except RuntimeError` double-start handling sees no new exception type.

`push_audio_tx_opus`'s push-opus-as-pcm oddity is kept byte-for-byte unchanged and documented as legacy shim behavior.

## Tests (TDD, `tests/test_yaesu_audio.py`)

All five new tests confirmed failing before implementation, passing after:

1. `isinstance(YaesuCatRadio(...), AudioTransport)` is True.
2. `start_rx` packets carry `ident == SYNTHETIC_RX_IDENT == 0x9781`, incrementing seq, payload passthrough.
3. Full `AudioPacket` equality + identical driver-call traces, legacy vs neutral RX session (mirrors the MOR-540 test approach).
4. Identical driver-call traces legacy-opus vs neutral TX session (delegates only, no divergent framing logic).
5. Regression: `start_audio_tx_opus` now arms TX (driver `start_tx` called, `tx_running` True) where before it was a no-op.

Existing FTX-1/Yaesu audio tests pass unmodified.

## Gate results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7335 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — All checks passed; `ruff format --check` — 551 files already formatted
- `uv run mypy src/` — 21 errors in 8 files, **identical to the 582e4d7d baseline** (diff is line-number shifts only; zero new errors)
- `uv run lint-imports` — Contracts: 4 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)