### PR TITLE
feat: AudioBus on the neutral AudioTransport surface (MOR-542, AudioTransport 9/12)

### DIFF
--- a/src/rigplane/audio/bus.py
+++ b/src/rigplane/audio/bus.py
@@ -28,14 +28,18 @@ Usage::
             save(packet)
 
 Lifecycle:
-    - First subscriber triggers ``radio.start_audio_rx_opus()``
-    - Last subscriber removal triggers ``radio.stop_audio_rx_opus()``
+    - First subscriber triggers ``radio.start_rx()`` (or the legacy
+      ``radio.start_audio_rx_opus()`` for radios without the neutral
+      AudioTransport surface)
+    - Last subscriber removal triggers ``radio.stop_rx()`` (or the legacy
+      ``radio.stop_audio_rx_opus()``)
     - Subscribers can join/leave at any time
 """
 
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -48,6 +52,22 @@ __all__ = ["AudioBus", "AudioSubscription"]
 
 _DEFAULT_QUEUE_SIZE = 64
 _DEFAULT_CLOSE_TIMEOUT = 2.0
+
+
+def _accepts_jitter_depth(start_rx: Any) -> bool:
+    """True when *start_rx* accepts a ``jitter_depth`` keyword argument.
+
+    The neutral ``AudioTransport.start_rx`` is minimal (callback only); the
+    LAN mixin widens it with a keyword-optional ``jitter_depth`` (MOR-539)
+    while the serial and Yaesu implementations do not (MOR-540/541).
+    """
+    try:
+        parameters = inspect.signature(start_rx).parameters
+    except (TypeError, ValueError):  # pragma: no cover — exotic callables
+        return False
+    if "jitter_depth" in parameters:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values())
 
 
 class AudioSubscription:
@@ -304,15 +324,32 @@ class AudioBus:
                 # to prevent new subscribers from seeing a dying stream
                 await self._stop_rx()
 
+    async def _begin_rx(self) -> None:
+        """Invoke radio RX start, preferring the neutral AudioTransport surface.
+
+        Falls back to the legacy ``start_audio_rx_opus`` for radios that only
+        implement the Opus-specific surface (third-party/Pro radios, MOR-542).
+        ``jitter_depth`` is threaded through only when the implementation
+        accepts it — the minimal ``AudioTransport.start_rx`` takes the
+        callback alone.
+        """
+        start_rx = getattr(self._radio, "start_rx", None)
+        if start_rx is None:
+            await self._radio.start_audio_rx_opus(
+                self._on_opus_packet,
+                jitter_depth=self._jitter_depth,
+            )
+        elif _accepts_jitter_depth(start_rx):
+            await start_rx(self._on_opus_packet, jitter_depth=self._jitter_depth)
+        else:
+            await start_rx(self._on_opus_packet)
+
     async def _start_rx(self) -> None:
         """Start receiving audio from the radio."""
         if self._rx_active:
             return
         try:
-            await self._radio.start_audio_rx_opus(
-                self._on_opus_packet,
-                jitter_depth=self._jitter_depth,
-            )
+            await self._begin_rx()
             self._rx_active = True
             logger.info("audio-bus: RX started")
         except Exception:
@@ -330,10 +367,7 @@ class AudioBus:
             if not self._subscribers:
                 return
             try:
-                await self._radio.start_audio_rx_opus(
-                    self._on_opus_packet,
-                    jitter_depth=self._jitter_depth,
-                )
+                await self._begin_rx()
                 self._rx_active = True
                 logger.info("audio-bus: RX re-armed after TX")
             except Exception:
@@ -345,7 +379,11 @@ class AudioBus:
             return
         self._rx_active = False
         try:
-            await self._radio.stop_audio_rx_opus()
+            stop_rx = getattr(self._radio, "stop_rx", None)
+            if stop_rx is not None:
+                await stop_rx()
+            else:
+                await self._radio.stop_audio_rx_opus()
             logger.info("audio-bus: RX stopped")
         except Exception:
             logger.debug("audio-bus: stop RX error", exc_info=True)

--- a/tests/test_audio_bus.py
+++ b/tests/test_audio_bus.py
@@ -367,3 +367,75 @@ async def test_remove_nonexistent_subscriber(bus):
     sub = AudioSubscription(bus, name="ghost")
     # Should not raise
     await bus._remove_subscriber(sub)
+
+
+# ---------------------------------------------------------------------------
+# Neutral AudioTransport surface (MOR-542)
+# ---------------------------------------------------------------------------
+
+
+class _NeutralRadio:
+    """Fake exposing the neutral surface; ``start_rx`` takes callback only."""
+
+    def __init__(self):
+        self.start_calls: list[tuple] = []
+        self.stop_calls = 0
+        self.start_audio_rx_opus = AsyncMock()
+        self.stop_audio_rx_opus = AsyncMock()
+
+    async def start_rx(self, callback):
+        self.start_calls.append((callback,))
+
+    async def stop_rx(self):
+        self.stop_calls += 1
+
+
+class _NeutralJitterRadio(_NeutralRadio):
+    """Fake whose ``start_rx`` accepts the optional ``jitter_depth`` kwarg."""
+
+    async def start_rx(self, callback, *, jitter_depth=5):
+        self.start_calls.append((callback, jitter_depth))
+
+
+async def test_bus_prefers_neutral_surface_over_legacy():
+    radio = _NeutralRadio()
+    bus = AudioBus(radio)
+    sub = bus.subscribe(name="s1")
+    await sub.start()
+    assert radio.start_calls == [(bus._on_opus_packet,)]
+    radio.start_audio_rx_opus.assert_not_awaited()
+
+    await sub.aclose()
+    assert radio.stop_calls == 1
+    radio.stop_audio_rx_opus.assert_not_awaited()
+
+
+async def test_neutral_start_rx_threads_jitter_depth_when_accepted():
+    radio = _NeutralJitterRadio()
+    bus = AudioBus(radio, jitter_depth=9)
+    sub = bus.subscribe(name="s1")
+    await sub.start()
+    assert radio.start_calls == [(bus._on_opus_packet, 9)]
+    await sub.aclose()
+
+
+async def test_restart_rx_rearm_uses_neutral_surface():
+    radio = _NeutralRadio()
+    bus = AudioBus(radio)
+    sub = bus.subscribe(name="s1")
+    await sub.start()
+
+    await bus.restart_rx()  # MOR-506 re-arm after a TX cycle
+
+    assert radio.start_calls == [(bus._on_opus_packet,)] * 2
+    assert bus.rx_active
+    radio.start_audio_rx_opus.assert_not_awaited()
+    await sub.aclose()
+
+
+async def test_restart_rx_noop_without_subscribers_neutral():
+    radio = _NeutralRadio()
+    bus = AudioBus(radio)
+    await bus.restart_rx()
+    assert radio.start_calls == []
+    assert not bus.rx_active


### PR DESCRIPTION
## Summary

Step 9/12 of the MOR-532 AudioTransport epic (Linear MOR-542).

`AudioBus` now consumes the codec-neutral `AudioTransport` surface: `_start_rx`, `restart_rx` (the MOR-506 re-arm; still a no-op without subscribers) and `_stop_rx` call `radio.start_rx(cb)` / `radio.stop_rx()` when the radio exposes them, with a `getattr` fallback to the legacy `start_audio_rx_opus` / `stop_audio_rx_opus` for radios that only implement the legacy surface (third-party/Pro radios, existing test fakes). Behavior for every existing caller is unchanged.

### jitter_depth threading

The neutral `AudioTransport.start_rx` is minimal (callback only). In-tree implementations differ:

- LAN mixin (MOR-539): `start_rx(callback, *, jitter_depth=5)` — accepts it
- Serial base (MOR-540) and YaesuCatRadio (MOR-541): `start_rx(callback)` — do not

The bus inspects `inspect.signature(radio.start_rx)` once per start: if the implementation declares a `jitter_depth` parameter (or `**kwargs`), the bus passes `jitter_depth=self._jitter_depth`; otherwise it calls `start_rx(cb)` alone. This avoids the ugly try/TypeError-retry pattern and never silently drops the kwarg for implementations that honour it. The legacy fallback path keeps passing `jitter_depth` exactly as before.

## Changes

- `src/rigplane/audio/bus.py`: module-level `_accepts_jitter_depth()` helper + private `AudioBus._begin_rx()` shared by `_start_rx` and `restart_rx`; neutral-first `stop_rx` in `_stop_rx`; docstring lifecycle update.
- `tests/test_audio_bus.py`: 2 neutral fakes + 4 new tests.

## Tests (TDD)

New tests written first and confirmed failing (3 red, the no-op guard green by design), then green after implementation:

1. `test_bus_prefers_neutral_surface_over_legacy` — a fake exposing BOTH surfaces gets `start_rx`/`stop_rx`, never the legacy names
2. `test_neutral_start_rx_threads_jitter_depth_when_accepted` — `AudioBus(radio, jitter_depth=9)` threads `9` into a `start_rx` that accepts the kwarg
3. `test_restart_rx_rearm_uses_neutral_surface` — MOR-506 re-arm goes through `start_rx`
4. `test_restart_rx_noop_without_subscribers_neutral` — re-arm stays a no-op with zero subscribers

All pre-existing legacy-only tests pass unmodified.

## Gate results

- `uv run pytest tests/ -q --ignore=tests/integration` — 7339 passed, 9 skipped, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — clean; `ruff format --check` — 551 files already formatted
- `uv run mypy src/` — 21 errors in 8 files, error set diffed line-by-line against main baseline: identical (zero new)
- `uv run lint-imports` — 4 contracts kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)