### PR TITLE
feat: radio_poller PTT path reads audio_duplex_mode + neutral TX (MOR-543, AudioTransport 10/12)

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -187,12 +187,32 @@ _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
 
 
 def _audio_tx_codec_and_rate(radio: Any) -> tuple[AudioCodec | None, int]:
+    """Legacy TX-format resolution for radios WITHOUT the neutral
+    ``AudioTransport`` surface; only reachable from the PTT fallback path
+    (MOR-543). Radios exposing ``start_tx``/``stop_tx`` resolve the format
+    themselves from their negotiated contract.
+    """
     contract = getattr(radio, "audio_stream_contract", None)
     tx_codec = getattr(contract, "tx_codec", None)
     tx_sr = getattr(contract, "tx_sample_rate_hz", None)
     if not isinstance(tx_sr, int) or isinstance(tx_sr, bool) or tx_sr <= 0:
         tx_sr = 48000
     return tx_codec, tx_sr
+
+
+def _should_restart_rx(mode: str) -> bool:
+    """Whether the RX path must be re-armed after a PTT TX cycle.
+
+    *mode* is the radio's ``audio_duplex_mode`` descriptor. Returns True
+    for ALL modes for now, preserving the MOR-506 unconditional re-arm
+    semantics exactly: the re-arm reinstates the single-slot RX callback
+    through the AudioBus, and skipping it for ``"full"`` transports is
+    deferred to a hardware-gated follow-up (verify on a real IC-7610
+    first). When that flip lands, this helper is the one-line decision
+    point (MOR-543).
+    """
+    logger.debug("poller: audio_duplex_mode=%s -> restart_rx=True", mode)
+    return True
 
 
 # ------------------------------------------------------------------
@@ -1166,16 +1186,28 @@ class RadioPoller:
                 # Start TX audio stream before PTT (LAN audio requires this)
                 if CAP_AUDIO in self._caps:
                     try:
-                        tx_codec, tx_sr = _audio_tx_codec_and_rate(radio)
-                        if tx_codec == AudioCodec.PCM_1CH_16BIT:
-                            await radio.start_audio_tx_pcm(sample_rate=tx_sr)
+                        start_tx = getattr(radio, "start_tx", None)
+                        if start_tx is not None:
+                            # Neutral AudioTransport surface (MOR-543): the
+                            # backend resolves the TX format from its
+                            # negotiated contract.
+                            await start_tx()
+                            logger.info(
+                                "poller: TX audio stream started (neutral start_tx)"
+                            )
                         else:
-                            await radio.start_audio_tx_opus()
-                        logger.info(
-                            "poller: TX audio stream started (tx_codec=%s, sr=%d)",
-                            tx_codec,
-                            tx_sr,
-                        )
+                            # Legacy per-codec fallback for radios without
+                            # the neutral surface.
+                            tx_codec, tx_sr = _audio_tx_codec_and_rate(radio)
+                            if tx_codec == AudioCodec.PCM_1CH_16BIT:
+                                await radio.start_audio_tx_pcm(sample_rate=tx_sr)
+                            else:
+                                await radio.start_audio_tx_opus()
+                            logger.info(
+                                "poller: TX audio stream started (tx_codec=%s, sr=%d)",
+                                tx_codec,
+                                tx_sr,
+                            )
                     except Exception as e:
                         logger.warning("poller: start TX audio failed: %s", e)
                 await radio.set_ptt(True)
@@ -1185,20 +1217,32 @@ class RadioPoller:
                 # Stop TX audio stream after PTT, then restart RX
                 if CAP_AUDIO in self._caps:
                     try:
-                        tx_codec, _tx_sr = _audio_tx_codec_and_rate(radio)
-                        if tx_codec == AudioCodec.PCM_1CH_16BIT:
-                            await radio.stop_audio_tx_pcm()
+                        stop_tx = getattr(radio, "stop_tx", None)
+                        if stop_tx is not None:
+                            # Neutral AudioTransport surface (MOR-543).
+                            await stop_tx()
                         else:
-                            await radio.stop_audio_tx_opus()
+                            # Legacy per-codec fallback.
+                            tx_codec, _tx_sr = _audio_tx_codec_and_rate(radio)
+                            if tx_codec == AudioCodec.PCM_1CH_16BIT:
+                                await radio.stop_audio_tx_pcm()
+                            else:
+                                await radio.stop_audio_tx_opus()
                         logger.info("poller: TX audio stream stopped")
 
-                        # Restart RX audio after TX (IC-7610 doesn't support
-                        # full duplex). Re-arm through the AudioBus so the
-                        # real subscriber callback is reinstated rather than a
-                        # throwaway no-op clobbering the single-slot RX callback
-                        # (MOR-506).
-                        await radio.audio_bus.restart_rx()
-                        logger.info("poller: RX audio stream restarted")
+                        # Re-arm RX through the AudioBus so the real
+                        # subscriber callback is reinstated rather than a
+                        # throwaway no-op clobbering the single-slot RX
+                        # callback (MOR-506). The LAN stream itself IS
+                        # full-duplex; the re-arm currently fires for every
+                        # audio_duplex_mode (including "full") until skipping
+                        # it is verified on real IC-7610 hardware — that flip
+                        # is a hardware-gated follow-up to MOR-543, one line
+                        # inside _should_restart_rx.
+                        duplex_mode = getattr(radio, "audio_duplex_mode", "half")
+                        if _should_restart_rx(duplex_mode):
+                            await radio.audio_bus.restart_rx()
+                            logger.info("poller: RX audio stream restarted")
                     except Exception as e:
                         logger.debug("poller: audio stream transition failed: %s", e)
             case SetPower(level=level, unit=unit):

--- a/tests/test_audio_rx_tx_transition.py
+++ b/tests/test_audio_rx_tx_transition.py
@@ -37,6 +37,7 @@ from rigplane.web.radio_poller import (
     PttOff,
     PttOn,
     RadioPoller,
+    _should_restart_rx,
 )
 
 
@@ -225,6 +226,89 @@ async def test_ptt_cycle_uses_pcm_when_audio_contract_tx_codec_is_pcm(
     radio.start_audio_tx_opus.assert_not_awaited()
     radio.stop_audio_tx_pcm.assert_awaited_once()
     radio.stop_audio_tx_opus.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# MOR-543: PTT path on the neutral AudioTransport surface (no behavior flip)
+# ---------------------------------------------------------------------------
+
+
+def _make_neutral_radio(duplex_mode: str | None = "full") -> SimpleNamespace:
+    """Stub radio exposing the neutral AudioTransport TX surface.
+
+    Keeps the legacy per-codec mocks so tests can assert they are NOT
+    used once ``start_tx``/``stop_tx`` are present. ``duplex_mode=None``
+    models a radio without the ``audio_duplex_mode`` descriptor.
+    """
+    radio = _make_audio_capable_radio()
+    radio.start_tx = AsyncMock()
+    radio.stop_tx = AsyncMock()
+    if duplex_mode is not None:
+        radio.audio_duplex_mode = duplex_mode
+    return radio
+
+
+@pytest.mark.asyncio
+async def test_ptt_on_neutral_radio_uses_start_tx() -> None:
+    """PTT ON on a neutral radio calls start_tx() with no codec branching."""
+    radio = _make_neutral_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    await poller._execute(PttOn())
+
+    radio.start_tx.assert_awaited_once_with()
+    radio.start_audio_tx_opus.assert_not_awaited()
+    radio.start_audio_tx_pcm.assert_not_awaited()
+    radio.set_ptt.assert_awaited_once_with(True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("duplex_mode", ["full", "exclusive", None])
+async def test_ptt_off_neutral_radio_stops_tx_then_restarts_rx(
+    duplex_mode: str | None,
+) -> None:
+    """PTT OFF calls stop_tx() then re-arms RX via the bus for EVERY mode.
+
+    Pins the MOR-543 no-flip decision: even ``"full"`` (and a missing
+    ``audio_duplex_mode`` attribute) must still re-arm RX, preserving
+    the MOR-506 unconditional restart semantics exactly.
+    """
+    radio = _make_neutral_radio(duplex_mode)
+    order: list[str] = []
+    radio.stop_tx.side_effect = lambda: order.append("stop_tx")
+    radio.audio_bus.restart_rx.side_effect = lambda: order.append("restart_rx")
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    await poller._execute(PttOff())
+
+    radio.set_ptt.assert_awaited_once_with(False)
+    radio.stop_tx.assert_awaited_once_with()
+    radio.stop_audio_tx_opus.assert_not_awaited()
+    radio.stop_audio_tx_pcm.assert_not_awaited()
+    radio.audio_bus.restart_rx.assert_awaited_once()
+    assert order == ["stop_tx", "restart_rx"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_radio_without_neutral_methods_uses_codec_fallback(
+    poller: RadioPoller, radio: SimpleNamespace
+) -> None:
+    """A radio lacking start_tx/stop_tx still uses the per-codec path."""
+    assert not hasattr(radio, "start_tx")
+    assert not hasattr(radio, "stop_tx")
+
+    await poller._execute(PttOn())
+    await poller._execute(PttOff())
+
+    radio.start_audio_tx_opus.assert_awaited_once()
+    radio.stop_audio_tx_opus.assert_awaited_once()
+    radio.audio_bus.restart_rx.assert_awaited_once()
+
+
+def test_should_restart_rx_returns_true_for_all_modes() -> None:
+    """No behavior flip in MOR-543: RX re-arm fires for every duplex mode."""
+    for mode in ("full", "half", "exclusive"):
+        assert _should_restart_rx(mode) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Step 10/12 of the MOR-532 AudioTransport epic (Linear MOR-543). The radio_poller PTT audio path now targets the codec/transport-neutral `AudioTransport` surface and reads the `audio_duplex_mode` descriptor — with **NO behavior flip**: RX re-arm after TX still fires unconditionally for every radio, exactly as in MOR-506.

### Changes (`src/rigplane/web/radio_poller.py`)

- **PttOn**: when the radio exposes the neutral surface, `await radio.start_tx()` (backend resolves the TX format from its negotiated contract). `getattr` fallback keeps the current `_audio_tx_codec_and_rate()` codec-branched path for legacy radios.
- **PttOff**: `await radio.stop_tx()` when neutral (same fallback), then the RX re-arm is gated through a new explicit helper `_should_restart_rx(mode: str) -> bool` that takes `getattr(radio, "audio_duplex_mode", "half")`, logs the mode at debug level, and **returns True for ALL modes** — preserving MOR-506 unconditional re-arm semantics exactly. The future skip-on-"full" flip becomes a one-line change with the decision point visible.
- Deleted the misleading "IC-7610 doesn't support full duplex" comment — the LAN stream IS full-duplex; the re-arm exists to re-install the single-slot RX callback (MOR-506). Replaced with the duplex-mode rationale + the pending hardware-gated flip note.
- `_audio_tx_codec_and_rate` retained, now only reachable from the legacy fallback (docstring states this).

**Behavior is identical to today for every radio.** The IC-7610 LAN path goes through neutral `start_tx`/`stop_tx`, which MOR-539's review proved byte-equivalent to the per-codec calls; the re-arm still always fires. The operator decision to defer the skip-restart_rx-on-"full" flip to a separate hardware-gated ticket (after live IC-7610 verification) is intentional and out of scope here.

### Tests (`tests/test_audio_rx_tx_transition.py`, TDD red → green)

New tests (failed before implementation, pass after):
- `test_ptt_on_neutral_radio_uses_start_tx` — neutral radio: `start_tx()` awaited, NO codec branching (legacy mocks not awaited).
- `test_ptt_off_neutral_radio_stops_tx_then_restarts_rx[full|exclusive|None]` — `stop_tx()` then `audio_bus.restart_rx()` in order, for mode `"full"`, `"exclusive"`, AND missing-attr — all re-arm (behavior preserved).
- `test_legacy_radio_without_neutral_methods_uses_codec_fallback` — legacy radio still routes through `_audio_tx_codec_and_rate` branches.
- `test_should_restart_rx_returns_true_for_all_modes` — pins the no-flip decision for `"full"`/`"half"`/`"exclusive"`.

All 7 existing MOR-506 tests pass **unmodified** (incl. the real-AudioBus clobber regression and the PCM-contract test).

### Gate results (worktree)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7341 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` → All checks passed; `ruff format --check` → 551 files already formatted
- `uv run mypy src/` → 21 errors in 8 files — **identical to the main baseline** (the 4 radio_poller entries are pre-existing `SetData*ModInput` capture-pattern errors, shifted by exactly the +44-line diff offset; zero new)
- `uv run lint-imports` → Contracts: 4 kept, 0 broken

Guardrails: 2 files, +148/−20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)