### PR TITLE
feat: AudioBroadcaster TX on the neutral surface (MOR-544, AudioTransport 11/12)

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -41,6 +41,20 @@ logger = logging.getLogger(__name__)
 _TX_CLEANUP_STOP_TIMEOUT_SECONDS = 2.0
 
 
+def _is_benign_tx_restart(exc: RuntimeError) -> bool:
+    """True when TX start failed only because the stream is already open.
+
+    The Icom LAN stream raises ``RuntimeError("Already transmitting")``
+    while the USB driver raises
+    ``AudioDriverLifecycleError("TX stream already started.")`` (a
+    ``RuntimeError`` subclass). Both mean the poller (or a prior client)
+    already opened TX and the handler can simply reuse it — re-raising
+    would close the audio WebSocket (MOR-541 review note, MOR-544).
+    """
+    text = str(exc).lower()
+    return "already transmitting" in text or "already started" in text
+
+
 def _parse_preferred_rx_codec(msg: dict[str, Any]) -> int | None:
     value = msg.get("preferred_rx_codec")
     if value in ("pcm16", "pcm", "raw"):
@@ -703,14 +717,16 @@ class AudioHandler:
                 if self._radio and CAP_AUDIO in self._radio.capabilities:
                     self._ensure_tx_transcoder()
                     try:
-                        if self._tx_codec() == AudioCodec.PCM_1CH_16BIT:
-                            await self._radio.start_audio_tx_pcm(  # type: ignore[attr-defined]
-                                sample_rate=self._tx_sample_rate()
-                            )
+                        start_tx = getattr(self._radio, "start_tx", None)
+                        if start_tx is not None:
+                            # Neutral AudioTransport surface (MOR-544): the
+                            # backend resolves the TX format from its
+                            # negotiated contract.
+                            await start_tx()
                         else:
-                            await self._radio.start_audio_tx_opus()  # type: ignore[attr-defined]
+                            await self._legacy_tx_lifecycle("start")
                     except RuntimeError as exc:
-                        if "Already transmitting" in str(exc):
+                        if _is_benign_tx_restart(exc):
                             logger.info("audio: TX already started by poller, reusing")
                         else:
                             raise
@@ -745,10 +761,12 @@ class AudioHandler:
                 return
 
             try:
-                if self._tx_codec() == AudioCodec.PCM_1CH_16BIT:
-                    stop_tx = self._radio.stop_audio_tx_pcm()  # type: ignore[attr-defined]
+                stop_tx_method = getattr(self._radio, "stop_tx", None)
+                if stop_tx_method is not None:
+                    # Neutral AudioTransport surface (MOR-544).
+                    stop_tx: Awaitable[None] = stop_tx_method()
                 else:
-                    stop_tx = self._radio.stop_audio_tx_opus()  # type: ignore[attr-defined]
+                    stop_tx = self._legacy_tx_lifecycle("stop")
                 if timeout is None:
                     await stop_tx
                 else:
@@ -908,13 +926,7 @@ class AudioHandler:
         and the radio silently dropped TX audio. Called on ``audio_start
         direction=tx``, when the rate is guaranteed available.
         """
-        contract = getattr(self._radio, "audio_stream_contract", None)
-        sr = getattr(contract, "tx_sample_rate_hz", None)
-        if not isinstance(sr, int) or isinstance(sr, bool) or sr <= 0:
-            sr = getattr(self._radio, "audio_sample_rate", None)
-        rate = (
-            sr if isinstance(sr, int) and not isinstance(sr, bool) and sr > 0 else 48000
-        )
+        rate = self._tx_sample_rate()
         if self._transcoder is not None and self._transcoder_rate == rate:
             return
         try:
@@ -935,6 +947,12 @@ class AudioHandler:
         # carrying a runtime-redundant ``cast``.  ``warn_unused_ignores`` is
         # off for ``rigplane.web.*``, so the ignore stays safe in any future
         # non-strict context.
+        #
+        # Preference order (MOR-544): first-class ``audio_tx_codec``
+        # (AudioTransport) → contract ``tx_codec`` → RX ``audio_codec``.
+        tx_codec = getattr(self._radio, "audio_tx_codec", None)
+        if tx_codec is not None:
+            return tx_codec  # type: ignore[no-any-return]
         contract = getattr(self._radio, "audio_stream_contract", None)
         tx_codec = getattr(contract, "tx_codec", None)
         if tx_codec is not None:
@@ -942,11 +960,42 @@ class AudioHandler:
         return getattr(self._radio, "audio_codec", None)  # type: ignore[no-any-return]
 
     def _tx_sample_rate(self) -> int:
+        """Resolve the TX sample rate: contract → radio property → 48000.
+
+        Single source for both the legacy ``start_audio_tx_pcm`` call and
+        the TX transcoder (the two used to carry half-duplicated fallback
+        chains; unified in MOR-544)."""
         contract = getattr(self._radio, "audio_stream_contract", None)
-        tx_sr = getattr(contract, "tx_sample_rate_hz", None)
-        if isinstance(tx_sr, int) and not isinstance(tx_sr, bool) and tx_sr > 0:
-            return tx_sr
+        sr = getattr(contract, "tx_sample_rate_hz", None)
+        if not isinstance(sr, int) or isinstance(sr, bool) or sr <= 0:
+            sr = getattr(self._radio, "audio_sample_rate", None)
+        if isinstance(sr, int) and not isinstance(sr, bool) and sr > 0:
+            return sr
         return 48000
+
+    async def _legacy_tx_lifecycle(self, op: str) -> None:
+        """Per-codec TX ``"start"``/``"stop"`` fallback for radios without
+        the neutral ``AudioTransport`` surface (MOR-544)."""
+        if self._tx_codec() == AudioCodec.PCM_1CH_16BIT:
+            if op == "start":
+                await self._radio.start_audio_tx_pcm(  # type: ignore[union-attr]
+                    sample_rate=self._tx_sample_rate()
+                )
+            else:
+                await self._radio.stop_audio_tx_pcm()  # type: ignore[union-attr]
+        elif op == "start":
+            await self._radio.start_audio_tx_opus()  # type: ignore[union-attr]
+        else:
+            await self._radio.stop_audio_tx_opus()  # type: ignore[union-attr]
+
+    async def _push_tx(self, data: bytes, *, legacy_method: str) -> None:
+        """Push TX bytes via neutral ``push_tx``; fall back to the named
+        legacy per-codec push method (MOR-544)."""
+        push_tx = getattr(self._radio, "push_tx", None)
+        if push_tx is not None:
+            await push_tx(data)
+        else:
+            await getattr(self._radio, legacy_method)(data)
 
     async def _start_rx(self, *, preferred_rx_codec: int | None = None) -> None:
         """Subscribe to audio broadcaster for RX frames."""
@@ -999,7 +1048,7 @@ class AudioHandler:
             try:
                 tx_codec = self._tx_codec()
                 if browser_codec == AUDIO_CODEC_PCM16:
-                    await self._radio.push_audio_tx_pcm(audio_data)  # type: ignore[attr-defined]
+                    await self._push_tx(audio_data, legacy_method="push_audio_tx_pcm")
                     tx_data_desc = f"{len(audio_data)} bytes pcm"
                 elif (
                     browser_codec == AUDIO_CODEC_OPUS
@@ -1017,7 +1066,7 @@ class AudioHandler:
                     try:
                         # Decode Opus → PCM16
                         pcm_data = self._transcoder.opus_to_pcm(audio_data)
-                        await self._radio.push_audio_tx_pcm(pcm_data)  # type: ignore[attr-defined]
+                        await self._push_tx(pcm_data, legacy_method="push_audio_tx_pcm")
                         tx_data_desc = f"{len(pcm_data)} bytes pcm"
                     except Exception as e:
                         logger.warning(
@@ -1031,7 +1080,7 @@ class AudioHandler:
                         return
                 elif browser_codec == AUDIO_CODEC_OPUS:
                     # Radio uses Opus or PCM_1CH_8BIT/etc → send Opus as-is
-                    await self._radio.push_audio_tx_opus(audio_data)  # type: ignore[attr-defined]
+                    await self._push_tx(audio_data, legacy_method="push_audio_tx_opus")
                     tx_data_desc = f"{len(audio_data)} bytes opus"
                 else:
                     logger.warning(

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1691,6 +1691,123 @@ async def test_audio_handler_pushes_pcm_browser_tx_directly() -> None:
     radio.push_audio_tx_opus.assert_not_awaited()
 
 
+def _make_neutral_tx_radio(contract: AudioStreamContract) -> SimpleNamespace:
+    """Legacy fake radio extended with the neutral AudioTransport surface."""
+    radio = _make_web_tx_radio(contract)
+    radio.audio_tx_codec = contract.tx_codec
+    radio.audio_duplex_mode = "full"
+    radio.start_tx = AsyncMock()
+    radio.push_tx = AsyncMock()
+    radio.stop_tx = AsyncMock()
+    return radio
+
+
+async def test_audio_handler_neutral_radio_uses_start_tx_and_stop_tx() -> None:
+    """audio_start/audio_stop tx use the neutral surface, no codec branching."""
+    contract = _make_web_tx_contract(AudioCodec.PCM_1CH_16BIT)
+    radio = _make_neutral_tx_radio(contract)
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+    assert handler._tx_active is True
+    radio.start_tx.assert_awaited_once_with()
+    radio.start_audio_tx_pcm.assert_not_awaited()
+    radio.start_audio_tx_opus.assert_not_awaited()
+
+    await handler._handle_control({"type": "audio_stop", "direction": "tx"})
+    assert handler._tx_active is False
+    radio.stop_tx.assert_awaited_once_with()
+    radio.stop_audio_tx_pcm.assert_not_awaited()
+    radio.stop_audio_tx_opus.assert_not_awaited()
+
+
+async def test_audio_handler_legacy_radio_keeps_per_codec_branches() -> None:
+    """Radios without the neutral surface traverse the legacy codec branches."""
+    contract = _make_web_tx_contract(AudioCodec.PCM_1CH_16BIT)
+    radio = _make_web_tx_radio(contract)
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+    radio.start_audio_tx_pcm.assert_awaited_once_with(sample_rate=16000)
+    radio.start_audio_tx_opus.assert_not_awaited()
+
+    await handler._handle_control({"type": "audio_stop", "direction": "tx"})
+    radio.stop_audio_tx_pcm.assert_awaited_once()
+    radio.stop_audio_tx_opus.assert_not_awaited()
+
+
+def test_tx_codec_prefers_first_class_audio_tx_codec() -> None:
+    """First-class audio_tx_codec wins over the contract's tx_codec."""
+    contract = _make_web_tx_contract(AudioCodec.OPUS_1CH)
+    radio = _make_web_tx_radio(contract)
+    radio.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+    handler = AudioHandler(SimpleNamespace(), radio, None)
+    assert handler._tx_codec() == AudioCodec.PCM_1CH_16BIT
+
+
+def test_tx_codec_falls_back_to_contract_tx_codec() -> None:
+    contract = _make_web_tx_contract(AudioCodec.OPUS_1CH)
+    radio = _make_web_tx_radio(contract)  # no audio_tx_codec attribute
+    handler = AudioHandler(SimpleNamespace(), radio, None)
+    assert handler._tx_codec() == AudioCodec.OPUS_1CH
+
+
+def test_tx_codec_falls_back_to_audio_codec() -> None:
+    radio = SimpleNamespace(
+        capabilities={"audio"},
+        audio_codec=AudioCodec.OPUS_2CH,
+    )
+    handler = AudioHandler(SimpleNamespace(), radio, None)
+    assert handler._tx_codec() == AudioCodec.OPUS_2CH
+
+
+async def test_audio_handler_push_tx_byte_compatible_with_legacy_pcm_push() -> None:
+    """Browser PCM frame on a PCM radio: push_tx gets the same bytes as
+    push_audio_tx_pcm did on the legacy path."""
+    contract = _make_web_tx_contract(AudioCodec.PCM_1CH_16BIT, tx_sample_rate_hz=48000)
+    pcm_bytes = b"pcm-payload-\x01\x02\x03"
+    frame = _make_web_tx_audio_frame(AUDIO_CODEC_PCM16, pcm_bytes)
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+
+    legacy = _make_web_tx_radio(contract)
+    legacy_handler = AudioHandler(ws, legacy, None)
+    legacy_handler._tx_active = True
+    await legacy_handler._handle_tx_audio(frame)
+    legacy.push_audio_tx_pcm.assert_awaited_once_with(pcm_bytes)
+
+    neutral = _make_neutral_tx_radio(contract)
+    neutral_handler = AudioHandler(ws, neutral, None)
+    neutral_handler._tx_active = True
+    await neutral_handler._handle_tx_audio(frame)
+    neutral.push_tx.assert_awaited_once_with(pcm_bytes)
+    neutral.push_audio_tx_pcm.assert_not_awaited()
+    neutral.push_audio_tx_opus.assert_not_awaited()
+    # Byte-for-byte identical to what the legacy per-codec path pushed.
+    assert neutral.push_tx.await_args.args == legacy.push_audio_tx_pcm.await_args.args
+
+
+async def test_audio_handler_tolerates_usb_lifecycle_double_start() -> None:
+    """Poller-first double start on USB radios raises
+    AudioDriverLifecycleError('TX stream already started.') — the handler
+    must treat it as the benign already-transmitting case (MOR-541/MOR-544)."""
+    from rigplane.audio.usb_driver import AudioDriverLifecycleError
+
+    contract = _make_web_tx_contract(AudioCodec.PCM_1CH_16BIT)
+    radio = _make_neutral_tx_radio(contract)
+    radio.start_tx = AsyncMock(
+        side_effect=AudioDriverLifecycleError("TX stream already started.")
+    )
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+
+    assert handler._tx_active is True
+    radio.start_tx.assert_awaited_once()
+
+
 async def test_audio_handler_drops_non_tx_or_unknown_browser_audio_frames() -> None:
     radio = SimpleNamespace(
         capabilities={"audio"},


### PR DESCRIPTION
## Summary

Step 11/12 of the MOR-532 AudioTransport epic (Linear MOR-544). Moves the web audio handler's TX path onto the codec/transport-neutral `AudioTransport` surface, with explicit legacy fallback for non-AudioTransport radios. RX side was already neutral; `AudioFftScope` untouched.

### Changes (`src/rigplane/web/handlers/audio.py`)

- **TX start/stop**: `audio_start`/`audio_stop direction=tx` now call `radio.start_tx()` / `radio.stop_tx()` when the radio exposes the neutral surface (detected via `getattr`, same pattern as the MOR-543 poller migration). One explicit legacy helper `_legacy_tx_lifecycle("start"|"stop")` preserves the previous per-codec `start_audio_tx_pcm(sample_rate=...)`/`start_audio_tx_opus()` branching.
- **TX push**: all radio pushes in `_handle_tx_audio` route through `radio.push_tx(...)` via `_push_tx(data, legacy_method=...)`; browser-codec branching (PCM vs Opus from the browser) and transcode decisions still key off `_tx_codec()`.
- **`_tx_codec()` ordering**: first-class `audio_tx_codec` property → `audio_stream_contract.tx_codec` → `audio_codec`. (For FTX-1 this keeps selecting PCM either way; for Icom LAN the property reads the same contract.)
- **`_tx_sample_rate()` unified** with the half-duplicated fallback in `_ensure_tx_transcoder`: one helper, `contract.tx_sample_rate_hz` → `radio.audio_sample_rate` → 48000.
- **Double-start tolerance broadened (MOR-541 review note)**: the handler previously string-matched only `"Already transmitting"` (LAN stream). The USB driver raises `AudioDriverLifecycleError("TX stream already started.")` — a poller-first double start on USB radios re-raised and closed the audio WS. `_is_benign_tx_restart()` now accepts "already transmitting" / "already started" case-insensitively.

### Tests (`tests/test_handlers_coverage.py`, +7, TDD red→green)

1. Neutral radio: `audio_start tx` → `start_tx()` (no per-codec methods touched); stop → `stop_tx()`.
2. Legacy-only radio still traverses the old per-codec branches.
3. `_tx_codec()` ordering: first-class wins over contract; contract-only; `audio_codec` fallback.
4. Push byte-compat: browser PCM frame on a PCM radio — `push_tx` receives bytes identical to what `push_audio_tx_pcm` received on the legacy path.
5. Regression: USB-style `AudioDriverLifecycleError("TX stream already started.")` on start → treated as already-transmitting, `_tx_active=True`, no raise (WS stays open).

4 of the new tests failed before the implementation (red), all pass after; existing handler tests pass unmodified.

### Gate results (worktree)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7352 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — clean; `uv run ruff format --check` — 551 files already formatted
- `uv run mypy src/` — 21 errors in 8 files, identical to baseline (zero in `audio.py`; zero new)
- `uv run lint-imports` — 4 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)