### PR TITLE
fix: subscribe bridge RX before arming radio TX — LAN RX dead + packet-queue flood (MOR-556)

### DIFF
--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -501,6 +501,15 @@ class AudioBridge:
         else:
             self._decoder = None
 
+        # --- Subscribe to AudioBus BEFORE arming radio TX (MOR-556). The
+        # first subscriber triggers radio RX start, and the LAN stream state
+        # machine supports RX-then-TX only: arming TX first puts it in
+        # TRANSMITTING and the later RX start raises, leaving RX dead and the
+        # transport packet queue undrained (regression from #1735).
+        bus = self._radio.audio_bus
+        self._subscription = bus.subscribe(name="audio-bridge")
+        await self._subscription.start()
+
         # --- Arm the radio TX path BEFORE choosing the device-stream topology.
         # The radio may reject TX (serial backend with no USB-audio TX path):
         # degrade to RX-only and use a plain output stream, never a duplex one
@@ -583,11 +592,6 @@ class AudioBridge:
                 frame_ms=self._frame_ms,
             )
             await self._rx_stream.start()
-
-        # Subscribe to AudioBus
-        bus = self._radio.audio_bus
-        self._subscription = bus.subscribe(name="audio-bridge")
-        await self._subscription.start()
 
         # --- TX path: device input → radio (capture) ---
         if tx_armed:

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -300,6 +300,102 @@ async def test_bridge_stop_when_not_running():
 
 
 # ---------------------------------------------------------------------------
+# RX-before-TX start order against a LAN-like state machine (MOR-556)
+# ---------------------------------------------------------------------------
+
+
+class _LanLikeRadio:
+    """Radio stub mirroring ``LanAudioStream``'s RX/TX state machine.
+
+    The real LAN stream supports RX-then-TX only: ``start_rx`` requires
+    IDLE state, while ``start_tx`` flips the single state field to
+    "transmitting". Arming radio TX before the AudioBus RX subscribe
+    therefore kills RX entirely (regression from #1735, MOR-556).
+    ``FakeAudioBackend``-style order-insensitive stubs cannot catch this.
+    """
+
+    def __init__(self) -> None:
+        from rigplane.audio_bus import AudioBus
+        from rigplane.types import AudioCodec
+
+        self.state = "idle"
+        self.calls: list[str] = []
+        self.rx_callback: object | None = None
+        self.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+        self.audio_bus = AudioBus(self)
+
+    async def start_rx(
+        self, callback: object, *, jitter_depth: int | None = None
+    ) -> None:
+        self.calls.append("start_rx")
+        if self.state != "idle":
+            raise RuntimeError(f"Cannot start RX in state {self.state}")
+        self.rx_callback = callback
+        self.state = "receiving"
+
+    async def stop_rx(self) -> None:
+        if self.state == "receiving":
+            self.state = "idle"
+        self.rx_callback = None
+
+    async def start_tx(self) -> None:
+        self.calls.append("start_tx")
+        if self.state == "transmitting":
+            raise RuntimeError("Already transmitting")
+        self.state = "transmitting"
+
+    async def stop_tx(self) -> None:
+        if self.state != "transmitting":
+            return
+        self.state = "receiving" if self.rx_callback is not None else "idle"
+
+    async def push_tx(self, audio_data: bytes) -> None:
+        if self.state != "transmitting":
+            raise RuntimeError(f"Cannot push TX in state {self.state}")
+
+
+async def test_bridge_subscribes_rx_before_arming_tx():
+    """Regression MOR-556: bus RX subscribe must happen BEFORE radio TX arm.
+
+    On LAN, ``start_tx`` puts the stream in TRANSMITTING and a subsequent
+    ``start_rx`` raises — leaving RX dead and the packet queue undrained.
+    """
+    radio = _LanLikeRadio()
+    backend = _bridge_backend()
+    bridge = AudioBridge(radio, device_name="BlackHole", backend=backend)
+    await bridge.start()
+    try:
+        # RX must be live on the radio — the regression left it dead.
+        assert radio.audio_bus.rx_active
+        assert radio.rx_callback is not None
+        # TX is still armed for non-rx_only configs — after RX, never before.
+        assert radio.state == "transmitting"
+        assert radio.calls == ["start_rx", "start_tx"]
+        assert bridge._tx_started
+    finally:
+        await bridge.stop()
+    assert radio.audio_bus.subscriber_count == 0
+    assert radio.state == "idle"
+
+
+async def test_bridge_rx_only_never_arms_tx_on_lan_state_machine():
+    """rx_only semantics are preserved by the MOR-556 reorder: no TX arm."""
+    radio = _LanLikeRadio()
+    backend = _bridge_backend()
+    bridge = AudioBridge(
+        radio, device_name="BlackHole", tx_enabled=False, backend=backend
+    )
+    await bridge.start()
+    try:
+        assert radio.audio_bus.rx_active
+        assert radio.state == "receiving"
+        assert "start_tx" not in radio.calls
+    finally:
+        await bridge.stop()
+    assert radio.state == "idle"
+
+
+# ---------------------------------------------------------------------------
 # RX callback — packets flow from bus to backend TxStream
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause

Regression from #1735 (MOR-531; found in live IC-7610 validation). Commit `d0a15d27` reordered `AudioBridge._setup_streams` so the radio TX arm (which feeds the `use_duplex` device-stream topology decision) runs BEFORE the AudioBus subscribe. On LAN backends this kills RX entirely:

- `LanAudioStream.start_tx()` flips the single state field to TRANSMITTING (`audio/lan_stream.py:603`).
- The later first-subscriber `AudioBus._begin_rx` → LAN mixin `start_rx` → `lan_stream.start_rx` raises `RuntimeError("Cannot start RX in state transmitting")` (`lan_stream.py:522-523`).
- The LAN state machine supports RX-then-TX only (`_rx_loop` keeps running through TRANSMITTING; `stop_tx` reverts to RECEIVING when `_rx_callback` is set). TX-then-RX is impossible.
- With no `_rx_loop`, nothing drains the audio transport's packet queue → `core/transport.py:644` overflow warning floods at ~150/s.

**Live evidence (IC-7610 LAN, 2026-06-09):** "Audio TX started" → "audio-bus: +subscriber 'audio-bridge'" → `ERROR audio-bus: failed to start RX` (exact traceback), repeated for 'web-audio'; WS RX 0 frames / analyzer rms −96; 21k+ packet-queue overflow warnings in 3 minutes.

## Fix (MOR-556 option 1 — minimal)

Move the AudioBus subscribe + subscription start in `_setup_streams` BEFORE the radio-TX-arm block. The `use_duplex` decision depends only on `tx_armed` and device identity (RX/TX device IDs + virtual-loopback check), not on bus state, so the MOR-531 duplex topology is unaffected. `rx_only` semantics are unchanged — the TX-arm block is still skipped entirely when TX is disabled.

## Falsification evidence (TDD)

The regression test was written FIRST, against a LAN-like radio stub that mirrors the real `LanAudioStream` state machine (`start_rx` requires IDLE, `start_tx` flips to TRANSMITTING) — order-insensitive `FakeAudioBackend` stubs are why CI missed this.

- **Red on unmodified main (`a52263d9`):** `test_bridge_subscribes_rx_before_arming_tx` fails with `RuntimeError: Cannot start RX in state transmitting` + `ERROR audio-bus: failed to start RX` — the exact live traceback.
- **Green with the fix.** Also asserts TX is still armed AFTER RX for non-rx_only configs (`calls == ["start_rx", "start_tx"]`, state ends TRANSMITTING) and that rx_only never arms TX.

## Gate results (worktree @ fix)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7369 passed, 0 failed**, 9 skipped, 11 xfailed, 1 xpassed (one flaky perf-timing test `test_frame_creation_latency_distribution` failed once under full-suite load on the first run, passed in isolation and on full-suite rerun — unrelated to this change)
- `uv run ruff check src/ tests/` — All checks passed; `uv run ruff format --check` — 552 files already formatted
- `uv run mypy src/` — 21 errors in 8 files, error set **byte-identical** to main baseline (zero new)
- `uv run lint-imports` — 4 kept / 0 broken

Diff: 2 files, +105/−5 (within guardrails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)