### PR TITLE
fix: project 0x27 scope-control answers into the StateStore — v2 scope toolbar (MOR-557)

### DIFF
--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -1220,6 +1220,17 @@ def _global_specs() -> tuple[FieldSpec, ...]:
             "int",
             writable=True,
         ),
+        # Global scope-control display leaves (MOR-557): read-only ingress
+        # observations decoded from CI-V 0x27 answers; writes go through the
+        # scope command path, not the store.
+        spec(FieldPath.scope_control("display", "receiver"), "int"),
+        spec(FieldPath.scope_control("display", "dual"), "bool"),
+        spec(FieldPath.scope_control("display", "mode"), "int"),
+        spec(FieldPath.scope_control("display", "span"), "int"),
+        spec(FieldPath.scope_control("display", "edge"), "int"),
+        spec(FieldPath.scope_control("display", "hold"), "bool"),
+        spec(FieldPath.scope_control("display", "ref_db"), "float", unit="db"),
+        spec(FieldPath.scope_control("display", "speed"), "int"),
     )
 
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -1834,8 +1834,54 @@ class CivRuntime:
                         frame=frame,
                     )
                 )
+        elif frame.command == 0x27 and frame.sub:
+            observations.extend(self._scope_control_observations(frame))
 
         return tuple(observations)
+
+    def _scope_control_observations(self, frame: CivFrame) -> list[Observation]:
+        """Decode a 0x27 scope-control response into StateStore observations.
+
+        Mirrors the ``_handle_27`` sub-command dispatch for the leaves the web
+        layer publishes as ``scopeControls.*`` (MOR-557): receiver/dual/mode/
+        span/edge/hold/ref_db/speed. Sub 0x00 (waterfall pixel data) never
+        reaches here — ``_route_civ_frame`` short-circuits it — and command
+        echoes are dropped earlier by the ``from_addr`` filter. Malformed
+        payloads raise ``ValueError`` in the parse helpers and are swallowed
+        by ``_apply_state_store_observations``.
+        """
+        receiver: int | None = None
+        pairs: list[tuple[str, Any]] = []
+        if frame.sub == 0x12:
+            pairs.append(("receiver", parse_scope_main_sub_response(frame)))
+        elif frame.sub == 0x13:
+            pairs.append(("dual", parse_scope_single_dual_response(frame)))
+        elif frame.sub == 0x14:
+            receiver, mode = parse_scope_mode_response(frame)
+            pairs.append(("mode", mode))
+        elif frame.sub == 0x15:
+            receiver, span = parse_scope_span_response(frame)
+            pairs.append(("span", span))
+        elif frame.sub == 0x16:
+            receiver, edge = parse_scope_edge_response(frame)
+            pairs.append(("edge", edge))
+        elif frame.sub == 0x17:
+            receiver, hold = parse_scope_hold_response(frame)
+            pairs.append(("hold", hold))
+        elif frame.sub == 0x19:
+            receiver, ref_db = parse_scope_ref_response(frame)
+            pairs.append(("ref_db", ref_db))
+        elif frame.sub == 0x1A:
+            receiver, speed = parse_scope_speed_response(frame)
+            pairs.append(("speed", speed))
+        if receiver is not None:
+            pairs.append(("receiver", receiver))
+        return [
+            self._observation(
+                FieldPath.scope_control("display", name), value, frame=frame
+            )
+            for name, value in pairs
+        ]
 
     def _receiver_context(self, frame: CivFrame) -> tuple[str, str, str | None]:
         """Return receiver id/name plus any temporary VFO-slot override."""

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -181,6 +181,12 @@ _SCOPE_CONTROL_PUBLIC_FIELDS = {
     "dual": "dual",
     "receiver": "receiver",
 }
+# Inverse map: backend scope-control leaf name → public ``scopeControls.``
+# suffix, used to project store snapshot fields back out (MOR-557).
+_SCOPE_CONTROL_PUBLIC_SUFFIXES = {
+    control_name: public_suffix
+    for public_suffix, control_name in _SCOPE_CONTROL_PUBLIC_FIELDS.items()
+}
 
 
 def _receiver_public_key(name: str) -> str:
@@ -270,8 +276,11 @@ def _snapshot_field_public_paths(path: FieldPath) -> tuple[str, ...]:
         paths: list[str] = []
         if path.receiver_id is not None and _snapshot_receiver_key(path.receiver_id):
             paths.append("scopeControls.receiver")
-        if path.name == "span":
-            paths.append("scopeControls.span")
+        public_suffix = _SCOPE_CONTROL_PUBLIC_SUFFIXES.get(path.name)
+        if public_suffix is not None:
+            public_path = f"scopeControls.{public_suffix}"
+            if public_path not in paths:
+                paths.append(public_path)
         return tuple(paths)
 
     return ()
@@ -819,8 +828,8 @@ def _apply_snapshot_field(
                 scope_controls["receiver"] = 0
             elif receiver_key == "sub":
                 scope_controls["receiver"] = 1
-        if path.name == "span":
-            scope_controls["span"] = value
+        if path.name in _SCOPE_CONTROL_PUBLIC_SUFFIXES:
+            scope_controls[path.name] = value
 
 
 def _project_snapshot_state_dict(snapshot: StateSnapshot) -> dict[str, Any]:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -2549,6 +2549,127 @@ def test_update_radio_state_advanced_scope_family(
     assert rs.scope_controls.rbw == 2
 
 
+# ---------------------------------------------------------------------------
+# MOR-557: 0x27 scope-control answers must reach the StateStore, not only the
+# legacy RadioState mirror — otherwise the v2 scope toolbar gates every
+# control on ``availability: missing`` and goes dead.
+# (frame, {store path: expected decoded value})
+# ---------------------------------------------------------------------------
+_SCOPE_CONTROL_OBSERVATION_CASES = (
+    (
+        _make_frame(cmd=0x27, sub=0x12, data=b"\x01"),
+        {"scope_controls.global.display.receiver": 1},
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x13, data=b"\x01"),
+        {"scope_controls.global.display.dual": True},
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x14, data=b"\x00\x03"),
+        {
+            "scope_controls.global.display.mode": 3,
+            "scope_controls.global.display.receiver": 0,
+        },
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x15, data=b"\x00" + bcd_encode(250_000)),
+        {
+            "scope_controls.global.display.span": 6,
+            "scope_controls.global.display.receiver": 0,
+        },
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x16, data=b"\x00\x04"),
+        {
+            "scope_controls.global.display.edge": 4,
+            "scope_controls.global.display.receiver": 0,
+        },
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x17, data=b"\x00\x01"),
+        {
+            "scope_controls.global.display.hold": True,
+            "scope_controls.global.display.receiver": 0,
+        },
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x19, data=b"\x00\x10\x50\x01"),
+        {
+            "scope_controls.global.display.ref_db": -10.5,
+            "scope_controls.global.display.receiver": 0,
+        },
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x1A, data=b"\x00\x02"),
+        {
+            "scope_controls.global.display.speed": 2,
+            "scope_controls.global.display.receiver": 0,
+        },
+    ),
+)
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("frame", "expected"),
+    _SCOPE_CONTROL_OBSERVATION_CASES,
+    ids=[f"sub_0x{entry[0].sub:02x}" for entry in _SCOPE_CONTROL_OBSERVATION_CASES],
+)
+def test_scope_control_observation_backed(
+    radio: IcomRadio,
+    frame: CivFrame,
+    expected: dict[str, object],
+) -> None:
+    """MOR-557: 0x27 scope-control responses emit StateStore observations."""
+    radio._civ_runtime._update_state_cache_from_frame(frame)
+
+    snapshot = radio._state_store.snapshot()
+    for store_path, value in expected.items():
+        field = snapshot.field(store_path)
+        assert field.value == value
+        assert field.freshness is FreshnessState.FRESH
+        # Scope controls only change on user/poller action — no decay window,
+        # matching the slow-state toggle pattern (MOR-437).
+        assert field.max_age is None
+
+
+def test_scope_waterfall_data_emits_no_observations(radio: IcomRadio) -> None:
+    """0x27 sub 0x00 (waterfall pixel data) must never reach the StateStore."""
+    frame = _make_frame(cmd=0x27, sub=0x00, data=b"\x00\x01\x01" + b"\x00" * 16)
+    assert radio._civ_runtime._observations_from_frame(frame) == ()
+
+
+def test_scope_control_observations_project_public(radio: IcomRadio) -> None:
+    """MOR-557: observed scope controls surface as scopeControls.* available."""
+    from rigplane.web.runtime_helpers import (
+        build_public_state_payload_from_snapshot,
+    )
+
+    for frame, _expected in _SCOPE_CONTROL_OBSERVATION_CASES:
+        radio._civ_runtime._update_state_cache_from_frame(frame)
+
+    payload = build_public_state_payload_from_snapshot(
+        radio._state_store.snapshot(),
+        radio=None,
+        receiver_count=2,
+    )
+
+    sc = payload["scopeControls"]
+    assert sc["receiver"] == 0
+    assert sc["dual"] is True
+    assert sc["mode"] == 3
+    assert sc["span"] == 6
+    assert sc["edge"] == 4
+    assert sc["hold"] is True
+    assert sc["refDb"] == -10.5
+    assert sc["speed"] == 2
+
+    suffixes = ("receiver", "dual", "mode", "span", "edge", "hold", "refDb", "speed")
+    for suffix in suffixes:
+        status = payload["fieldStatus"][f"scopeControls.{suffix}"]
+        assert status["observed"] is True, suffix
+        assert status["availability"] == "available", suffix
+
+
 def test_civ_expects_response_scope_get(
     radio_with_state: IcomRadio,
 ) -> None:

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -262,6 +262,32 @@ def test_global_dial_lock_registered_as_tx_state_bool() -> None:
     assert spec.writable is True
 
 
+def test_global_scope_control_display_leaves_registered() -> None:
+    """MOR-557: the public scope-control leaves have canonical FieldSpecs.
+
+    The 0x27 ingress decoder emits observations at
+    ``scope_controls.global.display.<leaf>`` for every leaf the web layer
+    publishes as ``scopeControls.*``; each needs a registered read-only spec.
+    """
+    expected = {
+        "receiver": "int",
+        "dual": "bool",
+        "mode": "int",
+        "span": "int",
+        "edge": "int",
+        "hold": "bool",
+        "ref_db": "float",
+        "speed": "int",
+    }
+    for name, value_type in expected.items():
+        path = FieldPath.scope_control("display", name)
+        spec = DEFAULT_FIELD_REGISTRY.require(path)
+        assert spec.path == path
+        assert spec.family is FieldFamily.DISPLAY
+        assert spec.value_type == value_type
+        assert spec.writable is False
+
+
 def test_global_key_speed_registered_as_operator_control_int() -> None:
     """MOR-456: ``global.operator_controls.key_speed`` is a registered int.
 

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -335,3 +335,55 @@ def test_public_state_projection_uses_snapshot_revisions_and_meter_values() -> N
     assert payload["freshnessRevision"] == 2
     assert payload["main"]["freqHz"] == 14_074_000
     assert payload["main"]["sMeter"] == 42
+
+
+def test_public_state_projection_covers_all_scope_control_leaves() -> None:
+    """MOR-557: every scope_controls.global.display leaf must project.
+
+    The v2 scope toolbar gates each control on
+    ``fieldStatus["scopeControls.<leaf>"]``; before MOR-557 only ``span`` and
+    ``receiver`` were mapped, so observed mode/edge/speed/hold/ref_db/dual
+    stayed ``missing`` and the toolbar rendered dead.
+    """
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    leaves: dict[str, Any] = {
+        "receiver": 1,
+        "dual": True,
+        "mode": 3,
+        "span": 6,
+        "edge": 4,
+        "hold": True,
+        "ref_db": -10.5,
+        "speed": 2,
+    }
+    for name, value in leaves.items():
+        store.apply(
+            _observation(
+                FieldPath.scope_control("display", name),
+                value,
+                at=clock.now(),
+            )
+        )
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(),
+        radio=None,
+        receiver_count=2,
+    )
+
+    sc = payload["scopeControls"]
+    assert sc["receiver"] == 1
+    assert sc["dual"] is True
+    assert sc["mode"] == 3
+    assert sc["span"] == 6
+    assert sc["edge"] == 4
+    assert sc["hold"] is True
+    assert sc["refDb"] == -10.5
+    assert sc["speed"] == 2
+
+    suffixes = ("receiver", "dual", "mode", "span", "edge", "hold", "refDb", "speed")
+    for suffix in suffixes:
+        status = payload["fieldStatus"][f"scopeControls.{suffix}"]
+        assert status["observed"] is True, suffix
+        assert status["availability"] == "available", suffix


### PR DESCRIPTION
## Root cause (URGENT — v2 scope toolbar dead on IC-7610)

Regression from the MOR-334 squash-merge (`e19d8988`), verified live on the IC-7610 on 2026-06-09:

- The RadioPoller's 0x27 scope-control fetch works and `_handle_27` (`src/rigplane/runtime/_civ_rx.py`) decodes the answers — but writes them **only** to the legacy `RadioState` mirror.
- The StateStore observation decoder `_observations_from_frame` had **no 0x27 branch** (`_CIV_STATE_FIELD_FAMILIES[0x27]` is diagnostics labeling only).
- Post-MOR-334, `build_public_state` (`web/server.py`) is snapshot-only, so all 9 `scopeControls.*` web fields stayed `availability: missing, observed: false`.
- The v2 toolbar's `disabled={!isFieldAvailable(...)}` gating therefore disabled every control: SPAN/SPEED/REF rendered "—" and clicks never sent commands.

## Fix

1. **`src/rigplane/runtime/_civ_rx.py`** — new `_scope_control_observations()` mirrors the `_handle_27` sub-command dispatch (subs `0x12/0x13/0x14/0x15/0x16/0x17/0x19/0x1A`) using the already-imported `parse_scope_*_response` helpers, emitting `Observation`s at `FieldPath.scope_control("display", <name>)` → store paths `scope_controls.global.display.{receiver,dual,mode,span,edge,hold,ref_db,speed}` (exactly the storePaths the web fieldStatus seeds reference). Wired as an `elif frame.command == 0x27 and frame.sub` branch in `_observations_from_frame`; sub `0x00` waterfall data never reaches it (`_route_civ_frame` short-circuits it) and echoes are dropped by the `from_addr` filter.
2. **`src/rigplane/web/runtime_helpers.py`** — `_snapshot_field_public_paths` and `_apply_snapshot_field` now cover **all eight** scope-control leaves (previously only `span` + receiver-scoped `receiver`), via an inverse of `_SCOPE_CONTROL_PUBLIC_FIELDS`, projecting to the public fields the frontend reads: `scopeControls.{span,speed,refDb,mode,hold,edge,dual,receiver}`. No frontend changes.
3. **`src/rigplane/core/state_pipeline_contracts.py`** — the global `scope_controls.global.display.*` paths were **not** registered (only receiver-scoped `span` for main/sub existed), so minimal **read-only** specs for the eight leaves were added, following the existing `_global_specs()` pattern. Note: nothing enforces registry membership at `StateStore.apply` time, but the registry is the canonical field contract, so the new observation-backed leaves are declared (precedent: MOR-455/456).

## Falsification (red → green)

Tests written first and confirmed **RED on origin/main (`a52263d9`)** — 11 failures:
- `tests/test_civ_rx_coverage.py::test_scope_control_observation_backed` (8 parametrized synthetic 0x27 span/speed/ref/mode/edge/hold/dual/receiver response frames → expected StateStore observations) — all 8 RED;
- `tests/test_civ_rx_coverage.py::test_scope_control_observations_project_public` (frames → public payload `scopeControls.*` + fieldStatus available) — RED;
- `tests/test_web_runtime_helpers.py::test_public_state_projection_covers_all_scope_control_leaves` (store snapshot with all 8 leaves → public values + fieldStatus) — RED;
- `tests/test_state_pipeline_contracts.py::test_global_scope_control_display_leaves_registered` — RED;
- plus `test_scope_waterfall_data_emits_no_observations` (sub 0x00 → no observations) as a guard.

All GREEN after the fix. Existing 0x27 legacy RadioState tests and golden fixtures (`empty-store-field-status.json` etc.) pass **unmodified** — the default missing-status storePaths already matched the emitted paths.

## Gate results (worktree)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7379 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` → All checks passed; `ruff format --check` → 552 files already formatted
- `uv run mypy src/` → 21 errors in 8 files (baseline — identical set; the one `_civ_rx.py` error is the pre-existing line-734 redundant-cast, untouched region)
- `uv run lint-imports` → Contracts: 4 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)