### PR TITLE
fix: drop never-observed scope_controls group fieldStatus (MOR-557 fix 2 — parent veto)

### DIFF
--- a/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
+++ b/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
@@ -593,12 +593,6 @@
     "observed": false,
     "storePath": "global.slow_state.scanning"
   },
-  "scopeControls": {
-    "availability": "missing",
-    "freshness": "unknown",
-    "observed": false,
-    "storePath": "global.slow_state.scope_controls"
-  },
   "scopeControls.dual": {
     "availability": "missing",
     "freshness": "unknown",

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -407,6 +407,15 @@ def _default_snapshot_field_status(receiver_count: int) -> dict[str, dict[str, A
             FieldPath.global_("meters", name),
         )
     for name in _GLOBAL_SLOW_STATE_FIELDS:
+        if name == "scope_controls":
+            # No observation ever writes ``global.slow_state.scope_controls``
+            # (scope-control observations land under
+            # ``scope_controls.global.display.*``), so a group-level
+            # ``scopeControls`` entry would stay ``missing`` forever and the
+            # frontend MOR-429 parent-veto rule would disable every observed
+            # ``scopeControls.<leaf>`` (MOR-557). The eight per-leaf entries
+            # seeded below are the real gate.
+            continue
         _set_missing_field_status(
             statuses,
             _to_camel(name),

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -19,7 +19,7 @@ from rigplane.core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
-from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.core.state_store import FreshnessClock, StateSnapshot, StateStore
 
 
 class _FakeWriter:
@@ -387,3 +387,72 @@ def test_public_state_projection_covers_all_scope_control_leaves() -> None:
         status = payload["fieldStatus"][f"scopeControls.{suffix}"]
         assert status["observed"] is True, suffix
         assert status["availability"] == "available", suffix
+
+
+_SCOPE_TOOLBAR_SUFFIXES = (
+    "mode",
+    "edge",
+    "span",
+    "speed",
+    "hold",
+    "refDb",
+    "dual",
+    "receiver",
+)
+
+
+def _frontend_availability(field_status: dict[str, dict[str, Any]], path: str) -> str:
+    """Frontend MOR-429 resolver: nearest missing/stale ancestor vetoes a leaf."""
+    ancestors = (path[:i] for i in range(len(path) - 1, 0, -1) if path[i] == ".")
+    parent = next((field_status[p] for p in ancestors if p in field_status), None)
+    own = field_status.get(path)
+    if own is None:
+        return parent["availability"] if parent else "available"
+    if (
+        own["availability"] == "available"
+        and parent
+        and parent["availability"] != "available"
+    ):
+        return parent["availability"]
+    return own["availability"]
+
+
+def test_default_field_status_has_no_scope_controls_group_entry() -> None:
+    """MOR-557 fix 2: a bare ``scopeControls`` group entry, keyed to the
+    never-written ``global.slow_state.scope_controls`` path, stays ``missing``
+    forever and the frontend parent-veto disables every observed leaf. Only
+    the eight per-leaf entries may be seeded."""
+    payload = build_public_state_payload_from_snapshot(
+        StateSnapshot.empty(), radio=None, receiver_count=2
+    )
+    field_status = payload["fieldStatus"]
+    assert "scopeControls" not in field_status
+    for suffix in _SCOPE_TOOLBAR_SUFFIXES:
+        status = field_status[f"scopeControls.{suffix}"]
+        assert status["availability"] == "missing", suffix
+        assert status["observed"] is False, suffix
+
+
+def test_observed_scope_control_leaves_survive_frontend_parent_veto() -> None:
+    """MOR-557 fix 2: once scope-control observations land, every toolbar leaf
+    resolves ``available`` through the frontend parent-availability walk —
+    no never-observed ancestor entry may veto it."""
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    leaves: dict[str, Any] = {
+        "receiver": 0, "dual": False, "mode": 0, "span": 0,
+        "edge": 1, "hold": False, "ref_db": 0.0, "speed": 1,
+    }  # fmt: skip
+    for name, value in leaves.items():
+        store.apply(
+            _observation(
+                FieldPath.scope_control("display", name), value, at=clock.now()
+            )
+        )
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=2
+    )
+    field_status = payload["fieldStatus"]
+    for suffix in _SCOPE_TOOLBAR_SUFFIXES:
+        path = f"scopeControls.{suffix}"
+        assert _frontend_availability(field_status, path) == "available", suffix


### PR DESCRIPTION
## Root cause

The first MOR-557 fix (#1751) made the eight `scopeControls.<leaf>` fieldStatus entries genuinely observable, but the v2 scope toolbar remained dead. `_default_snapshot_field_status` (`src/rigplane/web/runtime_helpers.py`) seeded a **group-level** `fieldStatus["scopeControls"]` entry — because `"scope_controls"` is a member of `_GLOBAL_SLOW_STATE_FIELDS` — keyed to the store path `global.slow_state.scope_controls`. No observation ever writes that path (the #1751 observations land under `scope_controls.global.display.*`), so the group entry was permanently `availability: missing, observed: false`. The frontend's MOR-429 parent-veto rule (`frontend/src/lib/state/field-status.ts`: an own `available` entry is overridden by a `missing`/`stale` ancestor) therefore resolved `isFieldAvailable("scopeControls.<leaf>")` to false for ALL 8 leaves, keeping every toolbar control disabled despite the leaves being observed and available. Verified live on IC-7610.

## Fix (backend-only, no dist rebuild)

Skip seeding the group-level entry for `"scope_controls"` in the `_GLOBAL_SLOW_STATE_FIELDS` loop. The eight per-leaf `scopeControls.*` entries seeded immediately after remain the real gate. Every other slow-state field is seeded byte-identically.

Consumer audit: no code in `src/`, `tests/`, or `frontend/src` gates on the bare `scopeControls` fieldStatus key — the only reader was the generic `parentAvailability` ancestor walk (the veto itself). Frontend synthetic tests that construct a group entry by hand still exercise the (intentionally kept) parent-veto semantics. The committed golden fixture `frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json` regenerated via its own test (group key removed); the frontend vitest suite consuming it passes (8/8).

## Falsification (red → green)

Two new tests in `tests/test_web_runtime_helpers.py`, both RED on `c95bf377` (main):

1. `test_default_field_status_has_no_scope_controls_group_entry` — default snapshot contains no bare `scopeControls` entry while all 8 leaves remain seeded `missing`. RED: `assert 'scopeControls' not in {...}` failed.
2. `test_observed_scope_control_leaves_survive_frontend_parent_veto` — replicates the frontend MOR-429 parent-availability walk over the real backend payload; after observations land, every leaf must resolve `available`. RED: `mode` resolved `missing` (parent veto), exactly the live symptom.

Both GREEN after the fix; no existing test needed modification.

## Gate results (worktree, after final formatting)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7383 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — All checks passed; `ruff format --check` — 552 files already formatted
- `uv run mypy src/` — 21 errors in 8 files (baseline, zero new)
- `uv run lint-imports` — Contracts: 4 kept, 0 broken
- frontend `vitest run src/lib/state/__tests__/field-status.test.ts` — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)