### PR TITLE
fix: branch bridge stream order on audio_duplex_mode — restore FTX-1 exclusive duplex (MOR-559)

### DIFF
--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -501,14 +501,22 @@ class AudioBridge:
         else:
             self._decoder = None
 
-        # --- Subscribe to AudioBus BEFORE arming radio TX (MOR-556). The
-        # first subscriber triggers radio RX start, and the LAN stream state
-        # machine supports RX-then-TX only: arming TX first puts it in
-        # TRANSMITTING and the later RX start raises, leaving RX dead and the
-        # transport packet queue undrained (regression from #1735).
-        bus = self._radio.audio_bus
-        self._subscription = bus.subscribe(name="audio-bridge")
-        await self._subscription.start()
+        # --- Bus-subscribe vs radio-TX-arm order is backend-dependent
+        # (MOR-559); the first bus subscriber triggers radio RX start:
+        #
+        # - "full"/missing (LAN, MOR-556): subscribe BEFORE arming TX. The
+        #   LAN stream state machine supports RX-then-TX only — arming TX
+        #   first puts it in TRANSMITTING and the later RX start raises,
+        #   leaving RX dead and the packet queue undrained (#1735 regression).
+        # - "exclusive" (same-device macOS USB CODEC, MOR-531/534): arm TX
+        #   FIRST and subscribe only after the device streams are up. Adding
+        #   the TX leg to an already-running RX capture on one C-Media device
+        #   triggers CoreAudio AUHAL paramErr -50 and silently kills the
+        #   capture; the reverse order (RX onto a running TX leg) is the
+        #   MOR-531 live-validated path.
+        rx_first = getattr(self._radio, "audio_duplex_mode", "full") != "exclusive"
+        if rx_first:
+            await self._subscribe_bus()
 
         # --- Arm the radio TX path BEFORE choosing the device-stream topology.
         # The radio may reject TX (serial backend with no USB-audio TX path):
@@ -593,6 +601,11 @@ class AudioBridge:
             )
             await self._rx_stream.start()
 
+        # Exclusive same-device duplex: the radio TX leg is armed and the
+        # device streams are open — radio RX may start now (MOR-559).
+        if not rx_first:
+            await self._subscribe_bus()
+
         # --- TX path: device input → radio (capture) ---
         if tx_armed:
             self._tx_queue = asyncio.Queue(maxsize=64)
@@ -613,6 +626,23 @@ class AudioBridge:
 
         # Start the RX playback loop last so the streams above are live.
         self._rx_task = asyncio.create_task(self._rx_loop())
+
+    async def _subscribe_bus(self) -> None:
+        """Subscribe to the radio's AudioBus; first subscriber starts radio RX.
+
+        The bus swallows radio RX-start failures (logs "audio-bus: failed to
+        start RX" and keeps ``rx_active`` False) — surface them here instead
+        of letting the bridge report "started" with dead capture (MOR-559).
+        """
+        bus = self._radio.audio_bus
+        self._subscription = bus.subscribe(name="audio-bridge")
+        await self._subscription.start()
+        if getattr(bus, "rx_active", True) is False:
+            raise RuntimeError(
+                "radio RX failed to start for the bridge subscription "
+                "(AudioBus.rx_active is False after subscribe); see "
+                "'audio-bus: failed to start RX' in the log"
+            )
 
     async def _teardown_streams(self) -> None:
         """Cancel tasks and stop streams.

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -396,6 +396,99 @@ async def test_bridge_rx_only_never_arms_tx_on_lan_state_machine():
 
 
 # ---------------------------------------------------------------------------
+# TX-before-RX start order on same-device exclusive USB duplex (MOR-559)
+# ---------------------------------------------------------------------------
+
+
+class _ExclusiveUsbRadio:
+    """Radio stub mirroring the FTX-1 same-device USB CODEC (MOR-559).
+
+    ``audio_duplex_mode == "exclusive"`` (MOR-534): RX and TX resolve to ONE
+    physical macOS C-Media device. Per the MOR-531 live de-risk, adding the
+    TX playback leg to an ALREADY-RUNNING RX capture triggers CoreAudio AUHAL
+    paramErr -50 and silently kills the capture (no Python exception — live,
+    the bridge then reported "started (RX+TX)" with dead RX). Adding RX to a
+    running TX leg is clean. The stub reproduces the silent capture death so
+    the wrong order fails the test the same way it failed live.
+    """
+
+    audio_duplex_mode = "exclusive"
+
+    def __init__(self) -> None:
+        from rigplane.audio_bus import AudioBus
+        from rigplane.types import AudioCodec
+
+        self.rx_running = False
+        self.tx_running = False
+        self.calls: list[str] = []
+        self.rx_callback: object | None = None
+        self.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+        self.audio_bus = AudioBus(self)
+
+    async def start_rx(
+        self, callback: object, *, jitter_depth: int | None = None
+    ) -> None:
+        self.calls.append("start_rx")
+        self.rx_callback = callback
+        self.rx_running = True
+
+    async def stop_rx(self) -> None:
+        self.rx_running = False
+        self.rx_callback = None
+
+    async def start_tx(self) -> None:
+        self.calls.append("start_tx")
+        if self.rx_running:
+            # ||PaMacCore (AUHAL)|| err='-50': the TX open nominally succeeds
+            # but the device's running RX capture dies silently.
+            self.rx_running = False
+        self.tx_running = True
+
+    async def stop_tx(self) -> None:
+        self.tx_running = False
+
+    async def push_tx(self, audio_data: bytes) -> None:
+        if not self.tx_running:
+            raise RuntimeError("TX not armed")
+
+
+async def test_bridge_arms_tx_before_rx_on_exclusive_duplex():
+    """Regression MOR-559: ``audio_duplex_mode == "exclusive"`` radios need
+    the radio TX leg armed BEFORE the bus RX subscribe (pre-MOR-556 order) —
+    the same-device TX open kills an already-running RX capture (-50).
+    """
+    radio = _ExclusiveUsbRadio()
+    backend = _bridge_backend()
+    bridge = AudioBridge(radio, device_name="BlackHole", backend=backend)
+    await bridge.start()
+    try:
+        assert radio.calls == ["start_tx", "start_rx"]
+        # RX capture must survive bridge start — the regression killed it.
+        assert radio.rx_running
+        assert radio.audio_bus.rx_active
+        assert radio.tx_running
+        assert bridge._tx_started
+    finally:
+        await bridge.stop()
+    assert radio.audio_bus.subscriber_count == 0
+
+
+async def test_bridge_rx_only_on_exclusive_duplex_still_starts_rx():
+    """rx_only on an exclusive-duplex radio: RX starts, TX never armed."""
+    radio = _ExclusiveUsbRadio()
+    backend = _bridge_backend()
+    bridge = AudioBridge(
+        radio, device_name="BlackHole", tx_enabled=False, backend=backend
+    )
+    await bridge.start()
+    try:
+        assert radio.rx_running
+        assert "start_tx" not in radio.calls
+    finally:
+        await bridge.stop()
+
+
+# ---------------------------------------------------------------------------
 # RX callback — packets flow from bus to backend TxStream
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause

[MOR-559](https://linear.app/morozsm/issue/MOR-559) (URGENT). The MOR-556 reorder (#1750) made `AudioBridge._setup_streams` subscribe the AudioBus — whose first subscriber triggers radio `start_rx` — BEFORE arming radio TX. Two backends have **conflicting order requirements**:

- **LAN (IC-7610)**: `LanAudioStream` supports RX-then-TX only — `start_tx` flips the single state field to TRANSMITTING and a later `start_rx` raises `"Cannot start RX in state transmitting"`. RX must be subscribed first (MOR-556, correct for LAN).
- **FTX-1 (same-device macOS C-Media USB CODEC, `audio_duplex_mode == "exclusive"`)**: the radio side uses two separate `sd` streams (`UsbAudioDriver.start_rx`/`start_tx`; `start_duplex` is not yet wired into the radio path). Per the MOR-531 live de-risk, the AUHAL `-50` trigger is specifically **"add TX playback to an already-running RX capture"** on one C-Media device — and it kills the capture **silently** (no Python exception), so the bridge still logged `started (RX+TX)` while RX was dead. The reverse direction (RX onto a running TX leg) is the MOR-531 live-validated path.

Live evidence (FTX-1, 2026-06-09, main @ `7f271fcf`): `bridge codec=... duplex_mode=exclusive` → `audio-bus: RX started` → `||PaMacCore (AUHAL)|| Error on line 2523: err='-50'` → `started (RX+TX, 48000Hz, 1ch, 20ms frames)` — but WS audio probe 0 frames, `/api/v1/audio/analysis` rms −96, scope 0 frames.

## Fix

Branch `_setup_streams` on `getattr(radio, "audio_duplex_mode", "full")` — the MOR-534/537 descriptor built exactly for this arbitration, consulted on the **radio** (FakeAudioBackend-compatible; the FTX-1/X6200 properties delegate to the driver policy and fall back to `"full"`):

- `"exclusive"` → pre-MOR-556 order restored for this case: radio TX-arm + `use_duplex` topology decision first, bus subscribe (radio RX start) after the device streams are up.
- anything else (`"full"`/missing — LAN, virtual loopbacks, separate devices, non-macOS) → MOR-556 RX-first order kept.

Capture-health surface (cheap, in-scope): `AudioBus._start_rx` swallows radio RX-start failures (`logger.exception`, `rx_active` stays False). The new `_subscribe_bus` helper raises when `bus.rx_active` is False after subscribe, so the bridge fails loudly instead of claiming "started" with dead capture. Note: the CoreAudio-level **silent** capture death (tonight's -50 mode) is not Python-visible at open time — runtime capture-health probing (e.g. zero-RX-frame watchdog) is noted as a follow-up.

## Falsification

- NEW `test_bridge_arms_tx_before_rx_on_exclusive_duplex` + `_ExclusiveUsbRadio` stub mirroring the real semantics (`audio_duplex_mode = "exclusive"`; TX open while RX capture runs silently kills the capture — the live -50 behavior, not a raise): **RED on main** (`AssertionError: assert ['start_rx', 'start_tx'] == ['start_tx', 'start_rx']`, capture dead) → **GREEN with the fix**.
- MOR-556 LAN regression test `test_bridge_subscribes_rx_before_arming_tx` (`_LanLikeRadio` state machine): **green before and after** — LAN keeps RX-first.
- NEW `test_bridge_rx_only_on_exclusive_duplex_still_starts_rx` guards the `--bridge-rx-only` path under the exclusive branch.

## Gate (all in worktree)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7385 passed, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed**, zero failures
- `uv run ruff check src/ tests/` — All checks passed; `uv run ruff format --check` — 552 files already formatted
- `uv run mypy src/` — 21 errors in 8 files (exact baseline, **zero new**)
- `uv run lint-imports` — Contracts: 4 kept, 0 broken

Diff: 2 files, +131/−8.

## Acceptance still pending (live)

Live FTX-1 full-bridge validation (no `--bridge-rx-only`: no -50, WS RX frames non-silent, scope flowing) and IC-7610 LAN re-check per MOR-559 acceptance — to be run after merge on the live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)