### PR TITLE
fix(MOR-560): teardown bridge bus subscription on failed initial start

### DIFF
--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -787,6 +787,19 @@ class AudioBridge:
         try:
             await self._setup_streams()
         except Exception:
+            # _setup_streams may fail AFTER the bus subscription is registered
+            # (the rx-first path subscribes early, MOR-556). Tear down before
+            # re-raising — stop() early-returns on IDLE, so a leaked
+            # subscriber would keep radio RX running with no consumer
+            # draining the queue (MOR-560).
+            try:
+                await self._teardown_streams()
+            except Exception:
+                logger.debug(
+                    "%s: teardown after failed start error",
+                    self._label,
+                    exc_info=True,
+                )
             self._set_state(BridgeState.IDLE, "start_failed")
             raise
 

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -489,6 +489,87 @@ async def test_bridge_rx_only_on_exclusive_duplex_still_starts_rx():
 
 
 # ---------------------------------------------------------------------------
+# Failed initial start must release the bus subscription (MOR-560)
+# ---------------------------------------------------------------------------
+
+
+class _RxStartFailRadio:
+    """Radio stub whose RX start fails.
+
+    The AudioBus swallows the ``start_rx`` error (logs "audio-bus: failed to
+    start RX") and leaves ``rx_active`` False — ``_subscribe_bus`` then raises
+    AFTER the subscription is already registered with the bus.
+    """
+
+    def __init__(self) -> None:
+        from rigplane.audio_bus import AudioBus
+
+        self.audio_bus = AudioBus(self)
+
+    async def start_rx(
+        self, callback: object, *, jitter_depth: int | None = None
+    ) -> None:
+        raise RuntimeError("RX hardware unavailable")
+
+    async def stop_rx(self) -> None:
+        pass
+
+
+class _OpenFailBackend(FakeAudioBackend):
+    """FakeAudioBackend whose playback-stream open raises (post-subscribe)."""
+
+    def open_tx(self, device: AudioDeviceId, **kwargs: object) -> object:
+        raise OSError("simulated PortAudio open failure")
+
+
+async def test_bridge_failed_rx_start_releases_bus_subscription():
+    """Regression MOR-560: the ``_subscribe_bus`` rx_active=False raise must
+    not leak the just-registered bus subscription.
+
+    ``start()`` reverts to IDLE on failure and ``stop()`` early-returns on
+    IDLE, so without teardown in the failure path the orphaned subscriber
+    stays on the bus forever.
+    """
+    radio = _RxStartFailRadio()
+    backend = _bridge_backend()
+    bridge = AudioBridge(
+        radio, device_name="BlackHole", tx_enabled=False, backend=backend
+    )
+    with pytest.raises(RuntimeError, match="radio RX failed to start"):
+        await bridge.start()
+    assert bridge.bridge_state == BridgeState.IDLE
+    assert radio.audio_bus.subscriber_count == 0
+
+
+async def test_bridge_failed_stream_open_releases_bus_subscription():
+    """Regression MOR-560: a device-stream open failure AFTER the rx-first
+    bus subscribe must tear the subscription down — otherwise the leaked
+    subscriber keeps radio RX running with no consumer draining the queue.
+    """
+    radio = _make_radio()
+    backend = _OpenFailBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(0),
+                name="Built-in Output",
+                output_channels=2,
+            ),
+            _BH_DEVICE,
+        ]
+    )
+    bridge = AudioBridge(
+        radio, device_name="BlackHole", tx_enabled=False, backend=backend
+    )
+    with pytest.raises(OSError, match="simulated PortAudio open failure"):
+        await bridge.start()
+    assert bridge.bridge_state == BridgeState.IDLE
+    assert radio.audio_bus.subscriber_count == 0
+    # Last-subscriber removal must have stopped radio RX too.
+    assert radio.audio_bus.rx_active is False
+    radio.stop_audio_rx_opus.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
 # RX callback — packets flow from bus to backend TxStream
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem (MOR-560, step 1 of epic MOR-562)

`AudioBridge.start()` caught `_setup_streams` failures, set state IDLE, and re-raised **without teardown**. The rx-first path (MOR-556) subscribes to the AudioBus early in `_setup_streams`, so any later setup failure — device open, TX arm, `open_duplex`, or the `_subscribe_bus` `rx_active=False` RuntimeError itself — left the just-registered subscription orphaned on the bus. `stop()` early-returns on IDLE, so nothing ever removed it: the leaked subscriber kept the bus subscriber count > 0 and **radio RX running with no consumer draining the queue**.

The reconnect loop is NOT affected (it calls `_teardown_streams` before each retry); only the initial-start failure path leaked.

## Fix

In `start()`'s failure path, run the existing `_teardown_streams()` (which closes the early bus subscription via `aclose()`, triggering last-subscriber RX stop on the bus) before re-raising. The teardown call is guarded so a teardown error cannot mask the original exception (callers distinguish e.g. `LoopbackNotFoundError` in auto-bridge mode). No changes to the reconnect loop or the success path; no new abstractions.

## Red → green (falsification-first TDD)

Two regression tests written and confirmed **red** on the pre-fix code, both failing on the leak assertion:

```
assert radio.audio_bus.subscriber_count == 0
E   assert 1 == 0
```

- `test_bridge_failed_rx_start_releases_bus_subscription` — radio stub whose `start_rx` raises; the bus swallows it (`rx_active` stays False) and `_subscribe_bus` raises after the subscription is registered.
- `test_bridge_failed_stream_open_releases_bus_subscription` — `FakeAudioBackend` subclass whose `open_tx` raises after a successful subscribe; additionally asserts `rx_active is False` and `stop_audio_rx_opus` awaited once (last-subscriber removal stopped radio RX).

Both green after the fix. The MOR-556 (`test_bridge_subscribes_rx_before_arming_tx`) and MOR-559 (`test_bridge_arms_tx_before_rx_on_exclusive_duplex`, `test_bridge_rx_only_on_exclusive_duplex_still_starts_rx`) regressions still pass.

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7387 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → 552 files already formatted
- `uv run mypy src/` → 21 errors in 8 files (exact baseline, no new errors)
- `uv run lint-imports` → 4 contracts kept, 0 broken

Diff: 2 files, +94/-0 (`src/rigplane/audio/bridge.py` +13, `tests/test_audio_bridge.py` +81).

🤖 Generated with [Claude Code](https://claude.com/claude-code)