### PR TITLE
feat(MOR-564): AudioBus RX heartbeat exposed in runtime payload

### DIFF
--- a/src/rigplane/audio/bus.py
+++ b/src/rigplane/audio/bus.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -264,6 +265,7 @@ class AudioBus:
         self._subscribers: list[AudioSubscription] = []
         self._rx_active = False
         self._lock = asyncio.Lock()
+        self._last_rx_frame_monotonic: float | None = None
 
     @property
     def subscriber_count(self) -> int:
@@ -274,10 +276,19 @@ class AudioBus:
         return self._rx_active
 
     @property
+    def last_rx_frame_monotonic(self) -> float | None:
+        """``time.monotonic()`` of the most recent RX fan-out, or None.
+
+        RX liveness heartbeat (MOR-564): observability only, no watchdog.
+        """
+        return self._last_rx_frame_monotonic
+
+    @property
     def stats(self) -> dict[str, Any]:
         return {
             "rx_active": self._rx_active,
             "subscriber_count": len(self._subscribers),
+            "last_rx_frame_monotonic": self._last_rx_frame_monotonic,
             "subscribers": [s.stats for s in self._subscribers],
         }
 
@@ -291,6 +302,7 @@ class AudioBus:
 
     def _on_opus_packet(self, packet: "AudioPacket | None") -> None:
         """Internal callback — distributes packet to all active subscribers."""
+        self._last_rx_frame_monotonic = time.monotonic()
         for sub in self._subscribers:
             sub.deliver(packet)
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2367,6 +2367,22 @@ class WebServer:
             "stats": stats,
         }
 
+    def _runtime_audio_bus_payload(self) -> dict[str, Any]:
+        # Read the private slot (not the lazy ``audio_bus`` property) so a
+        # runtime poll never instantiates the bus as a side effect (MOR-564).
+        radio = self._radio
+        bus = getattr(radio, "_audio_bus", None) if radio is not None else None
+        if bus is None:
+            return {"enabled": False}
+        stats = getattr(bus, "stats", None)
+        if not isinstance(stats, dict):
+            stats = {}
+        return {
+            "enabled": True,
+            "lastRxFrameMonotonic": getattr(bus, "last_rx_frame_monotonic", None),
+            "stats": stats,
+        }
+
     def _state_acquisition_diagnostics_payload(self) -> dict[str, Any]:
         radio = self._radio
         scheduler = (
@@ -2412,6 +2428,7 @@ class WebServer:
                     "address": self._runtime_rigctld_addr,
                 },
                 "bridge": self._runtime_bridge_payload(),
+                "audioBus": self._runtime_audio_bus_payload(),
                 "stateAcquisition": self._state_acquisition_diagnostics_payload(),
                 "lastError": self._runtime_last_error,
             },

--- a/tests/test_audio_bus_heartbeat.py
+++ b/tests/test_audio_bus_heartbeat.py
@@ -1,0 +1,139 @@
+"""Tests for the AudioBus RX heartbeat exposed in the runtime payload (MOR-564).
+
+The bus stamps a monotonic timestamp on every RX frame fan-out and the web
+runtime payload surfaces it (plus the existing per-subscriber stats) so RX
+liveness becomes observable. Purely additive observability — no watchdog.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.audio import AudioPacket
+from rigplane.audio_bus import AudioBus
+from rigplane.web.server import WebConfig, WebServer
+
+
+@pytest.fixture
+def mock_radio():
+    radio = SimpleNamespace()
+    radio.start_audio_rx_opus = AsyncMock()
+    radio.stop_audio_rx_opus = AsyncMock()
+    return radio
+
+
+@pytest.fixture
+def bus(mock_radio):
+    return AudioBus(mock_radio)
+
+
+class _FakeWriter:
+    """Minimal writer capturing the HTTP response bytes."""
+
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+def _response_json(writer: _FakeWriter) -> tuple[int, dict]:
+    text = writer.buffer.decode("ascii", errors="replace")
+    status = int(text.split(" ", 2)[1])
+    body_start = text.index("\r\n\r\n") + 4
+    return status, json.loads(text[body_start:] or "{}")
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat stamp on the bus
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_is_none_before_any_packet(bus):
+    assert bus.last_rx_frame_monotonic is None
+    assert bus.stats["last_rx_frame_monotonic"] is None
+
+
+async def test_heartbeat_stamps_and_advances_on_each_packet(bus, mock_radio):
+    sub = bus.subscribe(name="s1")
+    await sub.start()
+
+    before = time.monotonic()
+    bus._on_opus_packet(AudioPacket(ident=0x80, send_seq=1, data=b"a"))
+    first = bus.last_rx_frame_monotonic
+    after = time.monotonic()
+    assert first is not None
+    assert before <= first <= after
+
+    bus._on_opus_packet(AudioPacket(ident=0x80, send_seq=2, data=b"b"))
+    second = bus.last_rx_frame_monotonic
+    assert second is not None
+    assert second >= first
+    assert bus.stats["last_rx_frame_monotonic"] == second
+
+    await sub.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Runtime payload exposure
+# ---------------------------------------------------------------------------
+
+
+async def test_runtime_payload_exposes_audio_bus_heartbeat(bus, mock_radio):
+    sub = bus.subscribe(name="probe")
+    await sub.start()
+    bus._on_opus_packet(AudioPacket(ident=0x80, send_seq=1, data=b"x"))
+
+    radio = SimpleNamespace(
+        model="IC-7610",
+        backend_id="rigplane",
+        connected=True,
+        control_connected=True,
+        radio_ready=True,
+        capabilities=set(),
+        _audio_bus=bus,
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    writer = _FakeWriter()
+
+    await srv._handle_http(writer, "GET", "/api/v1/runtime")  # noqa: SLF001
+
+    status, data = _response_json(writer)
+    assert status == 200
+    audio_bus = data["audioBus"]
+    assert audio_bus["enabled"] is True
+    assert isinstance(audio_bus["lastRxFrameMonotonic"], float)
+    stats = audio_bus["stats"]
+    assert stats["rx_active"] is True
+    assert stats["subscriber_count"] == 1
+    (sub_stats,) = stats["subscribers"]
+    assert sub_stats["name"] == "probe"
+    assert sub_stats["received"] == 1
+    assert sub_stats["dropped"] == 0
+
+    await sub.aclose()
+
+
+async def test_runtime_payload_audio_bus_disabled_without_bus():
+    srv = WebServer(None, WebConfig(host="127.0.0.1", port=0))
+    writer = _FakeWriter()
+
+    await srv._handle_http(writer, "GET", "/api/v1/runtime")  # noqa: SLF001
+
+    status, data = _response_json(writer)
+    assert status == 200
+    assert data["audioBus"] == {"enabled": False}


### PR DESCRIPTION
## Goal

MOR-564 (step 3 of epic MOR-562, RX health model): make RX liveness observable. Stamp a monotonic timestamp on every RX frame fan-out in `AudioBus` and expose it — plus the already-existing per-subscriber stats — in the web runtime payload (`GET /api/v1/runtime`).

**Additive observability only.** No watchdog, no behavior change, no new fields renamed or removed. This is the first brick of the health model; the watchdog comes in a later step.

## Changes

- `src/rigplane/audio/bus.py`
  - `AudioBus._last_rx_frame_monotonic: float | None`, stamped via a single `time.monotonic()` assignment at the top of `_on_opus_packet` (RX hot path — no locking, no logging).
  - Read-only property `last_rx_frame_monotonic`; also included in `AudioBus.stats` as `last_rx_frame_monotonic`.
- `src/rigplane/web/server.py`
  - New `_runtime_audio_bus_payload()` next to `_runtime_bridge_payload()`, wired into `_serve_runtime` as a new top-level `"audioBus"` key next to `"bridge"`:
    ```json
    "audioBus": {
      "enabled": true,
      "lastRxFrameMonotonic": 12345.678,
      "stats": {"rx_active": true, "subscriber_count": 1, "last_rx_frame_monotonic": 12345.678, "subscribers": [{"name": "...", "active": true, "received": N, "dropped": N, "queued": N}]}
    }
    ```
    `{"enabled": false}` when no bus exists. The helper reads the private `_audio_bus` slot (same pattern as the `_acquisition_scheduler` diagnostics read) so a runtime poll never lazily instantiates the bus as a side effect.
- `tests/test_audio_bus_heartbeat.py` — new falsification tests.

## Red → Green (falsification-first)

Tests written first; confirmed RED on the unmodified tree:
- `AttributeError: 'AudioBus' object has no attribute 'last_rx_frame_monotonic'` (x2)
- `KeyError: 'audioBus'` in the runtime payload (x2)

After implementation, all 4 GREEN: stamp is `None` before any packet; stamps within a `[before, after]` monotonic window and advances on a second packet; runtime payload exposes `audioBus.lastRxFrameMonotonic` + per-subscriber `received`/`dropped`; `{"enabled": false}` without a bus.

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → 7389 passed, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, **0 failures**
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → 553 files already formatted
- `uv run mypy src/` → exactly baseline: 21 errors in 8 files (no new errors)
- `uv run lint-imports` → 4 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)