### PR TITLE
refactor(MOR-563): typed audio lifecycle errors (AudioAlreadyStartedError/AudioNotStartedError)

### DIFF
--- a/src/rigplane/audio/lan_stream.py
+++ b/src/rigplane/audio/lan_stream.py
@@ -14,6 +14,7 @@ from typing import Callable
 
 from ..transport import IcomTransport
 from ..types import PacketType
+from .usb_driver import AudioAlreadyStartedError, AudioNotStartedError
 
 __all__ = [
     "AudioStream",
@@ -517,10 +518,10 @@ class AudioStream:
                 Defaults to the value set at construction time.
 
         Raises:
-            RuntimeError: If already receiving or transmitting.
+            AudioAlreadyStartedError: If already receiving or transmitting.
         """
         if self._state != AudioState.IDLE:
-            raise RuntimeError(f"Cannot start RX in state {self._state}")
+            raise AudioAlreadyStartedError(f"Cannot start RX in state {self._state}")
 
         depth = jitter_depth if jitter_depth is not None else self._jitter_depth
         self._reset_rx_stats()
@@ -596,10 +597,10 @@ class AudioStream:
         Can be called while already receiving (full-duplex).
 
         Raises:
-            RuntimeError: If already transmitting.
+            AudioAlreadyStartedError: If already transmitting.
         """
         if self._state == AudioState.TRANSMITTING:
-            raise RuntimeError("Already transmitting")
+            raise AudioAlreadyStartedError("Already transmitting")
         self._state = AudioState.TRANSMITTING
         self._tx_seq = 0
         self._tx_packets_sent = 0
@@ -616,10 +617,10 @@ class AudioStream:
             audio_data: Payload encoded with the negotiated TX audio codec.
 
         Raises:
-            RuntimeError: If not in transmitting state.
+            AudioNotStartedError: If not in transmitting state.
         """
         if self._state != AudioState.TRANSMITTING:
-            raise RuntimeError(f"Cannot push TX in state {self._state}")
+            raise AudioNotStartedError(f"Cannot push TX in state {self._state}")
 
         data = audio_data
         offset = 0

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -59,6 +59,25 @@ class AudioDriverLifecycleError(RuntimeError):
     """Raised on invalid USB audio lifecycle operations."""
 
 
+class AudioAlreadyStartedError(AudioDriverLifecycleError):
+    """Raised when starting an audio stream that is already running.
+
+    Shared by the USB driver and the Icom LAN stream (MOR-563) so
+    consumers can match the benign double-start case by type instead of
+    message text. Subclasses :class:`AudioDriverLifecycleError` (and thus
+    ``RuntimeError``) so existing ``except`` clauses keep catching it.
+    """
+
+
+class AudioNotStartedError(AudioDriverLifecycleError):
+    """Raised when using an audio stream that has not been started.
+
+    Shared by the USB driver and the Icom LAN stream (MOR-563).
+    Subclasses :class:`AudioDriverLifecycleError` (and thus
+    ``RuntimeError``) so existing ``except`` clauses keep catching it.
+    """
+
+
 _DEFAULT_SAMPLE_RATE_CANDIDATES: tuple[int, ...] = (48_000, 24_000, 16_000, 8_000)
 
 
@@ -806,7 +825,7 @@ class UsbAudioDriver:
 
         async with self._rx_lock:
             if self.rx_running:
-                raise AudioDriverLifecycleError("RX stream already started.")
+                raise AudioAlreadyStartedError("RX stream already started.")
 
             selected_rx, _ = self._ensure_selected_devices()
             sr = self._sample_rate if sample_rate is None else sample_rate
@@ -881,7 +900,7 @@ class UsbAudioDriver:
         """Start playback loop for outgoing PCM frames."""
         async with self._tx_lock:
             if self.tx_running:
-                raise AudioDriverLifecycleError("TX stream already started.")
+                raise AudioAlreadyStartedError("TX stream already started.")
 
             _, selected_tx = self._ensure_selected_devices()
             sr = self._sample_rate if sample_rate is None else sample_rate
@@ -1012,7 +1031,7 @@ class UsbAudioDriver:
     async def _push_tx_pcm(self, frame: bytes) -> None:
         """Queue one PCM frame for playback."""
         if not self.tx_running:
-            raise AudioDriverLifecycleError("Audio TX stream is not started.")
+            raise AudioNotStartedError("Audio TX stream is not started.")
         if not isinstance(frame, (bytes, bytearray, memoryview)):
             raise TypeError("PCM TX frame must be bytes-like.")
         # Same-device duplex: TX rides the single stream's TX queue.
@@ -1032,8 +1051,10 @@ class UsbAudioDriver:
 
 
 __all__ = [
+    "AudioAlreadyStartedError",
     "AudioDeviceSelectionError",
     "AudioDriverLifecycleError",
+    "AudioNotStartedError",
     "UsbAudioDevice",
     "UsbAudioContract",
     "UsbAudioDriver",

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 
 from ..._audio_codecs import decode_ulaw_to_pcm16
 from ..._audio_transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
+from ...audio.usb_driver import AudioAlreadyStartedError
 from ...dsp.tap_registry import TapHandle, TapRegistry
 from ...env_config import (
     get_audio_broadcaster_high_watermark,
@@ -44,13 +45,16 @@ _TX_CLEANUP_STOP_TIMEOUT_SECONDS = 2.0
 def _is_benign_tx_restart(exc: RuntimeError) -> bool:
     """True when TX start failed only because the stream is already open.
 
-    The Icom LAN stream raises ``RuntimeError("Already transmitting")``
-    while the USB driver raises
-    ``AudioDriverLifecycleError("TX stream already started.")`` (a
-    ``RuntimeError`` subclass). Both mean the poller (or a prior client)
-    already opened TX and the handler can simply reuse it — re-raising
-    would close the audio WebSocket (MOR-541 review note, MOR-544).
+    The Icom LAN stream and the USB driver raise
+    :class:`~rigplane.audio.usb_driver.AudioAlreadyStartedError` (a
+    ``RuntimeError`` subclass, MOR-563), meaning the poller (or a prior
+    client) already opened TX and the handler can simply reuse it —
+    re-raising would close the audio WebSocket (MOR-541 review note,
+    MOR-544). The substring fallback covers not-yet-migrated raisers that
+    still signal the same condition with a bare ``RuntimeError``.
     """
+    if isinstance(exc, AudioAlreadyStartedError):
+        return True
     text = str(exc).lower()
     return "already transmitting" in text or "already started" in text
 

--- a/tests/test_audio_fullduplex.py
+++ b/tests/test_audio_fullduplex.py
@@ -165,3 +165,17 @@ class TestAudioStreamState:
         with pytest.raises(RuntimeError, match="Already transmitting"):
             await stream.start_tx()
         await stream.stop_tx()
+
+    @pytest.mark.asyncio
+    async def test_double_start_tx_raises_typed_error(
+        self, mock_transport: MockTransport
+    ) -> None:
+        """Double TX start raises AudioAlreadyStartedError — a typed
+        lifecycle error, not a bare RuntimeError (MOR-563)."""
+        from rigplane.audio.usb_driver import AudioAlreadyStartedError
+
+        stream = AudioStream(mock_transport)
+        await stream.start_tx()
+        with pytest.raises(AudioAlreadyStartedError):
+            await stream.start_tx()
+        await stream.stop_tx()

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1808,6 +1808,28 @@ async def test_audio_handler_tolerates_usb_lifecycle_double_start() -> None:
     radio.start_tx.assert_awaited_once()
 
 
+async def test_audio_handler_tolerates_typed_already_started_by_type() -> None:
+    """AudioAlreadyStartedError is benign by TYPE, not by message text —
+    a message without the legacy magic substrings must still be tolerated
+    (MOR-563)."""
+    from rigplane.audio.usb_driver import AudioAlreadyStartedError
+    from rigplane.web.handlers.audio import _is_benign_tx_restart
+
+    exc = AudioAlreadyStartedError("wording with no magic substrings")
+    assert _is_benign_tx_restart(exc) is True
+
+    contract = _make_web_tx_contract(AudioCodec.PCM_1CH_16BIT)
+    radio = _make_neutral_tx_radio(contract)
+    radio.start_tx = AsyncMock(side_effect=exc)
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+
+    assert handler._tx_active is True
+    radio.start_tx.assert_awaited_once()
+
+
 async def test_audio_handler_drops_non_tx_or_unknown_browser_audio_frames() -> None:
     radio = SimpleNamespace(
         capabilities={"audio"},


### PR DESCRIPTION
## Problem (MOR-563, step 2 of epic MOR-562, ADR P7)

`_is_benign_tx_restart` in `src/rigplane/web/handlers/audio.py` decided whether a TX start failure is a benign double-start by case-insensitive substring matching on `"already transmitting"` / `"already started"`, because the Icom LAN stream raised a bare `RuntimeError("Already transmitting")` while the USB driver raised `AudioDriverLifecycleError("TX stream already started.")` with different text. Fragile: any message rewording silently breaks the benign-restart tolerance and closes the audio WebSocket.

## Change

- New typed errors in `rigplane.audio.usb_driver` (the module where `AudioDriverLifecycleError` already lives, keeping the change at 3 source files):
  - `AudioAlreadyStartedError(AudioDriverLifecycleError)`
  - `AudioNotStartedError(AudioDriverLifecycleError)`

  Both are `AudioDriverLifecycleError` → `RuntimeError` subclasses, so every existing `except RuntimeError` / `except AudioDriverLifecycleError` clause and `pytest.raises(..., match=...)` assertion keeps catching them. Messages are unchanged.
- LAN stream (`lan_stream.py`): `start_rx` from non-idle state and `start_tx` double-start now raise `AudioAlreadyStartedError`; `push_tx` outside TRANSMITTING raises `AudioNotStartedError`. (`usb_driver`/`backend` are stdlib-only at module import, so the new `lan_stream → usb_driver` import stays light.)
- USB driver (`usb_driver.py`): "RX stream already started." / "TX stream already started." → `AudioAlreadyStartedError`; "Audio TX stream is not started." → `AudioNotStartedError`. The duplex idle guard and format-validation guards intentionally stay plain `AudioDriverLifecycleError` — they are not benign restarts.
- Handler: `_is_benign_tx_restart` checks `isinstance(exc, AudioAlreadyStartedError)` FIRST; **the substring fallback is retained** for any not-yet-migrated raiser (back-compat, per issue requirement).

## Red → green (falsification-first TDD)

1. Wrote the tests first:
   - `test_audio_fullduplex.py::TestAudioStreamState::test_double_start_tx_raises_typed_error` — LAN double-start raises `AudioAlreadyStartedError` by type.
   - `test_handlers_coverage.py::test_audio_handler_tolerates_typed_already_started_by_type` — `_is_benign_tx_restart` returns True for `AudioAlreadyStartedError("wording with no magic substrings")` (message deliberately avoids the legacy substrings, proving the TYPE path), and the handler keeps the WebSocket alive (`_tx_active is True`).
2. Confirmed RED: both failed with `ImportError: cannot import name 'AudioAlreadyStartedError'`.
3. Implemented; confirmed GREEN.

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7387 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — clean; `ruff format --check` — 552 files already formatted
- `uv run mypy src/` — baseline exactly **21 errors in 8 files** (unchanged)
- `uv run lint-imports` — **4 kept, 0 broken** (new imports are downward/lateral only)

Behavior-preserving: error messages unchanged, all existing catchers (only `except RuntimeError` and broader exist in src/) still catch, existing benign-restart handler tests (#684, MOR-541/544) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)