### PR TITLE
feat(MOR-565): tract-wide tap-surface skeleton (named RX stages)

### DIFF
--- a/src/rigplane/audio/bus.py
+++ b/src/rigplane/audio/bus.py
@@ -44,12 +44,35 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from rigplane.dsp.tap_registry import TapRegistry
+
 if TYPE_CHECKING:
     from rigplane.audio import AudioPacket
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["AudioBus", "AudioSubscription"]
+__all__ = ["STAGE_RX_PCM", "STAGE_RX_POST_DSP", "AudioBus", "AudioSubscription"]
+
+# ── Named RX tap stages (MOR-565, ADR §3.7 "observable by construction") ─────
+#
+# Uniform stage-naming scheme for passive PCM tap points along the RX tract.
+# Only stages with a live frame source today have an instantiated
+# :class:`~rigplane.dsp.tap_registry.TapRegistry`:
+#
+#   ``rx.pcm``      — radio-native RX frames at the AudioBus fan-out
+#                     (post jitter-buffer/decode by the radio transport,
+#                     pre-DSP). Hosted on :class:`AudioBus`.
+#   ``rx.post_dsp`` — decoded PCM16 after the broadcaster's optional DSP
+#                     pipeline. Hosted on ``AudioBroadcaster``
+#                     (``rigplane.web.handlers.audio``) — this is the
+#                     pre-existing ``_tap_registry``, renamed into the scheme.
+#
+# Reserved stage names (documented, NOT instantiated — no producer yet):
+# ``rx.raw`` (pre jitter-buffer wire payload), ``rx.egress`` (per-consumer
+# transport frames), ``tx.pcm`` / ``tx.egress`` (TX-side mirror stages).
+# Asking a host for a reserved stage raises ``KeyError`` by design.
+STAGE_RX_PCM = "rx.pcm"
+STAGE_RX_POST_DSP = "rx.post_dsp"
 
 _DEFAULT_QUEUE_SIZE = 64
 _DEFAULT_CLOSE_TIMEOUT = 2.0
@@ -266,6 +289,11 @@ class AudioBus:
         self._rx_active = False
         self._lock = asyncio.Lock()
         self._last_rx_frame_monotonic: float | None = None
+        # Named RX tap stages (MOR-565): the bus hosts ``rx.pcm`` — a passive
+        # observer of radio-native frames, fed alongside (never instead of)
+        # the subscriber fan-out. Local-only, no telemetry (open-core).
+        self._rx_pcm_taps = TapRegistry()
+        self._stage_taps: dict[str, TapRegistry] = {STAGE_RX_PCM: self._rx_pcm_taps}
 
     @property
     def subscriber_count(self) -> int:
@@ -300,11 +328,25 @@ class AudioBus:
         """Create a new subscription (not yet active — call start() or use as context manager)."""
         return AudioSubscription(self, name=name, queue_size=queue_size)
 
+    def taps(self, stage: str) -> TapRegistry:
+        """Return the :class:`TapRegistry` for a named RX stage on this bus.
+
+        Only ``STAGE_RX_PCM`` is hosted here; reserved stage names raise
+        ``KeyError``. Taps are attachable/detachable at runtime and add no
+        cost when empty (the registry no-ops without subscribers).
+        """
+        return self._stage_taps[stage]
+
     def _on_opus_packet(self, packet: "AudioPacket | None") -> None:
         """Internal callback — distributes packet to all active subscribers."""
         self._last_rx_frame_monotonic = time.monotonic()
         for sub in self._subscribers:
             sub.deliver(packet)
+        # ``rx.pcm`` stage tap (MOR-565): passive observer of radio-native
+        # frames, fed after subscriber delivery so the hot path is untouched.
+        # The empty-registry check keeps the no-tap cost to one attribute read.
+        if packet is not None and self._rx_pcm_taps.active:
+            self._rx_pcm_taps.feed(packet.data)
 
     async def _add_subscriber(self, sub: AudioSubscription) -> None:
         """Register a subscriber and start RX if this is the first one."""

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 
 from ..._audio_codecs import decode_ulaw_to_pcm16
 from ..._audio_transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
+from ...audio.bus import STAGE_RX_POST_DSP
 from ...audio.usb_driver import AudioAlreadyStartedError
 from ...dsp.tap_registry import TapHandle, TapRegistry
 from ...env_config import (
@@ -129,8 +130,14 @@ class AudioBroadcaster:
         # One-shot flag so the Opus-DSP warning log fires at most once per
         # broadcaster lifetime, regardless of whether DSP or codec is set first.
         self._dsp_opus_warned: bool = False
-        # Multi-consumer PCM tap registry (replaces single _pcm_tap)
-        self._tap_registry = TapRegistry()
+        # Named RX tap stages (MOR-565): the broadcaster hosts ``rx.post_dsp``
+        # — decoded PCM16 after the optional DSP pipeline. This is the
+        # pre-existing multi-consumer tap registry, renamed into the
+        # stage scheme; ``_tap_registry`` stays as a compat alias for
+        # existing consumers (CW auto-tuner, tests). The pre-DSP ``rx.pcm``
+        # stage lives on AudioBus (see ``rigplane.audio.bus``).
+        self._stage_taps: dict[str, TapRegistry] = {STAGE_RX_POST_DSP: TapRegistry()}
+        self._tap_registry = self._stage_taps[STAGE_RX_POST_DSP]
         self._legacy_tap_handle: TapHandle | None = None
         # Flag raised by invalidate_codec_state(); checked at top of each
         # _relay_loop iteration to pick up mid-stream mono↔stereo switches
@@ -201,12 +208,22 @@ class AudioBroadcaster:
                 "audio-broadcaster: client count callback failed", exc_info=True
             )
 
+    def taps(self, stage: str) -> TapRegistry:
+        """Return the :class:`TapRegistry` for a named RX stage (MOR-565).
+
+        Only ``STAGE_RX_POST_DSP`` is hosted on the broadcaster; reserved
+        stage names raise ``KeyError``. Same accessor shape as
+        :meth:`rigplane.audio.bus.AudioBus.taps`.
+        """
+        return self._stage_taps[stage]
+
     def set_pcm_tap(self, callback: "Callable[[bytes], None] | None") -> None:
         """Register a tap that receives decoded PCM16 audio data.
 
-        Compatibility wrapper around :class:`TapRegistry`. Manages a
-        single "legacy" tap slot. For new consumers prefer
-        ``_tap_registry.register()`` directly.
+        Compatibility wrapper around :class:`TapRegistry` (Pro-stable
+        surface). Manages a single "legacy" tap slot on the
+        ``rx.post_dsp`` stage. For new consumers prefer
+        ``taps(STAGE_RX_POST_DSP).register()`` directly.
 
         Args:
             callback: Function receiving PCM16 bytes, or None to unregister.

--- a/tests/test_tap_surface.py
+++ b/tests/test_tap_surface.py
@@ -1,0 +1,146 @@
+"""Tests for the named RX tap-stage surface (MOR-565, ADR §3.7 skeleton).
+
+Stage scheme — only stages with a live frame source are instantiated:
+
+- ``rx.pcm``      — radio-native RX frames at the AudioBus fan-out
+  (hosted on :class:`~rigplane.audio.bus.AudioBus`).
+- ``rx.post_dsp`` — decoded PCM16 after the broadcaster's DSP pipeline
+  (hosted on :class:`~rigplane.web.handlers.audio.AudioBroadcaster`; this
+  is the pre-existing ``_tap_registry``, renamed into the scheme).
+
+Reserved stage names (``rx.raw``, ``rx.egress``, ``tx.*``) have NO registry —
+asking for them must fail loudly rather than silently swallow frames.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from rigplane.audio import AudioPacket
+from rigplane.audio.bus import STAGE_RX_PCM, STAGE_RX_POST_DSP, AudioBus
+from rigplane.capabilities import CAP_AUDIO
+from rigplane.web.handlers.audio import AudioBroadcaster
+
+
+@pytest.fixture
+def bus():
+    radio = SimpleNamespace(
+        start_audio_rx_opus=AsyncMock(),
+        stop_audio_rx_opus=AsyncMock(),
+    )
+    return AudioBus(radio)
+
+
+class TestRxPcmStage:
+    """``rx.pcm`` — passive tap at the AudioBus fan-out."""
+
+    async def test_tap_observes_frames_without_altering_delivery(self, bus):
+        sub = bus.subscribe(name="s1")
+        await sub.start()
+        seen: list[bytes] = []
+        handle = bus.taps(STAGE_RX_PCM).register("debug", seen.append)
+
+        pkt = AudioPacket(ident=0x80, send_seq=1, data=b"abc")
+        bus._on_opus_packet(pkt)
+        assert seen == [b"abc"]
+        # Passive observer: subscriber delivery and heartbeat are untouched.
+        assert await sub.get(timeout=1.0) is pkt
+        assert bus.last_rx_frame_monotonic is not None
+
+        bus.taps(STAGE_RX_PCM).unregister(handle)
+        bus._on_opus_packet(AudioPacket(ident=0x80, send_seq=2, data=b"def"))
+        assert seen == [b"abc"], "detach must restore no-op"
+        assert bus.taps(STAGE_RX_PCM).active is False
+        await sub.aclose()
+
+    def test_empty_stage_is_noop(self, bus):
+        bus._on_opus_packet(AudioPacket(ident=0x80, send_seq=1, data=b"x"))
+        assert bus.taps(STAGE_RX_PCM).active is False
+        assert bus.last_rx_frame_monotonic is not None
+
+    def test_none_packet_is_not_fed_to_taps(self, bus):
+        seen: list[bytes] = []
+        bus.taps(STAGE_RX_PCM).register("debug", seen.append)
+        bus._on_opus_packet(None)  # EOF/idle marker
+        assert seen == []
+        assert bus.last_rx_frame_monotonic is not None, "heartbeat preserved"
+
+    def test_reserved_stage_has_no_registry(self, bus):
+        with pytest.raises(KeyError):
+            bus.taps("rx.raw")
+
+
+class TestRxPostDspStage:
+    """``rx.post_dsp`` — the broadcaster's pre-existing registry, renamed."""
+
+    def test_post_dsp_stage_is_the_existing_tap_registry(self):
+        broadcaster = AudioBroadcaster(radio=None)
+        assert broadcaster.taps(STAGE_RX_POST_DSP) is broadcaster._tap_registry
+
+    def test_set_pcm_tap_compat_registers_on_post_dsp_stage(self):
+        broadcaster = AudioBroadcaster(radio=None)
+        received: list[bytes] = []
+        broadcaster.set_pcm_tap(received.append)
+        broadcaster.taps(STAGE_RX_POST_DSP).feed(b"\xaa")
+        assert received == [b"\xaa"]
+        broadcaster.set_pcm_tap(None)
+        assert broadcaster.taps(STAGE_RX_POST_DSP).active is False
+
+    def test_reserved_stage_has_no_registry(self):
+        broadcaster = AudioBroadcaster(radio=None)
+        with pytest.raises(KeyError):
+            broadcaster.taps("rx.egress")
+
+
+# ── FFT scope behavior preservation ──────────────────────────────────────────
+
+
+class _AudioOnlyRadio:
+    """Minimal fake radio with audio but no hardware scope."""
+
+    def __init__(self) -> None:
+        from rigplane.radio_state import RadioState
+
+        self.capabilities = frozenset({CAP_AUDIO})
+        self.radio_state = RadioState()
+        self.audio_codec = None
+        self.audio_sample_rate = 48_000
+
+
+class _FakeScopeHandler:
+    def __init__(self) -> None:
+        self.frames: list = []
+
+    def enqueue_frame(self, frame) -> None:
+        self.frames.append(frame)
+
+
+def test_fft_scope_receives_frames_via_named_post_dsp_stage() -> None:
+    """The FFT scope (wired via ``set_pcm_tap`` at server init) is a tap on
+    the named ``rx.post_dsp`` stage — feeding that stage produces scope
+    frames exactly as it did through ``_tap_registry`` before the rename.
+    """
+    from rigplane.web.server import WebConfig, WebServer
+
+    radio = _AudioOnlyRadio()
+    server = WebServer(radio=radio, config=WebConfig())
+    scope = server._audio_fft_scope
+    assert scope is not None, "audio FFT scope not wired"
+    radio.radio_state.main.freq = 14_074_000
+    scope.set_center_freq(14_074_000)
+    scope._last_frame_time = 0.0  # bypass the fps rate-limit for the first frame
+
+    handler = _FakeScopeHandler()
+    server._audio_scope_handlers.add(handler)
+
+    rng = np.random.default_rng(565)
+    registry = server._audio_broadcaster.taps(STAGE_RX_POST_DSP)
+    for _ in range(9):  # 9 × 960 samples (20 ms @ 48 kHz) ≥ 4 FFT windows
+        pcm = (rng.uniform(-1, 1, 960) * 5000).astype(np.int16).tobytes()
+        registry.feed(pcm)
+
+    assert len(handler.frames) >= 1, "FFT scope stopped receiving via rx.post_dsp"


### PR DESCRIPTION
## Goal

Step 4 of epic MOR-562 (T5 "observable by construction", ADR §3.7): establish a uniform, stage-named PCM tap surface along the RX tract — skeleton only, behavior byte-identical. No ownership migration to AudioSession (that is step 8), no adaptive/health logic.

## Stage scheme

Defined in `rigplane.audio.bus` (importable by both `audio/` and `web/`; reuses `dsp.tap_registry.TapRegistry`, so no import-matrix change):

| Stage | Constant | Host | Status |
|---|---|---|---|
| `rx.pcm` | `STAGE_RX_PCM` | `AudioBus` | **instantiated** — radio-native frames at the bus fan-out, fed in `_on_opus_packet` |
| `rx.post_dsp` | `STAGE_RX_POST_DSP` | `AudioBroadcaster` | **instantiated** — the pre-existing `_tap_registry`, renamed into the scheme |
| `rx.raw`, `rx.egress`, `tx.pcm`, `tx.egress` | — | — | **reserved** — named in the scheme docstring only; no producer exists yet, so no registry (`taps()` raises `KeyError`) |

Both hosts expose the same-shaped accessor `taps(stage) -> TapRegistry`.

## Behavior-preserving rationale (FFT scope + analyzer)

- The broadcaster's `rx.post_dsp` registry **is** the previous `_tap_registry` object — `_tap_registry` is kept as a compat alias (asserted by identity in tests), so the CW auto-tuner (`handlers/control.py`) and existing tests keep working unchanged.
- The Pro-stable `set_pcm_tap` wrapper is untouched (grep confirmed consumers: `web/server.py` + tests only); it registers on the `rx.post_dsp` stage. The FFT scope and the audio analyzer therefore become named-stage taps with **identical frames, identical order, identical behavior** — zero call-site changes in `server.py`.
- The new `rx.pcm` tap on `AudioBus` is fed *after* subscriber delivery and never instead of it; the MOR-564 heartbeat stamp is untouched (covered by tests). When empty, the cost is a single attribute read (`TapRegistry.active`). Local-only, no telemetry (open-core).

## Red → Green (falsification-first)

- RED: `tests/test_tap_surface.py` fails collection on origin/main — `ImportError: cannot import name 'STAGE_RX_PCM' from 'rigplane.audio.bus'` (the named stage surface does not exist).
- GREEN after wiring: a debug tap at `rx.pcm` observes frames pushed through `_on_opus_packet`; detach restores no-op; empty stage adds no frames/no error; `None` (EOF) packets are not fed but the heartbeat still stamps; FFT scope still emits frames when the named `rx.post_dsp` stage is fed (mirrors `test_audio_scope_dispatch.py`); reserved stages raise `KeyError`.

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7401 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — clean; `ruff format --check` — 554 files already formatted
- `uv run mypy src/` — **21 errors in 8 files** (exact baseline, no new errors)
- `uv run lint-imports` — **4 kept / 0 broken**

Files: `src/rigplane/audio/bus.py` (+44/−1), `src/rigplane/web/handlers/audio.py` (+27/−6), `tests/test_tap_surface.py` (new, 146 lines) — 3 files, +211/−6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)