### PR TITLE
test(MOR-566): stateful FakeAudioBackend (strict_device_exclusive) + shared order-sensitive radio stubs

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -1274,14 +1274,58 @@ class PortAudioBackend:
 # ---------------------------------------------------------------------------
 
 
+def _exclusive_device_busy(device: int) -> OSError:
+    """The -50-shaped error strict mode raises (MOR-566).
+
+    Models the macOS CoreAudio AUHAL ``paramErr -50`` kill observed live when
+    a second PortAudio stream opens a device that already drives one
+    (MOR-531/559): an :class:`OSError` with ``errno == -50`` and the PaMacCore
+    marker in the message, mirroring the ``||PaMacCore (AUHAL)|| err='-50'``
+    line PortAudio logs on the real failure.
+    """
+    return OSError(
+        -50,
+        f"PaMacCore (AUHAL) err='-50' (paramErr): device {device} already "
+        "has an open stream (strict_device_exclusive)",
+    )
+
+
+def _claim_exclusive_device(
+    registry: dict[int, object] | None, device: int | None, stream: object
+) -> None:
+    """Claim *device* for *stream*; raise the -50 error if another holds it."""
+    if registry is None or device is None:
+        return
+    holder = registry.get(device)
+    if holder is not None and holder is not stream:
+        raise _exclusive_device_busy(device)
+    registry[device] = stream
+
+
+def _release_exclusive_device(
+    registry: dict[int, object] | None, device: int | None, stream: object
+) -> None:
+    """Free *device* if *stream* holds it — closing frees the device."""
+    if registry is not None and device is not None and registry.get(device) is stream:
+        del registry[device]
+
+
 class FakeRxStream:
     """Test double: records lifecycle and delivers injected frames."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        device: int | None = None,
+        exclusive: dict[int, object] | None = None,
+    ) -> None:
         self._running = False
         self._callback: Callable[[bytes], None] | None = None
+        self._device = device
+        self._exclusive = exclusive
         self.started_count = 0
         self.stopped_count = 0
+        self.heartbeat_count = 0
         self.fail_on_inject: Exception | None = None
 
     @property
@@ -1291,11 +1335,13 @@ class FakeRxStream:
     async def start(self, callback: Callable[[bytes], None]) -> None:
         if self._running:
             raise RuntimeError("FakeRxStream already running.")
+        _claim_exclusive_device(self._exclusive, self._device, self)
         self._callback = callback
         self._running = True
         self.started_count += 1
 
     async def stop(self) -> None:
+        _release_exclusive_device(self._exclusive, self._device, self)
         self._running = False
         self._callback = None
         self.stopped_count += 1
@@ -1312,12 +1358,31 @@ class FakeRxStream:
         if self._callback is not None:
             self._callback(frame)
 
+    def inject_heartbeat(self, frame: bytes = b"\x00\x00") -> None:
+        """Advance RX liveness by one synthetic capture tick (MOR-566).
+
+        Opt-in test helper: increments :attr:`heartbeat_count` and, when a
+        callback is registered, delivers *frame* (default: one s16le zero
+        sample) exactly like a live capture callback would. Tests that never
+        call it see no behavior change.
+        """
+        self.heartbeat_count += 1
+        if self._callback is not None:
+            self._callback(frame)
+
 
 class FakeTxStream:
     """Test double: records lifecycle and captures written frames."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        device: int | None = None,
+        exclusive: dict[int, object] | None = None,
+    ) -> None:
         self._running = False
+        self._device = device
+        self._exclusive = exclusive
         self.started_count = 0
         self.stopped_count = 0
         self.written_frames: list[bytes] = []
@@ -1344,10 +1409,12 @@ class FakeTxStream:
     async def start(self) -> None:
         if self._running:
             raise RuntimeError("FakeTxStream already running.")
+        _claim_exclusive_device(self._exclusive, self._device, self)
         self._running = True
         self.started_count += 1
 
     async def stop(self) -> None:
+        _release_exclusive_device(self._exclusive, self._device, self)
         self._running = False
         self.stopped_count += 1
 
@@ -1371,9 +1438,16 @@ class FakeDuplexStream:
     frames) so the same-device duplex path can be exercised without PortAudio.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        device: int | None = None,
+        exclusive: dict[int, object] | None = None,
+    ) -> None:
         self._running = False
         self._callback: Callable[[bytes], None] | None = None
+        self._device = device
+        self._exclusive = exclusive
         self.started_count = 0
         self.stopped_count = 0
         self.written_frames: list[bytes] = []
@@ -1392,11 +1466,13 @@ class FakeDuplexStream:
     async def start(self, callback: Callable[[bytes], None]) -> None:
         if self._running:
             raise RuntimeError("FakeDuplexStream already running.")
+        _claim_exclusive_device(self._exclusive, self._device, self)
         self._callback = callback
         self._running = True
         self.started_count += 1
 
     async def stop(self) -> None:
+        _release_exclusive_device(self._exclusive, self._device, self)
         self._running = False
         self._callback = None
         self.stopped_count += 1
@@ -1421,6 +1497,13 @@ class FakeAudioBackend:
     :class:`FakeTxStream` doubles so consumer code can be exercised without
     PortAudio or any optional extras.
 
+    ``strict_device_exclusive`` (MOR-566, default OFF — behavior identical to
+    before): when ON, opening or starting a second stream (rx/tx/duplex) on a
+    device id that already has an open (started, not yet stopped) stream
+    raises the -50-shaped :class:`OSError` modeling the macOS CoreAudio AUHAL
+    ``paramErr -50`` kill (MOR-531/559). Stopping the holding stream frees
+    the device.
+
     Stability: breaking changes require a CHANGELOG note plus a minor version
     bump per ``docs/api/public-api-surface.md``. No strict semver guarantee.
     """
@@ -1430,6 +1513,7 @@ class FakeAudioBackend:
         devices: list[AudioDeviceInfo] | None = None,
         *,
         supported_sample_rates: set[int] | None = None,
+        strict_device_exclusive: bool = False,
     ) -> None:
         self._devices: list[AudioDeviceInfo] = devices or []
         self._supported_rates: set[int] = supported_sample_rates or {
@@ -1439,9 +1523,26 @@ class FakeAudioBackend:
             48_000,
             96_000,
         }
+        self._strict_device_exclusive = strict_device_exclusive
+        self._exclusive_streams: dict[int, object] = {}
         self.rx_streams: list[FakeRxStream] = []
         self.tx_streams: list[FakeTxStream] = []
         self.duplex_streams: list[FakeDuplexStream] = []
+
+    def _strict_stream_kwargs(self, device: AudioDeviceId) -> dict[str, Any]:
+        """Strict-mode plumbing for a new fake stream (MOR-566).
+
+        With ``strict_device_exclusive`` ON, opening a stream on a device
+        that already has an open (started, not stopped) stream raises the
+        -50-shaped error immediately; otherwise the returned kwargs let the
+        stream enforce exclusivity at ``start()``/``stop()`` time. Default
+        mode returns no kwargs — streams behave exactly as before.
+        """
+        if not self._strict_device_exclusive:
+            return {}
+        if int(device) in self._exclusive_streams:
+            raise _exclusive_device_busy(int(device))
+        return {"device": int(device), "exclusive": self._exclusive_streams}
 
     def list_devices(self) -> list[AudioDeviceInfo]:
         return list(self._devices)
@@ -1478,7 +1579,7 @@ class FakeAudioBackend:
         # ``deliver_channels`` selects the software downmix in the real
         # PortAudio stream; FakeRxStream is a verbatim pass-through, so it only
         # records what it was opened at for assertions.
-        stream = FakeRxStream()
+        stream = FakeRxStream(**self._strict_stream_kwargs(device))
         self.rx_streams.append(stream)
         return stream
 
@@ -1492,7 +1593,7 @@ class FakeAudioBackend:
     ) -> FakeTxStream:
         if not any(d.id == device for d in self._devices):
             raise ValueError(f"Unknown device id {device}")
-        stream = FakeTxStream()
+        stream = FakeTxStream(**self._strict_stream_kwargs(device))
         self.tx_streams.append(stream)
         return stream
 
@@ -1509,7 +1610,7 @@ class FakeAudioBackend:
     ) -> FakeDuplexStream:
         if not any(d.id == device for d in self._devices):
             raise ValueError(f"Unknown device id {device}")
-        stream = FakeDuplexStream()
+        stream = FakeDuplexStream(**self._strict_stream_kwargs(device))
         self.duplex_streams.append(stream)
         return stream
 

--- a/tests/_order_sensitive_radios.py
+++ b/tests/_order_sensitive_radios.py
@@ -1,0 +1,141 @@
+"""Shared order-sensitive radio stubs for start-order regression tests (MOR-566).
+
+Promoted from the bespoke stubs in ``tests/test_audio_bridge.py`` (MOR-556 /
+MOR-559 regression suites) so any test can exercise the stream start-order
+bug class without hand-building stateful stubs. Order-insensitive doubles
+(``FakeAudioBackend``-style) cannot catch this class — these stubs exist
+precisely because the transition ORDER is the contract under test.
+
+Both stubs expose the neutral ``AudioTransport``-ish surface the bridge
+consumes (``start_rx`` / ``stop_rx`` / ``start_tx`` / ``stop_tx`` /
+``push_tx``, ``audio_tx_codec``, ``audio_bus``) plus call-order tracking via
+the ``calls`` list.
+
+Declared transition graphs
+--------------------------
+
+``LanLikeRadio`` — single state field mirroring ``LanAudioStream``::
+
+    idle --start_rx--> receiving
+    receiving --start_tx--> transmitting
+    idle --start_tx--> transmitting            (RX never armed!)
+    transmitting --start_rx--> AudioAlreadyStartedError    <- MOR-556
+    transmitting --stop_tx--> receiving (rx_callback set) | idle
+    receiving --stop_rx--> idle
+
+RX can only start from IDLE: arming radio TX before the AudioBus RX
+subscribe kills RX entirely (regression from #1735).
+
+``ExclusiveUsbRadio`` — two legs on ONE exclusive physical device
+(``audio_duplex_mode == "exclusive"``, MOR-534)::
+
+    rx_running --start_tx--> rx DEAD (silent!), tx_running  <- MOR-559
+    tx_running --start_rx--> rx_running, tx_running          (clean)
+
+Adding the TX playback leg to an already-running RX capture models the
+macOS CoreAudio AUHAL ``paramErr -50``: no Python exception is raised —
+the capture just dies, exactly as observed live (MOR-531 de-risk).
+"""
+
+from __future__ import annotations
+
+from rigplane.audio.bus import AudioBus
+from rigplane.audio.usb_driver import AudioAlreadyStartedError, AudioNotStartedError
+from rigplane.core.types import AudioCodec
+
+
+class LanLikeRadio:
+    """Radio stub mirroring ``LanAudioStream``'s RX/TX state machine.
+
+    The real LAN stream supports RX-then-TX only: ``start_rx`` requires
+    IDLE state, while ``start_tx`` flips the single state field to
+    "transmitting". Arming radio TX before the AudioBus RX subscribe
+    therefore kills RX entirely (regression from #1735, MOR-556).
+    See the module docstring for the declared transition graph.
+    """
+
+    def __init__(self) -> None:
+        self.state = "idle"
+        self.calls: list[str] = []
+        self.rx_callback: object | None = None
+        self.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+        self.audio_bus = AudioBus(self)
+
+    async def start_rx(
+        self, callback: object, *, jitter_depth: int | None = None
+    ) -> None:
+        self.calls.append("start_rx")
+        if self.state != "idle":
+            raise AudioAlreadyStartedError(f"Cannot start RX in state {self.state}")
+        self.rx_callback = callback
+        self.state = "receiving"
+
+    async def stop_rx(self) -> None:
+        if self.state == "receiving":
+            self.state = "idle"
+        self.rx_callback = None
+
+    async def start_tx(self) -> None:
+        self.calls.append("start_tx")
+        if self.state == "transmitting":
+            raise AudioAlreadyStartedError("Already transmitting")
+        self.state = "transmitting"
+
+    async def stop_tx(self) -> None:
+        if self.state != "transmitting":
+            return
+        self.state = "receiving" if self.rx_callback is not None else "idle"
+
+    async def push_tx(self, audio_data: bytes) -> None:
+        if self.state != "transmitting":
+            raise AudioNotStartedError(f"Cannot push TX in state {self.state}")
+
+
+class ExclusiveUsbRadio:
+    """Radio stub mirroring the FTX-1 same-device USB CODEC (MOR-559).
+
+    ``audio_duplex_mode == "exclusive"`` (MOR-534): RX and TX resolve to ONE
+    physical macOS C-Media device. Per the MOR-531 live de-risk, adding the
+    TX playback leg to an ALREADY-RUNNING RX capture triggers CoreAudio AUHAL
+    paramErr -50 and silently kills the capture (no Python exception — live,
+    the bridge then reported "started (RX+TX)" with dead RX). Adding RX to a
+    running TX leg is clean. The stub reproduces the silent capture death so
+    the wrong order fails the test the same way it failed live.
+    See the module docstring for the declared transition graph.
+    """
+
+    audio_duplex_mode = "exclusive"
+
+    def __init__(self) -> None:
+        self.rx_running = False
+        self.tx_running = False
+        self.calls: list[str] = []
+        self.rx_callback: object | None = None
+        self.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+        self.audio_bus = AudioBus(self)
+
+    async def start_rx(
+        self, callback: object, *, jitter_depth: int | None = None
+    ) -> None:
+        self.calls.append("start_rx")
+        self.rx_callback = callback
+        self.rx_running = True
+
+    async def stop_rx(self) -> None:
+        self.rx_running = False
+        self.rx_callback = None
+
+    async def start_tx(self) -> None:
+        self.calls.append("start_tx")
+        if self.rx_running:
+            # ||PaMacCore (AUHAL)|| err='-50': the TX open nominally succeeds
+            # but the device's running RX capture dies silently.
+            self.rx_running = False
+        self.tx_running = True
+
+    async def stop_tx(self) -> None:
+        self.tx_running = False
+
+    async def push_tx(self, audio_data: bytes) -> None:
+        if not self.tx_running:
+            raise AudioNotStartedError("TX not armed")

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -8,6 +8,7 @@ import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from _order_sensitive_radios import ExclusiveUsbRadio, LanLikeRadio
 
 from rigplane.audio._bridge_metrics import BridgeMetrics
 from rigplane.audio._bridge_state import BridgeState, BridgeStateChange
@@ -15,6 +16,7 @@ from rigplane.audio.backend import (
     AudioDeviceId,
     AudioDeviceInfo,
     FakeAudioBackend,
+    FakeRxStream,
 )
 from rigplane.audio.lan_stream import AudioPacket
 from rigplane.audio_bridge import (
@@ -301,57 +303,10 @@ async def test_bridge_stop_when_not_running():
 
 # ---------------------------------------------------------------------------
 # RX-before-TX start order against a LAN-like state machine (MOR-556)
+#
+# The order-sensitive radio stubs live in tests/_order_sensitive_radios.py
+# (shared fixtures with declared transition graphs, MOR-566).
 # ---------------------------------------------------------------------------
-
-
-class _LanLikeRadio:
-    """Radio stub mirroring ``LanAudioStream``'s RX/TX state machine.
-
-    The real LAN stream supports RX-then-TX only: ``start_rx`` requires
-    IDLE state, while ``start_tx`` flips the single state field to
-    "transmitting". Arming radio TX before the AudioBus RX subscribe
-    therefore kills RX entirely (regression from #1735, MOR-556).
-    ``FakeAudioBackend``-style order-insensitive stubs cannot catch this.
-    """
-
-    def __init__(self) -> None:
-        from rigplane.audio_bus import AudioBus
-        from rigplane.types import AudioCodec
-
-        self.state = "idle"
-        self.calls: list[str] = []
-        self.rx_callback: object | None = None
-        self.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
-        self.audio_bus = AudioBus(self)
-
-    async def start_rx(
-        self, callback: object, *, jitter_depth: int | None = None
-    ) -> None:
-        self.calls.append("start_rx")
-        if self.state != "idle":
-            raise RuntimeError(f"Cannot start RX in state {self.state}")
-        self.rx_callback = callback
-        self.state = "receiving"
-
-    async def stop_rx(self) -> None:
-        if self.state == "receiving":
-            self.state = "idle"
-        self.rx_callback = None
-
-    async def start_tx(self) -> None:
-        self.calls.append("start_tx")
-        if self.state == "transmitting":
-            raise RuntimeError("Already transmitting")
-        self.state = "transmitting"
-
-    async def stop_tx(self) -> None:
-        if self.state != "transmitting":
-            return
-        self.state = "receiving" if self.rx_callback is not None else "idle"
-
-    async def push_tx(self, audio_data: bytes) -> None:
-        if self.state != "transmitting":
-            raise RuntimeError(f"Cannot push TX in state {self.state}")
 
 
 async def test_bridge_subscribes_rx_before_arming_tx():
@@ -360,7 +315,7 @@ async def test_bridge_subscribes_rx_before_arming_tx():
     On LAN, ``start_tx`` puts the stream in TRANSMITTING and a subsequent
     ``start_rx`` raises — leaving RX dead and the packet queue undrained.
     """
-    radio = _LanLikeRadio()
+    radio = LanLikeRadio()
     backend = _bridge_backend()
     bridge = AudioBridge(radio, device_name="BlackHole", backend=backend)
     await bridge.start()
@@ -380,7 +335,7 @@ async def test_bridge_subscribes_rx_before_arming_tx():
 
 async def test_bridge_rx_only_never_arms_tx_on_lan_state_machine():
     """rx_only semantics are preserved by the MOR-556 reorder: no TX arm."""
-    radio = _LanLikeRadio()
+    radio = LanLikeRadio()
     backend = _bridge_backend()
     bridge = AudioBridge(
         radio, device_name="BlackHole", tx_enabled=False, backend=backend
@@ -400,64 +355,12 @@ async def test_bridge_rx_only_never_arms_tx_on_lan_state_machine():
 # ---------------------------------------------------------------------------
 
 
-class _ExclusiveUsbRadio:
-    """Radio stub mirroring the FTX-1 same-device USB CODEC (MOR-559).
-
-    ``audio_duplex_mode == "exclusive"`` (MOR-534): RX and TX resolve to ONE
-    physical macOS C-Media device. Per the MOR-531 live de-risk, adding the
-    TX playback leg to an ALREADY-RUNNING RX capture triggers CoreAudio AUHAL
-    paramErr -50 and silently kills the capture (no Python exception — live,
-    the bridge then reported "started (RX+TX)" with dead RX). Adding RX to a
-    running TX leg is clean. The stub reproduces the silent capture death so
-    the wrong order fails the test the same way it failed live.
-    """
-
-    audio_duplex_mode = "exclusive"
-
-    def __init__(self) -> None:
-        from rigplane.audio_bus import AudioBus
-        from rigplane.types import AudioCodec
-
-        self.rx_running = False
-        self.tx_running = False
-        self.calls: list[str] = []
-        self.rx_callback: object | None = None
-        self.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
-        self.audio_bus = AudioBus(self)
-
-    async def start_rx(
-        self, callback: object, *, jitter_depth: int | None = None
-    ) -> None:
-        self.calls.append("start_rx")
-        self.rx_callback = callback
-        self.rx_running = True
-
-    async def stop_rx(self) -> None:
-        self.rx_running = False
-        self.rx_callback = None
-
-    async def start_tx(self) -> None:
-        self.calls.append("start_tx")
-        if self.rx_running:
-            # ||PaMacCore (AUHAL)|| err='-50': the TX open nominally succeeds
-            # but the device's running RX capture dies silently.
-            self.rx_running = False
-        self.tx_running = True
-
-    async def stop_tx(self) -> None:
-        self.tx_running = False
-
-    async def push_tx(self, audio_data: bytes) -> None:
-        if not self.tx_running:
-            raise RuntimeError("TX not armed")
-
-
 async def test_bridge_arms_tx_before_rx_on_exclusive_duplex():
     """Regression MOR-559: ``audio_duplex_mode == "exclusive"`` radios need
     the radio TX leg armed BEFORE the bus RX subscribe (pre-MOR-556 order) —
     the same-device TX open kills an already-running RX capture (-50).
     """
-    radio = _ExclusiveUsbRadio()
+    radio = ExclusiveUsbRadio()
     backend = _bridge_backend()
     bridge = AudioBridge(radio, device_name="BlackHole", backend=backend)
     await bridge.start()
@@ -475,7 +378,7 @@ async def test_bridge_arms_tx_before_rx_on_exclusive_duplex():
 
 async def test_bridge_rx_only_on_exclusive_duplex_still_starts_rx():
     """rx_only on an exclusive-duplex radio: RX starts, TX never armed."""
-    radio = _ExclusiveUsbRadio()
+    radio = ExclusiveUsbRadio()
     backend = _bridge_backend()
     bridge = AudioBridge(
         radio, device_name="BlackHole", tx_enabled=False, backend=backend
@@ -1073,3 +976,132 @@ async def test_on_metrics_callback():
     assert len(metrics_list) >= 1
     assert isinstance(metrics_list[0], BridgeMetrics)
     assert metrics_list[0].rx_frames > 0
+
+
+# ---------------------------------------------------------------------------
+# FakeAudioBackend strict device exclusivity + RX heartbeat (MOR-566)
+# ---------------------------------------------------------------------------
+
+_CODEC_DEVICE = AudioDeviceInfo(
+    id=AudioDeviceId(7),
+    name="USB Audio CODEC",
+    input_channels=2,
+    output_channels=2,
+)
+
+
+def _strict_backend() -> FakeAudioBackend:
+    return FakeAudioBackend([_CODEC_DEVICE], strict_device_exclusive=True)
+
+
+async def test_strict_open_on_device_with_running_stream_raises_minus_50():
+    """MOR-566: a second open on a busy device fails like CoreAudio AUHAL -50."""
+    backend = _strict_backend()
+    rx = backend.open_rx(_CODEC_DEVICE.id)
+    await rx.start(lambda _frame: None)
+    with pytest.raises(OSError) as tx_err:
+        backend.open_tx(_CODEC_DEVICE.id)
+    assert tx_err.value.errno == -50
+    assert "-50" in str(tx_err.value)
+    with pytest.raises(OSError) as duplex_err:
+        backend.open_duplex(_CODEC_DEVICE.id)
+    assert duplex_err.value.errno == -50
+
+
+async def test_strict_start_of_second_preopened_stream_raises_minus_50():
+    """Streams opened up-front still collide at start() — where -50 fires live."""
+    backend = _strict_backend()
+    rx = backend.open_rx(_CODEC_DEVICE.id)
+    tx = backend.open_tx(_CODEC_DEVICE.id)
+    await rx.start(lambda _frame: None)
+    with pytest.raises(OSError) as err:
+        await tx.start()
+    assert err.value.errno == -50
+    assert not tx.running
+    assert rx.running
+
+
+async def test_strict_stop_frees_device_for_next_stream():
+    """Closing the holding stream frees the device for a new open+start."""
+    backend = _strict_backend()
+    rx = backend.open_rx(_CODEC_DEVICE.id)
+    await rx.start(lambda _frame: None)
+    await rx.stop()
+    tx = backend.open_tx(_CODEC_DEVICE.id)
+    await tx.start()
+    assert tx.running
+    await tx.stop()
+
+
+async def test_strict_streams_on_different_devices_coexist():
+    """Exclusivity is per-device: distinct device ids never collide."""
+    backend = FakeAudioBackend(
+        [_CODEC_DEVICE, _BH_DEVICE], strict_device_exclusive=True
+    )
+    rx = backend.open_rx(_CODEC_DEVICE.id)
+    tx = backend.open_tx(_BH_DEVICE.id)
+    await rx.start(lambda _frame: None)
+    await tx.start()
+    assert rx.running and tx.running
+
+
+async def test_default_mode_allows_concurrent_same_device_streams():
+    """Default (strict OFF) keeps the historical permissive fake behavior."""
+    backend = FakeAudioBackend([_CODEC_DEVICE])
+    rx = backend.open_rx(_CODEC_DEVICE.id)
+    tx = backend.open_tx(_CODEC_DEVICE.id)
+    await rx.start(lambda _frame: None)
+    await tx.start()
+    assert rx.running and tx.running
+
+
+async def test_fake_rx_stream_inject_heartbeat_advances_liveness():
+    """MOR-566: opt-in heartbeat injection — counter + synthetic frame."""
+    backend = _bridge_backend()
+    stream = backend.open_rx(AudioDeviceId(1))
+    assert stream.heartbeat_count == 0  # unused -> no behavior change
+    frames: list[bytes] = []
+    await stream.start(frames.append)
+    stream.inject_heartbeat()
+    stream.inject_heartbeat(b"\x01\x02")
+    assert stream.heartbeat_count == 2
+    assert frames == [b"\x00\x00", b"\x01\x02"]
+    # Without a registered callback the counter still advances (liveness only).
+    bare = FakeRxStream()
+    bare.inject_heartbeat()
+    assert bare.heartbeat_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Shared order-sensitive stubs reproduce both ordering constraints (MOR-566)
+# ---------------------------------------------------------------------------
+
+
+async def test_lan_like_radio_rejects_rx_start_from_transmitting():
+    """Declared LAN graph edge: transmitting --start_rx--> raises (MOR-556)."""
+    from rigplane.audio.usb_driver import AudioAlreadyStartedError
+
+    radio = LanLikeRadio()
+    await radio.start_tx()
+    with pytest.raises(AudioAlreadyStartedError, match="Cannot start RX"):
+        await radio.start_rx(lambda _packet: None)
+    assert radio.state == "transmitting"
+
+
+async def test_exclusive_usb_radio_tx_start_kills_running_rx():
+    """Declared exclusive graph edge: TX on running RX -> silent kill (MOR-559)."""
+    radio = ExclusiveUsbRadio()
+    await radio.start_rx(lambda _packet: None)
+    assert radio.rx_running
+    await radio.start_tx()
+    # The -50 kill is silent: no exception, the capture just dies.
+    assert not radio.rx_running
+    assert radio.tx_running
+
+
+async def test_exclusive_usb_radio_rx_after_tx_is_clean():
+    """Declared exclusive graph edge: RX onto a running TX leg is clean."""
+    radio = ExclusiveUsbRadio()
+    await radio.start_tx()
+    await radio.start_rx(lambda _packet: None)
+    assert radio.rx_running and radio.tx_running


### PR DESCRIPTION
## Summary

Step 5 of epic MOR-562 (ADR P6). Tests-only / test-infrastructure change — no production code path is touched, and the default behavior of every fake is byte-identical to before.

Closes MOR-566.

### 1. `FakeAudioBackend(strict_device_exclusive=...)` — stateful device exclusivity

- New keyword-only flag, **default `False`** → all existing constructions behave exactly as before (the strict plumbing returns no kwargs and the fakes take the pre-existing code path).
- When **ON**: opening (`open_rx`/`open_tx`/`open_duplex`) **or** starting a second fake stream on a device id that already has an open (started, not yet stopped) stream raises the **-50-shaped error**:

  ```python
  OSError(-50, "PaMacCore (AUHAL) err='-50' (paramErr): device <id> already has an open stream (strict_device_exclusive)")
  ```

  i.e. `errno == -50` with the `||PaMacCore (AUHAL)|| err='-50'` marker PortAudio logs on the real macOS CoreAudio AUHAL paramErr kill (MOR-531/559). `OSError` was chosen over `sounddevice.PortAudioError` because the fakes must work without the optional `[bridge]` extras, the bridge's failure paths already key on `OSError` (`fail_on_write: OSError`, `except OSError` in the TX loop), and the issue specifies an OSError shape.
- Enforced at both seams: `open_*` raises immediately when the device is busy, and `start()` raises when a pre-opened second stream tries to start on a busy device (the seam where the real -50 fires live). **Stopping the holding stream frees the device.** Exclusivity is per-device id.

### 2. `FakeRxStream.inject_heartbeat()` — opt-in RX liveness injection

Increments a new `heartbeat_count` and delivers a synthetic frame (default: one s16le zero sample) to the registered callback, exactly like a live capture callback tick — for the epic's step-3/step-14 health tests. No behavior change when unused.

### 3. Shared order-sensitive radio stubs

The bespoke `_LanLikeRadio` / `_ExclusiveUsbRadio` stubs are **moved** out of `tests/test_audio_bridge.py` into **`tests/_order_sensitive_radios.py`** (`LanLikeRadio`, `ExclusiveUsbRadio`) — same root-underscore shared-fake pattern as `tests/_audio_stream_fake.py`. The module docstring declares both transition graphs:

- **LAN** (`LanLikeRadio`): `idle → receiving → transmitting`; `transmitting --start_rx--> AudioAlreadyStartedError` (MOR-556 — RX can only start from IDLE).
- **Exclusive USB** (`ExclusiveUsbRadio`): `rx_running --start_tx--> rx DEAD (silent), tx_running` (MOR-559 -50 kill); `tx_running --start_rx-->` clean.

The MOR-556/559 regression tests now consume the shared stubs (no duplicate definitions left). One deliberate alignment while promoting: the stubs raise the typed `AudioAlreadyStartedError`/`AudioNotStartedError` (MOR-563, merged in 2840780b) instead of bare `RuntimeError`, mirroring the real `LanAudioStream` — behavior-compatible since both subclass `RuntimeError`.

## Red → Green (falsification first)

New tests were written and run **before** touching `backend.py`:

```
FAILED test_strict_open_on_device_with_running_stream_raises_minus_50   — TypeError: FakeAudioBackend.__init__() got an unexpected keyword argument 'strict_device_exclusive'
FAILED test_strict_start_of_second_preopened_stream_raises_minus_50     — (same TypeError)
FAILED test_strict_stop_frees_device_for_next_stream                    — (same TypeError)
FAILED test_strict_streams_on_different_devices_coexist                 — (same TypeError)
FAILED test_fake_rx_stream_inject_heartbeat_advances_liveness           — AttributeError: 'FakeRxStream' object has no attribute 'heartbeat_count'
```

All 5 GREEN after the implementation; plus 3 new transition-graph tests pinning that the shared fixtures reproduce BOTH ordering constraints, and `test_default_mode_allows_concurrent_same_device_streams` pinning the permissive default.

## Default-mode behavior unchanged

- Full suite: **7402 passed, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures** (the xpass is outside the audio area — no xfail markers exist in any `tests/test_audio*` / `tests/contracts/*` file).
- Conformance gate `tests/contracts/test_audio_transport_conformance.py` (pins fake behavior + Pro export surface): **passes unchanged**.
- All fake-stream constructor additions are keyword-only with `None` defaults; every direct `FakeRxStream()` / `FakeTxStream()` / `FakeDuplexStream()` construction in the suite is unaffected.

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → 7402 passed, 0 failures
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → 554 files already formatted
- `uv run mypy src/` → baseline exactly **21 errors in 8 files** (no new errors)
- `uv run lint-imports` → **4 kept, 0 broken**

## Files (3, per guardrail)

- `src/rigplane/audio/backend.py` — strict mode + heartbeat (fakes only; real PortAudio paths untouched)
- `tests/_order_sensitive_radios.py` — new shared stubs module (~106 of its 141 lines are the verbatim-moved stub bodies)
- `tests/test_audio_bridge.py` — consumes shared stubs, adds the strict/heartbeat/graph tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)