### PR TITLE
feat(MOR-575): audio_setup_order descriptor derived from audio_duplex_mode

### DIFF
--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Callable, Protocol
+from typing import TYPE_CHECKING, Callable, Literal, Protocol
 
 from .._connection_state import RadioConnectionState
 from ..audio import AudioPacket
@@ -207,6 +207,29 @@ class _IcomSerialRadioBase(CoreRadio):
         except Exception:
             return "full"
         return mode if isinstance(mode, str) else "full"
+
+    @property
+    def audio_setup_order(self) -> Literal["rx_first", "tx_first", "atomic"]:
+        """Setup ordering descriptor (MOR-575, ADR §3.3).
+
+        Derived from :attr:`audio_duplex_mode` — single source of truth,
+        so the two descriptors never drift: ``"exclusive"`` (same-device
+        macOS: one duplex stream, setup does not decompose into
+        rx/tx-first) → ``"atomic"``; ``"full"`` (separate RX/TX devices,
+        order-indifferent) → ``"rx_first"``; ``"half"`` or any
+        unexpected/raising duplex mode degrades to the ``"rx_first"``
+        safe default — the same robustness ``audio_duplex_mode`` has
+        toward the driver. Nothing consumes this yet — the AudioSession
+        (MOR-562 step 8) and bridge (step 9) will read it.
+        """
+        try:
+            mode = self.audio_duplex_mode
+        except Exception:
+            return "rx_first"
+        if mode == "exclusive":
+            return "atomic"
+        # "full", "half", and anything unexpected → rx_first (safe default).
+        return "rx_first"
 
     # ------------------------------------------------------------------
     # Connection properties

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -351,6 +351,29 @@ class YaesuCatRadio:
         return "full"
 
     @property
+    def audio_setup_order(self) -> Literal["rx_first", "tx_first", "atomic"]:
+        """Setup ordering descriptor (MOR-575, ADR §3.3).
+
+        Derived from :attr:`audio_duplex_mode` — single source of truth,
+        so the two descriptors never drift: ``"exclusive"`` (same-device
+        macOS USB CODEC: one duplex stream, setup does not decompose
+        into rx/tx-first) → ``"atomic"``; ``"full"`` (separate RX/TX
+        devices, order-indifferent) → ``"rx_first"``; ``"half"`` or any
+        unexpected/raising duplex mode degrades to the ``"rx_first"``
+        safe default — the same robustness ``audio_duplex_mode`` has
+        toward the driver. Nothing consumes this yet — the AudioSession
+        (MOR-562 step 8) and bridge (step 9) will read it.
+        """
+        try:
+            mode = self.audio_duplex_mode
+        except Exception:
+            return "rx_first"
+        if mode == "exclusive":
+            return "atomic"
+        # "full", "half", and anything unexpected → rx_first (safe default).
+        return "rx_first"
+
+    @property
     def audio_sample_rate(self) -> int:
         """Configured audio sample rate in Hz (default 48000)."""
         return self._audio_sample_rate

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -7,7 +7,7 @@ Part of the radio.py decomposition (#505). All methods are accessed via
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from typing import Callable
@@ -541,6 +541,29 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         epic steps.
         """
         return "full"
+
+    @property
+    def audio_setup_order(self) -> Literal["rx_first", "tx_first", "atomic"]:
+        """Setup ordering descriptor (MOR-575, ADR §3.3).
+
+        Derived from :attr:`audio_duplex_mode` — single source of truth,
+        so the two descriptors never drift. The LAN UDP stream is
+        ``"full"``-duplex, but ``stop_tx`` reverts the stream state from
+        TRANSMITTING back to RECEIVING, so RX must be armed before TX →
+        ``"rx_first"``. ``"exclusive"`` would map to ``"atomic"`` (one
+        duplex stream — setup does not decompose into rx/tx-first);
+        ``"half"`` or any unexpected/raising duplex mode degrades to the
+        ``"rx_first"`` safe default. Nothing consumes this yet — the
+        AudioSession (MOR-562 step 8) and bridge (step 9) will read it.
+        """
+        try:
+            mode = self.audio_duplex_mode
+        except Exception:
+            return "rx_first"
+        if mode == "exclusive":
+            return "atomic"
+        # "full", "half", and anything unexpected → rx_first (safe default).
+        return "rx_first"
 
     @property
     def audio_sample_rate(self) -> int:

--- a/tests/contracts/test_audio_transport_conformance.py
+++ b/tests/contracts/test_audio_transport_conformance.py
@@ -15,7 +15,10 @@ pins:
    guard different files);
 4. uint16 wrap of the serial synthetic RX sequence (0xFFFF -> 0);
 5. the AudioBridge radio-side TX path on the neutral surface, including
-   the non-PCM degrade.
+   the non-PCM degrade;
+6. the additive ``audio_setup_order`` descriptor (MOR-575, ADR §3.3) —
+   derived from ``audio_duplex_mode``, duck-typed (NOT on the
+   ``AudioTransport`` Protocol; the 10-member pin stays frozen).
 
 Known edge (documented per the MOR-544 review note): a custom LAN
 profile that negotiates a non-PCM ``tx_codec`` combined with PCM input
@@ -35,7 +38,12 @@ import types
 from unittest.mock import AsyncMock
 
 import pytest
-from test_icom7610_serial_radio import _FakeSerialCivLink, _FakeUsbAudioDriver
+from test_icom7610_serial_radio import (
+    _DuplexAwareUsbAudioDriver,
+    _FakeSerialCivLink,
+    _FakeUsbAudioDriver,
+    _RaisingDuplexUsbAudioDriver,
+)
 
 import rigplane.audio
 from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
@@ -339,3 +347,82 @@ async def test_bridge_legacy_radio_keeps_pcm_path() -> None:
 
     radio.push_audio_tx_pcm.assert_awaited_with(_LOUD_FRAME)
     radio.stop_audio_tx_pcm.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 6. audio_setup_order descriptor derived from audio_duplex_mode (MOR-575)
+# ---------------------------------------------------------------------------
+
+# ADR §3.3 derivation, pinned explicitly: ``"full"`` -> ``"rx_first"``
+# (the LAN UDP stream reverts RX state from TRANSMITTING, so RX must be
+# armed before TX; USB separate-devices "full" is order-indifferent and
+# keeps the same value), ``"exclusive"`` -> ``"atomic"`` (one same-device
+# duplex stream — setup does not decompose into rx/tx-first), ``"half"``
+# -> ``"rx_first"`` (safe default). Additive duck-typed descriptor: NOT
+# on the AudioTransport Protocol (the 10-member pin above stays frozen);
+# consumers read it via ``getattr(radio, "audio_setup_order",
+# "rx_first")`` — exactly how the bridge reads ``audio_duplex_mode``.
+# Nothing consumes it yet (the bridge keeps its own rx-first branch
+# until MOR-562 steps 8/9).
+DUPLEX_TO_SETUP_ORDER = {
+    "full": "rx_first",
+    "exclusive": "atomic",
+    "half": "rx_first",
+}
+
+
+@pytest.mark.parametrize("backend_cls", SHIPPING_BACKENDS)
+def test_shipping_backend_exposes_audio_setup_order(backend_cls: type) -> None:
+    """Every shipping backend class carries the MOR-575 descriptor."""
+    assert hasattr(backend_cls, "audio_setup_order"), (
+        f"{backend_cls.__name__} lacks the audio_setup_order descriptor"
+    )
+
+
+def test_lan_radio_setup_order_is_rx_first() -> None:
+    """LAN duplex mode is hard-``"full"`` -> setup order ``"rx_first"``."""
+    radio = IcomRadio("192.168.1.100", model="IC-7300")
+    assert radio.audio_duplex_mode == "full"
+    assert radio.audio_setup_order == "rx_first"
+
+
+@pytest.mark.parametrize("duplex_mode", sorted(DUPLEX_TO_SETUP_ORDER))
+def test_serial_setup_order_consistent_with_duplex_mode(duplex_mode: str) -> None:
+    """Serial backends derive setup order from the driver duplex policy."""
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=_DuplexAwareUsbAudioDriver(duplex_mode),
+    )
+    assert radio.audio_duplex_mode == duplex_mode
+    assert radio.audio_setup_order == DUPLEX_TO_SETUP_ORDER[duplex_mode]
+
+
+def test_serial_setup_order_defaults_to_rx_first_when_driver_raises() -> None:
+    """Raising duplex enumeration degrades like duplex_mode: full/rx_first."""
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=_FakeSerialCivLink(),
+        audio_driver=_RaisingDuplexUsbAudioDriver(),
+    )
+    assert radio.audio_duplex_mode == "full"
+    assert radio.audio_setup_order == "rx_first"
+
+
+@pytest.mark.parametrize("duplex_mode", sorted(DUPLEX_TO_SETUP_ORDER))
+def test_yaesu_setup_order_consistent_with_duplex_mode(duplex_mode: str) -> None:
+    """YaesuCatRadio (the "exclusive"-capable backend) maps per the table."""
+    radio = YaesuCatRadio(
+        device="/dev/fake0",
+        audio_driver=_DuplexAwareUsbAudioDriver(duplex_mode),  # type: ignore[arg-type]
+    )
+    assert radio.audio_duplex_mode == duplex_mode
+    assert radio.audio_setup_order == DUPLEX_TO_SETUP_ORDER[duplex_mode]
+
+
+def test_setup_order_not_on_audio_transport_protocol() -> None:
+    """MOR-575 is duck-typed — the Protocol member pin must NOT grow."""
+    assert "audio_setup_order" not in AUDIO_TRANSPORT_MEMBERS
+    protocol_attrs = getattr(AudioTransport, "__protocol_attrs__", None)
+    if protocol_attrs is not None:
+        assert "audio_setup_order" not in protocol_attrs


### PR DESCRIPTION
## Summary

MOR-562 epic step 7 (ADR §3.3): add the **additive** `audio_setup_order -> Literal["rx_first", "tx_first", "atomic"]` property to the three AudioTransport-shaped backend bases, derived from each backend's own `audio_duplex_mode` so the two descriptors share a single source of truth and can never drift. Behavior is byte-identical — **nothing consumes the descriptor yet** (the bridge keeps its own `rx_first` branch until steps 8/9).

## Derivation (reproduces current semantics exactly)

| `audio_duplex_mode` | `audio_setup_order` | Why |
|---|---|---|
| `"full"` | `"rx_first"` | LAN UDP stream reverts RX from TRANSMITTING — RX must be armed before TX; USB separate-devices "full" is order-indifferent |
| `"exclusive"` | `"atomic"` | Same-device macOS: one duplex stream — setup does not decompose into rx/tx-first |
| `"half"` (or anything unexpected/raising) | `"rx_first"` | Safe default, same robustness `audio_duplex_mode` has toward the driver |

## Where

- `src/rigplane/runtime/_audio_runtime_mixin.py` — LAN `IcomRadio` (duplex hard-`"full"` → `"rx_first"`)
- `src/rigplane/backends/_icom_serial_base.py` — IC-705/7300/9700/7610-serial + X6200 family
- `src/rigplane/backends/yaesu_cat/radio.py` — FTX-1 (the `"exclusive"`-capable backend)

Each property mirrors the exact style/placement of the adjacent `audio_duplex_mode` property, including the try/except-with-default degrade.

## Deliberately NOT on the Protocol

`audio_setup_order` is duck-typed — it is NOT added to the `AudioTransport` Protocol in `core/radio_protocol.py`, so the frozen 10-member conformance pin is untouched. Consumers will read it via `getattr(radio, "audio_setup_order", "rx_first")` — exactly how the bridge reads `audio_duplex_mode` today. A new pin (`test_setup_order_not_on_audio_transport_protocol`) guards that the Protocol member set did not grow.

## TDD (red → green)

Pins written first in `tests/contracts/test_audio_transport_conformance.py` (section 6): 14 new tests failed with `AttributeError: ... has no attribute 'audio_setup_order'` (16 pre-existing green), then the three properties were added → all 30 pass. Covers: presence on all 6 shipping backend classes, per-backend duplex→setup-order consistency (LAN, serial, Yaesu × full/exclusive/half), raising-driver degrade to `"rx_first"`, and the Protocol-pin-not-grown guard.

(Pins live in `test_audio_transport_conformance.py`, not `test_audio_lifecycle_conformance.py`, to stay clear of the parallel MOR-574 PR.)

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7466 passed**, 9 skipped, 3 deselected, 12 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` — clean; `ruff format --check` — 556 files already formatted
- `uv run mypy src/` — baseline preserved: exactly **21 errors in 8 files**
- `uv run lint-imports` — **4 kept, 0 broken**

No bridge changes, no new abstractions. 3 src files + 1 test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)