### PR TITLE
fix(MOR-574): stop bridge TX before dropping RX demand to prevent LAN RX-stream leak

### DIFF
--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -835,7 +835,21 @@ class AudioBridge:
                 pass
         self._reconnect_task = None
 
-        await self._teardown_streams()
+        # Stop the radio TX leg BEFORE _teardown_streams() drops the RX
+        # demand (closes the bus subscription) — teardown is the inverse of
+        # the MOR-556 setup order. On LAN, closing the subscription while
+        # the stream is TRANSMITTING makes ``stop_rx`` early-return; the
+        # later ``stop_tx`` would then resurrect RECEIVING with a live RX
+        # task and zero bus subscribers — a leaked RX stream (MOR-574).
+        # Cancel the bridge TX loop first so it cannot push a captured
+        # frame into the just-stopped radio TX path.
+        if self._tx_task and not self._tx_task.done():
+            self._tx_task.cancel()
+            try:
+                await self._tx_task
+            except asyncio.CancelledError:
+                pass
+        self._tx_task = None
 
         if self._tx_started:
             self._tx_started = False
@@ -848,6 +862,8 @@ class AudioBridge:
                     await self._radio.stop_audio_tx_pcm()
             except Exception:
                 logger.debug("%s: stop TX error", self._label, exc_info=True)
+
+        await self._teardown_streams()
 
         logger.info(
             "%s: stopped (rx=%d frames, tx=%d frames, drops=%d)",

--- a/tests/contracts/test_audio_lifecycle_conformance.py
+++ b/tests/contracts/test_audio_lifecycle_conformance.py
@@ -28,19 +28,20 @@ running TX is clean, TX onto running RX dies with AUHAL -50) while
 That graph is therefore exercised via ``ExclusiveUsbRadio`` (declared
 from the MOR-531 live de-risk), not a real backend row.
 
-Known shipping bug surfaced by this suite (kept as a strict xfail, not
-fixed here — MOR-567 is tests-only): ``AudioBridge.stop()`` drops the
-RX demand BEFORE stopping radio TX, and ``LanAudioStream.stop_rx``
-early-returns while TRANSMITTING — so on the LAN backend a bridge stop
-with TX armed leaks the running RX stream (state ends RECEIVING with a
-live ``_rx_task`` and zero bus subscribers). Stop-side instance of the
-MOR-556 ordering class.
+Shipping bug surfaced by this suite and fixed in MOR-574 (was a strict
+xfail): ``AudioBridge.stop()`` dropped the RX demand BEFORE stopping
+radio TX, and ``LanAudioStream.stop_rx`` early-returns while
+TRANSMITTING — so on the LAN backend a bridge stop with TX armed leaked
+the running RX stream (state ended RECEIVING with a live ``_rx_task``
+and zero bus subscribers). Stop-side instance of the MOR-556 ordering
+class; the bridge now stops radio TX before closing the bus
+subscription, and the round-trip test asserts the clean end state.
 """
 
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
 import pytest
@@ -98,7 +99,6 @@ class _Harness:
     close: Callable[[], Awaitable[None]] | None = None
     # LAN single-state stream: RX can only start from IDLE (MOR-556 edge).
     rx_while_tx_raises: bool = False
-    marks: list[str] = field(default_factory=list)
 
 
 def _lan_harness() -> _Harness:
@@ -130,7 +130,6 @@ def _lan_harness() -> _Harness:
         ),
         close=_close,
         rx_while_tx_raises=True,
-        marks=["lan-bridge-stop-leak"],
     )
 
 
@@ -301,12 +300,9 @@ async def _assert_bridge_roundtrip(h: _Harness) -> None:
     await bridge.stop()
     assert h.radio.audio_bus.subscriber_count == 0
     assert not h.tx_live()
-    if "lan-bridge-stop-leak" in h.marks:
-        # Known shipping bug (see module docstring): bridge.stop() drops the
-        # RX demand while the LAN state is TRANSMITTING, LanAudioStream
-        # .stop_rx early-returns, and the RX loop leaks. Encoded, not fixed.
-        assert h.rx_live() and h.open_streams() == 1
-        pytest.xfail("LAN bridge.stop() leaks the running RX stream")
+    # MOR-574: stop with TX armed must not leak the RX stream — the bridge
+    # stops radio TX before dropping the RX demand, so even the LAN state
+    # machine (stop_rx early-returns while TRANSMITTING) ends clean.
     assert not h.rx_live()
     assert h.open_streams() == 0
 


### PR DESCRIPTION
## Bug (MOR-574, surfaced by the MOR-567 conformance suite, epic MOR-562)

`AudioBridge.stop()` on the LAN backend with TX armed leaked the running RX stream:

1. `stop()` called `_teardown_streams()` first, which closed the bus subscription → bus `_stop_rx()` → `radio.stop_rx()` **before** stopping radio TX.
2. `LanAudioStream.stop_rx` early-returns while the state machine is `TRANSMITTING` (`src/rigplane/audio/lan_stream.py:536`) — the stop was a silent no-op.
3. The later `stop_tx` saw a live `_rx_task` and set state back to `RECEIVING` (`lan_stream.py:648-649`) — the RX loop kept running with **zero bus subscribers**, draining packets into nothing.

Since a full-duplex LAN bridge keeps the stream in `TRANSMITTING` for its whole session, this hit **every** LAN bridge stop with TX enabled. Stop-side instance of the MOR-556/559 ordering bug class.

## Fix — Option A (bridge owns teardown ordering)

Teardown is now the inverse of the MOR-556 setup order, localized to `AudioBridge.stop()`:

1. cancel the bridge TX loop (so it cannot race a captured frame into the just-stopped radio TX path and flip `_tx_enabled` off),
2. stop radio TX — on LAN this transitions `TRANSMITTING → RECEIVING` (RX task alive),
3. then `_teardown_streams()` — closing the bus subscription now triggers `radio.stop_rx()` from `RECEIVING`, which cleanly cancels the RX task, flushes the jitter buffer, and ends at `IDLE`.

Option B (making `LanAudioStream.stop_rx` force-stop while `TRANSMITTING`) was rejected: it would change the LAN state-machine invariants that the live-validated IC-7610 full-duplex path (MOR-531/556, PR #1735) depends on, and it could not handle the "stop_tx resurrects RECEIVING with a dead subscriber" half without further surgery. The bridge-side reorder is smaller and leaves the transport untouched. Partial-stop semantics are preserved: the bus refcounts subscribers, so if another consumer (e.g. the web audio relay) is still subscribed, radio RX keeps running after the bridge stops — only the **last** unsubscribe stops radio RX.

`_teardown_streams()` itself is unchanged (still TX-agnostic), so the reconnect and failed-start (MOR-560) paths behave exactly as before.

## xfail → pass

The MOR-567 suite pinned this leak as a strict xfail in `tests/contracts/test_audio_lifecycle_conformance.py` (`_assert_bridge_roundtrip`, `lan-bridge-stop-leak` mark). Confirmed RED first: on the base commit the LAN row xfails (41 passed, 1 xfailed). After the fix the xfail branch is removed and the round-trip asserts the correct end state on every backend row: zero bus subscribers, RX not live, zero open radio-side streams. Suite is now 42/42 passed.

## Conformance / regression confirmation

- MOR-567 conformance suite: **42 passed** across all rows (lan-icom, 4 serial classes, yaesu-ftx1, lan/exclusive stub graphs).
- MOR-556 `test_bridge_subscribes_rx_before_arming_tx` and MOR-559 `test_bridge_arms_tx_before_rx_on_exclusive_duplex` + `test_bridge_rx_only_on_exclusive_duplex_still_starts_rx`: **pass**.
- Full suite: `uv run pytest tests/ -q --ignore=tests/integration` → **7452 passed, 9 skipped, 11 xfailed, 1 xpassed** (the xpass is the pre-existing, unrelated `test_naming_parity.py::test_toml_commands_in_radio[x6100]`, epic #295).
- `ruff check` + `ruff format --check`: clean. `mypy src/`: baseline exactly 21 errors in 8 files. `lint-imports`: 4 kept / 0 broken.

## Deferred live validation (operator-gated)

The radio is currently disconnected, so **no live run was attempted**. This fix touches bridge stop ordering; the conformance suite and unit tests cover the leak, but **IC-7610 LAN full-duplex and FTX-1 live re-validation should be re-checked when hardware is available** (bridge start → TX → stop cycle, confirming clean RX shutdown and no regression of the live-validated full-duplex path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)