### PR TITLE
feat(MOR-576): AudioSession skeleton (demand-driven RX×TX state machine)

### DIFF
--- a/src/rigplane/audio/session.py
+++ b/src/rigplane/audio/session.py
@@ -1,0 +1,356 @@
+"""AudioSession — demand-driven RX×TX state machine (MOR-576, ADR §3.2/§3.3).
+
+Skeleton of the desired-state component that will become the SOLE caller of
+the radio's ``start_rx``/``stop_rx``/``start_tx``/``stop_tx`` (target audio
+architecture ADR, ``docs/plans/2026-06-09-target-audio-architecture.md``).
+Consumers declare *demand* instead of issuing transport calls:
+
+- :meth:`AudioSession.subscribe_rx` → RX demand (delegated to the existing
+  :class:`~rigplane.audio.bus.AudioBus` refcount — the bus subscription IS
+  the session's RX demand; bus public API unchanged);
+- :meth:`AudioSession.acquire_tx` → a refcounted :class:`TxLease`.
+
+The session computes the desired state from ``(rx_demand>0, tx_demand>0)``
+and reconciles under ONE asyncio lock, so concurrent/repeated consumer
+actions can never interleave arming calls (deletes the double-start class
+at the source — MOR-556/MOR-559).
+
+State machine (ADR §3.3)::
+
+    IDLE ⇄ RX_ONLY ⇄ RX_TX          RECOVERING / FAILED reserved (step 14)
+
+Arming order is transport-owned via the MOR-575 descriptor
+``audio_setup_order`` (read with ``getattr(radio, ..., "rx_first")``):
+
+- ``"rx_first"`` (LAN, separate-device USB): RX up, then arm TX.
+- ``"tx_first"`` / ``"atomic"`` (same-device exclusive USB): the TX leg
+  must be up before RX joins the device — entering RX_TX from RX_ONLY
+  stops RX, arms TX, then re-arms RX through the bus (the MOR-559
+  live-validated order). Step 11 (MOR-546) moves the same-device duplex
+  topology behind ``UsbAudioDriver.ensure()`` inside the backend's
+  ``start_tx``; the session's sequencing here is that seam's caller.
+
+Teardown always stops TX BEFORE dropping RX (the MOR-574 lesson): RX is
+never stopped from a TRANSMITTING transport. TX never runs without RX
+(there is no TX_ONLY state); leases held across an RX gap are re-armed
+when RX demand returns.
+
+This module is consumed by NOTHING in src yet — wiring the bridge, the
+poller PTT hooks, and the web handlers through the session is steps
+9/11/12 of epic MOR-562.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from enum import Enum
+from typing import TYPE_CHECKING, Any, AsyncIterator, Literal, cast
+
+from rigplane.audio.bus import AudioBus, AudioSubscription
+
+if TYPE_CHECKING:
+    from rigplane.audio import AudioPacket
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AudioSession", "AudioSessionState", "RxSubscription", "TxLease"]
+
+_SetupOrder = Literal["rx_first", "tx_first", "atomic"]
+_VALID_SETUP_ORDERS: frozenset[str] = frozenset({"rx_first", "tx_first", "atomic"})
+
+# RX_TX → RX_ONLY re-arm policy seam (step 12, MOR-554): after dropping TX,
+# re-arm RX via the bus for these setup orders. Defaults to ALL orders —
+# today's MOR-506 unconditional post-TX re-arm semantics (the bus swallows
+# the redundant re-arm on full-duplex transports, exactly like the poller
+# path does). MOR-554 narrows this to {"tx_first", "atomic"} once skipping
+# the re-arm on "rx_first" transports is hardware-validated.
+_REARM_RX_AFTER_TX_DROP: frozenset[str] = _VALID_SETUP_ORDERS
+
+
+class AudioSessionState(Enum):
+    """Session lifecycle states (ADR §3.3)."""
+
+    IDLE = "idle"
+    RX_ONLY = "rx_only"
+    RX_TX = "rx_tx"
+    #: Reserved — the health/recovery loop lands in step 14 (no transitions
+    #: into these states yet).
+    RECOVERING = "recovering"
+    FAILED = "failed"
+
+
+class RxSubscription:
+    """Session-owned RX demand handle wrapping a bus subscription.
+
+    Releasing goes through the session (NOT the underlying bus handle) so
+    teardown ordering stays under the session lock.
+    """
+
+    def __init__(self, session: AudioSession, inner: AudioSubscription) -> None:
+        self._session = session
+        self._inner = inner
+
+    @property
+    def name(self) -> str:
+        return self._inner.name
+
+    async def get(self, timeout: float | None = None) -> AudioPacket | None:
+        """Get the next packet (blocks until available or timeout)."""
+        return await self._inner.get(timeout=timeout)
+
+    def get_nowait(self) -> AudioPacket | None:
+        return self._inner.get_nowait()
+
+    def __aiter__(self) -> AsyncIterator[AudioPacket | None]:
+        return self._inner
+
+    async def release(self) -> None:
+        """Drop this RX demand (idempotent)."""
+        await self._session._release_rx(self)
+
+
+class TxLease:
+    """Refcounted TX demand handle; ``push`` forwards to the radio."""
+
+    def __init__(self, session: AudioSession, owner: str) -> None:
+        self._session = session
+        self.owner = owner
+        self._released = False
+
+    @property
+    def released(self) -> bool:
+        return self._released
+
+    async def push(self, audio_data: bytes) -> None:
+        """Push TX audio (encoded per the radio's ``audio_tx_codec``)."""
+        if self._released:
+            raise RuntimeError(f"TX lease {self.owner!r} already released")
+        await self._session._radio.push_tx(audio_data)
+
+    async def release(self) -> None:
+        """Drop this TX demand (idempotent)."""
+        await self._session._release_tx(self)
+
+
+class AudioSession:
+    """Per-radio demand-driven audio session (skeleton — ADR §3.2).
+
+    Args:
+        radio: AudioTransport-shaped duck type (same contract as
+            :class:`AudioBus` — no import-matrix change).
+        bus: Existing bus to wrap; defaults to ``radio.audio_bus`` or a
+            fresh :class:`AudioBus`.
+    """
+
+    def __init__(self, radio: Any, *, bus: AudioBus | None = None) -> None:
+        self._radio = radio
+        self._bus: AudioBus = (
+            bus if bus is not None else getattr(radio, "audio_bus", None)
+        ) or AudioBus(radio)
+        self._lock = asyncio.Lock()
+        self._state = AudioSessionState.IDLE
+        self._rx_subs: list[RxSubscription] = []
+        self._tx_leases: list[TxLease] = []
+
+    @property
+    def state(self) -> AudioSessionState:
+        return self._state
+
+    @property
+    def rx_demand(self) -> int:
+        return len(self._rx_subs)
+
+    @property
+    def tx_demand(self) -> int:
+        return len(self._tx_leases)
+
+    @property
+    def bus(self) -> AudioBus:
+        """The wrapped AudioBus (fan-out; public API unchanged)."""
+        return self._bus
+
+    @property
+    def stats(self) -> dict[str, Any]:
+        return {
+            "state": self._state.value,
+            "rx_demand": len(self._rx_subs),
+            "tx_demand": len(self._tx_leases),
+            "setup_order": self._setup_order(),
+            "bus": self._bus.stats,
+        }
+
+    # ── Demand API ───────────────────────────────────────────────────────
+
+    async def subscribe_rx(self, name: str = "") -> RxSubscription:
+        """Add RX demand; first subscriber arms RX (via the bus refcount).
+
+        Raises if the radio RX leg fails to start — with the failed
+        subscription fully unwound (no leaked demand, no leaked bus
+        subscription).
+        """
+        async with self._lock:
+            sub = RxSubscription(self, self._bus.subscribe(name=name))
+            self._rx_subs.append(sub)
+            try:
+                await self._apply()
+            except BaseException:
+                self._rx_subs.remove(sub)
+                await sub._inner.aclose()
+                raise
+            return sub
+
+    async def acquire_tx(self, owner: str = "") -> TxLease:
+        """Add TX demand; arms TX in the transport-declared order.
+
+        With no RX demand the lease is recorded but nothing is armed (no
+        TX_ONLY state); arming happens when RX demand arrives. A TX start
+        failure unwinds the lease and re-raises.
+        """
+        async with self._lock:
+            lease = TxLease(self, owner)
+            self._tx_leases.append(lease)
+            try:
+                await self._apply()
+            except BaseException:
+                self._tx_leases.remove(lease)
+                lease._released = True
+                raise
+            return lease
+
+    async def _release_rx(self, sub: RxSubscription) -> None:
+        async with self._lock:
+            if sub not in self._rx_subs:
+                return
+            self._rx_subs.remove(sub)
+            try:
+                # Orders TX-down-before-RX when demand hits zero (MOR-574).
+                await self._apply()
+            finally:
+                await sub._inner.aclose()
+
+    async def _release_tx(self, lease: TxLease) -> None:
+        async with self._lock:
+            if lease not in self._tx_leases:
+                lease._released = True
+                return
+            self._tx_leases.remove(lease)
+            lease._released = True
+            await self._apply()
+
+    # ── Desired-state reconciliation (single lock holder) ────────────────
+
+    def _desired(self) -> AudioSessionState:
+        if not self._rx_subs:
+            return AudioSessionState.IDLE
+        if self._tx_leases:
+            return AudioSessionState.RX_TX
+        return AudioSessionState.RX_ONLY
+
+    def _setup_order(self) -> _SetupOrder:
+        order = getattr(self._radio, "audio_setup_order", "rx_first")
+        if order not in _VALID_SETUP_ORDERS:
+            logger.warning(
+                "audio-session: unknown audio_setup_order %r — using rx_first",
+                order,
+            )
+            return "rx_first"
+        return cast(_SetupOrder, order)
+
+    async def _apply(self) -> None:
+        desired = self._desired()
+        if desired is self._state:
+            if desired is not AudioSessionState.IDLE:
+                await self._arm_rx()  # new subscribers join the live RX leg
+            return
+        if desired is AudioSessionState.RX_TX:
+            await self._enter_rx_tx(self._setup_order())
+        elif desired is AudioSessionState.RX_ONLY:
+            if self._state is AudioSessionState.RX_TX:
+                await self._disarm_tx()
+                if self._setup_order() in _REARM_RX_AFTER_TX_DROP:
+                    await self._bus.restart_rx()
+            else:
+                await self._arm_rx()
+            self._state = AudioSessionState.RX_ONLY
+        else:  # IDLE
+            if self._state is AudioSessionState.RX_TX:
+                await self._disarm_tx()  # MOR-574: TX down BEFORE RX drops
+            await self._drop_rx()
+            self._state = AudioSessionState.IDLE
+
+    async def _enter_rx_tx(self, order: _SetupOrder) -> None:
+        if self._state is AudioSessionState.IDLE:
+            # Reached only via subscribe_rx (TX demand was deferred at
+            # IDLE), so a TX arm failure here has no demanding caller to
+            # raise to: log, settle at RX_ONLY, keep the leases — the next
+            # demand edge retries (the step-14 recovery loop owns more).
+            if order == "rx_first":
+                await self._arm_rx()
+                try:
+                    await self._radio.start_tx()
+                except Exception:
+                    logger.warning(
+                        "audio-session: deferred TX arm failed — RX_ONLY",
+                        exc_info=True,
+                    )
+                    self._state = AudioSessionState.RX_ONLY
+                    return
+            else:  # "tx_first" / "atomic": TX leg up before RX joins
+                try:
+                    await self._radio.start_tx()
+                except Exception:
+                    logger.warning(
+                        "audio-session: deferred TX arm failed — RX_ONLY",
+                        exc_info=True,
+                    )
+                    await self._arm_rx()
+                    self._state = AudioSessionState.RX_ONLY
+                    return
+                try:
+                    await self._arm_rx()
+                except BaseException:
+                    await self._disarm_tx()  # never leave TX without RX
+                    raise
+        elif order == "rx_first":  # RX_ONLY → RX_TX, RX already up
+            await self._radio.start_tx()
+        else:
+            # RX_ONLY → RX_TX on an exclusive/tx-first transport: tear the
+            # RX leg down, arm TX, re-arm RX onto the running TX leg (the
+            # MOR-559 live-validated order). The bus keeps its subscribers
+            # throughout; ``restart_rx`` re-arms with the bus's own
+            # callback — also on TX-arm failure, so RX demand never
+            # strands (the failure propagates to the acquiring caller).
+            await self._radio.stop_rx()
+            try:
+                await self._radio.start_tx()
+            finally:
+                await self._bus.restart_rx()
+        self._state = AudioSessionState.RX_TX
+
+    async def _arm_rx(self) -> None:
+        """Start any not-yet-active bus subscriptions; verify RX is live.
+
+        The bus swallows radio RX-start failures (``rx_active`` stays
+        False) — surface them to the demanding subscriber instead.
+        """
+        for sub in self._rx_subs:
+            if not sub._inner.active:
+                await sub._inner.start()
+        if self._rx_subs and not self._bus.rx_active:
+            raise RuntimeError(
+                "radio RX failed to start for the session subscription "
+                "(AudioBus.rx_active is False after subscribe); see "
+                "'audio-bus: failed to start RX' in the log"
+            )
+
+    async def _disarm_tx(self) -> None:
+        try:
+            await self._radio.stop_tx()
+        except Exception:
+            logger.debug("audio-session: stop TX error", exc_info=True)
+
+    async def _drop_rx(self) -> None:
+        for sub in list(self._rx_subs):
+            await sub._inner.aclose()
+        self._rx_subs.clear()

--- a/tests/test_audio_session.py
+++ b/tests/test_audio_session.py
@@ -1,0 +1,430 @@
+"""AudioSession skeleton tests (MOR-576, ADR §3.2/§3.3 — epic MOR-562 step 8).
+
+Falsification-first: the demand-driven RX×TX state machine must
+
+- converge demand permutations to the same final state,
+- honor the backend-declared ``audio_setup_order`` (MOR-575) so the
+  strict ``FakeAudioBackend`` never raises the -50-shaped OSError and the
+  shared order-sensitive stubs (MOR-566) never see the silent RX kill,
+- refcount RX subscriptions / TX leases (no double-start),
+- stop TX BEFORE dropping RX on teardown (the MOR-574 lesson — never
+  ``stop_rx`` from a TRANSMITTING transport),
+- leak no demand and no bus subscription when a start fails.
+
+The session is consumed by NOTHING in src yet (steps 9/11/12 wire it).
+"""
+
+from __future__ import annotations
+
+import pytest
+from _order_sensitive_radios import ExclusiveUsbRadio, LanLikeRadio
+
+from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.audio.bus import AudioBus
+from rigplane.audio.lan_stream import AudioPacket
+from rigplane.audio.session import AudioSession, AudioSessionState
+from rigplane.core.types import AudioCodec
+
+_PACKET = AudioPacket(ident=0x0080, send_seq=1, data=b"\x01\x00" * 160)
+
+# ── Radio stubs ──────────────────────────────────────────────────────────────
+#
+# The shared MOR-566 stubs predate the MOR-575 descriptor; LanLikeRadio's
+# implicit order is the ``getattr`` default ("rx_first"), the exclusive stub
+# declares "atomic" here exactly as the shipping backend derivation does
+# ("exclusive" → "atomic").
+
+
+class _AtomicExclusiveRadio(ExclusiveUsbRadio):
+    """Shared exclusive stub + the MOR-575 ``audio_setup_order`` descriptor."""
+
+    audio_setup_order = "atomic"
+
+
+class _RecordingLanRadio(LanLikeRadio):
+    """LAN stub recording the state each stop call was made from (MOR-574)."""
+
+    async def stop_rx(self) -> None:
+        self.calls.append(f"stop_rx@{self.state}")
+        await super().stop_rx()
+
+    async def stop_tx(self) -> None:
+        self.calls.append(f"stop_tx@{self.state}")
+        await super().stop_tx()
+
+
+class _FailingTxLanRadio(LanLikeRadio):
+    """LAN stub whose TX arm fails once (induced start failure)."""
+
+    fail_start_tx = True
+
+    async def start_tx(self) -> None:
+        if self.fail_start_tx:
+            self.calls.append("start_tx")
+            raise RuntimeError("induced TX start failure")
+        await super().start_tx()
+
+
+class _FailingRxLanRadio(LanLikeRadio):
+    """LAN stub whose RX arm fails until repaired (induced start failure)."""
+
+    fail_start_rx = True
+
+    async def start_rx(
+        self, callback: object, *, jitter_depth: int | None = None
+    ) -> None:
+        if self.fail_start_rx:
+            self.calls.append("start_rx")
+            raise ConnectionError("induced RX start failure")
+        await super().start_rx(callback, jitter_depth=jitter_depth)
+
+
+class _FailingTxAtomicRadio(_AtomicExclusiveRadio):
+    """Atomic stub whose TX arm fails — the session must re-arm RX."""
+
+    async def start_tx(self) -> None:
+        self.calls.append("start_tx")
+        raise RuntimeError("induced TX start failure")
+
+
+_CODEC_DEV = AudioDeviceInfo(
+    id=AudioDeviceId(7), name="FTX-1 USB CODEC", input_channels=2, output_channels=2
+)
+
+
+class _StrictExclusiveRadio:
+    """Exclusive same-device radio over ``FakeAudioBackend(strict)``.
+
+    Models the step-11 target arming on ONE physical device (MOR-531/546):
+    when the TX leg comes up first it opens the single full-duplex stream
+    and a later RX arm just joins it (the MOR-559 live-validated clean
+    path). The naive order — TX onto an already-running RX-only stream —
+    opens a second stream on the busy device and the strict fake raises
+    the -50-shaped OSError, exactly like live CoreAudio.
+    """
+
+    audio_duplex_mode = "exclusive"
+    audio_setup_order = "atomic"
+
+    def __init__(self) -> None:
+        self.backend = FakeAudioBackend([_CODEC_DEV], strict_device_exclusive=True)
+        self.audio_bus = AudioBus(self)
+        self.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+        self.calls: list[str] = []
+        self._rx_stream = None
+        self._duplex = None
+        self._rx_callback: object | None = None
+
+    @property
+    def rx_live(self) -> bool:
+        if self._duplex is not None and self._duplex.running:
+            return self._rx_callback is not None
+        return self._rx_stream is not None and self._rx_stream.running
+
+    @property
+    def tx_live(self) -> bool:
+        return self._duplex is not None and self._duplex.running
+
+    async def start_rx(
+        self, callback: object, *, jitter_depth: int | None = None
+    ) -> None:
+        self.calls.append("start_rx")
+        self._rx_callback = callback
+        if self._duplex is not None and self._duplex.running:
+            return  # RX joins the running duplex stream — clean (MOR-531)
+        self._rx_stream = self.backend.open_rx(_CODEC_DEV.id)
+        await self._rx_stream.start(lambda frame: None)
+
+    async def stop_rx(self) -> None:
+        self.calls.append("stop_rx")
+        self._rx_callback = None
+        if self._rx_stream is not None:
+            await self._rx_stream.stop()
+            self._rx_stream = None
+
+    async def start_tx(self) -> None:
+        self.calls.append("start_tx")
+        # Single full-duplex stream on the one device; with an RX-only
+        # stream still open this raises the strict fake's -50 OSError.
+        self._duplex = self.backend.open_duplex(_CODEC_DEV.id)
+        await self._duplex.start(lambda frame: None)
+
+    async def stop_tx(self) -> None:
+        self.calls.append("stop_tx")
+        if self._duplex is not None:
+            await self._duplex.stop()
+            self._duplex = None
+
+    async def push_tx(self, audio_data: bytes) -> None:
+        if self._duplex is None or not self._duplex.running:
+            raise RuntimeError("TX not armed")
+        await self._duplex.write(audio_data)
+
+
+def _snapshot(session: AudioSession) -> dict[str, object]:
+    return {
+        "state": session.state,
+        "rx_demand": session.rx_demand,
+        "tx_demand": session.tx_demand,
+        "bus_subscribers": session.bus.subscriber_count,
+    }
+
+
+# ── The strict fake's teeth (falsification baseline) ─────────────────────────
+
+
+async def test_strict_fake_raises_minus_50_on_tx_over_running_rx() -> None:
+    """Naive TX-onto-running-RX on the exclusive device raises -50."""
+    radio = _StrictExclusiveRadio()
+    await radio.start_rx(lambda p: None)
+    with pytest.raises(OSError) as excinfo:
+        await radio.start_tx()
+    assert excinfo.value.errno == -50
+
+
+# ── Skeleton shape ───────────────────────────────────────────────────────────
+
+
+async def test_session_starts_idle_with_reserved_states() -> None:
+    session = AudioSession(LanLikeRadio())
+    assert session.state is AudioSessionState.IDLE
+    assert session.rx_demand == 0
+    assert session.tx_demand == 0
+    # RECOVERING / FAILED are reserved members (recovery loop is step 14).
+    assert AudioSessionState.RECOVERING is not None
+    assert AudioSessionState.FAILED is not None
+
+
+async def test_subscribe_rx_starts_rx_and_delivers_frames() -> None:
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("test-consumer")
+    assert session.state is AudioSessionState.RX_ONLY
+    assert radio.state == "receiving"
+    assert radio.rx_callback is not None
+    radio.rx_callback(_PACKET)  # type: ignore[operator]
+    assert await sub.get(timeout=1.0) == _PACKET
+    await sub.release()
+    assert session.state is AudioSessionState.IDLE
+    assert radio.state == "idle"
+    assert session.bus.subscriber_count == 0
+
+
+# ── Demand permutations converge ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("make_radio", [LanLikeRadio, _AtomicExclusiveRadio])
+async def test_demand_permutations_converge(make_radio: type) -> None:
+    """rx-then-tx and tx-then-rx both reach RX_TX with identical state."""
+    snapshots = []
+    for order in ("rx_then_tx", "tx_then_rx"):
+        radio = make_radio()
+        session = AudioSession(radio)
+        if order == "rx_then_tx":
+            await session.subscribe_rx("a")
+            await session.acquire_tx("ptt")
+        else:
+            await session.acquire_tx("ptt")
+            await session.subscribe_rx("a")
+        snapshots.append(_snapshot(session))
+    assert snapshots[0] == snapshots[1]
+    assert snapshots[0]["state"] is AudioSessionState.RX_TX
+
+
+async def test_acquire_tx_at_idle_defers_arming() -> None:
+    """A TX lease at IDLE registers demand but arms nothing (no TX_ONLY)."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    lease = await session.acquire_tx("ptt")
+    assert session.state is AudioSessionState.IDLE
+    assert session.tx_demand == 1
+    assert radio.calls == []  # nothing armed — the MOR-556 trap avoided
+    await session.subscribe_rx("a")
+    assert session.state is AudioSessionState.RX_TX
+    assert radio.calls == ["start_rx", "start_tx"]  # rx_first order
+    await lease.release()
+
+
+# ── audio_setup_order drives arming (descriptor-read, not hardcoded) ─────────
+
+
+async def test_rx_first_order_honored_on_lan_graph() -> None:
+    """LAN graph: RX must arm before TX or start_rx raises (MOR-556)."""
+    radio = LanLikeRadio()  # descriptor default: "rx_first"
+    session = AudioSession(radio)
+    await session.subscribe_rx("a")
+    await session.acquire_tx("ptt")
+    assert session.state is AudioSessionState.RX_TX
+    assert radio.state == "transmitting"
+    assert radio.rx_callback is not None  # RX leg survived
+    assert radio.calls == ["start_rx", "start_tx"]
+
+
+async def test_atomic_order_honored_on_exclusive_graph() -> None:
+    """Exclusive graph: TX onto running RX silently kills RX (MOR-559)."""
+    radio = _AtomicExclusiveRadio()
+    session = AudioSession(radio)
+    await session.subscribe_rx("a")
+    await session.acquire_tx("ptt")
+    assert session.state is AudioSessionState.RX_TX
+    assert radio.tx_running is True
+    assert radio.rx_running is True  # silent kill avoided — RX re-armed
+    # stop RX → arm TX → re-arm RX (the MOR-559 live-validated order)
+    assert radio.calls == ["start_rx", "start_tx", "start_rx"]
+
+
+@pytest.mark.parametrize("first", ["rx", "tx"])
+async def test_atomic_order_no_minus_50_on_strict_fake(first: str) -> None:
+    """Strict fake: the session's sequencing never opens a busy device."""
+    radio = _StrictExclusiveRadio()
+    session = AudioSession(radio)
+    if first == "rx":
+        await session.subscribe_rx("a")
+        await session.acquire_tx("ptt")
+    else:
+        await session.acquire_tx("ptt")
+        await session.subscribe_rx("a")
+    assert session.state is AudioSessionState.RX_TX
+    assert radio.rx_live is True
+    assert radio.tx_live is True
+
+
+# ── Refcounting (no double-start) ────────────────────────────────────────────
+
+
+async def test_double_subscribe_rx_refcounted() -> None:
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub_a = await session.subscribe_rx("a")
+    sub_b = await session.subscribe_rx("b")
+    assert radio.calls.count("start_rx") == 1  # no double-start, no raise
+    assert session.rx_demand == 2
+    await sub_a.release()
+    assert session.state is AudioSessionState.RX_ONLY
+    assert radio.state == "receiving"
+    await sub_b.release()
+    assert session.state is AudioSessionState.IDLE
+    assert radio.state == "idle"
+
+
+async def test_double_acquire_tx_refcounted() -> None:
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    await session.subscribe_rx("a")
+    lease_a = await session.acquire_tx("web")
+    lease_b = await session.acquire_tx("ptt")
+    assert radio.calls.count("start_tx") == 1  # no AlreadyStarted leaked
+    assert session.tx_demand == 2
+    await lease_a.release()
+    assert session.state is AudioSessionState.RX_TX  # demand survives
+    await lease_b.release()
+    assert session.state is AudioSessionState.RX_ONLY
+    assert radio.state == "receiving"
+
+
+async def test_double_release_is_noop() -> None:
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("a")
+    lease = await session.acquire_tx("ptt")
+    await lease.release()
+    await lease.release()
+    assert session.tx_demand == 0
+    await sub.release()
+    await sub.release()
+    assert session.rx_demand == 0
+    assert session.state is AudioSessionState.IDLE
+
+
+# ── Teardown ordering (the MOR-574 lesson) ───────────────────────────────────
+
+
+@pytest.mark.parametrize("release_order", ["tx_then_rx", "rx_then_tx"])
+async def test_teardown_stops_tx_before_rx(release_order: str) -> None:
+    """RX_TX → IDLE never calls stop_rx from a TRANSMITTING transport."""
+    radio = _RecordingLanRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("a")
+    lease = await session.acquire_tx("ptt")
+    if release_order == "tx_then_rx":
+        await lease.release()
+        await sub.release()
+    else:
+        await sub.release()
+        await lease.release()
+    assert "stop_rx@transmitting" not in radio.calls
+    assert radio.state == "idle"  # no leaked RX (the conformance-suite bug)
+    assert session.state is AudioSessionState.IDLE
+    assert session.bus.subscriber_count == 0
+
+
+async def test_rx_demand_returning_rearms_held_tx_lease() -> None:
+    """A lease held across an RX gap re-arms when RX demand returns."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("a")
+    await session.acquire_tx("ptt")
+    await sub.release()  # rx → 0 while the lease is held
+    assert session.state is AudioSessionState.IDLE
+    assert session.tx_demand == 1
+    assert radio.state == "idle"
+    await session.subscribe_rx("b")  # demand convergence
+    assert session.state is AudioSessionState.RX_TX
+    assert radio.state == "transmitting"
+
+
+# ── Start failures leak nothing ──────────────────────────────────────────────
+
+
+async def test_rx_start_failure_leaks_no_subscription() -> None:
+    radio = _FailingRxLanRadio()
+    session = AudioSession(radio)
+    with pytest.raises(RuntimeError):
+        await session.subscribe_rx("a")
+    assert session.rx_demand == 0
+    assert session.bus.subscriber_count == 0
+    assert session.state is AudioSessionState.IDLE
+    # No poisoned state: repair the radio and subscribe again.
+    radio.fail_start_rx = False
+    await session.subscribe_rx("a")
+    assert session.state is AudioSessionState.RX_ONLY
+
+
+async def test_tx_start_failure_leaks_no_lease_rx_first() -> None:
+    radio = _FailingTxLanRadio()
+    session = AudioSession(radio)
+    await session.subscribe_rx("a")
+    with pytest.raises(RuntimeError):
+        await session.acquire_tx("ptt")
+    assert session.tx_demand == 0
+    assert session.state is AudioSessionState.RX_ONLY
+    assert radio.state == "receiving"  # RX untouched
+
+
+async def test_tx_start_failure_atomic_rearms_rx() -> None:
+    """Atomic arm failure must not strand RX down (it was stopped first)."""
+    radio = _FailingTxAtomicRadio()
+    session = AudioSession(radio)
+    await session.subscribe_rx("a")
+    with pytest.raises(RuntimeError):
+        await session.acquire_tx("ptt")
+    assert session.tx_demand == 0
+    assert session.state is AudioSessionState.RX_ONLY
+    assert radio.rx_running is True  # re-armed by the unwind
+    assert radio.tx_running is False
+
+
+# ── TX lease push ────────────────────────────────────────────────────────────
+
+
+async def test_lease_push_delegates_and_release_guards() -> None:
+    radio = _StrictExclusiveRadio()
+    session = AudioSession(radio)
+    await session.subscribe_rx("a")
+    lease = await session.acquire_tx("bridge")
+    await lease.push(b"\x01\x00" * 160)
+    assert radio._duplex is not None
+    assert radio._duplex.written_frames == [b"\x01\x00" * 160]
+    await lease.release()
+    with pytest.raises(RuntimeError):
+        await lease.push(b"\x00\x00")


### PR DESCRIPTION
## Summary

Step 8 of epic MOR-562 (the core of the epic): introduce `AudioSession` in a new `src/rigplane/audio/session.py` per ADR §3.2/§3.3 (PR #1754). It is the desired-state component that will (in later steps) become the **sole caller** of the radio's `start_rx`/`stop_rx`/`start_tx`/`stop_tx`. This PR is a pure-additive skeleton: **consumed by NOTHING in src** — bridge/poller/web wiring is steps 9/11/12. Grep-verified: the only `AudioSession` mentions outside the new file are pre-existing docstrings pointing at this step.

## Demand API (ADR §3.3 pt 1 — "demand counters, not calls")

- `subscribe_rx(name) -> RxSubscription` — RX demand. Delegated to the existing `AudioBus` refcount: the bus subscription **is** the session's RX demand (first subscriber → radio RX start, last release → RX stop). Bus public API unchanged; `bus.py` untouched.
- `acquire_tx(owner) -> TxLease` — refcounted TX demand; `push()` forwards to `radio.push_tx`; `release()` idempotent.
- Both compute the desired state from `(rx_demand>0, tx_demand>0)` and reconcile via a single `_apply(desired)` under **one asyncio lock**, so concurrent/repeated consumer actions cannot interleave arming calls — the MOR-556/MOR-559 double-start class is deleted at the source, not just detected.

## State machine

```
IDLE ⇄ RX_ONLY ⇄ RX_TX        RECOVERING / FAILED reserved (enum members only;
                               the recovery loop is step 14)
```

- TX never runs without RX (no TX_ONLY state): `acquire_tx` at IDLE records the lease but arms nothing; arming happens when RX demand arrives — all demand permutations converge to the identical RX_TX state.
- Teardown RX_TX → IDLE always stops TX **before** dropping RX (the MOR-574 lesson — RX is never stopped from a TRANSMITTING transport), in both release orders.

## `audio_setup_order` drives arming (MOR-575 descriptor, not a hardcoded branch)

Read via `getattr(radio, "audio_setup_order", "rx_first")`:

- `"rx_first"` (LAN, separate-device USB): RX up, then arm TX onto the live RX leg.
- `"tx_first"` / `"atomic"` (same-device exclusive USB): entering RX_TX from RX_ONLY runs `stop_rx → start_tx → bus.restart_rx()` — the MOR-559 live-validated order (TX leg up first; RX joins the running TX leg cleanly). The `restart_rx` sits in a `finally`, so a TX-arm failure still re-arms RX before propagating to the acquiring caller.
- **Step-11 seam (MOR-546):** the session does NOT wire `UsbAudioDriver.ensure()`; it only sequences the radio's existing arming calls. The backend's `start_tx` is where the single-duplex topology lands in step 11 — documented in the module docstring and modeled by the test's `_StrictExclusiveRadio` (TX-first opens the duplex stream; later RX joins it).
- **Step-12 seam (MOR-554):** the RX_TX → RX_ONLY post-TX re-arm policy is the parameterized `_REARM_RX_AFTER_TX_DROP` constant, defaulting to ALL orders — today's MOR-506 unconditional re-arm semantics (the bus swallows the redundant re-arm on full-duplex transports exactly like the poller path does).

## Red → Green

- RED: `tests/test_audio_session.py` written first; run → `ModuleNotFoundError: No module named 'rigplane.audio.session'` (collection error).
- GREEN: 20/20 after implementing `session.py`, no test edits.

Falsification tests run against `FakeAudioBackend(strict_device_exclusive=True)` and the shared MOR-566 order-sensitive stubs (`LanLikeRadio`, `ExclusiveUsbRadio`):

- baseline proves the strict fake's teeth: naive TX-onto-running-RX raises the -50-shaped `OSError`;
- demand permutations (rx-then-tx vs tx-then-rx) converge to identical snapshots on both graph stubs;
- descriptor-driven ordering: LAN graph sees `start_rx → start_tx` (no `AudioAlreadyStartedError`), exclusive graph sees `start_rx → start_tx → start_rx` with RX alive (no silent kill), strict fake never raises -50 in either permutation;
- double subscribe / double acquire refcounted (exactly one radio start per leg);
- teardown stops TX before RX in both release orders (`stop_rx@transmitting` never observed; no leaked LAN RX stream);
- RX-start failure leaves zero demand and zero bus subscriptions (and the session is not poisoned — retry works); TX-start failure unwinds the lease (rx_first: RX untouched; atomic: RX re-armed by the unwind).

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7486 passed, 9 skipped, 3 deselected, 12 xfailed, 1 xpassed, 0 failures**
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → clean
- `uv run mypy src/` → baseline **exactly 21 errors in 8 files** (new module mypy-clean)
- `uv run lint-imports` → **4 kept, 0 broken** (session lives in `audio/`, references the radio via the same `AudioTransport` duck type as `AudioBus` — no new cross-layer import)

Files: `src/rigplane/audio/session.py` (new, 356 lines incl. docstrings) + `tests/test_audio_session.py` (new, 430 lines). No `__init__.py` export added — direct submodule import is the canonical path for heavier audio abstractions; the lazy export can land with the first production consumer (step 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)