### PR TITLE
refactor(MOR-578): AudioDeviceConfig carrier replaces per-keyword audio plumbing

### DIFF
--- a/src/rigplane/audio/__init__.py
+++ b/src/rigplane/audio/__init__.py
@@ -39,6 +39,7 @@ from .lan_stream import (  # noqa: F401
 _LAZY_MAP: dict[str, tuple[str, str]] = {
     # Audio backend abstraction (protocol + implementations)
     "AudioBackend": ("rigplane.audio.backend", "AudioBackend"),
+    "AudioDeviceConfig": ("rigplane.audio.backend", "AudioDeviceConfig"),
     "AudioDeviceId": ("rigplane.audio.backend", "AudioDeviceId"),
     "AudioDeviceInfo": ("rigplane.audio.backend", "AudioDeviceInfo"),
     "FakeAudioBackend": ("rigplane.audio.backend", "FakeAudioBackend"),
@@ -110,6 +111,7 @@ def __dir__() -> list[str]:
 __all__ = [
     # Audio backend abstraction
     "AudioBackend",
+    "AudioDeviceConfig",
     "AudioDeviceId",
     "AudioDeviceInfo",
     "FakeAudioBackend",

--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -41,6 +41,35 @@ def _platform_uid_from_device_name(name: str) -> str:
 
 
 @dataclass(frozen=True, slots=True)
+class AudioDeviceConfig:
+    """Per-device audio configuration carrier (MOR-578).
+
+    Bundles the per-device audio knobs that historically travelled as six
+    separate keyword parameters across every layer (``rigs/*.toml [audio]`` →
+    rig loader → backend ctor → :class:`UsbAudioDriver` → ``open_rx`` →
+    ``_RxFramer`` → downmix) into ONE frozen object, so adding a knob no
+    longer means threading a new keyword through each hop. Fields and
+    defaults mirror the historical per-keyword plumbing 1:1.
+
+    ``channels`` keeps the exact per-layer meaning the ``channels=`` keyword
+    had: the requested capture/playback channel count at the driver level,
+    and the OS-open channel count for the per-stream copy the backend hands
+    to its internal streams (the delivered count stays a separate
+    ``deliver_channels`` value, as before — it is a derived downmix
+    instruction, not device config). ``rx_device``/``tx_device`` are the
+    driver-level selection overrides; they are not consulted below the
+    driver, exactly like the old keywords.
+    """
+
+    rx_device: str | None = None
+    tx_device: str | None = None
+    sample_rate: int = 48_000
+    channels: int = 1
+    frame_ms: int = 20
+    rx_audio_channel: str = "mix"
+
+
+@dataclass(frozen=True, slots=True)
 class AudioDeviceInfo:
     """Normalized audio device descriptor returned by a backend."""
 
@@ -358,18 +387,16 @@ class _RxFramer:
     def __init__(
         self,
         *,
-        channels: int,
+        config: AudioDeviceConfig,
         deliver_channels: int,
-        sample_rate: int,
-        frame_ms: int,
-        rx_audio_channel: str,
     ) -> None:
-        self._rx_audio_channel = rx_audio_channel
+        self._rx_audio_channel = config.rx_audio_channel
         # Software downmix only fires for the stereo-native → mono case. Any
         # other deliver/open relationship passes interleaved PCM through
         # unchanged (over-request already clamps open == deliver upstream).
-        self._downmix_stereo_to_mono = channels == 2 and deliver_channels == 1
-        frame_samples = (sample_rate * frame_ms) // 1000
+        # ``config.channels`` is the OS-open count in this per-stream scope.
+        self._downmix_stereo_to_mono = config.channels == 2 and deliver_channels == 1
+        frame_samples = (config.sample_rate * config.frame_ms) // 1000
         self._frame_bytes = max(1, frame_samples * deliver_channels * 2)
         self._accumulator = bytearray()
 
@@ -459,23 +486,21 @@ class _PortAudioRxStream:
         self,
         sd: Any,
         device_index: int,
-        sample_rate: int,
-        channels: int,
+        *,
+        config: AudioDeviceConfig,
         blocksize: int,
-        frame_ms: int,
         deliver_channels: int | None = None,
-        rx_audio_channel: str = "mix",
     ) -> None:
         self._sd = sd
         self._device_index = device_index
-        self._sample_rate = sample_rate
-        # ``channels`` is the OS open count; ``_deliver_channels`` is what the
-        # consumer receives. When deliver < open (mono request on a stereo-
-        # native device, MOR-504) the framer downmixes interleaved s16le to
-        # the deliver count before chunking. Default: deliver == open.
-        self._channels = channels
+        self._sample_rate = config.sample_rate
+        # ``config.channels`` is the OS open count; ``_deliver_channels`` is
+        # what the consumer receives. When deliver < open (mono request on a
+        # stereo-native device, MOR-504) the framer downmixes interleaved
+        # s16le to the deliver count before chunking. Default: deliver == open.
+        self._channels = config.channels
         self._deliver_channels = (
-            channels if deliver_channels is None else deliver_channels
+            config.channels if deliver_channels is None else deliver_channels
         )
         # Capture is callback-driven with blocksize=0 (engine-native period),
         # mirroring a clean sd.rec. blocksize=0 was previously rejected by the
@@ -486,11 +511,8 @@ class _PortAudioRxStream:
         # duplex stream). It carries the sub-frame remainder between audio-thread
         # callbacks; the audio thread is the only writer, so no lock is needed.
         self._framer = _RxFramer(
-            channels=self._channels,
+            config=config,
             deliver_channels=self._deliver_channels,
-            sample_rate=sample_rate,
-            frame_ms=frame_ms,
-            rx_audio_channel=rx_audio_channel,
         )
         self._stream: Any = None
         self._running = False
@@ -975,34 +997,29 @@ class _PortAudioDuplexStream:
         sd: Any,
         np: Any,
         device_index: int,
-        sample_rate: int,
-        channels: int,
+        *,
+        config: AudioDeviceConfig,
         blocksize: int,
-        frame_ms: int,
         deliver_channels: int | None = None,
-        rx_audio_channel: str = "mix",
         tx_channels: int | None = None,
     ) -> None:
         self._sd = sd
         self._device_index = device_index
-        self._sample_rate = sample_rate
-        # RX leg opens at the native ``channels`` count and delivers
+        self._sample_rate = config.sample_rate
+        # RX leg opens at the native ``config.channels`` count and delivers
         # ``deliver_channels`` (downmix when fewer, MOR-504). The TX leg opens at
         # its own ``tx_channels`` count (the mono playback the radio's USB MOD
         # consumes); ``sd.Stream`` accepts a ``(in, out)`` channel pair so the
         # two legs need not match.
-        self._channels = channels
+        self._channels = config.channels
         self._deliver_channels = (
-            channels if deliver_channels is None else deliver_channels
+            config.channels if deliver_channels is None else deliver_channels
         )
-        self._tx_channels = channels if tx_channels is None else tx_channels
+        self._tx_channels = config.channels if tx_channels is None else tx_channels
         self._blocksize = blocksize
         self._framer = _RxFramer(
-            channels=self._channels,
+            config=config,
             deliver_channels=self._deliver_channels,
-            sample_rate=sample_rate,
-            frame_ms=frame_ms,
-            rx_audio_channel=rx_audio_channel,
         )
         # Embed a TX stream purely for its ring + write()/output-callback; its
         # own ``sd`` stream is never opened (we drive its ``_output_callback``
@@ -1012,7 +1029,7 @@ class _PortAudioDuplexStream:
             sd,
             np,
             device_index=device_index,
-            sample_rate=sample_rate,
+            sample_rate=config.sample_rate,
             channels=self._tx_channels,
             blocksize=blocksize,
         )
@@ -1213,12 +1230,14 @@ class PortAudioBackend:
         return _PortAudioRxStream(
             sd,
             device_index=int(device),
-            sample_rate=sample_rate,
-            channels=channels,
+            config=AudioDeviceConfig(
+                sample_rate=sample_rate,
+                channels=channels,
+                frame_ms=frame_ms,
+                rx_audio_channel=rx_audio_channel,
+            ),
             blocksize=0,
-            frame_ms=frame_ms,
             deliver_channels=deliver_channels,
-            rx_audio_channel=rx_audio_channel,
         )
 
     def open_tx(
@@ -1259,12 +1278,14 @@ class PortAudioBackend:
             sd,
             np,
             device_index=int(device),
-            sample_rate=sample_rate,
-            channels=channels,
+            config=AudioDeviceConfig(
+                sample_rate=sample_rate,
+                channels=channels,
+                frame_ms=frame_ms,
+                rx_audio_channel=rx_audio_channel,
+            ),
             blocksize=blocksize,
-            frame_ms=frame_ms,
             deliver_channels=deliver_channels,
-            rx_audio_channel=rx_audio_channel,
             tx_channels=tx_channels,
         )
 
@@ -1617,6 +1638,7 @@ class FakeAudioBackend:
 
 __all__ = [
     "AudioBackend",
+    "AudioDeviceConfig",
     "AudioDeviceId",
     "AudioDeviceInfo",
     "DuplexStream",

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Literal
 
 from .backend import (
     AudioBackend,
+    AudioDeviceConfig,
     AudioDeviceId,
     AudioDeviceInfo,
     DuplexStream,
@@ -514,6 +515,7 @@ class UsbAudioDriver:
 
     def __init__(
         self,
+        config: AudioDeviceConfig | None = None,
         *,
         rx_device: str | None = None,
         tx_device: str | None = None,
@@ -524,19 +526,34 @@ class UsbAudioDriver:
         backend: AudioBackend | None = None,
         rx_audio_channel: str = "mix",
     ) -> None:
-        self._rx_device_override = rx_device
-        self._tx_device_override = tx_device
+        # ONE per-device config carrier (MOR-578). Callers either hand a
+        # ready-made :class:`AudioDeviceConfig` or use the historical keyword
+        # parameters, from which an identical carrier is built (back-compat:
+        # when ``config`` is provided it is authoritative and the per-keyword
+        # equivalents are ignored). ``serial_port`` (topology-resolution hint)
+        # and ``backend`` (stream implementation) are not device config and
+        # stay separate keywords.
+        #
+        # ``rx_audio_channel`` — stereo→mono downmix selection (MOR-508):
+        # "mix" = (L+R)//2 (default, unchanged for every rig), "left"/"right"
+        # = that channel at full level. Only consulted when a mono request
+        # opens a stereo-native device (MOR-504 under-request downmix). The
+        # FTX-1 sets "left" because its USB RX audio is on the LEFT channel
+        # only.
+        self._config = (
+            config
+            if config is not None
+            else AudioDeviceConfig(
+                rx_device=rx_device,
+                tx_device=tx_device,
+                sample_rate=sample_rate,
+                channels=channels,
+                frame_ms=frame_ms,
+                rx_audio_channel=rx_audio_channel,
+            )
+        )
         self._serial_port = serial_port
-        self._sample_rate = sample_rate
-        self._channels = channels
-        self._frame_ms = frame_ms
         self._backend: AudioBackend = backend or PortAudioBackend()
-        # Stereo→mono downmix channel selection (MOR-508): "mix" = (L+R)//2
-        # (default, unchanged for every rig), "left"/"right" = that channel at
-        # full level. Only consulted when a mono request opens a stereo-native
-        # device (MOR-504 under-request downmix). The FTX-1 sets "left" because
-        # its USB RX audio is on the LEFT channel only.
-        self._rx_audio_channel = rx_audio_channel
 
         self._selected_rx: UsbAudioDevice | None = None
         self._selected_tx: UsbAudioDevice | None = None
@@ -597,8 +614,8 @@ class UsbAudioDriver:
         # topology-based resolution to find the correct audio pair.
         if (
             self._serial_port
-            and self._rx_device_override is None
-            and self._tx_device_override is None
+            and self._config.rx_device is None
+            and self._config.tx_device is None
         ):
             resolved = self._try_resolve_from_serial(devices)
             if resolved is not None:
@@ -607,8 +624,8 @@ class UsbAudioDriver:
 
         selected_rx, selected_tx = select_usb_audio_devices(
             devices,
-            rx_device=self._rx_device_override,
-            tx_device=self._tx_device_override,
+            rx_device=self._config.rx_device,
+            tx_device=self._config.tx_device,
         )
         self._selected_rx = selected_rx
         self._selected_tx = selected_tx
@@ -828,9 +845,9 @@ class UsbAudioDriver:
                 raise AudioAlreadyStartedError("RX stream already started.")
 
             selected_rx, _ = self._ensure_selected_devices()
-            sr = self._sample_rate if sample_rate is None else sample_rate
-            ch = self._channels if channels is None else channels
-            fm = self._frame_ms if frame_ms is None else frame_ms
+            sr = self._config.sample_rate if sample_rate is None else sample_rate
+            ch = self._config.channels if channels is None else channels
+            fm = self._config.frame_ms if frame_ms is None else frame_ms
             if (sr * fm) % 1000 != 0:
                 raise AudioDriverLifecycleError(
                     "Invalid RX frame format: sample_rate * frame_ms must be divisible by 1000."
@@ -871,7 +888,7 @@ class UsbAudioDriver:
                 channels=contract.effective_open_channels,
                 frame_ms=fm,
                 deliver_channels=contract.channels,
-                rx_audio_channel=self._rx_audio_channel,
+                rx_audio_channel=self._config.rx_audio_channel,
             )
             await self._rx_stream.start(callback)
             self._store_stream_contract(contract)
@@ -903,9 +920,9 @@ class UsbAudioDriver:
                 raise AudioAlreadyStartedError("TX stream already started.")
 
             _, selected_tx = self._ensure_selected_devices()
-            sr = self._sample_rate if sample_rate is None else sample_rate
-            ch = self._channels if channels is None else channels
-            fm = self._frame_ms if frame_ms is None else frame_ms
+            sr = self._config.sample_rate if sample_rate is None else sample_rate
+            ch = self._config.channels if channels is None else channels
+            fm = self._config.frame_ms if frame_ms is None else frame_ms
             if (sr * fm) % 1000 != 0:
                 raise AudioDriverLifecycleError(
                     "Invalid TX frame format: sample_rate * frame_ms must be divisible by 1000."
@@ -966,9 +983,9 @@ class UsbAudioDriver:
                     "use start_rx/start_tx for separate devices."
                 )
 
-            sr = self._sample_rate if sample_rate is None else sample_rate
-            ch = self._channels if channels is None else channels
-            fm = self._frame_ms if frame_ms is None else frame_ms
+            sr = self._config.sample_rate if sample_rate is None else sample_rate
+            ch = self._config.channels if channels is None else channels
+            fm = self._config.frame_ms if frame_ms is None else frame_ms
             if (sr * fm) % 1000 != 0:
                 raise AudioDriverLifecycleError(
                     "Invalid duplex frame format: sample_rate * frame_ms must "
@@ -1008,7 +1025,7 @@ class UsbAudioDriver:
                 channels=rx_contract.effective_open_channels,
                 frame_ms=fm,
                 deliver_channels=rx_contract.channels,
-                rx_audio_channel=self._rx_audio_channel,
+                rx_audio_channel=self._config.rx_audio_channel,
                 tx_channels=tx_contract.channels,
             )
             await self._duplex_stream.start(callback)
@@ -1052,6 +1069,7 @@ class UsbAudioDriver:
 
 __all__ = [
     "AudioAlreadyStartedError",
+    "AudioDeviceConfig",
     "AudioDeviceSelectionError",
     "AudioDriverLifecycleError",
     "AudioNotStartedError",

--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -112,7 +112,7 @@ class _IcomSerialRadioBase(CoreRadio):
     ) -> None:
         from .icom7610.drivers.serial_civ_link import SerialCivLink
         from .icom7610.drivers.serial_session import SerialSessionDriver
-        from ..audio.usb_driver import UsbAudioDriver
+        from ..audio.usb_driver import AudioDeviceConfig, UsbAudioDriver
 
         if session_driver is not None and civ_link is not None:
             raise ValueError("Provide either civ_link or session_driver, not both.")
@@ -154,12 +154,14 @@ class _IcomSerialRadioBase(CoreRadio):
         serial_link = civ_link or SerialCivLink(device=device, baudrate=baudrate)
         self._serial_session = session_driver or SerialSessionDriver(serial_link)
         self._serial_audio_driver = audio_driver or UsbAudioDriver(
-            rx_device=rx_device,
-            tx_device=tx_device,
+            AudioDeviceConfig(
+                rx_device=rx_device,
+                tx_device=tx_device,
+                sample_rate=audio_sample_rate,
+                channels=self._serial_audio_channels_for_codec(),
+                frame_ms=20,
+            ),
             serial_port=device,
-            sample_rate=audio_sample_rate,
-            channels=self._serial_audio_channels_for_codec(),
-            frame_ms=20,
             backend=None,  # default PortAudioBackend
         )
         self._serial_audio_seq = 0

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -200,20 +200,24 @@ class YaesuCatRadio:
         if audio_driver is None:
             # Lazy import: avoids pulling rigplane.audio.backend (PortAudio,
             # numpy DSP) into top-level package import. PR #1200 / #1194.
+            from ...audio.usb_driver import AudioDeviceConfig as _AudioDeviceConfig
             from ...audio.usb_driver import UsbAudioDriver as _UsbAudioDriver
 
             self._audio_driver: UsbAudioDriver = _UsbAudioDriver(
+                _AudioDeviceConfig(
+                    rx_device=rx_device,
+                    tx_device=tx_device,
+                    sample_rate=audio_sample_rate,
+                    channels=1,
+                    # The FTX-1 presents USB RX audio on the LEFT channel only;
+                    # the profile's [audio].rx_audio_channel selects which
+                    # channel the stereo→mono downmix keeps at full level
+                    # (MOR-508). Defaults to "mix" (legacy (L+R)//2) for any
+                    # profile that omits it.
+                    rx_audio_channel=self._config.rx_audio_channel,
+                ),
                 serial_port=device,
-                rx_device=rx_device,
-                tx_device=tx_device,
-                sample_rate=audio_sample_rate,
-                channels=1,
                 backend=None,  # default PortAudioBackend
-                # The FTX-1 presents USB RX audio on the LEFT channel only; the
-                # profile's [audio].rx_audio_channel selects which channel the
-                # stereo→mono downmix keeps at full level (MOR-508). Defaults to
-                # "mix" (legacy (L+R)//2) for any profile that omits it.
-                rx_audio_channel=self._config.rx_audio_channel,
             )
         else:
             self._audio_driver = audio_driver

--- a/tests/test_audio_device_config_mor578.py
+++ b/tests/test_audio_device_config_mor578.py
@@ -1,0 +1,366 @@
+"""MOR-578 — ``AudioDeviceConfig`` carrier replaces per-keyword audio plumbing.
+
+Falsification pins for a behavior byte-identical refactor: per-device audio
+config (``rx_device``/``tx_device``/``sample_rate``/``channels``/``frame_ms``/
+``rx_audio_channel``) used to travel as six separate keyword parameters
+loader → backend ctor → ``UsbAudioDriver`` → ``AudioBackend.open_rx`` →
+``_RxFramer`` → downmix. The carrier bundles them into ONE frozen dataclass.
+
+The pins below were captured by RUNNING the pre-refactor per-keyword path
+(origin/main @ 3f08f659) and hardcoding its effective arguments, so they fail
+on any drift — not just on config/kwargs divergence:
+
+- the config-built driver must produce the SAME effective ``open_rx`` /
+  ``open_tx`` arguments as the per-keyword driver for IC-7610-shaped (mix,
+  2 ch), X6200-shaped (mix, channel clamp MOR-238) and FTX-1-shaped (left,
+  under-request downmix MOR-504/508) scenarios;
+- the stereo→mono downmix (``mix``/``left``/``right``) through ``_RxFramer``
+  is byte-identical;
+- the rig profiles keep pinning the loader leg (``rigs/*.toml [audio]``);
+- the production backend ctors thread ONE carrier into the driver.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from rigplane.audio.backend import (
+    AudioDeviceConfig,
+    AudioDeviceId,
+    AudioDeviceInfo,
+    FakeAudioBackend,
+    FakeRxStream,
+    FakeTxStream,
+    _RxFramer,
+)
+from rigplane.audio.usb_driver import UsbAudioDriver
+
+RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingBackend(FakeAudioBackend):
+    """FakeAudioBackend that records effective open_rx/open_tx arguments."""
+
+    def __init__(self, devices: list[AudioDeviceInfo]) -> None:
+        super().__init__(devices)
+        self.rx_calls: list[dict[str, object]] = []
+        self.tx_calls: list[dict[str, object]] = []
+
+    def open_rx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+        deliver_channels: int | None = None,
+        rx_audio_channel: str = "mix",
+    ) -> FakeRxStream:
+        self.rx_calls.append(
+            {
+                "device": int(device),
+                "sample_rate": sample_rate,
+                "channels": channels,
+                "frame_ms": frame_ms,
+                "deliver_channels": deliver_channels,
+                "rx_audio_channel": rx_audio_channel,
+            }
+        )
+        return super().open_rx(
+            device,
+            sample_rate=sample_rate,
+            channels=channels,
+            frame_ms=frame_ms,
+            deliver_channels=deliver_channels,
+            rx_audio_channel=rx_audio_channel,
+        )
+
+    def open_tx(
+        self,
+        device: AudioDeviceId,
+        *,
+        sample_rate: int = 48_000,
+        channels: int = 1,
+        frame_ms: int = 20,
+    ) -> FakeTxStream:
+        self.tx_calls.append(
+            {
+                "device": int(device),
+                "sample_rate": sample_rate,
+                "channels": channels,
+                "frame_ms": frame_ms,
+            }
+        )
+        return super().open_tx(
+            device,
+            sample_rate=sample_rate,
+            channels=channels,
+            frame_ms=frame_ms,
+        )
+
+
+def _stereo_codec(index: int = 7) -> AudioDeviceInfo:
+    """Stereo-native duplex USB CODEC (IC-7610 / FTX-1 shape)."""
+    return AudioDeviceInfo(
+        id=AudioDeviceId(index),
+        name="USB Audio CODEC",
+        input_channels=2,
+        output_channels=2,
+    )
+
+
+def _mono_capture_codec(index: int = 4) -> AudioDeviceInfo:
+    """Mono-capture duplex USB CODEC (X6200 channel-clamp shape, MOR-238)."""
+    return AudioDeviceInfo(
+        id=AudioDeviceId(index),
+        name="USB Audio CODEC",
+        input_channels=1,
+        output_channels=2,
+    )
+
+
+async def _effective_open_args(
+    driver: UsbAudioDriver,
+    backend: _RecordingBackend,
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    await driver.start_rx(lambda _frame: None)
+    await driver.start_tx()
+    return backend.rx_calls, backend.tx_calls
+
+
+# ---------------------------------------------------------------------------
+# Carrier shape: fields + defaults mirror the per-keyword plumbing 1:1
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults_mirror_per_keyword_defaults() -> None:
+    """Default carrier == the historical per-keyword defaults, frozen."""
+    config = AudioDeviceConfig()
+    assert config.rx_device is None
+    assert config.tx_device is None
+    assert config.sample_rate == 48_000
+    assert config.channels == 1
+    assert config.frame_ms == 20
+    assert config.rx_audio_channel == "mix"
+    with pytest.raises(AttributeError):
+        config.sample_rate = 24_000  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Loader leg: rigs/*.toml [audio] still pins the per-rig channel selector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rig_file", "expected_channel"),
+    [
+        ("ic7610.toml", "mix"),
+        ("x6200.toml", "mix"),
+        ("ftx1.toml", "left"),
+    ],
+)
+def test_rig_profiles_pin_rx_audio_channel(
+    rig_file: str,
+    expected_channel: str,
+) -> None:
+    from rigplane.profiles.rig_loader import load_rig
+
+    rig = load_rig(RIGS_DIR / rig_file)
+    assert rig.rx_audio_channel == expected_channel
+
+
+# ---------------------------------------------------------------------------
+# Same-args pin: config path == per-keyword path == pre-refactor behavior
+# ---------------------------------------------------------------------------
+
+# Effective arguments captured by RUNNING the per-keyword path BEFORE the
+# refactor (origin/main @ 3f08f659). Any drift fails the pin.
+_SCENARIOS: list[
+    tuple[
+        str,
+        Callable[[], AudioDeviceInfo],
+        AudioDeviceConfig,
+        dict[str, object],
+        dict[str, object],
+    ]
+] = [
+    (
+        # IC-7610 serial: default 2-ch LPCM codec, default "mix".
+        "ic7610-mix",
+        _stereo_codec,
+        AudioDeviceConfig(
+            rx_device="USB Audio CODEC",
+            tx_device="USB Audio CODEC",
+            sample_rate=48_000,
+            channels=2,
+            frame_ms=20,
+        ),
+        {
+            "device": 7,
+            "sample_rate": 48_000,
+            "channels": 2,
+            "frame_ms": 20,
+            "deliver_channels": 2,
+            "rx_audio_channel": "mix",
+        },
+        {"device": 7, "sample_rate": 48_000, "channels": 2, "frame_ms": 20},
+    ),
+    (
+        # X6200: 2-ch request on a mono capture endpoint clamps (MOR-238).
+        "x6200-mix-clamp",
+        _mono_capture_codec,
+        AudioDeviceConfig(
+            rx_device="USB Audio CODEC",
+            tx_device="USB Audio CODEC",
+            sample_rate=48_000,
+            channels=2,
+            frame_ms=20,
+        ),
+        {
+            "device": 4,
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "deliver_channels": 1,
+            "rx_audio_channel": "mix",
+        },
+        {"device": 4, "sample_rate": 48_000, "channels": 2, "frame_ms": 20},
+    ),
+    (
+        # FTX-1: mono request on a stereo-native device opens native and
+        # downmixes (MOR-504); profile selects the LEFT channel (MOR-508).
+        "ftx1-left-downmix",
+        _stereo_codec,
+        AudioDeviceConfig(
+            rx_device="USB Audio CODEC",
+            tx_device="USB Audio CODEC",
+            sample_rate=48_000,
+            channels=1,
+            frame_ms=20,
+            rx_audio_channel="left",
+        ),
+        {
+            "device": 7,
+            "sample_rate": 48_000,
+            "channels": 2,
+            "frame_ms": 20,
+            "deliver_channels": 1,
+            "rx_audio_channel": "left",
+        },
+        {"device": 7, "sample_rate": 48_000, "channels": 1, "frame_ms": 20},
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config", "make_device", "expected_rx", "expected_tx"),
+    [(cfg, dev, rx, tx) for _, dev, cfg, rx, tx in _SCENARIOS],
+    ids=[name for name, _, _, _, _ in _SCENARIOS],
+)
+async def test_config_path_produces_identical_effective_open_args(
+    config: AudioDeviceConfig,
+    make_device: Callable[[], AudioDeviceInfo],
+    expected_rx: dict[str, object],
+    expected_tx: dict[str, object],
+) -> None:
+    """Config-built and per-keyword drivers reach open_rx/open_tx identically."""
+    kwargs_backend = _RecordingBackend([make_device()])
+    kwargs_driver = UsbAudioDriver(
+        rx_device=config.rx_device,
+        tx_device=config.tx_device,
+        sample_rate=config.sample_rate,
+        channels=config.channels,
+        frame_ms=config.frame_ms,
+        rx_audio_channel=config.rx_audio_channel,
+        backend=kwargs_backend,
+    )
+    kwargs_rx, kwargs_tx = await _effective_open_args(kwargs_driver, kwargs_backend)
+
+    config_backend = _RecordingBackend([make_device()])
+    config_driver = UsbAudioDriver(config, backend=config_backend)
+    config_rx, config_tx = await _effective_open_args(config_driver, config_backend)
+
+    # The two construction paths are indistinguishable at the backend seam...
+    assert config_rx == kwargs_rx
+    assert config_tx == kwargs_tx
+    # ...and both match the pre-refactor per-keyword behavior exactly.
+    assert config_rx == [expected_rx]
+    assert config_tx == [expected_tx]
+
+
+# ---------------------------------------------------------------------------
+# Downmix pin: _RxFramer reads fields off the carrier, bytes unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("channel", "expected_sample"),
+    [("mix", 1500), ("left", 1000), ("right", 2000)],
+)
+def test_framer_downmix_off_config_is_byte_identical(
+    channel: str,
+    expected_sample: int,
+) -> None:
+    """One 20 ms stereo block (L=1000, R=2000) → the pre-refactor mono frame.
+
+    Pre-refactor values: mix → (1000+2000)//2 == 1500, left → 1000,
+    right → 2000; one 1920-byte mono fixed frame at 48 kHz / 20 ms.
+    """
+    framer = _RxFramer(
+        config=AudioDeviceConfig(
+            sample_rate=48_000,
+            channels=2,
+            frame_ms=20,
+            rx_audio_channel=channel,
+        ),
+        deliver_channels=1,
+    )
+    assert framer.frame_bytes == 1920
+
+    frames: list[bytes] = []
+    framer.feed(struct.pack("<hh", 1000, 2000) * 960, frames.append)
+    assert frames == [struct.pack("<h", expected_sample) * 960]
+
+
+# ---------------------------------------------------------------------------
+# Backend ctor leg: production radios thread ONE carrier into the driver
+# ---------------------------------------------------------------------------
+
+
+def test_icom_serial_ctor_builds_single_config_carrier() -> None:
+    """IC-7610 serial backend hands the driver ONE AudioDeviceConfig.
+
+    Pre-refactor keywords: sample_rate=48000 (default), channels=2 (default
+    2-ch LPCM codec), frame_ms=20, no device overrides, default "mix".
+    """
+    from rigplane.backends.icom7610 import Icom7610SerialRadio
+
+    radio = Icom7610SerialRadio(device="/dev/ttyUSB-test")
+    assert radio._serial_audio_driver._config == AudioDeviceConfig(
+        sample_rate=48_000,
+        channels=2,
+        frame_ms=20,
+    )
+
+
+def test_yaesu_ctor_threads_profile_channel_into_config_carrier() -> None:
+    """FTX-1 backend threads [audio].rx_audio_channel="left" via the carrier."""
+    from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+
+    radio = YaesuCatRadio(device="/dev/cu.fake-ftx1", profile="ftx1")
+    assert radio._audio_driver._config == AudioDeviceConfig(
+        sample_rate=48_000,
+        channels=1,
+        frame_ms=20,
+        rx_audio_channel="left",
+    )

--- a/tests/test_ftx1_audio.py
+++ b/tests/test_ftx1_audio.py
@@ -60,7 +60,12 @@ def test_audio_driver_default_construction():
     The driver is imported lazily inside ``__init__`` (so the top-level
     ``rigplane`` import doesn't pull ``audio.backend``), so we patch the
     canonical module path rather than a re-export.
+
+    Since MOR-578 the per-device knobs travel as ONE ``AudioDeviceConfig``
+    carrier; the pinned effective values are unchanged.
     """
+    from rigplane.audio.usb_driver import AudioDeviceConfig
+
     with (
         patch("rigplane.backends.yaesu_cat.radio.YaesuCatTransport"),
         patch("rigplane.audio.usb_driver.UsbAudioDriver") as MockDriver,
@@ -73,15 +78,18 @@ def test_audio_driver_default_construction():
             audio_sample_rate=48000,
         )
         MockDriver.assert_called_once_with(
+            AudioDeviceConfig(
+                rx_device="hw:1,0",
+                tx_device="hw:1,1",
+                sample_rate=48000,
+                channels=1,
+                frame_ms=20,
+                # FTX-1 profile selects the LEFT channel for the stereo→mono RX
+                # downmix (MOR-508); USB RX audio is on L only.
+                rx_audio_channel="left",
+            ),
             serial_port="/dev/ttyUSB0",
-            rx_device="hw:1,0",
-            tx_device="hw:1,1",
-            sample_rate=48000,
-            channels=1,
             backend=None,
-            # FTX-1 profile selects the LEFT channel for the stereo→mono RX
-            # downmix (MOR-508); USB RX audio is on L only.
-            rx_audio_channel="left",
         )
 
 


### PR DESCRIPTION
## Summary

Implements Linear **MOR-578** (step 16 of epic MOR-562, ADR P5): collapse the 6-layer per-keyword audio config plumbing into ONE frozen `AudioDeviceConfig` carrier. **Behavior byte-identical** — no new knobs, no behavior change, no session/bridge coupling (`audio/session.py` and `audio/bridge.py` untouched).

## The carrier

`AudioDeviceConfig` (frozen, slots) — fields and defaults mirror the historical per-keyword plumbing 1:1:

| field | default |
|---|---|
| `rx_device` | `None` |
| `tx_device` | `None` |
| `sample_rate` | `48_000` |
| `channels` | `1` |
| `frame_ms` | `20` |
| `rx_audio_channel` | `"mix"` |

`serial_port` (topology-resolution hint) and `backend` (stream implementation) are not device config and stay separate keywords.

**Home:** top of `src/rigplane/audio/backend.py` (descriptors section) — the lowest module of the audio consumer cluster, importable by `usb_driver.py` and the backends layer without cycles and without a new module (file count stays down; import matrix clean). Re-exported via `usb_driver.__all__` and additively via `rigplane.audio` lazy map (`tests/contracts/test_lazy_imports.py` auto-covers the superset; all conformance suites green).

## Layers threaded

- **loader→driver leg** (flag): `profiles/rig_loader.py` is intentionally **untouched** — `rigplane.profiles` and `rigplane.audio` are independent siblings (`independence-mid` import-linter contract), so the loader layer cannot hold the audio type. The carrier is built where RigConfig profile values + CLI overrides already merge: `backends/_icom_serial_base.py` and `backends/yaesu_cat/radio.py` now construct ONE `AudioDeviceConfig` and hand it to the driver (this replaces the expected rig_loader edit in the issue's file list).
- **driver**: `UsbAudioDriver` stores a single `self._config` instead of six attributes; all internal reads go through it.
- **backend→framer**: `PortAudioBackend.open_rx`/`open_duplex` build a per-stream carrier and hand it to `_PortAudioRxStream` / `_PortAudioDuplexStream` / `_RxFramer`, which read fields off the config instead of five separate kwargs.

## Changed signatures + back-compat

- `UsbAudioDriver.__init__` — now `(config: AudioDeviceConfig | None = None, *, <all old kwargs unchanged>)`. Accept the config OR the old kwargs: when `config` is omitted an identical carrier is built from the keywords. All in-tree callers and every existing test constructing `UsbAudioDriver(...)` with old kwargs keep working unchanged (the old signature was keyword-only, so the new leading positional cannot collide).
- `AudioBackend` protocol / `PortAudioBackend` / `FakeAudioBackend` `open_rx`/`open_tx`/`open_duplex` — **keyword signatures unchanged** (Pro-stable surface; rigplane-pro's bridge calls `open_rx`/`open_tx` with these keywords and its `PacatBackend` implements them — verified by grep). The driver keeps passing the same resolved per-contract keywords; the carrier conversion happens inside `PortAudioBackend`.
- `_RxFramer` / `_PortAudioRxStream` / `_PortAudioDuplexStream` — private internals, now take `config=` + `deliver_channels` (no external consumers; verified by grep over core + rigplane-pro).

## Byte-identical falsification evidence

`tests/test_audio_device_config_mor578.py` (12 tests) — written FIRST, confirmed meaningfully RED (`ImportError: cannot import name 'AudioDeviceConfig'`) before wiring, GREEN after:

- **Same-args pin**: the config-built driver produces the SAME effective `open_rx`/`open_tx` arguments (device, sample_rate, channels, frame_ms, deliver_channels, rx_audio_channel) as the per-keyword driver, AND both match values hardcoded from **running the pre-refactor path on origin/main @ 3f08f659**, for IC-7610-shaped (mix, 2ch), X6200-shaped (mix + MOR-238 channel clamp) and FTX-1-shaped (left + MOR-504/508 under-request downmix) scenarios.
- **Downmix pin**: `_RxFramer` fed off the carrier reproduces the pre-refactor mono bytes exactly (mix→1500, left→1000, right→2000 for an L=1000/R=2000 block; 1920-byte fixed frame).
- **Loader leg pin**: `rigs/ic7610.toml`→mix, `rigs/x6200.toml`→mix, `rigs/ftx1.toml`→left.
- **Ctor leg pin**: both production backends thread ONE carrier with the exact pre-refactor values.

Existing-test churn: exactly ONE test edited — `tests/test_ftx1_audio.py::test_audio_driver_default_construction`, a mock-based pin of the literal ctor call shape being refactored (strictly necessary; the pinned effective values are unchanged). Zero other test edits; all `UsbAudioDriver(...)`-old-kwarg tests pass via the back-compat path.

## Files + scope

5 src files (+1 test): `audio/backend.py` (dataclass home + internals), `audio/usb_driver.py`, `backends/_icom_serial_base.py`, `backends/yaesu_cat/radio.py` (the loader→driver bridge, substituting the layer-blocked `rig_loader` edit), `audio/__init__.py` (sanctioned additive export). Net +56 src LOC excluding the new test.

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7479 passed**, 0 failed (9 skipped, 3 deselected, 11 xfailed, 1 xpassed)
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → 557 files already formatted
- `uv run mypy src/` → baseline exactly **21 errors in 8 files** (no new errors)
- `uv run lint-imports` → **4 kept, 0 broken**

🤖 Generated with [Claude Code](https://claude.com/claude-code)