### PR TITLE
refactor(MOR-577): route AudioBridge through AudioSession, delete the rx_first branch

### DIFF
--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -53,6 +53,7 @@ from .backend import (
     RxStream,
     TxStream,
 )
+from .session import AudioSession, AudioSessionState, RxSubscription, TxLease
 
 if TYPE_CHECKING:
     from rigplane.radio_protocol import AudioCapable
@@ -272,10 +273,6 @@ class AudioBridge:
         self._frame_ms = frame_ms
         self._tx_enabled = tx_enabled
         self._tx_started = False
-        # True when TX was armed via the neutral AudioTransport surface
-        # (``start_tx``/``push_tx``/``stop_tx``, MOR-545); False on the
-        # legacy ``*_audio_tx_pcm`` path.
-        self._use_neutral_tx = False
         self._tx_executor = tx_executor
         self._backend: AudioBackend = backend or PortAudioBackend()
 
@@ -308,7 +305,15 @@ class AudioBridge:
         self._tx_task: asyncio.Task[None] | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._decoder: Any = None
-        self._subscription: Any = None
+        # Radio-side demand handles (MOR-577): the bridge declares RX demand
+        # + a TX lease on the AudioSession (which wraps the radio's shared
+        # AudioBus); the SESSION owns the bus-subscribe vs radio-TX-arm
+        # ordering, read from the transport's ``audio_setup_order``
+        # descriptor (MOR-575). The legacy ``*_audio_tx_pcm`` TX path (no
+        # neutral surface) stays bridge-owned: ``_tx_lease`` is None there.
+        self._session: AudioSession | None = None
+        self._rx_sub: RxSubscription | None = None
+        self._tx_lease: TxLease | None = None
         self._samples_per_frame = sample_rate * frame_ms // 1000
         self._tx_queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=64)
 
@@ -432,7 +437,7 @@ class AudioBridge:
     # ------------------------------------------------------------------
 
     async def _setup_streams(self) -> None:
-        """Find device, open streams, subscribe to bus, create tasks.
+        """Find device, declare session demands, open streams, create tasks.
 
         Raises on failure (RuntimeError, ValueError, OSError, etc.).
         """
@@ -501,31 +506,27 @@ class AudioBridge:
         else:
             self._decoder = None
 
-        # --- Bus-subscribe vs radio-TX-arm order is backend-dependent
-        # (MOR-559); the first bus subscriber triggers radio RX start:
+        # --- Radio-side RX/TX demand is DECLARED on the AudioSession
+        # (MOR-577, ADR §3.3); the session owns the bus-subscribe vs
+        # radio-TX-arm order, read from the transport's ``audio_setup_order``
+        # descriptor (MOR-575):
         #
-        # - "full"/missing (LAN, MOR-556): subscribe BEFORE arming TX. The
-        #   LAN stream state machine supports RX-then-TX only — arming TX
-        #   first puts it in TRANSMITTING and the later RX start raises,
-        #   leaving RX dead and the packet queue undrained (#1735 regression).
-        # - "exclusive" (same-device macOS USB CODEC, MOR-531/534): arm TX
-        #   FIRST and subscribe only after the device streams are up. Adding
-        #   the TX leg to an already-running RX capture on one C-Media device
-        #   triggers CoreAudio AUHAL paramErr -50 and silently kills the
-        #   capture; the reverse order (RX onto a running TX leg) is the
-        #   MOR-531 live-validated path.
-        rx_first = getattr(self._radio, "audio_duplex_mode", "full") != "exclusive"
-        if rx_first:
-            await self._subscribe_bus()
+        # - "rx_first" (LAN, MOR-556): RX up, then arm TX — arming TX first
+        #   puts the LAN stream in TRANSMITTING and the later RX start
+        #   raises, leaving RX dead and the queue undrained (#1735).
+        # - "atomic"/"tx_first" (same-device macOS USB CODEC, MOR-531/559):
+        #   the TX leg comes up before RX joins the device — TX onto an
+        #   already-running RX capture triggers CoreAudio AUHAL paramErr
+        #   -50 and silently kills the capture.
+        #
+        # The TX lease is acquired BEFORE the RX subscription: at IDLE the
+        # session defers arming to the RX-demand edge and then sequences
+        # both legs in the declared order under its single lock.
+        session = self._session
+        if session is None:
+            session = AudioSession(self._radio)  # wraps radio.audio_bus
+            self._session = session
 
-        # --- Arm the radio TX path BEFORE choosing the device-stream topology.
-        # The radio may reject TX (serial backend with no USB-audio TX path):
-        # degrade to RX-only and use a plain output stream, never a duplex one
-        # (MOR-242). Only when TX is armed AND the capture leg targets the SAME
-        # device as the playback leg do we open ONE full-duplex stream (MOR-531):
-        # separate playback + capture on one C-Media CODEC fails with AUHAL -50.
-        tx_armed = False
-        self._use_neutral_tx = False
         if self._tx_enabled:
             start_tx = getattr(self._radio, "start_tx", None)
             tx_codec = getattr(self._radio, "audio_tx_codec", None)
@@ -543,31 +544,53 @@ class AudioBridge:
                     self._label,
                     getattr(tx_codec, "name", tx_codec),
                 )
+            elif start_tx is not None:
+                self._tx_lease = await session.acquire_tx("audio-bridge")
+
+        self._rx_sub = await session.subscribe_rx("audio-bridge")
+
+        # The radio may reject TX (serial backend with no USB-audio TX
+        # path): degrade to RX-only and use a plain output stream, never a
+        # duplex one (MOR-242). Only when TX is armed AND the capture leg
+        # targets the SAME device as the playback leg do we open ONE
+        # full-duplex stream (MOR-531): separate playback + capture on one
+        # C-Media CODEC fails with AUHAL -50.
+        tx_armed = False
+        if self._tx_lease is not None:
+            if session.state is AudioSessionState.RX_TX:
+                tx_armed = True
+                self._tx_started = True
             else:
-                try:
-                    if start_tx is not None:
-                        # Neutral AudioTransport surface (MOR-545): the
-                        # backend owns format resolution from its
-                        # negotiated contract — no format arguments.
-                        await start_tx()
-                    else:
-                        await self._radio.start_audio_tx_pcm(
-                            sample_rate=self._sample_rate,
-                            channels=self._channels,
-                            frame_ms=self._frame_ms,
-                        )
-                except (RuntimeError, NotImplementedError) as exc:
-                    self._tx_enabled = False
-                    self._tx_started = False
-                    logger.warning(
-                        "%s: radio rejected TX start (%s); running RX-only",
-                        self._label,
-                        exc,
-                    )
-                else:
-                    tx_armed = True
-                    self._tx_started = True
-                    self._use_neutral_tx = start_tx is not None
+                # The session's deferred TX arm failed (radio rejected TX):
+                # drop the lease and degrade to RX-only — RX stays live.
+                await self._tx_lease.release()
+                self._tx_lease = None
+                self._tx_enabled = False
+                self._tx_started = False
+                logger.warning(
+                    "%s: radio rejected TX start; running RX-only",
+                    self._label,
+                )
+        elif self._tx_enabled:
+            # Legacy ``*_audio_tx_pcm`` TX path (no neutral AudioTransport
+            # surface) — armed directly, outside the session.
+            try:
+                await self._radio.start_audio_tx_pcm(
+                    sample_rate=self._sample_rate,
+                    channels=self._channels,
+                    frame_ms=self._frame_ms,
+                )
+            except (RuntimeError, NotImplementedError) as exc:
+                self._tx_enabled = False
+                self._tx_started = False
+                logger.warning(
+                    "%s: radio rejected TX start (%s); running RX-only",
+                    self._label,
+                    exc,
+                )
+            else:
+                tx_armed = True
+                self._tx_started = True
 
         # Same-device duplex only for a REAL CODEC: a virtual loopback
         # (BlackHole/VB-Cable/PipeWire) has no AUHAL -50 limitation and stays on
@@ -601,11 +624,6 @@ class AudioBridge:
             )
             await self._rx_stream.start()
 
-        # Exclusive same-device duplex: the radio TX leg is armed and the
-        # device streams are open — radio RX may start now (MOR-559).
-        if not rx_first:
-            await self._subscribe_bus()
-
         # --- TX path: device input → radio (capture) ---
         if tx_armed:
             self._tx_queue = asyncio.Queue(maxsize=64)
@@ -627,27 +645,13 @@ class AudioBridge:
         # Start the RX playback loop last so the streams above are live.
         self._rx_task = asyncio.create_task(self._rx_loop())
 
-    async def _subscribe_bus(self) -> None:
-        """Subscribe to the radio's AudioBus; first subscriber starts radio RX.
-
-        The bus swallows radio RX-start failures (logs "audio-bus: failed to
-        start RX" and keeps ``rx_active`` False) — surface them here instead
-        of letting the bridge report "started" with dead capture (MOR-559).
-        """
-        bus = self._radio.audio_bus
-        self._subscription = bus.subscribe(name="audio-bridge")
-        await self._subscription.start()
-        if getattr(bus, "rx_active", True) is False:
-            raise RuntimeError(
-                "radio RX failed to start for the bridge subscription "
-                "(AudioBus.rx_active is False after subscribe); see "
-                "'audio-bus: failed to start RX' in the log"
-            )
-
     async def _teardown_streams(self) -> None:
-        """Cancel tasks and stop streams.
+        """Cancel tasks, release session demands, stop device streams.
 
-        Does NOT call ``radio.stop_audio_tx_pcm()`` — that belongs in
+        Radio-side teardown goes through the AudioSession: releasing the RX
+        demand makes the session stop the radio TX leg BEFORE dropping RX
+        (MOR-574) — RX is never stopped from a TRANSMITTING transport. The
+        legacy ``*_audio_tx_pcm`` TX stop (no session lease) belongs in
         :meth:`stop` only.
         """
         if self._rx_task and not self._rx_task.done():
@@ -658,10 +662,8 @@ class AudioBridge:
                 pass
         self._rx_task = None
 
-        if self._subscription is not None:
-            await self._subscription.aclose()
-            self._subscription = None
-
+        # Cancel the TX loop BEFORE releasing the demands so it cannot push
+        # a captured frame into a just-stopped radio TX path.
         if self._tx_task and not self._tx_task.done():
             self._tx_task.cancel()
             try:
@@ -669,6 +671,16 @@ class AudioBridge:
             except asyncio.CancelledError:
                 pass
         self._tx_task = None
+
+        # Release the RX demand with the TX lease still held: the session
+        # sequences stop_tx → RX drop (MOR-574); the lease release after
+        # that is a no-op state-wise.
+        if self._rx_sub is not None:
+            await self._rx_sub.release()
+            self._rx_sub = None
+        if self._tx_lease is not None:
+            await self._tx_lease.release()
+            self._tx_lease = None
 
         if self._tx_stream is not None:
             try:
@@ -787,8 +799,8 @@ class AudioBridge:
         try:
             await self._setup_streams()
         except Exception:
-            # _setup_streams may fail AFTER the bus subscription is registered
-            # (the rx-first path subscribes early, MOR-556). Tear down before
+            # _setup_streams may fail AFTER the session demands are declared
+            # (device streams open after subscribe_rx). Tear down before
             # re-raising — stop() early-returns on IDLE, so a leaked
             # subscriber would keep radio RX running with no consumer
             # draining the queue (MOR-560).
@@ -835,14 +847,8 @@ class AudioBridge:
                 pass
         self._reconnect_task = None
 
-        # Stop the radio TX leg BEFORE _teardown_streams() drops the RX
-        # demand (closes the bus subscription) — teardown is the inverse of
-        # the MOR-556 setup order. On LAN, closing the subscription while
-        # the stream is TRANSMITTING makes ``stop_rx`` early-return; the
-        # later ``stop_tx`` would then resurrect RECEIVING with a live RX
-        # task and zero bus subscribers — a leaked RX stream (MOR-574).
         # Cancel the bridge TX loop first so it cannot push a captured
-        # frame into the just-stopped radio TX path.
+        # frame into a just-stopped radio TX path.
         if self._tx_task and not self._tx_task.done():
             self._tx_task.cancel()
             try:
@@ -853,15 +859,18 @@ class AudioBridge:
 
         if self._tx_started:
             self._tx_started = False
-            try:
-                stop_tx = getattr(self._radio, "stop_tx", None)
-                if self._use_neutral_tx and stop_tx is not None:
-                    # Neutral AudioTransport surface (MOR-545).
-                    await stop_tx()
-                else:
+            if self._tx_lease is None:
+                # Legacy ``*_audio_tx_pcm`` TX path — armed outside the
+                # session, stopped here BEFORE teardown drops the RX
+                # demand (MOR-574). Session-managed TX needs no call:
+                # _teardown_streams releases the demands and the session
+                # stops radio TX before dropping RX — on LAN the reverse
+                # order leaks a running RX stream (``stop_rx``
+                # early-returns while TRANSMITTING).
+                try:
                     await self._radio.stop_audio_tx_pcm()
-            except Exception:
-                logger.debug("%s: stop TX error", self._label, exc_info=True)
+                except Exception:
+                    logger.debug("%s: stop TX error", self._label, exc_info=True)
 
         await self._teardown_streams()
 
@@ -922,9 +931,12 @@ class AudioBridge:
         return self._rx_stream
 
     async def _rx_loop(self) -> None:
-        """Read packets from AudioBus subscription, decode, write to device."""
+        """Read packets from the session RX subscription, decode, write to device."""
+        sub = self._rx_sub
+        if sub is None:  # pragma: no cover — task is created after subscribe_rx
+            return
         try:
-            async for packet in self._subscription:
+            async for packet in sub:
                 if not self._running:
                     break
                 if packet is None:
@@ -1029,12 +1041,12 @@ class AudioBridge:
                     )
 
                 try:
-                    push_tx = getattr(self._radio, "push_tx", None)
-                    if self._use_neutral_tx and push_tx is not None:
-                        # Neutral AudioTransport surface (MOR-545); only
-                        # armed when the negotiated TX codec is raw PCM —
-                        # see the guard in _setup_streams.
-                        await push_tx(pcm_bytes)
+                    lease = self._tx_lease
+                    if lease is not None:
+                        # Session-managed TX lease (MOR-577); only acquired
+                        # when the negotiated TX codec is raw PCM — see the
+                        # guard in _setup_streams.
+                        await lease.push(pcm_bytes)
                     else:
                         await self._radio.push_audio_tx_pcm(pcm_bytes)
                 except (RuntimeError, NotImplementedError) as exc:

--- a/tests/_order_sensitive_radios.py
+++ b/tests/_order_sensitive_radios.py
@@ -105,6 +105,11 @@ class ExclusiveUsbRadio:
     """
 
     audio_duplex_mode = "exclusive"
+    # MOR-575 descriptor, mirroring the shipping backend derivation
+    # ("exclusive" → "atomic"). Declared here since MOR-577 — the bridge
+    # routes radio-side demand through the AudioSession, which reads the
+    # arming order from this descriptor instead of audio_duplex_mode.
+    audio_setup_order = "atomic"
 
     def __init__(self) -> None:
         self.rx_running = False

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -392,6 +392,35 @@ async def test_bridge_rx_only_on_exclusive_duplex_still_starts_rx():
 
 
 # ---------------------------------------------------------------------------
+# Radio-side RX/TX demand is declared on the AudioSession (MOR-577)
+# ---------------------------------------------------------------------------
+
+
+async def test_bridge_routes_radio_side_through_audio_session():
+    """MOR-577: the bridge declares RX demand + a TX lease on an AudioSession
+    wrapping the radio's SHARED bus; the session owns the arming order."""
+    from rigplane.audio.session import AudioSession, AudioSessionState
+
+    radio = LanLikeRadio()
+    backend = _bridge_backend()
+    bridge = AudioBridge(radio, device_name="BlackHole", backend=backend)
+    await bridge.start()
+    try:
+        assert isinstance(bridge._session, AudioSession)
+        # Same bus the web/scope consumers use — never a second bus.
+        assert bridge._session.bus is radio.audio_bus
+        assert bridge._session.state is AudioSessionState.RX_TX
+        assert bridge._session.rx_demand == 1
+        assert bridge._session.tx_demand == 1
+        assert bridge._tx_lease is not None and not bridge._tx_lease.released
+    finally:
+        await bridge.stop()
+    assert bridge._session.state is AudioSessionState.IDLE
+    assert bridge._session.rx_demand == 0
+    assert bridge._session.tx_demand == 0
+
+
+# ---------------------------------------------------------------------------
 # Failed initial start must release the bus subscription (MOR-560)
 # ---------------------------------------------------------------------------
 
@@ -400,8 +429,8 @@ class _RxStartFailRadio:
     """Radio stub whose RX start fails.
 
     The AudioBus swallows the ``start_rx`` error (logs "audio-bus: failed to
-    start RX") and leaves ``rx_active`` False — ``_subscribe_bus`` then raises
-    AFTER the subscription is already registered with the bus.
+    start RX") and leaves ``rx_active`` False — the session's RX arm then
+    raises, with the just-registered bus subscription unwound.
     """
 
     def __init__(self) -> None:
@@ -426,8 +455,8 @@ class _OpenFailBackend(FakeAudioBackend):
 
 
 async def test_bridge_failed_rx_start_releases_bus_subscription():
-    """Regression MOR-560: the ``_subscribe_bus`` rx_active=False raise must
-    not leak the just-registered bus subscription.
+    """Regression MOR-560: the session's rx_active=False raise must not
+    leak the just-registered bus subscription.
 
     ``start()`` reverts to IDLE on failure and ``stop()`` early-returns on
     IDLE, so without teardown in the failure path the orphaned subscriber
@@ -445,8 +474,8 @@ async def test_bridge_failed_rx_start_releases_bus_subscription():
 
 
 async def test_bridge_failed_stream_open_releases_bus_subscription():
-    """Regression MOR-560: a device-stream open failure AFTER the rx-first
-    bus subscribe must tear the subscription down — otherwise the leaked
+    """Regression MOR-560: a device-stream open failure AFTER the session
+    RX subscribe must tear the subscription down — otherwise the leaked
     subscriber keeps radio RX running with no consumer draining the queue.
     """
     radio = _make_radio()
@@ -487,10 +516,10 @@ async def test_bridge_rx_via_bus():
 
     packet = AudioPacket(ident=0x80, send_seq=0, data=b"\x01\x02\x03")
     radio.audio_bus._on_opus_packet(packet)
-    assert bridge._subscription._received == 1
+    assert bridge._rx_sub._inner._received == 1
 
     radio.audio_bus._on_opus_packet(None)
-    assert bridge._subscription._received == 2
+    assert bridge._rx_sub._inner._received == 2
 
     await bridge.stop()
 

--- a/tests/test_audio_duplex.py
+++ b/tests/test_audio_duplex.py
@@ -335,11 +335,14 @@ class _FakeRadio:
 
 
 class _FakeSubscription:
+    def __init__(self) -> None:
+        self.active = False  # mirrors AudioSubscription.active (MOR-577)
+
     async def start(self) -> None:
-        pass
+        self.active = True
 
     async def aclose(self) -> None:
-        pass
+        self.active = False
 
     def __aiter__(self) -> "_FakeSubscription":
         return self
@@ -352,6 +355,8 @@ class _FakeSubscription:
 
 
 class _FakeBus:
+    rx_active = True  # mirrors AudioBus.rx_active (read by the session)
+
     def subscribe(self, *, name: str) -> _FakeSubscription:
         return _FakeSubscription()
 


### PR DESCRIPTION
## Summary

Step 9 of epic MOR-562 (target audio architecture ADR §3.3) — the payoff step: `AudioBridge`'s **radio-side** RX subscription and TX arming are now *demand declarations* on `AudioSession` (MOR-576), which reads the arming order from the transport's `audio_setup_order` descriptor (MOR-575). External behavior is identical; the ordering logic is no longer bridge-internal imperative branching.

## What was deleted

- **The `rx_first` branch** in `_setup_streams` (`rx_first = getattr(self._radio, "audio_duplex_mode", "full") != "exclusive"` + the two conditional `_subscribe_bus()` call sites) — the MOR-556/MOR-559 patch-on-patch.
- **The `_subscribe_bus` band-aid** (MOR-559 RuntimeError-if-not-rx_active check) — superseded by the session's `_arm_rx`, which raises the same `"radio RX failed to start"` error **with the bus subscription unwound** (MOR-560 semantics preserved).
- **`_use_neutral_tx`** — `self._tx_lease is None` now discriminates the legacy `*_audio_tx_pcm` path.

Grep evidence: `grep -n "rx_first\|_subscribe_bus\|_use_neutral_tx\|_subscription" src/rigplane/audio/bridge.py` → one hit, a comment naming the `"rx_first"` descriptor value. No branch, no variable, no method.

## How the session now owns ordering

`_setup_streams` acquires the TX lease **before** the RX subscription. At IDLE the session defers arming to the RX-demand edge, then sequences both legs under its single lock per the descriptor:

- `"rx_first"` (LAN, legacy default): `start_rx` → `start_tx` — MOR-556 order, `radio.calls == ["start_rx", "start_tx"]` still asserted green.
- `"atomic"` (same-device exclusive USB): `start_tx` → `start_rx` — MOR-559 order, `radio.calls == ["start_tx", "start_rx"]` still asserted green; no AUHAL −50 silent RX kill.

RX flow: `session.subscribe_rx("audio-bridge")` → frames → the bridge's existing loopback output stream. TX flow: loopback capture → `tx_lease.push(pcm)` → `radio.push_tx`. A deferred TX-arm failure inside the session leaves it at RX_ONLY; the bridge detects that, releases the lease, and degrades to RX-only exactly as before (MOR-242 test green).

**Scope boundaries respected:** device-side loopback streams + reconnect machinery stay in the bridge (radio-side recovery is step 14); the session wraps the radio's **shared** `audio_bus` (pinned by a new test asserting `bridge._session.bus is radio.audio_bus`); web TX handler and poller PTT untouched (steps 13/12). The legacy `*_audio_tx_pcm` path (radios without the neutral surface) stays bridge-owned outside the session — unchanged behavior, covered by existing tests.

## MOR-574 teardown preserved by the session

`stop()`/`_teardown_streams` release the RX demand while the TX lease is still held: the session's `_apply` sequences `stop_tx` → RX drop, so radio TX stops **before** the bus subscription closes — the LAN leaked-RX-stream trap stays closed. The conformance round-trip (`assert not h.rx_live()` after stop with TX armed, the flipped MOR-574 assertion) is green on every backend row. Legacy TX stop stays in `stop()` before teardown, same order as before.

## Tests

- New falsification test `test_bridge_routes_radio_side_through_audio_session` (failed pre-rewire with `AttributeError: no attribute '_session'`, green post).
- `ExclusiveUsbRadio` (shared MOR-566 stub) gains the MOR-575 descriptor `audio_setup_order = "atomic"`, mirroring the shipping `"exclusive" → "atomic"` derivation — required now that the session (not `audio_duplex_mode`) drives the order.
- `test_audio_duplex.py` bus fakes mirror the real `AudioSubscription.active` / `AudioBus.rx_active` surface the session reads (4th file — minimal 9-line fake-fidelity fix, flagging the ≤3-file guardrail overage).
- `test_bridge_rx_via_bus` reaches the received-counter via `bridge._rx_sub._inner` (same underlying bus subscription).

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7488 passed**, 9 skipped, 3 deselected, 11 xfailed, 1 xpassed — incl. full MOR-567 conformance suite (both orders, all backend rows), MOR-556 (`test_bridge_subscribes_rx_before_arming_tx`), MOR-559 (`test_bridge_arms_tx_before_rx_on_exclusive_duplex`, `test_bridge_rx_only_on_exclusive_duplex_still_starts_rx`), MOR-560, MOR-574 round-trip.
- `uv run ruff check src/ tests/` clean; `ruff format --check` clean.
- `uv run mypy src/` → baseline exactly **21 errors in 8 files** (no new).
- `uv run lint-imports` → **4 kept, 0 broken** (bridge → session, both in `audio/`).

## Deferred — live re-validation (operator-gated)

Live re-validation on IC-7610 LAN (full-duplex bridge, no RX flood) and FTX-1 same-device exclusive (started RX+TX, no −50) is **required before MOR-577 closes** but the radios are currently offline — do not merge-and-close without it being scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)