### PR TITLE
refactor(MOR-579): radio-owned AudioSession singleton (lazy radio.audio_session)

### DIFF
--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -524,7 +524,14 @@ class AudioBridge:
         # both legs in the declared order under its single lock.
         session = self._session
         if session is None:
-            session = AudioSession(self._radio)  # wraps radio.audio_bus
+            # Prefer the radio-owned session singleton (MOR-579): ONE
+            # session per radio shared by all consumers, so TX refcounts
+            # never split across independent sessions. The duck-typed
+            # fallback keeps bare radio doubles (no ``audio_session``
+            # property) working with a bridge-local session.
+            session = getattr(self._radio, "audio_session", None) or AudioSession(
+                self._radio
+            )
             self._session = session
 
         if self._tx_enabled:

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -24,6 +24,7 @@ from .transport import YaesuCatTransport
 
 if TYPE_CHECKING:
     from ..._poller_types import CommandQueue
+    from ...audio.session import AudioSession
     from ...audio.usb_driver import UsbAudioDriver
     from ...audio_bus import AudioBus
     from ...core.state_pipeline_contracts import Observation
@@ -193,6 +194,7 @@ class YaesuCatRadio:
         self._transport = YaesuCatTransport(device=device, baudrate=baudrate)
         self._state = RadioState()
         self._audio_bus: AudioBus | None = None
+        self._audio_session: AudioSession | None = None
         self._audio_seq = 0
         self._opus_rx_user_callback: Callable[[AudioPacket | None], None] | None = None
         self._pcm_rx_user_callback: Callable[[bytes | None], None] | None = None
@@ -396,6 +398,20 @@ class YaesuCatRadio:
 
             self._audio_bus = AudioBus(self)
         return self._audio_bus
+
+    @property
+    def audio_session(self) -> "AudioSession":
+        """Radio-owned AudioSession singleton (MOR-579).
+
+        ONE session per radio, shared by every consumer (bridge, web TX
+        handler, poller PTT hooks) so the TX refcount can never split
+        across independent sessions. Wraps the shared :attr:`audio_bus`.
+        """
+        if self._audio_session is None:
+            from ...audio.session import AudioSession
+
+            self._audio_session = AudioSession(self)
+        return self._audio_session
 
     # -- Neutral AudioTransport surface (MOR-532 epic, MOR-541) --------------
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -765,6 +765,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._opus_rx_jitter_depth: int = 5
         # AudioBus — lazy-initialized pub/sub for multi-consumer audio
         self._audio_bus: Any = None
+        # AudioSession — lazy-initialized radio-owned singleton (MOR-579)
+        self._audio_session: Any = None
         self._scope_assembler: ScopeAssembler = ScopeAssembler()
         self._scope_callback: Callable[[ScopeFrame], Any] | None = None
         # Raw CI-V pipe listeners (MOR-164): receive inbound on-wire frame bytes.
@@ -1020,6 +1022,20 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
             self._audio_bus = AudioBus(self)
         return self._audio_bus
+
+    @property
+    def audio_session(self) -> Any:
+        """Lazy-initialized radio-owned AudioSession singleton (MOR-579).
+
+        ONE session per radio, shared by every consumer (bridge, web TX
+        handler, poller PTT hooks) so the TX refcount can never split
+        across independent sessions. Wraps the shared :attr:`audio_bus`.
+        """
+        if self._audio_session is None:
+            from rigplane.audio.session import AudioSession
+
+            self._audio_session = AudioSession(self)
+        return self._audio_session
 
     @property
     def profile(self) -> RadioProfile:

--- a/tests/test_audio_session_radio_owned.py
+++ b/tests/test_audio_session_radio_owned.py
@@ -1,0 +1,125 @@
+"""MOR-579: radio-owned AudioSession singleton (epic MOR-562 step 9b).
+
+MOR-577 had the bridge build its OWN ``AudioSession(radio)``. Before the
+web TX handler (step 13) or the poller PTT hooks (step 12) also go through
+the session, each consumer building a private session would split the TX
+refcount — two sessions per radio arm/stop radio TX independently →
+premature stop / double-arm. The session must be ONE per radio: a lazy
+cached ``radio.audio_session`` property (mirroring the lazy ``audio_bus``),
+with the bridge preferring it via a duck-typed lookup and falling back to
+constructing its own for bare test doubles.
+"""
+
+from __future__ import annotations
+
+import types
+
+from _order_sensitive_radios import LanLikeRadio
+
+from rigplane.audio.backend import (
+    AudioDeviceId,
+    AudioDeviceInfo,
+    FakeAudioBackend,
+)
+from rigplane.audio.bridge import AudioBridge
+from rigplane.audio.session import AudioSession
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.runtime.radio import IcomRadio
+
+# ---------------------------------------------------------------------------
+# radio.audio_session — lazy cached singleton on real backends
+# ---------------------------------------------------------------------------
+
+
+def test_icom_audio_session_is_cached_singleton() -> None:
+    """Repeated access returns the SAME session object (lazy + cached)."""
+    radio = IcomRadio("192.168.1.100")
+    session = radio.audio_session
+    assert isinstance(session, AudioSession)
+    assert radio.audio_session is session
+
+
+def test_icom_audio_session_wraps_shared_audio_bus() -> None:
+    """The radio-owned session wraps the radio's shared AudioBus."""
+    radio = IcomRadio("192.168.1.100")
+    assert radio.audio_session.bus is radio.audio_bus
+
+
+def test_yaesu_audio_session_is_cached_singleton() -> None:
+    radio = YaesuCatRadio(
+        device="/dev/fake0",
+        audio_driver=types.SimpleNamespace(),  # type: ignore[arg-type]
+    )
+    session = radio.audio_session
+    assert isinstance(session, AudioSession)
+    assert radio.audio_session is session
+
+
+def test_yaesu_audio_session_wraps_shared_audio_bus() -> None:
+    radio = YaesuCatRadio(
+        device="/dev/fake0",
+        audio_driver=types.SimpleNamespace(),  # type: ignore[arg-type]
+    )
+    assert radio.audio_session.bus is radio.audio_bus
+
+
+# ---------------------------------------------------------------------------
+# AudioBridge uses the radio-owned session (not a private one)
+# ---------------------------------------------------------------------------
+
+
+class _SessionOwningLanRadio(LanLikeRadio):
+    """LAN-like stub exposing the radio-owned ``audio_session`` property."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._audio_session: AudioSession | None = None
+
+    @property
+    def audio_session(self) -> AudioSession:
+        if self._audio_session is None:
+            self._audio_session = AudioSession(self)
+        return self._audio_session
+
+
+def _bridge_backend() -> FakeAudioBackend:
+    return FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="BlackHole 2ch",
+                input_channels=2,
+                output_channels=2,
+            )
+        ]
+    )
+
+
+async def test_bridge_uses_radio_owned_session() -> None:
+    """With a radio exposing ``audio_session``, the bridge must share it —
+    never build a second session with an independent TX refcount."""
+    radio = _SessionOwningLanRadio()
+    bridge = AudioBridge(radio, device_name="BlackHole", backend=_bridge_backend())
+    await bridge.start()
+    try:
+        assert bridge._session is radio.audio_session
+        assert radio.audio_session.rx_demand == 1
+        assert radio.audio_session.tx_demand == 1
+    finally:
+        await bridge.stop()
+    assert radio.audio_session.rx_demand == 0
+    assert radio.audio_session.tx_demand == 0
+
+
+async def test_bridge_falls_back_to_own_session_without_property() -> None:
+    """Duck-typed fallback: a radio double WITHOUT ``audio_session`` still
+    lets the bridge construct one (no crash, behavior unchanged)."""
+    radio = LanLikeRadio()
+    assert not hasattr(radio, "audio_session")
+    bridge = AudioBridge(radio, device_name="BlackHole", backend=_bridge_backend())
+    await bridge.start()
+    try:
+        assert isinstance(bridge._session, AudioSession)
+        assert bridge._session.bus is radio.audio_bus
+    finally:
+        await bridge.stop()


### PR DESCRIPTION
## Why

Epic MOR-562 step 9b — resolves ADR open-question #1 (radio-owned vs bridge-owned session).

MOR-577 (#1765) had `AudioBridge` construct its OWN `AudioSession(radio)`. That is fine while the bridge is the only consumer, but before the web TX handler (step 13) or the poller PTT hooks (step 12) also go "through the session", each consumer would build its own session with an **independent TX refcount** — two sessions per radio would arm/stop radio TX independently, causing premature TX stop or double-arm. The session must be ONE per radio, shared by all consumers.

## What

**Behavior-preserving:** still exactly one session per radio — just radio-owned instead of bridge-owned.

- **Lazy cached `audio_session` property** added next to the existing lazy `audio_bus` on both radio classes, matching the `audio_bus` style exactly (lazy import inside the property body, `_audio_session = None` initialized next to `_audio_bus = None`):
  - `src/rigplane/runtime/radio.py` (CoreRadio — Icom/LAN)
  - `src/rigplane/backends/yaesu_cat/radio.py` (YaesuCatRadio — FTX-1)
- **Bridge migration** (`src/rigplane/audio/bridge.py`): the MOR-577 `session = AudioSession(self._radio)` becomes `session = getattr(self._radio, "audio_session", None) or AudioSession(self._radio)`. The duck-typed fallback keeps bare radio doubles (no `audio_session` property) working with a bridge-local session. No other bridge behavior changed.

## Import-matrix handling

`runtime/` and `backends/` sit ABOVE `audio/` in the layer matrix, so the radio importing `rigplane.audio.session` is a legal downward import. The import is lazy (inside the property body) to mirror the `audio_bus` pattern and keep top-level package import light. `uv run lint-imports`: **4 kept / 0 broken** (unchanged).

## Red → Green (falsification-first TDD)

New `tests/test_audio_session_radio_owned.py`, written and run BEFORE the implementation:

- RED: `AttributeError: 'IcomRadio'/'YaesuCatRadio' object has no attribute 'audio_session'` (4 tests) + `bridge._session is not radio.audio_session` (1 test); the duck-typed-fallback guard passed pre-change as expected.
- GREEN after the property + bridge migration: all 6 pass.

Covers: property caching (`radio.audio_session is radio.audio_session`) on both backends, shared-bus wrapping (`radio.audio_session.bus is radio.audio_bus`), bridge sharing the radio-owned session (incl. TX/RX demand released back to 0 on stop), and the no-property fallback.

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7506 passed**, 9 skipped, 11 xfailed, 1 xpassed, 0 failures (MOR-556/559/560/574 bridge tests + MOR-567 conformance suite green unchanged)
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → 560 files already formatted
- `uv run mypy src/` → baseline exactly **21 errors in 8 files** (unchanged)
- `uv run lint-imports` → **4 kept / 0 broken**

🤖 Generated with [Claude Code](https://claude.com/claude-code)