### PR TITLE
refactor(MOR-580): route web TX handler through AudioSession lease

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -30,6 +30,7 @@ from ..transport import Connection  # noqa: TID251
 from ..websocket import WS_OP_BINARY, WS_OP_TEXT  # noqa: TID251
 
 if TYPE_CHECKING:
+    from ...audio.session import TxLease
     from ...capabilities import CAP_AUDIO as _CAP_AUDIO_TYPE  # noqa: F401
     from ...dsp.pipeline import DSPPipeline
     from ...radio_protocol import Radio
@@ -637,6 +638,10 @@ class AudioHandler:
         self._broadcaster = broadcaster
         self._rx_active = False
         self._tx_active = False
+        # TX lease on the radio-owned AudioSession singleton (MOR-580,
+        # ADR §3.3). None when the radio lacks a session (legacy direct
+        # path) or when TX is not active.
+        self._tx_lease: TxLease | None = None
         self._tx_stop_lock = asyncio.Lock()
         self._seq: int = 0
         self._frame_queue: asyncio.Queue[bytes] = asyncio.Queue()
@@ -737,20 +742,35 @@ class AudioHandler:
             elif direction == "tx":
                 if self._radio and CAP_AUDIO in self._radio.capabilities:
                     self._ensure_tx_transcoder()
-                    try:
-                        start_tx = getattr(self._radio, "start_tx", None)
-                        if start_tx is not None:
-                            # Neutral AudioTransport surface (MOR-544): the
-                            # backend resolves the TX format from its
-                            # negotiated contract.
-                            await start_tx()
-                        else:
-                            await self._legacy_tx_lifecycle("start")
-                    except RuntimeError as exc:
-                        if _is_benign_tx_restart(exc):
-                            logger.info("audio: TX already started by poller, reusing")
-                        else:
-                            raise
+                    session = getattr(self._radio, "audio_session", None)
+                    if session is not None:
+                        # Shared AudioSession lease (MOR-580, ADR §3.3): the
+                        # session's single-lock refcount serializes arming
+                        # with other lease holders (bridge, poller PTT), so
+                        # the double-start benign-tolerance below is
+                        # unnecessary on this path.
+                        if self._tx_lease is None or self._tx_lease.released:
+                            self._tx_lease = await session.acquire_tx("web")
+                    else:
+                        # Legacy direct-arm fallback for radios without a
+                        # session (bare test doubles, not-yet-migrated
+                        # backends).
+                        try:
+                            start_tx = getattr(self._radio, "start_tx", None)
+                            if start_tx is not None:
+                                # Neutral AudioTransport surface (MOR-544):
+                                # the backend resolves the TX format from
+                                # its negotiated contract.
+                                await start_tx()
+                            else:
+                                await self._legacy_tx_lifecycle("start")
+                        except RuntimeError as exc:
+                            if _is_benign_tx_restart(exc):
+                                logger.info(
+                                    "audio: TX already started by poller, reusing"
+                                )
+                            else:
+                                raise
                 self._tx_active = True
                 logger.info("audio: TX active")
         elif msg_type == "audio_stop":
@@ -771,7 +791,7 @@ class AudioHandler:
     ) -> None:
         """Release this handler's active TX ownership, optionally bounded."""
         async with self._tx_stop_lock:
-            if not self._tx_active and not force:
+            if not self._tx_active and not force and self._tx_lease is None:
                 return
             self._tx_active = False
 
@@ -782,12 +802,28 @@ class AudioHandler:
                 return
 
             try:
-                stop_tx_method = getattr(self._radio, "stop_tx", None)
-                if stop_tx_method is not None:
-                    # Neutral AudioTransport surface (MOR-544).
-                    stop_tx: Awaitable[None] = stop_tx_method()
+                lease = self._tx_lease
+                if lease is not None:
+                    # Session path (MOR-580): drop this handler's TX demand;
+                    # the session disarms radio TX only when the lease
+                    # refcount reaches zero (release is idempotent).
+                    self._tx_lease = None
+                    stop_tx: Awaitable[None] = lease.release()
+                elif getattr(self._radio, "audio_session", None) is not None:
+                    # Session radio with no held lease: this handler owns no
+                    # TX demand — never direct-stop the radio out from under
+                    # other lease holders (bridge, poller PTT). MOR-580.
+                    logger.info(
+                        "audio: TX stop skipped (%s, no session lease held)", reason
+                    )
+                    return
                 else:
-                    stop_tx = self._legacy_tx_lifecycle("stop")
+                    stop_tx_method = getattr(self._radio, "stop_tx", None)
+                    if stop_tx_method is not None:
+                        # Neutral AudioTransport surface (MOR-544).
+                        stop_tx = stop_tx_method()
+                    else:
+                        stop_tx = self._legacy_tx_lifecycle("stop")
                 if timeout is None:
                     await stop_tx
                 else:
@@ -1010,8 +1046,13 @@ class AudioHandler:
             await self._radio.stop_audio_tx_opus()  # type: ignore[union-attr]
 
     async def _push_tx(self, data: bytes, *, legacy_method: str) -> None:
-        """Push TX bytes via neutral ``push_tx``; fall back to the named
-        legacy per-codec push method (MOR-544)."""
+        """Push TX bytes via the held session lease (MOR-580); without one,
+        via neutral ``push_tx``, falling back to the named legacy per-codec
+        push method (MOR-544)."""
+        lease = self._tx_lease
+        if lease is not None and not lease.released:
+            await lease.push(data)
+            return
         push_tx = getattr(self._radio, "push_tx", None)
         if push_tx is not None:
             await push_tx(data)

--- a/tests/test_web_audio_tx_session.py
+++ b/tests/test_web_audio_tx_session.py
@@ -1,0 +1,203 @@
+"""Web AudioHandler TX path through the shared AudioSession lease (MOR-580).
+
+Falsification-first (epic MOR-562 step 13, ADR §3.3): on radios exposing the
+radio-owned ``audio_session`` singleton (MOR-579), ``audio_start
+direction=tx`` must ACQUIRE A LEASE on that session instead of direct-arming
+``radio.start_tx`` — the session's single-lock refcount is what lets the web
+handler coexist with the bridge (and future poller PTT hooks) on the same
+radio TX leg without double-arms or premature stops.
+
+The CRITICAL coexistence property: with the bridge already holding a lease
+on the SAME session, the web handler acquiring + releasing its own lease
+must NOT stop radio TX while the bridge still wants it — and vice versa.
+
+Radios without a session (bare test doubles, not-yet-migrated backends)
+keep the legacy direct-arm path with the ``_is_benign_tx_restart``
+string-match tolerance (covered by ``tests/test_handlers_coverage.py``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from _order_sensitive_radios import LanLikeRadio
+
+from rigplane.audio.session import AudioSession
+from rigplane.web.handlers import AudioHandler
+from rigplane.web.protocol import (
+    AUDIO_CODEC_PCM16,
+    AUDIO_HEADER_SIZE,
+    MSG_TYPE_AUDIO_TX,
+)
+
+
+class _SessionLanRadio(LanLikeRadio):
+    """LAN-like stub + radio-owned session singleton (MOR-579 shape)."""
+
+    capabilities = {"audio"}
+    audio_sample_rate = 48000
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.pushed: list[bytes] = []
+        self._audio_session: AudioSession | None = None
+
+    @property
+    def audio_session(self) -> AudioSession:
+        if self._audio_session is None:
+            self._audio_session = AudioSession(self)
+        return self._audio_session
+
+    async def push_tx(self, audio_data: bytes) -> None:
+        await super().push_tx(audio_data)  # raises unless TX is armed
+        self.pushed.append(audio_data)
+
+
+def _make_handler(radio: _SessionLanRadio) -> AudioHandler:
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    return AudioHandler(ws, radio, None)
+
+
+def _pcm_tx_frame(payload: bytes) -> bytes:
+    return (
+        bytes([MSG_TYPE_AUDIO_TX, AUDIO_CODEC_PCM16])
+        + b"\x00" * (AUDIO_HEADER_SIZE - 2)
+        + payload
+    )
+
+
+async def _start_tx(handler: AudioHandler) -> None:
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+
+
+async def _stop_tx(handler: AudioHandler) -> None:
+    await handler._handle_control({"type": "audio_stop", "direction": "tx"})
+
+
+async def test_audio_start_tx_acquires_session_lease_not_direct_arm() -> None:
+    """audio_start tx → a lease on radio.audio_session, frames flow, stop releases."""
+    radio = _SessionLanRadio()
+    session = radio.audio_session
+    rx_anchor = await session.subscribe_rx("rx-anchor")  # session RX demand up
+    handler = _make_handler(radio)
+
+    await _start_tx(handler)
+    assert session.tx_demand == 1, "handler must acquire a session TX lease"
+    assert handler._tx_active is True
+    # TX armed exactly once, BY the session (refcount), not by a direct call.
+    assert radio.calls.count("start_tx") == 1
+    assert radio.state == "transmitting"
+
+    # Browser TX PCM reaches the radio through the lease.
+    await handler._handle_tx_audio(_pcm_tx_frame(b"web-pcm-frame"))
+    assert radio.pushed == [b"web-pcm-frame"]
+
+    # audio_stop releases the lease; last lease down → session disarms TX.
+    await _stop_tx(handler)
+    assert session.tx_demand == 0
+    assert handler._tx_active is False
+    assert radio.state == "receiving"
+
+    await rx_anchor.release()
+
+
+async def test_web_lease_coexists_with_bridge_lease_on_same_session() -> None:
+    """CRITICAL: web acquire/release must not disturb the bridge's TX demand."""
+    radio = _SessionLanRadio()
+    session = radio.audio_session
+    # Bridge shape (MOR-577/579): TX lease first, then RX demand arms both.
+    bridge_lease = await session.acquire_tx("audio-bridge")
+    bridge_rx = await session.subscribe_rx("audio-bridge")
+    assert radio.state == "transmitting"
+    assert radio.calls.count("start_tx") == 1
+
+    handler = _make_handler(radio)
+    await _start_tx(handler)
+    # No double-arm: the session refcounts the second lease.
+    assert session.tx_demand == 2
+    assert radio.calls.count("start_tx") == 1
+
+    # Web stop releases ONLY the web lease — bridge TX keeps running.
+    await _stop_tx(handler)
+    assert session.tx_demand == 1
+    assert radio.state == "transmitting", "web release must not stop bridge TX"
+
+    # Bridge done → TX disarms.
+    await bridge_lease.release()
+    assert radio.state == "receiving"
+    await bridge_rx.release()
+
+
+async def test_bridge_release_keeps_web_tx_running() -> None:
+    """Vice versa: bridge releasing its lease must not stop the web's TX."""
+    radio = _SessionLanRadio()
+    session = radio.audio_session
+    bridge_lease = await session.acquire_tx("audio-bridge")
+    bridge_rx = await session.subscribe_rx("audio-bridge")
+
+    handler = _make_handler(radio)
+    await _start_tx(handler)
+
+    await bridge_lease.release()
+    assert session.tx_demand == 1
+    assert radio.state == "transmitting", "bridge release must not stop web TX"
+    # Web TX frames still reach the radio.
+    await handler._handle_tx_audio(_pcm_tx_frame(b"still-on-air"))
+    assert radio.pushed == [b"still-on-air"]
+
+    await _stop_tx(handler)
+    assert radio.state == "receiving"
+    await bridge_rx.release()
+
+
+async def test_double_audio_start_tx_reuses_lease_no_leak() -> None:
+    """Repeated audio_start tx must not stack leases (one release frees TX)."""
+    radio = _SessionLanRadio()
+    session = radio.audio_session
+    rx_anchor = await session.subscribe_rx("rx-anchor")
+    handler = _make_handler(radio)
+
+    await _start_tx(handler)
+    await _start_tx(handler)
+    assert session.tx_demand == 1, "double start must reuse the held lease"
+
+    await _stop_tx(handler)
+    assert session.tx_demand == 0
+    assert radio.state == "receiving"
+    await rx_anchor.release()
+
+
+async def test_audio_stop_without_lease_never_direct_stops_session_radio() -> None:
+    """audio_stop tx with no held lease must not kill another owner's TX."""
+    radio = _SessionLanRadio()
+    session = radio.audio_session
+    bridge_lease = await session.acquire_tx("audio-bridge")
+    bridge_rx = await session.subscribe_rx("audio-bridge")
+    assert radio.state == "transmitting"
+
+    handler = _make_handler(radio)
+    await _stop_tx(handler)  # force-stop path, but no web lease held
+    assert radio.state == "transmitting", "stray stop must not disarm bridge TX"
+    assert session.tx_demand == 1
+
+    await bridge_lease.release()
+    await bridge_rx.release()
+
+
+async def test_handler_exit_cleanup_releases_lease() -> None:
+    """run()-finally cleanup path (disconnect) must release the lease too."""
+    radio = _SessionLanRadio()
+    session = radio.audio_session
+    rx_anchor = await session.subscribe_rx("rx-anchor")
+    handler = _make_handler(radio)
+
+    await _start_tx(handler)
+    assert session.tx_demand == 1
+
+    # Same invocation run() uses in its finally block.
+    await handler._stop_tx(reason="handler exit", timeout=2.0, suppress_errors=True)
+    assert session.tx_demand == 0
+    assert handler._tx_lease is None
+    assert radio.state == "receiving"
+    await rx_anchor.release()


### PR DESCRIPTION
## Summary

Epic MOR-562 step 13 (ADR §3.3) — the web `AudioHandler` TX path now goes through a TX lease on the radio-owned `AudioSession` singleton (MOR-579) instead of direct-arming the radio. **[BP]** Web TX still reaches the radio; only the ownership/arming discipline changes.

### Lease migration (`src/rigplane/web/handlers/audio.py`)

| Site | Before | After |
|---|---|---|
| `audio_start direction=tx` | `radio.start_tx()` / `_legacy_tx_lifecycle("start")` + benign-restart tolerance | `self._tx_lease = await radio.audio_session.acquire_tx("web")` — reused if already held (no lease stacking on double start) |
| Browser TX frame push (`_push_tx`, all 3 codec branches) | `radio.push_tx` / legacy per-codec push | `lease.push(pcm)` when a live lease is held |
| `audio_stop` / disconnect cleanup (`_stop_tx`) | `radio.stop_tx()` / `_legacy_tx_lifecycle("stop")` | `lease.release()` (idempotent; bounded by the existing cleanup timeout) |

The browser-Opus→PCM transcode (`opus_to_pcm`, #691 rate plumbing) is untouched — only the radio-side arming/push/stop moved.

### Bridge coexistence (the refcount property)

The bridge already holds its own lease on the SAME `radio.audio_session` (MOR-577/579). New tests prove both directions:

- web acquire while bridge transmits → **no double-arm** (`start_tx` called exactly once, by the session);
- web `audio_stop` → only the web lease drops; **bridge TX keeps running** (`tx_demand 2→1`, radio stays `transmitting`);
- bridge release while web holds → **web TX keeps running** and frames still reach the radio;
- a session radio with **no held lease is never direct-stopped** — a stray `audio_stop` can no longer kill another owner's TX (this was live behavior before: force-stop called `radio.stop_tx` unconditionally).

### Retained legacy fallback

Radios without `audio_session` (bare test doubles, not-yet-migrated backends) keep the exact previous path: neutral `start_tx`/`stop_tx` → `_legacy_tx_lifecycle` per-codec branches, with `_is_benign_tx_restart` tolerance (typed `AudioAlreadyStartedError` per MOR-563 + ADR P7 string fallback). No typed-error handling regressed; all pre-existing handler tests pass unmodified.

### Red → Green

`tests/test_web_audio_tx_session.py` (6 tests) was written first and **failed against the direct-arm code** (session `tx_demand` stayed 0; web stop disarmed the bridge's TX; stray stop killed bridge TX), then went green after the migration. Existing web/bridge/session suites (405 tests) pass without assertion changes.

### Gate

- `uv run pytest tests/ -q --ignore=tests/integration` → **7512 passed**, 9 skipped, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → 561 files already formatted
- `uv run mypy src/` → baseline exactly **21 errors in 8 files** (no new)
- `uv run lint-imports` → **4 kept, 0 broken**

Parallel-PR safety: `src/rigplane/audio/session.py` and `src/rigplane/web/server.py` are NOT touched — this PR only consumes the session's existing public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)