### PR TITLE
fix(MOR-582): surface RX-start failures instead of swallowing them (bus + broadcaster)

### DIFF
--- a/src/rigplane/audio/bus.py
+++ b/src/rigplane/audio/bus.py
@@ -44,6 +44,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from rigplane.audio.usb_driver import AudioAlreadyStartedError
 from rigplane.dsp.tap_registry import TapRegistry
 
 if TYPE_CHECKING:
@@ -137,13 +138,22 @@ class AudioSubscription:
         }
 
     async def start(self) -> None:
-        """Activate this subscription (registers with the bus)."""
+        """Activate this subscription (registers with the bus).
+
+        Raises if this subscription's demand triggers the radio RX start
+        and the start fails (MOR-582): the subscription is left inactive
+        and unregistered — never "attached" to a bus that is not receiving.
+        """
         if self._active:
             return
         if self._close_task is not None and not self._close_task.done():
             await self._close_task
         self._active = True
-        await self._bus._add_subscriber(self)
+        try:
+            await self._bus._add_subscriber(self)
+        except BaseException:
+            self._active = False
+            raise
 
     def stop(self) -> None:
         """Deactivate this subscription and schedule bus removal.
@@ -349,9 +359,16 @@ class AudioBus:
             self._rx_pcm_taps.feed(packet.data)
 
     async def _add_subscriber(self, sub: AudioSubscription) -> None:
-        """Register a subscriber and start RX if this is the first one."""
+        """Register a subscriber and start RX if this is the first one.
+
+        When this subscriber's demand triggers the RX start and the start
+        fails, the registration is rolled back before the error propagates
+        (MOR-582, ADR §3.4 rule 3): a subscriber must never be left
+        registered on a bus that is not actually receiving.
+        """
         async with self._lock:
-            if sub not in self._subscribers:
+            added = sub not in self._subscribers
+            if added:
                 self._subscribers.append(sub)
                 logger.info(
                     "audio-bus: +subscriber %r (%d total)",
@@ -359,7 +376,12 @@ class AudioBus:
                     len(self._subscribers),
                 )
             if not self._rx_active and len(self._subscribers) > 0:
-                await self._start_rx()
+                try:
+                    await self._start_rx()
+                except BaseException:
+                    if added:
+                        self._subscribers.remove(sub)
+                    raise
 
     async def _remove_subscriber(self, sub: AudioSubscription) -> None:
         """Unregister a subscriber. Stops RX if no subscribers remain."""
@@ -399,15 +421,23 @@ class AudioBus:
             await start_rx(self._on_opus_packet)
 
     async def _start_rx(self) -> None:
-        """Start receiving audio from the radio."""
+        """Start receiving audio from the radio.
+
+        A start failure is NOT swallowed (MOR-582, ADR §3.4 rule 3): the
+        demanding caller must never believe it is attached to a live
+        stream. The radio error is chained into a ``RuntimeError`` so every
+        backend surfaces the same exception type to subscribers;
+        ``rx_active`` stays False, reflecting reality.
+        """
         if self._rx_active:
             return
         try:
             await self._begin_rx()
-            self._rx_active = True
-            logger.info("audio-bus: RX started")
-        except Exception:
+        except Exception as exc:
             logger.exception("audio-bus: failed to start RX")
+            raise RuntimeError(f"radio RX failed to start: {exc}") from exc
+        self._rx_active = True
+        logger.info("audio-bus: RX started")
 
     async def restart_rx(self) -> None:
         """Re-establish RX on the radio using the bus's own callback.
@@ -416,16 +446,29 @@ class AudioBus:
         transition on Icom CI-V backends): the radio's single-slot RX
         callback must be restored to :meth:`_on_opus_packet` so subscribers
         keep receiving frames. No-op when the bus has no active subscribers.
+
+        A re-arm failure is non-fatal for the established session (a hiccup
+        must not crash healthy subscribers) but never masked as success:
+        ``rx_active`` drops to False so stats and the recovery watchdog see
+        the dead RX leg (MOR-582). The typed already-started case is benign
+        — RX stayed live through the TX cycle (LAN) and remains wired to
+        this bus, so it stays marked live.
         """
         async with self._lock:
             if not self._subscribers:
                 return
             try:
                 await self._begin_rx()
+            except AudioAlreadyStartedError:
                 self._rx_active = True
-                logger.info("audio-bus: RX re-armed after TX")
+                logger.debug("audio-bus: RX already live on re-arm", exc_info=True)
+                return
             except Exception:
+                self._rx_active = False
                 logger.exception("audio-bus: failed to re-arm RX")
+                return
+            self._rx_active = True
+            logger.info("audio-bus: RX re-armed after TX")
 
     async def _stop_rx(self) -> None:
         """Stop receiving audio from the radio."""

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -487,9 +487,34 @@ class AudioBroadcaster:
             self._subscription = cast(_AudioBus, bus).subscribe(name="web-audio")
             await self._subscription.start()
             self._relay_task = asyncio.create_task(self._relay_loop())
-        except Exception:
+        except Exception as exc:
             logger.exception("audio-broadcaster: failed to start relay")
             self._subscription = None
+            await self._notify_relay_start_failure(exc)
+
+    async def _notify_relay_start_failure(self, exc: Exception) -> None:
+        """Surface a relay/RX start failure to connected WS clients (MOR-582).
+
+        Without this the browser was told nothing and waited on dead air
+        forever (ADR §3.4 problem P2: "subscribed" with zero frames). Reuses
+        the handler's error envelope shape: ``{"type": "error", "message"}``.
+        """
+        if not self._client_ws:
+            return
+        payload = encode_json(
+            {
+                "type": "error",
+                "message": f"audio_start: RX audio failed to start: {exc}",
+            }
+        )
+        for ws in list(self._client_ws.values()):
+            try:
+                await ws.send_text(payload)
+            except Exception:
+                logger.debug(
+                    "audio-broadcaster: failed to notify client of RX start failure",
+                    exc_info=True,
+                )
 
     async def _relay_loop(self) -> None:
         """Read packets from AudioBus subscription and fan out to WS clients."""

--- a/tests/test_audio_bus.py
+++ b/tests/test_audio_bus.py
@@ -342,15 +342,32 @@ async def test_bus_stats(bus, mock_radio):
 # ---------------------------------------------------------------------------
 
 
-async def test_rx_start_failure_handled(mock_radio):
+async def test_rx_start_failure_raises_to_first_subscriber(mock_radio):
+    """[BC] MOR-582: the demanding subscriber's RX-start failure PROPAGATES.
+
+    Pre-MOR-582 the bus swallowed the error and left the subscriber
+    registered-but-silent (dead air). Now ``start()`` raises (RuntimeError
+    chained from the radio error) and the registration is rolled back.
+    """
     mock_radio.start_audio_rx_opus = AsyncMock(
         side_effect=ConnectionError("not connected")
     )
     bus = AudioBus(mock_radio)
     sub = bus.subscribe(name="s1")
-    await sub.start()
-    # Should not crash, rx_active stays False
+    with pytest.raises(RuntimeError, match="radio RX failed to start") as excinfo:
+        await sub.start()
+    assert isinstance(excinfo.value.__cause__, ConnectionError)
     assert not bus.rx_active
+    assert not sub.active  # never falsely "attached"
+    assert bus.subscriber_count == 0  # registration rolled back
+
+    # No poisoned state: repair the radio and the same subscription recovers.
+    mock_radio.start_audio_rx_opus = AsyncMock()
+    await sub.start()
+    assert bus.rx_active
+    assert sub.active
+    assert bus.subscriber_count == 1
+    await sub.aclose()
 
 
 async def test_get_with_timeout(bus, mock_radio):
@@ -439,3 +456,24 @@ async def test_restart_rx_noop_without_subscribers_neutral():
     await bus.restart_rx()
     assert radio.start_calls == []
     assert not bus.rx_active
+
+
+async def test_restart_rx_failure_nonfatal_but_observable():
+    """MOR-582: a re-arm failure must not crash an established session,
+    but must not be masked as success — ``rx_active`` reflects reality."""
+    radio = _NeutralRadio()
+    bus = AudioBus(radio)
+    sub = bus.subscribe(name="s1")
+    await sub.start()
+    assert bus.rx_active
+
+    async def _failing_start_rx(callback):
+        raise ConnectionError("re-arm hiccup")
+
+    radio.start_rx = _failing_start_rx
+    await bus.restart_rx()  # non-fatal: must NOT raise
+
+    assert not bus.rx_active  # observable (step-14 watchdog input)
+    assert sub.active  # established subscriber survives
+    assert bus.subscriber_count == 1
+    await sub.aclose()

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1222,8 +1222,61 @@ async def test_audio_broadcaster_start_relay_failure() -> None:
 
     bad = AudioBroadcaster(failing_radio)
     await bad._start_relay()
-    # Bus subscription exists but RX failed to start
+    # RX failed to start: not active, and the bus subscription was rolled
+    # back (MOR-582) — no registered-but-silent subscriber remains.
     assert not bus.rx_active
+    assert bus.subscriber_count == 0
+
+
+async def test_audio_broadcaster_start_relay_failure_notifies_ws_client() -> None:
+    """MOR-582: a failed RX start sends an ``error`` envelope to the WS
+    client instead of presenting "subscribed" with dead air forever."""
+    from rigplane.audio_bus import AudioBus
+
+    failing_radio = SimpleNamespace(
+        capabilities={"audio"},
+        audio_codec=AudioCodec.PCM_1CH_16BIT,
+        audio_sample_rate=48_000,
+        start_audio_rx_opus=AsyncMock(side_effect=RuntimeError("start fail")),
+        stop_audio_rx_opus=AsyncMock(),
+    )
+    bus = AudioBus(failing_radio)
+    failing_radio.audio_bus = bus
+
+    ws = SimpleNamespace(send_text=AsyncMock(), is_alive=lambda: True)
+    broadcaster = AudioBroadcaster(failing_radio)
+    queue = await broadcaster.subscribe(ws=ws)
+    assert isinstance(queue, asyncio.Queue)
+    assert not bus.rx_active
+
+    ws.send_text.assert_awaited_once()
+    envelope = decode_json(ws.send_text.await_args.args[0])
+    assert envelope["type"] == "error"
+    assert "RX audio failed to start" in envelope["message"]
+    assert "start fail" in envelope["message"]
+
+
+async def test_audio_broadcaster_subscribe_success_sends_no_error_envelope() -> None:
+    """MOR-582 success path unchanged: no spurious error on normal subscribe."""
+    from rigplane.audio_bus import AudioBus
+
+    radio = SimpleNamespace(
+        capabilities={"audio"},
+        audio_codec=AudioCodec.PCM_1CH_16BIT,
+        audio_sample_rate=48_000,
+        start_audio_rx_opus=AsyncMock(),
+        stop_audio_rx_opus=AsyncMock(),
+    )
+    bus = AudioBus(radio)
+    radio.audio_bus = bus
+
+    ws = SimpleNamespace(send_text=AsyncMock(), is_alive=lambda: True)
+    broadcaster = AudioBroadcaster(radio)
+    queue = await broadcaster.subscribe(ws=ws)
+    assert bus.rx_active
+    ws.send_text.assert_not_awaited()
+    await broadcaster.unsubscribe(queue)
+    await asyncio.sleep(0.05)  # let the scheduled bus unsubscribe complete
 
 
 async def test_audio_broadcaster_without_radio_noops() -> None:


### PR DESCRIPTION
## Summary

Implements **MOR-582** (step 10 of epic MOR-562, ADR §3.4 rule 3 / problem P2): `AudioBus` stops swallowing RX-start failures, and the web broadcaster surfaces them to the WS client instead of silent dead air.

**[BC] note for release notes:** RX-start failures are now VISIBLE. A new audio subscriber whose demand fails to start radio RX gets a raised `RuntimeError` (previously: silently "attached" with zero frames); browser WS clients receive an `error` envelope (previously: "subscribed" + dead air forever).

## The swallow → raise split

| Path | Before | After |
|---|---|---|
| **First/demanding subscriber** (`_start_rx` via `_add_subscriber`) | `except Exception: logger.exception(...)` — subscriber left registered-but-silent, `rx_active` False | Raises `RuntimeError("radio RX failed to start: ...")` chained `from` the radio error; registration **rolled back** (`_add_subscriber`) and `AudioSubscription.start()` resets `active=False`. Recovery works: repairing the radio and re-calling `start()` succeeds. |
| **`restart_rx`** (established-demand re-arm after a TX cycle) | failure swallowed, `rx_active` left stale-True (masked as success) | Still **non-fatal** (a re-arm hiccup must not crash healthy subscribers), but observable: `rx_active` drops to False so stats and the step-14 watchdog see the dead leg. The typed `AudioAlreadyStartedError` (MOR-563) case is benign — on LAN, RX stays live through the TX cycle — and keeps `rx_active` True (otherwise the final `stop_rx` would be skipped and RX would leak, caught by `test_teardown_stops_tx_before_rx`). |

The error type/message (`RuntimeError`, "radio RX failed to start") deliberately matches the existing AudioSession (MOR-576) and MOR-567 conformance-suite contract (`pytest.raises(RuntimeError, match="radio RX failed to start")`), so `session.py` and `tests/contracts/` needed **zero changes** and stay green.

## WS error envelope (broadcaster)

`AudioBroadcaster._start_relay` catches the now-propagating failure and sends the handler's existing error envelope shape to registered WS clients:

```json
{"type": "error", "message": "audio_start: RX audio failed to start: <cause>"}
```

(Same `{"type": "error", "message"}` shape as `AudioHandler._send_error`.) `subscribe()` / `ensure_relay()` remain non-raising, so the PCM-tap (FFT scope) path is unaffected.

## Red → green (falsification-first TDD)

Tests written first; against `main` they fail exactly on the swallow behavior:

```
FAILED tests/test_audio_bus.py::test_rx_start_failure_raises_to_first_subscriber
FAILED tests/test_audio_bus.py::test_restart_rx_failure_nonfatal_but_observable
FAILED tests/test_handlers_coverage.py::test_audio_broadcaster_start_relay_failure
FAILED tests/test_handlers_coverage.py::test_audio_broadcaster_start_relay_failure_notifies_ws_client
4 failed, 1 passed (success-path test passes pre-change, proving no spurious errors)
```

All green after the implementation.

## Existing tests updated ([BC])

- `tests/test_audio_bus.py::test_rx_start_failure_handled` → renamed `test_rx_start_failure_raises_to_first_subscriber`: now expects the raise (`RuntimeError` chained from `ConnectionError`), rollback (`subscriber_count == 0`, `not sub.active`), and recovery after repair. This was the test pinning the old swallow behavior.
- `tests/test_handlers_coverage.py::test_audio_broadcaster_start_relay_failure` strengthened (not weakened): now also asserts the bus subscription is rolled back (`subscriber_count == 0`).

New tests: bus first-subscriber raise + rollback + recovery; `restart_rx` non-fatal-but-observable; broadcaster error-envelope on failed start; broadcaster success path sends no error envelope.

## Files (4 — flagged: 3 + 1 extra existing test file needing new/updated coverage)

- `src/rigplane/audio/bus.py` (+53/−10)
- `src/rigplane/web/handlers/audio.py` (+26/−1)
- `tests/test_audio_bus.py` (+42/−2)
- `tests/test_handlers_coverage.py` (+53/−2)

Total: +174/−15. No new abstractions; keep-alive/hot-path untouched; `session.py` / `server.py` untouched (parallel PR).

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7515 passed**, 9 skipped, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → clean
- `uv run mypy src/` → baseline exactly **21 errors in 8 files** (no new)
- `uv run lint-imports` → **4 kept, 0 broken**

🤖 Generated with [Claude Code](https://claude.com/claude-code)