### PR TITLE
feat(MOR-584): per-connection web egress codecs (per-client encoder pool)

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -115,8 +115,13 @@ class AudioBroadcaster:
         self._radio_codec: AudioCodec | None = None
         self._sample_rate: int = 48000
         self._channels: int = 1
-        self._browser_opus_transcoder: PcmOpusTranscoder | None = None
-        self._browser_opus_transcoder_key: tuple[int, int, int] | None = None
+        # Per-client egress encoder pool (MOR-584, ADR §3.6): each Opus
+        # WS client owns a dedicated transcoder (Opus encoders are
+        # stateful), keyed by client id and torn down on disconnect.
+        # Value: (transcoder, (sample_rate, channels, frame_ms)).
+        self._client_opus_transcoders: dict[
+            int, tuple[PcmOpusTranscoder, tuple[int, int, int]]
+        ] = {}
         self._browser_opus_warned: bool = False
         self._lock = asyncio.Lock()
         # Optional DSP pipeline (inserted between codec decode and tap/distribute).
@@ -173,8 +178,6 @@ class AudioBroadcaster:
                     self._subscription = None
                 if self._radio:
                     await self._start_relay()
-            elif preferred_rx_codec is not None:
-                self.invalidate_codec_state()
         self._notify_client_count_change()
         logger.info("audio-broadcaster: client added (total=%d)", len(self._clients))
         return queue
@@ -186,9 +189,8 @@ class AudioBroadcaster:
         async with self._lock:
             removed = self._clients.pop(client_id, None) is not None
             self._client_ws.pop(client_id, None)
-            removed_codec = self._client_rx_codec.pop(client_id, None)
-            if removed_codec is not None:
-                self.invalidate_codec_state()
+            self._client_rx_codec.pop(client_id, None)
+            self._client_opus_transcoders.pop(client_id, None)
             if (
                 not self._clients
                 and self._subscription is not None
@@ -295,6 +297,8 @@ class AudioBroadcaster:
             for cid in dead_ids:
                 self._clients.pop(cid, None)
                 self._client_ws.pop(cid, None)
+                self._client_rx_codec.pop(cid, None)
+                self._client_opus_transcoders.pop(cid, None)
             # Stop relay if no clients remain (and no PCM tap active)
             if (
                 not self._clients
@@ -372,16 +376,14 @@ class AudioBroadcaster:
         self._maybe_warn_dsp_opus_gate()
 
     def _resolve_web_rx_codec(self, radio_codec: AudioCodec) -> int:
-        """Resolve browser RX transport codec from profile consumer policy."""
+        """Resolve the DEFAULT browser RX transport from profile policy.
+
+        Applies to clients that sent no ``preferred_rx_codec``; clients
+        with an explicit preference are resolved per-connection in
+        :meth:`_client_egress_codec` (MOR-584).
+        """
         if radio_codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
             return AUDIO_CODEC_OPUS
-
-        # The frontend can explicitly ask for PCM16 when its WebView/browser
-        # cannot decode Opus with WebCodecs.  Keep this as an aggregate
-        # transport decision because the relay currently builds one shared
-        # frame for all browser clients.
-        if AUDIO_CODEC_PCM16 in self._client_rx_codec.values():
-            return AUDIO_CODEC_PCM16
 
         default_codec = {
             AudioCodec.PCM_1CH_16BIT: AUDIO_CODEC_PCM16,
@@ -405,30 +407,67 @@ class AudioBroadcaster:
             return AUDIO_CODEC_OPUS
         return default_codec
 
-    def _encode_browser_rx_frame(
+    def _client_egress_codec(self, client_id: int) -> int:
+        """Resolve one client's egress codec (MOR-584, static per connection).
+
+        Ladder: client-requested (``preferred_rx_codec`` at negotiation)
+        → profile policy default (``_resolve_web_rx_codec`` cached in
+        ``_web_codec``) → PCM16.  Opus-native radios pass through
+        un-decoded for every client — there is no PCM to re-encode
+        (issue #762).
+        """
+        if self._radio_codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
+            return AUDIO_CODEC_OPUS
+        return self._client_rx_codec.get(client_id, self._web_codec)
+
+    def negotiated_rx_format(self, queue: asyncio.Queue[bytes]) -> dict[str, Any]:
+        """Describe the egress format a subscribed client will receive.
+
+        Backs the ``audio_format`` ack sent after ``audio_start``
+        (MOR-584).  ``frame_ms`` is the 20 ms nominal — advisory like
+        the wire header; consumers must size buffers from actual
+        payloads (#765).
+        """
+        codec = self._client_egress_codec(id(queue))
+        return {
+            "codec": "opus" if codec == AUDIO_CODEC_OPUS else "pcm16",
+            "sample_rate": self._sample_rate,
+            "channels": self._channels,
+            "frame_ms": 20,
+        }
+
+    def _encode_client_rx_frame(
         self,
+        client_id: int,
         pcm_data: bytes,
         frame_ms: int,
     ) -> tuple[int, bytes]:
-        """Apply browser-only RX transport encoding after PCM consumers run."""
-        if self._web_codec != AUDIO_CODEC_OPUS:
-            return self._web_codec, pcm_data
+        """Apply ONE client's RX transport encoding after PCM consumers run.
+
+        Sits downstream of the PCM spine (decode → DSP → tap fan-out):
+        only browser WS clients reach here.  The AudioBridge, FFT scope
+        and other taps consume PCM upstream and never touch these
+        encoders (T1a digital-path invariant).
+        """
+        if self._client_egress_codec(client_id) != AUDIO_CODEC_OPUS:
+            return AUDIO_CODEC_PCM16, pcm_data
         if self._radio_codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
             return AUDIO_CODEC_OPUS, pcm_data
 
         key = (self._sample_rate, self._channels, frame_ms)
         try:
-            if (
-                self._browser_opus_transcoder is None
-                or self._browser_opus_transcoder_key != key
-            ):
-                self._browser_opus_transcoder = create_pcm_opus_transcoder(
-                    sample_rate=self._sample_rate,
-                    channels=self._channels,
-                    frame_ms=frame_ms,
+            entry = self._client_opus_transcoders.get(client_id)
+            if entry is None or entry[1] != key:
+                entry = (
+                    create_pcm_opus_transcoder(
+                        sample_rate=self._sample_rate,
+                        channels=self._channels,
+                        frame_ms=frame_ms,
+                    ),
+                    key,
                 )
-                self._browser_opus_transcoder_key = key
-            return AUDIO_CODEC_OPUS, self._browser_opus_transcoder.pcm_to_opus(pcm_data)
+                self._client_opus_transcoders[client_id] = entry
+            return AUDIO_CODEC_OPUS, entry[0].pcm_to_opus(pcm_data)
         except Exception as exc:
             if not self._browser_opus_warned:
                 logger.warning(
@@ -436,8 +475,7 @@ class AudioBroadcaster:
                     exc,
                 )
                 self._browser_opus_warned = True
-            self._browser_opus_transcoder = None
-            self._browser_opus_transcoder_key = None
+            self._client_opus_transcoders.pop(client_id, None)
             return AUDIO_CODEC_PCM16, pcm_data
 
     async def _apply_phones_mix_off(self) -> None:
@@ -580,26 +618,34 @@ class AudioBroadcaster:
                 _bytes_per_sample = 2
                 _denom = max(1, self._sample_rate * self._channels * _bytes_per_sample)
                 _frame_ms = max(1, min((len(audio_data) * 1000) // _denom, 255))
-                _frame_codec, _frame_audio_data = self._encode_browser_rx_frame(
-                    audio_data,
-                    _frame_ms,
-                )
-                frame = encode_audio_frame(
-                    MSG_TYPE_AUDIO_RX,
-                    _frame_codec,
-                    self._seq,
-                    self._sample_rate // 100,
-                    self._channels,
-                    _frame_ms,
-                    _frame_audio_data,
-                )
-                self._seq = (self._seq + 1) & 0xFFFF
+                # Per-client egress encode (MOR-584): the PCM spine above
+                # (decode → DSP → taps) is shared; from here each browser
+                # WS client gets its own negotiated wire codec.  Pass-
+                # through payloads (PCM16, Opus-native) reuse one cached
+                # frame per codec; Opus transcodes are per-client.
+                shared_frames: dict[int, bytes] = {}
                 dead_ids: list[int] = []
                 for client_id, q in list(self._clients.items()):
                     ws = self._client_ws.get(client_id)
                     if ws is not None and not ws.is_alive():
                         dead_ids.append(client_id)
                         continue
+                    codec, payload = self._encode_client_rx_frame(
+                        client_id, audio_data, _frame_ms
+                    )
+                    frame = shared_frames.get(codec) if payload is audio_data else None
+                    if frame is None:
+                        frame = encode_audio_frame(
+                            MSG_TYPE_AUDIO_RX,
+                            codec,
+                            self._seq,
+                            self._sample_rate // 100,
+                            self._channels,
+                            _frame_ms,
+                            payload,
+                        )
+                        if payload is audio_data:
+                            shared_frames[codec] = frame
                     try:
                         q.put_nowait(frame)
                     except asyncio.QueueFull:
@@ -611,9 +657,12 @@ class AudioBroadcaster:
                             q.put_nowait(frame)
                         except asyncio.QueueFull:
                             pass
+                self._seq = (self._seq + 1) & 0xFFFF
                 for client_id in dead_ids:
                     self._clients.pop(client_id, None)
                     self._client_ws.pop(client_id, None)
+                    self._client_rx_codec.pop(client_id, None)
+                    self._client_opus_transcoders.pop(client_id, None)
                     logger.info("audio-broadcaster: removed dead client during relay")
                 if dead_ids:
                     self._notify_client_count_change()
@@ -1092,6 +1141,16 @@ class AudioHandler:
         self._frame_queue = await self._broadcaster.subscribe(
             ws=self._ws,
             preferred_rx_codec=preferred_rx_codec,
+        )
+        # Per-connection negotiation ack (MOR-584): tell the client which
+        # wire codec/format it will receive.  Advisory and fire-and-forget
+        # — legacy clients ignore text frames on the audio WS and keep
+        # decoding from the per-frame binary header.
+        await self._send_json(
+            {
+                "type": "audio_format",
+                **self._broadcaster.negotiated_rx_format(self._frame_queue),
+            }
         )
         logger.info("audio: subscribed to RX broadcast")
 

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1334,6 +1334,7 @@ async def test_audio_handler_reader_control_tx_and_sender_paths(
     broadcaster = SimpleNamespace(
         subscribe=AsyncMock(return_value=asyncio.Queue()),
         unsubscribe=AsyncMock(),
+        negotiated_rx_format=lambda _q: {"codec": "pcm16"},
     )
     # Mock radio needs to pass isinstance(AudioCapable) check
     radio = MagicMock(spec=AudioCapable)
@@ -1430,6 +1431,7 @@ async def test_audio_handler_control_and_tx_guard_paths() -> None:
     broadcaster = SimpleNamespace(
         subscribe=AsyncMock(return_value=asyncio.Queue()),
         unsubscribe=AsyncMock(),
+        negotiated_rx_format=lambda _q: {"codec": "pcm16"},
     )
     handler = AudioHandler(ws, radio, broadcaster)
 

--- a/tests/test_web_audio_per_client_codec.py
+++ b/tests/test_web_audio_per_client_codec.py
@@ -1,0 +1,260 @@
+"""Per-connection web egress codecs (MOR-584, ADR §3.6 problem P11).
+
+Falsification suite: the broadcaster must encode egress PER CLIENT — a
+PCM16-preferring browser must not force PCM16 onto a concurrently
+connected Opus client (the old aggregate ``_web_codec`` did exactly
+that). The PCM spine (bus → DSP → taps → bridge) stays PCM and never
+grows an encoder (T1a digital-path invariant): only browser WS clients
+get per-client codecs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from rigplane.audio_bus import AudioBus
+from rigplane.radio_protocol import AudioCapable
+from rigplane.types import AudioCodec
+from rigplane.web.handlers import AudioBroadcaster, AudioHandler
+from rigplane.web.protocol import (
+    AUDIO_CODEC_OPUS,
+    AUDIO_CODEC_PCM16,
+    AUDIO_HEADER_SIZE,
+    MSG_TYPE_AUDIO_RX,
+    encode_audio_frame,
+)
+from rigplane.web.websocket import WebSocketConnection
+
+# 20 ms @ 48 kHz mono s16le.
+PCM_PAYLOAD = b"\x01\x02" * 960
+
+
+def _make_radio(
+    codec: AudioCodec = AudioCodec.PCM_1CH_16BIT, sample_rate: int = 48000
+) -> tuple[Any, AudioBus]:
+    radio = MagicMock(spec=AudioCapable)
+    radio.capabilities = {"audio"}
+    radio.audio_codec = codec
+    radio.audio_sample_rate = sample_rate
+    radio.start_audio_rx_opus = AsyncMock()
+    radio.stop_audio_rx_opus = AsyncMock()
+    bus = AudioBus(radio)
+    radio.audio_bus = bus
+    return radio, bus
+
+
+def _make_ws() -> MagicMock:
+    ws = MagicMock(spec=WebSocketConnection)
+    ws.send_text = AsyncMock()
+    return ws
+
+
+class _FakeTranscoder:
+    """Stands in for PcmOpusTranscoder — native libopus may be absent."""
+
+    def __init__(self) -> None:
+        self.frames: list[bytes] = []
+
+    def pcm_to_opus(self, pcm: bytes) -> bytes:
+        self.frames.append(bytes(pcm))
+        return b"opus-frame"
+
+
+async def _inject(bus: AudioBus, payload: bytes = PCM_PAYLOAD) -> None:
+    pkt = MagicMock()
+    pkt.data = payload
+    bus._on_opus_packet(pkt)
+    await asyncio.sleep(0.1)
+
+
+class TestPerClientEgressCodec:
+    async def test_mixed_clients_each_receive_their_own_codec(self) -> None:
+        """Two concurrent clients: PCM16-preferring must NOT force PCM16
+        on the Opus-preferring one (the aggregate-_web_codec regression)."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        h_pcm = AudioHandler(_make_ws(), radio, broadcaster)
+        h_opus = AudioHandler(_make_ws(), radio, broadcaster)
+        created: list[_FakeTranscoder] = []
+
+        def _factory(**_kwargs: Any) -> _FakeTranscoder:
+            t = _FakeTranscoder()
+            created.append(t)
+            return t
+
+        with patch(
+            "rigplane.web.handlers.audio.create_pcm_opus_transcoder",
+            side_effect=_factory,
+        ):
+            await h_pcm._start_rx(preferred_rx_codec=AUDIO_CODEC_PCM16)
+            await h_opus._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            await _inject(bus)
+
+        f_pcm = h_pcm._frame_queue.get_nowait()
+        f_opus = h_opus._frame_queue.get_nowait()
+        assert f_pcm[1] == AUDIO_CODEC_PCM16
+        assert f_pcm[AUDIO_HEADER_SIZE:] == PCM_PAYLOAD
+        assert f_opus[1] == AUDIO_CODEC_OPUS, (
+            "PCM16 client forced PCM16 onto the Opus client — egress "
+            "must be per-connection (MOR-584)"
+        )
+        assert f_opus[AUDIO_HEADER_SIZE:] == b"opus-frame"
+        # One dedicated encoder, fed the shared post-DSP PCM frame.
+        assert len(created) == 1
+        assert created[0].frames == [PCM_PAYLOAD]
+        # Both frames stem from the same packet → same sequence number.
+        seq_pcm = struct.unpack_from("<H", f_pcm, 2)[0]
+        seq_opus = struct.unpack_from("<H", f_opus, 2)[0]
+        assert seq_pcm == seq_opus
+
+    async def test_single_default_client_pcm16_frame_byte_identical(self) -> None:
+        """The common case — one browser, no preference — stays byte-
+        identical to the pre-MOR-584 wire format, and no encoder pool
+        entry is ever created. The bare (non-async) ws mock also proves
+        a legacy client that cannot take the audio_format ack still
+        streams."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        handler = AudioHandler(MagicMock(spec=WebSocketConnection), radio, broadcaster)
+        await handler._start_rx()
+        await _inject(bus)
+
+        frame = handler._frame_queue.get_nowait()
+        expected = encode_audio_frame(
+            MSG_TYPE_AUDIO_RX, AUDIO_CODEC_PCM16, 0, 480, 1, 20, PCM_PAYLOAD
+        )
+        assert frame == expected
+        assert broadcaster._client_opus_transcoders == {}
+
+    async def test_pcm_spine_and_bridge_path_never_get_an_encoder(self) -> None:
+        """T1a boundary: the post-DSP tap (FFT scope) and a bus
+        subscriber (how the AudioBridge consumes RX, upstream of the
+        broadcaster) both see raw PCM; the encoder pool is keyed by WS
+        client id only."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        tap_frames: list[bytes] = []
+        broadcaster.set_pcm_tap(tap_frames.append)
+        bridge_sub = bus.subscribe(name="audio-bridge")
+        await bridge_sub.start()
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        with patch(
+            "rigplane.web.handlers.audio.create_pcm_opus_transcoder",
+            return_value=_FakeTranscoder(),
+        ):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            await _inject(bus)
+
+        assert tap_frames == [PCM_PAYLOAD]
+        bridge_pkt = bridge_sub.get_nowait()
+        assert bridge_pkt is not None and bridge_pkt.data == PCM_PAYLOAD
+        assert set(broadcaster._client_opus_transcoders) == {
+            id(handler._frame_queue)
+        }, "encoders must exist for browser WS clients only (T1a)"
+        bridge_sub.stop()
+
+    async def test_disconnect_tears_down_client_encoder(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        with patch(
+            "rigplane.web.handlers.audio.create_pcm_opus_transcoder",
+            return_value=_FakeTranscoder(),
+        ):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            await _inject(bus)
+        assert len(broadcaster._client_opus_transcoders) == 1
+
+        await broadcaster.unsubscribe(handler._frame_queue)
+        assert broadcaster._client_opus_transcoders == {}
+        assert broadcaster._client_rx_codec == {}
+
+    async def test_reap_dead_clients_tears_down_client_encoder(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        ws = _make_ws()
+        handler = AudioHandler(ws, radio, broadcaster)
+        with patch(
+            "rigplane.web.handlers.audio.create_pcm_opus_transcoder",
+            return_value=_FakeTranscoder(),
+        ):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            await _inject(bus)
+        assert len(broadcaster._client_opus_transcoders) == 1
+
+        ws.is_alive.return_value = False
+        assert await broadcaster.reap_dead_clients() == 1
+        assert broadcaster._client_opus_transcoders == {}
+        assert broadcaster._client_rx_codec == {}
+
+    async def test_opus_native_radio_passes_through_for_all_clients(self) -> None:
+        """Opus-native radios (IC-705) stay un-decoded passthrough for
+        every client regardless of preference — there is no PCM to
+        re-encode (issue #762), so no pool encoder is created either."""
+        radio, bus = _make_radio(codec=AudioCodec.OPUS_1CH)
+        broadcaster = AudioBroadcaster(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_PCM16)
+        opus_payload = b"\x42" * 120
+        await _inject(bus, opus_payload)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_OPUS
+        assert frame[AUDIO_HEADER_SIZE:] == opus_payload
+        assert broadcaster._client_opus_transcoders == {}
+
+
+class TestAudioFormatAck:
+    async def test_ack_sent_with_negotiated_format(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        ws = _make_ws()
+        handler = AudioHandler(ws, radio, broadcaster)
+        with patch(
+            "rigplane.web.handlers.audio.create_pcm_opus_transcoder",
+            return_value=_FakeTranscoder(),
+        ):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+
+        sent = [json.loads(c.args[0]) for c in ws.send_text.await_args_list]
+        acks = [m for m in sent if m.get("type") == "audio_format"]
+        assert acks == [
+            {
+                "type": "audio_format",
+                "codec": "opus",
+                "sample_rate": 48000,
+                "channels": 1,
+                "frame_ms": 20,
+            }
+        ]
+
+    async def test_default_client_ack_reports_pcm16(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        ws = _make_ws()
+        handler = AudioHandler(ws, radio, broadcaster)
+        await handler._start_rx()
+
+        sent = [json.loads(c.args[0]) for c in ws.send_text.await_args_list]
+        acks = [m for m in sent if m.get("type") == "audio_format"]
+        assert len(acks) == 1
+        assert acks[0]["codec"] == "pcm16"
+
+    async def test_ack_send_failure_does_not_break_rx(self) -> None:
+        """An old client may close the text path or choke on the ack —
+        absence of ack handling must not affect frame delivery."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        ws = _make_ws()
+        ws.send_text = AsyncMock(side_effect=RuntimeError("legacy client"))
+        handler = AudioHandler(ws, radio, broadcaster)
+        await handler._start_rx()
+        await _inject(bus)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_PCM16
+        assert frame[AUDIO_HEADER_SIZE:] == PCM_PAYLOAD


### PR DESCRIPTION
## Summary

Implements Linear **MOR-584** (step 17 of epic MOR-562, ADR §3.6 problem P11): web egress encoding is now **per-connection** instead of one aggregate codec for all browser clients.

### Problem

The relay built ONE shared frame for all WS clients from an aggregate `_web_codec` — `_resolve_web_rx_codec` contained `if AUDIO_CODEC_PCM16 in self._client_rx_codec.values(): return AUDIO_CODEC_PCM16`, so a single PCM16-preferring client forced PCM16 for everyone, and an explicit Opus request was never honored. This coupled codec choice to the client population and blocked the WAN/Opus story.

### Per-client encoder pool design

Position in the pipeline (unchanged spine, new fan-out):

```
ulaw decode → DSP → tap fan-out (FFT scope) → frame_ms derive
                                   │  (PCM spine — untouched)
                                   ▼
              per-client egress encode + per-client queue fan-out   ← MOR-584
```

- The post-DSP/tap **PCM frame is produced once**; at fan-out each client's codec is resolved via `_client_egress_codec`: **client-requested (`preferred_rx_codec`) → profile policy default (`browser_rx_transport`, cached `_web_codec`) → PCM16**.
- Each **Opus client owns a dedicated `PcmOpusTranscoder`** (Opus encoders are stateful), keyed by client id in `_client_opus_transcoders`, format-keyed `(sample_rate, channels, frame_ms)` for mid-stream format changes. Reuses the existing transcoder — no new encoder code.
- **Teardown on every disconnect path**: `unsubscribe`, `reap_dead_clients`, and the relay-loop dead-WS sweep (also now drops the stale `_client_rx_codec` entry — pre-existing leak in the reap path).
- **PCM16 clients share one cached zero-copy frame** per packet; Opus-native passthrough likewise. All frames for one packet carry the same sequence number.
- Per-client Opus encode failure (libopus missing) falls back to PCM16 for that client with the existing one-shot warning.

### Negotiation ack + back-compat ladder

After `audio_start direction=rx` the server sends an advisory text ack:

```json
{"type": "audio_format", "codec": "pcm16|opus", "sample_rate": 48000, "channels": 1, "frame_ms": 20}
```

- Fire-and-forget through `_send_json` (failure tolerated — tested).
- **Absence of ack handling = legacy**: a client that ignores the ack, or sends no `preferred_rx_codec`, gets exactly today's default (profile policy → PCM16). The single-default-client PCM16 frame is **byte-identical** to pre-change output (pinned by `test_single_default_client_pcm16_frame_byte_identical` against a literal `encode_audio_frame(...)` expectation).
- `frame_ms` in the ack is the 20 ms nominal — advisory like the wire header (#765 rule: consumers size buffers from payloads).
- Static per-connection choice only; adaptive switching is explicitly **out of scope** (step 19, MOR-586).

### T1a / spine-stays-PCM boundary

- The encoder pool lives **only** in the broadcaster's WS fan-out. The AudioBridge consumes RX via `session.subscribe_rx` → AudioBus, **upstream** of the broadcaster; FFT scope/taps are fed raw PCM before the egress encode.
- `test_pcm_spine_and_bridge_path_never_get_an_encoder` proves: the post-DSP tap and a bridge-like bus subscriber both receive raw PCM, and the pool is keyed exclusively by the Opus WS client's queue id.
- Opus-native radios (IC-705) keep un-decoded passthrough for every client regardless of preference (no PCM exists to re-encode, issue #762 unchanged).

### Frontend

**Untouched.** Verified: `rx-player.ts` dispatches per-frame on the binary header codec byte (PCM16 direct / Opus via WebCodecs), and `audio-manager.ts`'s `ws.onmessage` only processes `ArrayBuffer` data — the JSON ack is silently ignored by the existing client, which is exactly the legacy-tolerant behavior required.

### Falsification (RED → GREEN)

New suite `tests/test_web_audio_per_client_codec.py` — **8/9 failed on main**, all green after:

- (a) **mixed clients**: PCM16 + Opus concurrently → each receives its own codec; on main the Opus client was forced to PCM16. Same seq across both frames; one encoder, fed the shared PCM.
- (b) **default single client**: PCM16 frame byte-identical, empty encoder pool.
- (c) **T1a boundary**: tap + bridge-like bus subscriber get raw PCM; pool keyed by WS client only.
- (d) **teardown**: encoder destroyed on `unsubscribe` and on `reap_dead_clients`.
- (e) **ack**: sent with negotiated format (opus and pcm16 variants); ack send failure does not break frame delivery.
- Opus-native passthrough for all clients pinned.

Adapted: 2 `SimpleNamespace` broadcaster doubles in `tests/test_handlers_coverage.py` gained the new `negotiated_rx_format` method (no assertions weakened).

### Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7532 passed**, 0 failed (9 skipped, 3 deselected, 11 xfailed, 1 xpassed)
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → 563 files already formatted
- `uv run mypy src/` → baseline exactly **21 errors in 8 files** (no new)
- `uv run lint-imports` → **4 kept, 0 broken**
- Frontend not touched → no frontend build required

Files: `src/rigplane/web/handlers/audio.py` (+104/−45), `tests/test_web_audio_per_client_codec.py` (new, 260), `tests/test_handlers_coverage.py` (+2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)