### PR TITLE
refactor(MOR-586): session-demand re-establishment replaces legacy audio reconnect replay

### DIFF
--- a/src/rigplane/audio/session.py
+++ b/src/rigplane/audio/session.py
@@ -23,7 +23,9 @@ RECOVERING (MOR-581, ADR §3.4, tenet T3 "no silent audio death"): a ~1 s
 watchdog task — decoupled from the keep-alives — reads the bus RX heartbeat
 (MOR-564); ~3 s of silence ⇒ RECOVERING + a local
 :class:`AudioSessionEvent`; frames resuming return the demand-derived
-state. Step 14 only SURFACES the death — the recovery loop is step 20.
+state. Step 14 only SURFACES the death; step 20 (MOR-586) adds
+:meth:`AudioSession.reestablish` — the radio-side reconnect re-arms the
+session's LIVE demand instead of replaying the legacy snapshot.
 
 Arming order is transport-owned via the MOR-575 descriptor
 ``audio_setup_order`` (read with ``getattr(radio, ..., "rx_first")``):
@@ -57,6 +59,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Literal, cast
 
 from rigplane.audio.bus import AudioBus, AudioSubscription
+from rigplane.audio.usb_driver import AudioAlreadyStartedError
 
 if TYPE_CHECKING:
     from rigplane.audio import AudioPacket
@@ -454,6 +457,79 @@ class AudioSession:
         for sub in list(self._rx_subs):
             await sub._inner.aclose()
         self._rx_subs.clear()
+
+    # ── Reconnect re-establishment (MOR-586, ADR §3.4 rule 4) ────────────
+
+    async def reestablish(self) -> None:
+        """Re-arm the radio RX/TX legs from LIVE demand after a reconnect.
+
+        The radio-side reconnect (``runtime/_audio_recovery.py``) rebuilds
+        the audio transport underneath the session: demand handles (bus
+        subscriptions, TX leases) survive the outage, but the radio's RX
+        callback and TX leg do not. The target state is derived from the
+        CURRENT demand counters — never from a pre-disconnect snapshot —
+        so demand dropped during the outage stays dropped, and the re-arm
+        runs in the transport-declared order under the session lock.
+        Idempotent: already-live legs are benign typed no-ops.
+
+        Raises:
+            RuntimeError: when demanded RX fails to come back live, so the
+                recovery caller can surface FAILED. Demand is preserved —
+                the next reconnect or demand edge retries.
+        """
+        async with self._lock:
+            self._recovering_from = None
+            desired = self._desired()
+            if desired is AudioSessionState.IDLE:
+                # Demand dropped during the outage — nothing to resurrect.
+                self._state = AudioSessionState.IDLE
+                await self._sync_watchdog()
+                return
+            order = self._setup_order()
+            tx_wanted = desired is AudioSessionState.RX_TX
+            tx_live = False
+            if tx_wanted and order != "rx_first":
+                # "tx_first"/"atomic": the TX leg must be up before RX
+                # joins the device (the MOR-559 live-validated order).
+                tx_live = await self._try_rearm_tx()
+            await self._bus.restart_rx()
+            if not self._bus.rx_active:
+                if tx_live:
+                    await self._disarm_tx()  # never leave TX without RX
+                self._state = AudioSessionState.RX_ONLY
+                self._rx_armed_at = time.monotonic()
+                await self._sync_watchdog()
+                raise RuntimeError(
+                    "radio RX failed to re-establish after reconnect "
+                    "(AudioBus.rx_active is False after re-arm); see "
+                    "'audio-bus: failed to re-arm RX' in the log"
+                )
+            if tx_wanted and order == "rx_first":
+                tx_live = await self._try_rearm_tx()
+            self._state = (
+                AudioSessionState.RX_TX if tx_live else AudioSessionState.RX_ONLY
+            )
+            # Fresh liveness reference: silence is measured from this
+            # re-arm, not from the stale pre-outage heartbeat.
+            self._rx_armed_at = time.monotonic()
+            await self._sync_watchdog()
+
+    async def _try_rearm_tx(self) -> bool:
+        """Best-effort TX re-arm for :meth:`reestablish`; True when live.
+
+        Mirrors the deferred-arm policy in :meth:`_enter_rx_tx`: a TX
+        failure here has no demanding caller to raise to — settle at
+        RX_ONLY, keep the leases, and let the next demand edge (or the
+        next reconnect) retry.
+        """
+        try:
+            await self._radio.start_tx()
+        except AudioAlreadyStartedError:
+            logger.debug("audio-session: TX already live on re-arm", exc_info=True)
+        except Exception:
+            logger.warning("audio-session: TX re-arm failed — RX_ONLY", exc_info=True)
+            return False
+        return True
 
     # ── Health watchdog (MOR-581 — surface only, recovery is step 20) ────
 

--- a/src/rigplane/runtime/_audio_recovery.py
+++ b/src/rigplane/runtime/_audio_recovery.py
@@ -1,11 +1,17 @@
-"""Audio snapshot/resume logic for IcomRadio reconnect scenarios."""
+"""Audio snapshot/resume logic for IcomRadio reconnect scenarios.
+
+Session-managed audio (MOR-586, ADR §3.4 rule 4 — "one recovery loop")
+recovers through :meth:`AudioSession.reestablish` from the session's LIVE
+demand; the legacy ``*_opus``/``*_pcm`` snapshot replay remains only for
+direct legacy consumers with no session demand.
+"""
 
 from __future__ import annotations
 
 import dataclasses
 import enum
 import logging
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from rigplane.audio import AudioPacket, AudioState
 
@@ -42,17 +48,53 @@ class _AudioSnapshot:
     jitter_depth: int
 
 
+#: Marker snapshot for session-managed audio (MOR-586): the reconnect hooks
+#: gate recovery on ``capture_snapshot() is not None``, so live session
+#: demand must produce a snapshot even when the legacy stream state looks
+#: idle. The legacy fields are inert — ``recover`` re-derives everything
+#: from the session's live demand.
+_SESSION_MANAGED_SNAPSHOT = _AudioSnapshot(
+    rx_active=False,
+    tx_active=False,
+    pcm_mode=False,
+    pcm_rx_callback=None,
+    opus_rx_callback=None,
+    pcm_params=None,
+    jitter_depth=0,
+)
+
+
 class AudioRecoveryRuntime:
     """Composed audio recovery runtime for IcomRadio reconnect scenarios."""
 
     def __init__(self, host: "AudioRuntimeHost") -> None:
         self._host = host
 
+    def _session_with_demand(self) -> Any:
+        """The host's AudioSession when it exists AND holds live demand.
+
+        Reads the private ``_audio_session`` slot — NOT the lazy
+        ``audio_session`` property — so probing never instantiates a
+        session on a radio whose consumers are all legacy (the same
+        pattern as the web runtime payload).
+        """
+        session = getattr(self._host, "_audio_session", None)
+        if session is None:
+            return None
+        if session.rx_demand > 0 or session.tx_demand > 0:
+            return session
+        return None
+
     def capture_snapshot(self) -> _AudioSnapshot | None:
         """Capture current audio state for recovery after reconnect.
 
         Returns None if no audio stream is active.
         """
+        if self._session_with_demand() is not None:
+            # Session-managed audio (MOR-586): the session's LIVE demand —
+            # not the legacy stream state — decides recoverability.
+            return _SESSION_MANAGED_SNAPSHOT
+
         if self._host._audio_stream is None:
             return None
 
@@ -91,7 +133,16 @@ class AudioRecoveryRuntime:
         )
 
     async def recover(self, snapshot: _AudioSnapshot) -> None:
-        """Attempt to restart audio streams from a pre-disconnect snapshot.
+        """Re-establish audio after a transport reconnect.
+
+        Session-managed audio (MOR-586, ADR §3.4 rule 4) re-establishes
+        from the session's LIVE demand via
+        :meth:`AudioSession.reestablish`. The legacy snapshot replay would
+        re-arm the radio BEHIND the session — clobbering the bus RX
+        callback ordering, resurrecting demand dropped during the outage,
+        and desyncing the session state from the transport. The replay
+        remains only for direct legacy ``*_opus``/``*_pcm`` consumers with
+        no live session demand.
 
         Recovery failure is logged but does not raise.
         """
@@ -99,33 +150,11 @@ class AudioRecoveryRuntime:
             self._host._on_audio_recovery(AudioRecoveryState.RECOVERING)
 
         try:
-            if snapshot.rx_active:
-                if snapshot.pcm_mode and snapshot.pcm_rx_callback is not None:
-                    sr, ch, fms = snapshot.pcm_params or (48000, 1, 20)
-                    await self._host.start_audio_rx_pcm(
-                        snapshot.pcm_rx_callback,
-                        sample_rate=sr,
-                        channels=ch,
-                        frame_ms=fms,
-                        jitter_depth=snapshot.jitter_depth,
-                    )
-                elif snapshot.opus_rx_callback is not None:
-                    await self._host.start_audio_rx_opus(
-                        snapshot.opus_rx_callback,
-                        jitter_depth=snapshot.jitter_depth,
-                    )
-
-            if snapshot.tx_active:
-                if snapshot.pcm_mode and snapshot.pcm_params is not None:
-                    sr, ch, fms = snapshot.pcm_params
-                    await self._host.start_audio_tx_pcm(
-                        sample_rate=sr,
-                        channels=ch,
-                        frame_ms=fms,
-                    )
-                else:
-                    await self._host.start_audio_tx_opus()
-
+            session = self._session_with_demand()
+            if session is not None:
+                await session.reestablish()
+            else:
+                await self._replay_legacy(snapshot)
         except Exception as exc:
             logger.warning("Audio auto-recovery failed: %s", exc)
             if self._host._on_audio_recovery is not None:
@@ -134,3 +163,32 @@ class AudioRecoveryRuntime:
 
         if self._host._on_audio_recovery is not None:
             self._host._on_audio_recovery(AudioRecoveryState.RECOVERED)
+
+    async def _replay_legacy(self, snapshot: _AudioSnapshot) -> None:
+        """Replay the legacy ``*_opus``/``*_pcm`` starts from *snapshot*."""
+        if snapshot.rx_active:
+            if snapshot.pcm_mode and snapshot.pcm_rx_callback is not None:
+                sr, ch, fms = snapshot.pcm_params or (48000, 1, 20)
+                await self._host.start_audio_rx_pcm(
+                    snapshot.pcm_rx_callback,
+                    sample_rate=sr,
+                    channels=ch,
+                    frame_ms=fms,
+                    jitter_depth=snapshot.jitter_depth,
+                )
+            elif snapshot.opus_rx_callback is not None:
+                await self._host.start_audio_rx_opus(
+                    snapshot.opus_rx_callback,
+                    jitter_depth=snapshot.jitter_depth,
+                )
+
+        if snapshot.tx_active:
+            if snapshot.pcm_mode and snapshot.pcm_params is not None:
+                sr, ch, fms = snapshot.pcm_params
+                await self._host.start_audio_tx_pcm(
+                    sample_rate=sr,
+                    channels=ch,
+                    frame_ms=fms,
+                )
+            else:
+                await self._host.start_audio_tx_opus()

--- a/tests/test_audio_recovery_session.py
+++ b/tests/test_audio_recovery_session.py
@@ -1,0 +1,363 @@
+"""Reconnect recovery re-establishes the SESSION's live demand (MOR-586).
+
+Epic MOR-562 step 20, ADR §3.4 rule 4 ("one recovery loop"): on a radio
+transport reconnect ``AudioRecoveryRuntime.recover`` used to replay the
+LEGACY ``*_opus``/``*_pcm`` start methods from a pre-disconnect snapshot.
+After the MOR-562 migration the AudioSession owns the radio RX/TX legs,
+so the legacy replay re-armed the radio BEHIND the session:
+
+- demand dropped during the outage was resurrected (a re-armed radio leg
+  with no consumer draining it),
+- the snapshot's stale TX leg desynced the actual transport state from
+  the session's demand-derived state,
+- the replay order was hardcoded rx-then-tx, ignoring the MOR-575
+  ``audio_setup_order`` descriptor.
+
+Falsification-first: the desync tests below FAIL on the legacy replay and
+pass only when recovery routes through ``AudioSession.reestablish()``
+(live demand, transport-declared order, under the session lock). Radios
+with NO live session demand keep the legacy replay — pinned both here and
+in ``tests/test_audio_recovery.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from _audio_stream_fake import FakeAudioStream
+from _order_sensitive_radios import ExclusiveUsbRadio, LanLikeRadio
+
+from rigplane.audio import AudioPacket, AudioState
+from rigplane.audio.session import AudioSession, AudioSessionState
+from rigplane.audio.usb_driver import AudioAlreadyStartedError
+from rigplane.runtime._audio_recovery import AudioRecoveryState
+from rigplane.runtime.radio import IcomRadio
+
+_PACKET = AudioPacket(ident=0x0080, send_seq=1, data=b"\x01\x00" * 160)
+
+
+# ── Stubs / helpers ──────────────────────────────────────────────────────────
+
+
+def _wipe(radio: LanLikeRadio) -> None:
+    """Simulate the radio-side transport rebuild: the radio's RX callback
+    and stream state are gone; the session/bus handles survive."""
+    radio.state = "idle"
+    radio.rx_callback = None
+    radio.calls.clear()
+
+
+class _RxFailsOnRearmRadio(LanLikeRadio):
+    fail_rx = False
+
+    async def start_rx(
+        self, callback: object, *, jitter_depth: int | None = None
+    ) -> None:
+        if self.fail_rx:
+            self.calls.append("start_rx")
+            raise ConnectionError("induced RX re-arm failure")
+        await super().start_rx(callback, jitter_depth=jitter_depth)
+
+
+class _TxFailsOnRearmRadio(LanLikeRadio):
+    fail_tx = False
+
+    async def start_tx(self) -> None:
+        if self.fail_tx:
+            self.calls.append("start_tx")
+            raise RuntimeError("induced TX re-arm failure")
+        await super().start_tx()
+
+
+class _StatefulFakeStream(FakeAudioStream):
+    """FakeAudioStream + the LAN transition graph the snapshot/replay reads
+    (MOR-556 AlreadyStarted teeth and the MOR-574 stop_rx early-return)."""
+
+    async def start_rx(
+        self, callback: object, *, jitter_depth: int | None = None
+    ) -> None:
+        if self.state is not AudioState.IDLE:
+            raise AudioAlreadyStartedError(f"Cannot start RX in state {self.state}")
+        await super().start_rx(callback, jitter_depth=jitter_depth)
+        self.state = AudioState.RECEIVING
+
+    async def stop_rx(self) -> None:
+        await super().stop_rx()
+        if self.state is AudioState.RECEIVING:
+            self.state = AudioState.IDLE
+
+    async def start_tx(self) -> None:
+        if self.state is AudioState.TRANSMITTING:
+            raise AudioAlreadyStartedError("Already transmitting")
+        await super().start_tx()
+        self.state = AudioState.TRANSMITTING
+
+    async def stop_tx(self) -> None:
+        await super().stop_tx()
+        if self.state is AudioState.TRANSMITTING:
+            self.state = (
+                AudioState.RECEIVING
+                if self.last_start_rx_callback is not None
+                else AudioState.IDLE
+            )
+
+
+def _make_radio(**kwargs: object) -> IcomRadio:
+    radio = IcomRadio("192.168.1.100", **kwargs)  # type: ignore[arg-type]
+    radio._ctrl_transport = MagicMock()
+    radio._civ_transport = MagicMock()
+    radio._connected = True
+    return radio
+
+
+def _install_stream(radio: IcomRadio) -> _StatefulFakeStream:
+    stream = _StatefulFakeStream()
+    radio._audio_stream = stream  # type: ignore[assignment]
+    radio._audio_transport = MagicMock()
+    return stream
+
+
+# ── AudioSession.reestablish — live demand, declared order, no leaks ─────────
+
+
+async def test_reestablish_rearms_rx_only_from_live_demand() -> None:
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("web")
+    _wipe(radio)
+    assert session.bus.rx_active is True  # the stale flag the bus can't see
+
+    await session.reestablish()
+
+    assert radio.state == "receiving"
+    # Re-armed THROUGH the session's bus — never a bypassing legacy replay.
+    # (== — bound-method objects are recreated per attribute access.)
+    assert radio.rx_callback == session.bus._on_opus_packet  # noqa: SLF001
+    assert session.state is AudioSessionState.RX_ONLY
+    assert session.bus.subscriber_count == 1  # no leaked/dropped subscription
+    radio.rx_callback(_PACKET)  # type: ignore[operator]
+    assert await sub.get(timeout=1.0) == _PACKET
+    await session.reestablish()  # idempotent — already-live legs left alone
+    assert radio.state == "receiving"
+    await sub.release()
+    assert session.state is AudioSessionState.IDLE
+
+
+@pytest.mark.parametrize("make_radio", [LanLikeRadio, ExclusiveUsbRadio])
+async def test_reestablish_rx_tx_in_transport_declared_order(
+    make_radio: type,
+) -> None:
+    """The legacy replay hardcoded rx-then-tx; the session reads MOR-575."""
+    radio = make_radio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("bridge")
+    lease = await session.acquire_tx("bridge")
+    if isinstance(radio, ExclusiveUsbRadio):
+        radio.rx_running = False
+        radio.tx_running = False
+        radio.rx_callback = None
+        radio.calls.clear()
+        await session.reestablish()
+        assert radio.calls == ["start_tx", "start_rx"]  # atomic order
+        assert radio.rx_running is True  # no silent -50-shaped RX kill
+        assert radio.tx_running is True
+    else:
+        _wipe(radio)
+        await session.reestablish()
+        assert radio.calls == ["start_rx", "start_tx"]  # rx_first order
+        assert radio.state == "transmitting"
+        assert radio.rx_callback is not None  # RX leg survived
+    assert session.state is AudioSessionState.RX_TX
+    await lease.release()
+    await sub.release()
+
+
+async def test_reestablish_with_idle_demand_arms_nothing() -> None:
+    """Demand dropped during the outage stays dropped — no resurrection."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("web")
+    await sub.release()
+    radio.calls.clear()
+    await session.reestablish()
+    assert radio.calls == []
+    assert session.state is AudioSessionState.IDLE
+    assert session._watchdog_task is None  # noqa: SLF001
+
+
+async def test_reestablish_returns_recovering_session_to_demand_state() -> None:
+    radio = LanLikeRadio()
+    session = AudioSession(radio, watchdog_interval=0.02, rx_liveness_timeout=0.06)
+    sub = await session.subscribe_rx("web")
+    deadline = asyncio.get_running_loop().time() + 2.0
+    while (
+        session.state is not AudioSessionState.RECOVERING
+        and asyncio.get_running_loop().time() < deadline
+    ):
+        await asyncio.sleep(0.005)
+    assert session.state is AudioSessionState.RECOVERING
+    _wipe(radio)
+    await session.reestablish()
+    assert session.state is AudioSessionState.RX_ONLY
+    assert session._recovering_from is None  # noqa: SLF001
+    await sub.release()
+
+
+async def test_reestablish_rx_failure_raises_and_keeps_demand() -> None:
+    radio = _RxFailsOnRearmRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("web")
+    _wipe(radio)
+    radio.fail_rx = True
+    with pytest.raises(RuntimeError):
+        await session.reestablish()
+    assert session.bus.rx_active is False  # reality surfaced, not masked
+    assert session.rx_demand == 1  # demand preserved — next reconnect retries
+    radio.fail_rx = False
+    await session.reestablish()
+    assert session.state is AudioSessionState.RX_ONLY
+    await sub.release()
+
+
+async def test_reestablish_tx_failure_settles_rx_only() -> None:
+    radio = _TxFailsOnRearmRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("web")
+    lease = await session.acquire_tx("ptt")
+    _wipe(radio)
+    radio.fail_tx = True
+    await session.reestablish()  # no raise — same policy as the deferred arm
+    assert session.state is AudioSessionState.RX_ONLY
+    assert radio.state == "receiving"  # RX leg is back regardless
+    assert session.tx_demand == 1  # lease kept; next demand edge retries
+    await lease.release()
+    await sub.release()
+
+
+async def test_no_leaked_watchdog_task_across_reconnect_cycle() -> None:
+    """MOR-567/MOR-581 hygiene: one watchdog task across the whole cycle."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("web")
+    task = session._watchdog_task  # noqa: SLF001
+    assert task is not None and not task.done()
+    _wipe(radio)
+    await session.reestablish()
+    assert session._watchdog_task is task  # noqa: SLF001 — reused, not piled
+    assert not task.done()
+    await sub.release()
+    assert session._watchdog_task is None  # noqa: SLF001
+    assert task.done()  # cancelled AND awaited — nothing leaked
+
+
+# ── Recovery runtime routing (the desync falsification) ──────────────────────
+
+
+async def test_recover_reestablishes_live_demand_not_stale_snapshot() -> None:
+    """THE MOR-586 desync: TX demand dropped during the outage.
+
+    Legacy replay re-arms the snapshot's TX leg → the transport ends
+    TRANSMITTING while the session (demand-derived) says RX_ONLY. The fix
+    re-establishes from live demand: RX back via the session's bus, no TX.
+    """
+    radio = _make_radio()
+    _install_stream(radio)
+    session = radio.audio_session
+    sub = await session.subscribe_rx("web")
+    lease = await session.acquire_tx("ptt")
+    assert session.state is AudioSessionState.RX_TX
+
+    snapshot = radio._audio_runtime.capture_snapshot()
+    assert snapshot is not None  # reconnect hooks gate recovery on this
+    await lease.release()  # demand edge during the outage window
+    assert session.state is AudioSessionState.RX_ONLY
+
+    fresh = _install_stream(radio)  # transport rebuilt by the reconnect
+    await radio._audio_runtime.recover(snapshot)
+
+    assert fresh.state is AudioState.RECEIVING  # NOT TRANSMITTING (desync)
+    assert fresh.start_tx_count == 0  # nobody holds a TX lease anymore
+    assert session.state is AudioSessionState.RX_ONLY
+    # RX re-armed through the session's bus — the same single fan-out.
+    assert fresh.last_start_rx_callback == session.bus._on_opus_packet  # noqa: SLF001
+    assert session.bus.subscriber_count == 1  # no leaked subscription
+    await sub.release()
+
+
+async def test_recover_with_all_demand_dropped_resurrects_nothing() -> None:
+    radio = _make_radio()
+    _install_stream(radio)
+    session = radio.audio_session
+    sub = await session.subscribe_rx("web")
+    snapshot = radio._audio_runtime.capture_snapshot()
+    assert snapshot is not None
+    await sub.release()  # last consumer left during the outage
+
+    fresh = _install_stream(radio)
+    await radio._audio_runtime.recover(snapshot)
+
+    assert fresh.start_rx_count == 0  # no re-armed leg without a consumer
+    assert fresh.start_tx_count == 0
+    assert session.state is AudioSessionState.IDLE
+
+
+async def test_recover_without_session_demand_keeps_legacy_replay() -> None:
+    """Direct legacy ``*_opus`` consumers (no session) keep the replay."""
+    radio = _make_radio()
+    stream = _install_stream(radio)
+    legacy_cb = MagicMock()
+    await radio.start_audio_rx_opus(legacy_cb, jitter_depth=3)
+    assert stream.state is AudioState.RECEIVING
+
+    snapshot = radio._audio_runtime.capture_snapshot()
+    assert snapshot is not None
+    fresh = _install_stream(radio)
+    await radio._audio_runtime.recover(snapshot)
+
+    assert fresh.start_rx_count == 1
+    assert fresh.last_start_rx_callback is legacy_cb
+    assert fresh.last_start_rx_jitter_depth == 3
+    # Probing for a session must never instantiate one as a side effect.
+    assert radio._audio_session is None
+
+
+async def test_recover_session_path_emits_recovering_then_recovered() -> None:
+    recovery_cb = MagicMock()
+    radio = _make_radio(on_audio_recovery=recovery_cb)
+    _install_stream(radio)
+    sub = await radio.audio_session.subscribe_rx("web")
+    snapshot = radio._audio_runtime.capture_snapshot()
+    assert snapshot is not None
+
+    _install_stream(radio)
+    await radio._audio_runtime.recover(snapshot)
+
+    states = [c.args[0] for c in recovery_cb.call_args_list]
+    assert states == [AudioRecoveryState.RECOVERING, AudioRecoveryState.RECOVERED]
+    await sub.release()
+
+
+async def test_recover_session_path_emits_failed_on_dead_rx() -> None:
+    class _DeadRxStream(_StatefulFakeStream):
+        async def start_rx(
+            self, callback: object, *, jitter_depth: int | None = None
+        ) -> None:
+            raise ConnectionError("audio port gone")
+
+    recovery_cb = MagicMock()
+    radio = _make_radio(on_audio_recovery=recovery_cb)
+    _install_stream(radio)
+    sub = await radio.audio_session.subscribe_rx("web")
+    snapshot = radio._audio_runtime.capture_snapshot()
+    assert snapshot is not None
+
+    dead = _DeadRxStream()
+    radio._audio_stream = dead  # type: ignore[assignment]
+    await radio._audio_runtime.recover(snapshot)  # logged, never raises
+
+    states = [c.args[0] for c in recovery_cb.call_args_list]
+    assert states == [AudioRecoveryState.RECOVERING, AudioRecoveryState.FAILED]
+    assert radio.audio_session.bus.rx_active is False  # reality, not masked
+    await sub.release()


### PR DESCRIPTION
## Summary

Epic MOR-562 step 20 — recovery unification (ADR §3.4 rule 4, "one recovery loop"). Linear: MOR-586.

### The latent bypass bug

`runtime/_audio_recovery.py` predates the AudioSession: on transport reconnect (LAN reconnect loop + EPIPE-storm audio watchdog in `runtime/radio_reconnect.py`) it replayed the legacy `*_opus`/`*_pcm` start methods from a pre-disconnect snapshot. After the MOR-562 migration the session owns the radio RX/TX legs, so the replay re-armed the radio **behind the session**:

- demand dropped during the outage was **resurrected** (a re-armed radio leg with zero consumers draining it);
- a stale snapshot TX leg left the transport `TRANSMITTING` while the session's demand-derived state said `RX_ONLY` — **session vs radio desync**;
- the replay order was hardcoded rx-then-tx, ignoring the MOR-575 `audio_setup_order` descriptor.

### The mechanism

- **`AudioSession.reestablish()`** (new, `audio/session.py`): re-arms the radio legs from the **live demand counters** — never the snapshot — under the session lock, in the transport-declared order (`tx_first`/`atomic`: TX before RX joins the device, the MOR-559 order). RX re-arm goes through `bus.restart_rx()` (the bus's own callback — single fan-out preserved). Idempotent (typed already-started errors are benign). A dead RX leg raises so the caller surfaces FAILED (demand preserved; the next reconnect or demand edge retries); a TX re-arm failure settles at RX_ONLY, mirroring the deferred-arm policy, and never leaves TX without RX. Resets the watchdog liveness reference so the fresh leg gets its grace window; clears `RECOVERING` shadowing.
- **`AudioRecoveryRuntime`** (`runtime/_audio_recovery.py`): `recover()` routes through `session.reestablish()` when the session holds live demand; otherwise falls back to the legacy replay (extracted unchanged into `_replay_legacy`). The probe reads the **private `_audio_session` slot** (web-server runtime-payload pattern) rather than the lazy `audio_session` property, so probing never instantiates a session on a legacy-only radio. `capture_snapshot()` returns a marker snapshot when session demand is live, so the reconnect hooks' `snapshot is not None` gating becomes demand-driven (covers RX dying before the reconnect fires). The `RECOVERING`/`RECOVERED`/`FAILED` callback surface and the reconnect hooks themselves are unchanged.

### Moved to the session vs kept legacy

- **Moved**: all session-managed audio (bus subscribers — web relay, bridge, recorder — and TX leases) now recovers exclusively through the session's live demand.
- **Kept legacy**: direct `*_opus`/`*_pcm` consumers with no session demand (public API users; pinned by `tests/test_audio_recovery.py`, untouched and green, plus a new fallback test).
- **Bridge radio-side fold**: no `bridge.py` change needed — landed **by construction**. The bridge's reconnect state machine is device-side only (loopback stream errors); its radio-side demand already lives in session handles (MOR-577) that survive the outage and are re-armed by `reestablish()`. Nothing remained to migrate or delete.

### Desync falsification (RED → GREEN)

On the pre-fix code, `tests/test_audio_recovery_session.py` fails exactly on the inconsistency:

- `test_recover_reestablishes_live_demand_not_stale_snapshot` — RED: `AudioState.TRANSMITTING is not RECEIVING` (legacy replay re-armed the released TX lease; session said RX_ONLY).
- `test_recover_with_all_demand_dropped_resurrects_nothing` — RED: `start_rx_count 1 != 0` (replay re-armed RX with no consumer).
- Plus: declared-order re-arm (rx_first vs atomic), RX-failure → `RuntimeError` + FAILED, TX-failure → RX_ONLY with leases kept, recovery-callback state sequences, legacy fallback without session instantiation, and no leaked watchdog task / bus subscription across a reconnect cycle (MOR-567/MOR-581 hygiene).

### Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7551 passed**, 1 failed: `tests/smoke/test_audio_path_smoke.py::test_web_audio_ws_relays_nonsilent_rx_frames` — **pre-existing on origin/main @ ddd8c232** (verified failing identically on a clean baseline worktree): the MOR-584 per-connection egress merge sends a text WS frame before binary audio, breaking the MOR-583 smoke test from the previous commit. The fix belongs to the parallel PR touching `web/handlers/audio.py` + frontend (out of bounds for this PR).
- `uv run ruff check src/ tests/` — clean; `ruff format --check` — clean.
- `uv run mypy src/` — baseline exactly **21 errors in 8 files** (no new).
- `uv run lint-imports` — **4 kept, 0 broken**.
- MOR-567 conformance, MOR-576/581 session/health, `tests/test_audio_recovery.py`, smoke (except the pre-existing failure above) — green.

### Deferred

- **Live reconnect re-validation is operator-gated** (radio offline): IC-7610 LAN EPIPE / network-blip recovery and FTX-1 USB replug must be re-validated on hardware before this is considered live-proven. Gate here is fakes + conformance + smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)