### PR TITLE
feat(MOR-585): client link-quality uplink (audio_stats) for adaptive codec

### DIFF
--- a/frontend/src/lib/audio/__tests__/audio-manager.test.ts
+++ b/frontend/src/lib/audio/__tests__/audio-manager.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const rxStart = vi.fn();
 const rxStop = vi.fn();
 const rxFlush = vi.fn();
 const rxSetJitterBounds = vi.fn();
+const rxStats = vi.fn(() => ({ underruns: 3, bufferDepthMs: 140, droppedFrames: 2 }));
 const txStart = vi.fn().mockResolvedValue(null);
 const txStop = vi.fn();
 
@@ -13,6 +14,7 @@ vi.mock('../rx-player', () => ({
     stop = rxStop;
     flush = rxFlush;
     setJitterBounds = rxSetJitterBounds;
+    stats = rxStats;
     setFocus = vi.fn();
     setSplitStereo = vi.fn();
     setChannelGainDb = vi.fn();
@@ -144,5 +146,76 @@ describe('AudioManager websocket subscriptions', () => {
       direction: 'rx',
       preferred_rx_codec: 'pcm16',
     }));
+  });
+});
+
+describe('AudioManager audio_stats uplink (MOR-585)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5173' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function statsMessages(ws: FakeWebSocket): unknown[] {
+    return ws.sent
+      .map((s) => JSON.parse(s as string))
+      .filter((m) => m.type === 'audio_stats');
+  }
+
+  it('sends periodic audio_stats with player counters while RX is active', async () => {
+    const { audioManager } = await import('../audio-manager');
+
+    audioManager.startRx();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    ws.sent = [];
+
+    vi.advanceTimersByTime(1500);
+    expect(statsMessages(ws)).toEqual([{
+      type: 'audio_stats',
+      underruns: 3,
+      buffer_depth_ms: 140,
+      dropped_frames: 2,
+    }]);
+
+    vi.advanceTimersByTime(3000);
+    expect(statsMessages(ws).length).toBe(3);  // low rate: one per 1.5 s
+
+    audioManager.stopRx();
+  });
+
+  it('does not send audio_stats when only TX is active', async () => {
+    const { audioManager } = await import('../audio-manager');
+
+    await audioManager.startTx();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    ws.sent = [];
+
+    vi.advanceTimersByTime(5000);
+    expect(statsMessages(ws)).toEqual([]);
+
+    audioManager.stopTx();
+  });
+
+  it('clears the stats timer on close — no timer leak after stopRx', async () => {
+    const { audioManager } = await import('../audio-manager');
+
+    audioManager.startRx();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+
+    audioManager.stopRx();
+    ws.sent = [];
+    vi.advanceTimersByTime(10000);
+    expect(statsMessages(ws)).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/frontend/src/lib/audio/__tests__/rx-player.test.ts
+++ b/frontend/src/lib/audio/__tests__/rx-player.test.ts
@@ -307,6 +307,99 @@ describe('RxPlayer suspended-context recovery (MOR-239)', () => {
   });
 });
 
+describe('RxPlayer link-quality stats (MOR-585)', () => {
+  it('starts with zeroed stats', () => {
+    const p = new RxPlayer();
+    p.start();
+    expect(p.stats()).toEqual({ underruns: 0, bufferDepthMs: 0, droppedFrames: 0 });
+    p.stop();
+  });
+
+  it('does NOT count the initial priming rebase as an underrun', () => {
+    const p = new RxPlayer();
+    p.start();
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));           // first frame: nextPlayTime 0 → floor rebase
+    expect(p.stats().underruns).toBe(0);
+    p.stop();
+  });
+
+  it('counts a real underrun when playback catches up with the schedule', () => {
+    const p = new RxPlayer();
+    p.start();
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));           // primes: nextPlayTime ≈ 0.06
+    ctx.currentTime = 10;         // playback ran past the buffer — it drained
+    p.feed(pcm16(480));           // late frame → rebase = underrun
+    expect(p.stats().underruns).toBe(1);
+    p.stop();
+  });
+
+  it('flush() rebase after reconnect is not an underrun', () => {
+    const p = new RxPlayer();
+    p.start();
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));
+    p.flush();                    // reconnect path resets the schedule
+    ctx.currentTime = 10;
+    p.feed(pcm16(480));
+    expect(p.stats().underruns).toBe(0);
+    p.stop();
+  });
+
+  it('reports current jitter-buffer depth in ms', () => {
+    const p = new RxPlayer();
+    p.start();
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));           // floor 50 ms + 10 ms frame → 60 ms ahead
+    expect(p.stats().bufferDepthMs).toBe(60);
+    p.stop();
+  });
+
+  it('buffer depth is 0 when idle or stopped', () => {
+    const p = new RxPlayer();
+    expect(p.stats().bufferDepthMs).toBe(0);
+    p.start();
+    expect(p.stats().bufferDepthMs).toBe(0);
+    p.stop();
+    expect(p.stats().bufferDepthMs).toBe(0);
+  });
+
+  it('counts frames dropped at the jitter ceiling', () => {
+    const p = new RxPlayer();
+    p.start();
+    p.setJitterBounds(50, 65);    // ceiling between frame boundaries (no FP ties)
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));           // → 0.06
+    p.feed(pcm16(480));           // 0.06 < 0.065 → scheduled → 0.07
+    p.feed(pcm16(480));           // 0.07 > 0.065 → dropped
+    expect(p.stats().droppedFrames).toBe(1);
+    p.stop();
+  });
+
+  it('counts frames dropped while the context is suspended', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    ctx.state = 'suspended';
+    const p = new RxPlayer();
+    p.start();
+    p.feed(pcm16(480));
+    expect(p.stats().droppedFrames).toBe(1);
+    p.stop();
+    warn.mockRestore();
+  });
+
+  it('stop() resets all counters', () => {
+    const p = new RxPlayer();
+    p.start();
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));
+    ctx.currentTime = 10;
+    p.feed(pcm16(480));           // 1 underrun
+    p.stop();
+    expect(p.stats()).toEqual({ underruns: 0, bufferDepthMs: 0, droppedFrames: 0 });
+  });
+});
+
 describe('RxPlayer mono routing (MOR-239)', () => {
   it('routes a mono (1-ch) PCM16 buffer to the audible MAIN channel', () => {
     const p = new RxPlayer();

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -25,6 +25,9 @@ export interface AudioRoutingConfig {
 
 const BACKOFF_MIN = 500;
 const BACKOFF_MAX = 10000;
+// Link-quality uplink rate (MOR-585, ADR §3.6): low — one audio_stats
+// message per 1.5 s while RX is active.
+const AUDIO_STATS_INTERVAL_MS = 1500;
 
 function preferredRxCodec(): 'opus' | 'pcm16' {
   const globals = globalThis as typeof globalThis & {
@@ -45,6 +48,7 @@ class AudioManager {
   private _txEnabled = false;
   private backoff = BACKOFF_MIN;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private statsTimer: ReturnType<typeof setInterval> | null = null;
   private _listeners: Set<() => void> = new Set();
 
   // Reactive state (read externally)
@@ -248,6 +252,7 @@ class AudioManager {
       if (this._audioConfigPending) {
         this._flushPendingAudioConfig();
       }
+      this._startStatsTimer();
       this.rxPlayer.flush();
       this.notify();
     };
@@ -265,6 +270,7 @@ class AudioManager {
 
     ws.onclose = (ev) => {
       console.warn(`[audio-ws] closed code=${ev.code} reason=${ev.reason}`);
+      this._clearStatsTimer();
       this.ws = null;
       setAudioConnected(false);
       this.notify();
@@ -276,7 +282,38 @@ class AudioManager {
     };
   }
 
+  // ── Link-quality uplink (MOR-585, ADR §3.6) ──
+  //
+  // While RX is active, periodically reports the player's link-quality
+  // counters so the server can record them per client (the step-19
+  // adaptive codec controller's client-side signal). Stats only — the
+  // server changes no behavior on receipt.
+
+  private _startStatsTimer(): void {
+    if (this.statsTimer) return;
+    this.statsTimer = setInterval(() => this._sendAudioStats(), AUDIO_STATS_INTERVAL_MS);
+  }
+
+  private _clearStatsTimer(): void {
+    if (this.statsTimer) {
+      clearInterval(this.statsTimer);
+      this.statsTimer = null;
+    }
+  }
+
+  private _sendAudioStats(): void {
+    if (!this._rxEnabled || this.ws?.readyState !== WebSocket.OPEN) return;
+    const stats = this.rxPlayer.stats();
+    this.ws.send(JSON.stringify({
+      type: 'audio_stats',
+      underruns: stats.underruns,
+      buffer_depth_ms: stats.bufferDepthMs,
+      dropped_frames: stats.droppedFrames,
+    }));
+  }
+
   private close(): void {
+    this._clearStatsTimer();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/frontend/src/lib/audio/rx-player.ts
+++ b/frontend/src/lib/audio/rx-player.ts
@@ -57,6 +57,14 @@ export class RxPlayer {
   private _droppedSuspendedFrames = 0;
   private _resumeListenersAttached = false;
 
+  // Link-quality counters for the periodic audio_stats uplink (MOR-585,
+  // ADR §3.6). Real playback underruns (the jitter buffer ran dry while
+  // playing — NOT the priming rebase after start()/flush()) plus all
+  // frames the player dropped (suspended context, jitter ceiling).
+  // Cumulative since start(); reset on stop().
+  private _underruns = 0;
+  private _droppedFrames = 0;
+
   get volume(): number {
     return this._volume;
   }
@@ -167,6 +175,24 @@ export class RxPlayer {
     this.nextPlayTime = 0;
     this.opusTs = 0;
     this._droppedSuspendedFrames = 0;
+    this._underruns = 0;
+    this._droppedFrames = 0;
+  }
+
+  /** Link-quality snapshot for the periodic audio_stats uplink (MOR-585).
+   *  bufferDepthMs is the audio currently scheduled ahead of playback —
+   *  the live jitter-buffer depth; 0 when idle or stopped. */
+  stats(): { underruns: number; bufferDepthMs: number; droppedFrames: number } {
+    let depthMs = 0;
+    if (this.ctx) {
+      const depth = (this.nextPlayTime - this.ctx.currentTime) * 1000;
+      if (depth > 0) depthMs = Math.round(depth);
+    }
+    return {
+      underruns: this._underruns,
+      bufferDepthMs: depthMs,
+      droppedFrames: this._droppedFrames,
+    };
   }
 
   /** Best-effort resume of a suspended context. Safe to call repeatedly. */
@@ -218,6 +244,7 @@ export class RxPlayer {
     if (this.ctx.state === 'suspended') {
       this._resume();
       this._droppedSuspendedFrames++;
+      this._droppedFrames++;
       if (this._droppedSuspendedFrames <= 3 || this._droppedSuspendedFrames % 200 === 0) {
         console.warn(
           `RxPlayer: AudioContext suspended — dropped ${this._droppedSuspendedFrames} ` +
@@ -323,9 +350,16 @@ export class RxPlayer {
 
     const now = this.ctx.currentTime;
     if (this.nextPlayTime < now + this._floorSec / 2) {
+      // A rebase while a schedule exists means playback caught up with
+      // the buffered audio — a real underrun (MOR-585), distinct from
+      // the priming rebase after start()/flush() where nextPlayTime is 0.
+      if (this.nextPlayTime > 0) this._underruns++;
       this.nextPlayTime = now + this._floorSec;
     }
-    if (this.nextPlayTime > now + this._ceilingSec) return;
+    if (this.nextPlayTime > now + this._ceilingSec) {
+      this._droppedFrames++;
+      return;
+    }
 
     src.start(this.nextPlayTime);
     this.nextPlayTime += buf.duration;

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -122,6 +122,13 @@ class AudioBroadcaster:
         self._client_opus_transcoders: dict[
             int, tuple[PcmOpusTranscoder, tuple[int, int, int]]
         ] = {}
+        # Per-client link-quality state (MOR-585, ADR §3.6): the latest
+        # client-reported ``audio_stats`` snapshot plus the server-side
+        # drop-oldest eviction counter for the bounded WS queue.  Stats
+        # collection only — read by the step-19 adaptive egress codec
+        # controller; nothing here changes codec selection or behavior.
+        self._client_link_quality: dict[int, dict[str, int | float]] = {}
+        self._client_queue_drops: dict[int, int] = {}
         self._browser_opus_warned: bool = False
         self._lock = asyncio.Lock()
         # Optional DSP pipeline (inserted between codec decode and tap/distribute).
@@ -191,6 +198,8 @@ class AudioBroadcaster:
             self._client_ws.pop(client_id, None)
             self._client_rx_codec.pop(client_id, None)
             self._client_opus_transcoders.pop(client_id, None)
+            self._client_link_quality.pop(client_id, None)
+            self._client_queue_drops.pop(client_id, None)
             if (
                 not self._clients
                 and self._subscription is not None
@@ -299,6 +308,8 @@ class AudioBroadcaster:
                 self._client_ws.pop(cid, None)
                 self._client_rx_codec.pop(cid, None)
                 self._client_opus_transcoders.pop(cid, None)
+                self._client_link_quality.pop(cid, None)
+                self._client_queue_drops.pop(cid, None)
             # Stop relay if no clients remain (and no PCM tap active)
             if (
                 not self._clients
@@ -435,6 +446,41 @@ class AudioBroadcaster:
             "channels": self._channels,
             "frame_ms": 20,
         }
+
+    def record_client_stats(
+        self,
+        queue: asyncio.Queue[bytes],
+        stats: dict[str, int | float],
+    ) -> None:
+        """Record one client's latest self-reported link-quality (MOR-585).
+
+        Latest-wins snapshot from the periodic ``audio_stats`` uplink
+        (underruns, buffer depth, client-side drops).  Ignored for
+        queues not (or no longer) subscribed, so a stats message racing
+        a disconnect cannot leak per-client state.
+        """
+        client_id = id(queue)
+        if client_id not in self._clients:
+            return
+        self._client_link_quality[client_id] = dict(stats)
+
+    def client_link_quality(
+        self, queue: asyncio.Queue[bytes]
+    ) -> dict[str, int | float]:
+        """One client's link-quality snapshot (MOR-585, ADR §3.6).
+
+        The latest client-reported ``audio_stats`` fields merged with the
+        server-side ``ws_queue_drops`` counter (drop-oldest evictions of
+        the bounded per-client WS queue).  This is the signal surface the
+        step-19 adaptive egress codec controller and the ``rx.egress``
+        taps read; nothing in this step consumes it.
+        """
+        client_id = id(queue)
+        snapshot: dict[str, int | float] = dict(
+            self._client_link_quality.get(client_id, {})
+        )
+        snapshot["ws_queue_drops"] = self._client_queue_drops.get(client_id, 0)
+        return snapshot
 
     def _encode_client_rx_frame(
         self,
@@ -649,6 +695,13 @@ class AudioBroadcaster:
                     try:
                         q.put_nowait(frame)
                     except asyncio.QueueFull:
+                        # Drop-oldest eviction: count it per client — this
+                        # is the server-side WS congestion signal for the
+                        # adaptive egress codec controller (MOR-585,
+                        # ADR §3.6 detection-signals table).
+                        self._client_queue_drops[client_id] = (
+                            self._client_queue_drops.get(client_id, 0) + 1
+                        )
                         try:
                             q.get_nowait()
                         except asyncio.QueueEmpty:
@@ -663,6 +716,8 @@ class AudioBroadcaster:
                     self._client_ws.pop(client_id, None)
                     self._client_rx_codec.pop(client_id, None)
                     self._client_opus_transcoders.pop(client_id, None)
+                    self._client_link_quality.pop(client_id, None)
+                    self._client_queue_drops.pop(client_id, None)
                     logger.info("audio-broadcaster: removed dead client during relay")
                 if dead_ids:
                     self._notify_client_count_change()
@@ -718,6 +773,10 @@ class AudioHandler:
         self._tx_lease: TxLease | None = None
         self._tx_stop_lock = asyncio.Lock()
         self._seq: int = 0
+        # Latest client-reported link-quality snapshot from the periodic
+        # ``audio_stats`` uplink (MOR-585) — mirrored per client on the
+        # broadcaster while RX is subscribed.
+        self._link_quality: dict[str, int | float] = {}
         self._frame_queue: asyncio.Queue[bytes] = asyncio.Queue()
         self._done = asyncio.Event()
         # Opus decoder for TX when radio uses PCM codec.
@@ -806,8 +865,14 @@ class AudioHandler:
 
     async def _handle_control(self, msg: dict[str, Any]) -> None:
         """Handle audio_start / audio_stop messages."""
-        logger.info("audio: control msg: %s", msg)
         msg_type = msg.get("type", "")
+        # Periodic audio_stats (~1.5 s per client, MOR-585) stays at DEBUG;
+        # everything else keeps the established INFO trace.
+        logger.log(
+            logging.DEBUG if msg_type == "audio_stats" else logging.INFO,
+            "audio: control msg: %s",
+            msg,
+        )
         direction = msg.get("direction", "rx")
 
         if msg_type == "audio_start":
@@ -854,6 +919,28 @@ class AudioHandler:
                 await self._stop_tx(reason="client request", force=True)
         elif msg_type == "audio_config":
             await self._handle_audio_config(msg)
+        elif msg_type == "audio_stats":
+            self._handle_audio_stats(msg)
+
+    def _handle_audio_stats(self, msg: dict[str, Any]) -> None:
+        """Record the client's periodic link-quality report (MOR-585).
+
+        Stats collection only (ADR §3.6 step 18): the browser player
+        reports playback ``underruns``, ``buffer_depth_ms`` and
+        ``dropped_frames`` every ~1.5 s; only numeric fields are kept
+        (latest-wins), and unknown numeric fields pass through so future
+        carriers (WebRTC RTCP, step 19) can reuse the envelope.  Clients
+        that never send ``audio_stats`` are entirely unaffected.
+        """
+        stats: dict[str, int | float] = {}
+        for key, value in msg.items():
+            if key == "type" or isinstance(value, bool):
+                continue
+            if isinstance(value, (int, float)):
+                stats[key] = value
+        self._link_quality = stats
+        if self._rx_active and self._broadcaster is not None:
+            self._broadcaster.record_client_stats(self._frame_queue, stats)
 
     async def _stop_tx(
         self,

--- a/tests/smoke/test_audio_path_smoke.py
+++ b/tests/smoke/test_audio_path_smoke.py
@@ -372,7 +372,16 @@ async def test_web_audio_ws_relays_nonsilent_rx_frames(usb_rig: _UsbSerialRig) -
                 usb_rig.inject_rx(_NONSILENT_PCM)
                 await asyncio.sleep(0)
 
-            opcode, payload = await _ws_recv_frame(reader)
+            # The server may send JSON text control messages on the same WS
+            # before the first audio frame — e.g. the per-connection
+            # ``audio_format`` ack (MOR-584). This smoke test pins binary
+            # audio FLOW, not the control-message choreography: skip the
+            # bounded text preamble. (Pre-existing #1770×#1771 semantic
+            # conflict on main; surfaced while landing MOR-585.)
+            for _ in range(10):
+                opcode, payload = await _ws_recv_frame(reader)
+                if opcode != 0x1:
+                    break
             assert opcode == 0x2, "audio frames must arrive as binary WS frames"
             assert payload[0] == MSG_TYPE_AUDIO_RX
             audio = payload[AUDIO_HEADER_SIZE:]

--- a/tests/test_web_audio_link_quality.py
+++ b/tests/test_web_audio_link_quality.py
@@ -1,0 +1,190 @@
+"""Client link-quality uplink (MOR-585, ADR §3.6 — step 18 of MOR-562).
+
+Falsification suite: the server must RECORD per-client link-quality
+signals so the step-19 adaptive egress codec controller can later read
+them — an inbound ``audio_stats`` message updates the per-client
+snapshot, and the broadcaster's drop-oldest queue eviction increments
+an observable per-client counter.
+
+[BP] stats collection only: a client that never sends ``audio_stats``
+behaves exactly as before — no error, codec unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.audio_bus import AudioBus
+from rigplane.radio_protocol import AudioCapable
+from rigplane.types import AudioCodec
+from rigplane.web.handlers import AudioBroadcaster, AudioHandler
+from rigplane.web.protocol import AUDIO_CODEC_PCM16, AUDIO_HEADER_SIZE
+from rigplane.web.websocket import WebSocketConnection
+
+# 20 ms @ 48 kHz mono s16le.
+PCM_PAYLOAD = b"\x01\x02" * 960
+
+STATS_MSG: dict[str, Any] = {
+    "type": "audio_stats",
+    "underruns": 3,
+    "buffer_depth_ms": 140,
+    "dropped_frames": 2,
+}
+
+
+def _make_radio() -> tuple[Any, AudioBus]:
+    radio = MagicMock(spec=AudioCapable)
+    radio.capabilities = {"audio"}
+    radio.audio_codec = AudioCodec.PCM_1CH_16BIT
+    radio.audio_sample_rate = 48000
+    radio.start_audio_rx_opus = AsyncMock()
+    radio.stop_audio_rx_opus = AsyncMock()
+    bus = AudioBus(radio)
+    radio.audio_bus = bus
+    return radio, bus
+
+
+def _make_ws() -> MagicMock:
+    ws = MagicMock(spec=WebSocketConnection)
+    ws.send_text = AsyncMock()
+    return ws
+
+
+async def _inject(bus: AudioBus, count: int = 1) -> None:
+    for _ in range(count):
+        pkt = MagicMock()
+        pkt.data = PCM_PAYLOAD
+        bus._on_opus_packet(pkt)
+    await asyncio.sleep(0.1)
+
+
+class TestAudioStatsUplink:
+    async def test_audio_stats_records_per_client_link_quality(self) -> None:
+        """An inbound audio_stats message must update both the handler's
+        snapshot and the broadcaster's per-client map (the structure the
+        step-19 controller reads)."""
+        radio, _bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx()
+
+        await handler._handle_control(dict(STATS_MSG))
+
+        expected = {"underruns": 3, "buffer_depth_ms": 140, "dropped_frames": 2}
+        assert handler._link_quality == expected
+        snapshot = broadcaster.client_link_quality(handler._frame_queue)
+        assert snapshot == {**expected, "ws_queue_drops": 0}
+
+    async def test_latest_stats_win(self) -> None:
+        radio, _bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx()
+
+        await handler._handle_control(dict(STATS_MSG))
+        await handler._handle_control(
+            {"type": "audio_stats", "underruns": 7, "buffer_depth_ms": 60}
+        )
+
+        snapshot = broadcaster.client_link_quality(handler._frame_queue)
+        assert snapshot == {
+            "underruns": 7,
+            "buffer_depth_ms": 60,
+            "ws_queue_drops": 0,
+        }
+
+    async def test_non_numeric_fields_are_dropped(self) -> None:
+        """Defensive contract: only numeric signals are recorded — a
+        malicious/buggy client cannot park arbitrary payloads server-side."""
+        radio, _bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx()
+
+        await handler._handle_control(
+            {
+                "type": "audio_stats",
+                "underruns": 1,
+                "note": "free text",
+                "flag": True,
+                "blob": {"a": 1},
+                "nothing": None,
+            }
+        )
+
+        snapshot = broadcaster.client_link_quality(handler._frame_queue)
+        assert snapshot == {"underruns": 1, "ws_queue_drops": 0}
+
+    async def test_stats_before_rx_start_do_not_register_with_broadcaster(
+        self,
+    ) -> None:
+        """audio_stats before audio_start must not leak entries into the
+        broadcaster's per-client maps (the queue is not subscribed yet)."""
+        radio, _bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+
+        await handler._handle_control(dict(STATS_MSG))
+
+        assert handler._link_quality["underruns"] == 3
+        assert broadcaster._client_link_quality == {}
+
+
+class TestQueueDropCounter:
+    async def test_drop_oldest_eviction_increments_per_client_counter(self) -> None:
+        """Forcing the bounded per-client WS queue past its watermark must
+        evict-oldest AND count it — the counter is the server-side WS
+        congestion signal of ADR §3.6."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        broadcaster.HIGH_WATERMARK = 2  # tiny queue → forced evictions
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx()
+
+        await _inject(bus, count=4)  # nobody drains → 2 fill + 2 evictions
+
+        snapshot = broadcaster.client_link_quality(handler._frame_queue)
+        assert snapshot["ws_queue_drops"] == 2
+        # Eviction kept the stream flowing: queue still holds newest frames.
+        assert handler._frame_queue.qsize() == 2
+
+    async def test_unsubscribe_clears_link_quality_state(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        broadcaster.HIGH_WATERMARK = 2
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx()
+        await handler._handle_control(dict(STATS_MSG))
+        await _inject(bus, count=4)
+
+        await broadcaster.unsubscribe(handler._frame_queue)
+
+        assert broadcaster._client_link_quality == {}
+        assert broadcaster._client_queue_drops == {}
+
+
+class TestNoStatsClientUnchanged:
+    async def test_client_that_never_sends_audio_stats_behaves_as_today(
+        self,
+    ) -> None:
+        """[BP] gate: no audio_stats → no error envelope, frames still
+        arrive in the unchanged default PCM16 codec, and the link-quality
+        snapshot is just the zeroed server-side counter."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        ws = _make_ws()
+        handler = AudioHandler(ws, radio, broadcaster)
+        await handler._handle_control({"type": "audio_start", "direction": "rx"})
+        await _inject(bus)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_PCM16
+        assert frame[AUDIO_HEADER_SIZE:] == PCM_PAYLOAD
+        sent = [json.loads(c.args[0]) for c in ws.send_text.await_args_list]
+        assert [m for m in sent if m.get("type") == "error"] == []
+        assert broadcaster.client_link_quality(handler._frame_queue) == {
+            "ws_queue_drops": 0
+        }


### PR DESCRIPTION
## Summary

Step 18 of epic MOR-562 (ADR §3.6, `docs/plans/2026-06-09-target-audio-architecture.md`): give the server per-client link-quality signals so step 19 (adaptive egress codec controller) can consume them. **[BP] — stats collection only: no codec selection and no audio-behavior change.** The per-client PCM16/Opus choice from step 17 (MOR-584) is untouched, and a client that never sends `audio_stats` behaves exactly as today (pinned by test).

## `audio_stats` message shape (client → server, periodic ~1.5 s while RX active)

```json
{
  "type": "audio_stats",
  "underruns": 3,          // cumulative real playback underruns since player start
  "buffer_depth_ms": 140,  // current jitter-buffer depth (audio scheduled ahead)
  "dropped_frames": 2      // cumulative frames the player dropped (suspend + jitter ceiling)
}
```

Only numeric fields are recorded (latest-wins); unknown numeric fields pass through so future carriers (WebRTC RTCP, step 19) can reuse the envelope.

## Server (`src/rigplane/web/handlers/audio.py`)

- `AudioHandler._handle_audio_stats` records the snapshot on the handler (`_link_quality`) and mirrors it per client on the broadcaster while RX is subscribed (`record_client_stats`, guarded so a stats message racing a disconnect cannot leak state).
- The bounded per-client WS queue's drop-oldest eviction (previously unobservable) now increments a per-client `ws_queue_drops` counter — the server-side WS congestion signal from the ADR §3.6 detection-signals table.
- `AudioBroadcaster.client_link_quality(queue)` exposes the merged per-client snapshot (client-reported fields + `ws_queue_drops`) — the surface step 19 and the `rx.egress` taps will read.
- Per-client link-quality state is cleaned up on unsubscribe, reap, and dead-client removal alongside the existing per-client maps.
- The periodic `audio_stats` logs at DEBUG; all other control messages keep the INFO trace.

## Frontend (`frontend/src/lib/audio/`)

- `rx-player.ts`: real underrun counting — a non-priming jitter-schedule rebase (playback caught up with buffered audio) counts as one underrun; `start()`/`flush()` priming does not. Cumulative `droppedFrames` (suspended-context drops + jitter-ceiling drops). New `stats()` snapshot with live `bufferDepthMs`. Counters reset on `stop()`. (Previously only autoplay-suspend drops were counted, per the ADR note.)
- `audio-manager.ts`: `setInterval` started on WS open sends `audio_stats` every 1.5 s while RX is enabled; cleared in `close()` and `onclose` (no timer leak, pinned by test).

## Red → Green

- 7 new server tests (`tests/test_web_audio_link_quality.py`) written first — all RED (missing API), GREEN after implementation: stats recording, latest-wins, numeric-only filtering, no-leak-before-subscribe, forced queue-eviction counter (HIGH_WATERMARK=2 → 2 drops counted), cleanup on unsubscribe, and the [BP] no-stats-client-unchanged gate.
- 10 new frontend tests (rx-player: underruns/depth/drops/reset; audio-manager: periodic send shape + rate, RX-only gating, timer cleared on close) — RED first, GREEN after.

## Pre-existing main breakage fixed (flagged)

`tests/smoke/test_audio_path_smoke.py::test_web_audio_ws_relays_nonsilent_rx_frames` fails on `main` @ `ddd8c232` itself: #1770 (smoke test, expects the FIRST WS frame to be binary) and #1771 (MOR-584 `audio_format` text ack sent before binary frames) merged the same day and conflict semantically. The failure is visible in the latest quick-CI log on main (`FAILED ... audio frames must arrive as binary WS frames`) but the run reports success because the pytest exit code is swallowed by the `| tee pytest-output.txt` pipe (no `pipefail`) — separate CI issue worth its own fix. This PR makes the smoke test skip the bounded text preamble, preserving its intent (binary audio FLOW). Also seen in the same CI log: `tests/test_cli.py::TestBuildParser::test_discover_serial_alias_and_hamlib_flags` fails on CI only (passes locally) — not touched here.

## File count (flag)

7 files (> 3-file guardrail): 1 server, 2 frontend src, 2 frontend tests, 1 new server test file, 1 smoke-test fix — inherent to a server+frontend feature; each hunk is minimal.

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7546 passed**, 10 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failures
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → clean
- `uv run mypy src/` → **21 errors in 8 files** (exact baseline, no new)
- `uv run lint-imports` → **4 kept, 0 broken**
- Frontend: `npm run test` → **2063 passed (119 files)**; `npm run lint` → clean; `npm run check` → 0 errors/0 warnings; `npm run build` → success

## Not touched

`src/rigplane/audio/session.py`, `src/rigplane/audio/bridge.py`, `src/rigplane/runtime/_audio_recovery.py` (parallel PR territory) — confirmed untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)