### PR TITLE
ci: fail quick.yml on pytest failure (pipefail; exit code was swallowed by tee) [MOR-587]

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -93,11 +93,18 @@ jobs:
       - name: Run tests
         id: tests
         run: |
+          # Without pipefail the pipe's exit status is tee's (always 0), so
+          # pytest failures were swallowed and the step reported success.
+          # Capture pytest's exit code via PIPESTATUS, extract the summary
+          # (still needed for the badge, including on failure), then exit
+          # with pytest's code so failing tests fail the step.
           uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread \
             | tee pytest-output.txt
+          rc=${PIPESTATUS[0]}
           SUMMARY=$(tail -1 pytest-output.txt)
           PASSED=$(echo "$SUMMARY" | grep -oP '\d+ passed' | grep -oP '\d+' || echo "0")
           echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
+          exit "$rc"
 
       - name: Extract version
         if: matrix.python-version == '3.11' && github.ref == 'refs/heads/main'

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -112,11 +112,18 @@ jobs:
       - name: Run tests
         id: tests
         run: |
+          # Without pipefail the pipe's exit status is tee's (always 0), so
+          # pytest failures were swallowed and the step reported success.
+          # Capture pytest's exit code via PIPESTATUS, extract the summary
+          # (still needed for the badge, including on failure), then exit
+          # with pytest's code so failing tests fail the step.
           uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread \
             | tee pytest-output.txt
+          rc=${PIPESTATUS[0]}
           SUMMARY=$(tail -1 pytest-output.txt)
           PASSED=$(echo "$SUMMARY" | grep -oP '\d+ passed' | grep -oP '\d+' || echo "0")
           echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
+          exit "$rc"
 
       - name: Extract version
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## The bug (MOR-587)

The `Run tests` step in `quick.yml` (and identically in `full.yml`) ran:

```bash
uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread \
  | tee pytest-output.txt
SUMMARY=$(tail -1 pytest-output.txt)
...
```

GitHub Actions runs `run:` scripts with `bash` but **without** `pipefail`.
So the pipeline's exit status is `tee`'s — always `0` — and the step's
final command (`echo "passed=..." >> "$GITHUB_OUTPUT"`) also exits `0`.
Result: **pytest FAILURES did not fail the step**, and the `quick` check
reported SUCCESS with failing tests. (This previously let a broken smoke
test merge — since fixed.)

## The fix

Capture pytest's real exit code via `PIPESTATUS[0]` immediately after the
pipe, keep the `tee` output so the existing SUMMARY/badge extraction still
runs (including on failure), then `exit "$rc"` at the end of the step:

```bash
uv run pytest ... | tee pytest-output.txt
rc=${PIPESTATUS[0]}
SUMMARY=$(tail -1 pytest-output.txt)
PASSED=$(echo "$SUMMARY" | grep -oP '\d+ passed' | grep -oP '\d+' || echo "0")
echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
exit "$rc"
```

Chose `PIPESTATUS` + explicit `exit` over `set -o pipefail` because the
step deliberately tolerates non-zero on later commands (the `|| echo "0"`
fallback in the `grep` extraction); `PIPESTATUS` captures pytest's code
without changing `set -e` semantics for the rest of the script, and the
badge logic still runs on a failing test run.

## Which workflows shared the bug

| Workflow | Shared the bug? | Action |
|---|---|---|
| `quick.yml` | Yes | Fixed |
| `full.yml` | Yes (identical `tee` step) | Fixed |
| `publish.yml` | No — runs `pytest` directly, no `tee` pipe | Left unchanged (already correct) |

## Local proof the exit code now propagates

Real pytest piped through `tee`, reproducing the step logic:

```bash
$ uv run pytest /tmp/deliberate_failure.py --tb=line -q | tee out.txt
  rc=${PIPESTATUS[0]}; echo "PIPESTATUS[0] = $rc"; exit "$rc"
1 failed in 0.01s
PIPESTATUS[0] (pytest rc) = 1
step exit code = 1            # <-- step now FAILS
```

Old vs fixed step under `bash -e`:

```
OLD (no rc capture):  ( echo x; exit 1 ) | tee /dev/null  ->  step rc=0   (bug)
FIXED, failing pytest summary "1 failed, 7545 passed"     ->  step rc=1   (caught)
FIXED, passing pytest summary "7546 passed"               ->  step rc=0   (green)
```

The badge extraction still works on both: `GITHUB_OUTPUT` captured
`passed=7545` (failure case) and `passed=7546` (success case).

## Precondition: suite is green under the CI xdist invocation

Enabling the fix must not red-wall a currently-green pipeline. Ran the
exact CI command in the worktree:

```
uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread -q
====== 7546 passed, 10 skipped, 11 xfailed, 1 xpassed in 80.11s ======
pytest exit code: 0
```

0 failures, so the fix turns the check honest without breaking the
current green state.

## Scope

YAML-only, 2 files, +14 lines. No test selection / timeout / badge-logic
changes beyond exit-code propagation. Other jobs (ruff, import-linter,
frontend, badges) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)