### PR TITLE
feat(MOR-588): adaptive per-client egress codec controller (PCM16↔Opus, flag-gated)

### DIFF
--- a/frontend/src/lib/audio/__tests__/rx-player.test.ts
+++ b/frontend/src/lib/audio/__tests__/rx-player.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { RxPlayer } from '../rx-player';
-import { AUDIO_HEADER_SIZE, MSG_TYPE_RX, CODEC_PCM16, SAMPLE_RATE, FRAME_DURATION_MS } from '../constants';
+import { AUDIO_HEADER_SIZE, MSG_TYPE_RX, CODEC_OPUS, CODEC_PCM16, SAMPLE_RATE, FRAME_DURATION_MS } from '../constants';
 
 let ctx: any;
 beforeEach(() => {
@@ -397,6 +397,105 @@ describe('RxPlayer link-quality stats (MOR-585)', () => {
     p.feed(pcm16(480));           // 1 underrun
     p.stop();
     expect(p.stats()).toEqual({ underruns: 0, bufferDepthMs: 0, droppedFrames: 0 });
+  });
+});
+
+describe('RxPlayer mid-stream codec switch (MOR-588)', () => {
+  // Adaptive egress (server-side controller) switches PCM16↔Opus
+  // mid-stream; the codec byte travels per frame. The player must
+  // re-init the WebCodecs Opus decoder on every switch (the server
+  // starts a fresh encoder stream) without rebasing the schedule.
+  class FakeAudioDecoder {
+    static instances: FakeAudioDecoder[] = [];
+    state = 'unconfigured';
+    config: any = null;
+    chunks: any[] = [];
+    constructor(public init: any) { FakeAudioDecoder.instances.push(this); }
+    configure(cfg: any) { this.config = cfg; this.state = 'configured'; }
+    decode(chunk: any) {
+      this.chunks.push(chunk);
+      // Synchronously emit one decoded 480-frame mono buffer.
+      this.init.output({
+        numberOfFrames: 480, numberOfChannels: 1, sampleRate: SAMPLE_RATE,
+        copyTo: vi.fn(), close: vi.fn(),
+      });
+    }
+    close() { this.state = 'closed'; }
+  }
+  class FakeEncodedAudioChunk {
+    constructor(public init: any) {}
+  }
+
+  function opus(): ArrayBuffer {
+    const buf = new ArrayBuffer(AUDIO_HEADER_SIZE + 40);
+    const v = new DataView(buf);
+    v.setUint8(0, MSG_TYPE_RX); v.setUint8(1, CODEC_OPUS);
+    v.setUint16(4, SAMPLE_RATE / 100, true); v.setUint8(6, 1); v.setUint8(7, FRAME_DURATION_MS);
+    return buf;
+  }
+
+  beforeEach(() => {
+    FakeAudioDecoder.instances = [];
+    vi.stubGlobal('AudioDecoder', FakeAudioDecoder);
+    vi.stubGlobal('EncodedAudioChunk', FakeEncodedAudioChunk);
+  });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('PCM16→Opus switch initialises a fresh Opus decoder', () => {
+    const p = new RxPlayer(); p.start();
+    p.feed(pcm16(480));
+    expect(FakeAudioDecoder.instances.length).toBe(0);
+    p.feed(opus());
+    expect(FakeAudioDecoder.instances.length).toBe(1);
+    expect(FakeAudioDecoder.instances[0].config?.codec).toBe('opus');
+    p.stop();
+  });
+
+  it('Opus→PCM16 switch closes the stale Opus decoder and keeps playing', () => {
+    const p = new RxPlayer(); p.start();
+    p.feed(opus());
+    const dec = FakeAudioDecoder.instances[0];
+    expect(dec.state).toBe('configured');
+    p.feed(pcm16(480));
+    expect(dec.state).toBe('closed');
+    // PCM frame still scheduled — switch is seamless.
+    expect(ctx._lastSrc.start).toHaveBeenCalled();
+    p.stop();
+  });
+
+  it('Opus→PCM16→Opus re-init builds a NEW decoder for the fresh server stream', () => {
+    const p = new RxPlayer(); p.start();
+    p.feed(opus());
+    p.feed(pcm16(480));
+    p.feed(opus());
+    expect(FakeAudioDecoder.instances.length).toBe(2);
+    expect(FakeAudioDecoder.instances[0].state).toBe('closed');
+    expect(FakeAudioDecoder.instances[1].state).toBe('configured');
+    // The fresh decoder's timestamps restart at 0 (fresh encoder stream).
+    expect(FakeAudioDecoder.instances[1].chunks[0].init.timestamp).toBe(0);
+    p.stop();
+  });
+
+  it('does not rebase the playback schedule on a switch (no audible gap)', () => {
+    const p = new RxPlayer(); p.start();
+    ctx.currentTime = 0;
+    p.feed(pcm16(480));   // primes: floor 0.05 + 10 ms → nextPlayTime 0.06
+    p.feed(opus());        // decoded buffer must continue at 0.06, not re-floor
+    const calls = ctx._lastSrc.start.mock.calls;
+    expect(calls[0][0]).toBeCloseTo(0.06, 5);
+    expect(p.stats().underruns).toBe(0);
+    p.stop();
+  });
+
+  it('stop() resets codec tracking — restart does not misread a switch', () => {
+    const p = new RxPlayer(); p.start();
+    p.feed(opus());
+    p.stop();
+    p.start();
+    p.feed(opus());
+    expect(FakeAudioDecoder.instances.length).toBe(2);
+    expect(FakeAudioDecoder.instances[1].state).toBe('configured');
+    p.stop();
   });
 });
 

--- a/frontend/src/lib/audio/rx-player.ts
+++ b/frontend/src/lib/audio/rx-player.ts
@@ -38,6 +38,9 @@ export class RxPlayer {
   private decoder: AudioDecoder | null = null;
   private nextPlayTime = 0;
   private opusTs = 0;
+  // Codec byte of the previously fed frame — detects a mid-stream
+  // adaptive egress switch (MOR-588, ADR §3.6).
+  private lastCodec: number | null = null;
   private _volume = 1.0;
 
   // Routing state — applied whenever any of the nodes exist.
@@ -157,10 +160,8 @@ export class RxPlayer {
   }
 
   stop(): void {
-    if (this.decoder) {
-      try { this.decoder.close(); } catch { /* ok */ }
-      this.decoder = null;
-    }
+    this.resetDecoder();
+    this.lastCodec = null;
     this._detachResumeListeners();
     if (this.ctx) {
       this.ctx.close().catch(() => {});
@@ -260,11 +261,33 @@ export class RxPlayer {
     const hdr = parseRxHeader(buffer);
     if (!hdr) return;
 
+    if (this.lastCodec !== null && hdr.codec !== this.lastCodec) {
+      // Mid-stream adaptive egress switch (MOR-588, ADR §3.6): the
+      // server starts a FRESH Opus encoder stream on every PCM16↔Opus
+      // switch, so the WebCodecs decoder must be re-initialised —
+      // feeding a new stream into stale decoder state yields garbage.
+      // The playback schedule (nextPlayTime) is intentionally NOT
+      // rebased: decoded frames keep landing on the same timeline, so
+      // the switch stays seamless.
+      this.resetDecoder();
+    }
+    this.lastCodec = hdr.codec;
+
     if (hdr.codec === CODEC_PCM16) {
       this.playPcm16(hdr.payload, hdr.sampleRate, hdr.channels);
     } else if (hdr.codec === CODEC_OPUS) {
       this.decodeOpus(hdr.payload, hdr.sampleRate, hdr.channels);
     }
+  }
+
+  /** Close the Opus decoder (if any) and restart its timestamp clock —
+   *  the next Opus frame lazily configures a fresh decoder. */
+  private resetDecoder(): void {
+    if (this.decoder) {
+      try { this.decoder.close(); } catch { /* ok */ }
+      this.decoder = null;
+    }
+    this.opusTs = 0;
   }
 
   /** Flush pipeline (e.g. on reconnect) */

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import AsyncIterator, Awaitable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 
 from ..._audio_codecs import decode_ulaw_to_pcm16
@@ -42,6 +44,40 @@ __all__ = ["AudioBroadcaster", "AudioHandler"]
 logger = logging.getLogger(__name__)
 
 _TX_CLEANUP_STOP_TIMEOUT_SECONDS = 2.0
+
+# Adaptive egress codec controller windows (MOR-588, ADR §3.6).
+# Degradation must be SUSTAINED for DEGRADE_WINDOW_S before PCM16→Opus
+# engages; Opus→PCM16 requires a fully clean CLEAN_WINDOW_S; DWELL_S is
+# the minimum hold after ANY switch (anti-flap). Per-instance copies on
+# the broadcaster make them injectable for deterministic tests.
+DEGRADE_WINDOW_S = 3.0
+CLEAN_WINDOW_S = 30.0
+DWELL_S = 10.0
+
+
+@dataclass
+class _AdaptiveEgressState:
+    """Per-client adaptive egress controller state (MOR-588, ADR §3.6).
+
+    Exists ONLY for browser WS clients that declared Opus decode
+    capability (``preferred_rx_codec=opus``) on an adaptive-enabled
+    broadcaster. The initial codec is always PCM16 — Opus is never the
+    initial codec and engages only on sustained link degradation.
+    """
+
+    codec: int = AUDIO_CODEC_PCM16
+    # time.monotonic() of the last codec switch (dwell anchor); None
+    # until the first switch.
+    last_switch: float | None = None
+    # Start of the current continuous degradation episode; reset when
+    # evidence stops for longer than the degrade window.
+    degrade_since: float | None = None
+    # Most recent degradation evidence (clean-window anchor).
+    last_evidence: float | None = None
+    # High-water marks of the cumulative MOR-585 counters; a counter
+    # rising past its mark is one unit of degradation evidence.
+    seen_underruns: int = 0
+    seen_queue_drops: int = 0
 
 
 def _is_benign_tx_restart(exc: RuntimeError) -> bool:
@@ -101,6 +137,7 @@ class AudioBroadcaster:
         radio: "Radio | None",
         *,
         on_client_count_change: Callable[[], None] | None = None,
+        adaptive_egress: bool = False,
     ) -> None:
         self.HIGH_WATERMARK = get_audio_broadcaster_high_watermark()
         self._radio = radio
@@ -129,6 +166,19 @@ class AudioBroadcaster:
         # controller; nothing here changes codec selection or behavior.
         self._client_link_quality: dict[int, dict[str, int | float]] = {}
         self._client_queue_drops: dict[int, int] = {}
+        # Adaptive egress codec controller (MOR-588, ADR §3.6): per-client
+        # PCM16↔Opus switching driven by the MOR-585 link-quality signals.
+        # INERT when ``adaptive_egress`` is off (the default) — egress
+        # stays the static MOR-584 per-connection choice and a client's
+        # codec never changes mid-stream. Windows/dwell and the clock are
+        # per-instance so tests can drive them deterministically.
+        self._adaptive_egress = adaptive_egress
+        self._adaptive_degrade_window_s: float = DEGRADE_WINDOW_S
+        self._adaptive_clean_window_s: float = CLEAN_WINDOW_S
+        self._adaptive_dwell_s: float = DWELL_S
+        self._adaptive_monotonic: Callable[[], float] = time.monotonic
+        self._client_adaptive: dict[int, _AdaptiveEgressState] = {}
+        self._ack_tasks: set[asyncio.Task[None]] = set()
         self._browser_opus_warned: bool = False
         self._lock = asyncio.Lock()
         # Optional DSP pipeline (inserted between codec decode and tap/distribute).
@@ -172,6 +222,13 @@ class AudioBroadcaster:
                 self._client_ws[client_id] = ws
             if preferred_rx_codec is not None:
                 self._client_rx_codec[client_id] = preferred_rx_codec
+            if self._adaptive_egress and preferred_rx_codec == AUDIO_CODEC_OPUS:
+                # Adaptive eligibility (MOR-588): only clients that
+                # DECLARED Opus decode capability adapt; explicit-PCM16
+                # and no-preference clients keep the static MOR-584
+                # choice (clients without Opus decode are pinned PCM16,
+                # ADR §3.6). Initial state is always PCM16.
+                self._client_adaptive[client_id] = _AdaptiveEgressState()
             # Start relay if no active subscription, or if relay task died
             relay_alive = self._relay_task is not None and not self._relay_task.done()
             if self._subscription is None or not relay_alive:
@@ -200,6 +257,7 @@ class AudioBroadcaster:
             self._client_opus_transcoders.pop(client_id, None)
             self._client_link_quality.pop(client_id, None)
             self._client_queue_drops.pop(client_id, None)
+            self._client_adaptive.pop(client_id, None)
             if (
                 not self._clients
                 and self._subscription is not None
@@ -310,6 +368,7 @@ class AudioBroadcaster:
                 self._client_opus_transcoders.pop(cid, None)
                 self._client_link_quality.pop(cid, None)
                 self._client_queue_drops.pop(cid, None)
+                self._client_adaptive.pop(cid, None)
             # Stop relay if no clients remain (and no PCM tap active)
             if (
                 not self._clients
@@ -421,14 +480,18 @@ class AudioBroadcaster:
     def _client_egress_codec(self, client_id: int) -> int:
         """Resolve one client's egress codec (MOR-584, static per connection).
 
-        Ladder: client-requested (``preferred_rx_codec`` at negotiation)
-        → profile policy default (``_resolve_web_rx_codec`` cached in
-        ``_web_codec``) → PCM16.  Opus-native radios pass through
-        un-decoded for every client — there is no PCM to re-encode
-        (issue #762).
+        Ladder: adaptive controller state (MOR-588, flag-gated; PCM16
+        initial, Opus only on sustained degradation) → client-requested
+        (``preferred_rx_codec`` at negotiation) → profile policy default
+        (``_resolve_web_rx_codec`` cached in ``_web_codec``) → PCM16.
+        Opus-native radios pass through un-decoded for every client —
+        there is no PCM to re-encode (issue #762).
         """
         if self._radio_codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
             return AUDIO_CODEC_OPUS
+        adaptive = self._client_adaptive.get(client_id)
+        if adaptive is not None:
+            return adaptive.codec
         return self._client_rx_codec.get(client_id, self._web_codec)
 
     def negotiated_rx_format(self, queue: asyncio.Queue[bytes]) -> dict[str, Any]:
@@ -463,6 +526,7 @@ class AudioBroadcaster:
         if client_id not in self._clients:
             return
         self._client_link_quality[client_id] = dict(stats)
+        self._adaptive_evaluate(client_id)
 
     def client_link_quality(
         self, queue: asyncio.Queue[bytes]
@@ -481,6 +545,124 @@ class AudioBroadcaster:
         )
         snapshot["ws_queue_drops"] = self._client_queue_drops.get(client_id, 0)
         return snapshot
+
+    def _adaptive_evaluate(self, client_id: int) -> None:
+        """Run one adaptive controller step for one client (MOR-588).
+
+        Called per ``audio_stats`` uplink and per relay-loop frame (the
+        latter covers the server-side ``ws_queue_drops`` signal for
+        clients whose stats uplink is absent or stalled). No-op for
+        non-adaptive clients, so the flag-off path stays MOR-584 static.
+
+        Evidence = either MOR-585 cumulative counter rising (client
+        playback ``underruns``, server ``ws_queue_drops``). A degradation
+        episode is continuous evidence with gaps shorter than the degrade
+        window; PCM16→Opus fires once an episode spans the window, Opus→
+        PCM16 once no evidence arrives for the clean window — both gated
+        by the dwell since the previous switch.
+        """
+        state = self._client_adaptive.get(client_id)
+        if state is None:
+            return
+        if self._radio_codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
+            return  # pass-through for everyone — nothing to adapt (#762)
+        now = self._adaptive_monotonic()
+        stats = self._client_link_quality.get(client_id, {})
+        underruns = int(stats.get("underruns", 0))
+        queue_drops = self._client_queue_drops.get(client_id, 0)
+        evidence = (
+            underruns > state.seen_underruns or queue_drops > state.seen_queue_drops
+        )
+        state.seen_underruns = max(state.seen_underruns, underruns)
+        state.seen_queue_drops = max(state.seen_queue_drops, queue_drops)
+        if evidence:
+            state.last_evidence = now
+            if state.degrade_since is None:
+                state.degrade_since = now
+        elif (
+            state.degrade_since is not None
+            and state.last_evidence is not None
+            and now - state.last_evidence > self._adaptive_degrade_window_s
+        ):
+            state.degrade_since = None  # episode over — evidence stopped
+
+        dwell_ok = (
+            state.last_switch is None
+            or now - state.last_switch >= self._adaptive_dwell_s
+        )
+        if (
+            state.codec == AUDIO_CODEC_PCM16
+            and dwell_ok
+            and state.degrade_since is not None
+            and now - state.degrade_since >= self._adaptive_degrade_window_s
+        ):
+            self._adaptive_switch(client_id, state, AUDIO_CODEC_OPUS, now)
+        elif (
+            state.codec == AUDIO_CODEC_OPUS
+            and dwell_ok
+            and (
+                state.last_evidence is None
+                or now - state.last_evidence >= self._adaptive_clean_window_s
+            )
+        ):
+            self._adaptive_switch(client_id, state, AUDIO_CODEC_PCM16, now)
+
+    def _adaptive_switch(
+        self, client_id: int, state: _AdaptiveEgressState, codec: int, now: float
+    ) -> None:
+        """Apply one adaptive codec switch (MOR-588).
+
+        Changing ``state.codec`` re-routes ``_client_egress_codec`` and
+        thereby the MOR-584 encoder pool: the next Opus frame lazily
+        constructs a FRESH per-client transcoder; switching back to
+        PCM16 tears the encoder down here. A fresh ``audio_format`` ack
+        mirrors the new codec to the client.
+        """
+        state.codec = codec
+        state.last_switch = now
+        state.degrade_since = None
+        if codec != AUDIO_CODEC_OPUS:
+            self._client_opus_transcoders.pop(client_id, None)
+        logger.info(
+            "audio-broadcaster: adaptive egress switch → %s (client=%d)",
+            "opus" if codec == AUDIO_CODEC_OPUS else "pcm16",
+            client_id,
+        )
+        self._send_adaptive_format_ack(client_id)
+
+    def _send_adaptive_format_ack(self, client_id: int) -> None:
+        """Send a fresh ``audio_format`` ack after an adaptive switch.
+
+        Advisory and fire-and-forget, like the ``audio_start`` ack
+        (MOR-584): the browser decodes from the per-frame header codec
+        byte regardless; this only refreshes its negotiated-format view.
+        Never blocks the relay loop — whole WS frames are written
+        atomically, so a text send may interleave with the sender loop's
+        binary frames but never corrupt them.
+        """
+        ws = self._client_ws.get(client_id)
+        queue = self._clients.get(client_id)
+        if ws is None or queue is None:
+            return
+        payload = encode_json(
+            {"type": "audio_format", **self.negotiated_rx_format(queue)}
+        )
+
+        async def _send() -> None:
+            try:
+                await ws.send_text(payload)
+            except Exception:
+                logger.debug(
+                    "audio-broadcaster: adaptive audio_format ack failed",
+                    exc_info=True,
+                )
+
+        try:
+            task = asyncio.get_running_loop().create_task(_send())
+        except RuntimeError:
+            return  # no running loop (sync test context) — ack is advisory
+        self._ack_tasks.add(task)
+        task.add_done_callback(self._ack_tasks.discard)
 
     def _encode_client_rx_frame(
         self,
@@ -676,6 +858,10 @@ class AudioBroadcaster:
                     if ws is not None and not ws.is_alive():
                         dead_ids.append(client_id)
                         continue
+                    # Adaptive controller step (MOR-588): no-op unless the
+                    # client opted into adaptation on a flag-on broadcaster.
+                    if self._client_adaptive:
+                        self._adaptive_evaluate(client_id)
                     codec, payload = self._encode_client_rx_frame(
                         client_id, audio_data, _frame_ms
                     )
@@ -718,6 +904,7 @@ class AudioBroadcaster:
                     self._client_opus_transcoders.pop(client_id, None)
                     self._client_link_quality.pop(client_id, None)
                     self._client_queue_drops.pop(client_id, None)
+                    self._client_adaptive.pop(client_id, None)
                     logger.info("audio-broadcaster: removed dead client during relay")
                 if dead_ids:
                     self._notify_client_count_change()

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -625,6 +625,10 @@ class WebConfig:
     emit_startup_event: bool = False  # emit JSON runtime startup event to stdout
     webrtc_enabled: bool = False  # enable the gated WebRTC transport entrypoint
     state_diagnostics: bool = False  # enable behavior-neutral state diagnostics
+    # Adaptive per-client egress codec controller (MOR-588, ADR §3.6):
+    # PCM16↔Opus switching on detected slow/lossy links. Off (default) =
+    # static MOR-584 per-connection codecs, never switched mid-stream.
+    audio_adaptive_egress: bool = False
 
 
 class ConnectionManager:
@@ -749,6 +753,7 @@ class WebServer:
         self._audio_broadcaster = AudioBroadcaster(
             radio,
             on_client_count_change=self._broadcast_ws_client_state_update,
+            adaptive_egress=self._config.audio_adaptive_egress,
         )
         # Gated WebRTC transport session manager (A2.3 / MOR-307). Lazily
         # constructed on first use so the import stays out of the no-extra path.

--- a/tests/contracts/test_adaptive_egress_conformance.py
+++ b/tests/contracts/test_adaptive_egress_conformance.py
@@ -1,0 +1,152 @@
+"""T1a conformance pin for the adaptive egress codec controller (MOR-588).
+
+ADR §3.6 / tenet T1a: lossless-class consumers (the AudioBridge /
+digital path → WSJT-X, the FFT-scope PCM taps) are categorically exempt
+from adaptive codec switching — by construction, NO egress encoder is
+ever constructible on a bridge/digital path, even while the controller
+actively degrades a browser WS client on the same broadcaster.
+
+The bridge consumes RX as an AudioBus subscriber UPSTREAM of the
+broadcaster's per-client egress encode; the FFT scope consumes the
+post-DSP PCM tap. Both must observe bit-identical spine PCM throughout
+an adaptive PCM16→Opus switch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from rigplane.audio_bus import AudioBus
+from rigplane.radio_protocol import AudioCapable
+from rigplane.types import AudioCodec
+from rigplane.web.handlers import AudioBroadcaster, AudioHandler
+from rigplane.web.handlers.audio import DEGRADE_WINDOW_S
+from rigplane.web.protocol import AUDIO_CODEC_OPUS
+from rigplane.web.websocket import WebSocketConnection
+
+# 20 ms @ 48 kHz mono s16le.
+PCM_PAYLOAD = b"\x01\x02" * 960
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class _FakeTranscoder:
+    def pcm_to_opus(self, pcm: bytes) -> bytes:
+        return b"opus-frame"
+
+
+def _make_radio() -> tuple[Any, AudioBus]:
+    radio = MagicMock(spec=AudioCapable)
+    radio.capabilities = {"audio"}
+    radio.audio_codec = AudioCodec.PCM_1CH_16BIT
+    radio.audio_sample_rate = 48000
+    radio.start_audio_rx_opus = AsyncMock()
+    radio.stop_audio_rx_opus = AsyncMock()
+    bus = AudioBus(radio)
+    radio.audio_bus = bus
+    return radio, bus
+
+
+def _make_ws() -> MagicMock:
+    ws = MagicMock(spec=WebSocketConnection)
+    ws.send_text = AsyncMock()
+    return ws
+
+
+async def _inject(bus: AudioBus) -> None:
+    pkt = MagicMock()
+    pkt.data = PCM_PAYLOAD
+    bus._on_opus_packet(pkt)
+    await asyncio.sleep(0.1)
+
+
+async def _storm(handler: AudioHandler, clock: _Clock) -> None:
+    """Sustained degradation evidence past DEGRADE_WINDOW_S."""
+    underruns = 0
+    elapsed = 0.0
+    while elapsed <= DEGRADE_WINDOW_S:
+        underruns += 1
+        await handler._handle_control({"type": "audio_stats", "underruns": underruns})
+        clock.now += 1.5
+        elapsed += 1.5
+    await asyncio.sleep(0)
+
+
+class TestT1aLosslessPathUnderAdaptation:
+    async def test_bridge_and_taps_get_no_encoder_during_adaptive_switch(
+        self,
+    ) -> None:
+        """While the controller degrades a WS client to Opus, the bridge
+        bus subscriber and the post-DSP PCM tap keep receiving the spine
+        PCM bit-identically; every encoder construction is keyed to the
+        WS client only."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio, adaptive_egress=True)
+        clock = _Clock()
+        broadcaster._adaptive_monotonic = clock
+
+        tap_frames: list[bytes] = []
+        broadcaster.set_pcm_tap(tap_frames.append)
+        bridge_sub = bus.subscribe(name="audio-bridge")
+        await bridge_sub.start()
+
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        constructed: list[dict[str, Any]] = []
+
+        def _factory(**kwargs: Any) -> _FakeTranscoder:
+            constructed.append(kwargs)
+            return _FakeTranscoder()
+
+        with patch(
+            "rigplane.web.handlers.audio.create_pcm_opus_transcoder",
+            side_effect=_factory,
+        ):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            await _inject(bus)  # healthy: PCM16, no encoder anywhere
+            assert constructed == []
+            await _storm(handler, clock)  # controller flips WS client → Opus
+            await _inject(bus)
+
+        ws_client_id = id(handler._frame_queue)
+        assert broadcaster._client_adaptive[ws_client_id].codec == AUDIO_CODEC_OPUS
+        # T1a: the encoder pool is keyed by the WS client id ONLY — no
+        # encoder is constructible on the bridge/digital path.
+        assert set(broadcaster._client_opus_transcoders) == {ws_client_id}
+        assert len(constructed) == 1
+        # Lossless-class consumers observed bit-identical spine PCM
+        # through the entire adaptive switch.
+        assert tap_frames == [PCM_PAYLOAD, PCM_PAYLOAD]
+        bridge_packets: list[bytes] = []
+        while True:
+            try:
+                pkt = bridge_sub.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if pkt is not None:
+                bridge_packets.append(pkt.data)
+        assert bridge_packets == [PCM_PAYLOAD, PCM_PAYLOAD]
+        bridge_sub.stop()
+
+    async def test_no_encoder_constructed_while_links_healthy(self) -> None:
+        """Flag ON + healthy link: the controller stays PCM16 and never
+        constructs an encoder for anyone (ADR §3.6: zero cost in the
+        common case)."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio, adaptive_egress=True)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        with patch(
+            "rigplane.web.handlers.audio.create_pcm_opus_transcoder",
+        ) as factory:
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            await _inject(bus)
+
+        factory.assert_not_called()
+        assert broadcaster._client_opus_transcoders == {}

--- a/tests/test_web_audio_adaptive_egress.py
+++ b/tests/test_web_audio_adaptive_egress.py
@@ -172,6 +172,10 @@ class TestAdaptiveDegrade:
             "(MOR-588 headline behavior)"
         )
         assert frame[AUDIO_HEADER_SIZE:] == b"opus-frame"
+        state = broadcaster._client_adaptive[id(handler._frame_queue)]
+        assert state.codec == AUDIO_CODEC_OPUS, (
+            "the controller DECISION itself must be Opus — not just the wire"
+        )
         assert [a["codec"] for a in _acks(ws)] == ["pcm16", "opus"]
 
     async def test_isolated_burst_does_not_flip(self) -> None:
@@ -192,6 +196,17 @@ class TestAdaptiveDegrade:
         frame = handler._frame_queue.get_nowait()
         assert frame[1] == AUDIO_CODEC_PCM16
         assert broadcaster._client_opus_transcoders == {}
+        # The wire frame alone cannot discriminate here: without libopus
+        # the MOR-584 fallback emits PCM16 + a clean encoder pool EVEN IF
+        # the controller wrongly switched. Assert the controller's own
+        # decision so a neutered DEGRADE_WINDOW_S gate or a removed
+        # degrade-episode reset fails this test (mutation-testing gap).
+        state = broadcaster._client_adaptive[id(handler._frame_queue)]
+        assert state.codec == AUDIO_CODEC_PCM16, (
+            "non-continuous evidence must not flip the controller decision: "
+            "PCM16->Opus requires a CONTINUOUS episode >= DEGRADE_WINDOW_S, "
+            "and an evidence gap > DEGRADE_WINDOW_S must reset the episode"
+        )
 
     async def test_server_side_queue_drops_alone_flip_without_stats_uplink(
         self,
@@ -241,6 +256,8 @@ class TestAdaptiveUpgrade:
         assert broadcaster._client_opus_transcoders == {}, (
             "upgrade must tear down the per-client encoder (MOR-584 pool)"
         )
+        state = broadcaster._client_adaptive[id(handler._frame_queue)]
+        assert state.codec == AUDIO_CODEC_PCM16
         assert [a["codec"] for a in _acks(ws)] == ["pcm16", "opus", "pcm16"]
 
     async def test_clean_window_not_met_stays_opus(self) -> None:

--- a/tests/test_web_audio_adaptive_egress.py
+++ b/tests/test_web_audio_adaptive_egress.py
@@ -1,0 +1,413 @@
+"""Adaptive egress codec controller (MOR-588, ADR §3.6 — step 19 of MOR-562).
+
+Falsification suite: with ``audio_adaptive_egress`` ON the broadcaster
+must switch a browser client PCM16↔Opus automatically from the MOR-585
+link-quality signals (client-reported ``underruns`` + server-side
+``ws_queue_drops``) with sustained-degradation windows and anti-flap
+dwell; with the flag OFF (the default) a client's codec must NEVER
+change mid-stream — exactly the static MOR-584 per-connection choice.
+
+Deterministic: the controller clock is injected (``_FakeClock``) — no
+test sleeps through the real 3 s / 10 s / 30 s windows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from rigplane.audio_bus import AudioBus
+from rigplane.radio_protocol import AudioCapable
+from rigplane.types import AudioCodec
+from rigplane.web.handlers import AudioBroadcaster, AudioHandler
+from rigplane.web.handlers.audio import CLEAN_WINDOW_S, DEGRADE_WINDOW_S, DWELL_S
+from rigplane.web.protocol import (
+    AUDIO_CODEC_OPUS,
+    AUDIO_CODEC_PCM16,
+    AUDIO_HEADER_SIZE,
+)
+from rigplane.web.server import WebConfig, WebServer
+from rigplane.web.websocket import WebSocketConnection
+
+# 20 ms @ 48 kHz mono s16le.
+PCM_PAYLOAD = b"\x01\x02" * 960
+
+
+class _FakeClock:
+    """Injected monotonic clock — drives windows/dwell without sleeping."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _FakeTranscoder:
+    """Stands in for PcmOpusTranscoder — native libopus may be absent."""
+
+    def __init__(self) -> None:
+        self.frames: list[bytes] = []
+
+    def pcm_to_opus(self, pcm: bytes) -> bytes:
+        self.frames.append(bytes(pcm))
+        return b"opus-frame"
+
+
+def _make_radio(
+    codec: AudioCodec = AudioCodec.PCM_1CH_16BIT, sample_rate: int = 48000
+) -> tuple[Any, AudioBus]:
+    radio = MagicMock(spec=AudioCapable)
+    radio.capabilities = {"audio"}
+    radio.audio_codec = codec
+    radio.audio_sample_rate = sample_rate
+    radio.start_audio_rx_opus = AsyncMock()
+    radio.stop_audio_rx_opus = AsyncMock()
+    bus = AudioBus(radio)
+    radio.audio_bus = bus
+    return radio, bus
+
+
+def _make_ws() -> MagicMock:
+    ws = MagicMock(spec=WebSocketConnection)
+    ws.send_text = AsyncMock()
+    return ws
+
+
+def _make_adaptive(
+    radio: Any, clock: _FakeClock | None = None
+) -> tuple[AudioBroadcaster, _FakeClock]:
+    clock = clock or _FakeClock()
+    broadcaster = AudioBroadcaster(radio, adaptive_egress=True)
+    broadcaster._adaptive_monotonic = clock
+    return broadcaster, clock
+
+
+async def _inject(bus: AudioBus, payload: bytes = PCM_PAYLOAD, count: int = 1) -> None:
+    for _ in range(count):
+        pkt = MagicMock()
+        pkt.data = payload
+        bus._on_opus_packet(pkt)
+    await asyncio.sleep(0.1)
+
+
+async def _report(handler: AudioHandler, underruns: int) -> None:
+    await handler._handle_control({"type": "audio_stats", "underruns": underruns})
+    # Let a fire-and-forget audio_format ack task (if any) run.
+    await asyncio.sleep(0)
+
+
+def _acks(ws: MagicMock) -> list[dict[str, Any]]:
+    sent = [json.loads(c.args[0]) for c in ws.send_text.await_args_list]
+    return [m for m in sent if m.get("type") == "audio_format"]
+
+
+def _drain_codecs(handler: AudioHandler) -> list[int]:
+    codecs: list[int] = []
+    while True:
+        try:
+            codecs.append(handler._frame_queue.get_nowait()[1])
+        except asyncio.QueueEmpty:
+            return codecs
+
+
+_TRANSCODER_PATCH = "rigplane.web.handlers.audio.create_pcm_opus_transcoder"
+
+
+async def _degrade_to_opus(
+    handler: AudioHandler, clock: _FakeClock, *, underruns_from: int = 0
+) -> int:
+    """Drive sustained degradation past DEGRADE_WINDOW_S; return underruns."""
+    underruns = underruns_from + 1
+    await _report(handler, underruns)  # evidence — episode starts
+    elapsed = 0.0
+    while elapsed < DEGRADE_WINDOW_S:
+        clock.advance(1.5)
+        elapsed += 1.5
+        underruns += 1
+        await _report(handler, underruns)
+    return underruns
+
+
+class TestAdaptiveDegrade:
+    async def test_initial_codec_is_pcm16_even_for_opus_capable_client(self) -> None:
+        """ADR §3.6: Opus is NEVER the initial codec under adaptation —
+        ``preferred_rx_codec=opus`` is a capability declaration, not a
+        static choice. A healthy link stays PCM16 and constructs no
+        encoder."""
+        radio, bus = _make_radio()
+        broadcaster, _clock = _make_adaptive(radio)
+        ws = _make_ws()
+        handler = AudioHandler(ws, radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+        await _inject(bus)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_PCM16
+        assert frame[AUDIO_HEADER_SIZE:] == PCM_PAYLOAD
+        assert broadcaster._client_opus_transcoders == {}
+        assert [a["codec"] for a in _acks(ws)] == ["pcm16"]
+
+    async def test_sustained_degradation_flips_client_to_opus(self) -> None:
+        """Client-reported underruns rising continuously past
+        DEGRADE_WINDOW_S must flip the client PCM16 → Opus, with a fresh
+        audio_format ack reflecting the new codec."""
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        ws = _make_ws()
+        handler = AudioHandler(ws, radio, broadcaster)
+        with patch(_TRANSCODER_PATCH, return_value=_FakeTranscoder()):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            await _degrade_to_opus(handler, clock)
+            await _inject(bus)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_OPUS, (
+            "sustained degradation past DEGRADE_WINDOW_S must engage Opus "
+            "(MOR-588 headline behavior)"
+        )
+        assert frame[AUDIO_HEADER_SIZE:] == b"opus-frame"
+        assert [a["codec"] for a in _acks(ws)] == ["pcm16", "opus"]
+
+    async def test_isolated_burst_does_not_flip(self) -> None:
+        """A single evidence burst that is NOT sustained (episode gap >
+        DEGRADE_WINDOW_S) must not engage Opus."""
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+
+        await _report(handler, 1)  # one burst
+        clock.advance(DEGRADE_WINDOW_S + 1.0)
+        await _report(handler, 1)  # clean — episode reset
+        clock.advance(0.1)
+        await _report(handler, 2)  # new episode, not yet sustained
+        await _inject(bus)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_PCM16
+        assert broadcaster._client_opus_transcoders == {}
+
+    async def test_server_side_queue_drops_alone_flip_without_stats_uplink(
+        self,
+    ) -> None:
+        """The server-side ws_queue_drops signal must drive adaptation on
+        its own — a congested client that never sends audio_stats still
+        degrades to Opus (relay-loop evaluation)."""
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        broadcaster.HIGH_WATERMARK = 2  # tiny queue → forced evictions
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        with patch(_TRANSCODER_PATCH, return_value=_FakeTranscoder()):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            # Nobody drains the queue: each relay iteration past the
+            # watermark evicts-oldest and increments ws_queue_drops.
+            for _ in range(8):
+                await _inject(bus)
+                clock.advance(1.0)
+
+        state = broadcaster._client_adaptive[id(handler._frame_queue)]
+        assert state.codec == AUDIO_CODEC_OPUS, (
+            "sustained ws_queue_drops must flip the client without any "
+            "client-side audio_stats uplink"
+        )
+        assert _drain_codecs(handler)[-1] == AUDIO_CODEC_OPUS
+
+
+class TestAdaptiveUpgrade:
+    async def test_clean_window_restores_pcm16_and_tears_down_encoder(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        ws = _make_ws()
+        handler = AudioHandler(ws, radio, broadcaster)
+        with patch(_TRANSCODER_PATCH, return_value=_FakeTranscoder()):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            underruns = await _degrade_to_opus(handler, clock)
+            await _inject(bus)  # encodes one Opus frame → encoder exists
+            assert len(broadcaster._client_opus_transcoders) == 1
+
+            clock.advance(CLEAN_WINDOW_S)
+            await _report(handler, underruns)  # unchanged counters = clean
+            await _inject(bus)
+
+        assert _drain_codecs(handler)[-1] == AUDIO_CODEC_PCM16, (
+            "a fully clean CLEAN_WINDOW_S must restore PCM16"
+        )
+        assert broadcaster._client_opus_transcoders == {}, (
+            "upgrade must tear down the per-client encoder (MOR-584 pool)"
+        )
+        assert [a["codec"] for a in _acks(ws)] == ["pcm16", "opus", "pcm16"]
+
+    async def test_clean_window_not_met_stays_opus(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        with patch(_TRANSCODER_PATCH, return_value=_FakeTranscoder()):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            underruns = await _degrade_to_opus(handler, clock)
+
+            clock.advance(CLEAN_WINDOW_S - 1.0)
+            await _report(handler, underruns)
+            await _inject(bus)
+
+        assert _drain_codecs(handler)[-1] == AUDIO_CODEC_OPUS
+
+
+class TestAdaptiveDwell:
+    async def test_no_flap_within_dwell(self) -> None:
+        """Rapid degradation right after a switch must NOT flip again
+        until DWELL_S has passed — then, with evidence still sustained,
+        the switch happens."""
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        with patch(_TRANSCODER_PATCH, side_effect=lambda **_kw: _FakeTranscoder()):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            underruns = await _degrade_to_opus(handler, clock)
+            clock.advance(CLEAN_WINDOW_S)
+            await _report(handler, underruns)  # upgrade switch → PCM16
+            switch_at = clock.now
+
+            # Fresh sustained degradation immediately after the upgrade.
+            elapsed = 0.0
+            while elapsed < DEGRADE_WINDOW_S + 1.5:
+                clock.advance(1.5)
+                elapsed += 1.5
+                underruns += 1
+                await _report(handler, underruns)
+            assert clock.now - switch_at < DWELL_S
+            await _inject(bus)
+            assert _drain_codecs(handler)[-1] == AUDIO_CODEC_PCM16, (
+                "a switch within DWELL_S of the previous one is flapping"
+            )
+
+            # Keep the episode alive until the dwell expires → now it flips.
+            while clock.now - switch_at < DWELL_S:
+                clock.advance(1.5)
+                underruns += 1
+                await _report(handler, underruns)
+            await _inject(bus)
+            assert _drain_codecs(handler)[-1] == AUDIO_CODEC_OPUS
+
+
+class TestAdaptiveExemptions:
+    async def test_pcm16_pinned_client_never_adapts(self) -> None:
+        """A client without Opus decode (declared pcm16) is pinned PCM16
+        and fully exempt — no controller state, no encoder, ever."""
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_PCM16)
+        await _degrade_to_opus(handler, clock)
+        await _inject(bus)
+
+        assert broadcaster._client_adaptive == {}
+        assert broadcaster._client_opus_transcoders == {}
+        assert _drain_codecs(handler) == [AUDIO_CODEC_PCM16]
+
+    async def test_no_preference_client_keeps_static_behavior(self) -> None:
+        """Unknown decode capability (legacy client, no preferred_rx_codec)
+        → exempt: static MOR-584 resolution, no adaptation."""
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx()
+        await _degrade_to_opus(handler, clock)
+        await _inject(bus)
+
+        assert broadcaster._client_adaptive == {}
+        assert _drain_codecs(handler) == [AUDIO_CODEC_PCM16]
+
+    async def test_opus_native_radio_stays_passthrough(self) -> None:
+        """Opus-native radios pass through un-decoded for every client
+        (issue #762) — the controller never re-encodes or interferes."""
+        radio, bus = _make_radio(codec=AudioCodec.OPUS_1CH)
+        broadcaster, clock = _make_adaptive(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+        await _degrade_to_opus(handler, clock)
+        opus_payload = b"\x42" * 120
+        await _inject(bus, opus_payload)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_OPUS
+        assert frame[AUDIO_HEADER_SIZE:] == opus_payload
+        assert broadcaster._client_opus_transcoders == {}
+
+
+class TestFlagOff:
+    async def test_flag_off_opus_client_is_static_and_never_switches(self) -> None:
+        """[BC] pin: default (flag off) is EXACTLY MOR-584 — an Opus-
+        preferring client gets Opus from the first frame, a degradation
+        storm changes nothing, and no controller state exists."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        clock = _FakeClock()
+        broadcaster._adaptive_monotonic = clock
+        ws = _make_ws()
+        handler = AudioHandler(ws, radio, broadcaster)
+        with patch(_TRANSCODER_PATCH, return_value=_FakeTranscoder()):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            await _inject(bus)
+            await _degrade_to_opus(handler, clock)
+            await _inject(bus)
+
+        assert _drain_codecs(handler) == [AUDIO_CODEC_OPUS, AUDIO_CODEC_OPUS]
+        assert broadcaster._client_adaptive == {}
+        assert [a["codec"] for a in _acks(ws)] == ["opus"], (
+            "flag off must not emit adaptive audio_format acks"
+        )
+
+    async def test_flag_off_pcm16_client_never_switches(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        clock = _FakeClock()
+        broadcaster._adaptive_monotonic = clock
+        broadcaster.HIGH_WATERMARK = 2
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_PCM16)
+        await _degrade_to_opus(handler, clock)
+        for _ in range(8):  # server-side congestion signal too
+            await _inject(bus)
+            clock.advance(1.0)
+
+        assert set(_drain_codecs(handler)) == {AUDIO_CODEC_PCM16}
+        assert broadcaster._client_adaptive == {}
+        assert broadcaster._client_opus_transcoders == {}
+
+    async def test_webconfig_flag_defaults_off_and_plumbs_to_broadcaster(
+        self,
+    ) -> None:
+        assert WebConfig().audio_adaptive_egress is False
+        assert WebServer()._audio_broadcaster._adaptive_egress is False
+        server = WebServer(config=WebConfig(audio_adaptive_egress=True))
+        assert server._audio_broadcaster._adaptive_egress is True
+
+
+class TestAdaptiveCleanup:
+    async def test_unsubscribe_clears_adaptive_state(self) -> None:
+        radio, _bus = _make_radio()
+        broadcaster, _clock = _make_adaptive(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+        assert len(broadcaster._client_adaptive) == 1
+
+        await broadcaster.unsubscribe(handler._frame_queue)
+        assert broadcaster._client_adaptive == {}
+
+    async def test_reap_dead_clients_clears_adaptive_state(self) -> None:
+        radio, _bus = _make_radio()
+        broadcaster, _clock = _make_adaptive(radio)
+        ws = _make_ws()
+        handler = AudioHandler(ws, radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+        assert len(broadcaster._client_adaptive) == 1
+
+        ws.is_alive.return_value = False
+        assert await broadcaster.reap_dead_clients() == 1
+        assert broadcaster._client_adaptive == {}


### PR DESCRIPTION
## Summary

Step 19 of epic MOR-562 (ADR `docs/plans/2026-06-09-target-audio-architecture.md` §3.6) — the headline WAN feature: **Opus engages ONLY on detected slow/lossy links**, automatically and per connection, with dwell/hysteresis. `[BC]` — PCM16 default unchanged; **flag-gated**, default off.

## Controller state machine (server, `web/handlers/audio.py`)

Per-client `_AdaptiveEgressState` in `AudioBroadcaster`, evaluated on every `audio_stats` uplink **and** per relay-loop frame (the latter keeps the server-side signal live for congested clients whose stats uplink stalls). Signals are the MOR-585 surfaces: client-reported playback `underruns` + server-side `ws_queue_drops` (drop-oldest evictions of the bounded WS queue). A rising cumulative counter is one unit of degradation *evidence*; a degradation *episode* is continuous evidence with gaps shorter than the degrade window.

| Transition | Condition |
|---|---|
| PCM16 → Opus | evidence episode sustained ≥ `DEGRADE_WINDOW_S = 3.0` s |
| Opus → PCM16 | zero evidence for `CLEAN_WINDOW_S = 30.0` s |
| any switch | only after `DWELL_S = 10.0` s since the previous switch (anti-flap) |

Windows/dwell are named module constants, copied per-instance (injectable for tests); the clock is `time.monotonic` (injectable). On a switch the client's effective codec re-routes through `_client_egress_codec`, so the **MOR-584 encoder pool** lazily constructs a FRESH per-client transcoder on degrade and tears it down on upgrade — no encoding machinery was rewritten. A fresh `audio_format` ack (fire-and-forget, advisory) mirrors every switch.

**Eligibility:** only browser WS clients that declared Opus decode capability (`preferred_rx_codec=opus`) adapt; under the flag that declaration is a *capability*, not a static choice — initial codec is always PCM16 (ADR: "Opus is never the initial codec"). Explicit-PCM16 clients (no WebCodecs), no-preference/legacy clients, and Opus-native radios (pass-through, #762) keep MOR-584 static behavior.

## Flag

`WebConfig.audio_adaptive_egress: bool = False` → plumbed to `AudioBroadcaster(adaptive_egress=...)`. **Off (default) = controller inert**: egress is exactly the static MOR-584 per-connection choice; a client's codec never changes mid-stream; the PCM spine + bridge + scope are untouched (controller sits strictly at the WS-client egress). Pinned by `TestFlagOff` (opus client static-Opus + zero adaptive acks; pcm16 client static under a drop storm; `WebConfig` default + plumbing).

## T1a conformance pin (`tests/contracts/test_adaptive_egress_conformance.py`)

While the controller actively degrades a WS client to Opus, the bridge bus subscriber (digital path → WSJT-X) and the post-DSP PCM tap (FFT scope) observe **bit-identical spine PCM**; every encoder construction is keyed to the WS client id only — no encoder is constructible on a lossless-class path. Plus: flag ON + healthy link constructs zero encoders (zero cost in the common case).

## Frontend mid-stream switch (`frontend/src/lib/audio/rx-player.ts`)

The codec byte travels in every frame header. On a PCM16↔Opus change, the player closes and lazily re-initialises the WebCodecs Opus decoder (the server starts a fresh encoder stream per switch) with `opusTs` restarted at 0; the playback schedule (`nextPlayTime`) is intentionally NOT rebased, so the switch is seamless (no gap, no underrun count). Codec tracking resets on `stop()`. 5 new vitest cases cover fresh-decoder init, stale-decoder close, re-init on Opus→PCM16→Opus, schedule continuity, and stop/restart.

## Falsification (deterministic — injected clock, no real 3 s/30 s waits)

RED first (no flag/controller existed: import + `TypeError` failures), then GREEN:

- flag ON + sustained underrun evidence past `DEGRADE_WINDOW_S` → flips PCM16→Opus + fresh `audio_format: opus` ack
- flag ON + `ws_queue_drops` alone (client never sends `audio_stats`) → flips via relay-loop evaluation
- isolated burst (episode gap > window) → no switch
- 30 s clean → flips back to PCM16 + encoder torn down; 29 s clean → stays Opus
- sustained re-degradation within `DWELL_S` of a switch → blocked; same evidence past dwell → switches
- exemptions: pcm16-pinned, no-preference, Opus-native radio
- flag OFF → never switches (static MOR-584 pins)
- cleanup: unsubscribe + dead-client reap clear controller state

## Gate

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7563 passed**, 10 skipped, 3 deselected, 11 xfailed, 1 xpassed (incl. MOR-567 conformance, MOR-583 smoke, MOR-584/585 suites)
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → clean
- `uv run mypy src/` → **21 errors in 8 files** (baseline exact, no new)
- `uv run lint-imports` → **4 kept / 0 broken**
- frontend: `npm run lint` clean · `npm run check` 0 errors/0 warnings · `npm run test` **2068 passed (119 files)** · `npm run build` ✓ built

## Notes

- File count: 6 (2 src + 1 frontend src + 2 new test files + 1 frontend test) — exceeds the 3-file guardrail, expected for a flagged feature spanning server+frontend+conformance; each hunk kept minimal.
- Deferred: live WAN re-validation (real degraded-link behavior with the flag enabled) — hardware/network-gated, to be exercised when the flag is first turned on in a real remote session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)