### PR TITLE
fix(MOR-589): disable arg abbreviation so discover --serial works on Python 3.11

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -502,6 +502,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p = _RigplaneArgumentParser(
         prog="rigplane",
         description="Control Icom transceivers over LAN",
+        # Abbreviation matching makes the discover subparser's --serial alias
+        # ambiguous against the global --serial-port/--serial-baud/
+        # --serial-ptt-mode options on Python 3.11 (ArgumentError, exit 2).
+        allow_abbrev=False,
         epilog=(
             "examples:\n"
             "  rigplane web                          # auto-discover radio, start web UI\n"


### PR DESCRIPTION
## Problem

Main's `quick` CI is RED: `tests/test_cli.py::TestBuildParser::test_discover_serial_alias_and_hamlib_flags` fails with `SystemExit: 2`.

`rigplane discover --serial` dies before the token ever reaches the discover subparser:

```
rigplane: error: ambiguous option: --serial could match --serial-port, --serial-baud, --serial-ptt-mode
```

argparse abbreviation matching on the **top-level** parser treats `--serial` (appearing after the `discover` subcommand) as an ambiguous abbreviation of the global `--serial-port`/`--serial-baud`/`--serial-ptt-mode` options, instead of letting it flow through to the discover subparser's exact `--serial` alias of `--serial-only`. This is a real user-facing CLI bug, previously masked by the `| tee` exit-code swallowing in quick.yml (fixed in bb86dce1).

Reproduced under Python 3.11.13:

```
uv run --python 3.11 python -c "from rigplane.cli import _build_parser; _build_parser().parse_args(['discover','--serial'])"
# -> SystemExit 2, "ambiguous option: --serial could match ..."
```

Also reproduced on stdlib argparse of **CPython 3.13.0**. Python 3.13.5 (local default) tolerates the overlap, which is why the bug never showed locally.

## Fix

Set `allow_abbrev=False` on the top-level `_RigplaneArgumentParser` in `_build_parser()` (4 lines incl. comment, 1 file). With abbreviation disabled, the top-level parser no longer claims `--serial`, and the `PARSER`-nargs subcommand positional passes it to the discover subparser where it matches the exact alias.

No global option loses anything users were promised: all documented invocations use full option names, and explicit aliases (`--port`, `--pass`, `--password`, `--serial`) are real option strings, not abbreviations, so they keep working.

## Verification

**Python 3.11.13** (`uv sync --all-extras --python 3.11`, full suite minus integration):
- Target test: FAIL on base -> PASS with fix.
- Full failure-list diff (base vs fix) is **exactly one line**: the target test. Zero new failures, zero collateral from `allow_abbrev=False` — no test or feature relies on option abbreviation.
- Remaining 136 FAILED/ERROR entries on 3.11 are **pre-existing on origin/main base** (identical list with the fix reverted), concentrated in `test_rigctld_handler.py`/`test_web_server.py` — an unrelated latent issue (`isinstance(AsyncMock(), runtime_checkable Protocol)` is always True on 3.11's hasattr-based check, sending mocks down the `RigctldRoutable` path). Out of scope here; see note below on why CI never sees them.

**Python 3.13.5** (default): full suite minus integration: **7559 passed, 0 failed**, 10 skipped, 11 xfailed, 1 xpassed.

**CPython 3.13.0** (the interpreter CI actually used, see below): structural repro errors with abbreviation enabled, parses `discover --serial` correctly with `allow_abbrev=False`.

**Gates:** `ruff check` clean; `ruff format --check` clean (567 files); `mypy src/` at baseline (21 errors in 8 files); `lint-imports` 4 kept / 0 broken.

## CI observation (follow-up material, not addressed here)

The failing quick run on main (run 27268601273) has a "Set up Python 3.11" step, but its pytest header reads `platform linux -- Python 3.13.0` — the venv was created with 3.13.0, not 3.11. So quick CI is not actually exercising 3.11 (which is also why the pre-existing 3.11 AsyncMock/Protocol failures above never appear in CI). The CLI test failed there because 3.13.0's argparse still has the ambiguity (relaxed only in a later 3.13 patch). This fix makes the parse robust on every interpreter version; pinning the quick job's venv to the advertised 3.11 deserves a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)