### PR TITLE
docs(MOR-562): as-built audio architecture — LAYER.md + ADR status

### DIFF
--- a/docs/plans/2026-06-09-target-audio-architecture.md
+++ b/docs/plans/2026-06-09-target-audio-architecture.md
@@ -1,7 +1,9 @@
 # Target Audio Architecture — Universal Audio Path ADR
 
 **Date:** 2026-06-09
-**Status:** Proposed — rev 2. Operator approved the overall direction
+**Status:** Implemented (2026-06-10) — see **As-built status** below for the
+step → issue → PR mapping and the deferred items. Design history: rev 2.
+Operator approved the overall direction
 (AudioSession + desired-state machine + PCM spine + edge-only lossy) and added
 three requirements folded in below: adaptive/opt-in lossy egress with a strict
 lossless digital-path invariant (T1a, §3.6), a tract-wide debug/analytics tap
@@ -12,6 +14,74 @@ MOR-556/559 (stream-order regressions), MOR-241/506 (single-slot callback bugs),
 MOR-307/#104 (WebRTC DataChannel transport)
 **Format model:** `docs/plans/2026-04-12-target-frontend-architecture.md`
 **Base commit:** `467f40bd` (main)
+
+## As-built status (2026-06-10, main @ `1cc5e72a`)
+
+The MOR-562 epic is **implemented**: 17 of the 20 §4 migration steps plus one
+added step (9b) are merged to `main`; the exceptions are steps 11, 12, and 15
+plus the live hardware re-validations, all listed below. Where the realized
+code deviates from a step's "files (indicative)" column, the merged PR is
+authoritative (notable deviations noted inline).
+
+### Merged (§4 step → issue → PR)
+
+| §4 step | Issue | PR | As-built notes |
+|---|---|---|---|
+| 1 — bridge teardown on failed start | MOR-560 | #1755 | |
+| 2 — typed lifecycle errors | MOR-563 | #1757 | `AudioAlreadyStartedError`/`AudioNotStartedError` live in `audio/usb_driver.py` (subclassing `AudioDriverLifecycleError`), not `core/exceptions.py` |
+| 3 — AudioBus RX heartbeat | MOR-564 | #1756 | `AudioBus.last_rx_frame_monotonic` in the runtime payload |
+| 4 — tap-surface skeleton | MOR-565 | #1758 | `STAGE_RX_PCM`/`STAGE_RX_POST_DSP` in `audio/bus.py`; `rx.pcm` hosted on the bus, `rx.post_dsp` on the broadcaster |
+| 5 — stateful test fakes | MOR-566 | #1759 | `FakeAudioBackend(strict_device_exclusive=True)` + shared order-sensitive radio stubs |
+| 6 — lifecycle conformance suite | MOR-567 | #1760 | `tests/contracts/test_audio_lifecycle_conformance.py` |
+| 7 — `audio_setup_order` descriptor | MOR-575 | #1761 | Additive on the backends, derived from `audio_duplex_mode`; conformance-pinned to stay OUT of the frozen 10-member `AudioTransport` — consumers read it via `getattr(radio, "audio_setup_order", "rx_first")` |
+| 8 — `AudioSession` skeleton | MOR-576 | #1763 | `audio/session.py`, single-lock `_apply()` reconciliation |
+| 9 — bridge on session | MOR-577 | #1765 | `rx_first` branch + `_subscribe_bus` band-aid deleted |
+| 9b — radio-owned session singleton *(added step)* | MOR-579 | #1766 | Lazy `radio.audio_session` (`runtime/radio.py`) — resolves open question 1 |
+| 10 — bus surfaces RX-start failures | MOR-582 | #1769 | Subscriber rollback in the bus + broadcaster error envelope to WS clients |
+| 13 — web TX through session lease | MOR-580 | #1767 | `session.acquire_tx("web")` |
+| 14 — health watchdog + events | MOR-581 | #1768 | ~1 s watchdog on the bus heartbeat; ~3 s silence ⇒ RECOVERING + local `AudioSessionEvent` |
+| 16 — `AudioDeviceConfig` carrier | MOR-578 | #1764 | Frozen dataclass in `audio/backend.py` |
+| 17 — per-connection egress codecs | MOR-584 | #1771 | Per-client encoder pool + `audio_format` ack |
+| 18 — client link-quality uplink | MOR-585 | #1773 | `audio_stats` every ~1.5 s per client |
+| 19 — adaptive egress controller | MOR-588 | #1775 | Flag-gated `WebConfig.audio_adaptive_egress` (default off); T1a pinned by `tests/contracts/test_adaptive_egress_conformance.py` |
+| 20 — recovery unification | MOR-586 | #1772 | `AudioSession.reestablish()` from live demand; legacy snapshot replay retired |
+
+Found and fixed along the way (not §4 steps): MOR-574 (#1762) — bridge
+`stop()` with TX armed leaked the running LAN RX stream, surfaced by the
+step-6 conformance suite; MOR-583 (#1770) — end-to-end audio-path smoke tests
+over fakes.
+
+### Deferred / not yet merged
+
+- **Step 11 — `UsbAudioDriver.ensure()` exclusive-duplex wiring (MOR-546).**
+  Hardware-gated (FTX-1 / X6200). `start_duplex` still has no production
+  caller; the session's `tx_first`/`atomic` sequencing is the prepared seam.
+- **Step 12 — poller PTT through the session + the `_should_restart_rx` flip
+  (MOR-554).** Hardware-gated (IC-7610). As-built the poller PTT path still
+  arms `radio.start_tx` directly on the neutral surface (MOR-543, #1747) and
+  re-arms RX for every duplex mode — the one remaining audio-arming path not
+  routed through `AudioSession`. The session's `_REARM_RX_AFTER_TX_DROP` seam
+  is pre-built for the flip.
+- **Step 15 — decode-at-ingress / `PcmFrame` (MOR-591, open).** The
+  per-consumer decoders are still in place (bridge opuslib decoder,
+  broadcaster uLaw branch, Opus DSP/tap gates — #762). Dormant in practice:
+  every shipping default delivers PCM natively. Planned as additive PR-1
+  (carrier + dual-publish) then PR-2 (per-consumer-decoder removal).
+- **All live hardware re-validations** (radio offline 2026-06-10): IC-7610
+  LAN full-duplex + reconnect `reestablish()`, FTX-1 exclusive duplex +
+  WSJT-X FT8 through the bridge, browser TX over the session lease, adaptive
+  egress over a real WAN.
+
+### CI/infra fixes found along the way
+
+- **MOR-587** (#1774): quick.yml swallowed the pytest exit code (`tee`
+  without `pipefail`) — CI failures were masked.
+- **MOR-589** (#1776): `discover --serial` raised `SystemExit(2)` on
+  Python 3.11/3.13.0 (argparse prefix abbreviation) — `allow_abbrev=False`.
+- **MOR-590** (open): quick.yml's "Set up Python 3.11" does not pin the
+  pytest interpreter (runs 3.13.0), and real 3.11 hides 136 latent
+  AsyncMock / runtime-`Protocol` test failures that must be fixed before
+  pinning.
 
 ## Purpose
 
@@ -901,7 +971,7 @@ test-gated. **[BP]** = behavior-preserving, **[BC]** = behavior-changing.
 Steps 1–6 are pure de-risking and can ship this week — the tap surface
 (step 4) lands early deliberately: it is behavior-preserving and makes every
 later step observable. Steps 7–9 build the session without changing
-behavior. Steps 10–12, 14, 15, and 19 are the behavior changes, each
+behavior. Steps 10–12, 14, 15, 17, and 19 are the behavior changes, each
 individually flagged and hardware-gated where noted. The legacy
 `AudioCapable` shims and `rigplane.audio` export pins are untouched throughout
 (constraint 1/2).

--- a/src/rigplane/audio/LAYER.md
+++ b/src/rigplane/audio/LAYER.md
@@ -2,13 +2,68 @@
 
 ## Charter
 
-End-to-end audio subsystem: `AudioBackend` Protocol + PortAudio/Fake
+End-to-end audio subsystem, organised around a per-radio `AudioSession`
+(epic MOR-562; full design in
+`docs/plans/2026-06-09-target-audio-architecture.md`): session state
+machine, audio bus, `AudioBackend` Protocol + PortAudio/Fake
 implementations, codecs (PCM / Opus / μ-law), transcoder, audio bridge,
-audio bus, FFT scope (panadapter), reconnect-time recovery, and platform
-USB audio resolution. `audio.route` resolves the radio audio route used by
-WSJT-X DATA policy; it must not treat the local loopback bridge as proof of
-LAN audio. The `audio.backend` and `audio.dsp` submodule paths are part of
-the rigplane-pro contract and **must remain stable**.
+FFT scope (panadapter), and platform USB audio resolution. `audio.route`
+resolves the radio audio route used by WSJT-X DATA policy; it must not
+treat the local loopback bridge as proof of LAN audio. The
+`audio.backend` and `audio.dsp` submodule paths are part of the
+rigplane-pro contract and **must remain stable**.
+
+## Components and ownership
+
+- **`audio/session.py` — `AudioSession`** (one per radio, lazily owned
+  by the radio as `radio.audio_session`, `runtime/radio.py`). The sole
+  arbiter of the radio audio lifecycle: a demand-driven
+  IDLE ⇄ RX_ONLY ⇄ RX_TX state machine (plus RECOVERING/FAILED)
+  reconciled under one asyncio lock (`_apply`). Consumers declare
+  demand — `subscribe_rx(name)` / `acquire_tx(owner)` → refcounted
+  `TxLease` — and never call radio
+  `start_rx`/`stop_rx`/`start_tx`/`stop_tx` themselves. Arming order is
+  transport-owned via the additive `audio_setup_order` descriptor
+  (`"rx_first"` / `"tx_first"` / `"atomic"`, read with `getattr`,
+  defaulting to `"rx_first"`); teardown always drops TX before RX. A
+  ~1 s health watchdog reads the bus heartbeat; ~3 s of RX silence ⇒
+  RECOVERING + a local `AudioSessionEvent` (listeners only — no
+  telemetry). `reestablish()` re-arms the session's *live* demand after
+  a transport reconnect (called by `runtime/_audio_recovery.py`).
+- **`audio/bus.py` — `AudioBus`**: RX fan-out to bounded
+  per-subscriber queues. The first-subscriber/last-unsubscribe refcount
+  IS the session's RX demand. Exposes the `last_rx_frame_monotonic`
+  heartbeat and hosts the `rx.pcm` tap stage (`STAGE_RX_PCM`, a
+  `dsp.TapRegistry`). RX-start failures raise to the demanding
+  subscriber — never swallowed — with the failed subscriber rolled
+  back.
+- **`audio/bridge.py` — `AudioBridge`**: pure session consumer +
+  device-side loopback pump (BlackHole / PipeWire null-sink / VB-Cable
+  → WSJT-X/fldigi). Declares RX demand and a TX lease on
+  `radio.audio_session`; owns no radio-side ordering (the old
+  `rx_first` branch is gone) and no radio-side recovery — only
+  loopback-device reconnect. The bridge output is the lossless
+  digital-decode path (ADR tenet T1a): no lossy codec may ever sit on
+  it (conformance-pinned in
+  `tests/contracts/test_adaptive_egress_conformance.py`).
+- **`audio/fft_scope.py` — `AudioFftScope`**: panadapter frames from
+  PCM, fed from the web broadcaster's `rx.post_dsp` tap stage
+  (`STAGE_RX_POST_DSP`).
+- **Device/wire tier — `audio/backend.py`, `audio/usb_driver.py`,
+  `audio/lan_stream.py`**: `AudioBackend` Protocol +
+  PortAudio/Fake implementations (`FakeAudioBackend` grows
+  `strict_device_exclusive` for order-sensitive tests), the frozen
+  `AudioDeviceConfig` carrier (one object threaded
+  loader→backend→driver→framer), `UsbAudioDriver` (device selection +
+  duplex policy), LAN UDP framing + jitter buffer. Typed lifecycle
+  errors (`AudioAlreadyStartedError`, `AudioNotStartedError`) live in
+  `usb_driver.py`.
+
+Edge note: per-client egress encoding, `audio_format` negotiation, and
+the flag-gated adaptive PCM16↔Opus controller live at the web edge
+(`web/handlers/audio.py`), downstream of this layer. The spine through
+bus/taps/bridge stays uncompressed — lossy codecs exist only at the
+client edge, and never on the bridge/digital path.
 
 ## Public API
 
@@ -20,9 +75,10 @@ types used by transport/radio/sync at import time) and a PEP 562
   `AudioStats`, `JitterBuffer`, `build_audio_packet`,
   `parse_audio_packet`, `AUDIO_HEADER_SIZE`, `MAX_AUDIO_PAYLOAD`,
   `RX_IDENT_0xA0`, `TX_IDENT`.
-- **Lazy — backend**: `AudioBackend`, `AudioDeviceId`,
-  `AudioDeviceInfo`, `RxStream`, `TxStream`, `PortAudioBackend`,
-  `FakeAudioBackend`, `FakeRxStream`, `FakeTxStream`.
+- **Lazy — backend**: `AudioBackend`, `AudioDeviceConfig`,
+  `AudioDeviceId`, `AudioDeviceInfo`, `RxStream`, `TxStream`,
+  `PortAudioBackend`, `FakeAudioBackend`, `FakeRxStream`,
+  `FakeTxStream`.
 - **Lazy — config**: `AudioConfig`, `load_audio_config`,
   `save_audio_config`.
 - **Lazy — DSP**: `DspPipeline`, `DspStage`, `Limiter`, `NoiseGate`,
@@ -32,7 +88,13 @@ types used by transport/radio/sync at import time) and a PEP 562
 - **Lazy — USB**: `UsbAudioDriver`, `UsbAudioDevice`,
   `list_usb_audio_devices`, `select_usb_audio_devices`,
   plus driver-lifecycle/selection exceptions.
-- **Direct submodule**: `audio.route` exposes the route resolver and
+- **Direct submodule — `audio.session`**: `AudioSession`,
+  `AudioSessionState`, `AudioSessionEvent`, `RxSubscription`,
+  `TxLease` (not re-exported from `audio/__init__.py`; reach the
+  session via `radio.audio_session`).
+- **Direct submodule — `audio.bus`**: `AudioBus`, `AudioSubscription`,
+  `STAGE_RX_PCM`, `STAGE_RX_POST_DSP` (the named tap-stage scheme).
+- **Direct submodule — `audio.route`**: the route resolver and
   route-derived rigctld WSJT-X DATA policy.
 
 The `AudioBackend` Protocol is Tier 2 (best-effort; lazily exposed via
@@ -40,23 +102,46 @@ PEP 562) — see #1275.
 
 ## Allowed dependencies
 
-`core`, `scope` (plan §3 matrix row `audio`). The `audio → scope` edge
-is single-direction, used by `audio/fft_scope.py` to assemble panadapter
-frames from PCM. No `runtime`, no `commands`, no transport caller.
+`core`, `scope`, `dsp` (plan §3 matrix row `audio`). Both sibling edges
+are single-direction: `audio → scope` is used by `audio/fft_scope.py`
+to assemble panadapter frames from PCM; `audio → dsp` is used by
+`audio/bus.py` for the `TapRegistry` tap stages. No `runtime`, no
+`commands`, no transport caller. Anything in this layer that needs a
+radio reference takes it as a duck-typed `AudioTransport`-shaped object
+(`core.radio_protocol.AudioTransport`) — exactly as `AudioSession` and
+`AudioBus` do — so the import matrix is untouched.
 
 ## Forbidden patterns
 
 - `from rigplane.runtime` / `from rigplane.commands` — audio is a leaf
   that runtime composes; the inverse direction is forbidden.
+- Calling radio `start_rx`/`stop_rx`/`start_tx`/`stop_tx` from a
+  consumer. Declare demand on `radio.audio_session` instead; the
+  session owns the ordering and the recovery. (The poller PTT path is
+  the one legacy exception until MOR-554 lands.)
+- Lossy codecs on the bridge/digital path (tenet T1a) or anywhere on
+  the spine. Egress encoding belongs to the web edge only.
+- Single-slot callbacks on shared paths. Use the named tap stages
+  (`TapRegistry`) — see MOR-241/MOR-506 history.
 - Eager imports of `numpy`, `sounddevice`, `opuslib`, or `pyaudio` at
   module top level. Use `core._optional_deps._require_*()` and gate at
   call time. The eager block in `audio/__init__.py` is intentionally
   limited to wire-protocol types.
 - One-off mocks in audio tests. Use `FakeAudioBackend` only (per
-  CLAUDE.md project rule).
+  CLAUDE.md project rule); order-sensitive lifecycle tests use
+  `strict_device_exclusive=True` and the shared stateful radio stubs.
 
 ## Common operations
 
+- **Add a new audio consumer** → `await radio.audio_session.subscribe_rx(name)`
+  for RX frames, `await radio.audio_session.acquire_tx(owner)` for a TX
+  lease; release both. Passive observation → register on a named tap
+  stage instead of subscribing.
+- **Add a new radio audio transport** → implement the neutral
+  `AudioTransport` surface (`core.radio_protocol`) + the additive
+  `audio_setup_order` descriptor; the session, bus, bridge, scope, and
+  web egress are transport-blind. Extend
+  `tests/contracts/test_audio_lifecycle_conformance.py` to cover it.
 - **Add a new codec** → add to `audio/_codecs.py` plus a Python ID
   constant in `core.types.AudioCodec`; verify wire-format roundtrip in
   `tests/test_audio_codecs*.py`.
@@ -73,9 +158,15 @@ frames from PCM. No `runtime`, no `commands`, no transport caller.
 
 ## See also
 
+- `docs/plans/2026-06-09-target-audio-architecture.md` — the universal
+  audio path ADR (design, tenets T1–T6, migration status as-built).
 - `docs/plans/2026-04-29-modularization-plan.md` §1.2 ("audio.backend
   and audio.dsp paths are the rigplane-pro contract"), §2.2, §3.
 - `docs/api/public-api-surface.md` — Tier 2 surface for AudioBackend.
 - `audio/backend.py` — the stable Protocol definition.
+- `tests/contracts/test_audio_lifecycle_conformance.py` +
+  `tests/contracts/test_audio_transport_conformance.py` +
+  `tests/contracts/test_adaptive_egress_conformance.py` — the lifecycle,
+  protocol-surface, and T1a pins.
 - `tests/test_audio_*.py` — coverage; `FakeAudioBackend` lives in
   `audio/backend.py`.


### PR DESCRIPTION
## What

Docs-only PR (2 markdown files, zero source/test/config changes) documenting the AS-BUILT audio architecture after the MOR-562 universal-audio-path epic. Everything is verified against the code at `main` @ `1cc5e72a` and against git history / Linear.

### `src/rigplane/audio/LAYER.md` — layer charter rewrite

Now describes the AudioSession-centric architecture as built:

- **Components and ownership** (new section): `AudioSession` as the sole arbiter of the radio audio lifecycle (demand-driven IDLE ⇄ RX_ONLY ⇄ RX_TX + RECOVERING/FAILED, single-lock `_apply()`, `subscribe_rx`/`acquire_tx` leases, transport-declared `audio_setup_order`, ~1 s watchdog + `reestablish()`); `AudioBus` (fan-out refcount = RX demand, `last_rx_frame_monotonic` heartbeat, `rx.pcm` tap stage, RX-start failures raised not swallowed); `AudioBridge` (pure session consumer + device pump, `rx_first` branch gone, lossless T1a path); `AudioFftScope` on the `rx.post_dsp` tap; the device/wire tier incl. `AudioDeviceConfig` and the typed lifecycle errors.
- Public API updated: `audio.session` / `audio.bus` as direct submodules (session reached via `radio.audio_session`), `AudioDeviceConfig` in the lazy block.
- Allowed dependencies now include `dsp` (the bus imports `TapRegistry`), matching the `.importlinter` matrix; radio references stay duck-typed `AudioTransport`.
- New forbidden patterns: consumers never call radio `start/stop` directly (poller PTT noted as the one legacy exception until MOR-554); no lossy codecs on the spine/bridge; no single-slot callbacks on shared paths.

### `docs/plans/2026-06-09-target-audio-architecture.md` — ADR as-built status

- Status flipped to **Implemented (2026-06-10)** with a new **As-built status** section after the header block.
- Step → issue → PR table for the 17 merged §4 steps + added step 9b: 1/MOR-560/#1755, 2/MOR-563/#1757, 3/MOR-564/#1756, 4/MOR-565/#1758, 5/MOR-566/#1759, 6/MOR-567/#1760, 7/MOR-575/#1761, 8/MOR-576/#1763, 9/MOR-577/#1765, 9b/MOR-579/#1766, 10/MOR-582/#1769, 13/MOR-580/#1767, 14/MOR-581/#1768, 16/MOR-578/#1764, 17/MOR-584/#1771, 18/MOR-585/#1773, 19/MOR-588/#1775, 20/MOR-586/#1772 — plus MOR-574 (#1762) and MOR-583 (#1770) found along the way.
- **Deferred:** step 11 (MOR-546, `UsbAudioDriver.ensure()` exclusive-duplex wiring — hardware-gated FTX-1/X6200); step 12 (MOR-554 flip — hardware-gated IC-7610; poller PTT is the last arming path not on the session); step 15 (MOR-591, decode-at-ingress/`PcmFrame` — open; per-consumer decoders still present, PR-2 removal follows the additive PR-1); all live hardware re-validations (radio offline 2026-06-10): IC-7610 LAN full-duplex + reconnect, FTX-1 exclusive duplex + WSJT-X FT8, browser TX, adaptive-egress WAN.
- CI/infra fixes noted: MOR-587 (#1774 pipefail), MOR-589 (#1776 allow_abbrev), MOR-590 (open — CI interpreter pin + 136 latent 3.11 AsyncMock/Protocol failures).
- **§4 nit fixed:** the behavior-changes enumeration now includes step 17 (also [BC]): "Steps 10–12, 14, 15, 17, and 19".

## Verification

- `git diff --stat` — only the two doc files.
- Every cited symbol/path grep-verified against the code (e.g. `_REARM_RX_AFTER_TX_DROP`, `WebConfig.audio_adaptive_egress`, `STAGE_RX_PCM`/`STAGE_RX_POST_DSP`, `AudioSession.reestablish`, `radio.audio_session`, the three `tests/contracts/` pins).
- Markdown tables/fences lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)