### PR TITLE
feat(MOR-591): PcmFrame carrier + LAN decode-at-ingress (dual-publish, additive)

### DIFF
--- a/src/rigplane/audio/__init__.py
+++ b/src/rigplane/audio/__init__.py
@@ -58,6 +58,8 @@ _LAZY_MAP: dict[str, tuple[str, str]] = {
     "Limiter": ("rigplane.audio.dsp", "Limiter"),
     "NoiseGate": ("rigplane.audio.dsp", "NoiseGate"),
     "RmsNormalizer": ("rigplane.audio.dsp", "RmsNormalizer"),
+    # PCM spine carrier (MOR-591, ADR §3.5)
+    "PcmFrame": ("rigplane.audio.pcm", "PcmFrame"),
     # Resampling
     "PcmResampler": ("rigplane.audio.resample", "PcmResampler"),
     "SampleRateNegotiation": (
@@ -139,6 +141,8 @@ __all__ = [
     "Limiter",
     "NoiseGate",
     "RmsNormalizer",
+    # PCM spine carrier
+    "PcmFrame",
     # Resampling
     "PcmResampler",
     "SampleRateNegotiation",

--- a/src/rigplane/audio/pcm.py
+++ b/src/rigplane/audio/pcm.py
@@ -1,0 +1,38 @@
+"""PcmFrame — codec-neutral s16le carrier for the PCM audio spine.
+
+ADR §3.5 (``docs/plans/2026-06-09-target-audio-architecture.md``, tenet
+T1): transport adapters decode the radio-negotiated wire codec ONCE at
+ingress and publish PCM s16le frames, so the spine (bus / DSP / taps /
+bridge) never has to know a compressed codec exists. During the
+migration the ingress dual-publishes: the legacy
+:class:`~rigplane.audio.lan_stream.AudioPacket` (Pro-pinned export)
+keeps flowing unchanged alongside this carrier (MOR-591).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["PcmFrame"]
+
+
+@dataclass(frozen=True, slots=True)
+class PcmFrame:
+    """One decoded PCM audio frame on the spine (MOR-591, ADR §3.5).
+
+    Attributes:
+        sample_rate: Sample rate in Hz of the decoded payload.
+        channels: Interleaved channel count (1 or 2).
+        payload: Interleaved signed 16-bit little-endian PCM bytes —
+            ALWAYS s16le, regardless of the radio's negotiated wire
+            codec. For PCM16-native radios this is the wire payload
+            itself (zero-copy passthrough, no decode).
+        seq: Locally counted monotonic frame sequence for the current
+            RX session (starts at 0 per session; never wraps — unlike
+            the uint16 ``AudioPacket.send_seq``).
+    """
+
+    sample_rate: int
+    channels: int
+    payload: bytes
+    seq: int

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -19,12 +19,14 @@ if TYPE_CHECKING:
 else:
     _MixinBase = object
 
+from rigplane.audio._codecs import decode_ulaw_to_pcm16
 from rigplane.audio._transcoder import (
     PcmAudioFormat,
     PcmOpusTranscoder,
     create_pcm_opus_transcoder,
 )
 from rigplane.audio import AudioStats, AudioStream
+from rigplane.audio.pcm import PcmFrame
 from rigplane.core.exceptions import AudioFormatError, ConnectionError
 from rigplane.core.transport import IcomTransport
 from rigplane.core.types import AudioCodec
@@ -47,6 +49,13 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     _audio_sample_rate: int
     _audio_stream_request: AudioStreamRequest
     _audio_stream_contract: AudioStreamContract
+
+    # -- PCM-spine ingress state (MOR-591) — lazily initialized ----------
+    _pcm_rx_taps: list[Callable[[PcmFrame | None], None]]
+    _pcm_ingress_seq: int
+    _pcm_ingress_transcoder: PcmOpusTranscoder
+    _pcm_ingress_transcoder_fmt: tuple[int, int, int]
+    _pcm_ingress_opus_dead: bool
 
     # ------------------------------------------------------------------
     # Neutral AudioTransport surface (MOR-532 epic, MOR-539)
@@ -78,6 +87,7 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         assert self._audio_stream is not None
         self._opus_rx_user_callback = callback
         self._opus_rx_jitter_depth = jitter_depth
+        self._arm_pcm_ingress()
         await self._audio_stream.start_rx(callback, jitter_depth=jitter_depth)
 
     async def stop_rx(self) -> None:
@@ -136,6 +146,150 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         await self._ensure_audio_transport()
         assert self._audio_stream is not None
         await self._audio_stream.start_tx()
+
+    # ------------------------------------------------------------------
+    # PCM-spine ingress: decode-at-ingress dual-publish (MOR-591, ADR §3.5)
+    # ------------------------------------------------------------------
+
+    def add_pcm_rx_tap(self, callback: Callable[[PcmFrame | None], None]) -> None:
+        """Register a PCM-spine listener fed decoded frames at LAN ingress.
+
+        The LAN adapter decodes the radio-negotiated RX wire codec
+        (PCM16 / uLaw / Opus) to s16le ONCE and feeds every registered
+        tap a :class:`PcmFrame` per delivered RX packet (``None`` for
+        jitter-buffer gap placeholders) — in parallel with, never
+        instead of, the legacy :class:`AudioPacket` callback
+        (dual-publish during the spine migration, tenet T1). With no
+        taps registered the decode is skipped entirely, so the default
+        AudioPacket-only path stays byte- and cost-identical.
+        """
+        taps = getattr(self, "_pcm_rx_taps", None)
+        if taps is None:
+            taps = []
+            self._pcm_rx_taps = taps
+        if callback not in taps:
+            taps.append(callback)
+
+    def remove_pcm_rx_tap(self, callback: Callable[[PcmFrame | None], None]) -> None:
+        """Remove a PCM-spine listener (no-op if not registered)."""
+        taps = getattr(self, "_pcm_rx_taps", None)
+        if taps is None:
+            return
+        try:
+            taps.remove(callback)
+        except ValueError:
+            pass
+
+    def _arm_pcm_ingress(self) -> None:
+        """Arm the PCM ingress tap for a new RX session (MOR-591).
+
+        Registers a single parallel RX tap on the LAN stream (duck-typed:
+        stream doubles without ``add_rx_tap`` simply skip the PCM spine)
+        and resets the per-session monotonic frame sequence. The legacy
+        AudioPacket callback handed to ``AudioStream.start_rx`` is never
+        wrapped or replaced — dual-publish, not substitution.
+        """
+        self._pcm_ingress_seq = 0
+        self._pcm_ingress_opus_dead = False
+        add_rx_tap = getattr(self._audio_stream, "add_rx_tap", None)
+        if add_rx_tap is not None:
+            add_rx_tap(self._on_pcm_ingress_packet)
+
+    def _on_pcm_ingress_packet(self, packet: AudioPacket | None) -> None:
+        """LAN-stream RX tap: decode once at ingress, fan out PcmFrames.
+
+        Runs for every delivered RX packet, including jitter-buffer gap
+        placeholders (forwarded as ``None``). Never raises — the stream
+        RX loop has no exception guard around tap dispatch.
+        """
+        taps = getattr(self, "_pcm_rx_taps", None)
+        if not taps:
+            return
+        frame: PcmFrame | None
+        if packet is None:
+            frame = None
+        else:
+            try:
+                frame = self._decode_pcm_ingress(packet)
+            except Exception:
+                logger.debug("PCM ingress: decode failed", exc_info=True)
+                return
+            if frame is None:
+                return
+        for tap in list(taps):
+            try:
+                tap(frame)
+            except Exception:
+                logger.debug("PCM ingress: tap error", exc_info=True)
+
+    def _decode_pcm_ingress(self, packet: AudioPacket) -> PcmFrame | None:
+        """Decode one wire packet to s16le per the negotiated RX codec.
+
+        Returns ``None`` for wire codecs without an s16le mapping here
+        (8-bit PCM — no shipping profile negotiates it) and for Opus
+        when the codec backend is unavailable; the legacy AudioPacket
+        carrier keeps flowing either way.
+        """
+        codec = self.audio_codec
+        if codec in (AudioCodec.PCM_1CH_16BIT, AudioCodec.PCM_2CH_16BIT):
+            channels = 2 if codec == AudioCodec.PCM_2CH_16BIT else 1
+            payload = packet.data  # already s16le — zero-copy passthrough
+        elif codec in (AudioCodec.ULAW_1CH, AudioCodec.ULAW_2CH):
+            channels = 2 if codec == AudioCodec.ULAW_2CH else 1
+            payload = decode_ulaw_to_pcm16(packet.data)
+        elif codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
+            channels = 2 if codec == AudioCodec.OPUS_2CH else 1
+            opus_payload = self._decode_opus_ingress(packet.data, channels)
+            if opus_payload is None:
+                return None
+            payload = opus_payload
+        else:
+            return None
+        seq = self._pcm_ingress_seq
+        self._pcm_ingress_seq = seq + 1
+        return PcmFrame(
+            sample_rate=self.audio_sample_rate,
+            channels=channels,
+            payload=payload,
+            seq=seq,
+        )
+
+    def _decode_opus_ingress(self, data: bytes, channels: int) -> bytes | None:
+        """Decode one Opus wire frame to s16le with a session-cached decoder.
+
+        Uses a DEDICATED transcoder (not the ``_get_pcm_transcoder``
+        cache) so the stateful Opus decoder is never evicted by the
+        user-facing PCM RX/TX APIs. A failed backend init dead-flags the
+        ingress for the session (reset on the next ``start_rx``) instead
+        of retrying per frame.
+        """
+        if getattr(self, "_pcm_ingress_opus_dead", False):
+            return None
+        fmt = (self.audio_sample_rate, channels, 20)
+        transcoder = getattr(self, "_pcm_ingress_transcoder", None)
+        if (
+            transcoder is None
+            or getattr(self, "_pcm_ingress_transcoder_fmt", None) != fmt
+        ):
+            try:
+                transcoder = create_pcm_opus_transcoder(
+                    sample_rate=fmt[0], channels=fmt[1], frame_ms=fmt[2]
+                )
+            except Exception:
+                logger.warning(
+                    "PCM ingress: Opus decode unavailable — "
+                    "PcmFrame publishing disabled for this RX session",
+                    exc_info=True,
+                )
+                self._pcm_ingress_opus_dead = True
+                return None
+            self._pcm_ingress_transcoder = transcoder
+            self._pcm_ingress_transcoder_fmt = fmt
+        try:
+            return transcoder.opus_to_pcm(data)
+        except Exception:
+            logger.debug("PCM ingress: Opus frame decode failed", exc_info=True)
+            return None
 
     # ------------------------------------------------------------------
     # Audio streaming (legacy opus-family delegates + PCM conveniences)

--- a/tests/_audio_stream_fake.py
+++ b/tests/_audio_stream_fake.py
@@ -8,6 +8,7 @@ that production code and tests interact with:
     start_tx()
     stop_tx()
     push_tx(opus_data)
+    add_rx_tap(callback) / remove_rx_tap(callback)
 
 Call-tracking attributes allow assertions without MagicMock:
 
@@ -42,6 +43,7 @@ class FakeAudioStream:
         self.last_start_rx_callback: Callable[..., Any] | None = None
         self.last_start_rx_jitter_depth: int | None = None
 
+        self.rx_taps: list[Callable[..., Any]] = []
         self.tx_frames: list[bytes] = []
 
     async def start_rx(
@@ -65,3 +67,22 @@ class FakeAudioStream:
 
     async def push_tx(self, opus_data: bytes) -> None:
         self.tx_frames.append(opus_data)
+
+    def add_rx_tap(self, callback: Callable[..., Any]) -> None:
+        """Mirror of ``AudioStream.add_rx_tap`` (parallel RX listener)."""
+        if callback not in self.rx_taps:
+            self.rx_taps.append(callback)
+
+    def remove_rx_tap(self, callback: Callable[..., Any]) -> None:
+        """Mirror of ``AudioStream.remove_rx_tap``."""
+        try:
+            self.rx_taps.remove(callback)
+        except ValueError:
+            pass
+
+    def emit_rx(self, packet: Any) -> None:
+        """Deliver one RX packet to the callback and all taps (real fan-out order)."""
+        if self.last_start_rx_callback is not None:
+            self.last_start_rx_callback(packet)
+        for tap in list(self.rx_taps):
+            tap(packet)

--- a/tests/test_pcm_ingress_decode.py
+++ b/tests/test_pcm_ingress_decode.py
@@ -1,0 +1,383 @@
+"""Falsification tests for MOR-591 PR-1: PcmFrame + LAN decode-at-ingress.
+
+ADR §3.5 (tenet T1 PCM spine): the LAN transport adapter decodes any
+compressed wire codec (Icom LAN-negotiated uLaw or Opus) to PCM s16le
+ONCE at ingress and DUAL-PUBLISHES — the legacy :class:`AudioPacket`
+keeps flowing unchanged to the existing callback (Pro-pinned carrier),
+while registered PCM taps receive the decoded :class:`PcmFrame`.
+
+PR-1 is additive: no per-consumer decoder is removed here (that is the
+PR-2 follow-up). These tests pin:
+
+1. uLaw ingress → correctly decoded s16le PcmFrame (known mu-law
+   values) + legacy AudioPacket untouched;
+2. Opus ingress → decoded through the Opus transcoder at the
+   negotiated (sample_rate, channels, 20 ms) format;
+3. PCM16-native (IC-7610 LAN default PCM_2CH_16BIT) → zero-copy
+   passthrough, byte-identical legacy path;
+4. no PCM taps registered → no decode work at all (cost-identical);
+5. monotonic PcmFrame.seq across uint16 send_seq wrap + gap (None)
+   forwarding;
+6. failure isolation: tap exceptions and a missing Opus backend never
+   disturb the legacy carrier.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from _audio_stream_fake import FakeAudioStream
+
+import rigplane.audio
+from rigplane.audio import AudioPacket, PcmFrame
+from rigplane.audio._codecs import decode_ulaw_to_pcm16
+from rigplane.core.types import AudioCodec
+from rigplane.runtime.radio import IcomRadio
+
+_MIXIN_MODULE = "rigplane.runtime._audio_runtime_mixin"
+
+
+def _lan_radio(codec: AudioCodec, stream: FakeAudioStream) -> IcomRadio:
+    """Connected LAN radio with a fake audio stream and a forced RX codec."""
+    radio = IcomRadio("192.168.1.100")
+    radio._connected = True
+    radio._civ_transport = MagicMock()
+    radio._audio_stream = stream  # type: ignore[assignment]
+    radio._audio_codec = codec
+    return radio
+
+
+class _StubTranscoder:
+    """Deterministic stand-in for PcmOpusTranscoder (no libopus needed)."""
+
+    def opus_to_pcm(self, opus_data: bytes) -> bytes:
+        return b"pcm:" + bytes(opus_data)
+
+
+# ---------------------------------------------------------------------------
+# Carrier export (additive — the Pro superset pin must stay green)
+# ---------------------------------------------------------------------------
+
+
+def test_pcm_frame_exported_additively() -> None:
+    assert "PcmFrame" in rigplane.audio.__all__
+    from rigplane.audio.pcm import PcmFrame as canonical
+
+    assert rigplane.audio.PcmFrame is canonical
+
+
+# ---------------------------------------------------------------------------
+# uLaw ingress decode
+# ---------------------------------------------------------------------------
+
+
+async def test_ulaw_ingress_publishes_decoded_pcm_frame() -> None:
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.ULAW_1CH, stream)
+    legacy: list[AudioPacket | None] = []
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+    await radio.start_rx(legacy.append)
+
+    ulaw = bytes([0x00, 0x80]) + bytes(range(64))
+    pkt = AudioPacket(ident=0x9781, send_seq=7, data=ulaw)
+    stream.emit_rx(pkt)
+
+    # Dual-publish: the legacy carrier is the SAME object, untouched.
+    assert legacy == [pkt]
+    assert legacy[0] is pkt
+
+    [frame] = frames
+    assert isinstance(frame, PcmFrame)
+    assert frame.sample_rate == radio.audio_sample_rate
+    assert frame.channels == 1
+    assert frame.seq == 0
+    # One s16le sample per uLaw byte.
+    assert len(frame.payload) == 2 * len(ulaw)
+    # Known anchor: mu-law byte 0x00 decodes to -32124 (table maximum).
+    assert frame.payload[:2] == struct.pack("<h", -32124)
+    # Bit-exact match with the production decoder the broadcaster's
+    # per-consumer branch would have applied (decode-once equivalence).
+    assert frame.payload == decode_ulaw_to_pcm16(ulaw)
+
+
+async def test_ulaw_stereo_ingress_reports_two_channels() -> None:
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.ULAW_2CH, stream)
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+    await radio.start_rx(lambda _pkt: None)
+
+    stream.emit_rx(AudioPacket(ident=0x9781, send_seq=0, data=bytes(8)))
+
+    [frame] = frames
+    assert frame is not None
+    assert frame.channels == 2
+    assert frame.payload == decode_ulaw_to_pcm16(bytes(8))
+
+
+# ---------------------------------------------------------------------------
+# Opus ingress decode
+# ---------------------------------------------------------------------------
+
+
+async def test_opus_ingress_decodes_via_negotiated_transcoder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[tuple[int, int, int]] = []
+
+    def _factory(*, sample_rate: int, channels: int, frame_ms: int) -> Any:
+        created.append((sample_rate, channels, frame_ms))
+        return _StubTranscoder()
+
+    monkeypatch.setattr(f"{_MIXIN_MODULE}.create_pcm_opus_transcoder", _factory)
+
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.OPUS_2CH, stream)
+    legacy: list[AudioPacket | None] = []
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+    await radio.start_rx(legacy.append)
+
+    opus_payload = b"\xde\xad\xbe\xef"
+    pkt = AudioPacket(ident=0x9781, send_seq=1, data=opus_payload)
+    stream.emit_rx(pkt)
+    stream.emit_rx(AudioPacket(ident=0x9781, send_seq=2, data=b"\x01\x02"))
+
+    # Decoder negotiated once at the radio's (sample_rate, channels, 20ms).
+    assert created == [(radio.audio_sample_rate, 2, 20)]
+    assert [f.payload for f in frames if f is not None] == [
+        b"pcm:" + opus_payload,
+        b"pcm:\x01\x02",
+    ]
+    assert all(f is not None and f.channels == 2 for f in frames)
+    # Legacy carrier still ships the compressed wire payload (dual-publish).
+    assert [p.data for p in legacy if p is not None] == [opus_payload, b"\x01\x02"]
+
+
+async def test_opus_ingress_backend_failure_keeps_legacy_carrier(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    calls: list[int] = []
+
+    def _factory(**_kwargs: Any) -> Any:
+        calls.append(1)
+        raise RuntimeError("no opus backend")
+
+    monkeypatch.setattr(f"{_MIXIN_MODULE}.create_pcm_opus_transcoder", _factory)
+
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.OPUS_1CH, stream)
+    legacy: list[AudioPacket | None] = []
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+    await radio.start_rx(legacy.append)
+
+    with caplog.at_level(logging.WARNING, logger=_MIXIN_MODULE):
+        stream.emit_rx(AudioPacket(ident=0x9781, send_seq=0, data=b"\x01"))
+        stream.emit_rx(AudioPacket(ident=0x9781, send_seq=1, data=b"\x02"))
+
+    # Dead-flagged after the first failure: factory not retried per frame.
+    assert calls == [1]
+    assert frames == []
+    assert len(legacy) == 2  # legacy carrier unaffected
+    assert any("Opus decode unavailable" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# PCM16-native passthrough (IC-7610 LAN default)
+# ---------------------------------------------------------------------------
+
+
+async def test_pcm16_native_ingress_is_zero_copy_passthrough() -> None:
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.PCM_2CH_16BIT, stream)
+    legacy: list[AudioPacket | None] = []
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+    await radio.start_rx(legacy.append)
+
+    payload = struct.pack("<4h", 1, -2, 3, -4)
+    pkt = AudioPacket(ident=0x9781, send_seq=3, data=payload)
+    stream.emit_rx(pkt)
+
+    assert legacy == [pkt]
+    [frame] = frames
+    assert frame is not None
+    # The PcmFrame payload IS the wire payload — no decode, no copy.
+    assert frame.payload is pkt.data
+    assert frame.channels == 2
+    assert frame.sample_rate == radio.audio_sample_rate
+
+
+async def test_no_pcm_taps_means_no_decode_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default path (no PCM consumers): byte- and cost-identical."""
+
+    def _boom(_data: bytes) -> bytes:
+        raise AssertionError("decode must not run without PCM taps")
+
+    monkeypatch.setattr(f"{_MIXIN_MODULE}.decode_ulaw_to_pcm16", _boom)
+
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.ULAW_1CH, stream)
+    legacy: list[AudioPacket | None] = []
+    await radio.start_rx(legacy.append)
+
+    pkt = AudioPacket(ident=0x9781, send_seq=0, data=bytes(4))
+    stream.emit_rx(pkt)
+
+    assert legacy == [pkt]  # legacy delivery, no decode attempted
+
+
+async def test_callback_identity_preserved_for_legacy_consumers() -> None:
+    """The bus callback handed to AudioStream.start_rx is NOT wrapped."""
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.PCM_2CH_16BIT, stream)
+
+    def _cb(_pkt: AudioPacket | None) -> None:
+        pass
+
+    await radio.start_rx(_cb)
+    assert stream.last_start_rx_callback is _cb
+
+
+# ---------------------------------------------------------------------------
+# Sequence + gap semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_pcm_seq_is_monotonic_and_gaps_forward_as_none() -> None:
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.PCM_1CH_16BIT, stream)
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+    await radio.start_rx(lambda _pkt: None)
+
+    stream.emit_rx(AudioPacket(ident=0x9781, send_seq=0xFFFF, data=b"\x01\x02"))
+    stream.emit_rx(None)  # jitter-buffer gap placeholder
+    stream.emit_rx(AudioPacket(ident=0x9781, send_seq=0x0000, data=b"\x03\x04"))
+
+    assert frames[1] is None
+    seqs = [f.seq for f in frames if f is not None]
+    assert seqs == [0, 1]  # monotonic, no uint16 wrap
+
+
+async def test_pcm_seq_resets_per_rx_session() -> None:
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.PCM_1CH_16BIT, stream)
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+
+    await radio.start_rx(lambda _pkt: None)
+    stream.emit_rx(AudioPacket(ident=0x9781, send_seq=1, data=b"\x01\x02"))
+    await radio.stop_rx()
+
+    await radio.start_rx(lambda _pkt: None)
+    stream.emit_rx(AudioPacket(ident=0x9781, send_seq=2, data=b"\x03\x04"))
+
+    assert [f.seq for f in frames if f is not None] == [0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Tap management + failure isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_remove_pcm_rx_tap_stops_delivery() -> None:
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.PCM_1CH_16BIT, stream)
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+    radio.add_pcm_rx_tap(frames.append)  # idempotent registration
+    await radio.start_rx(lambda _pkt: None)
+
+    stream.emit_rx(AudioPacket(ident=0x9781, send_seq=0, data=b"\x01\x02"))
+    assert len(frames) == 1
+
+    radio.remove_pcm_rx_tap(frames.append)
+    radio.remove_pcm_rx_tap(frames.append)  # double-remove is a no-op
+    stream.emit_rx(AudioPacket(ident=0x9781, send_seq=1, data=b"\x03\x04"))
+    assert len(frames) == 1
+
+
+async def test_tap_exception_does_not_break_legacy_or_other_taps() -> None:
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.PCM_1CH_16BIT, stream)
+    legacy: list[AudioPacket | None] = []
+    frames: list[PcmFrame | None] = []
+
+    def _bad_tap(_frame: PcmFrame | None) -> None:
+        raise RuntimeError("tap boom")
+
+    radio.add_pcm_rx_tap(_bad_tap)
+    radio.add_pcm_rx_tap(frames.append)
+    await radio.start_rx(legacy.append)
+
+    pkt = AudioPacket(ident=0x9781, send_seq=0, data=b"\x01\x02")
+    stream.emit_rx(pkt)  # must not raise into the RX loop
+
+    assert legacy == [pkt]
+    assert len(frames) == 1
+
+
+async def test_8bit_pcm_codec_publishes_no_frame_but_legacy_flows() -> None:
+    """No s16le mapping for 8-bit wire codecs — legacy carrier only."""
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.PCM_1CH_8BIT, stream)
+    legacy: list[AudioPacket | None] = []
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+    await radio.start_rx(legacy.append)
+
+    pkt = AudioPacket(ident=0x9781, send_seq=0, data=bytes(4))
+    stream.emit_rx(pkt)
+
+    assert legacy == [pkt]
+    assert frames == []
+
+
+# ---------------------------------------------------------------------------
+# Real-codec round-trip (CI has libopus; macOS dev hosts may not)
+# ---------------------------------------------------------------------------
+
+try:  # opuslib raises a plain Exception (not ImportError) without libopus
+    import opuslib  # noqa: F401
+
+    _HAS_OPUS = True
+except Exception:  # pragma: no cover - environment-dependent
+    _HAS_OPUS = False
+
+
+@pytest.mark.skipif(not _HAS_OPUS, reason="libopus not available")
+async def test_opus_ingress_real_codec_roundtrip() -> None:
+    import math
+
+    from rigplane.audio._transcoder import create_pcm_opus_transcoder
+
+    encoder = create_pcm_opus_transcoder(sample_rate=48000, channels=1, frame_ms=20)
+    samples = [
+        int(20000 * math.sin(2 * math.pi * 1000 * n / 48000)) for n in range(960)
+    ]
+    pcm_in = struct.pack("<960h", *samples)
+    opus_frame = encoder.pcm_to_opus(pcm_in)
+
+    stream = FakeAudioStream()
+    radio = _lan_radio(AudioCodec.OPUS_1CH, stream)
+    frames: list[PcmFrame | None] = []
+    radio.add_pcm_rx_tap(frames.append)
+    await radio.start_rx(lambda _pkt: None)
+
+    stream.emit_rx(AudioPacket(ident=0x9781, send_seq=0, data=opus_frame))
+
+    [frame] = frames
+    assert frame is not None
+    assert len(frame.payload) == 1920  # 20 ms mono s16le at 48 kHz
+    decoded = struct.unpack("<960h", frame.payload)
+    assert max(abs(s) for s in decoded) > 1000  # decoded audio, not silence


### PR DESCRIPTION
## Summary

Step 15 (**PR-1 of 2**) of the MOR-562 universal audio path epic — ADR `docs/plans/2026-06-09-target-audio-architecture.md` §3.5, tenet T1 (PCM spine). Groundwork for #762 (FFT scope dark on Opus-native radios). Runtime benefit is dormant by design (no shipping radio delivers Opus by default; uLaw is non-default) — the value is architectural: decode-at-ingress, so the spine can carry PCM.

### PcmFrame carrier (additive)

New `rigplane.audio.pcm.PcmFrame` frozen dataclass: `sample_rate`, `channels`, `payload` (ALWAYS interleaved s16le), `seq` (monotonic per RX session, never wraps — unlike the uint16 `AudioPacket.send_seq`). Exported additively from `rigplane.audio` via the lazy map; the Pro export **superset pin** (`tests/contracts/test_audio_transport_conformance.py`) stays green.

### LAN decode-at-ingress + dual-publish

`AudioRuntimeMixin` (the LAN transport adapter) now decodes the radio-negotiated RX wire codec ONCE at ingress:

- **PCM16 (1/2ch)** — zero-copy passthrough: `PcmFrame.payload` IS the wire payload object (no decode, no copy).
- **uLaw (1/2ch)** — via the same production `decode_ulaw_to_pcm16` the broadcaster uses, so ingress output is bit-exact with what the per-consumer branch would have produced.
- **Opus (1/2ch)** — via a DEDICATED session-cached `PcmOpusTranscoder` at the negotiated `(sample_rate, channels, 20 ms)` (never evicts the user-facing `_get_pcm_transcoder` cache; stateful decoder preserved).

**Dual-publish:** the legacy `AudioPacket` callback handed to `AudioStream.start_rx` is never wrapped or replaced (callback identity preserved — existing identity-asserting tests untouched). The decoded `PcmFrame` flows in parallel through a single `AudioStream` RX tap to listeners registered via the new duck-typed `add_pcm_rx_tap` / `remove_pcm_rx_tap` (gap placeholders forwarded as `None`). The `AudioTransport` protocol pin (10 members) and `AudioCapable` freeze (14 members) are untouched.

**Safety:** with no PCM taps registered the decode is skipped entirely — the default path is byte- AND cost-identical (pinned by test). Opus backend init failure dead-flags the ingress for the session (one warning, no per-frame retry); decode/tap exceptions are contained — the legacy carrier keeps flowing no matter what.

### Falsification tests (`tests/test_pcm_ingress_decode.py`, RED→GREEN)

- fake LAN radio negotiating **uLaw** → published `PcmFrame` is correctly decoded s16le (2 bytes/sample, known table anchor `0x00 → -32124`, bit-exact with the production decoder), legacy `AudioPacket` still delivered as the same object;
- fake LAN radio negotiating **Opus** (stub transcoder + libopus-gated real-codec round-trip for CI) → decoded at the negotiated `(sr, ch, 20 ms)`, legacy carrier still ships the compressed wire payload;
- **PCM16-native (IC-7610 LAN default `PCM_2CH_16BIT`) byte-identical**: zero-copy payload identity + no-taps → no decode work + `start_rx` callback identity preserved;
- monotonic seq across uint16 wrap, per-session reset, gap (`None`) forwarding, tap add/remove idempotency, tap-exception isolation, 8-bit-codec no-mapping, Opus-backend-dead fallback.

`FakeAudioStream` (shared test double) gains `add_rx_tap` / `remove_rx_tap` / `emit_rx`, mirroring the real `AudioStream` tap surface.

### Deferred to PR-2 ([BC] follow-up — the actual #762 fix)

Per the staging note in MOR-591, NOTHING is removed here. PR-2, once consumers read `PcmFrame`: remove the broadcaster uLaw decode branch (`web/handlers/audio.py`), the Opus gates that skip DSP/taps for Opus-native radios (the #762 FFT-scope-dark crutch), and the bridge's own opuslib decoder (`audio/bridge.py`), with the fake-Opus-radio scope falsification.

### Gate

- `pytest tests/ -q --ignore=tests/integration`: **7589 passed**, 0 failed (conformance superset, AudioCapable freeze, MOR-583 smoke, MOR-567 lifecycle all green)
- `ruff check` + `ruff format --check`: clean
- `mypy src/`: baseline exactly **21 errors in 8 files** (unchanged)
- `lint-imports`: **4 kept / 0 broken**

⚠️ Live IC-7610 LAN re-validation (incl. a forced uLaw-negotiated session if feasible) is operator-gated — radio offline; flagged per the issue acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)