### PR TITLE
docs(MOR-555): 2.9.0 audio release notes + ADR step-15 status + session docstring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+- **CLI: option abbreviations are no longer accepted.** The `rigplane`
+  argument parser now sets `allow_abbrev=False`, so abbreviated long options
+  (e.g. `--ser-port` for `--serial-port`) are rejected — scripts must spell
+  options out in full. This also fixes `rigplane discover --serial` exiting
+  with an argparse ambiguity error on Python 3.11, where prefix matching
+  collided with the global `--serial-port`/`--serial-baud`/`--serial-ptt-mode`
+  options (MOR-589, #1776, 878ff355).
+
+### Added
+
+- Adaptive audio egress codec (opt-in): new `WebConfig.audio_adaptive_egress`
+  flag, **default off**. When enabled, the server switches each browser
+  client between PCM16 and Opus per connection based on observed link
+  quality (client-reported playback underruns + server-side send-queue
+  drops), with dwell windows to prevent flapping; bridge/digital paths stay
+  lossless. With the flag off (the default) egress behavior is unchanged and
+  a client's codec never changes mid-stream (MOR-588, #1775, 1cc5e72a;
+  link-quality `audio_stats` uplink MOR-585, #1773, 2dc28f84).
+
+### Changed
+
+- Per-client web RX audio codec: each browser client now gets its own egress
+  codec (client preference → profile policy → PCM16 default) instead of one
+  aggregate codec for all clients — a PCM16-only client no longer forces
+  PCM16 on an Opus-capable client. After `audio_start` the server sends an
+  advisory `audio_format` ack `{codec, sample_rate, channels, frame_ms}`;
+  legacy clients ignore it and keep header-driven decode (MOR-584, #1771,
+  ddd8c232).
+- Audio RX-start failures now surface instead of being swallowed: a failed
+  radio RX start raises to the demanding consumer, and the web audio handler
+  sends an `error` envelope to subscribed clients instead of presenting a
+  "subscribed" stream that never delivers frames (MOR-582, #1769, 593e0815).
+- Audio TX lifecycle is now owned by a radio-owned `AudioSession`: web TX
+  and the audio bridge share one refcounted session per radio, so a stray
+  `audio_stop` from one consumer can no longer disarm another consumer's
+  active TX (MOR-576/577/579/580, #1763/#1765/#1766/#1767). Related internal
+  work in this cycle — session health watchdog + liveness events (MOR-581),
+  unified reconnect recovery via `AudioSession.reestablish()` (MOR-586), RX
+  tap surface (MOR-565), additive `PcmFrame` decode-at-ingress carrier
+  (MOR-591) — changes no default behavior.
+- Audio bridge degrades to RX-only (with a warning) when a neutral-surface
+  radio negotiates a non-PCM TX codec, instead of pushing mis-typed raw PCM;
+  no shipping backend produces this configuration (MOR-545, #1749, a52263d9).
+
+### Fixed
+
+- FTX-1 / Yaesu CAT: `start_audio_tx_opus` was a silent no-op, so the web
+  handler's Opus TX branch did nothing on Yaesu backends; it now arms real
+  TX via the neutral transport surface (MOR-541, #1745, d9b8caad).
+- Web audio TX double-start: the benign poller-first re-arm on USB-audio
+  radios (`AudioDriverLifecycleError("TX stream already started.")`) is now
+  tolerated instead of closing the audio WebSocket (MOR-544, #1748,
+  438930e7).
+- Audio bridge stop ordering: stopping the bridge with TX armed leaked a
+  running LAN RX stream (RX demand was dropped before radio TX was stopped);
+  the bridge now stops TX first, then tears down RX (MOR-574, #1762,
+  3f08f659).
+
 ## [2.8.0] — 2026-06-02
 
 ### Added

--- a/docs/plans/2026-06-09-target-audio-architecture.md
+++ b/docs/plans/2026-06-09-target-audio-architecture.md
@@ -15,10 +15,11 @@ MOR-307/#104 (WebRTC DataChannel transport)
 **Format model:** `docs/plans/2026-04-12-target-frontend-architecture.md`
 **Base commit:** `467f40bd` (main)
 
-## As-built status (2026-06-10, main @ `1cc5e72a`)
+## As-built status (2026-06-10, main @ `314c0df9`)
 
 The MOR-562 epic is **implemented**: 17 of the 20 §4 migration steps plus one
-added step (9b) are merged to `main`; the exceptions are steps 11, 12, and 15
+added step (9b) are fully merged to `main`, and step 15 is half-merged (PR-1
+of 2, MOR-591); the remaining exceptions are steps 11 and 12, step 15 PR-2,
 plus the live hardware re-validations, all listed below. Where the realized
 code deviates from a step's "files (indicative)" column, the merged PR is
 authoritative (notable deviations noted inline).
@@ -40,6 +41,7 @@ authoritative (notable deviations noted inline).
 | 10 — bus surfaces RX-start failures | MOR-582 | #1769 | Subscriber rollback in the bus + broadcaster error envelope to WS clients |
 | 13 — web TX through session lease | MOR-580 | #1767 | `session.acquire_tx("web")` |
 | 14 — health watchdog + events | MOR-581 | #1768 | ~1 s watchdog on the bus heartbeat; ~3 s silence ⇒ RECOVERING + local `AudioSessionEvent` |
+| 15 (PR-1 of 2) — `PcmFrame` carrier + LAN decode-at-ingress | MOR-591 | #1778 | Additive dual-publish: legacy `AudioPacket` path byte-identical; decoded `PcmFrame` fans out to registered PCM taps; decode skipped with no taps. PR-2 (decoder removal) is MOR-592, deferred |
 | 16 — `AudioDeviceConfig` carrier | MOR-578 | #1764 | Frozen dataclass in `audio/backend.py` |
 | 17 — per-connection egress codecs | MOR-584 | #1771 | Per-client encoder pool + `audio_format` ack |
 | 18 — client link-quality uplink | MOR-585 | #1773 | `audio_stats` every ~1.5 s per client |
@@ -62,11 +64,14 @@ over fakes.
   re-arms RX for every duplex mode — the one remaining audio-arming path not
   routed through `AudioSession`. The session's `_REARM_RX_AFTER_TX_DROP` seam
   is pre-built for the flip.
-- **Step 15 — decode-at-ingress / `PcmFrame` (MOR-591, open).** The
+- **Step 15 PR-2 — per-consumer decoder removal + the #762 fix (MOR-592,
+  deferred).** PR-1 (MOR-591, #1778, `314c0df9`) merged the additive
+  `PcmFrame` carrier and LAN decode-at-ingress dual-publish; the
   per-consumer decoders are still in place (bridge opuslib decoder,
-  broadcaster uLaw branch, Opus DSP/tap gates — #762). Dormant in practice:
-  every shipping default delivers PCM natively. Planned as additive PR-1
-  (carrier + dual-publish) then PR-2 (per-consumer-decoder removal).
+  broadcaster uLaw branch, Opus DSP/tap gates — #762) until consumers read
+  `PcmFrame`. Dormant in practice: every shipping default delivers PCM
+  natively. PR-2 is the [BC] half (#762 pass-through replaced by re-encode;
+  FFT scope lights up on Opus-native radios).
 - **All live hardware re-validations** (radio offline 2026-06-10): IC-7610
   LAN full-duplex + reconnect `reestablish()`, FTX-1 exclusive duplex +
   WSJT-X FT8 through the bridge, browser TX over the session lease, adaptive

--- a/src/rigplane/audio/session.py
+++ b/src/rigplane/audio/session.py
@@ -43,9 +43,9 @@ never stopped from a TRANSMITTING transport. TX never runs without RX
 (there is no TX_ONLY state); leases held across an RX gap are re-armed
 when RX demand returns.
 
-This module is consumed by NOTHING in src yet — wiring the bridge, the
-poller PTT hooks, and the web handlers through the session is steps
-9/11/12 of epic MOR-562.
+As-built, the session is consumed via the radio-owned singleton
+``radio.audio_session`` (MOR-579) by the AudioBridge (MOR-577), the web
+TX handler (MOR-580), and the reconnect/recovery path (MOR-586).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Finalizes the MOR-562 audio epic documentation for 2.9.0 (MOR-555). Docs-only except for a one-line `session.py` docstring fix; no logic change.

## Release notes (`docs/CHANGELOG.md`, `[Unreleased]`)

Added a user-facing audio section grouped per Keep-a-Changelog style. Each item verified against `git log`:

**Breaking changes**
- CLI option abbreviations no longer accepted (`allow_abbrev=False`) — write `--serial-port` in full; also fixes `discover --serial` on Python 3.11 (MOR-589, #1776).

**Added**
- Opt-in adaptive audio egress codec `WebConfig.audio_adaptive_egress` (default **off**); when on, switches a browser client PCM16↔Opus on link quality (MOR-588, #1775; uplink MOR-585, #1773).

**Changed**
- Per-client web RX egress codec; a PCM16-only client no longer forces PCM16 on an Opus-capable client; advisory `audio_format` ack (MOR-584, #1771).
- Audio RX-start failures now surface (raise + WS `error` envelope) instead of attaching with no frames (MOR-582, #1769).
- Audio TX lifecycle owned by a radio-owned `AudioSession` shared by web TX + bridge; a stray `audio_stop` can't kill another consumer's TX (MOR-576/577/579/580). Related internal work (MOR-581/586/565/591) — no default behavior change.
- Bridge degrades to RX-only on a non-PCM TX codec instead of pushing mis-typed PCM (MOR-545, #1749).

**Fixed**
- FTX-1 `start_audio_tx_opus` no-op → real TX arming (MOR-541, #1745).
- Web TX benign double-start tolerated instead of closing the audio WS (MOR-544, #1748).
- Bridge stop-ordering LAN RX-stream leak when TX armed (MOR-574, #1762).

## ADR step-15 status (`docs/plans/2026-06-09-target-audio-architecture.md`)

- As-built header bumped to main @ `314c0df9`; step 15 noted as half-merged (PR-1 of 2).
- Added a Merged-table row for step 15 PR-1 (MOR-591, #1778 — additive `PcmFrame` carrier + LAN decode-at-ingress).
- Rewrote the deferred bullet: removed "step 15 PcmFrame absent"; the remaining per-consumer decoder removal + #762 fix is now PR-2 (MOR-592, deferred).

## Docstring fix (`src/rigplane/audio/session.py`)

Module docstring said AudioSession "is consumed by NOTHING in src yet" — stale. Corrected to: consumed via the radio-owned singleton `radio.audio_session` (MOR-579) by the AudioBridge (MOR-577), the web TX handler (MOR-580), and the reconnect/recovery path (MOR-586). No code change.

## Gate
- `pytest tests/ -q --ignore=tests/integration`: 7589 passed, 11 skipped, 11 xfailed, 1 xpassed, **0 failures**
- `ruff check` + `ruff format --check`: clean
- `mypy src/`: baseline **21 errors in 8 files** (unchanged)
- `lint-imports`: **4 kept / 0 broken**

🤖 Generated with [Claude Code](https://claude.com/claude-code)