### PR TITLE
fix(MOR-596): per-client PCM→20ms reframing for Opus egress (no PCM16 fallback on non-Opus radios)

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -54,6 +54,12 @@ DEGRADE_WINDOW_S = 3.0
 CLEAN_WINDOW_S = 30.0
 DWELL_S = 10.0
 
+# Fixed Opus egress frame duration (MOR-596).  Radio RX packets are not
+# Opus-frame-aligned (IC-7610 LAN @48k stereo ≈1280 B ≈6.67 ms), while
+# ``PcmOpusTranscoder`` accepts exactly one fixed frame per encode call —
+# per-client PCM is therefore reframed into exact 20 ms frames before encode.
+OPUS_EGRESS_FRAME_MS = 20
+
 
 @dataclass
 class _AdaptiveEgressState:
@@ -159,6 +165,11 @@ class AudioBroadcaster:
         self._client_opus_transcoders: dict[
             int, tuple[PcmOpusTranscoder, tuple[int, int, int]]
         ] = {}
+        # Per-client PCM reframing accumulators for Opus egress (MOR-596):
+        # s16le bytes buffered until a full 20 ms frame is available.
+        # Cleared on unsubscribe/reap, adaptive switch to PCM16, and any
+        # codec-state refresh (sample rate / channel changes).
+        self._client_opus_pcm_buffers: dict[int, bytearray] = {}
         # Per-client link-quality state (MOR-585, ADR §3.6): the latest
         # client-reported ``audio_stats`` snapshot plus the server-side
         # drop-oldest eviction counter for the bounded WS queue.  Stats
@@ -255,6 +266,7 @@ class AudioBroadcaster:
             self._client_ws.pop(client_id, None)
             self._client_rx_codec.pop(client_id, None)
             self._client_opus_transcoders.pop(client_id, None)
+            self._client_opus_pcm_buffers.pop(client_id, None)
             self._client_link_quality.pop(client_id, None)
             self._client_queue_drops.pop(client_id, None)
             self._client_adaptive.pop(client_id, None)
@@ -366,6 +378,7 @@ class AudioBroadcaster:
                 self._client_ws.pop(cid, None)
                 self._client_rx_codec.pop(cid, None)
                 self._client_opus_transcoders.pop(cid, None)
+                self._client_opus_pcm_buffers.pop(cid, None)
                 self._client_link_quality.pop(cid, None)
                 self._client_queue_drops.pop(cid, None)
                 self._client_adaptive.pop(cid, None)
@@ -441,6 +454,9 @@ class AudioBroadcaster:
             self._sample_rate,
             self._channels,
         )
+        # Format may have changed — drop partial reframing buffers so no
+        # stale PCM concatenates across a codec/format switch (MOR-596).
+        self._client_opus_pcm_buffers.clear()
         # Re-check DSP-on-Opus after the codec may have just flipped.
         # Issue #762.
         self._maybe_warn_dsp_opus_gate()
@@ -623,6 +639,7 @@ class AudioBroadcaster:
         state.degrade_since = None
         if codec != AUDIO_CODEC_OPUS:
             self._client_opus_transcoders.pop(client_id, None)
+            self._client_opus_pcm_buffers.pop(client_id, None)
         logger.info(
             "audio-broadcaster: adaptive egress switch → %s (client=%d)",
             "opus" if codec == AUDIO_CODEC_OPUS else "pcm16",
@@ -669,20 +686,30 @@ class AudioBroadcaster:
         client_id: int,
         pcm_data: bytes,
         frame_ms: int,
-    ) -> tuple[int, bytes]:
+    ) -> list[tuple[int, int, bytes]]:
         """Apply ONE client's RX transport encoding after PCM consumers run.
 
         Sits downstream of the PCM spine (decode → DSP → tap fan-out):
         only browser WS clients reach here.  The AudioBridge, FFT scope
         and other taps consume PCM upstream and never touch these
         encoders (T1a digital-path invariant).
+
+        Returns 0..N ``(codec, frame_ms, payload)`` frames.  PCM16 and
+        Opus-native pass-through stay strictly 1:1; Opus egress on PCM
+        radios buffers s16le per client and emits exact 20 ms Opus
+        frames (MOR-596) — radio packets are not Opus-frame-aligned, so
+        per-packet encode raised ``AudioFormatError`` on every frame and
+        silently fell back to PCM16.
         """
         if self._client_egress_codec(client_id) != AUDIO_CODEC_OPUS:
-            return AUDIO_CODEC_PCM16, pcm_data
+            return [(AUDIO_CODEC_PCM16, frame_ms, pcm_data)]
         if self._radio_codec in (AudioCodec.OPUS_1CH, AudioCodec.OPUS_2CH):
-            return AUDIO_CODEC_OPUS, pcm_data
+            return [(AUDIO_CODEC_OPUS, frame_ms, pcm_data)]
 
-        key = (self._sample_rate, self._channels, frame_ms)
+        key = (self._sample_rate, self._channels, OPUS_EGRESS_FRAME_MS)
+        frame_bytes = (
+            self._sample_rate * OPUS_EGRESS_FRAME_MS // 1000 * self._channels * 2
+        )
         try:
             entry = self._client_opus_transcoders.get(client_id)
             if entry is None or entry[1] != key:
@@ -690,12 +717,20 @@ class AudioBroadcaster:
                     create_pcm_opus_transcoder(
                         sample_rate=self._sample_rate,
                         channels=self._channels,
-                        frame_ms=frame_ms,
+                        frame_ms=OPUS_EGRESS_FRAME_MS,
                     ),
                     key,
                 )
                 self._client_opus_transcoders[client_id] = entry
-            return AUDIO_CODEC_OPUS, entry[0].pcm_to_opus(pcm_data)
+            buf = self._client_opus_pcm_buffers.setdefault(client_id, bytearray())
+            buf.extend(pcm_data)
+            frames: list[tuple[int, int, bytes]] = []
+            while len(buf) >= frame_bytes:
+                chunk = bytes(buf[:frame_bytes])
+                del buf[:frame_bytes]
+                opus = entry[0].pcm_to_opus(chunk)
+                frames.append((AUDIO_CODEC_OPUS, OPUS_EGRESS_FRAME_MS, opus))
+            return frames
         except Exception as exc:
             if not self._browser_opus_warned:
                 logger.warning(
@@ -704,7 +739,8 @@ class AudioBroadcaster:
                 )
                 self._browser_opus_warned = True
             self._client_opus_transcoders.pop(client_id, None)
-            return AUDIO_CODEC_PCM16, pcm_data
+            self._client_opus_pcm_buffers.pop(client_id, None)
+            return [(AUDIO_CODEC_PCM16, frame_ms, pcm_data)]
 
     async def _apply_phones_mix_off(self) -> None:
         """Force Phones L/R Mix = OFF so the LAN stream is separated stereo.
@@ -850,7 +886,10 @@ class AudioBroadcaster:
                 # (decode → DSP → taps) is shared; from here each browser
                 # WS client gets its own negotiated wire codec.  Pass-
                 # through payloads (PCM16, Opus-native) reuse one cached
-                # frame per codec; Opus transcodes are per-client.
+                # frame per codec and stay strictly 1:1; Opus transcodes
+                # are per-client and N:M — the reframing accumulator may
+                # emit 0..N exact 20 ms frames per radio packet (MOR-596),
+                # all carrying this packet's seq.
                 shared_frames: dict[int, bytes] = {}
                 dead_ids: list[int] = []
                 for client_id, q in list(self._clients.items()):
@@ -862,46 +901,49 @@ class AudioBroadcaster:
                     # client opted into adaptation on a flag-on broadcaster.
                     if self._client_adaptive:
                         self._adaptive_evaluate(client_id)
-                    codec, payload = self._encode_client_rx_frame(
+                    out_frames = self._encode_client_rx_frame(
                         client_id, audio_data, _frame_ms
                     )
-                    frame = shared_frames.get(codec) if payload is audio_data else None
-                    if frame is None:
-                        frame = encode_audio_frame(
-                            MSG_TYPE_AUDIO_RX,
-                            codec,
-                            self._seq,
-                            self._sample_rate // 100,
-                            self._channels,
-                            _frame_ms,
-                            payload,
-                        )
-                        if payload is audio_data:
-                            shared_frames[codec] = frame
-                    try:
-                        q.put_nowait(frame)
-                    except asyncio.QueueFull:
-                        # Drop-oldest eviction: count it per client — this
-                        # is the server-side WS congestion signal for the
-                        # adaptive egress codec controller (MOR-585,
-                        # ADR §3.6 detection-signals table).
-                        self._client_queue_drops[client_id] = (
-                            self._client_queue_drops.get(client_id, 0) + 1
-                        )
-                        try:
-                            q.get_nowait()
-                        except asyncio.QueueEmpty:
-                            pass
+                    for codec, hdr_frame_ms, payload in out_frames:
+                        shared = payload is audio_data
+                        frame = shared_frames.get(codec) if shared else None
+                        if frame is None:
+                            frame = encode_audio_frame(
+                                MSG_TYPE_AUDIO_RX,
+                                codec,
+                                self._seq,
+                                self._sample_rate // 100,
+                                self._channels,
+                                hdr_frame_ms,
+                                payload,
+                            )
+                            if shared:
+                                shared_frames[codec] = frame
                         try:
                             q.put_nowait(frame)
                         except asyncio.QueueFull:
-                            pass
+                            # Drop-oldest eviction: count it per client —
+                            # this is the server-side WS congestion signal
+                            # for the adaptive egress codec controller
+                            # (MOR-585, ADR §3.6 detection-signals table).
+                            self._client_queue_drops[client_id] = (
+                                self._client_queue_drops.get(client_id, 0) + 1
+                            )
+                            try:
+                                q.get_nowait()
+                            except asyncio.QueueEmpty:
+                                pass
+                            try:
+                                q.put_nowait(frame)
+                            except asyncio.QueueFull:
+                                pass
                 self._seq = (self._seq + 1) & 0xFFFF
                 for client_id in dead_ids:
                     self._clients.pop(client_id, None)
                     self._client_ws.pop(client_id, None)
                     self._client_rx_codec.pop(client_id, None)
                     self._client_opus_transcoders.pop(client_id, None)
+                    self._client_opus_pcm_buffers.pop(client_id, None)
                     self._client_link_quality.pop(client_id, None)
                     self._client_queue_drops.pop(client_id, None)
                     self._client_adaptive.pop(client_id, None)

--- a/tests/test_web_audio_opus_egress_reframing.py
+++ b/tests/test_web_audio_opus_egress_reframing.py
@@ -1,0 +1,245 @@
+"""Opus egress PCM→20 ms reframing (MOR-596).
+
+Falsification suite: real radio RX packets are not Opus-frame-aligned
+(IC-7610 LAN @48k stereo ≈1280 B ≈6.67 ms), but ``PcmOpusTranscoder``
+accepts EXACTLY one fixed frame per encode.  Per-packet transcode
+therefore raised ``AudioFormatError`` on every frame and silently fell
+back to PCM16 — an Opus-egress client on a PCM radio never received
+Opus.  The broadcaster must buffer s16le per client and emit exact
+20 ms Opus frames (N packets → M frames); PCM16 and Opus-native
+pass-through stay strictly 1:1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rigplane.audio_bus import AudioBus
+from rigplane.core.exceptions import AudioFormatError
+from rigplane.radio_protocol import AudioCapable
+from rigplane.types import AudioCodec
+from rigplane.web.handlers import AudioBroadcaster
+from rigplane.web.protocol import (
+    AUDIO_CODEC_OPUS,
+    AUDIO_CODEC_PCM16,
+    AUDIO_HEADER_SIZE,
+)
+from rigplane.web.websocket import WebSocketConnection
+
+# IC-7610 LAN-like RX packet: 1280 B @ 48 kHz stereo s16le ≈ 6.67 ms.
+PACKET_BYTES = 1280
+# One 20 ms egress frame @ 48 kHz stereo s16le.
+FRAME_BYTES = 48000 * 20 // 1000 * 2 * 2  # 3840
+
+_FACTORY = "rigplane.web.handlers.audio.create_pcm_opus_transcoder"
+
+
+class _StrictFakeTranscoder:
+    """Mimics PcmOpusTranscoder's fixed-frame contract without libopus."""
+
+    def __init__(self, frame_bytes: int) -> None:
+        self.frame_bytes = frame_bytes
+        self.chunks: list[bytes] = []
+
+    def pcm_to_opus(self, pcm: bytes) -> bytes:
+        self.chunks.append(bytes(pcm))
+        if len(pcm) != self.frame_bytes:
+            raise AudioFormatError(
+                f"PCM frame size mismatch: expected {self.frame_bytes}, got {len(pcm)}."
+            )
+        return b"opus-frame"
+
+
+def _strict_factory(created: list[_StrictFakeTranscoder]) -> Any:
+    def factory(*, sample_rate: int, channels: int, frame_ms: int) -> Any:
+        if frame_ms not in (10, 20, 40, 60):
+            raise AudioFormatError(f"Unsupported frame_ms={frame_ms}.")
+        t = _StrictFakeTranscoder(sample_rate * frame_ms // 1000 * channels * 2)
+        created.append(t)
+        return t
+
+    return factory
+
+
+def _make_radio(
+    codec: AudioCodec = AudioCodec.PCM_2CH_16BIT, sample_rate: int = 48000
+) -> tuple[Any, AudioBus]:
+    radio = MagicMock(spec=AudioCapable)
+    radio.capabilities = {"audio"}
+    radio.audio_codec = codec
+    radio.audio_sample_rate = sample_rate
+    radio.start_audio_rx_opus = AsyncMock()
+    radio.stop_audio_rx_opus = AsyncMock()
+    bus = AudioBus(radio)
+    radio.audio_bus = bus
+    return radio, bus
+
+
+def _make_ws() -> MagicMock:
+    ws = MagicMock(spec=WebSocketConnection)
+    ws.send_text = AsyncMock()
+    return ws
+
+
+async def _inject(bus: AudioBus, payloads: list[bytes]) -> None:
+    for payload in payloads:
+        pkt = MagicMock()
+        pkt.data = payload
+        bus._on_opus_packet(pkt)
+    await asyncio.sleep(0.1)
+
+
+def _drain(queue: asyncio.Queue[bytes]) -> list[tuple[int, int, bytes]]:
+    """Drain (codec, header_frame_ms, payload) from a client queue."""
+    frames: list[tuple[int, int, bytes]] = []
+    while True:
+        try:
+            f = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return frames
+        frames.append((f[1], f[7], f[AUDIO_HEADER_SIZE:]))
+
+
+class TestOpusEgressReframing:
+    async def test_non_aligned_packets_reframe_to_exact_20ms_opus(self) -> None:
+        """8×1280 B → exactly floor(10240/3840)=2 Opus frames, every
+        encode fed exactly FRAME_BYTES, the remainder carried over to the
+        next packet, and NO PCM16 fallback (codec stays 0x01)."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        created: list[_StrictFakeTranscoder] = []
+        packets = [bytes([0x10 + i]) * PACKET_BYTES for i in range(8)]
+        with patch(_FACTORY, side_effect=_strict_factory(created)):
+            queue = await broadcaster.subscribe(
+                ws=_make_ws(), preferred_rx_codec=AUDIO_CODEC_OPUS
+            )
+            await _inject(bus, packets)
+            frames = _drain(queue)
+            assert [c for c, _, _ in frames] == [AUDIO_CODEC_OPUS] * 2, (
+                "Opus egress fell back to PCM16 — non-aligned radio packets "
+                "must be reframed, not encoded per packet (MOR-596)"
+            )
+            assert all(ms == 20 for _, ms, _ in frames)
+            stream = b"".join(packets)
+            assert len(created) == 1
+            assert all(len(c) == FRAME_BYTES for c in created[0].chunks)
+            assert created[0].chunks == [stream[:3840], stream[3840:7680]]
+            # Remainder (2560 B) is retained: one more packet completes
+            # the third frame.
+            await _inject(bus, [bytes([0x99]) * PACKET_BYTES])
+            stream += bytes([0x99]) * PACKET_BYTES
+            assert _drain(queue) == [(AUDIO_CODEC_OPUS, 20, b"opus-frame")]
+            assert created[0].chunks[2] == stream[7680:11520]
+
+    async def test_pcm16_client_stays_one_to_one(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        queue = await broadcaster.subscribe(
+            ws=_make_ws(), preferred_rx_codec=AUDIO_CODEC_PCM16
+        )
+        packet = b"\x01\x02" * (PACKET_BYTES // 2)
+        await _inject(bus, [packet] * 3)
+        frames = _drain(queue)
+        assert [(c, p) for c, _, p in frames] == [(AUDIO_CODEC_PCM16, packet)] * 3
+        assert broadcaster._client_opus_transcoders == {}
+        assert broadcaster._client_opus_pcm_buffers == {}
+
+    async def test_codec_switch_to_pcm16_clears_accumulator(self) -> None:
+        """Adaptive Opus→PCM16 switch must flush the partial frame; a
+        later switch back to Opus must not prepend stale PCM."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio, adaptive_egress=True)
+        broadcaster._adaptive_monotonic = lambda: 1000.0
+        created: list[_StrictFakeTranscoder] = []
+        with patch(_FACTORY, side_effect=_strict_factory(created)):
+            queue = await broadcaster.subscribe(
+                ws=_make_ws(), preferred_rx_codec=AUDIO_CODEC_OPUS
+            )
+            client_id = id(queue)
+            state = broadcaster._client_adaptive[client_id]
+            state.codec = AUDIO_CODEC_OPUS
+            state.last_switch = 1000.0  # inside dwell — controller holds
+            await _inject(bus, [b"\xaa" * PACKET_BYTES])  # partial: buffered
+            assert _drain(queue) == []
+            broadcaster._adaptive_switch(client_id, state, AUDIO_CODEC_PCM16, 1000.0)
+            assert broadcaster._client_opus_pcm_buffers == {}
+            broadcaster._adaptive_switch(client_id, state, AUDIO_CODEC_OPUS, 1000.0)
+            await _inject(bus, [b"\xbb" * PACKET_BYTES] * 3)
+        frames = _drain(queue)
+        assert [c for c, _, _ in frames] == [AUDIO_CODEC_OPUS]
+        assert created[-1].chunks == [b"\xbb" * FRAME_BYTES]
+
+    async def test_unsubscribe_clears_accumulator(self) -> None:
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        with patch(_FACTORY, side_effect=_strict_factory([])):
+            queue = await broadcaster.subscribe(
+                ws=_make_ws(), preferred_rx_codec=AUDIO_CODEC_OPUS
+            )
+            await _inject(bus, [b"\xaa" * PACKET_BYTES])
+            assert broadcaster._client_opus_pcm_buffers != {}
+            await broadcaster.unsubscribe(queue)
+        assert broadcaster._client_opus_pcm_buffers == {}
+
+    async def test_format_change_does_not_concatenate_mismatched_pcm(self) -> None:
+        """A stereo partial frame must not prefix mono PCM after a codec
+        state refresh (invalidate_codec_state path)."""
+        radio, bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+        created: list[_StrictFakeTranscoder] = []
+        with patch(_FACTORY, side_effect=_strict_factory(created)):
+            queue = await broadcaster.subscribe(
+                ws=_make_ws(), preferred_rx_codec=AUDIO_CODEC_OPUS
+            )
+            await _inject(bus, [b"\xaa" * PACKET_BYTES])  # stereo partial
+            radio.audio_codec = AudioCodec.PCM_1CH_16BIT
+            broadcaster.invalidate_codec_state()
+            mono_20ms = b"\xbb" * (48000 * 20 // 1000 * 2)  # 1920 B
+            await _inject(bus, [mono_20ms])
+        frames = _drain(queue)
+        assert [c for c, _, _ in frames] == [AUDIO_CODEC_OPUS]
+        assert created[-1].chunks == [mono_20ms]
+
+    async def test_opus_native_radio_passthrough_unchanged(self) -> None:
+        radio, bus = _make_radio(codec=AudioCodec.OPUS_1CH)
+        broadcaster = AudioBroadcaster(radio)
+        queue = await broadcaster.subscribe(
+            ws=_make_ws(), preferred_rx_codec=AUDIO_CODEC_OPUS
+        )
+        opus_packet = b"\x42" * 120
+        await _inject(bus, [opus_packet] * 2)
+        frames = _drain(queue)
+        assert [(c, p) for c, _, p in frames] == [(AUDIO_CODEC_OPUS, opus_packet)] * 2
+        assert broadcaster._client_opus_transcoders == {}
+        assert broadcaster._client_opus_pcm_buffers == {}
+
+
+def _libopus_available() -> bool:
+    try:
+        import opuslib  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _libopus_available(), reason="native libopus unavailable")
+async def test_real_opus_frames_decode_back_to_20ms() -> None:
+    """End-to-end with real libopus: emitted frames are valid Opus and
+    decode back to exactly one 20 ms PCM frame each."""
+    from rigplane.audio._transcoder import create_pcm_opus_transcoder
+
+    radio, bus = _make_radio()
+    broadcaster = AudioBroadcaster(radio)
+    queue = await broadcaster.subscribe(
+        ws=_make_ws(), preferred_rx_codec=AUDIO_CODEC_OPUS
+    )
+    await _inject(bus, [b"\x00" * PACKET_BYTES] * 6)
+    frames = _drain(queue)
+    assert [c for c, _, _ in frames] == [AUDIO_CODEC_OPUS] * 2
+    decoder = create_pcm_opus_transcoder(sample_rate=48000, channels=2, frame_ms=20)
+    for _, _, payload in frames:
+        assert len(decoder.opus_to_pcm(payload)) == FRAME_BYTES


### PR DESCRIPTION
## What

Fix **MOR-596** (High): the per-client / adaptive Opus egress (MOR-584/MOR-588) never produced Opus on non-Opus-native radios (PCM16/uLaw) — it silently fell back to PCM16 on every frame because it transcoded **per radio packet** and `PcmOpusTranscoder` requires an exact 10/20/40/60 ms frame. Live IC-7610 LAN packets are ~1280 B ≈ 6.67 ms → `Unsupported frame_ms=6` → PCM16 fallback.

## How

- `_encode_client_rx_frame` now returns `list[(codec, frame_ms, payload)]` (0..N). PCM16 / Opus-native clients stay strictly 1:1 (single passthrough frame, preserving the per-codec `shared_frames` cache).
- Opus egress on PCM radios appends to a per-client PCM **reframing accumulator** (`_client_opus_pcm_buffers`) and pops exact fixed frames (`OPUS_EGRESS_FRAME_MS = 20`, 3840 B @48k/2ch) to encode; remainder carries across packets. Header codec=0x01, frame_ms=20.
- Relay loop enqueues each returned frame; drop-oldest QueueFull eviction + MOR-588 adaptive evaluation unchanged.
- Buffer lifecycle: cleared on `unsubscribe`, `reap_dead_clients`, relay-loop dead-client cleanup, `_adaptive_switch` to PCM16, and `_refresh_codec_state` (sample-rate/channel/codec flips never concatenate mismatched PCM). On a genuine libopus-missing encode failure the existing one-shot-warned PCM16 fallback is preserved.
- `_transcoder.py` untouched; the tap/bridge/FFT path upstream is untouched (T1a lossless digital invariant).

## Tests

New `tests/test_web_audio_opus_egress_reframing.py` (7 tests): reframing accumulation (spy transcoder always receives exactly 3840 B; N×1280 B → floor(total/3840) Opus frames; remainder retained; no PCM16 fallback), PCM16 1:1 passthrough unaffected, codec-switch flushes the buffer, Opus-native pass-through unchanged, and a `skipif`-gated real-libopus encode/decode round-trip. Falsification confirmed: the accumulation + real-encode tests fail on the unfixed code (PCM16 fallback) and pass after.

## Gate

- pytest (no integration, libopus present): 7599 passed, 8 skipped, 11 xfailed, 1 xpassed — 0 failures
- ruff check + format: clean · mypy: 21 errors in 8 files (baseline) · lint-imports: 4 kept / 0 broken

Found during the live IC-7610 Echelon-A OPUS validation. Related: MOR-588, MOR-584, MOR-562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)