### PR TITLE
chore(MOR-610): audio tech-debt sweep — dead code, doc-rot, canonical imports, cosmetic (behavior-neutral)

### DIFF
--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -57,7 +57,7 @@ from .session import AudioSession, AudioSessionState, RxSubscription, TxLease
 if TYPE_CHECKING:
     from concurrent.futures import Executor
 
-    from rigplane.radio_protocol import AudioCapable
+    from rigplane.core.radio_protocol import AudioCapable
 
 logger = logging.getLogger(__name__)
 
@@ -471,7 +471,7 @@ class AudioBridge:
                 tx_dev_id = tx_dev.id
 
         # Codec detection
-        from rigplane.types import AudioCodec
+        from rigplane.core.types import AudioCodec
 
         _codec = getattr(self._radio, "audio_codec", None)
         self._is_opus = isinstance(_codec, AudioCodec) and _codec in (

--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -35,7 +35,6 @@ import logging
 import sys
 import time
 from array import array
-from concurrent.futures import Executor
 from typing import TYPE_CHECKING, Any, Callable
 
 import math
@@ -56,6 +55,8 @@ from .backend import (
 from .session import AudioSession, AudioSessionState, RxSubscription, TxLease
 
 if TYPE_CHECKING:
+    from concurrent.futures import Executor
+
     from rigplane.radio_protocol import AudioCapable
 
 logger = logging.getLogger(__name__)
@@ -236,7 +237,8 @@ class AudioBridge:
         channels: Number of audio channels (default 1, mono).
         frame_ms: PCM frame duration in milliseconds (default 20).
         tx_enabled: Whether to bridge TX audio (device → radio). Default True.
-        tx_executor: Deprecated — backend now owns threading.
+        tx_executor: Accepted but ignored (deprecated) — the backend owns
+            threading. Kept only so existing callers passing it keep working.
         label: Descriptive label used in log messages (default ``"rigplane"``).
         backend: Audio backend for device discovery and stream I/O.
         max_retries: Maximum reconnect attempts (0 = infinite).
@@ -273,7 +275,6 @@ class AudioBridge:
         self._frame_ms = frame_ms
         self._tx_enabled = tx_enabled
         self._tx_started = False
-        self._tx_executor = tx_executor
         self._backend: AudioBackend = backend or PortAudioBackend()
 
         # State machine

--- a/src/rigplane/audio/bus.py
+++ b/src/rigplane/audio/bus.py
@@ -355,6 +355,9 @@ class AudioBus:
         # ``rx.pcm`` stage tap (MOR-565): passive observer of radio-native
         # frames, fed after subscriber delivery so the hot path is untouched.
         # The empty-registry check keeps the no-tap cost to one attribute read.
+        # NOTE: despite the stage name, this carries RADIO-NATIVE wire bytes
+        # (not guaranteed s16le); the decode-at-ingress s16le path is the
+        # MOR-591 PcmFrame ingress on the runtime audio mixin.
         if packet is not None and self._rx_pcm_taps.active:
             self._rx_pcm_taps.feed(packet.data)
 

--- a/src/rigplane/audio/lan_stream.py
+++ b/src/rigplane/audio/lan_stream.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Callable
 
-from ..transport import IcomTransport
-from ..types import PacketType
+from rigplane.core.transport import IcomTransport
+from rigplane.core.types import PacketType
 from .usb_driver import AudioAlreadyStartedError, AudioNotStartedError
 
 __all__ = [

--- a/src/rigplane/audio/session.py
+++ b/src/rigplane/audio/session.py
@@ -17,7 +17,7 @@ at the source — MOR-556/MOR-559).
 
 State machine (ADR §3.3)::
 
-    IDLE ⇄ RX_ONLY ⇄ RX_TX ⇄ RECOVERING        FAILED reserved (step 20)
+    IDLE ⇄ RX_ONLY ⇄ RX_TX ⇄ RECOVERING        FAILED defined, not yet entered
 
 RECOVERING (MOR-581, ADR §3.4, tenet T3 "no silent audio death"): a ~1 s
 watchdog task — decoupled from the keep-alives — reads the bus RX heartbeat
@@ -99,9 +99,13 @@ class AudioSessionState(Enum):
     IDLE = "idle"
     RX_ONLY = "rx_only"
     RX_TX = "rx_tx"
-    #: Watchdog-detected silent RX death (MOR-581; recovery loop = step 20).
+    #: Watchdog-detected silent RX death (MOR-581). Surface-only as built:
+    #: recovery currently rides the transport reconnect (MOR-586
+    #: :meth:`AudioSession.reestablish`); a session-owned retry loop is a
+    #: follow-up (MOR-609).
     RECOVERING = "recovering"
-    #: Reserved for the step-20 recovery loop (no transitions in yet).
+    #: Defined but never entered yet — no transitions target FAILED. The
+    #: MOR-609 follow-up tracks adding a session-owned retry/FAILED path.
     FAILED = "failed"
 
 

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -480,8 +480,9 @@ def resolve_usb_duplex_mode(
     Everything else — separate devices, virtual loopbacks, non-macOS
     platforms — supports the two-stream path: ``"full"``.
 
-    Pure read-only policy (MOR-534, AudioTransport 1/12): nothing consumes
-    it yet; later epic steps route stream setup through it.
+    Pure read-only policy (MOR-534, AudioTransport 1/12). Consumed via
+    :attr:`UsbAudioDriver.duplex_mode`, which the backends expose as
+    ``audio_duplex_mode`` for the AudioSession's setup-order sequencing.
     """
     if sys.platform != "darwin":
         return "full"

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -3084,7 +3084,7 @@ async def _cmd_scope(radio: Radio, args: argparse.Namespace) -> int:
 async def _cmd_audio_bridge(radio: Radio, args: argparse.Namespace) -> int:
     """Bridge radio audio to a virtual audio device."""
     try:
-        from rigplane.audio_bridge import (
+        from rigplane.audio.bridge import (
             AudioBridge,
             derive_bridge_label,
             list_audio_devices,
@@ -3178,7 +3178,7 @@ async def _cmd_audio_bridge(radio: Radio, args: argparse.Namespace) -> int:
 def _detect_loopback_hint() -> str | None:
     """Try to detect a loopback audio device; return a hint string or None."""
     try:
-        from rigplane.audio_bridge import find_loopback_device
+        from rigplane.audio.bridge import find_loopback_device
 
         dev = find_loopback_device()
         if dev:
@@ -3387,7 +3387,7 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
         tx_device_name = getattr(args, "web_bridge_tx_device", None)
         rx_only = getattr(args, "web_bridge_rx_only", False)
         bridge_label = getattr(args, "web_bridge_label", None)
-        from rigplane.audio_bridge import LoopbackNotFoundError
+        from rigplane.audio.bridge import LoopbackNotFoundError
 
         try:
             await server.start_audio_bridge(

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -691,8 +691,8 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         ``"rx_first"``. ``"exclusive"`` would map to ``"atomic"`` (one
         duplex stream — setup does not decompose into rx/tx-first);
         ``"half"`` or any unexpected/raising duplex mode degrades to the
-        ``"rx_first"`` safe default. Nothing consumes this yet — the
-        AudioSession (MOR-562 step 8) and bridge (step 9) will read it.
+        ``"rx_first"`` safe default. Consumed by the AudioSession
+        (``audio/session.py`` ``_setup_order``) to sequence RX/TX arming.
         """
         try:
             mode = self.audio_duplex_mode

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -382,22 +382,6 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
         """
         await self.stop_rx()
 
-    def _add_opus_rx_tap(
-        self,
-        callback: Callable[[AudioPacket | None], None],
-    ) -> None:
-        """Add an additional opus RX listener (non-exclusive, parallel to main callback)."""
-        if self._audio_stream is not None:
-            self._audio_stream.add_rx_tap(callback)
-
-    def _remove_opus_rx_tap(
-        self,
-        callback: Callable[[AudioPacket | None], None],
-    ) -> None:
-        """Remove an opus RX tap."""
-        if self._audio_stream is not None:
-            self._audio_stream.remove_rx_tap(callback)
-
     async def start_audio_tx_opus(self) -> None:
         """Start transmitting Opus audio to the radio.
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -1018,7 +1018,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     def audio_bus(self) -> Any:
         """Lazy-initialized AudioBus for pub/sub audio distribution."""
         if self._audio_bus is None:
-            from rigplane.audio_bus import AudioBus
+            from rigplane.audio.bus import AudioBus
 
             self._audio_bus = AudioBus(self)
         return self._audio_bus

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -34,7 +34,6 @@ from ..websocket import WS_OP_BINARY, WS_OP_TEXT  # noqa: TID251
 
 if TYPE_CHECKING:
     from ...audio.session import TxLease
-    from ...capabilities import CAP_AUDIO as _CAP_AUDIO_TYPE  # noqa: F401
     from ...dsp.pipeline import DSPPipeline
     from ...radio_protocol import Radio
 

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -9,8 +9,8 @@ from collections.abc import AsyncIterator, Awaitable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 
-from ..._audio_codecs import decode_ulaw_to_pcm16
-from ..._audio_transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
+from rigplane.audio._codecs import decode_ulaw_to_pcm16
+from rigplane.audio._transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
 from ...audio.bus import STAGE_RX_POST_DSP
 from ...audio.session import RxSubscription
 from ...audio.usb_driver import AudioAlreadyStartedError

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -104,7 +104,8 @@ from .websocket import (  # noqa: TID251
 from ..radio_protocol import CivTransactionCapable, StateStoreCapable
 
 if TYPE_CHECKING:
-    from ..audio_bridge import AudioBridge
+    from rigplane.audio.bridge import AudioBridge
+
     from ..profiles import RadioProfile
     from ..radio_protocol import Radio
     from .transport.webrtc_session import WebRtcSessionManager  # noqa: TID251
@@ -1926,7 +1927,7 @@ class WebServer:
             tx_enabled: Whether to bridge TX (device → radio).
             label: Descriptive label for log messages. If ``None``, derived from radio model.
         """
-        from ..audio_bridge import AudioBridge, derive_bridge_label
+        from rigplane.audio.bridge import AudioBridge, derive_bridge_label
 
         if self._audio_bridge is not None and self._audio_bridge.running:
             logger.warning("audio-bridge: already running")

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -62,6 +62,7 @@ from ..core.state_store import StateSnapshot, StateStore
 from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO, CAP_SCOPE
 from ..exceptions import TimeoutError as RigplaneTimeoutError
+from ..audio.bus import STAGE_RX_POST_DSP
 from ..audio.session import AudioSession, AudioSessionEvent
 from ..audio_analyzer import AudioAnalyzer
 from ..audio_fft_scope import AudioFftScope
@@ -784,9 +785,9 @@ class WebServer:
         self._audio_analyzer: AudioAnalyzer | None = None
         if radio is not None and _has_audio:
             self._audio_analyzer = AudioAnalyzer()
-            self._audio_analyzer_tap = self._audio_broadcaster._tap_registry.register(
-                "audio-analyzer", self._audio_analyzer.feed_audio
-            )
+            self._audio_analyzer_tap = self._audio_broadcaster.taps(
+                STAGE_RX_POST_DSP
+            ).register("audio-analyzer", self._audio_analyzer.feed_audio)
         self._command_queue: CommandQueue = CommandQueue()
         self._radio_poller: RadioPoller | None = None
         self._state_poller: Any | None = None  # StatePoller (lazy, optional)

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -237,7 +237,10 @@ def test_bridge_init_custom():
         assert bridge._channels == 2
         assert bridge._frame_ms == 40
         assert bridge._tx_enabled is False
-        assert bridge._tx_executor is custom_executor
+        # tx_executor is deprecated and ignored (backend owns threading):
+        # the contract is that the kwarg is still ACCEPTED — constructing
+        # with it must not raise. Nothing is stored, so there is no
+        # attribute to assert.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Behavior-neutral cleanup sweep from the MOR-562 post-epic audit. Six groups, one commit each. NONE touch back-compat shims, frozen `AudioCapable` delegates, `_replay_legacy`, or MOR-592-deferred decoders.

- **D1 dead code** — delete private `_add_opus_rx_tap`/`_remove_opus_rx_tap` (0 call sites; `AudioStream.add_rx_tap` stays) + unused `_CAP_AUDIO_TYPE` TYPE_CHECKING import.
- **D2 doc-rot** (comments only) — `audio_setup_order`, `resolve_usb_duplex_mode` "nothing consumes this yet" are stale (both ARE consumed via the session chain); `session.py` FAILED/"step 20" comments reworded to as-built (FAILED defined-not-entered; RECOVERING surface-only; session-owned retry tracked as MOR-609).
- **D3 `tx_executor`** — keep the public kwarg (accepted-but-ignored, deprecated) but drop the never-read `self._tx_executor` storage; `Executor` import moved into TYPE_CHECKING (annotation-only). Test now asserts the kwarg is accepted.
- **D4 canonical imports** — internal callers off shim paths → canonical (`rigplane.core.*` / `rigplane.audio.*`) in bridge.py, lan_stream.py, handlers/audio.py, runtime/radio.py, web/server.py (×2), cli/__init__.py (×3). Shims untouched; canonical exports AST-verified; gated by `lint-imports`.
- **D5 cosmetic** — analyzer registers via public `taps(STAGE_RX_POST_DSP)` instead of the private `_tap_registry` (same registry object).
- **D6 cosmetic** — NOTE at the `STAGE_RX_PCM` bus feed clarifying it carries radio-native wire bytes (s16le path = MOR-591 PcmFrame ingress).

## Gate

- pytest (no integration, libopus present): 7606 passed, 8 skipped, 11 xfailed, 1 xpassed — 0 failures
- ruff check + format clean · mypy 21 errors in 8 files (baseline, unchanged) · lint-imports 4 kept / 0 broken

`git diff --stat origin/main`: 11 files, +40/−43. All changes behavior-neutral (existing suite is the regression guard). Related: MOR-562, MOR-591, MOR-592, MOR-609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)