### PR TITLE
test(MOR-607): inject monotonic clock into AudioSession watchdog for deterministic health tests

### DIFF
--- a/src/rigplane/audio/session.py
+++ b/src/rigplane/audio/session.py
@@ -118,8 +118,10 @@ _WATCHED_STATES: frozenset[AudioSessionState] = frozenset(AudioSessionState) - {
 
 @dataclass(frozen=True, slots=True)
 class AudioSessionEvent:
-    """Local liveness event (NO telemetry — open-core). ``timestamp`` is
-    ``time.monotonic()``, comparable to ``AudioBus.last_rx_frame_monotonic``."""
+    """Local liveness event (NO telemetry — open-core). ``timestamp`` comes
+    from the session's monotonic clock (``time.monotonic`` by default) and is
+    comparable to ``AudioBus.last_rx_frame_monotonic`` — see the
+    ``AudioSession`` ``monotonic`` argument for the clock-injection caveat."""
 
     state: AudioSessionState
     reason: str
@@ -188,6 +190,13 @@ class AudioSession:
             :class:`AudioBus` — no import-matrix change).
         bus: Existing bus to wrap; defaults to ``radio.audio_bus`` or a
             fresh :class:`AudioBus`.
+        monotonic: Monotonic clock used for the liveness watchdog and the
+            :class:`AudioSessionEvent` timestamps; defaults to
+            :func:`time.monotonic` — production behavior is unchanged.
+            Test-only seam (MOR-607): liveness compares this clock against
+            ``AudioBus.last_rx_frame_monotonic``, and the bus stamps real
+            ``time.monotonic()`` on its own — callers injecting a fake
+            clock MUST also feed the bus heartbeat from that SAME clock.
     """
 
     def __init__(
@@ -197,6 +206,7 @@ class AudioSession:
         bus: AudioBus | None = None,
         watchdog_interval: float = WATCHDOG_INTERVAL_S,
         rx_liveness_timeout: float = RX_LIVENESS_TIMEOUT_S,
+        monotonic: Callable[[], float] = time.monotonic,
     ) -> None:
         self._radio = radio
         self._bus: AudioBus = (
@@ -208,6 +218,7 @@ class AudioSession:
         self._tx_leases: list[TxLease] = []
         self._watchdog_interval = watchdog_interval
         self._rx_liveness_timeout = rx_liveness_timeout
+        self._monotonic: Callable[[], float] = monotonic
         self._watchdog_task: asyncio.Task[None] | None = None
         self._rx_armed_at: float = 0.0
         self._recovering_from: AudioSessionState | None = None
@@ -260,7 +271,7 @@ class AudioSession:
 
     def _emit(self, reason: str, leg: str = "rx") -> None:
         event = AudioSessionEvent(
-            state=self._state, reason=reason, leg=leg, timestamp=time.monotonic()
+            state=self._state, reason=reason, leg=leg, timestamp=self._monotonic()
         )
         self._last_event = event
         for listener in list(self._listeners):
@@ -501,7 +512,7 @@ class AudioSession:
                 if tx_live:
                     await self._disarm_tx()  # never leave TX without RX
                 self._state = AudioSessionState.RX_ONLY
-                self._rx_armed_at = time.monotonic()
+                self._rx_armed_at = self._monotonic()
                 await self._sync_watchdog()
                 raise RuntimeError(
                     "radio RX failed to re-establish after reconnect "
@@ -515,7 +526,7 @@ class AudioSession:
             )
             # Fresh liveness reference: silence is measured from this
             # re-arm, not from the stale pre-outage heartbeat.
-            self._rx_armed_at = time.monotonic()
+            self._rx_armed_at = self._monotonic()
             await self._sync_watchdog()
 
     async def _try_rearm_tx(self) -> bool:
@@ -545,7 +556,7 @@ class AudioSession:
             if task is None or task.done():
                 # Silence is measured from this arm point until the first
                 # heartbeat ("starting" — the MOR-559 verified-start idea).
-                self._rx_armed_at = time.monotonic()
+                self._rx_armed_at = self._monotonic()
                 self._watchdog_task = asyncio.get_running_loop().create_task(
                     self._watchdog_loop(), name="audio-session-watchdog"
                 )
@@ -563,7 +574,7 @@ class AudioSession:
                 self._check_liveness_locked()
 
     def _check_liveness_locked(self) -> None:
-        now = time.monotonic()
+        now = self._monotonic()
         last = self._bus.last_rx_frame_monotonic
         if self._state in (AudioSessionState.RX_ONLY, AudioSessionState.RX_TX):
             # Reference = the later of the last heartbeat and the arm point, so

--- a/tests/test_audio_session_health.py
+++ b/tests/test_audio_session_health.py
@@ -60,6 +60,48 @@ async def _wait_for(predicate: Callable[[], bool], deadline_s: float = 2.0) -> b
     return predicate()
 
 
+class _ManualClock:
+    """Deterministic ``time.monotonic`` stand-in (MOR-607).
+
+    The watchdog still wakes on the real event loop, but every liveness
+    comparison reads THIS clock — time only moves when the test says so,
+    so the assertions are immune to scheduling jitter under xdist load.
+    ``calls`` counts reads, letting tests wait until the watchdog has
+    observed a given clock state without real-time assumptions.
+    """
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+        self.calls = 0
+
+    def __call__(self) -> float:
+        self.calls += 1
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _clocked_session(radio: Any, clock: _ManualClock) -> AudioSession:
+    return AudioSession(
+        radio,
+        watchdog_interval=_INTERVAL,
+        rx_liveness_timeout=_TIMEOUT,
+        monotonic=clock,
+    )
+
+
+def _stamp_heartbeat(radio: Any, session: AudioSession, clock: _ManualClock) -> None:
+    """Deliver a frame, then re-stamp the bus heartbeat from the test clock.
+
+    The bus stamps real ``time.monotonic()`` internally; the session's
+    liveness math runs on the injected clock, so the heartbeat must be fed
+    from the SAME clock (see the ``AudioSession`` ``monotonic`` docs).
+    """
+    radio.rx_callback(_PACKET)  # type: ignore[operator]
+    session.bus._last_rx_frame_monotonic = clock.now  # noqa: SLF001
+
+
 class _FakeWriter:
     """Minimal writer capturing the HTTP response bytes."""
 
@@ -122,20 +164,22 @@ async def test_silent_rx_after_start_surfaces_recovering_and_event() -> None:
 
 
 async def test_frames_resuming_returns_to_demand_state() -> None:
+    """Deterministic via the injected clock (MOR-607): the old real-time
+    version could grow a third spurious ``rx_silent`` if the feeder starved
+    past the timeout between the last frame and the events assert."""
+    clock = _ManualClock()
     radio = LanLikeRadio()
-    session = _fast_session(radio)
+    session = _clocked_session(radio, clock)
     events: list[AudioSessionEvent] = []
     session.add_listener(events.append)
     sub = await session.subscribe_rx("a")
+    # No frame ever lands; jump the clock past the timeout → rx_silent.
+    clock.advance(2 * _TIMEOUT)
     assert await _wait_for(lambda: session.state is AudioSessionState.RECOVERING)
-    # Frames resume — keep the heartbeat advancing while we wait.
-    deadline = time.monotonic() + 2.0
-    while (
-        session.state is not AudioSessionState.RX_ONLY and time.monotonic() < deadline
-    ):
-        radio.rx_callback(_PACKET)  # type: ignore[operator]
-        await asyncio.sleep(0.005)
-    assert session.state is AudioSessionState.RX_ONLY  # demand-derived state
+    # Frames resume — one fresh same-clock heartbeat is enough.
+    _stamp_heartbeat(radio, session, clock)
+    assert await _wait_for(lambda: session.state is AudioSessionState.RX_ONLY)
+    # The clock no longer moves, so no further event can possibly fire.
     assert [e.reason for e in events] == ["rx_silent", "rx_resumed"]
     await sub.release()
 
@@ -146,16 +190,49 @@ async def test_frames_resuming_returns_to_demand_state() -> None:
 
 
 async def test_healthy_heartbeat_never_false_positives() -> None:
+    """A healthy, recently-heartbeat RX leg must NEVER go RECOVERING.
+
+    Deterministic (MOR-607): the old version fed real-time heartbeats from
+    a coroutine loop and flaked under parallel load whenever that loop
+    starved past ``rx_liveness_timeout`` — by wall clock the heartbeat WAS
+    stale, so the watchdog fired per its contract. Here time is the
+    injected clock: each step advances to just under the threshold, lands
+    a fresh same-clock heartbeat, then waits until the watchdog has read
+    the clock again. No assertion depends on real sleep durations.
+    """
+    clock = _ManualClock()
     radio = LanLikeRadio()
-    session = _fast_session(radio)
+    session = _clocked_session(radio, clock)
     events: list[AudioSessionEvent] = []
     session.add_listener(events.append)
     sub = await session.subscribe_rx("a")
-    deadline = time.monotonic() + max(0.3, 6 * _TIMEOUT)
-    while time.monotonic() < deadline:
-        radio.rx_callback(_PACKET)  # type: ignore[operator]
+    for _ in range(6):
+        clock.advance(_TIMEOUT * 0.9)  # close to, but under, the threshold
+        _stamp_heartbeat(radio, session, clock)
+        reads = clock.calls
+        # ≥1 watchdog liveness check at exactly this clock state.
+        assert await _wait_for(lambda: clock.calls > reads)
         assert session.state is AudioSessionState.RX_ONLY
-        await asyncio.sleep(_INTERVAL / 2)
+    assert events == []
+    await sub.release()
+
+
+async def test_watchdog_overrun_with_fresh_heartbeat_does_not_misfire() -> None:
+    """The MOR-607 jitter shape, pinned: the clock jumps FAR past the
+    timeout in one step (a starved watchdog waking late), but the heartbeat
+    is fresh on the same clock — the ``max(last, _rx_armed_at)`` reference
+    in ``_check_liveness_locked`` must not declare RECOVERING."""
+    clock = _ManualClock()
+    radio = LanLikeRadio()
+    session = _clocked_session(radio, clock)
+    events: list[AudioSessionEvent] = []
+    session.add_listener(events.append)
+    sub = await session.subscribe_rx("a")
+    clock.advance(10 * _TIMEOUT)  # one giant scheduling-jitter jump
+    _stamp_heartbeat(radio, session, clock)
+    reads = clock.calls
+    assert await _wait_for(lambda: clock.calls > reads)
+    assert session.state is AudioSessionState.RX_ONLY
     assert events == []
     await sub.release()
 


### PR DESCRIPTION
## What

Fix **MOR-607** (Low): `test_audio_session_health.py::test_healthy_heartbeat_never_false_positives` flaked under `pytest-xdist` heavy parallel load — the watchdog's heartbeat-feeder coroutine starved past `rx_liveness_timeout`, so by wall clock the heartbeat genuinely went stale and the watchdog fired per its contract (a test-timing artifact, NOT a production false-positive).

## How

- `AudioSession.__init__` gains a keyword-only `monotonic: Callable[[], float] = time.monotonic`; all 5 wall-clock reads in the watchdog/liveness path (`_emit` timestamp, `_rx_armed_at` in `_sync_watchdog` + `reestablish` ×2, `now` in `_check_liveness_locked`) route through it. Default `time.monotonic` → **zero production behavior change**; `rx_liveness_timeout` NOT loosened.
- Tests rewritten deterministically with a `_ManualClock` (counts reads so tests advance on "watchdog observed this state" rather than real time) + `_stamp_heartbeat` (delivers a real fan-out frame, re-stamps the bus heartbeat from the same clock). The sibling `test_frames_resuming_returns_to_demand_state` shared the flake shape and was rewritten too; added `test_watchdog_overrun_with_fresh_heartbeat_does_not_misfire` pinning the exact jitter shape.

## Falsification + stability

The 3 rewritten tests fail with `TypeError: unexpected keyword argument 'monotonic'` on unmodified code (red), pass after (green). Touched tests 50× → 50/50 green; health file under `-n auto` ×3 → all green (and ~3× faster, no real-time burn).

## Gate

- pytest (no integration): 7607 passed, 0 failed
- ruff check + format clean · mypy 21 errors in 8 files (baseline) · lint-imports 4 kept / 0 broken

`git diff --stat origin/main`: 2 files, +109/−21. Related: MOR-581, MOR-562, MOR-596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)