### PR TITLE
feat(MOR-594): surface reconnect status + attempt countdown in runtime payload and WS events

### DIFF
--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -749,6 +749,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._auto_recover_audio = auto_recover_audio
         self._on_audio_recovery = on_audio_recovery
         self._on_reconnect: Callable[[], None] | None = None
+        self._on_reconnect_status: Callable[[dict[str, Any]], None] | None = None
         self._civ_stream_ready: bool = False
         self._civ_recovering: bool = False
         self._last_civ_data_received: float | None = None
@@ -1085,6 +1086,19 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     def set_reconnect_callback(self, callback: Callable[[], None] | None) -> None:
         """Register callback invoked after successful soft reconnect."""
         self._on_reconnect = callback
+
+    def set_reconnect_status_callback(
+        self, callback: Callable[[dict[str, Any]], None] | None
+    ) -> None:
+        """Register callback for reconnect-status updates (MOR-594).
+
+        The callback receives a small structured payload at each meaningful
+        reconnect edge: ``{"state": "reconnecting" | "connected" |
+        "disconnected", "attempt": int, "next_retry_seconds": float | None}``.
+        Invocation is best-effort — a raising callback never breaks the
+        watchdog/reconnect loops.
+        """
+        self._on_reconnect_status = callback
 
     def civ_stats(self) -> dict[str, int]:
         """Return CI-V request tracker statistics for monitoring.

--- a/src/rigplane/runtime/radio_reconnect.py
+++ b/src/rigplane/runtime/radio_reconnect.py
@@ -30,6 +30,33 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _emit_reconnect_status(
+    radio: IcomRadio,
+    state: str,
+    attempt: int,
+    next_retry_seconds: float | None,
+) -> None:
+    """Best-effort reconnect-status notification (MOR-594).
+
+    A raising callback must never break the watchdog/reconnect path, so
+    failures are logged at debug level and swallowed — mirroring how
+    ``_on_reconnect`` is invoked after a soft reconnect.
+    """
+    callback = getattr(radio, "_on_reconnect_status", None)
+    if callback is None:
+        return
+    try:
+        callback(
+            {
+                "state": state,
+                "attempt": attempt,
+                "next_retry_seconds": next_retry_seconds,
+            }
+        )
+    except Exception:
+        logger.debug("reconnect: status callback failed", exc_info=True)
+
+
 async def watchdog_loop(radio: IcomRadio) -> None:
     """Monitor connection health via transport packet queue activity.
 
@@ -82,6 +109,13 @@ async def watchdog_loop(radio: IcomRadio) -> None:
                     idle,
                 )
                 radio._conn_state = RadioConnectionState.RECONNECTING
+                # Surface the trigger immediately — first attempt is imminent.
+                _emit_reconnect_status(
+                    radio,
+                    "reconnecting",
+                    attempt=1,
+                    next_retry_seconds=radio._reconnect_delay,
+                )
                 radio._civ_runtime.advance_generation("watchdog-timeout")
                 radio._reconnect_task = asyncio.create_task(radio._reconnect_loop())
                 return
@@ -97,6 +131,9 @@ async def reconnect_loop(radio: IcomRadio) -> None:
         while radio._conn_state != RadioConnectionState.DISCONNECTED:
             attempt += 1
             logger.info("Reconnect attempt %d (delay=%.1fs)", attempt, delay)
+            _emit_reconnect_status(
+                radio, "reconnecting", attempt=attempt, next_retry_seconds=delay
+            )
             try:
                 radio._civ_runtime.advance_generation("reconnect-attempt")
                 # Capture audio state for auto-recovery.
@@ -145,6 +182,9 @@ async def reconnect_loop(radio: IcomRadio) -> None:
                 radio._ctrl_transport = IcomTransport()
                 await radio.connect()
                 logger.info("Reconnected successfully after %d attempts", attempt)
+                _emit_reconnect_status(
+                    radio, "connected", attempt=attempt, next_retry_seconds=None
+                )
                 if radio._auto_recover_audio and audio_snapshot is not None:
                     await radio._audio_runtime.recover(audio_snapshot)
                 return
@@ -155,6 +195,10 @@ async def reconnect_loop(radio: IcomRadio) -> None:
                     exc,
                 )
                 radio._conn_state = RadioConnectionState.DISCONNECTED
+                # Do not leave the surfaced status stuck at "reconnecting".
+                _emit_reconnect_status(
+                    radio, "disconnected", attempt=attempt, next_retry_seconds=None
+                )
                 return
             except Exception as exc:
                 radio._conn_state = RadioConnectionState.RECONNECTING

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -811,6 +811,8 @@ class WebServer:
         self._audio_bridge: "AudioBridge | None" = None
         # AudioSession whose liveness events are forwarded to WS (MOR-581)
         self._watched_audio_session: AudioSession | None = None
+        # Latest reconnect status forwarded from the radio (MOR-594)
+        self._connection_status: dict[str, Any] | None = None
         # Scope health monitor
         self._scope_last_nonzero: float = 0.0
         self._scope_health_task: asyncio.Task[None] | None = None
@@ -1898,12 +1900,40 @@ class WebServer:
     def _on_audio_session_event(self, event: "AudioSessionEvent") -> None:
         self.broadcast_event("audio_session", _audio_session_event_json(event))
 
+    def _attach_reconnect_status_listener(self) -> None:
+        """Forward radio reconnect-status updates to control WS clients and
+        the runtime payload (MOR-594). Local-only — the existing WS surface,
+        no telemetry."""
+        radio = self._radio
+        setter = (
+            getattr(radio, "set_reconnect_status_callback", None)
+            if radio is not None
+            else None
+        )
+        if callable(setter):
+            setter(self._on_reconnect_status)
+
+    def _detach_reconnect_status_listener(self) -> None:
+        radio = self._radio
+        setter = (
+            getattr(radio, "set_reconnect_status_callback", None)
+            if radio is not None
+            else None
+        )
+        if callable(setter):
+            setter(None)
+
+    def _on_reconnect_status(self, status: dict[str, Any]) -> None:
+        self._connection_status = dict(status)
+        self.broadcast_event("connection_status", dict(status))
+
     async def start(self) -> None:
         """Start the HTTP/WS listener and RadioPoller (if radio is connected)."""
         from .web_startup import start_web_server  # noqa: TID251
 
         self._stopping = False
         self._attach_audio_session_listener()
+        self._attach_reconnect_status_listener()
         await start_web_server(self)
 
     # ------------------------------------------------------------------
@@ -1985,6 +2015,7 @@ class WebServer:
 
         self._stopping = True
         self._detach_audio_session_listener()
+        self._detach_reconnect_status_listener()
         await stop_web_server(self)
 
     async def serve_forever(self) -> None:
@@ -2442,6 +2473,25 @@ class WebServer:
             "lastEvent": None if event is None else _audio_session_event_json(event),
         }
 
+    def _runtime_connection_payload(self) -> dict[str, Any]:
+        """Connection/reconnect status block for the runtime payload (MOR-594).
+
+        Mirrors the latest reconnect-status callback payload; before any
+        status arrives it is derived from the radio's ``connected`` flag.
+        """
+        status = self._connection_status
+        if status is not None:
+            return dict(status)
+        radio = self._radio
+        connected = (
+            bool(getattr(radio, "connected", False)) if radio is not None else False
+        )
+        return {
+            "state": "connected" if connected else "disconnected",
+            "attempt": 0,
+            "next_retry_seconds": None,
+        }
+
     def _state_acquisition_diagnostics_payload(self) -> dict[str, Any]:
         radio = self._radio
         scheduler = (
@@ -2489,6 +2539,7 @@ class WebServer:
                 "bridge": self._runtime_bridge_payload(),
                 "audioBus": self._runtime_audio_bus_payload(),
                 "audioSession": self._runtime_audio_session_payload(),
+                "connection": self._runtime_connection_payload(),
                 "stateAcquisition": self._state_acquisition_diagnostics_payload(),
                 "lastError": self._runtime_last_error,
             },

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -1,14 +1,19 @@
 """Tests for watchdog and auto-reconnect."""
 
 import asyncio
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from rigplane.core._bounded_queue import BoundedQueue
 from rigplane.runtime._connection_state import RadioConnectionState
 from rigplane.exceptions import AuthenticationError
 from rigplane.radio import IcomRadio
+from rigplane.web.server import WebConfig, WebServer
 
+from test_audio_session_health import _FakeWriter, _response_json
 from test_radio import MockTransport
 
 
@@ -229,3 +234,163 @@ class TestExternalCatSessionResetOnConnect:
         ):
             await radio.connect()
         assert radio.external_cat_session_active is False
+
+
+class TestReconnectStatusCallback:
+    """MOR-594: reconnect status surfaced via callback at each meaningful edge."""
+
+    @pytest.mark.asyncio
+    async def test_reports_each_attempt_then_connected(self, radio: IcomRadio) -> None:
+        """Each attempt emits ``reconnecting`` with attempt + backoff; success
+        emits ``connected``."""
+        statuses: list[dict[str, Any]] = []
+        radio.set_reconnect_status_callback(statuses.append)
+        radio._connected = False
+        radio._intentional_disconnect = False
+        with patch.object(radio, "connect", new_callable=AsyncMock) as mock_connect:
+            mock_connect.side_effect = [OSError("down"), OSError("down"), None]
+            radio._reconnect_task = asyncio.create_task(radio._reconnect_loop())
+            await asyncio.wait_for(radio._reconnect_task, timeout=5.0)
+        reconnecting = [s for s in statuses if s["state"] == "reconnecting"]
+        assert [s["attempt"] for s in reconnecting] == [1, 2, 3]
+        # Backoff: reconnect_delay=0.1 doubling toward reconnect_max_delay=0.5.
+        assert [s["next_retry_seconds"] for s in reconnecting] == [0.1, 0.2, 0.4]
+        assert statuses[-1] == {
+            "state": "connected",
+            "attempt": 3,
+            "next_retry_seconds": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_raising_callback_does_not_break_reconnect(
+        self, radio: IcomRadio
+    ) -> None:
+        """A raising status callback must never break the reconnect loop."""
+
+        def _boom(_status: dict[str, Any]) -> None:
+            raise RuntimeError("boom")
+
+        radio.set_reconnect_status_callback(_boom)
+        radio._connected = False
+        radio._intentional_disconnect = False
+        with patch.object(radio, "connect", new_callable=AsyncMock) as mock_connect:
+            mock_connect.side_effect = [OSError("down"), None]
+            radio._reconnect_task = asyncio.create_task(radio._reconnect_loop())
+            await asyncio.wait_for(radio._reconnect_task, timeout=5.0)
+        assert mock_connect.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_permanent_error_reports_disconnected(self, radio: IcomRadio) -> None:
+        """A permanent-error abort must not leave the status stuck at
+        ``reconnecting`` (no silent problems)."""
+        statuses: list[dict[str, Any]] = []
+        radio.set_reconnect_status_callback(statuses.append)
+        radio._connected = False
+        radio._intentional_disconnect = False
+        with patch.object(radio, "connect", new_callable=AsyncMock) as mock_connect:
+            mock_connect.side_effect = AuthenticationError("wrong password")
+            radio._reconnect_task = asyncio.create_task(radio._reconnect_loop())
+            await asyncio.wait_for(radio._reconnect_task, timeout=5.0)
+        assert statuses[-1] == {
+            "state": "disconnected",
+            "attempt": 1,
+            "next_retry_seconds": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_watchdog_trigger_reports_first_attempt(
+        self, radio: IcomRadio
+    ) -> None:
+        """The watchdog trigger point surfaces ``reconnecting`` immediately."""
+        statuses: list[dict[str, Any]] = []
+        radio.set_reconnect_status_callback(statuses.append)
+        radio._control_phase._start_watchdog()
+        await asyncio.sleep(0.6)  # > watchdog_timeout (0.3 s), no activity
+        assert statuses, "watchdog trigger must surface a reconnecting status"
+        assert statuses[0]["state"] == "reconnecting"
+        assert statuses[0]["attempt"] == 1
+        assert statuses[0]["next_retry_seconds"] == 0.1
+        # Clean up
+        radio._intentional_disconnect = True
+        radio._control_phase._stop_reconnect()
+        radio._control_phase._stop_watchdog()
+        await asyncio.sleep(0.05)
+
+
+def _web_radio_stub() -> SimpleNamespace:
+    """Minimal radio surface for WebServer runtime-payload tests (MOR-581 shape)."""
+    return SimpleNamespace(
+        model="IC-7610",
+        backend_id="rigplane",
+        connected=True,
+        control_connected=True,
+        radio_ready=True,
+        capabilities=set(),
+    )
+
+
+class TestWebReconnectStatusSurface:
+    """MOR-594: runtime payload ``connection`` block + ``connection_status``
+    WS event — local-only surfacing, no telemetry."""
+
+    @pytest.mark.asyncio
+    async def test_runtime_payload_defaults_to_radio_connected(self) -> None:
+        srv = WebServer(_web_radio_stub(), WebConfig(host="127.0.0.1", port=0))
+        writer = _FakeWriter()
+        await srv._handle_http(writer, "GET", "/api/v1/runtime")
+        status, data = _response_json(writer)
+        assert status == 200
+        assert data["connection"] == {
+            "state": "connected",
+            "attempt": 0,
+            "next_retry_seconds": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_runtime_payload_reflects_latest_status(self) -> None:
+        srv = WebServer(_web_radio_stub(), WebConfig(host="127.0.0.1", port=0))
+        srv._on_reconnect_status(
+            {"state": "reconnecting", "attempt": 3, "next_retry_seconds": 4.0}
+        )
+        writer = _FakeWriter()
+        await srv._handle_http(writer, "GET", "/api/v1/runtime")
+        status, data = _response_json(writer)
+        assert status == 200
+        assert data["connection"] == {
+            "state": "reconnecting",
+            "attempt": 3,
+            "next_retry_seconds": 4.0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_status_events_broadcast_on_control_ws_queues(
+        self, radio: IcomRadio
+    ) -> None:
+        """Reconnect statuses are forwarded as ``connection_status`` events on
+        the EXISTING control-WS event surface."""
+        srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+        srv._attach_reconnect_status_listener()  # start() wiring
+        q: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=16)
+        srv.register_control_event_queue(q)
+        radio._connected = False
+        radio._intentional_disconnect = False
+        with patch.object(radio, "connect", new_callable=AsyncMock) as mock_connect:
+            mock_connect.side_effect = [OSError("down"), None]
+            radio._reconnect_task = asyncio.create_task(radio._reconnect_loop())
+            await asyncio.wait_for(radio._reconnect_task, timeout=5.0)
+        events: list[dict[str, Any]] = []
+        while not q.empty():
+            events.append(q.get_nowait())
+        conn = [e for e in events if e.get("name") == "connection_status"]
+        assert [e["data"]["state"] for e in conn] == [
+            "reconnecting",
+            "reconnecting",
+            "connected",
+        ]
+        assert [e["data"]["attempt"] for e in conn] == [1, 2, 2]
+        assert conn[0]["data"]["next_retry_seconds"] == 0.1
+        assert conn[-1]["data"]["next_retry_seconds"] is None
+        srv.unregister_control_event_queue(q)
+        # stop() detaches — the radio must not keep a stale server reference.
+        srv._detach_reconnect_status_listener()
+        assert radio._on_reconnect_status is None


### PR DESCRIPTION
## What

Fix **MOR-594** (High) — backend surfacing for the "no silent problems" principle. During a reconnect the user had zero visibility (the ~105s IC-7610 stale-slot reconnect found in MOR-586). This exposes connection/reconnect status so a client can show it. **Scope = backend data surface; the frontend banner is a fast-follow (separate PR).**

## How

One canonical shape across the radio callback, the WS event, and the runtime payload:
```json
{"state": "reconnecting" | "connected" | "disconnected", "attempt": <int>, "next_retry_seconds": <float | null>}
```
- `IcomRadio.set_reconnect_status_callback(cb)`; emission edges in `radio_reconnect.py` via a guarded `_emit_reconnect_status` (a raising callback is logged + swallowed): watchdog trigger (`reconnecting`, attempt=1), each loop attempt (incrementing attempt + current backoff `delay`), success (`connected`), and permanent-error abort (`disconnected` — one edge beyond the ticket's three, so the surfaced status can't stick at "reconnecting" forever).
- WS event `{"type":"event","name":"connection_status","data":<shape>}` via the existing `broadcast_event`.
- Runtime payload `connection` block next to `audioSession` on `/api/v1/runtime`; before any status it derives connected/disconnected from the radio's `connected` flag (`attempt=0, next_retry_seconds=null`). Wired via `_attach_reconnect_status_listener()` in `start()`, detached in `stop()`.
- MOR-581 `AudioSessionEvent` (RECOVERING/rx_silent/rx_resumed) verified already surfaced (`audioSession.state`/`lastEvent` + `audio_session` WS events) — no change needed.
- Open-core: local events only, no telemetry.

## Tests / falsification

`tests/test_reconnect.py` +7 tests: callback fires `reconnecting` with incrementing attempt + numeric `next_retry_seconds` then `connected`; runtime payload includes the `connection` block; `connection_status` WS event broadcast; raising callback doesn't break reconnect. All 7 fail on pre-change code (missing API/fields), pass after.

## Gate

- pytest (no integration): 7613 passed, 0 failed
- ruff check + format clean · mypy 21 errors in 8 files (baseline) · lint-imports 4 kept / 0 broken

`git diff --stat origin/main`: 4 files, +274. **Frontend reconnect banner = fast-follow.** Related: MOR-586, MOR-581, MOR-562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)