### PR TITLE
fix(MOR-620): truthful PTT + degraded-session indicator

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -1083,6 +1083,12 @@ Error response:
 {"type":"response","id":"42","ok":false,"error":"command_failed","message":"..."}
 ```
 
+PTT keying (`ptt` with `state:true`, or `ptt_on`) on a degraded session — the
+backend reports `radio_ready:false` or a connect/reconnect cycle is in flight —
+is rejected with `"error":"radio_not_ready"` instead of a silent enqueue-ACK
+(MOR-620). Unkeying (`ptt` with `state:false`, or `ptt_off`) always goes
+through: it is the safe direction.
+
 Rate-limited high-frequency `set_*` commands are ACKed with:
 
 ```json

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -12,6 +12,7 @@
     getHttpConnected,
     getRadioPowerOn,
     getRigConnected,
+    getRadioReady,
     getRadioHealth,
   } from '$lib/stores/connection.svelte';
   import { getFrequency } from '$lib/stores/radio.svelte';
@@ -65,6 +66,7 @@
   let audioState = $derived(isPoweredOff ? 'disconnected' : (isAudioConnected() ? 'connected' : 'disconnected'));
   let httpState = $derived(getHttpConnected() ? 'connected' : 'disconnected'); // server link — always real
   let rigConnected = $derived(getRigConnected());
+  let radioReady = $derived(getRadioReady());
   let radioHealth = $derived(getRadioHealth());
   // Effective radio indicator: downgrade to 'disconnected' when rigCtld reports radio offline
   let radioIndicatorState = $derived.by(() => {
@@ -74,7 +76,9 @@
     if (radioHealth?.readiness === 'delayed' || radioHealth?.readiness === 'stalled') {
       return 'degraded';
     }
-    return radioState === 'connected' && !rigConnected ? 'degraded' : radioState;
+    // MOR-620: a session that is connected but not radio-ready (CI-V link
+    // degraded) must be visibly degraded, not silently green.
+    return radioState === 'connected' && (!rigConnected || !radioReady) ? 'degraded' : radioState;
   });
   let radioHealthLabel = $derived.by(() => {
     switch (radioHealth?.likelyCause) {
@@ -89,9 +93,13 @@
       case 'server_unreachable':
         return t('core.statusbar.health.serverUnreachable');
       default:
-        return !rigConnected && radioState === 'connected'
-          ? t('core.statusbar.health.rigOffline')
-          : '';
+        if (!rigConnected && radioState === 'connected') {
+          return t('core.statusbar.health.rigOffline');
+        }
+        if (!radioReady && radioState === 'connected') {
+          return t('core.statusbar.health.radioNotReady');
+        }
+        return '';
     }
   });
 

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -37,6 +37,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   isAudioConnected: vi.fn(() => false),
   getHttpConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),
+  getRadioReady: vi.fn(() => false),
   getRadioHealth: vi.fn(() => null),
 }));
 

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
@@ -32,6 +32,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   isAudioConnected: vi.fn(() => false),
   getHttpConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),
+  getRadioReady: vi.fn(() => false),
   getRadioHealth: vi.fn(() => null),
 }));
 

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -31,6 +31,7 @@
   "core.statusbar.health.radioPoweredOff": "radio appears powered off or unreachable",
   "core.statusbar.health.serverUnreachable": "server unreachable",
   "core.statusbar.health.rigOffline": "rig offline",
+  "core.statusbar.health.radioNotReady": "radio link degraded — radio not ready",
   "core.statusbar.power.toggleOn": "Toggle power (radio is ON — click to power off)",
   "core.statusbar.power.toggleOff": "Toggle power (radio is OFF — click to power on)",
   "core.statusbar.power.toggleUnknown": "Toggle power (radio state unknown — click to toggle)",

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -31,6 +31,7 @@
   "core.statusbar.health.radioPoweredOff": "トランシーバーの電源が切れているか到達できません",
   "core.statusbar.health.serverUnreachable": "サーバーに接続できません",
   "core.statusbar.health.rigOffline": "リグがオフラインです",
+  "core.statusbar.health.radioNotReady": "トランシーバーとの通信が低下しています — 準備未完了",
   "core.statusbar.power.toggleOn": "電源切り替え (トランシーバーは ON — クリックで電源オフ)",
   "core.statusbar.power.toggleOff": "電源切り替え (トランシーバーは OFF — クリックで電源オン)",
   "core.statusbar.power.toggleUnknown": "電源切り替え (トランシーバーの状態は不明 — クリックで切り替え)",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -31,6 +31,7 @@
   "core.statusbar.health.radioPoweredOff": "трансивер выключен или недоступен",
   "core.statusbar.health.serverUnreachable": "сервер недоступен",
   "core.statusbar.health.rigOffline": "трансивер не в сети",
+  "core.statusbar.health.radioNotReady": "связь с трансивером деградировала — трансивер не готов",
   "core.statusbar.power.toggleOn": "Переключить питание (трансивер ВКЛЮЧЁН — нажмите, чтобы выключить)",
   "core.statusbar.power.toggleOff": "Переключить питание (трансивер ВЫКЛЮЧЕН — нажмите, чтобы включить)",
   "core.statusbar.power.toggleUnknown": "Переключить питание (состояние трансивера неизвестно — нажмите для переключения)",

--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../stores/connection.svelte', () => ({
   setHttpConnected: vi.fn(),
   markStateUpdated: vi.fn(),
   setReconnecting: vi.fn(),
+  setRadioStatus: vi.fn(),
   isLiveRadioAvailable: vi.fn(() => true),
 }));
 
@@ -73,7 +74,7 @@ vi.mock('../../stores/radio.svelte', () => ({
   }),
 }));
 
-import { isLiveRadioAvailable, setWsConnected } from '../../stores/connection.svelte';
+import { isLiveRadioAvailable, setRadioStatus, setWsConnected } from '../../stores/connection.svelte';
 import { patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../../stores/radio.svelte';
 
 beforeEach(() => {
@@ -735,6 +736,33 @@ describe('control channel singleton', () => {
     expect(radioStoreMock.current?.stateRevision).toBe(6);
     expect(radioStoreMock.current?.observationSeq).toBe(6);
     expect(radioStoreMock.current?.ptt).toBe(true);
+  });
+
+  it('feeds connection_status events into the radio status store (MOR-620)', async () => {
+    vi.mocked(setRadioStatus).mockClear();
+    const { connect } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+
+    instances[0].simulateMessage(JSON.stringify({
+      type: 'event',
+      name: 'connection_status',
+      data: { state: 'reconnecting', attempt: 2, next_retry_seconds: 5 },
+    }));
+    expect(setRadioStatus).toHaveBeenCalledWith('reconnecting');
+
+    instances[0].simulateMessage(JSON.stringify({
+      type: 'event',
+      name: 'connection_status',
+      data: { state: 'connected' },
+    }));
+    expect(setRadioStatus).toHaveBeenLastCalledWith('connected');
+
+    // Malformed payloads must be ignored, not crash the handler.
+    vi.mocked(setRadioStatus).mockClear();
+    instances[0].simulateMessage(JSON.stringify({ type: 'event', name: 'connection_status' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'event', name: 'connection_status', data: { state: 7 } }));
+    expect(setRadioStatus).not.toHaveBeenCalled();
   });
 
   it('replaces accumulated state when a full snapshot follows a revision reset', async () => {

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -1,6 +1,6 @@
 import type { WsCommand, WsIncoming } from '../types/protocol';
 import { makeCommandId } from '../types/protocol';
-import { isLiveRadioAvailable, setWsConnected, setHttpConnected, markStateUpdated, setReconnecting } from '../stores/connection.svelte';
+import { isLiveRadioAvailable, setWsConnected, setHttpConnected, markStateUpdated, setReconnecting, setRadioStatus } from '../stores/connection.svelte';
 import { getRadioState, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
@@ -384,6 +384,17 @@ _ctrl.onMessage((msg) => {
       setRadioState(state as any);
       setHttpConnected(true);
       markStateUpdated();
+    }
+  }
+  // Radio reconnect/degraded status (MOR-594 backend event, consumed for
+  // the StatusBar radio indicator — MOR-620). Shape:
+  // { type: 'event', name: 'connection_status',
+  //   data: { state, attempt, next_retry_seconds } }
+  if (msg.type === 'event') {
+    const ev = msg as { name?: string; data?: Record<string, unknown> };
+    if (ev.name === 'connection_status') {
+      const state = ev.data?.state;
+      if (typeof state === 'string') setRadioStatus(state);
     }
   }
   // Companion-injected state (RC-28 tuning step, etc.)

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -171,10 +171,21 @@ from ...capabilities import (
 )
 from ...radio_protocol import CivCommandCapable, MemoryCapable, PowerControlCapable
 
-__all__ = ["ControlHandler"]
+__all__ = ["ControlHandler", "RadioNotReadyError"]
 
 logger = logging.getLogger(__name__)
 _MAX_CW_TEXT_CHARS = 512
+
+
+class RadioNotReadyError(RuntimeError):
+    """PTT keying rejected because the radio session is degraded (MOR-620).
+
+    Raised when the backend explicitly reports ``radio_ready`` False (CI-V
+    stream unhealthy — the command would be enqueued but never executed) or
+    a connect/reconnect cycle is in flight. Mapped to the ``radio_not_ready``
+    error code on the control WebSocket so the client gets a truthful
+    failure instead of a silent enqueue-ACK.
+    """
 
 
 @dataclass(slots=True)
@@ -622,6 +633,25 @@ class ControlHandler:
         connected_bool = connected if isinstance(connected, bool) else False
         return bool(connected_bool and not self._radio_ready())
 
+    def _ensure_tx_session_ready(self) -> None:
+        """Reject PTT keying when the session is degraded (MOR-620).
+
+        Only an explicit ``radio_ready: False`` bool from the backend (or an
+        in-flight connect/reconnect cycle per ``_backend_recovering``) blocks
+        keying; radios that expose no ``radio_ready`` bool are not gated.
+        PTT OFF intentionally bypasses this gate — unkeying is the safe
+        direction and must always be attempted.
+        """
+        if self._radio is None:
+            return
+        ready = getattr(self._radio, "radio_ready", None)
+        explicitly_not_ready = isinstance(ready, bool) and not ready
+        if explicitly_not_ready or self._backend_recovering():
+            raise RadioNotReadyError(
+                "radio session is not ready (CI-V link degraded or "
+                "reconnecting); PTT keying rejected"
+            )
+
     async def _handle_text(self, text: str) -> None:
         try:
             msg = decode_json(text)
@@ -897,11 +927,12 @@ class ControlHandler:
         except Exception as exc:
             logger.warning("control: command %r failed: %s", name, exc)
             message = str(exc)
-            error = (
-                "unsupported_command"
-                if "does not support" in message or "not supported" in message
-                else "command_failed"
-            )
+            if isinstance(exc, RadioNotReadyError):
+                error = "radio_not_ready"
+            elif "does not support" in message or "not supported" in message:
+                error = "unsupported_command"
+            else:
+                error = "command_failed"
             await self._ws.send_text(
                 encode_json(
                     {
@@ -1528,12 +1559,15 @@ class ControlHandler:
                 if self._read_only:
                     raise PermissionError("read-only mode: PTT rejected")
                 on = bool(params["state"])
+                if on:
+                    self._ensure_tx_session_ready()
                 logger.info("handler: PTT %s received", "ON" if on else "OFF")
                 q.put(PttOn() if on else PttOff())
                 return {"state": on}
             case "ptt_on":
                 if self._read_only:
                     raise PermissionError("read-only mode: PTT rejected")
+                self._ensure_tx_session_ready()
                 q.put(PttOn())
                 return {}
             case "ptt_off":

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -2227,3 +2227,112 @@ async def test_event_sender_loop_forwards_notifications_without_subscription() -
     finally:
         task.cancel()
         await task
+
+
+# ── MOR-620: PTT truthfulness on a degraded session ──────────────────────
+
+
+def _degraded_server() -> SimpleNamespace:
+    return SimpleNamespace(command_queue=_QueueRecorder())
+
+
+@pytest.mark.asyncio
+async def test_ptt_on_rejected_when_radio_not_ready() -> None:
+    """connected:true + radio_ready:false (degraded LAN session) must not
+    silently ACK a PTT ON the radio will never execute (MOR-620)."""
+    ws = SimpleNamespace(send_text=AsyncMock())
+    server = _degraded_server()
+    radio = _capable_radio()
+    radio.connected = True
+    radio.radio_ready = False
+    handler = _control_handler(ws=ws, radio=radio, server=server)
+
+    await handler._handle_command(
+        {"id": "p1", "name": "ptt", "params": {"state": True}}
+    )
+
+    msg = decode_json(ws.send_text.await_args_list[-1].args[0])
+    assert msg["ok"] is False
+    assert msg["error"] == "radio_not_ready"
+    assert server.command_queue.items == []
+
+
+@pytest.mark.asyncio
+async def test_ptt_on_alias_rejected_when_radio_not_ready() -> None:
+    """The bare ptt_on command honors the same degraded-session gate."""
+    ws = SimpleNamespace(send_text=AsyncMock())
+    server = _degraded_server()
+    radio = _capable_radio()
+    radio.connected = True
+    radio.radio_ready = False
+    handler = _control_handler(ws=ws, radio=radio, server=server)
+
+    await handler._handle_command({"id": "p2", "name": "ptt_on", "params": {}})
+
+    msg = decode_json(ws.send_text.await_args_list[-1].args[0])
+    assert msg["ok"] is False
+    assert msg["error"] == "radio_not_ready"
+    assert server.command_queue.items == []
+
+
+@pytest.mark.asyncio
+async def test_ptt_on_rejected_while_backend_reconnecting() -> None:
+    """A reconnect cycle in flight (conn_state=reconnecting) blocks PTT ON."""
+    ws = SimpleNamespace(send_text=AsyncMock())
+    server = _degraded_server()
+    radio = _capable_radio()
+    radio.conn_state = SimpleNamespace(value="reconnecting")
+    handler = _control_handler(ws=ws, radio=radio, server=server)
+
+    await handler._handle_command(
+        {"id": "p3", "name": "ptt", "params": {"state": True}}
+    )
+
+    msg = decode_json(ws.send_text.await_args_list[-1].args[0])
+    assert msg["ok"] is False
+    assert msg["error"] == "radio_not_ready"
+    assert server.command_queue.items == []
+
+
+@pytest.mark.asyncio
+async def test_ptt_off_allowed_when_radio_not_ready() -> None:
+    """Unkeying is the safe direction: PTT OFF must always be attempted, even
+    on a degraded session (never strand the radio transmitting)."""
+    ws = SimpleNamespace(send_text=AsyncMock())
+    server = _degraded_server()
+    radio = _capable_radio()
+    radio.connected = True
+    radio.radio_ready = False
+    handler = _control_handler(ws=ws, radio=radio, server=server)
+
+    await handler._handle_command(
+        {"id": "p4", "name": "ptt", "params": {"state": False}}
+    )
+    msg = decode_json(ws.send_text.await_args_list[-1].args[0])
+    assert msg["ok"] is True
+    assert isinstance(server.command_queue.items[-1], PttOff)
+
+    await handler._handle_command({"id": "p5", "name": "ptt_off", "params": {}})
+    msg = decode_json(ws.send_text.await_args_list[-1].args[0])
+    assert msg["ok"] is True
+    assert isinstance(server.command_queue.items[-1], PttOff)
+
+
+@pytest.mark.asyncio
+async def test_ptt_on_allowed_when_radio_ready() -> None:
+    """A healthy session keys normally."""
+    ws = SimpleNamespace(send_text=AsyncMock())
+    server = _degraded_server()
+    radio = _capable_radio()
+    radio.connected = True
+    radio.radio_ready = True
+    handler = _control_handler(ws=ws, radio=radio, server=server)
+
+    await handler._handle_command(
+        {"id": "p6", "name": "ptt", "params": {"state": True}}
+    )
+
+    msg = decode_json(ws.send_text.await_args_list[-1].args[0])
+    assert msg["ok"] is True
+    assert msg["result"] == {"state": True}
+    assert isinstance(server.command_queue.items[-1], PttOn)


### PR DESCRIPTION
## Problem (observed live on IC-7610 LAN, 2026-06-10)

After a long session the LAN link degraded: `hello` reported `connected:true` /
`radio_ready:false`, yet a control-WS PTT command returned
`{"ok":true,"result":{"state":true}}` while the radio never keyed. PTT
"success" meant "command enqueued", not "radio keyed", and the degraded
session was invisible in the UI.

## Why PTT lied

`ControlHandler._enqueue_rc_power` (`src/rigplane/web/handlers/control.py`)
ACKs PTT as soon as `PttOn()`/`PttOff()` is `q.put(...)` into the command
queue — RadioPoller executes `radio.set_ptt()` later and any failure never
reaches the WS response. No readiness check existed on the keying path.

## Changes

**Backend — truthful PTT (`web/handlers/control.py`):**
- New `RadioNotReadyError` + `_ensure_tx_session_ready()` gate on `ptt`
  (`state:true`) and `ptt_on`: rejected with the new `radio_not_ready` error
  envelope when the backend explicitly reports `radio_ready: False` (CI-V
  stream unhealthy) or a connect/reconnect cycle is in flight
  (`_backend_recovering()`, same predicate `radio_connect` already uses).
- **Unkeying always goes through**: `ptt state:false` / `ptt_off` bypass the
  gate — never strand the radio transmitting on a half-dead link.
- Radios that expose no `radio_ready` bool are not gated (no behavior change
  for simple/legacy backends and test fakes).
- An `ok:false` response already surfaces as an error toast via the existing
  `WsChannel` response-to-notification plumbing, so the rejection is visible.

**Frontend — degraded-session indicator (extends MOR-594, no new UI element):**
- `ws-client.ts` now consumes the MOR-594 `connection_status` WS event
  (previously broadcast but unconsumed — the deferred fast-follow) and feeds
  `setRadioStatus()`, so the StatusBar radio dot turns yellow during
  backend reconnect cycles in real time.
- `StatusBar.svelte`: the radio indicator degrades (yellow) when the session
  is `connected` but `radioReady=false`, with a tooltip label
  (`core.statusbar.health.radioNotReady`, added to en/ru/ja locales).

**Docs:** `docs/api/web.md` notes the `radio_not_ready` error code and the
PTT-OFF exemption.

## Tests

- `tests/test_handlers_coverage.py`: 6 new tests (TDD — written first,
  failing) — rejection on `radio_ready:false`, rejection during
  `conn_state=reconnecting`, `ptt_on` alias, PTT OFF allowed while degraded,
  PTT ON allowed when ready.
- `ws-client.test.ts`: `connection_status` → `setRadioStatus` routing +
  malformed-payload tolerance.
- `RadioLayout.test.ts` / `top-row-visual-regression.test.ts`: connection
  store mocks extended with `getRadioReady` (StatusBar now reads it).

## Gates

- `pytest` (no integration): 0 failures
- `ruff check` + `ruff format --check`: clean
- `mypy src/`: 21 errors / 8 files (baseline, unchanged)
- `lint-imports`: 4 kept / 0 broken
- frontend: `npm run i18n:check`, `npm run check` (0 errors), `npx vitest run`
  (2069 passed), `npm run lint` — all clean

Part of MOR-614 (T6: MOR-620).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
