### PR TITLE
feat(MOR-615): expose current MOD-input source in web state

### DIFF
--- a/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
+++ b/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
@@ -65,6 +65,30 @@
     "observed": false,
     "storePath": "global.operator_controls.dash_ratio"
   },
+  "data1ModInput": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "global.slow_state.data1_mod_input"
+  },
+  "data2ModInput": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "global.slow_state.data2_mod_input"
+  },
+  "data3ModInput": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "global.slow_state.data3_mod_input"
+  },
+  "dataOffModInput": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "global.slow_state.data_off_mod_input"
+  },
   "dialLock": {
     "availability": "missing",
     "freshness": "unknown",

--- a/src/rigplane/core/radio_state.py
+++ b/src/rigplane/core/radio_state.py
@@ -301,6 +301,13 @@ class RadioState:
     tx_antenna: int = 1  # 1 or 2
     rx_antenna_1: bool = False
     rx_antenna_2: bool = False
+    # MOD-input source per DATA mode group (IC-7610 0x1A 05 00 0x91-0x94):
+    #   0=MIC, 1=ACC, 2=MIC+ACC, 3=USB, 4=MIC+USB, 5=LAN
+    # None = not yet read from the radio (MOR-615).
+    data_off_mod_input: int | None = None
+    data1_mod_input: int | None = None
+    data2_mod_input: int | None = None
+    data3_mod_input: int | None = None
     tx_band_edges: list[TxBandEdge] = field(default_factory=list)
     scope_controls: ScopeControlsState = field(default_factory=ScopeControlsState)
 
@@ -364,6 +371,10 @@ class RadioState:
             "tx_antenna": self.tx_antenna,
             "rx_antenna_1": self.rx_antenna_1,
             "rx_antenna_2": self.rx_antenna_2,
+            "data_off_mod_input": self.data_off_mod_input,
+            "data1_mod_input": self.data1_mod_input,
+            "data2_mod_input": self.data2_mod_input,
+            "data3_mod_input": self.data3_mod_input,
             "tx_band_edges": [
                 {"start_hz": e.start_hz, "end_hz": e.end_hz} for e in self.tx_band_edges
             ],

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -185,6 +185,16 @@ _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
 
+# MOR-615: per-DATA-group MOD-input source fields (IC-7610 0x1A 05 00
+# 0x91-0x94). Field name == ``get_<name>`` / ``set_<name>`` radio method
+# suffix == legacy RadioState attribute == StateStore slow_state leaf.
+_MOD_INPUT_FIELDS: tuple[str, ...] = (
+    "data_off_mod_input",
+    "data1_mod_input",
+    "data2_mod_input",
+    "data3_mod_input",
+)
+
 
 def _audio_tx_codec_and_rate(radio: Any) -> tuple[AudioCodec | None, int]:
     """Legacy TX-format resolution for radios WITHOUT the neutral
@@ -426,6 +436,9 @@ class RadioPoller:
         # than once per _UNSELECTED_SLOT_INTERVAL.
         self._last_user_write_ts: float = 0.0
         self._last_unselected_poll: dict[int, float] = {}
+        # MOR-615: (main, sub) data_mode pair seen at the last MOD-input fetch;
+        # a change triggers a refetch of the per-DATA-group MOD-input sources.
+        self._mod_input_data_modes: tuple[int, int] | None = None
 
     def _apply_bsr_readback_observations(
         self,
@@ -788,22 +801,23 @@ class RadioPoller:
         name: str,
         value: Any,
         *,
+        family: str = "operator_controls",
         command_id: str | None = None,
         source: CommandSource | None = None,
         session_id: str | None = None,
         command_service: CommandService | None = None,
     ) -> None:
-        """Apply a confirmed global operator-control value to the StateStore.
+        """Apply a confirmed global readback value to the StateStore.
 
         Forward-consistent route (mirrors ``_apply_bsr_readback_observations``):
-        the web public-state projection reads ``global.operator_controls.<name>``
+        the web public-state projection reads ``global.<family>.<name>``
         from the StateStore, so a readback observation is the source of truth —
         not the legacy ``RadioState`` mirror. Used for NB depth/width whose
         4-byte menu GET (0x1A 05 02 90/91) cannot ride the poll-query envelope
-        (MOR-491-B).
+        (MOR-491-B) and for the MOD-input sources (``slow_state``, MOR-615).
         """
         observation = Observation(
-            path=FieldPath.global_("operator_controls", name),
+            path=FieldPath.global_(family, name),
             value=value,
             source=SourceMetadata(
                 source="poll_response",
@@ -850,6 +864,76 @@ class RadioPoller:
             self._apply_global_control_observation(name, value)
         logger.info("radio-poller: NB controls fetched")
 
+    async def _read_mod_input(
+        self,
+        name: str,
+        *,
+        command_id: str | None = None,
+        source: CommandSource | None = None,
+        session_id: str | None = None,
+        command_service: CommandService | None = None,
+    ) -> None:
+        """Read one DATA-group MOD-input source into the StateStore + mirror.
+
+        Resilient: a read error or timeout is logged at debug and never kills
+        the caller (mirrors ``_fetch_nb_controls``).
+        """
+        getter = getattr(self._radio, f"get_{name}", None)
+        if getter is None:
+            return
+        try:
+            value = int(await getter())
+        except Exception:
+            logger.debug("radio-poller: get_%s failed", name, exc_info=True)
+            return
+        if self._radio_state is not None:
+            setattr(self._radio_state, name, value)
+        self._apply_global_control_observation(
+            name,
+            value,
+            family="slow_state",
+            command_id=command_id,
+            source=source,
+            session_id=session_id,
+            command_service=command_service,
+        )
+
+    async def _fetch_mod_inputs(self) -> None:
+        """Readback of the per-DATA-group MOD-input sources (MOR-615).
+
+        DATA OFF/1/2/3 MOD (0x1A 05 00 0x91-0x94) are global menu items the
+        continuous poller never tracks. Read them via the direct getters and
+        apply the confirmed values as StateStore observations (+ legacy
+        RadioState mirror) so the web state exposes the radio's current MOD
+        routing. Gated on CAP_DATA_MODE so non-IC-7610 radios are unaffected.
+        """
+        if CAP_DATA_MODE not in self._caps:
+            return
+        if self._radio_state is not None:
+            self._mod_input_data_modes = (
+                self._radio_state.main.data_mode,
+                self._radio_state.sub.data_mode,
+            )
+        for name in _MOD_INPUT_FIELDS:
+            await self._read_mod_input(name)
+
+    async def _refresh_mod_inputs_on_data_mode_change(self) -> None:
+        """Refetch the MOD-input sources when any receiver's data_mode changed.
+
+        The legacy RadioState mirror's ``data_mode`` is kept current by the
+        regular 0x26 poll (``_handle_26``), so this catches both web-initiated
+        and front-panel data-mode changes within one poll cycle (MOR-615).
+        """
+        if CAP_DATA_MODE not in self._caps or self._radio_state is None:
+            return
+        current = (
+            self._radio_state.main.data_mode,
+            self._radio_state.sub.data_mode,
+        )
+        if current == self._mod_input_data_modes:
+            return
+        await self._fetch_mod_inputs()
+
     async def _run(self) -> None:
         _backoff = 0.0
         _MAX_BACKOFF = 5.0  # max pause when radio is disconnected
@@ -867,6 +951,13 @@ class RadioPoller:
             logger.debug(
                 "radio-poller: NB controls initial fetch failed", exc_info=True
             )
+
+        # Per-DATA-group MOD-input sources are global menu items the continuous
+        # poller never tracks; seed them once at connect (MOR-615).
+        try:
+            await self._fetch_mod_inputs()
+        except Exception:
+            logger.debug("radio-poller: MOD-input initial fetch failed", exc_info=True)
 
         try:
             while True:
@@ -955,6 +1046,13 @@ class RadioPoller:
                     continue
                 except Exception:
                     logger.debug("radio-poller: query error", exc_info=True)
+
+                # 2b. data_mode changed (web command or front panel) => refetch
+                # the per-DATA-group MOD-input sources (MOR-615).
+                try:
+                    await self._refresh_mod_inputs_on_data_mode_change()
+                except Exception:
+                    logger.debug("radio-poller: MOD-input refresh error", exc_info=True)
 
                 # 3. Issue #715: opportunistically refresh the unselected
                 # VFO slot on each receiver.  Fully gated (PTT, queue
@@ -1976,15 +2074,45 @@ class RadioPoller:
             case SetDataOffModInput(source=source):
                 if CAP_DATA_MODE in self._caps:
                     await radio.set_data_off_mod_input(source)
+                    # Write-through readback (MOR-615): confirm the value the
+                    # radio actually took, mirroring the NB depth/width route.
+                    await self._read_mod_input(
+                        "data_off_mod_input",
+                        command_id=command_id,
+                        source=command_source,
+                        session_id=session_id,
+                        command_service=command_service,
+                    )
             case SetData1ModInput(source=source):
                 if CAP_DATA_MODE in self._caps:
                     await radio.set_data1_mod_input(source)
+                    await self._read_mod_input(
+                        "data1_mod_input",
+                        command_id=command_id,
+                        source=command_source,
+                        session_id=session_id,
+                        command_service=command_service,
+                    )
             case SetData2ModInput(source=source):
                 if CAP_DATA_MODE in self._caps:
                     await radio.set_data2_mod_input(source)
+                    await self._read_mod_input(
+                        "data2_mod_input",
+                        command_id=command_id,
+                        source=command_source,
+                        session_id=session_id,
+                        command_service=command_service,
+                    )
             case SetData3ModInput(source=source):
                 if CAP_DATA_MODE in self._caps:
                     await radio.set_data3_mod_input(source)
+                    await self._read_mod_input(
+                        "data3_mod_input",
+                        command_id=command_id,
+                        source=command_source,
+                        session_id=session_id,
+                        command_service=command_service,
+                    )
             case SetAudioPeakFilter(on=on, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_audio_peak_filter")
                 if CAP_APF in self._caps:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -164,6 +164,11 @@ _GLOBAL_SLOW_STATE_FIELDS = {
     "tx_band_edges",
     "scope_controls",
     "yaesu",
+    # Per-DATA-group MOD-input sources (IC-7610 0x1A 05 00 0x91-0x94, MOR-615).
+    "data_off_mod_input",
+    "data1_mod_input",
+    "data2_mod_input",
+    "data3_mod_input",
 }
 # Public ``scopeControls.<suffix>`` leaves the toolbar/LCD gate on, mapped to
 # their backend scope-control field name. The whole group is unobserved until

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -291,6 +291,11 @@ _LEGACY_GLOBAL_SLOW_STATE_FIELDS: tuple[tuple[str, str], ...] = (
     ("tx_band_edges", "tx_band_edges"),
     ("scope_controls", "scope_controls"),
     ("yaesu", "yaesu"),
+    # Per-DATA-group MOD-input sources (IC-7610 0x1A 05 00 0x91-0x94, MOR-615).
+    ("data_off_mod_input", "data_off_mod_input"),
+    ("data1_mod_input", "data1_mod_input"),
+    ("data2_mod_input", "data2_mod_input"),
+    ("data3_mod_input", "data3_mod_input"),
 )
 
 _CivTransactionExpect = Literal["none", "ack", "data"]

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -46,6 +46,7 @@ from rigplane.web.radio_poller import (
     SetAfLevel,
     SetAgc,
     SetAttenuator,
+    SetData1ModInput,
     SetDataMode,
     SetDigiSel,
     SetFilterShape,
@@ -2525,3 +2526,215 @@ async def test_fetch_nb_controls_is_resilient_to_getter_failure() -> None:
     assert (
         snapshot.field(FieldPath.global_("operator_controls", "nb_width")).value == 120
     )
+
+
+# ---------------------------------------------------------------------------
+# MOR-615: current MOD-input source readback (DATA OFF/1/2/3 MOD, 0x1A 05 00
+# 0x91-0x94). Same Option-B direct-getter route as the NB controls above: the
+# four values are global menu items the continuous poller never tracks, so the
+# poller reads them at connect, when data_mode changes, and after a web set,
+# and applies the confirmed values as ``global.slow_state`` observations plus
+# legacy RadioState mirror writes. Gated on CAP_DATA_MODE so non-IC-7610
+# radios are unaffected.
+# ---------------------------------------------------------------------------
+
+
+class _FakeModInputRadio:
+    """Minimal DATA-mode-capable radio fake for MOD-input readback tests.
+
+    Getters either return a canned source value or raise to exercise the
+    resilient error path; calls are counted so tests can assert each getter
+    is invoked exactly the expected number of times.
+    """
+
+    def __init__(
+        self,
+        *,
+        sources: dict[str, int | Exception] | None = None,
+        capabilities: set[str] | None = None,
+    ) -> None:
+        self.model = "IC-7610"
+        self.capabilities = (
+            capabilities if capabilities is not None else {"data_mode", "dual_rx"}
+        )
+        self._sources: dict[str, int | Exception] = {
+            "data_off_mod_input": 0,
+            "data1_mod_input": 3,
+            "data2_mod_input": 3,
+            "data3_mod_input": 5,
+        }
+        if sources:
+            self._sources.update(sources)
+        self.get_calls: dict[str, int] = dict.fromkeys(self._sources, 0)
+        self.set_calls: list[tuple[str, int]] = []
+
+    def _get(self, name: str) -> int:
+        self.get_calls[name] += 1
+        value = self._sources[name]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    async def get_data_off_mod_input(self) -> int:
+        return self._get("data_off_mod_input")
+
+    async def get_data1_mod_input(self) -> int:
+        return self._get("data1_mod_input")
+
+    async def get_data2_mod_input(self) -> int:
+        return self._get("data2_mod_input")
+
+    async def get_data3_mod_input(self) -> int:
+        return self._get("data3_mod_input")
+
+    async def set_data1_mod_input(self, source: int) -> None:
+        self.set_calls.append(("data1_mod_input", source))
+        self._sources["data1_mod_input"] = source
+
+
+_MOD_INPUT_FIELD_NAMES = (
+    "data_off_mod_input",
+    "data1_mod_input",
+    "data2_mod_input",
+    "data3_mod_input",
+)
+
+
+@pytest.mark.asyncio
+async def test_fetch_mod_inputs_seeds_state_store_mirror_and_public_state() -> None:
+    """Initial fetch reads all four getters; values reach store + web state."""
+    from rigplane.web.runtime_helpers import (
+        build_public_state_payload_from_snapshot,
+    )
+
+    radio = _FakeModInputRadio(
+        sources={
+            "data_off_mod_input": 0,
+            "data1_mod_input": 3,
+            "data2_mod_input": 1,
+            "data3_mod_input": 5,
+        }
+    )
+    store = StateStore()
+    state = RadioState()
+    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
+
+    await poller._fetch_mod_inputs()  # noqa: SLF001
+
+    assert all(count == 1 for count in radio.get_calls.values())
+    snapshot = store.snapshot()
+    expected = {
+        "data_off_mod_input": 0,
+        "data1_mod_input": 3,
+        "data2_mod_input": 1,
+        "data3_mod_input": 5,
+    }
+    for name, value in expected.items():
+        assert snapshot.field(FieldPath.global_("slow_state", name)).value == value
+    # Legacy RadioState mirror stays coherent for compatibility consumers.
+    assert state.data_off_mod_input == 0
+    assert state.data1_mod_input == 3
+    assert state.data2_mod_input == 1
+    assert state.data3_mod_input == 5
+
+    # The public projection (the ``state_update`` snapshot body) exposes them.
+    payload = build_public_state_payload_from_snapshot(
+        snapshot,
+        radio=None,
+        receiver_count=2,
+    )
+    assert payload["dataOffModInput"] == 0
+    assert payload["data1ModInput"] == 3
+    assert payload["data2ModInput"] == 1
+    assert payload["data3ModInput"] == 5
+
+
+@pytest.mark.asyncio
+async def test_fetch_mod_inputs_skips_without_data_mode_capability() -> None:
+    """No data_mode capability => no getter calls, no observations."""
+    radio = _FakeModInputRadio(capabilities={"dual_rx"})
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    await poller._fetch_mod_inputs()  # noqa: SLF001
+
+    assert all(count == 0 for count in radio.get_calls.values())
+    with pytest.raises(KeyError):
+        store.snapshot().field(FieldPath.global_("slow_state", "data1_mod_input"))
+
+
+@pytest.mark.asyncio
+async def test_fetch_mod_inputs_is_resilient_to_getter_failure() -> None:
+    """A failing getter must not block the remaining readbacks."""
+    radio = _FakeModInputRadio(sources={"data1_mod_input": RuntimeError("boom")})
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    await poller._fetch_mod_inputs()  # noqa: SLF001
+
+    assert all(count == 1 for count in radio.get_calls.values())
+    snapshot = store.snapshot()
+    # data1 read failed => no observation applied.
+    with pytest.raises(KeyError):
+        snapshot.field(FieldPath.global_("slow_state", "data1_mod_input"))
+    # The other readbacks still succeeded.
+    assert snapshot.field(FieldPath.global_("slow_state", "data3_mod_input")).value == 5
+
+
+def test_unread_mod_inputs_project_as_null_with_missing_status() -> None:
+    """The public payload always carries the MOD-input keys (null until read)."""
+    from rigplane.web.runtime_helpers import (
+        build_public_state_payload_from_snapshot,
+    )
+
+    payload = build_public_state_payload_from_snapshot(
+        StateStore().snapshot(),
+        radio=None,
+        receiver_count=2,
+    )
+    for key in ("dataOffModInput", "data1ModInput", "data2ModInput", "data3ModInput"):
+        assert key in payload
+        assert payload[key] is None
+        assert payload["fieldStatus"][key]["availability"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_data_mode_change_triggers_mod_input_refetch() -> None:
+    """A data_mode change observed in the mirror (0x26 poll) => refetch."""
+    radio = _FakeModInputRadio()
+    store = StateStore()
+    state = RadioState()
+    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
+
+    await poller._fetch_mod_inputs()  # noqa: SLF001
+    assert all(count == 1 for count in radio.get_calls.values())
+
+    # No data_mode change => no refetch.
+    await poller._refresh_mod_inputs_on_data_mode_change()  # noqa: SLF001
+    assert all(count == 1 for count in radio.get_calls.values())
+
+    # data_mode change (0x26 poll response landing in the mirror) => refetch.
+    state.main.data_mode = 1
+    await poller._refresh_mod_inputs_on_data_mode_change()  # noqa: SLF001
+    assert all(count == 2 for count in radio.get_calls.values())
+
+    # Stable again afterwards => no further refetch.
+    await poller._refresh_mod_inputs_on_data_mode_change()  # noqa: SLF001
+    assert all(count == 2 for count in radio.get_calls.values())
+
+
+@pytest.mark.asyncio
+async def test_set_data1_mod_input_dispatch_reads_back_confirmed_value() -> None:
+    """SetData1ModInput sends the set, then reads back the confirmed value."""
+    radio = _FakeModInputRadio(sources={"data1_mod_input": 0})
+    store = StateStore()
+    state = RadioState()
+    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
+
+    await poller._execute(SetData1ModInput(5))  # noqa: SLF001
+
+    assert radio.set_calls == [("data1_mod_input", 5)]
+    assert radio.get_calls["data1_mod_input"] == 1
+    snapshot = store.snapshot()
+    assert snapshot.field(FieldPath.global_("slow_state", "data1_mod_input")).value == 5
+    assert state.data1_mod_input == 5

--- a/tests/test_radio_state.py
+++ b/tests/test_radio_state.py
@@ -201,6 +201,10 @@ def test_to_dict_structure() -> None:
         "tx_antenna",
         "rx_antenna_1",
         "rx_antenna_2",
+        "data_off_mod_input",
+        "data1_mod_input",
+        "data2_mod_input",
+        "data3_mod_input",
         "tx_band_edges",
         "scope_controls",
         "main",
@@ -514,3 +518,37 @@ class TestYaesuStateExtension:
         rs.yaesu = YaesuStateExtension(rx_func_mode=1, tx_func_mode=1)
         d = rs.to_dict()
         assert d["yaesu"] == {"rx_func_mode": 1, "tx_func_mode": 1}
+
+
+class TestModInputState:
+    """MOR-615: per-DATA-group MOD-input source fields (IC-7610 0x1A 05 00 91-94).
+
+    Values use the rig enum 0=MIC, 1=ACC, 2=MIC+ACC, 3=USB, 4=MIC+USB, 5=LAN;
+    ``None`` means "not yet read from the radio".
+    """
+
+    def test_defaults_are_none(self) -> None:
+        rs = RadioState()
+        assert rs.data_off_mod_input is None
+        assert rs.data1_mod_input is None
+        assert rs.data2_mod_input is None
+        assert rs.data3_mod_input is None
+
+    def test_to_dict_serialises_unknown_as_none(self) -> None:
+        d = RadioState().to_dict()
+        assert d["data_off_mod_input"] is None
+        assert d["data1_mod_input"] is None
+        assert d["data2_mod_input"] is None
+        assert d["data3_mod_input"] is None
+
+    def test_to_dict_serialises_assigned_sources(self) -> None:
+        rs = RadioState()
+        rs.data_off_mod_input = 0  # MIC
+        rs.data1_mod_input = 3  # USB
+        rs.data2_mod_input = 1  # ACC
+        rs.data3_mod_input = 5  # LAN
+        d = rs.to_dict()
+        assert d["data_off_mod_input"] == 0
+        assert d["data1_mod_input"] == 3
+        assert d["data2_mod_input"] == 1
+        assert d["data3_mod_input"] == 5


### PR DESCRIPTION
## Summary

T1 of the MOD-input routing epic: make the IC-7610's current MOD-input source per DATA mode group visible in the web state so the UI (T2) can display it. The CI-V SET builders + direct getters already existed; the gap was that current values were never read into state or pushed in the web snapshot.

- **State model** (`src/rigplane/core/radio_state.py`): four new global `RadioState` fields — `data_off_mod_input`, `data1_mod_input`, `data2_mod_input`, `data3_mod_input` (int per rig enum `0=MIC, 1=ACC, 2=MIC+ACC, 3=USB, 4=MIC+USB, 5=LAN`; `None` = not yet read), serialised in `to_dict()`.
- **Poller** (`src/rigplane/web/radio_poller.py`): new `_fetch_mod_inputs()` readback via the existing direct getters (`get_data_off_mod_input` + data1/2/3 — these already await + parse the `0x1A 05 00 0x91-0x94` response through `_get_bcd_level`/`parse_level_response`), applying confirmed values as `global.slow_state.*` StateStore observations + legacy-mirror writes. Mirrors the MOR-491-B NB depth/width Option-B route. Runs at connect (`_run` start), refetches when either receiver's `data_mode` changes (the regular 0x26 poll keeps the mirror current, so web-initiated *and* front-panel changes are caught within one poll cycle), and each `SetData*ModInput` command now does a write-through readback of the value the radio actually took.
- **Web snapshot** (`runtime_helpers.py`, `server.py`): the `state_update` body now carries `dataOffModInput` / `data1ModInput` / `data2ModInput` / `data3ModInput` (null until read) with seeded `fieldStatus` entries (`global.slow_state.*` store paths); legacy slow-state bridge extended to match. Golden frontend field-status fixture regenerated by its maintainer test (additive only — frontend consumers use `toContain`).
- **Gating**: everything behind `CAP_DATA_MODE`; non-IC-7610 radios are unaffected (no getter calls, fields stay null/missing).
- No changes to the audio byte path; no new layers/abstractions.

## Wire contract for T2 (frontend)

| Public payload key | Store path | fieldStatus key |
|---|---|---|
| `dataOffModInput` | `global.slow_state.data_off_mod_input` | `dataOffModInput` |
| `data1ModInput` | `global.slow_state.data1_mod_input` | `data1ModInput` |
| `data2ModInput` | `global.slow_state.data2_mod_input` | `data2ModInput` |
| `data3ModInput` | `global.slow_state.data3_mod_input` | `data3ModInput` |

## Tests (TDD — written failing first)

- `tests/test_radio_state.py`: new `TestModInputState` (defaults None, `to_dict` serialisation) + key-set contract test updated.
- `tests/test_radio_poller_coverage.py`: new MOR-615 section with a purpose-built `_FakeModInputRadio` — fetch seeds store + mirror + public payload; CAP gate skip; per-getter failure resilience; null-with-missing-status projection for an empty store; data_mode-change refetch (incl. no-change debounce); `SetData1ModInput` dispatch write-through readback.

## Gate results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7626 passed, 0 failed** (8 skipped, 11 xfailed, 1 xpassed)
- `uv run ruff check src/ tests/` → clean; `uv run ruff format --check src/ tests/` → 574 files already formatted
- `uv run mypy src/` → **21 errors in 8 files** (exact existing baseline; the 4 radio_poller capture-pattern errors are the pre-existing documented `Set*ModInput` arms, line numbers shifted only)
- `uv run lint-imports` → **4 contracts kept, 0 broken**

Part of MOR-614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)