### PR TITLE
feat(MOR-616): MOD-input display & config in ModePanel

### DIFF
--- a/frontend/src/components-v2/panels/ModePanel.svelte
+++ b/frontend/src/components-v2/panels/ModePanel.svelte
@@ -2,6 +2,8 @@
   import { HardwareButton } from '$lib/Button';
   import { getShortcutHint } from '../layout/shortcut-hints';
   import { deriveModeProps, getModeHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import { MOD_INPUT_SOURCES } from '$lib/radio/mod-input';
+  import { t } from '$lib/i18n';
 
   const handlers = getModeHandlers();
   let p = $derived(deriveModeProps());
@@ -13,8 +15,12 @@
   let hasDataMode = $derived(p.hasDataMode);
   let dataModeCount = $derived(p.dataModeCount ?? 0);
   let dataModeLabels = $derived(p.dataModeLabels ?? { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' });
+  // MOR-616: MOD-input source of the active DATA group (null until read).
+  let modInputSource = $derived(p.modInputSource ?? null);
+  let hasModInput = $derived(p.hasModInput ?? false);
   const onModeChange = handlers.onModeChange;
   const onDataModeChange = handlers.onDataModeChange;
+  const onModInputChange = handlers.onModInputChange;
 
   // Canonical display order — covers both IC-7610 and Yaesu naming conventions.
   const modeOrder = [
@@ -88,6 +94,30 @@
         {/each}
       </div>
     {/if}
+
+    {#if hasModInput}
+      <!-- MOR-616: MOD-input source of the active DATA group (DATA OFF/D1/D2/D3).
+           Tracks front-panel changes via the backend readback; selecting a
+           source emits the matching set_data*_mod_input command. -->
+      <div class="mod-input-row">
+        <span class="section-label">{t('core.modePanel.modInputLabel')}</span>
+        <select
+          class="mod-input-select"
+          data-testid="mod-input-select"
+          aria-label={t('core.modePanel.modInputAria')}
+          title={t('core.modePanel.modInputAria')}
+          value={modInputSource === null ? '' : String(modInputSource)}
+          onchange={(e) => onModInputChange(Number(e.currentTarget.value))}
+        >
+          {#if modInputSource === null}
+            <option value="" disabled>—</option>
+          {/if}
+          {#each MOD_INPUT_SOURCES as option (option.value)}
+            <option value={String(option.value)}>{option.label}</option>
+          {/each}
+        </select>
+      </div>
+    {/if}
   </div>
 
 <style>
@@ -116,5 +146,28 @@
   .mode-grid > :global(button),
   .data-grid > :global(button) {
     min-width: 0;
+  }
+
+  .mod-input-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .mod-input-select {
+    flex: 1;
+    min-width: 0;
+    background: var(--v2-bg-input, #111);
+    color: var(--v2-text-primary, #ddd);
+    border: 1px solid var(--v2-border, #333);
+    border-radius: 3px;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 11px;
+    padding: 3px 4px;
+  }
+
+  .mod-input-select:focus-visible {
+    outline: 1px solid var(--v2-accent-cyan, #0ff);
+    outline-offset: 1px;
   }
   </style>

--- a/frontend/src/components-v2/panels/__tests__/ModePanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/ModePanel.test.ts
@@ -8,11 +8,14 @@ const mockProps = {
   hasDataMode: true,
   dataModeCount: 3,
   dataModeLabels: { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' } as Record<string, string>,
+  modInputSource: null as number | null,
+  hasModInput: false,
 };
 
 const mockHandlers = {
   onModeChange: vi.fn(),
   onDataModeChange: vi.fn(),
+  onModInputChange: vi.fn(),
 };
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
@@ -42,8 +45,11 @@ beforeEach(() => {
   mockProps.hasDataMode = true;
   mockProps.dataModeCount = 3;
   mockProps.dataModeLabels = { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' };
+  mockProps.modInputSource = null;
+  mockProps.hasModInput = false;
   mockHandlers.onModeChange = vi.fn();
   mockHandlers.onDataModeChange = vi.fn();
+  mockHandlers.onModInputChange = vi.fn();
 });
 
 afterEach(() => {
@@ -90,5 +96,51 @@ describe('ModePanel', () => {
     dataButtons.find((b) => b.textContent?.trim() === 'D3')?.click();
     flushSync();
     expect(mockHandlers.onDataModeChange).toHaveBeenCalledWith(3);
+  });
+
+  describe('MOD-input source control (MOR-616)', () => {
+    function modInputSelect(target: HTMLElement): HTMLSelectElement | null {
+      return target.querySelector<HTMLSelectElement>('[data-testid="mod-input-select"]');
+    }
+
+    it('renders the dropdown with all six sources and the current one selected', () => {
+      const target = mountPanel({ hasModInput: true, modInputSource: 5 });
+      const select = modInputSelect(target);
+      expect(select).not.toBeNull();
+      expect(select!.value).toBe('5');
+      const labels = Array.from(select!.options)
+        .filter((option) => option.value !== '')
+        .map((option) => option.textContent?.trim());
+      expect(labels).toEqual(['MIC', 'ACC', 'MIC+ACC', 'USB', 'MIC+USB', 'LAN']);
+    });
+
+    it('shows an empty placeholder before the first readback', () => {
+      const target = mountPanel({ hasModInput: true, modInputSource: null });
+      const select = modInputSelect(target);
+      expect(select).not.toBeNull();
+      expect(select!.value).toBe('');
+    });
+
+    it('is hidden when the radio does not expose MOD-input routing', () => {
+      const target = mountPanel({ hasModInput: false, modInputSource: 3 });
+      expect(modInputSelect(target)).toBeNull();
+    });
+
+    it('fires onModInputChange with the numeric source', () => {
+      const target = mountPanel({ hasModInput: true, modInputSource: 0 });
+      const select = modInputSelect(target)!;
+      select.value = '5';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      flushSync();
+      expect(mockHandlers.onModInputChange).toHaveBeenCalledWith(5);
+    });
+
+    it('reflects external state changes in the selected value', () => {
+      const target = mountPanel({ hasModInput: true, modInputSource: 0 });
+      expect(modInputSelect(target)!.value).toBe('0');
+
+      const updated = mountPanel({ modInputSource: 3 });
+      expect(modInputSelect(updated)!.value).toBe('3');
+    });
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/mod-input-wiring.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/mod-input-wiring.test.ts
@@ -1,0 +1,85 @@
+/**
+ * MOD-input source wiring (MOR-616).
+ *
+ * `onModInputChange` must route the new source to the SET command of the
+ * active receiver's DATA group (T1/MOR-615 backend contract:
+ * `set_data_off_mod_input` / `set_data1_mod_input` / `set_data2_mod_input` /
+ * `set_data3_mod_input`, payload `{ source: int }`).
+ *
+ * Both duplicates are covered: the wiring `command-bus` and the runtime
+ * `panel-commands` (the one ModePanel actually uses via panel-adapters).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/transport/ws-client', () => ({
+  sendCommand: vi.fn(),
+}));
+
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getActiveReceiver: vi.fn(() => null),
+  getRadioState: vi.fn(() => null),
+  patchActiveReceiver: vi.fn(),
+  patchRadioState: vi.fn(),
+  patchReceiver: vi.fn(),
+}));
+
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    setAudioConfig: vi.fn(),
+    startRx: vi.fn(),
+    stopRx: vi.fn(),
+    setRxVolume: vi.fn(),
+    rxEnabled: false,
+  },
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+import { getActiveReceiver, patchRadioState } from '$lib/stores/radio.svelte';
+import { makeModeHandlers as makeWiringModeHandlers } from '../command-bus';
+import { makeModeHandlers as makeRuntimeModeHandlers } from '$lib/runtime/commands/panel-commands';
+
+const factories: ReadonlyArray<readonly [string, () => { onModInputChange: (source: number) => void }]> = [
+  ['command-bus', makeWiringModeHandlers],
+  ['panel-commands', makeRuntimeModeHandlers],
+];
+
+describe.each(factories)('%s onModInputChange (MOR-616)', (_name, makeHandlers) => {
+  beforeEach(() => {
+    vi.mocked(sendCommand).mockClear();
+    vi.mocked(patchRadioState).mockClear();
+    vi.mocked(getActiveReceiver).mockReturnValue(null);
+  });
+
+  it('emits set_data_off_mod_input when DATA is off', () => {
+    vi.mocked(getActiveReceiver).mockReturnValue({ dataMode: 0 } as never);
+
+    makeHandlers().onModInputChange(5);
+
+    expect(sendCommand).toHaveBeenCalledWith('set_data_off_mod_input', { source: 5 });
+    expect(patchRadioState).toHaveBeenCalledWith({ dataOffModInput: 5 });
+  });
+
+  it('emits the per-group command for D1/D2/D3', () => {
+    const cases = [
+      [1, 'set_data1_mod_input', 'data1ModInput'],
+      [2, 'set_data2_mod_input', 'data2ModInput'],
+      [3, 'set_data3_mod_input', 'data3ModInput'],
+    ] as const;
+
+    for (const [dataMode, command, stateKey] of cases) {
+      vi.mocked(getActiveReceiver).mockReturnValue({ dataMode } as never);
+
+      makeHandlers().onModInputChange(3);
+
+      expect(sendCommand).toHaveBeenCalledWith(command, { source: 3 });
+      expect(patchRadioState).toHaveBeenCalledWith({ [stateKey]: 3 });
+    }
+  });
+
+  it('falls back to the DATA OFF group when no receiver state exists', () => {
+    makeHandlers().onModInputChange(0);
+
+    expect(sendCommand).toHaveBeenCalledWith('set_data_off_mod_input', { source: 0 });
+    expect(patchRadioState).toHaveBeenCalledWith({ dataOffModInput: 0 });
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
@@ -40,6 +40,58 @@ describe('toModeProps', () => {
     expect(props.modes).toEqual(['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R']);
     expect(props.dataMode).toBe(0);
     expect(props.hasDataMode).toBe(false);
+    expect(props.modInputSource).toBeNull();
+    expect(props.hasModInput).toBe(false);
+  });
+
+  it('exposes the active DATA group MOD-input source (MOR-616)', () => {
+    const props = toModeProps(
+      {
+        active: 'MAIN',
+        main: { mode: 'USB', dataMode: 2 },
+        sub: { mode: 'LSB', dataMode: 0 },
+        data2ModInput: 5,
+        fieldStatus: {
+          data2ModInput: {
+            storePath: 'global.slow_state.data2_mod_input',
+            observed: true,
+            freshness: 'fresh',
+            availability: 'available',
+          },
+        },
+      } as any,
+      { capabilities: ['data_mode'] } as any,
+    );
+
+    expect(props.modInputSource).toBe(5);
+    expect(props.hasModInput).toBe(true);
+  });
+
+  it('hides the MOD-input control without the capability or before first read (MOR-616)', () => {
+    const unreadState = {
+      active: 'MAIN',
+      main: { mode: 'USB', dataMode: 0 },
+      sub: { mode: 'LSB', dataMode: 0 },
+      dataOffModInput: null,
+      fieldStatus: {
+        dataOffModInput: {
+          storePath: 'global.slow_state.data_off_mod_input',
+          observed: false,
+          freshness: 'unknown',
+          availability: 'missing',
+        },
+      },
+    } as any;
+
+    const unread = toModeProps(unreadState, { capabilities: ['data_mode'] } as any);
+    expect(unread.hasModInput).toBe(false);
+    expect(unread.modInputSource).toBeNull();
+
+    const noCap = toModeProps(
+      { ...unreadState, dataOffModInput: 3, fieldStatus: {} } as any,
+      { capabilities: [] } as any,
+    );
+    expect(noCap.hasModInput).toBe(false);
   });
 });
 

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -11,7 +11,7 @@
 
 import { sendCommand } from '$lib/transport/ws-client';
 import { getActiveReceiver, getRadioState, patchActiveReceiver, patchRadioState, patchReceiver } from '$lib/stores/radio.svelte';
-import type { ReceiverState } from '$lib/types/state';
+import type { ReceiverState, ServerState } from '$lib/types/state';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
@@ -22,6 +22,7 @@ import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls'
 import { clampRef, clampSpan } from '../../components/spectrum/spectrum-toolbar-logic';
 import { consumePendingFocus, setPendingFocus } from '$lib/radio/pending-focus';
 import { getModeFilter } from '$lib/radio/mode-filter-memory';
+import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
@@ -172,6 +173,15 @@ export function makeModeHandlers() {
       const receiver = activeReceiverParam();
       patchActiveReceiver({ dataMode: mode }, true);
       cmd('set_data_mode', { mode, receiver });
+    },
+    onModInputChange: (source: number) => {
+      // MOR-616: route the new source to the active receiver's DATA group
+      // (DATA OFF/1/2/3 MOD, CI-V 0x1A 05 00 0x91-0x94). Optimistic
+      // top-level patch; the backend confirms via write-through readback
+      // (MOR-615), which also reverts the patch if the radio rejects it.
+      const dataMode = getActiveReceiver()?.dataMode ?? 0;
+      patchRadioState({ [modInputStateKey(dataMode)]: source } as Partial<ServerState>);
+      cmd(modInputCommand(dataMode), { source });
     },
   };
 }

--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -10,7 +10,8 @@
 import type { ServerState, ReceiverState } from '$lib/types/state';
 import type { Capabilities, FilterModeConfig } from '$lib/types/capabilities';
 import type { VfoStateProps } from '../layout/layout-utils';
-import { isFieldAvailable } from '$lib/state/field-status';
+import { isFieldAvailable, getFieldAvailability } from '$lib/state/field-status';
+import { modInputStateKey } from '$lib/radio/mod-input';
 import { deriveIfShift, pbtRawToHz } from '../panels/filter-controls';
 import { nbDepthRawToDisplay, nrRawToDisplay } from '$lib/radio/filter-controls';
 
@@ -327,6 +328,10 @@ export interface ModeProps {
   hasDataMode: boolean;
   dataModeCount: number;
   dataModeLabels: Record<string, string>;
+  /** Active DATA group's MOD-input source (IC-7610 enum, MOR-616); null until read. */
+  modInputSource: number | null;
+  /** Show the MOD-input control: data_mode cap + the active group has been observed. */
+  hasModInput: boolean;
 }
 
 export function toModeProps(
@@ -334,6 +339,12 @@ export function toModeProps(
   caps: Capabilities | null,
 ): ModeProps {
   const rx = state ? activeRx(state) : null;
+  // MOR-616: surface the MOD-input source of the active receiver's DATA
+  // group (data_mode 0→DATA OFF, 1→D1, 2→D2, 3→D3). Hidden until the
+  // backend has actually read the group (fieldStatus !== missing), so
+  // radios with a data_mode capability but no MOD-input routing (e.g.
+  // IC-7300) never render a dead dropdown.
+  const modInputKey = modInputStateKey(rx?.dataMode ?? 0);
   return {
     currentMode: rx?.mode ?? 'USB',
     modes: caps?.modes ?? ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
@@ -341,6 +352,11 @@ export function toModeProps(
     hasDataMode: hasCap(caps, 'data_mode'),
     dataModeCount: caps?.dataModeCount ?? 0,
     dataModeLabels: caps?.dataModeLabels ?? { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' },
+    modInputSource: state?.[modInputKey] ?? null,
+    hasModInput:
+      hasCap(caps, 'data_mode') &&
+      state !== null &&
+      getFieldAvailability(state, modInputKey) !== 'missing',
   };
 }
 

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -165,6 +165,9 @@
   "core.mobile.setupButton": "Setup",
   "core.mobile.closeStepPicker": "Close step picker",
 
+  "core.modePanel.modInputLabel": "MOD IN",
+  "core.modePanel.modInputAria": "Modulation input source",
+
   "core.error.transport.timeout.title": "Connection Timed Out",
   "core.error.transport.timeout.body": "No response from {host}. Check that the radio is powered on and reachable.",
   "core.error.literalBrace.example": "Use '{'name} to refer to a placeholder.",

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -165,6 +165,9 @@
   "core.mobile.setupButton": "セットアップ",
   "core.mobile.closeStepPicker": "ステップ選択を閉じる",
 
+  "core.modePanel.modInputLabel": "MOD IN",
+  "core.modePanel.modInputAria": "変調入力ソース",
+
   "core.error.transport.timeout.title": "接続がタイムアウトしました",
   "core.error.transport.timeout.body": "{host} から応答がありません。トランシーバーの電源が入っており、到達可能であることを確認してください。",
   "core.error.literalBrace.example": "プレースホルダーを参照するには '{'name} と書きます。",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -165,6 +165,9 @@
   "core.mobile.setupButton": "Настройка",
   "core.mobile.closeStepPicker": "Закрыть выбор шага",
 
+  "core.modePanel.modInputLabel": "MOD IN",
+  "core.modePanel.modInputAria": "Источник входной модуляции",
+
   "core.error.transport.timeout.title": "Время ожидания соединения истекло",
   "core.error.transport.timeout.body": "Нет ответа от {host}. Убедитесь, что трансивер включён и доступен.",
   "core.error.literalBrace.example": "Используйте '{'name} для обозначения подстановки.",

--- a/frontend/src/lib/radio/mod-input.test.ts
+++ b/frontend/src/lib/radio/mod-input.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  MOD_INPUT_SOURCES,
+  modInputCommand,
+  modInputSourceLabel,
+  modInputStateKey,
+} from './mod-input';
+
+describe('MOD_INPUT_SOURCES (MOR-616)', () => {
+  it('lists the six IC-7610 sources in enum order', () => {
+    expect(MOD_INPUT_SOURCES.map((option) => option.value)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(MOD_INPUT_SOURCES.map((option) => option.label)).toEqual([
+      'MIC',
+      'ACC',
+      'MIC+ACC',
+      'USB',
+      'MIC+USB',
+      'LAN',
+    ]);
+  });
+});
+
+describe('modInputSourceLabel', () => {
+  it('maps enum values to human labels', () => {
+    expect(modInputSourceLabel(0)).toBe('MIC');
+    expect(modInputSourceLabel(5)).toBe('LAN');
+  });
+
+  it('returns null for unknown or unread values', () => {
+    expect(modInputSourceLabel(null)).toBeNull();
+    expect(modInputSourceLabel(undefined)).toBeNull();
+    expect(modInputSourceLabel(99)).toBeNull();
+  });
+});
+
+describe('modInputStateKey / modInputCommand', () => {
+  it('maps each DATA group to its state key and set command', () => {
+    expect(modInputStateKey(0)).toBe('dataOffModInput');
+    expect(modInputStateKey(1)).toBe('data1ModInput');
+    expect(modInputStateKey(2)).toBe('data2ModInput');
+    expect(modInputStateKey(3)).toBe('data3ModInput');
+
+    expect(modInputCommand(0)).toBe('set_data_off_mod_input');
+    expect(modInputCommand(1)).toBe('set_data1_mod_input');
+    expect(modInputCommand(2)).toBe('set_data2_mod_input');
+    expect(modInputCommand(3)).toBe('set_data3_mod_input');
+  });
+
+  it('falls back to the DATA OFF group for out-of-range data modes', () => {
+    expect(modInputStateKey(7)).toBe('dataOffModInput');
+    expect(modInputStateKey(-1)).toBe('dataOffModInput');
+    expect(modInputCommand(7)).toBe('set_data_off_mod_input');
+    expect(modInputCommand(-1)).toBe('set_data_off_mod_input');
+  });
+});

--- a/frontend/src/lib/radio/mod-input.ts
+++ b/frontend/src/lib/radio/mod-input.ts
@@ -1,0 +1,74 @@
+/**
+ * IC-7610 per-DATA-group MOD-input source helpers (MOR-616).
+ *
+ * Pure constants and mappers shared by the runtime prop mappers
+ * (`lib/runtime/props/panel-props`), the wiring duplicates
+ * (`components-v2/wiring/state-adapter` / `command-bus`) and the
+ * ModePanel dropdown.
+ *
+ * Source enum mirrors the radio's DATA OFF/1/2/3 MOD menu items
+ * (CI-V `0x1A 05 00 0x91`-`0x94`, see `rigs/ic7610.toml`):
+ * 0=MIC, 1=ACC, 2=MIC+ACC, 3=USB, 4=MIC+USB, 5=LAN.
+ *
+ * Backend contract (T1/MOR-615): the public `state_update` payload carries
+ * the camelCase keys below (null until first readback) and the web control
+ * handler accepts `set_data_off_mod_input` / `set_data1_mod_input` /
+ * `set_data2_mod_input` / `set_data3_mod_input` with `{ source: int }`.
+ */
+
+export interface ModInputOption {
+  readonly value: number;
+  readonly label: string;
+}
+
+export const MOD_INPUT_SOURCES: readonly ModInputOption[] = [
+  { value: 0, label: 'MIC' },
+  { value: 1, label: 'ACC' },
+  { value: 2, label: 'MIC+ACC' },
+  { value: 3, label: 'USB' },
+  { value: 4, label: 'MIC+USB' },
+  { value: 5, label: 'LAN' },
+];
+
+/** camelCase `ServerState` keys of the four DATA-group sources. */
+export type ModInputStateKey =
+  | 'dataOffModInput'
+  | 'data1ModInput'
+  | 'data2ModInput'
+  | 'data3ModInput';
+
+/** Backend SET-command names, indexable by data_mode group. */
+export type ModInputCommand =
+  | 'set_data_off_mod_input'
+  | 'set_data1_mod_input'
+  | 'set_data2_mod_input'
+  | 'set_data3_mod_input';
+
+const STATE_KEYS: readonly ModInputStateKey[] = [
+  'dataOffModInput',
+  'data1ModInput',
+  'data2ModInput',
+  'data3ModInput',
+];
+
+const COMMANDS: readonly ModInputCommand[] = [
+  'set_data_off_mod_input',
+  'set_data1_mod_input',
+  'set_data2_mod_input',
+  'set_data3_mod_input',
+];
+
+/** Human label for a source value; null when unknown or unread. */
+export function modInputSourceLabel(source: number | null | undefined): string | null {
+  return MOD_INPUT_SOURCES.find((option) => option.value === source)?.label ?? null;
+}
+
+/** `ServerState` key for a receiver's data_mode group (out-of-range → DATA OFF). */
+export function modInputStateKey(dataMode: number): ModInputStateKey {
+  return STATE_KEYS[dataMode] ?? 'dataOffModInput';
+}
+
+/** SET-command name for a receiver's data_mode group (out-of-range → DATA OFF). */
+export function modInputCommand(dataMode: number): ModInputCommand {
+  return COMMANDS[dataMode] ?? 'set_data_off_mod_input';
+}

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -24,7 +24,9 @@ import { audioManager } from '$lib/audio/audio-manager';
 import { setMuted, setVolume } from '$lib/stores/audio.svelte';
 import { consumePendingFocus } from '$lib/radio/pending-focus';
 import { getModeFilter } from '$lib/radio/mode-filter-memory';
+import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
+import type { ServerState } from '$lib/types/state';
 
 /* ── Shared helpers ──────────────────────────────────────────────── */
 
@@ -127,6 +129,15 @@ export function makeModeHandlers() {
       const receiver = activeReceiverParam();
       patchActiveReceiver({ dataMode: mode }, true);
       cmd('set_data_mode', { mode, receiver });
+    },
+    onModInputChange: (source: number) => {
+      // MOR-616: route the new source to the active receiver's DATA group
+      // (DATA OFF/1/2/3 MOD, CI-V 0x1A 05 00 0x91-0x94). Optimistic
+      // top-level patch; the backend confirms via write-through readback
+      // (MOR-615), which also reverts the patch if the radio rejects it.
+      const dataMode = getActiveReceiver()?.dataMode ?? 0;
+      patchRadioState({ [modInputStateKey(dataMode)]: source } as Partial<ServerState>);
+      cmd(modInputCommand(dataMode), { source });
     },
   };
 }

--- a/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
@@ -5,6 +5,7 @@ import {
   toAmberTelemetryProps,
   toCwProps,
   toDspProps,
+  toModeProps,
   toRfFrontEndProps,
   toTxProps,
 } from '../panel-props';
@@ -463,5 +464,70 @@ describe('AmberTelemetry props (MOR-483: drop dead TEMP tile)', () => {
     const props = toAmberTelemetryProps(makeState());
     expect(props.vdRaw).toBeNull();
     expect(props.idRaw).toBeNull();
+  });
+});
+
+describe('Mode panel MOD-input source (MOR-616)', () => {
+  const caps = { capabilities: ['data_mode'], dataModeCount: 3 } as any;
+
+  function modInputState(overrides: Record<string, unknown> = {}) {
+    return makeState({
+      dataOffModInput: 0,
+      data1ModInput: 3,
+      data2ModInput: 1,
+      data3ModInput: 5,
+      fieldStatus: {
+        dataOffModInput: fieldStatus('available'),
+        data1ModInput: fieldStatus('available'),
+        data2ModInput: fieldStatus('available'),
+        data3ModInput: fieldStatus('available'),
+      },
+      ...overrides,
+    });
+  }
+
+  it('exposes the DATA OFF group source when data mode is off', () => {
+    const props = toModeProps(modInputState(), caps);
+    expect(props.modInputSource).toBe(0);
+    expect(props.hasModInput).toBe(true);
+  });
+
+  it('follows the active receiver into its DATA group (D1 on SUB)', () => {
+    const state = modInputState({ active: 'SUB' });
+    state.sub.dataMode = 1;
+    const props = toModeProps(state, caps);
+    expect(props.modInputSource).toBe(3);
+  });
+
+  it('hides the control without the data_mode capability', () => {
+    const props = toModeProps(modInputState(), { capabilities: [] } as any);
+    expect(props.hasModInput).toBe(false);
+  });
+
+  it('hides the control while the active group is unread (missing)', () => {
+    const props = toModeProps(
+      modInputState({
+        dataOffModInput: null,
+        fieldStatus: { dataOffModInput: fieldStatus('missing', false) },
+      }),
+      caps,
+    );
+    expect(props.hasModInput).toBe(false);
+    expect(props.modInputSource).toBeNull();
+  });
+
+  it('keeps a stale-but-known source visible', () => {
+    const props = toModeProps(
+      modInputState({ fieldStatus: { dataOffModInput: fieldStatus('stale') } }),
+      caps,
+    );
+    expect(props.hasModInput).toBe(true);
+    expect(props.modInputSource).toBe(0);
+  });
+
+  it('defaults to hidden/null when state is missing', () => {
+    const props = toModeProps(null, caps);
+    expect(props.hasModInput).toBe(false);
+    expect(props.modInputSource).toBeNull();
   });
 });

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -20,6 +20,7 @@ import {
   pbtRawToHz,
 } from '$lib/radio/filter-controls';
 import { isFieldAvailable, getFieldAvailability } from '$lib/state/field-status';
+import { modInputStateKey } from '$lib/radio/mod-input';
 
 /* ── Private helpers ─────────────────────────────────────────── */
 
@@ -395,6 +396,10 @@ export interface ModeProps {
   hasDataMode: boolean;
   dataModeCount: number;
   dataModeLabels: Record<string, string>;
+  /** Active DATA group's MOD-input source (IC-7610 enum, MOR-616); null until read. */
+  modInputSource: number | null;
+  /** Show the MOD-input control: data_mode cap + the active group has been observed. */
+  hasModInput: boolean;
 }
 
 export function toModeProps(
@@ -402,6 +407,12 @@ export function toModeProps(
   caps: Capabilities | null,
 ): ModeProps {
   const rx = state ? activeRx(state) : null;
+  // MOR-616: surface the MOD-input source of the active receiver's DATA
+  // group (data_mode 0→DATA OFF, 1→D1, 2→D2, 3→D3). The control is hidden
+  // until the backend has actually read the group (fieldStatus !== missing),
+  // so radios with a data_mode capability but no MOD-input routing (e.g.
+  // IC-7300) never render a dead dropdown.
+  const modInputKey = modInputStateKey(rx?.dataMode ?? 0);
   return {
     currentMode: rx?.mode ?? 'USB',
     modes: caps?.modes ?? [
@@ -411,6 +422,11 @@ export function toModeProps(
     hasDataMode: hasCap(caps, 'data_mode'),
     dataModeCount: caps?.dataModeCount ?? 0,
     dataModeLabels: caps?.dataModeLabels ?? { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' },
+    modInputSource: state?.[modInputKey] ?? null,
+    hasModInput:
+      hasCap(caps, 'data_mode') &&
+      state !== null &&
+      getFieldAvailability(state, modInputKey) !== 'missing',
   };
 }
 

--- a/frontend/src/lib/types/state.ts
+++ b/frontend/src/lib/types/state.ts
@@ -169,6 +169,12 @@ export interface ServerState {
   rxAntenna2?: boolean;
   meterSource?: 'S' | 'SWR' | 'POWER';
   scopeControls?: ScopeControls;
+  // Per-DATA-group MOD-input sources (IC-7610, MOR-615/616). Mirror
+  // `global.slow_state.data*_mod_input`; null until the first readback.
+  dataOffModInput?: number | null;
+  data1ModInput?: number | null;
+  data2ModInput?: number | null;
+  data3ModInput?: number | null;
 }
 
 export interface UiState {


### PR DESCRIPTION
## Summary

Frontend control to **see and change the IC-7610 MOD-input source** for the active DATA group (DATA OFF/D1/D2/D3 MOD, CI-V `0x1A 05 00 0x91`–`0x94`), consuming the MOR-615 (T1) backend contract. Frontend-only change — no Python touched.

- **ModePanel**: new "MOD IN" row with a dropdown of the six IC-7610 sources (`MIC` / `ACC` / `MIC+ACC` / `USB` / `MIC+USB` / `LAN`). The dropdown shows the current source of the active receiver's DATA group and reflects external/front-panel changes via the backend write-through readback. Shows an em-dash placeholder until the first readback (`null`).
- **Prop mappers** (`lib/runtime/props/panel-props.ts` + the `components-v2/wiring/state-adapter.ts` duplicate): `ModeProps` gains `modInputSource: number | null` and `hasModInput: boolean`. Visibility gate = `hasCap(caps, 'data_mode')` **and** the active group's `fieldStatus` availability is not `missing` — radios that declare `data_mode` but have no MOD-input routing (IC-7300/IC-705/IC-9700/X6200…) never render a dead control, because the T1 payload keeps their fieldStatus `missing`.
- **Command handlers** (`lib/runtime/commands/panel-commands.ts` + the `components-v2/wiring/command-bus.ts` duplicate): `onModInputChange(source)` emits the SET command of the active receiver's `data_mode` group with `{ source }`, plus an optimistic top-level state patch:
  - `data_mode 0` → `set_data_off_mod_input`
  - `data_mode 1` → `set_data1_mod_input`
  - `data_mode 2` → `set_data2_mod_input`
  - `data_mode 3` → `set_data3_mod_input`
- **New pure module** `$lib/radio/mod-input.ts` shared by all layers: source enum/labels, `modInputStateKey(dataMode)`, `modInputCommand(dataMode)` (typed literal unions — T3's one-click "Set LAN" can reuse these directly).
- **Types**: `ServerState` gains `dataOffModInput` / `data1ModInput` / `data2ModInput` / `data3ModInput` (camelCase, `null` until first readback) per the T1 contract.
- **i18n**: `core.modePanel.modInputLabel` ("MOD IN") and `core.modePanel.modInputAria` for en-US / ru-RU / ja-JP.

Layering respected: panel reads props via `lib/runtime/adapters/panel-adapters` and handlers via the runtime command factories; no transport/store imports in the panel (eslint boundary lint clean).

## TDD

Failing tests written first (19 red), then implementation:
- `lib/radio/mod-input.test.ts` — enum order/labels, state-key + command mapping, out-of-range fallback.
- `lib/runtime/props/__tests__/panel-props.test.ts` + `wiring/__tests__/state-adapter.test.ts` — active-group source selection (incl. SUB/D1), capability gating, missing-vs-stale availability, null-state defaults.
- `wiring/__tests__/mod-input-wiring.test.ts` — both handler duplicates emit the right `set_data*_mod_input` command + optimistic patch for every DATA group.
- `panels/__tests__/ModePanel.test.ts` — dropdown renders all six sources with current selected, placeholder before first read, hidden without `hasModInput`, fires `onModInputChange(5)`, reflects state changes.

## Gate results (run in `frontend/`)

- `npm run check` — 0 errors, 0 warnings (4250 files)
- `npx vitest run` — 121 files, **2093 passed**, 0 failed
- `npm run lint` — clean
- `npm run i18n:check` — OK (3 locales, 161 source keys)

Python gate not applicable (no `src/**` / `tests/**` changes).

Part of MOR-614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)