### PR TITLE
fix(#1719): render FM/AM waterfall passband symmetric about the carrier

### DIFF
--- a/frontend/src/components/spectrum/__tests__/passband-geometry.test.ts
+++ b/frontend/src/components/spectrum/__tests__/passband-geometry.test.ts
@@ -28,8 +28,25 @@ describe('getPassbandEdgesHz', () => {
     expect(getPassbandEdgesHz('CW-R', 500, 0)).toEqual({ leftHz: -250, rightHz: 250 });
   });
 
-  it('places FM passband above carrier (same as USB)', () => {
-    expect(getPassbandEdgesHz('FM', 15000, 0)).toEqual({ leftHz: 0, rightHz: 15000 });
+  it('centers FM passband around carrier (#1719)', () => {
+    expect(getPassbandEdgesHz('FM', 15000, 0)).toEqual({ leftHz: -7500, rightHz: 7500 });
+  });
+
+  it('centers narrow/wide FM variants around carrier (#1719)', () => {
+    expect(getPassbandEdgesHz('FM-N', 10000, 0)).toEqual({ leftHz: -5000, rightHz: 5000 });
+    expect(getPassbandEdgesHz('WFM', 200000, 0)).toEqual({ leftHz: -100000, rightHz: 100000 });
+    expect(getPassbandEdgesHz('DATA-FM', 15000, 0)).toEqual({ leftHz: -7500, rightHz: 7500 });
+    expect(getPassbandEdgesHz('DATA-FM-N', 10000, 0)).toEqual({ leftHz: -5000, rightHz: 5000 });
+  });
+
+  it('centers digital FM-based modes around carrier (#1719)', () => {
+    expect(getPassbandEdgesHz('DV', 7000, 0)).toEqual({ leftHz: -3500, rightHz: 3500 });
+    expect(getPassbandEdgesHz('C4FM-DN', 12500, 0)).toEqual({ leftHz: -6250, rightHz: 6250 });
+    expect(getPassbandEdgesHz('C4FM-VW', 12500, 0)).toEqual({ leftHz: -6250, rightHz: 6250 });
+  });
+
+  it('centers narrow AM around carrier (#1719)', () => {
+    expect(getPassbandEdgesHz('AM-N', 6000, 0)).toEqual({ leftHz: -3000, rightHz: 3000 });
   });
 
   it('applies IF shift to both passband edges', () => {
@@ -132,6 +149,10 @@ describe('getFilterWidthFromRightEdgePx', () => {
 
   it('derives symmetric AM width from the right edge', () => {
     expect(getFilterWidthFromRightEdgePx('AM', 0, 12000, 600, 375)).toBe(3000);
+  });
+
+  it('derives symmetric FM width from the right edge (#1719)', () => {
+    expect(getFilterWidthFromRightEdgePx('FM', 0, 12000, 600, 375, 15000)).toBe(3000);
   });
 
   it('disables right-edge resize for LSB', () => {

--- a/frontend/src/components/spectrum/passband-geometry.ts
+++ b/frontend/src/components/spectrum/passband-geometry.ts
@@ -10,6 +10,29 @@ function clamp(value: number, min: number, max: number): number {
   return value < min ? min : value > max ? max : value;
 }
 
+// Modes whose passband is centered on the carrier (±width/2): CW/RTTY by
+// display convention, and double-sideband / FM-family modes (#1719).
+const SYMMETRIC_PASSBAND_MODES = new Set([
+  'CW',
+  'CW-R',
+  'RTTY',
+  'RTTY-R',
+  'AM',
+  'AM-N',
+  'FM',
+  'FM-N',
+  'WFM',
+  'DATA-FM',
+  'DATA-FM-N',
+  'C4FM-DN',
+  'C4FM-VW',
+  'DV',
+]);
+
+function isSymmetricPassbandMode(normalizedMode: string): boolean {
+  return SYMMETRIC_PASSBAND_MODES.has(normalizedMode);
+}
+
 export function getPassbandEdgesHz(mode: string, passbandHz: number, shiftHz: number): {
   leftHz: number;
   rightHz: number;
@@ -23,13 +46,7 @@ export function getPassbandEdgesHz(mode: string, passbandHz: number, shiftHz: nu
     };
   }
 
-  if (
-    normalizedMode === 'CW' ||
-    normalizedMode === 'CW-R' ||
-    normalizedMode === 'RTTY' ||
-    normalizedMode === 'RTTY-R' ||
-    normalizedMode === 'AM'
-  ) {
+  if (isSymmetricPassbandMode(normalizedMode)) {
     return {
       leftHz: shiftHz - passbandHz / 2,
       rightHz: shiftHz + passbandHz / 2,
@@ -94,13 +111,7 @@ export function getFilterWidthFromRightEdgePx(
   const normalizedMode = mode.toUpperCase();
 
   let widthHz: number;
-  if (
-    normalizedMode === 'CW' ||
-    normalizedMode === 'CW-R' ||
-    normalizedMode === 'RTTY' ||
-    normalizedMode === 'RTTY-R' ||
-    normalizedMode === 'AM'
-  ) {
+  if (isSymmetricPassbandMode(normalizedMode)) {
     widthHz = (rightEdgeHz - shiftHz) * 2;
   } else {
     widthHz = rightEdgeHz - shiftHz;


### PR DESCRIPTION
## Root cause

`getPassbandEdgesHz()` in `frontend/src/components/spectrum/passband-geometry.ts` classified only `CW`, `CW-R`, `RTTY`, `RTTY-R`, and `AM` as symmetric (carrier-centered) modes. **FM was not in that branch**, so it fell through to the default USB-like computation (`leftHz = shift`, `rightHz = shift + width`), drawing the waterfall/spectrum passband stripe entirely to the right of the carrier — looking like a USB signal. The same mis-bucketing existed in `getFilterWidthFromRightEdgePx()` (right-edge drag-resize).

The carrier-relative passband shape is computed entirely client-side from mode + filter width; the backend only supplies the width and mode string, so no backend change is needed. An existing unit test even codified the wrong behavior ("places FM passband above carrier (same as USB)") — it has been replaced.

## Change

- Introduced a single `SYMMETRIC_PASSBAND_MODES` set shared by `getPassbandEdgesHz()` and `getFilterWidthFromRightEdgePx()` (replacing the two duplicated equality chains, no new abstraction).
- Added the FM/AM family to the symmetric branch: `FM`, `FM-N`, `WFM`, `DATA-FM`, `DATA-FM-N`, `C4FM-DN`, `C4FM-VW`, `DV`, `AM-N` (mode vocabulary taken from the shipped `rigs/*.toml` profiles; `FM-D`/`AM-D` strings do not exist — data mode is a separate flag and the geometry helper receives the raw `rx.mode`).
- `USB`/`LSB` stay one-sided; `CW`/`RTTY` keep their existing centered convention.
- Display geometry only — audio/filter behavior untouched.

## Before / after

| Mode | Before | After |
|---|---|---|
| FM 15 kHz | carrier .. +15 kHz (USB-like) | −7.5 kHz .. +7.5 kHz (centered) |
| AM | centered (unchanged) | centered |
| USB/LSB | one-sided (unchanged) | one-sided |

TDD: failing tests first (FM/FM-N/WFM/DATA-FM/DV/C4FM/AM-N symmetry + FM right-edge resize), then the fix.

## Gate results

- `npm run check` — 0 errors, 0 warnings (4256 files)
- `npx vitest run` — 2137 passed / 124 files, run 3× (deterministic)
- `npm run lint` — clean
- `npm run i18n:check` — OK
- Python untouched

Fixes #1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)