### PR TITLE
chore(release): 2.9.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] — 2026-06-11
+
 ### Breaking changes
 
 - **CLI: option abbreviations are no longer accepted.** The `rigplane`
@@ -31,6 +33,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lossless. With the flag off (the default) egress behavior is unchanged and
   a client's codec never changes mid-stream (MOR-588, #1775, 1cc5e72a;
   link-quality `audio_stats` uplink MOR-585, #1773, 2dc28f84).
+- IC-7610 MOD-input routing in the Web UI (epic MOR-614, #1786–#1791): the
+  current MOD Input source for each DATA group (DATA OFF/D1/D2/D3 MOD, CI-V
+  `0x1A 05 00 0x91`–`0x94`) is now read into state and exposed in the web
+  `state_update` snapshot (MOR-615, #1788, 5bbf22d2), and the ModePanel shows
+  a "MOD IN" selector for the active DATA group with the six IC-7610 sources
+  (MIC/ACC/MIC+ACC/USB/MIC+USB/LAN) (MOR-616, #1789, dcd7f8e5). Radios
+  without MOD-input routing never render the control.
+- Network-voice-TX preflight guard: keying web voice TX while the active
+  mode group's MOD input is not LAN now shows a warn-only banner with a
+  one-click "Set LAN" action — TX is never blocked or delayed (MOR-617,
+  #1790, 87cd5f58). An **opt-in** (off by default) auto-set-LAN-on-TX
+  setting switches the active group to LAN when TX starts and restores the
+  previous source when TX stops (MOR-618, #1791, 1b9cfc14).
+- Docs: new troubleshooting section for the IC-7610 MOD-input requirement —
+  why network voice TX produces broadband noise, feedback squeal, or silence
+  when MIC is in the MOD-input source list, with the per-mode-group fix
+  (MOR-619, #1786, 25ead3ba).
 
 ### Changed
 
@@ -56,6 +75,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Audio bridge degrades to RX-only (with a warning) when a neutral-surface
   radio negotiates a non-PCM TX codec, instead of pushing mis-typed raw PCM;
   no shipping backend produces this configuration (MOR-545, #1749, a52263d9).
+- PTT over the web control channel is now truthful: keying is rejected with
+  a `radio_not_ready` error envelope when the radio session is not ready or
+  a reconnect cycle is in flight, instead of falsely reporting success while
+  the radio never keyed; unkeying always goes through. The status bar now
+  degrades the radio indicator (with a tooltip) on a connected-but-not-ready
+  session, built on the new reconnect-status surface (MOR-620, #1787,
+  58781f6d; reconnect status + attempt countdown MOR-594, #1784, 88a3b9b6).
 
 ### Fixed
 
@@ -70,6 +96,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   running LAN RX stream (RX demand was dropped before radio TX was stopped);
   the bridge now stops TX first, then tears down RX (MOR-574, #1762,
   3f08f659).
+- FM/AM-family waterfall passband (FM, FM-N, WFM, DATA-FM, AM-N, and the
+  digital FM modes) now renders symmetric about the carrier (±width/2)
+  instead of one-sided to the right like USB; display geometry only, no
+  audio or filter behavior change (#1719, #1792, 4a082e17).
+- A failed `connect()` now fully unwinds the commander and keep-alive tasks
+  it started, eliminating orphaned-future warnings after a connection
+  failure (MOR-595, #1785, 49c5ff93).
 
 ## [2.8.0] — 2026-06-02
 
@@ -1663,7 +1696,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.8.0...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.9.0...HEAD
+[2.9.0]: https://github.com/rigplane/rigplane-core/compare/v2.8.0...v2.9.0
 [2.8.0]: https://github.com/rigplane/rigplane-core/compare/v2.7.3...v2.8.0
 [2.7.3]: https://github.com/rigplane/rigplane-core/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/rigplane/rigplane-core/compare/v2.7.1...v2.7.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.9.0a1"
+version = "2.9.0"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.9.0a1"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Release-prep: 2.9.0 (NOT the release cut)

This is the **version bump + CHANGELOG top-up** PR, ready to merge. It does
**not** cut the release — no git tag, no `gh release create`. Tagging /
publishing happens separately after this merges.

### Version references changed (`2.9.0a1` → `2.9.0`)

- `pyproject.toml` — `version = "2.9.0"`
- `uv.lock` — `rigplane` package pin synced to `2.9.0`

No other version references needed changing:
- `src/rigplane/__init__.py` `__version__` reads installed package metadata
  at runtime (`importlib.metadata.version("rigplane")`), so it tracks
  `pyproject.toml` automatically — nothing hardcoded.
- No `VERSION`/`CORE_VERSION` file, no `CITATION.cff`.
- `frontend/package.json` is independently versioned (`2.0.0`) — left as-is.
- `docs/internals/radio-state-pipeline-validation.md` mentions `2.9.0a1` in
  recorded live-run log output (historical observations) — intentionally
  left untouched.
- The `v2.9.0-alpha` git tag was **not** touched.

### No version-contract test needed updating

Tests reference `__version__` by symbol (`tests/test_public_api_surface.py`,
`tests/test_exports.py`, `tests/test_discovery_responder.py`,
`tests/contracts/test_lazy_imports.py`) but none hardcode the version string,
so the bump required no test changes.

### CHANGELOG changes

- Renamed `## [Unreleased]` → `## [2.9.0] — 2026-06-11` and added a fresh
  empty `## [Unreleased]` section above it (Keep-a-Changelog style, matching
  the file's em-dash heading convention).
- Updated the compare links at the bottom (`[Unreleased]` now `v2.9.0...HEAD`,
  added `[2.9.0]: v2.8.0...v2.9.0`).
- Appended the work merged after the audio-epic section was written
  (verified against the actual merged commit bodies):
  - **Added** — IC-7610 MOD-input routing UI + guard (epic, #1786–#1791):
    per-DATA-group MOD Input source read into state + exposed in the web
    `state_update` snapshot (MOR-615), ModePanel "MOD IN" selector (MOR-616),
    network-voice-TX warn-only preflight guard with one-click "Set LAN"
    (MOR-617), opt-in (off by default) auto-set-LAN-on-TX (MOR-618), and the
    MOD-input troubleshooting docs (MOR-619).
  - **Changed** — PTT over the web control channel now returns a
    `radio_not_ready` error when the session isn't ready/degraded instead of
    falsely reporting success; UI surfaces a degraded/reconnecting indicator
    (MOR-620, #1787). [behavior change]
  - **Fixed** — FM/AM-family waterfall passband now renders symmetric about
    the carrier (#1719, #1792).
  - **Fixed** — commander/keep-alive tasks fully unwound on a failed
    `connect()`, eliminating orphaned-future warnings (MOR-595, #1785).

### Gate results

- `pytest tests/ ... --ignore=tests/integration` → **7631 passed, 8 skipped,
  3 deselected, 11 xfailed, 1 xpassed, 0 failures**
- `ruff check src/ tests/` → clean · `ruff format --check src/ tests/` →
  574 files already formatted
- `mypy src/` → **21 errors / 8 files** (baseline unchanged)
- `lint-imports` → **4 kept / 0 broken**
- `mkdocs build --strict` → built cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
