### PR TITLE
docs: mark IC-9700 as Community-validated (field report #1719)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Full guides: [getting started](https://rigplane.dev/guide/quickstart/),
 | **Icom IC-7300**   | USB CI-V           | Stable              | Single receiver, USB-only              |
 | **Yaesu FTX-1**    | USB CAT            | Stable              | 17 modes, VHF/UHF, C4FM, audio FFT scope |
 | Icom IC-705        | LAN (WiFi)         | Community-validated | CI-V `0xA4`                            |
-| Icom IC-9700       | LAN, USB CI-V      | Profile only        | VHF/UHF/SHF                            |
+| Icom IC-9700       | LAN, USB CI-V      | Community-validated | VHF/UHF/SHF                            |
 | Xiegu X6100        | USB CI-V / Hamlib candidate | Profile only / assisted discovery planned | IC-705 compatible, QRP |
 | Lab599 TX-500      | USB Kenwood CAT / Hamlib candidate | Profile only / assisted discovery planned | QRP, minimal CAT |
 

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -144,11 +144,6 @@ maintainer has not yet completed first-party hardware validation in this repo.
     - **[IC-705 USB Serial Backend Setup](ic705-usb-setup.md)** — Step-by-step USB configuration
     - Use **Menu → Set → Connectors → CI-V → CI-V USB Port** = `Link to [CI-V]`
 
-## Has Rig Profile (Not Yet Backend-Tested)
-
-These radios have complete rig profiles and the CI-V backend should support them, but they
-have not been tested by the maintainers. Community testing and reports welcome!
-
 ### IC-9700
 
 - **CI-V Address:** `0xA2`
@@ -157,7 +152,12 @@ have not been tested by the maintainers. Community testing and reports welcome!
 - **Rig profile:** `rigs/ic9700.toml`
 - **Expected features:** frequency, mode, power, S-meter, scope/waterfall, audio RX/TX,
   independent MAIN/SUB control, dual audio streaming
-- **Status:** Profile complete. Backend untested — reports welcome.
+- **Status:** Community-validated. A community IC-9700 user reported a field
+  issue — the FM/AM waterfall passband rendered asymmetric
+  ([#1719](https://github.com/rigplane/rigplane-core/issues/1719)) — which was
+  fixed in [#1792](https://github.com/rigplane/rigplane-core/pull/1792).
+  First-party maintainer hardware validation is still pending; broader backend
+  coverage still relies on community reports.
 
 !!! tip "Setup Guide"
     **[IC-9700 USB Serial & LAN Setup](ic9700-usb-setup.md)** — Setup guide covering


### PR DESCRIPTION
## What changed

Docs-only change (README.md + docs/guide/radios.md). No source or test changes.

- **README.md** — radio support table: IC-9700 status cell `Profile only` → `Community-validated` (exact wording of the existing IC-705 tier). Nothing else in the table touched.
- **docs/guide/radios.md** — moved the `### IC-9700` entry out of the "Has Rig Profile (Not Yet Backend-Tested)" section into **Community-Validated / Maintainer Hardware Pending**, right after IC-705, and updated its **Status** line. The old section held only the IC-9700, so its now-empty heading + intro were removed (no anchors elsewhere in the docs link to it). The rig-profile reference (`rigs/ic9700.toml`), the setup-guide link (ic9700-usb-setup.md), and all other entry details are kept unchanged.

## Why

A community IC-9700 owner (@AI7BQ) reported a reproducible field bug — the FM/AM waterfall passband rendered asymmetric about the carrier (#1719) — which was fixed in #1792. A genuine community field report plus a validated fix is exactly what the Community-validated tier describes ("working field reports and validated user integrations, but maintainer hardware pending"), the same tier the IC-705 already occupies.

## Honesty note

The new wording deliberately does **not** overstate the evidence: this is one field bug report and a display fix. The Status line states explicitly that first-party maintainer hardware validation is still pending and that broader backend coverage still relies on community reports.

## Verification

- `uv run mkdocs build --strict` — passes (radios.md is in the mkdocs site; only pre-existing INFO notes about pages outside nav).
- README support table remains a valid Markdown table (column padding preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)