### PR TITLE
feat: backend session-teardown MOD-input restore for abnormal disconnect (MOR-624)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.test.ts
@@ -201,6 +201,11 @@ describe('auto-set at TX start (MOR-618)', () => {
       key: 'data1ModInput',
       source: 0,
     });
+    // MOR-624: backend session-teardown net armed alongside the LAN set.
+    expect(sendCommand).toHaveBeenCalledWith('arm_mod_input_restore', {
+      command: 'set_data1_mod_input',
+      source: 0,
+    });
   });
 
   it('routes to the ACTIVE receiver group (SUB on D2)', async () => {
@@ -216,6 +221,11 @@ describe('auto-set at TX start (MOR-618)', () => {
     await getTxAudioControl().startTx();
 
     expect(sendCommand).toHaveBeenCalledWith('set_data2_mod_input', { source: 5 });
+    // MOR-624: the armed backend net carries the same group + previous source.
+    expect(sendCommand).toHaveBeenCalledWith('arm_mod_input_restore', {
+      command: 'set_data2_mod_input',
+      source: 3,
+    });
   });
 
   it('does nothing when the source is already LAN', async () => {
@@ -272,6 +282,8 @@ describe('restore at TX stop (MOR-618)', () => {
 
     expect(runtime.stopTx).toHaveBeenCalledTimes(1);
     expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    // MOR-624: a clean stop owns the restore — backend teardown net cleared.
+    expect(sendCommand).toHaveBeenCalledWith('disarm_mod_input_restore', {});
     expect(getRadioState()?.data1ModInput).toBe(0);
     expect(pendingInStorage()).toBeNull();
 
@@ -293,7 +305,11 @@ describe('restore at TX stop (MOR-618)', () => {
 
     getTxAudioControl().stopTx();
 
-    expect(sendCommand).not.toHaveBeenCalled();
+    // The manual choice wins: no restore SET — but the backend teardown net
+    // is still cleared (MOR-624), the clean stop owns the restore decision.
+    expect(sendCommand).toHaveBeenCalledTimes(1);
+    expect(sendCommand).toHaveBeenCalledWith('disarm_mod_input_restore', {});
+    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', expect.anything());
     expect(pendingInStorage()).toBeNull();
   });
 

--- a/frontend/src/lib/runtime/adapters/mod-input-auto.svelte.ts
+++ b/frontend/src/lib/runtime/adapters/mod-input-auto.svelte.ts
@@ -171,6 +171,12 @@ export function autoSetLanModInputForTx(): void {
   // (MOR-616); the backend confirms via write-through readback (MOR-615).
   patchRadioState({ [key]: LAN_MOD_INPUT_SOURCE } as Partial<ServerState>);
   sendCommand(pending.command, { source: LAN_MOD_INPUT_SOURCE });
+  // MOR-624: arm a backend session-teardown restore so an abnormal disconnect
+  // mid-TX (this browser never reconnects) still restores the previous source.
+  sendCommand('arm_mod_input_restore', {
+    command: pending.command,
+    source: pending.source,
+  });
 }
 
 /**
@@ -183,6 +189,8 @@ export function restoreModInputAfterTx(): void {
   pending = null;
   clearPersistedPending();
   if (!p) return;
+  // MOR-624: a clean stop owns the restore — clear the backend teardown net.
+  sendCommand('disarm_mod_input_restore', {});
   const current = getRadioState()?.[p.key] ?? null;
   if (current !== null && current !== LAN_MOD_INPUT_SOURCE) return;
   patchRadioState({ [p.key]: p.source } as Partial<ServerState>);

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -176,6 +176,15 @@ __all__ = ["ControlHandler", "RadioNotReadyError"]
 logger = logging.getLogger(__name__)
 _MAX_CW_TEXT_CHARS = 512
 
+# MOR-624: maps the per-DATA-group MOD-input SET command name (as sent by the
+# frontend auto-restore) to its poller action, for session-teardown restore.
+_MOD_INPUT_RESTORE_ACTIONS: dict[str, Any] = {
+    "set_data_off_mod_input": SetDataOffModInput,
+    "set_data1_mod_input": SetData1ModInput,
+    "set_data2_mod_input": SetData2ModInput,
+    "set_data3_mod_input": SetData3ModInput,
+}
+
 
 class RadioNotReadyError(RuntimeError):
     """PTT keying rejected because the radio session is degraded (MOR-620).
@@ -457,6 +466,9 @@ class ControlHandler:
             session_id if session_id is not None else f"websocket-{time.monotonic_ns()}"
         )
         self._subscribed_streams: set[str] = set()
+        # MOR-624: (command_name, previous_source) armed by the frontend auto-LAN
+        # feature at TX start; restored on abnormal session teardown. None = nothing armed.
+        self._mod_input_restore: tuple[str, int] | None = None
         self._event_queue: BoundedQueue[dict[str, Any]] = BoundedQueue(
             maxsize=100,
         )
@@ -519,6 +531,7 @@ class ControlHandler:
                 pass
             if self._server is not None:
                 self._server.unregister_control_event_queue(self._event_queue)
+            self._restore_mod_input_on_teardown()
 
     async def _event_sender_loop(self) -> None:
         """Drain event queue and forward events to WebSocket."""
@@ -848,6 +861,18 @@ class ControlHandler:
         name = msg.get("name", "")
         params = msg.get("params", {})
 
+        # MOR-624: session-local arm/disarm of the teardown MOD-input restore.
+        # Bookkeeping only (never a radio command) — intercepted before the
+        # _COMMANDS gate so the command catalog stays untouched.
+        if name in ("arm_mod_input_restore", "disarm_mod_input_restore"):
+            result = self._apply_mod_input_restore_cmd(name, params)
+            await self._ws.send_text(
+                encode_json(
+                    {"type": "response", "id": cmd_id, "ok": True, "result": result}
+                )
+            )
+            return
+
         # ── Server-side rate limiting (per client, per command) ──
         # Only throttle SET commands (continuous slider/knob drag).
         # GET and read-only commands pass through.
@@ -943,6 +968,59 @@ class ControlHandler:
                         "message": message,
                     }
                 )
+            )
+
+    def _apply_mod_input_restore_cmd(
+        self, name: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Arm/disarm the session MOD-input restore (MOR-624).
+
+        Session-local bookkeeping only — never touches the radio. ``arm`` records
+        the per-group SET command + the previous source to re-apply if this session
+        tears down before a clean disarm; ``disarm`` (clean TX stop owns the
+        restore) clears it.
+        """
+        if name == "disarm_mod_input_restore":
+            self._mod_input_restore = None
+            return {}
+        command = str(params.get("command", ""))
+        if command not in _MOD_INPUT_RESTORE_ACTIONS:
+            self._mod_input_restore = None
+            return {"armed": False}
+        self._mod_input_restore = (command, int(params.get("source", 0)))
+        return {"armed": True}
+
+    def _restore_mod_input_on_teardown(self) -> None:
+        """Restore the armed MOD-input source on abnormal session teardown (MOR-624).
+
+        A clean TX stop disarms (see ``_apply_mod_input_restore_cmd``), so a still-armed
+        restore here means the client vanished mid-TX. Enqueue PttOff first — restoring a
+        non-LAN source while the rig is still keyed would re-trigger the open-mic footgun
+        MOR-614 fixed — then the previous-source SET. Best-effort: the shared poller may be
+        shutting down too.
+        """
+        restore = self._mod_input_restore
+        self._mod_input_restore = None
+        if restore is None or self._server is None or self._radio is None:
+            return
+        queue = getattr(self._server, "command_queue", None)
+        if queue is None:
+            return
+        command, source = restore
+        action = _MOD_INPUT_RESTORE_ACTIONS.get(command)
+        if action is None:
+            return
+        try:
+            queue.put(PttOff())
+            queue.put(action(source))
+        except Exception:
+            logger.debug("control: MOD-input teardown restore failed", exc_info=True)
+        else:
+            logger.info(
+                "control: restored MOD-input %s=%d on session teardown (session=%s)",
+                command,
+                source,
+                self._session_id,
             )
 
     async def _enqueue_command(

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -1,0 +1,185 @@
+"""Tests for backend session-teardown MOD-input restore (MOR-624).
+
+The frontend auto-LAN feature (MOR-618) arms a restore on the backend
+session at TX start and disarms it on a clean TX stop. If the session
+tears down while still armed (abnormal mid-TX disconnect), the handler
+enqueues PttOff followed by the previous-source SET on the shared
+command queue.
+"""
+
+from __future__ import annotations
+
+from queue import Queue
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.radio_poller import (
+    PttOff,
+    SetDataOffModInput,
+    SetData1ModInput,
+    SetData2ModInput,
+)
+
+
+def _make_handler() -> tuple[ControlHandler, Queue[Any]]:
+    """Build a ControlHandler with a fake server and return (handler, command_queue)."""
+    ws = MagicMock()
+
+    command_queue: Queue[Any] = Queue()
+
+    server = SimpleNamespace(
+        command_queue=command_queue,
+    )
+
+    handler = ControlHandler(
+        ws=ws,
+        radio=MagicMock(),
+        server_version="test",
+        radio_model="IC-7610",
+        server=server,
+    )
+    return handler, command_queue
+
+
+def _drain(q: Queue[Any]) -> list[Any]:
+    items: list[Any] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+class TestArmDisarm:
+    """_apply_mod_input_restore_cmd is pure session-local bookkeeping."""
+
+    def test_arm_with_valid_command_sets_state(self) -> None:
+        handler, _ = _make_handler()
+
+        result = handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore",
+            {"command": "set_data1_mod_input", "source": 2},
+        )
+
+        assert handler._mod_input_restore == ("set_data1_mod_input", 2)
+        assert result == {"armed": True}
+
+    def test_arm_with_unknown_command_does_not_arm(self) -> None:
+        handler, _ = _make_handler()
+
+        result = handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore",
+            {"command": "set_freq", "source": 2},
+        )
+
+        assert handler._mod_input_restore is None
+        assert result == {"armed": False}
+
+    def test_disarm_clears_armed_state(self) -> None:
+        handler, _ = _make_handler()
+        handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore",
+            {"command": "set_data1_mod_input", "source": 2},
+        )
+
+        result = handler._apply_mod_input_restore_cmd("disarm_mod_input_restore", {})
+
+        assert handler._mod_input_restore is None
+        assert result == {}
+
+
+class TestTeardownRestore:
+    """_restore_mod_input_on_teardown enqueues PttOff then the restore SET."""
+
+    def test_teardown_when_armed_enqueues_ptt_off_then_restore(self) -> None:
+        handler, q = _make_handler()
+        handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore",
+            {"command": "set_data_off_mod_input", "source": 0},
+        )
+
+        handler._restore_mod_input_on_teardown()
+
+        items = _drain(q)
+        assert len(items) == 2
+        assert isinstance(items[0], PttOff)
+        assert isinstance(items[1], SetDataOffModInput)
+        assert items[1].source == 0
+        assert handler._mod_input_restore is None
+
+    def test_teardown_carries_armed_source(self) -> None:
+        handler, q = _make_handler()
+        handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore",
+            {"command": "set_data1_mod_input", "source": 3},
+        )
+
+        handler._restore_mod_input_on_teardown()
+
+        items = _drain(q)
+        assert isinstance(items[0], PttOff)
+        assert isinstance(items[1], SetData1ModInput)
+        assert items[1].source == 3
+
+    def test_teardown_when_not_armed_enqueues_nothing(self) -> None:
+        handler, q = _make_handler()
+
+        handler._restore_mod_input_on_teardown()
+
+        assert q.empty(), "nothing armed — teardown must not touch the queue"
+
+    def test_teardown_after_disarm_enqueues_nothing(self) -> None:
+        handler, q = _make_handler()
+        handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore",
+            {"command": "set_data1_mod_input", "source": 2},
+        )
+        handler._apply_mod_input_restore_cmd("disarm_mod_input_restore", {})
+
+        handler._restore_mod_input_on_teardown()
+
+        assert q.empty(), "clean disarm owns the restore — teardown must be a no-op"
+
+
+class TestCommandRouting:
+    """arm/disarm are intercepted in _handle_command before the _COMMANDS gate."""
+
+    @pytest.mark.asyncio
+    async def test_arm_routed_and_acked(self) -> None:
+        handler, _ = _make_handler()
+        handler._ws.send_text = AsyncMock()
+
+        await handler._handle_command(
+            {
+                "name": "arm_mod_input_restore",
+                "params": {"command": "set_data2_mod_input", "source": 3},
+                "id": "x",
+            }
+        )
+
+        assert handler._mod_input_restore == ("set_data2_mod_input", 3)
+        handler._ws.send_text.assert_awaited_once()
+        sent = handler._ws.send_text.await_args.args[0]
+        assert '"ok": true' in sent or '"ok":true' in sent
+
+    @pytest.mark.asyncio
+    async def test_teardown_after_routed_arm_restores(self) -> None:
+        handler, q = _make_handler()
+        handler._ws.send_text = AsyncMock()
+
+        await handler._handle_command(
+            {
+                "name": "arm_mod_input_restore",
+                "params": {"command": "set_data2_mod_input", "source": 3},
+                "id": "x",
+            }
+        )
+        handler._restore_mod_input_on_teardown()
+
+        items = _drain(q)
+        assert len(items) == 2
+        assert isinstance(items[0], PttOff)
+        assert isinstance(items[1], SetData2ModInput)
+        assert items[1].source == 3


### PR DESCRIPTION
## Summary

The MOR-618 opt-in auto-LAN feature (T4 of epic MOR-614) restores the radio's previous MOD-input source on a clean TX stop, but on an abnormal disconnect mid-TX (browser closed / network drop) the restore depended on the SAME browser reconnecting (`applyPendingModInputRestoreOnConnect` via localStorage). If that browser never came back, the radio stayed on LAN.

This change tracks the armed restore on the BACKEND session:

- **Frontend** (`mod-input-auto.svelte.ts`): when the auto-LAN SET fires at TX start, additionally send `arm_mod_input_restore { command, source }`; on a clean TX stop (which owns the restore) send `disarm_mod_input_restore` — fired whether or not the restore SET itself is skipped by the mid-TX manual-change guard. The localStorage reconnect path is kept unchanged as a complementary best-effort for the full-server-restart case.
- **Backend** (`web/handlers/control.py`): `arm`/`disarm` are session-local bookkeeping — NOT radio commands — intercepted in `_handle_command` before the `_COMMANDS` gate, so the command catalog (and its docs equality check) stays untouched. The armed `(command, previous_source)` tuple lives on the `ControlHandler`; `run()`'s `finally` calls `_restore_mod_input_on_teardown()`, which enqueues the restore on the shared command queue (which outlives the session) if still armed.

## PttOff-then-restore ordering

A still-armed restore at teardown means the client vanished mid-TX, i.e. the rig may still be keyed. Restoring a non-LAN source (e.g. MIC) while keyed would re-trigger the exact open-mic feedback footgun MOR-614 fixed. The teardown therefore enqueues `PttOff()` FIRST, then the previous-source SET. Best-effort: if the shared poller is shutting down too, the failure is logged at debug level.

## Safety properties

- **Opt-in only** — nothing arms unless the user enabled the auto-LAN toggle and an auto-set actually fired.
- **No behavior change when the toggle is OFF** — the OFF path sends no arm/disarm at all (covered by the existing OFF-behavior test).
- **Audio byte path untouched** — only session bookkeeping + two enqueued poller actions on teardown.

## Gates

| Gate | Result |
|---|---|
| `pytest tests/ --ignore=tests/integration` | 7640 passed, 8 skipped, 3 deselected, 11 xfailed, 1 xpassed |
| `ruff check` + `ruff format --check` | All checks passed · 575 files already formatted |
| `mypy src/` | 21 errors in 8 files — exactly the pre-existing baseline, no new errors |
| `lint-imports` | Contracts: 4 kept, 0 broken |
| `npm run check` | 4256 files, 0 errors, 0 warnings |
| `vitest` (full) | 124 files / 2137 tests passed (touched file: 20/20) |
| `npm run lint` | clean |

## Tests

- New `tests/test_web_mod_input_restore.py`: arm/disarm state machine, unknown-command rejection, teardown enqueues exactly `[PttOff, SetData*ModInput(source)]`, no-op when not armed / after disarm, and `_handle_command` routing with an `ok: true` ack.
- Extended `frontend/.../mod-input-auto.test.ts`: arm sent alongside the auto-LAN SET (active-group routing included), disarm on clean stop (including the manual-mid-TX-change path where the restore SET is skipped), OFF/already-LAN/no-pending paths still send nothing.

Closes MOR-624

🤖 Generated with [Claude Code](https://claude.com/claude-code)