### PR TITLE
chore: clear mypy baseline — fix all 21 type errors (0 remaining)

### DIFF
--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -405,8 +405,14 @@ class _IcomSerialRadioBase(CoreRadio):
     async def start_rx(
         self,
         callback: Callable[[AudioPacket | None], None],
+        *,
+        jitter_depth: int = 5,
     ) -> None:
         """Start RX capture from the USB CODEC (``AudioTransport.start_rx``).
+
+        ``jitter_depth`` is accepted for ``AudioRuntimeMixin.start_rx`` signature
+        compatibility but unused: this is a locally captured CODEC stream with no
+        network wire, so there is no inter-packet jitter to buffer against.
 
         Locally captured PCM (transcoded to Opus when the negotiated codec
         is an Opus variant) is framed into synthetic :class:`AudioPacket`

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -172,7 +172,8 @@ YAESU_PTT_PATH = _PTT
 
 
 class YaesuObservationRadio(Protocol):
-    capabilities: set[str]
+    @property
+    def capabilities(self) -> set[str]: ...
 
     async def read_freq(self, receiver: int = 0) -> int: ...
 

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -885,4 +885,5 @@ class YaesuCatPoller:
         except Exception:
             logger.debug("YaesuCatPoller: get_vfo_select failed", exc_info=True)
 
-        self._callback(state)
+        if self._callback is not None:
+            self._callback(state)

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
 
 from ...audio import AudioPacket
 from ...audio.lan_stream import SYNTHETIC_RX_IDENT
@@ -710,13 +710,15 @@ class YaesuCatRadio:
     def _default_nb_level(self) -> int:
         """Default NB level for turning on when current level is 0."""
         ctrl = (self._config.controls or {}).get("nb", {})
-        range_max = int(ctrl.get("range_max", 10))
+        raw_max = ctrl.get("range_max", 10)
+        range_max = int(raw_max) if isinstance(raw_max, (int, float, str)) else 10
         return max(1, range_max // 2)
 
     def _default_nr_level(self) -> int:
         """Default NR level for turning on when current level is 0."""
         ctrl = (self._config.controls or {}).get("nr", {})
-        range_max = int(ctrl.get("range_max", 15))
+        raw_max = ctrl.get("range_max", 15)
+        range_max = int(raw_max) if isinstance(raw_max, (int, float, str)) else 15
         return max(1, range_max // 2)
 
     # -- Internal helpers ---------------------------------------------------
@@ -1423,7 +1425,7 @@ class YaesuCatRadio:
             mode = getattr(target, "mode", None)
         rule = profile.resolve_filter_rule(mode)
         if rule and rule.table:
-            return cast("tuple[int, ...]", rule.table)
+            return rule.table
         return None
 
     async def read_filter_width(

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -1121,7 +1121,7 @@ class RigctldHandler:
             passband = _filter_to_passband(
                 None if projected_filter.value is None else int(projected_filter.value)
             )
-            data_mode = bool(projected_data_mode.value)
+            data_mode: int = bool(projected_data_mode.value)
             if data_mode:
                 if mode_str == "USB":
                     mode_str = "PKTUSB"
@@ -1881,7 +1881,9 @@ class RigctldHandler:
         vfo_arg: str | None,
     ) -> HamlibError:
         if self._routing is not None:
-            return (await self._routing.set_level(level, value, vfo=vfo_arg)).error
+            return HamlibError(
+                (await self._routing.set_level(level, value, vfo=vfo_arg)).error
+            )
 
         if level == "RFPOWER":
             await self._radio.set_rf_power(round(value * 255))
@@ -2017,7 +2019,9 @@ class RigctldHandler:
         vfo_arg: str | None,
     ) -> HamlibError:
         if self._routing is not None:
-            return (await self._routing.set_func(func, on, vfo=vfo_arg)).error
+            return HamlibError(
+                (await self._routing.set_func(func, on, vfo=vfo_arg)).error
+            )
 
         if func not in _FUNC_SET:
             return HamlibError.EINVAL

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -242,7 +242,7 @@ class RigctldServer:
                 "rigctld state acquisition: failed to resolve profile", exc_info=True
             )
             return None
-        return cast(RadioAcquisitionProfile | None, profile.state_acquisition)
+        return profile.state_acquisition
 
     def _radio_state_store(self) -> StateStore | None:
         if not isinstance(self._radio, StateStoreCapable):

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -7,7 +7,7 @@ import logging
 import time
 from dataclasses import dataclass
 from dataclasses import replace as _replace_dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from typing import Literal
 
 from rigplane.core.acquisition_scheduler import (
@@ -731,15 +731,12 @@ class CivRuntime:
     @staticmethod
     def _civ_frame_to_bytes(frame: CivFrame) -> bytes:
         """Rebuild canonical CI-V bytes from a parsed frame."""
-        return cast(
-            bytes,
-            build_civ_frame(
-                frame.to_addr,
-                frame.from_addr,
-                frame.command,
-                sub=frame.sub,
-                data=frame.data,
-            ),
+        return build_civ_frame(
+            frame.to_addr,
+            frame.from_addr,
+            frame.command,
+            sub=frame.sub,
+            data=frame.data,
         )
 
     def _remember_raw_received_frame_bytes(

--- a/src/rigplane/runtime/sync.py
+++ b/src/rigplane/runtime/sync.py
@@ -24,7 +24,7 @@ from rigplane.core.command_service import (
     command_intent_from_request,
     command_response_observation,
 )
-from rigplane.core.state_pipeline_contracts import CommandIntent
+from rigplane.core.state_pipeline_contracts import CommandIntent, Observation
 from rigplane.core.state_store import StateStore
 from .ic705 import (
     prepare_ic705_data_profile as _prepare_ic705_data_profile,
@@ -83,7 +83,7 @@ class _SyncCommandExecutor:
         else:
             raise ValueError(f"unsupported public API command intent: {intent.name!r}")
 
-        observations = ()
+        observations: tuple[Observation, ...] = ()
         if intent.target is not None:
             observations = (
                 command_response_observation(

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2071,9 +2071,9 @@ class RadioPoller:
             case SetBsr(bsr=bsr):
                 if isinstance(radio, MemoryCapable):
                     await radio.set_bsr(bsr)
-            case SetDataOffModInput(source=source):
+            case SetDataOffModInput(source=mod_source):
                 if CAP_DATA_MODE in self._caps:
-                    await radio.set_data_off_mod_input(source)
+                    await radio.set_data_off_mod_input(mod_source)
                     # Write-through readback (MOR-615): confirm the value the
                     # radio actually took, mirroring the NB depth/width route.
                     await self._read_mod_input(
@@ -2083,9 +2083,9 @@ class RadioPoller:
                         session_id=session_id,
                         command_service=command_service,
                     )
-            case SetData1ModInput(source=source):
+            case SetData1ModInput(source=mod_source):
                 if CAP_DATA_MODE in self._caps:
-                    await radio.set_data1_mod_input(source)
+                    await radio.set_data1_mod_input(mod_source)
                     await self._read_mod_input(
                         "data1_mod_input",
                         command_id=command_id,
@@ -2093,9 +2093,9 @@ class RadioPoller:
                         session_id=session_id,
                         command_service=command_service,
                     )
-            case SetData2ModInput(source=source):
+            case SetData2ModInput(source=mod_source):
                 if CAP_DATA_MODE in self._caps:
-                    await radio.set_data2_mod_input(source)
+                    await radio.set_data2_mod_input(mod_source)
                     await self._read_mod_input(
                         "data2_mod_input",
                         command_id=command_id,
@@ -2103,9 +2103,9 @@ class RadioPoller:
                         session_id=session_id,
                         command_service=command_service,
                     )
-            case SetData3ModInput(source=source):
+            case SetData3ModInput(source=mod_source):
                 if CAP_DATA_MODE in self._caps:
-                    await radio.set_data3_mod_input(source)
+                    await radio.set_data3_mod_input(mod_source)
                     await self._read_mod_input(
                         "data3_mod_input",
                         command_id=command_id,


### PR DESCRIPTION
## What

Resolves the long-standing **21-error / 8-file mypy baseline to zero** with real type fixes — **no new `# type: ignore`, no behavior change**. `uv run mypy src/` now reports `Success: no issues found in 266 source files`.

## Fixes (by error class)

| File | Error | Fix |
|---|---|---|
| `web/radio_poller.py` | capture pattern `source` (int) vs outer `source: CommandSource` (×4) | rename the `SetData*ModInput` capture to `mod_source` |
| `backends/yaesu_cat/observations.py` | protocol member `capabilities` expected settable, got read-only (×3) | declare `capabilities` as a read-only `@property` in `YaesuObservationRadio` |
| `backends/yaesu_cat/poller.py` | `"None" not callable` | guard the optional `_callback` before calling |
| `backends/yaesu_cat/radio.py` | `int(object)` overload (×2) + redundant `tuple[int, ...]` cast | narrow TOML `range_max` via `isinstance`; drop the cast (+ unused `cast` import) |
| `backends/_icom_serial_base.py` | `start_rx` signature incompatible with supertype | add `*, jitter_depth: int = 5` to match `AudioRuntimeMixin.start_rx` (unused on the local CODEC path) |
| `rigctld/handler.py` | bool↔int assignment (×2) + int→`HamlibError` return (×2) | annotate `data_mode: int`; wrap routing `.error` in `HamlibError(...)` |
| `rigctld/server.py` | redundant `RadioAcquisitionProfile \| None` cast | drop the cast |
| `runtime/_civ_rx.py` | redundant `bytes` cast | drop the cast (+ unused import) |
| `runtime/sync.py` | `tuple[Observation]` vs `tuple[()]` | annotate `observations: tuple[Observation, ...] = ()` |

## Notes

- The `HamlibError(...)` coercions are value-preserving: `RigctldResponse.error` only ever holds valid hamlib codes (`HamlibError` is an `IntEnum`, so `== 0` / `== HamlibError.OK` comparisons are unaffected). Exercised by the rigctld routing tests.
- `start_rx`'s new `jitter_depth` is accepted for signature compatibility and intentionally unused — the USB CODEC path is locally captured with no network wire, hence no inter-packet jitter to buffer.

## Gates

- `uv run mypy src/` → **Success, 0 errors** (was 21 in 8 files)
- `uv run pytest tests/ -q --ignore=tests/integration` → **7631 passed, 0 failed**
- `uv run ruff check` + `ruff format --check` → clean
- `uv run lint-imports` → **4 kept, 0 broken**

🤖 Generated with [Claude Code](https://claude.com/claude-code)