### PR TITLE
fix(#MOR-174): raise on unknown serial model; warn on unresolved web profile (no silent IC-7610 impersonation)

### DIFF
--- a/src/rigplane/backends/factory.py
+++ b/src/rigplane/backends/factory.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from ..radio import IcomRadio  # noqa: TID251
 from ..radio_protocol import Radio
 from .config import (
@@ -97,13 +95,16 @@ def create_radio(config: BackendConfig) -> Radio:
             serial_class = Ic7300SerialRadio
         elif model == "IC-9700":
             serial_class = Ic9700SerialRadio
-        else:
-            # Default to IC-7610 for compatibility
-            logging.getLogger(__name__).warning(
-                "Unknown model %r, defaulting to IC-7610",
-                model,
-            )
+        elif model == "IC-7610":
             serial_class = Icom7610SerialRadio
+        else:
+            # MOR-174: never silently impersonate an IC-7610 — driving real
+            # hardware with the wrong CI-V personality is a foot-gun.
+            raise ValueError(
+                f"Unsupported serial model {model!r}; supported: "
+                "IC-705, IC-7300, IC-7610, IC-9700, X6200, "
+                "and Yaesu FT-series (FTX-1, FT-710, ...)."
+            )
 
         return serial_class(
             device=config.device,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -165,7 +165,10 @@ def _install_shutdown_signal_handlers(
 
 
 _DEFAULT_STATIC_DIR = pathlib.Path(__file__).parent / "static"
-_RADIO_MODEL = "IC-7610"
+# Sentinel default for WebConfig.radio_model. Deliberately not a real rig
+# model: callers (CLI) inject the connected radio's model, and an
+# unconfigured server must not silently impersonate IC-7610 (MOR-174).
+_RADIO_MODEL_UNSPECIFIED = "unspecified"
 _MAX_POST_BODY = 256 * 1024  # 256 KiB — hard ceiling for all POST body reads
 _MAX_COMMAND_BATCH_STEPS = 128
 _COMMAND_BATCH_STEP_TIMEOUT = 10.0
@@ -616,7 +619,7 @@ class WebConfig:
     host: str = "0.0.0.0"
     port: int = 8080
     static_dir: pathlib.Path = field(default_factory=lambda: _DEFAULT_STATIC_DIR)
-    radio_model: str = _RADIO_MODEL
+    radio_model: str = _RADIO_MODEL_UNSPECIFIED
     max_clients: int = 100
     keepalive_interval: float = WS_KEEPALIVE_INTERVAL
     dx_cluster_host: str = ""
@@ -708,6 +711,7 @@ class WebServer:
     ) -> None:
         self._radio = radio
         self._config = config or WebConfig()
+        self._profile_fallback_warned = False
         self._state_diagnostics = StateDiagnosticsRecorder(
             enabled=self._config.state_diagnostics
         )
@@ -889,18 +893,31 @@ class WebServer:
         raw_profile = getattr(self._radio, "profile", None) if self._radio else None
         if isinstance(raw_profile, RadioProfile):
             return raw_profile
-        # Try resolving from the radio's own model name
+        # Try the radio's own model name first, then the configured one.
         radio_model = getattr(self._radio, "model", None) if self._radio else None
-        if isinstance(radio_model, str):
+        candidates = [
+            m
+            for m in (radio_model, self._config.radio_model)
+            if isinstance(m, str) and m != _RADIO_MODEL_UNSPECIFIED
+        ]
+        for candidate in candidates:
             try:
-                return resolve_radio_profile(model=radio_model)
+                return resolve_radio_profile(model=candidate)
             except KeyError:
-                pass
-        # Last resort: config default
-        try:
-            return resolve_radio_profile(model=self._config.radio_model)
-        except KeyError:
-            return resolve_radio_profile(model="IC-7610")
+                continue
+        # Unknown model: use the library-wide default resolution chain
+        # (reference LAN rig → any LAN rig → first loaded profile) and say
+        # so — never silently impersonate IC-7610 (MOR-174).
+        fallback = resolve_radio_profile()
+        if not self._profile_fallback_warned:
+            self._profile_fallback_warned = True
+            logger.warning(
+                "No rig profile matches radio model %r; falling back to %r — "
+                "capabilities, scope and CI-V behavior may not match the radio",
+                candidates[0] if candidates else self._config.radio_model,
+                fallback.model,
+            )
+        return fallback
 
     def _bootstrap_state_acquisition(self) -> None:
         """Attach shared StateStore-backed acquisition services when profiled."""

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -13,6 +13,7 @@ from rigplane.backends.config import (
     SerialBackendConfig,
     YaesuCatBackendConfig,
 )
+from rigplane.backends.ic7300.serial import Ic7300SerialRadio
 from rigplane.backends.icom7610 import Icom7610SerialRadio
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.backends.rigctld_client.radio import RigctldClientRadio
@@ -134,6 +135,35 @@ class TestCreateRadioFactory:
         radio = create_radio(RigctldBackendConfig(host="localhost"))
         assert isinstance(radio, RigctldClientRadio)
         assert radio.backend_id == "rigctld"
+
+    def test_create_radio_serial_unknown_model_raises(self) -> None:
+        """Regression for MOR-174: an unknown serial --model must ERROR, not
+        silently impersonate an IC-7610 against real hardware."""
+        with pytest.raises(ValueError, match="Unsupported serial model") as excinfo:
+            create_radio(SerialBackendConfig(device="/dev/ttyUSB0", model="TX-500"))
+        message = str(excinfo.value)
+        assert "TX-500" in message
+        for supported in ("IC-705", "IC-7300", "IC-7610", "IC-9700", "X6200"):
+            assert supported in message
+
+    def test_create_radio_serial_known_model_dispatches_to_its_class(self) -> None:
+        radio = create_radio(
+            SerialBackendConfig(device="/dev/ttyUSB0", model="IC-7300")
+        )
+        assert isinstance(radio, Ic7300SerialRadio)
+        assert radio.model == "IC-7300"
+
+    def test_create_radio_serial_explicit_ic7610_no_unknown_model_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Explicit --model IC-7610 is a supported model, not a fallback;
+        it must dispatch without any 'Unknown model' warning."""
+        with caplog.at_level("WARNING", logger="rigplane.backends.factory"):
+            radio = create_radio(
+                SerialBackendConfig(device="/dev/ttyUSB0", model="IC-7610")
+            )
+        assert isinstance(radio, Icom7610SerialRadio)
+        assert not any("Unknown model" in rec.getMessage() for rec in caplog.records)
 
     def test_create_radio_rejects_unknown_backend(self) -> None:
         @dataclass(slots=True)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3641,6 +3641,54 @@ class TestGetProfileRouting:
         assert isinstance(profile, RadioProfile)
         assert "IC-7610" in profile.model
 
+    def test_unresolved_radio_model_warns_and_names_model(self, caplog):
+        """Unknown radio model logs a WARNING naming it instead of silently
+        impersonating IC-7610 (MOR-174)."""
+        import logging
+
+        from rigplane.profiles import RadioProfile, resolve_radio_profile
+
+        radio = SimpleNamespace(model="ACME-9000", capabilities=set())
+        with caplog.at_level(logging.WARNING, logger="rigplane.web.server"):
+            srv = self._make_server(radio, radio_model="ACME-9000")
+            profile = srv._get_profile()
+
+        assert isinstance(profile, RadioProfile)
+        warnings = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "ACME-9000" in r.getMessage()
+        ]
+        assert warnings, "expected a WARNING naming the unresolved radio model"
+        # Fallback must be the library-wide default resolution chain, and the
+        # warning must name the profile actually used — never a silent
+        # hard-coded IC-7610.
+        assert profile == resolve_radio_profile()
+        assert profile.model in warnings[0]
+
+    def test_unresolved_config_model_warns_when_no_radio(self, caplog):
+        """Unresolvable config radio_model (no radio) warns and still yields a
+        profile via the default resolution chain (MOR-174)."""
+        import logging
+
+        from rigplane.profiles import RadioProfile
+
+        with caplog.at_level(logging.WARNING, logger="rigplane.web.server"):
+            srv = self._make_server(radio=None, radio_model="NOT-A-RADIO")
+            profile = srv._get_profile()
+
+        assert isinstance(profile, RadioProfile)
+        assert any(
+            "NOT-A-RADIO" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    def test_default_config_radio_model_is_not_ic7610(self):
+        """WebConfig.radio_model defaults to a neutral sentinel, not a silent
+        IC-7610 (MOR-174)."""
+        assert WebConfig().radio_model != "IC-7610"
+
 
 class TestGetMeterCalPayload:
     """Unit tests for WebServer._get_meter_cal_payload()."""


### PR DESCRIPTION
## Problem (MOR-174)

MOR-174's cited foot-gun: "--model fallback to IC-7610 is silent; should ERROR (foot-gun, real-hardware regressor)." Two places impersonated an IC-7610 when the model was unknown:

1. **`src/rigplane/backends/factory.py` (the ticket's actual citation, lines 101–106):** the serial-class dispatch ended in `else: serial_class = Icom7610SerialRadio` — any unknown serial model got an IC-7610 CI-V personality driven at real hardware, with only a WARNING. Side wart: explicit `--model IC-7610` *also* fell through this branch and logged a spurious `Unknown model 'IC-7610', defaulting to IC-7610`.
2. **`src/rigplane/web/server.py` (related hardening, first commit):** `WebServer._get_profile()` ended in a silent `resolve_radio_profile(model="IC-7610")` last resort, and `WebConfig.radio_model` defaulted to a hard-coded `"IC-7610"` literal.

## Fix

### Commit 2 — factory.py: raise instead of silent fallback (the ticket's foot-gun)

- Added an explicit `elif model == "IC-7610"` dispatch branch (kills the spurious warning for the legitimately supported model).
- The `else` branch now **raises** `ValueError("Unsupported serial model {model!r}; supported: IC-705, IC-7300, IC-7610, IC-9700, X6200, and Yaesu FT-series (FTX-1, FT-710, ...).")` — matching the surrounding `ValueError` error style.
- Removed the now-unused `import logging`.

**Caller audit (no legitimate fallback consumer found):**
- The CLI's `_resolve_model` already raises `ValueError("Unknown model ...")` for arbitrary strings, so only rig-profile-valid models reach the factory. Of those, **TX-500** and **X6100** have no serial backend class and were silently driven as IC-7610 — exactly the regressor the ticket describes. They now error clearly instead.
- `SerialBackendConfig(model=None)` → `"IC-7610"` documented default (factory.py line 68) is **preserved**; existing tests (`test_create_radio_builds_serial_backend`, `test_audio_probe_runner`) rely on it and still pass.
- No test asserted that the fallback warning *fires* — only that it does NOT fire for known models (MOR-170 regression tests), which still hold.

### Commit 1 — web/server.py: warn instead of silent profile impersonation

- `_get_profile()` now tries the radio's own model, then the configured one; when neither resolves it falls back to the library-wide default resolution chain (`resolve_radio_profile()` with no args: reference LAN rig → any LAN rig → first loaded profile) and logs a **WARNING** (once per server instance) naming both the unresolved model and the profile actually used.
- `_RADIO_MODEL = "IC-7610"` → `_RADIO_MODEL_UNSPECIFIED = "unspecified"` sentinel, excluded from profile-resolution candidates. The CLI always injects the real radio model, so runtime payloads are unaffected.

Out of scope (left as-is): `cli/__init__.py:3364` `getattr(radio, "model", "IC-7610")` — effectively dead (`Radio.model` is non-Optional).

## Tests (TDD — written first, red, then green)

`tests/test_backend_factory.py::TestCreateRadioFactory` (new, commit 2):
- `test_create_radio_serial_unknown_model_raises` — `model="TX-500"` raises `ValueError`; message names `TX-500` and lists all supported models.
- `test_create_radio_serial_known_model_dispatches_to_its_class` — `IC-7300` → `Ic7300SerialRadio`.
- `test_create_radio_serial_explicit_ic7610_no_unknown_model_warning` — explicit `IC-7610` dispatches with no "Unknown model" warning.

`tests/test_web_server.py::TestGetProfileRouting` (commit 1):
- `test_unresolved_radio_model_warns_and_names_model`, `test_unresolved_config_model_warns_when_no_radio`, `test_default_config_radio_model_is_not_ic7610`.

## Verification (after commit 2)

- `uv run pytest tests/ -q --ignore=tests/integration` — zero failures
- `uv run ruff check src/ tests/` + `ruff format` — clean
- `uv run mypy src/` — `Success: no issues found in 266 source files`
- `uv run lint-imports` — 4 contracts kept, 0 broken

## Review status

This push **supersedes the prior `Agent Review: PASS`** (it was for the web/server.py-only head). A fresh independent review is required for the current head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
