### PR TITLE
fix(#MOR-252): refresh radio credentials on reconnect

### DIFF
--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -1110,6 +1110,26 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """
         return self._civ_request_tracker.snapshot_stats()
 
+    def update_credentials(
+        self, *, username: str | None = None, password: str | None = None
+    ) -> None:
+        """Update the stored login credentials for future full reconnects.
+
+        The new values are used the next time a full ``connect()`` performs
+        authentication (the login packet is built from the stored
+        credentials). ``soft_reconnect()`` intentionally reuses the existing
+        session token and does NOT re-authenticate, so a rotated credential
+        only takes effect on a full reconnect.
+
+        Args:
+            username: New username, or ``None`` to keep the current one.
+            password: New password, or ``None`` to keep the current one.
+        """
+        if username is not None:
+            self._username = username
+        if password is not None:
+            self._password = password
+
     async def connect(self) -> None:
         """Open connection to the radio and authenticate.
 

--- a/tests/test_credential_refresh.py
+++ b/tests/test_credential_refresh.py
@@ -1,0 +1,114 @@
+"""Tests for CoreRadio.update_credentials (MOR-252).
+
+A rotated radio password must be honoured on the next full reconnect.
+``soft_reconnect`` intentionally reuses the existing session token and
+must NOT re-authenticate.
+"""
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rigplane.core.auth import build_login_packet as real_build_login_packet
+from rigplane.runtime.radio import IcomRadio
+
+
+class _AbortAfterLogin(Exception):
+    """Sentinel raised to stop _connect_once right after login-packet build."""
+
+
+class _FakeCtrlTransport:
+    """Minimal control-transport stand-in for driving _connect_once to auth."""
+
+    def __init__(self) -> None:
+        self.my_id = 0x00010001
+        self.remote_id = 0xDEADBEEF
+        self._discard_data_packets = True
+        self._udp_transport: object | None = object()
+
+    async def connect(
+        self, host: str, port: int, local_host: str | None = None
+    ) -> None:
+        pass
+
+    async def reconnect(
+        self, host: str, port: int, local_host: str | None = None
+    ) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        pass
+
+    def start_ping_loop(self) -> None:
+        pass
+
+    def start_retransmit_loop(self) -> None:
+        pass
+
+
+def test_update_credentials_mutates_stored_values() -> None:
+    r = IcomRadio("192.168.1.100", username="old-user", password="old-pass")
+    r.update_credentials(username="new-user", password="new-pass")
+    assert r._username == "new-user"
+    assert r._password == "new-pass"
+
+
+def test_update_credentials_partial_update_keeps_other_field() -> None:
+    r = IcomRadio("192.168.1.100", username="old-user", password="old-pass")
+    r.update_credentials(password="new-pass")
+    assert r._username == "old-user"
+    assert r._password == "new-pass"
+    r.update_credentials(username="new-user")
+    assert r._username == "new-user"
+    assert r._password == "new-pass"
+
+
+def test_update_credentials_noop_when_no_args() -> None:
+    r = IcomRadio("192.168.1.100", username="old-user", password="old-pass")
+    r.update_credentials()
+    assert r._username == "old-user"
+    assert r._password == "old-pass"
+
+
+@pytest.mark.asyncio
+async def test_full_reconnect_builds_login_packet_with_new_password() -> None:
+    r = IcomRadio("192.168.1.100", username="user", password="old-pass")
+    r._ctrl_transport = _FakeCtrlTransport()  # type: ignore[assignment]
+    r.update_credentials(password="new-pass")
+
+    captured: dict[str, str] = {}
+
+    def spy(username: str, password: str, **kwargs: Any) -> bytes:
+        # Exercise the REAL builder so signature drift is caught.
+        pkt = real_build_login_packet(username, password, **kwargs)
+        assert len(pkt) == 0x80
+        captured["username"] = username
+        captured["password"] = password
+        raise _AbortAfterLogin
+
+    with patch("rigplane.runtime._control_phase.build_login_packet", side_effect=spy):
+        with pytest.raises(_AbortAfterLogin):
+            await r._control_phase._connect_once()
+
+    assert captured == {"username": "user", "password": "new-pass"}
+
+
+@pytest.mark.asyncio
+async def test_soft_reconnect_reuses_token_and_does_not_reauth() -> None:
+    r = IcomRadio("192.168.1.100", username="user", password="old-pass")
+    r._ctrl_transport = _FakeCtrlTransport()  # type: ignore[assignment]
+    r._token = 0x1234
+    # Healthy CI-V transport with fresh data => soft_reconnect noop path.
+    civ = MagicMock()
+    civ._udp_transport = object()
+    r._civ_transport = civ
+    r._last_civ_data_received = time.monotonic()
+    r.update_credentials(password="new-pass")
+
+    with patch("rigplane.runtime._control_phase.build_login_packet") as mock_login:
+        await r.soft_reconnect()
+
+    mock_login.assert_not_called()
+    assert r._token == 0x1234


### PR DESCRIPTION
## Problem (MOR-252)

A radio password is captured ONCE in `CoreRadio.__init__` (`src/rigplane/runtime/radio.py`) and never re-read. It is consumed only at initial auth — `_control_phase.py` builds the login packet from `h._username`/`h._password`. Token renewal re-sends the existing token, and `soft_reconnect` reconnects CI-V without a fresh login. Result: a rotated credential is ignored until process restart.

## Fix

Add `CoreRadio.update_credentials(*, username: str | None = None, password: str | None = None)` which mutates the stored `_username`/`_password`. The login path in `_control_phase._connect_once` already reads `h._password`, so a subsequent full `connect()` authenticates with the new value — no protocol, transport, or audio-path changes.

The docstring explicitly notes that `soft_reconnect()` intentionally reuses the existing session token (does NOT re-auth), so a credential refresh only takes effect on a full reconnect.

Scope: +20 LOC in one source file + one new test file. No new abstractions.

## Tests

`tests/test_credential_refresh.py` (TDD — written first, red, then green):

- `update_credentials` mutates stored values; partial update keeps the other field; no-arg call is a no-op.
- Full-reconnect path: construct a real `IcomRadio`, call `update_credentials(password="new-pass")`, drive `_control_phase._connect_once()` with a minimal fake control transport, and spy on `build_login_packet` — the spy invokes the REAL builder (catching signature drift) and asserts the packet is built with the NEW password.
- `soft_reconnect` does not re-auth: healthy CI-V noop path; `build_login_packet` never called, token unchanged.

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **7645 passed, 8 skipped, 3 deselected, 11 xfailed, 1 xpassed, 0 failed**
- `uv run ruff check src/ tests/` → All checks passed; `ruff format` clean
- `uv run mypy src/` → Success: no issues found in 266 source files
- `uv run lint-imports` → Contracts: 4 kept, 0 broken
- `git diff` → no unintended changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)