### PR TITLE
test(#MOR-590): rigctld handler 3.11 async-dispatch (92 failures)

### DIFF
--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -39,6 +39,23 @@ from rigplane.types import CivFrame, Mode
 # ---------------------------------------------------------------------------
 
 
+def make_mock_radio() -> AsyncMock:
+    """Bare radio mock that does NOT satisfy the RigctldRoutable Protocol.
+
+    Python 3.11's runtime-checkable Protocol ``isinstance()`` uses
+    ``hasattr()``, which a bare AsyncMock always satisfies, so
+    ``create_routing()`` would call the auto-generated async
+    ``rigctld_routing()`` and store a *coroutine* as ``handler._routing``.
+    Python 3.12+ uses ``inspect.getattr_static()`` (gh-102433) and is immune.
+    Deleting the attribute makes both interpreters take the built-in Icom
+    routing path. Yaesu tests wire an explicit sync ``rigctld_routing``
+    lambda instead (see ``yaesu_radio``).
+    """
+    radio = AsyncMock()
+    del radio.rigctld_routing
+    return radio
+
+
 @pytest.fixture
 def config() -> RigctldConfig:
     return RigctldConfig()
@@ -47,7 +64,7 @@ def config() -> RigctldConfig:
 @pytest.fixture
 def mock_radio() -> AsyncMock:
     """Radio mock; implements MetersCapable (get_s_meter, get_swr, get_rf_power) for get_level tests."""
-    radio = AsyncMock()
+    radio = make_mock_radio()
     radio.capabilities = set(FULL_ICOM_CAPS)
     radio.get_data_mode.return_value = False
     radio.get_s_meter = AsyncMock(return_value=0)
@@ -778,7 +795,7 @@ async def test_set_mode_uses_core_contract_string_values() -> None:
 
 @pytest.mark.asyncio
 async def test_set_mode_packet_uses_configured_wsjtx_data_mode() -> None:
-    radio = AsyncMock()
+    radio = make_mock_radio()
     radio.set_mode = AsyncMock()
     radio.set_data_mode = AsyncMock()
     radio.set_data2_mod_input = AsyncMock()
@@ -802,7 +819,7 @@ async def test_set_mode_packet_uses_configured_wsjtx_data_mode() -> None:
 async def test_set_mode_packet_configured_data2_falls_back_on_single_data_profile() -> (
     None
 ):
-    radio = AsyncMock()
+    radio = make_mock_radio()
     radio.set_mode = AsyncMock()
     radio.set_data_mode = AsyncMock()
     radio.set_data2_mod_input = AsyncMock()
@@ -825,7 +842,7 @@ async def test_set_mode_packet_configured_data2_falls_back_on_single_data_profil
 async def test_set_mode_packet_without_wsjtx_data_config_does_not_touch_data_mod_input() -> (
     None
 ):
-    radio = AsyncMock()
+    radio = make_mock_radio()
     radio.set_mode = AsyncMock()
     radio.set_data_mode = AsyncMock()
     radio.set_data1_mod_input = AsyncMock()
@@ -1450,7 +1467,7 @@ async def test_get_info(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
 
 @pytest.mark.asyncio
 async def test_get_info_uses_runtime_model(config: RigctldConfig) -> None:
-    radio = AsyncMock()
+    radio = make_mock_radio()
     radio.model = "IC-9700"
     h = RigctldHandler(radio, config)
     resp = await h.execute(get_cmd("get_info"))
@@ -3606,7 +3623,7 @@ class _FakeProfile:
 @pytest.fixture
 def dual_rx_radio() -> AsyncMock:
     """IC-7610-style radio mock: dual-RX profile, main/sub VFO scheme."""
-    radio = AsyncMock()
+    radio = make_mock_radio()
     radio.capabilities = set(FULL_ICOM_CAPS)
     radio.profile = _FakeProfile(receiver_count=2, vfo_scheme="main_sub")
     return radio
@@ -3620,7 +3637,7 @@ def dual_rx_handler(dual_rx_radio: AsyncMock, config: RigctldConfig) -> RigctldH
 @pytest.fixture
 def single_rx_radio() -> AsyncMock:
     """IC-7300-style radio mock: single-RX profile, A/B VFO scheme."""
-    radio = AsyncMock()
+    radio = make_mock_radio()
     radio.capabilities = set(FULL_ICOM_CAPS)
     radio.profile = _FakeProfile(receiver_count=1, vfo_scheme="ab")
     return radio


### PR DESCRIPTION
## Linear

MOR-630 (MOR-590-B1): the entire `tests/test_rigctld_handler.py` (92 failed/errored) fails under Python 3.11 but passes under 3.13, with `AttributeError: 'coroutine' object has no attribute 'get_level'` (also `set_func`, etc.) swallowed into `RigctldResponse(error=HamlibError.EINTERNAL)`.

## Diagnosis: (b) test-harness/mock artifact — NOT a production bug

**Evidence:**

- `src/rigplane/rigctld/routing.py:454-456` — `create_routing()` checks `isinstance(radio, RigctldRoutable)` (a `@runtime_checkable` Protocol) and, on a match, calls `radio.rigctld_routing(cache, max_power_w)` **synchronously** and stores the result as `handler._routing`.
- `tests/test_rigctld_handler.py:50` (pre-fix) — the `mock_radio` fixture is a **bare `AsyncMock()`**.
- On **Python 3.11**, runtime-checkable Protocol `isinstance()` uses `hasattr()`-based lookup. A bare `AsyncMock` claims every attribute, so it spuriously satisfies `RigctldRoutable`; `radio.rigctld_routing(...)` is an auto-generated **AsyncMock call returning a coroutine**, and `handler._routing` becomes a coroutine. Every routed command (`handler.py:1638` `await self._routing.get_level(...)`, `:1885` `set_level`, `:1952` `get_func`, `:2023` `set_func`) then raises `AttributeError` on the coroutine object, caught by the broad `except Exception` at `handler.py:1009-1011` → `EINTERNAL` → `assert resp.ok` failures.
- On **Python 3.12+** (gh-102433), protocol `isinstance()` switched to `inspect.getattr_static()`, which does not trigger Mock's dynamic `__getattr__` — the check returns `False`, `create_routing()` returns `None`, and the handler takes the built-in Icom path. Verified empirically in this worktree: `isinstance(AsyncMock(), RigctldRoutable)` → `True` on 3.11.13, `False` on 3.13.5.

**Production path is correct:** `handler.py` awaits every `self._routing.*` call unconditionally, and real radios either implement `rigctld_routing` as a plain sync method returning a routing strategy (Yaesu, `YaesuRouting`) or do not have the attribute at all (Icom). No missing `await` exists; no source change is needed or made.

## Fix

`tests/test_rigctld_handler.py` only: add a `make_mock_radio()` helper that does `del radio.rigctld_routing` on the bare `AsyncMock` (Mock honors `del` — subsequent `hasattr` is `False`), so the mock fails the `RigctldRoutable` check identically on 3.11 and 3.13. Applied at all 7 bare-mock radio sites (the `mock_radio`, `dual_rx_radio`, `single_rx_radio` fixtures + 4 inline tests). The Yaesu tests already wire an explicit sync `rigctld_routing` lambda and are unaffected.

## Verification (both interpreters)

| Gate | Python 3.11.13 | Python 3.13.5 |
|---|---|---|
| `pytest tests/test_rigctld_handler.py -q` | **351 passed** (was 92 failed / 259 passed) | 351 passed |
| `pytest tests/ -q --ignore=tests/integration` | 7535 passed, 9 failed + 35 errors — **all pre-existing on clean `main`** (verified via `git stash`: same failures without this change), in unrelated files (`test_web_server*`, `test_security_headers`, `test_icom_receiver_tier`, `test_per_receiver_vfo_roundtrip`, `test_audio_rx_tx_transition`, `test_serial_backend_smoke`) — same Mock-vs-runtime-Protocol class of issue, outside MOR-590-B1 scope (sibling sub-tickets) | **7579 passed, 0 failed** |
| `ruff check src/ tests/` + `ruff format` | All checks passed, 0 reformats | — |
| `mypy src/` | `Success: no issues found in 266 source files` | — |
| `lint-imports` | Contracts: 4 kept, 0 broken | — |

No CI workflow files touched (3.11 pin is MOR-633).

🤖 Generated with [Claude Code](https://claude.com/claude-code)