### PR TITLE
feat(validation): golden-gate harness slice — artifact normalization + --gate + --regen-golden

### DIFF
--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -259,6 +259,17 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--regen-golden",
+        dest="regen_golden",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Write the NORMALIZED artifact (volatile fields stripped) to PATH "
+            "for use as a --gate golden baseline. Parent directories are "
+            "created as needed."
+        ),
+    )
+    p.add_argument(
         "--no-overrides",
         dest="no_overrides",
         action="store_true",
@@ -475,13 +486,23 @@ async def _run_hardware_both(
 def _apply_golden_flags(
     artifact: ValidationArtifact, args: argparse.Namespace, exit_code: int
 ) -> int:
-    """Apply ``--gate`` after the artifact is emitted.
+    """Apply ``--regen-golden`` and ``--gate`` after the artifact is emitted.
 
-    Normalizes both sides (the golden may be stored normalized already — the
-    projection is idempotent), prints a concise diff summary to stderr, and
-    elevates a successful run to exit code ``1`` on any regression. Existing
-    non-zero exit codes are preserved; a missing/unreadable golden is ``2``.
+    ``--regen-golden`` writes the normalized artifact to the given path (the
+    golden baseline format). ``--gate`` normalizes both sides (the golden may
+    be stored normalized already — the projection is idempotent), prints a
+    concise diff summary to stderr, and elevates a successful run to exit code
+    ``1`` on any regression. Existing non-zero exit codes are preserved; a
+    missing/unreadable golden is ``2``.
     """
+    regen_path = getattr(args, "regen_golden", None)
+    if regen_path:
+        normalized = normalize_artifact(artifact.to_dict())
+        path = Path(regen_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(normalized, indent=2) + "\n", encoding="utf-8")
+        print(f"Golden written to: {regen_path}", file=sys.stderr)
+
     gate_path = getattr(args, "gate", None)
     if not gate_path:
         return exit_code

--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -19,8 +19,10 @@ Exit codes:
 
 * ``0`` — success (dry-run or hardware artifact emitted). Failed/blocked checks
   do NOT change the exit code.
+* ``1`` — ``--gate`` detected a regression against the golden artifact.
 * ``2`` — template missing, unreadable, or schema-invalid; or ``--template``
-  and ``--model`` both absent; or model name is unknown.
+  and ``--model`` both absent; or model name is unknown; or the ``--gate``
+  golden file is missing/unreadable.
 * ``3`` — hardware run requested but blocked (gates closed), or the radio could
   not connect / authenticate / build a backend config (artifact still emitted
   on connect failure).
@@ -53,8 +55,11 @@ from rigplane.validation import (
     build_validation_artifact,
     compute_comparison_dimensions,
     dry_run_results,
+    format_gate_report,
+    gate_artifacts,
     human_summary,
     load_template,
+    normalize_artifact,
 )
 from rigplane.validation.schema import (
     CapabilityDeclaration,
@@ -243,6 +248,17 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--gate",
+        default=None,
+        metavar="GOLDEN",
+        help=(
+            "Gate this run against a golden normalized artifact JSON: print a "
+            "diff summary and exit 1 on any regression (a check that went "
+            "pass->fail, a new fail/blocked check, a missing check, or "
+            "declaration drift). Improvements never block."
+        ),
+    )
+    p.add_argument(
         "--no-overrides",
         dest="no_overrides",
         action="store_true",
@@ -372,7 +388,7 @@ def run(args: argparse.Namespace) -> int:
         if getattr(args, "compare", None):
             artifact = _attach_comparison(artifact, args.compare)
         _emit_artifact(artifact, args)
-        return rc
+        return _apply_golden_flags(artifact, args, rc)
 
     levels = dry_run_results(template, safety)
     transport = TransportInfo(backend="fixture")
@@ -394,7 +410,7 @@ def run(args: argparse.Namespace) -> int:
     if getattr(args, "compare", None):
         artifact = _attach_comparison(artifact, args.compare)
     _emit_artifact(artifact, args)
-    return 0
+    return _apply_golden_flags(artifact, args, 0)
 
 
 async def _run_hardware_both(
@@ -453,7 +469,37 @@ async def _run_hardware_both(
         metadata["overrides"] = overrides_audit
     art_n = dataclasses.replace(art_n, metadata=metadata)
     _emit_artifact(art_n, args)
-    return rc_n if rc_n else rc_h
+    return _apply_golden_flags(art_n, args, rc_n if rc_n else rc_h)
+
+
+def _apply_golden_flags(
+    artifact: ValidationArtifact, args: argparse.Namespace, exit_code: int
+) -> int:
+    """Apply ``--gate`` after the artifact is emitted.
+
+    Normalizes both sides (the golden may be stored normalized already — the
+    projection is idempotent), prints a concise diff summary to stderr, and
+    elevates a successful run to exit code ``1`` on any regression. Existing
+    non-zero exit codes are preserved; a missing/unreadable golden is ``2``.
+    """
+    gate_path = getattr(args, "gate", None)
+    if not gate_path:
+        return exit_code
+    try:
+        golden_obj = json.loads(Path(gate_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"Error: cannot load golden artifact: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(golden_obj, dict):
+        print("Error: cannot load golden artifact: not a JSON object", file=sys.stderr)
+        return 2
+    report = gate_artifacts(
+        normalize_artifact(artifact.to_dict()), normalize_artifact(golden_obj)
+    )
+    print(format_gate_report(report, golden_path=str(gate_path)), file=sys.stderr)
+    if not report.ok and exit_code == 0:
+        return 1
+    return exit_code
 
 
 def _stamp_overrides(

--- a/src/rigplane/validation/__init__.py
+++ b/src/rigplane/validation/__init__.py
@@ -9,6 +9,12 @@ path that plans checks from a template without touching hardware.
 from __future__ import annotations
 
 from rigplane.validation.comparison import compute_comparison_dimensions
+from rigplane.validation.gating import (
+    GateReport,
+    format_gate_report,
+    gate_artifacts,
+    normalize_artifact,
+)
 from rigplane.validation.hardware import execute_hardware_checks
 from rigplane.validation.overrides import (
     EXCLUDED,
@@ -74,6 +80,10 @@ __all__ = [
     "human_summary",
     "execute_hardware_checks",
     "compute_comparison_dimensions",
+    "GateReport",
+    "format_gate_report",
+    "gate_artifacts",
+    "normalize_artifact",
     "EXCLUDED",
     "OverrideEntry",
     "OverridePatch",

--- a/src/rigplane/validation/gating.py
+++ b/src/rigplane/validation/gating.py
@@ -1,0 +1,222 @@
+"""Golden-gate normalization and regression gating for validation artifacts.
+
+A raw ``ValidationArtifact`` is volatile: every run differs in
+``core_version``/``core_commit``, ``generated_at``, per-check timestamps,
+evidence payloads, and the transport endpoint. :func:`normalize_artifact`
+projects an artifact dict down to its STABLE, status-only comparison key —
+``(check_id, status, declaration, failure_domain)`` rows plus the radio
+identity — so two equivalent runs serialize identically and a committed
+"golden" can be diffed without spurious noise.
+
+:func:`gate_artifacts` compares a current artifact against a golden one and
+classifies every difference as a blocking regression (a check that
+disappeared, entered fail/blocked, left pass, or drifted in declaration /
+failure domain) or a non-blocking improvement/addition.
+
+Like :mod:`rigplane.validation.comparison`, this module operates entirely on
+plain ``dict`` objects (the output of ``ValidationArtifact.to_dict()`` or a
+JSON-loaded equivalent) and imports only ``rigplane.validation.schema`` enums
+and stdlib — no backends, no CLI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rigplane.validation.schema import CheckStatus
+
+_PASS = CheckStatus.PASS.value
+_FAILING_STATUSES: frozenset[str] = frozenset(
+    {CheckStatus.FAIL.value, CheckStatus.BLOCKED.value}
+)
+
+# The stable per-check key fields, in output order.
+_KEY_FIELDS = ("status", "declaration", "failure_domain")
+
+
+def _normalized_rows(artifact: dict[str, object]) -> list[dict[str, object]]:
+    """Collect the stable per-check rows from a raw OR normalized artifact dict.
+
+    Raw artifacts carry ``levels[*].checks[*]``; normalized ones carry a flat
+    ``checks`` list. Malformed entries are skipped defensively (mirroring
+    ``comparison._index``) so callers never raise on partial data.
+    """
+    raw_checks: list[object] = []
+    levels_obj = artifact.get("levels")
+    if isinstance(levels_obj, list):
+        for level in levels_obj:
+            if isinstance(level, dict):
+                checks_obj = level.get("checks")
+                if isinstance(checks_obj, list):
+                    raw_checks.extend(checks_obj)
+    else:
+        checks_obj = artifact.get("checks")
+        if isinstance(checks_obj, list):
+            raw_checks.extend(checks_obj)
+
+    rows: list[dict[str, object]] = []
+    for check in raw_checks:
+        if not isinstance(check, dict):
+            continue
+        check_id = check.get("check_id")
+        if not isinstance(check_id, str) or not check_id:
+            continue
+        row: dict[str, object] = {"check_id": check_id}
+        for field_name in _KEY_FIELDS:
+            value = check.get(field_name)
+            if value is not None:
+                row[field_name] = value
+        rows.append(row)
+    rows.sort(key=lambda row: str(row["check_id"]))
+    return rows
+
+
+def normalize_artifact(artifact: dict[str, object]) -> dict[str, object]:
+    """Project *artifact* down to its stable, status-only comparison key.
+
+    Keeps the radio identity, mode, and per-check
+    ``(check_id, status, declaration, failure_domain)`` rows sorted by
+    ``check_id``. Strips everything volatile: core version/commit, timestamps
+    and durations, evidence, summaries, and the transport endpoint.
+
+    Idempotent: normalizing an already-normalized dict is a no-op, so goldens
+    stored normalized on disk can be fed back through this function safely.
+    """
+    radio: dict[str, object] = {}
+    radio_obj = artifact.get("radio")
+    if isinstance(radio_obj, dict):
+        radio = {
+            "model": radio_obj.get("model"),
+            "profile_id": radio_obj.get("profile_id"),
+        }
+    return {
+        "schema_version": artifact.get("schema_version"),
+        "radio": radio,
+        "mode": artifact.get("mode"),
+        "checks": _normalized_rows(artifact),
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class GateReport:
+    """Outcome of gating a current artifact against a golden one."""
+
+    regressions: list[str]
+    improvements: list[str]
+    additions: list[str]
+    matched: int
+
+    @property
+    def ok(self) -> bool:
+        """True when no blocking regression was found."""
+        return not self.regressions
+
+
+def _row_key(row: dict[str, object]) -> tuple[object, ...]:
+    return tuple(row.get(field_name) for field_name in _KEY_FIELDS)
+
+
+def gate_artifacts(current: dict[str, object], golden: dict[str, object]) -> GateReport:
+    """Diff *current* against *golden* on the normalized comparison key.
+
+    Both inputs may be raw ``ValidationArtifact.to_dict()`` dicts or
+    already-normalized dicts; each is normalized first.
+
+    Blocking regressions:
+
+    * a check present in the golden but missing from the current run;
+    * a check (new or existing) whose current status is fail/blocked when the
+      golden did not record it as such;
+    * a check that left ``pass`` for any other status;
+    * declaration or failure-domain drift on a check that did not improve to
+      ``pass``.
+
+    Non-blocking:
+
+    * ``improvements`` — a previously non-passing check now passes (regen the
+      golden to adopt);
+    * ``additions`` — a new, non-failing check absent from the golden.
+    """
+    current_idx = {str(row["check_id"]): row for row in _normalized_rows(current)}
+    golden_idx = {str(row["check_id"]): row for row in _normalized_rows(golden)}
+
+    regressions: list[str] = []
+    improvements: list[str] = []
+    additions: list[str] = []
+    matched = 0
+
+    for check_id in sorted(set(current_idx) | set(golden_idx)):
+        cur = current_idx.get(check_id)
+        gold = golden_idx.get(check_id)
+
+        if cur is None:
+            golden_status = None if gold is None else gold.get("status")
+            regressions.append(
+                f"{check_id}: missing from current run "
+                f"(golden status {golden_status!r})"
+            )
+            continue
+        if gold is None:
+            if cur.get("status") in _FAILING_STATUSES:
+                regressions.append(
+                    f"{check_id}: new check with status {cur.get('status')!r}"
+                )
+            else:
+                additions.append(
+                    f"{check_id}: new check with status {cur.get('status')!r}"
+                )
+            continue
+        if _row_key(cur) == _row_key(gold):
+            matched += 1
+            continue
+
+        changes = ", ".join(
+            f"{field_name} {gold.get(field_name)!r} -> {cur.get(field_name)!r}"
+            for field_name in _KEY_FIELDS
+            if gold.get(field_name) != cur.get(field_name)
+        )
+        is_improvement = (
+            cur.get("status") == _PASS
+            and gold.get("status") != _PASS
+            and cur.get("declaration") == gold.get("declaration")
+        )
+        if is_improvement:
+            improvements.append(f"{check_id}: {changes}")
+        else:
+            regressions.append(f"{check_id}: {changes}")
+
+    return GateReport(
+        regressions=regressions,
+        improvements=improvements,
+        additions=additions,
+        matched=matched,
+    )
+
+
+def format_gate_report(report: GateReport, *, golden_path: str) -> str:
+    """Render a concise human-readable gate summary."""
+    lines: list[str] = []
+    verdict = "PASS" if report.ok else "FAIL"
+    lines.append(
+        f"Golden gate: {verdict} vs {golden_path} "
+        f"({report.matched} check(s) match, "
+        f"{len(report.regressions)} regression(s))"
+    )
+    if report.regressions:
+        lines.append("Regressions:")
+        lines.extend(f"  - {item}" for item in report.regressions)
+    if report.improvements:
+        lines.append("Improvements (regen the golden to adopt):")
+        lines.extend(f"  - {item}" for item in report.improvements)
+    if report.additions:
+        lines.append("New checks (regen the golden to adopt):")
+        lines.extend(f"  - {item}" for item in report.additions)
+    return "\n".join(lines)
+
+
+__all__ = [
+    "GateReport",
+    "format_gate_report",
+    "gate_artifacts",
+    "normalize_artifact",
+]

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -1,0 +1,272 @@
+{
+  "schema_version": 1,
+  "radio": {
+    "model": "IC-7610",
+    "profile_id": "icom_ic7610"
+  },
+  "mode": "dry-run",
+  "checks": [
+    {
+      "check_id": "af_level.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "agc.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "antenna.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "apf.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "attenuator.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "audio.rx",
+      "status": "manual_required",
+      "declaration": "manual_required"
+    },
+    {
+      "check_id": "band_edge.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "break_in.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "bsr.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "compressor.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "cw.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "data_mode.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "dial_lock.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "digisel.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "discovery.identify",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "drive_gain.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "dual_rx.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "dual_watch.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "filter_shape.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "filter_width.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "freq.reverse_sync",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "freq.write",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "ip_plus.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "lan_dual_rx_audio_routing.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "main_sub_tracking.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "meters.read",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "mode.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "monitor.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "nb.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "notch.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "nr.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "pbt.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "power_control.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "preamp.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "repeater_tone.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "rf_gain.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "rit.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "rx_antenna.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scan.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope.capture",
+      "status": "manual_required",
+      "declaration": "manual_required"
+    },
+    {
+      "check_id": "split.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "squelch.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "ssb_tx_bw.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "system_settings.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "tsql.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "tuner.tune",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "tuning_step.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "twin_peak.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "tx.ptt",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "vox.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "xfc.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "xit.set",
+      "status": "skip",
+      "declaration": "supported"
+    }
+  ]
+}

--- a/tests/test_validation_gating.py
+++ b/tests/test_validation_gating.py
@@ -10,7 +10,9 @@ Covers the pure layer (``rigplane.validation.gating``) and its CLI wiring in
 * ``gate_artifacts`` classifies regressions (pass->fail, new failing check,
   missing check, declaration drift) vs non-blocking improvements/additions;
 * ``rigplane validate --gate`` exits 0 against a matching golden and 1 on a
-  regression.
+  regression; ``--regen-golden`` writes the normalized artifact;
+* the committed IC-7610 dry-run golden (``tests/golden/validation/``) matches
+  the live generated matrix and gates clean.
 
 All tests are dry-run / no-hardware and use the REAL schema dataclasses
 (MagicMock hides signature bugs).
@@ -44,6 +46,14 @@ from rigplane.validation.schema import (
 )
 
 MODEL = "IC-7610"
+
+_GOLDEN_FIXTURE = (
+    Path(__file__).resolve().parent / "golden" / "validation" / "ic7610.dry-run.json"
+)
+_REGEN_COMMAND = (
+    "uv run rigplane --model IC-7610 validate --dry-run "
+    "--regen-golden tests/golden/validation/ic7610.dry-run.json"
+)
 
 
 def _make_artifact(
@@ -323,3 +333,75 @@ def test_cli_gate_missing_golden_exits_two(tmp_path: Path, capsys: Any) -> None:
     )
     assert rc == 2
     assert "cannot load golden" in err
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring: --regen-golden
+# ---------------------------------------------------------------------------
+
+
+def test_cli_regen_golden_writes_normalized_artifact(
+    tmp_path: Path, capsys: Any
+) -> None:
+    golden = tmp_path / "nested" / "golden.json"
+    rc, _out, err = _run_validate(
+        ["--model", MODEL, "validate", "--dry-run", "--regen-golden", str(golden)],
+        capsys,
+    )
+    assert rc == 0
+    assert "Golden written to" in err
+    data = json.loads(golden.read_text(encoding="utf-8"))
+    assert "levels" not in data
+    assert "core_version" not in data
+    assert "transport" not in data
+    assert data["mode"] == "dry-run"
+    assert data["radio"] == {"model": MODEL, "profile_id": "icom_ic7610"}
+    rows = data["checks"]
+    assert rows and all("check_id" in row and "status" in row for row in rows)
+
+
+def test_cli_regen_then_gate_round_trips(tmp_path: Path, capsys: Any) -> None:
+    """A freshly regenerated golden gates its own dry-run clean (exit 0)."""
+    golden = tmp_path / "golden.json"
+    rc, _out, _err = _run_validate(
+        ["--model", MODEL, "validate", "--dry-run", "--regen-golden", str(golden)],
+        capsys,
+    )
+    assert rc == 0
+    rc, _out, err = _run_validate(
+        ["--model", MODEL, "validate", "--dry-run", "--gate", str(golden)],
+        capsys,
+    )
+    assert rc == 0
+    assert "PASS" in err
+
+
+# ---------------------------------------------------------------------------
+# Committed IC-7610 dry-run golden fixture
+# ---------------------------------------------------------------------------
+
+
+def test_committed_ic7610_golden_matches_live_dry_run(capsys: Any) -> None:
+    """The committed golden equals the live normalized dry-run output exactly.
+
+    Regenerate after an intentional matrix change with::
+
+        uv run rigplane --model IC-7610 validate --dry-run \
+          --regen-golden tests/golden/validation/ic7610.dry-run.json
+    """
+    rc, out, _err = _run_validate(
+        ["--model", MODEL, "validate", "--dry-run", "--json"], capsys
+    )
+    assert rc == 0
+    live = normalize_artifact(json.loads(out))
+    committed = json.loads(_GOLDEN_FIXTURE.read_text(encoding="utf-8"))
+    assert live == committed, f"Golden fixture is stale; regen: {_REGEN_COMMAND}"
+
+
+def test_cli_gate_against_committed_golden_exits_zero(capsys: Any) -> None:
+    rc, _out, err = _run_validate(
+        ["--model", MODEL, "validate", "--dry-run", "--gate", str(_GOLDEN_FIXTURE)],
+        capsys,
+    )
+    assert rc == 0
+    assert "PASS" in err

--- a/tests/test_validation_gating.py
+++ b/tests/test_validation_gating.py
@@ -1,0 +1,325 @@
+"""Tests for golden-gate normalization and regression gating (validation).
+
+Covers the pure layer (``rigplane.validation.gating``) and its CLI wiring in
+``rigplane.cli._validate``:
+
+* ``normalize_artifact`` strips volatile fields (core version/commit,
+  timestamps, transport endpoint, evidence) so two runs that only differ in
+  those produce IDENTICAL normalized keys, while a status change produces a
+  different key;
+* ``gate_artifacts`` classifies regressions (pass->fail, new failing check,
+  missing check, declaration drift) vs non-blocking improvements/additions;
+* ``rigplane validate --gate`` exits 0 against a matching golden and 1 on a
+  regression.
+
+All tests are dry-run / no-hardware and use the REAL schema dataclasses
+(MagicMock hides signature bugs).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+from rigplane.cli import _build_parser, _validate
+from rigplane.validation.gating import (
+    GateReport,
+    format_gate_report,
+    gate_artifacts,
+    normalize_artifact,
+)
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CheckResult,
+    CheckStatus,
+    FailureDomain,
+    LevelResult,
+    OperatorSafetyBlock,
+    RadioTarget,
+    TransportInfo,
+    ValidationArtifact,
+    ValidationLevel,
+)
+
+MODEL = "IC-7610"
+
+
+def _make_artifact(
+    *,
+    checks: list[CheckResult],
+    core_version: str = "2.9.0",
+    core_commit: str | None = "abc123",
+    generated_at: str | None = "2026-06-10T00:00:00.000Z",
+    host: str | None = "192.168.55.40",
+    port: int | None = 50001,
+) -> ValidationArtifact:
+    """Build a real ``ValidationArtifact`` around *checks* (single level)."""
+    return ValidationArtifact(
+        radio=RadioTarget(model=MODEL, profile_id="icom_ic7610"),
+        transport=TransportInfo(backend="udp", host=host, port=port),
+        safety=OperatorSafetyBlock(),
+        levels=[LevelResult(level=ValidationLevel.BASIC_CONTROL, checks=checks)],
+        core_version=core_version,
+        core_commit=core_commit,
+        generated_at=generated_at,
+    )
+
+
+def _check(
+    check_id: str = "freq.set",
+    status: CheckStatus = CheckStatus.PASS,
+    declaration: CapabilityDeclaration = CapabilityDeclaration.SUPPORTED,
+    failure_domain: FailureDomain | None = None,
+    **kwargs: Any,
+) -> CheckResult:
+    return CheckResult(
+        check_id=check_id,
+        capability="freq",
+        level=ValidationLevel.BASIC_CONTROL,
+        status=status,
+        declaration=declaration,
+        summary="Set frequency and read it back.",
+        failure_domain=failure_domain,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# normalize_artifact
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_strips_volatile_fields() -> None:
+    """Two artifacts differing ONLY in volatile fields normalize identically."""
+    a = _make_artifact(
+        checks=[_check(started_at="2026-06-10T00:00:00Z", evidence={"raw": "fe"})]
+    )
+    b = _make_artifact(
+        checks=[_check(started_at="2026-06-11T09:30:00Z", evidence={"raw": "fd"})],
+        core_version="2.10.0",
+        core_commit="def456",
+        generated_at="2026-06-11T09:30:01.000Z",
+        host="127.0.0.1",
+        port=4532,
+    )
+    assert normalize_artifact(a.to_dict()) == normalize_artifact(b.to_dict())
+
+
+def test_normalize_differs_on_status_change() -> None:
+    """A status flip survives normalization (it is the comparison key)."""
+    a = _make_artifact(checks=[_check(status=CheckStatus.PASS)])
+    b = _make_artifact(
+        checks=[
+            _check(
+                status=CheckStatus.FAIL,
+                failure_domain=FailureDomain.COMMAND_EXECUTION,
+            )
+        ]
+    )
+    assert normalize_artifact(a.to_dict()) != normalize_artifact(b.to_dict())
+
+
+def test_normalize_keeps_stable_key_fields_and_sorts() -> None:
+    """Normalized rows carry exactly the stable key fields, sorted by check_id."""
+    artifact = _make_artifact(
+        checks=[
+            _check(check_id="mode.set"),
+            _check(
+                check_id="freq.set",
+                status=CheckStatus.BLOCKED,
+                failure_domain=FailureDomain.COMMAND_EXECUTION,
+            ),
+        ]
+    )
+    normalized = normalize_artifact(artifact.to_dict())
+    assert normalized["radio"] == {"model": MODEL, "profile_id": "icom_ic7610"}
+    assert "transport" not in normalized
+    assert "core_version" not in normalized
+    assert "generated_at" not in normalized
+    rows = normalized["checks"]
+    assert isinstance(rows, list)
+    assert [row["check_id"] for row in rows] == ["freq.set", "mode.set"]
+    assert rows[0] == {
+        "check_id": "freq.set",
+        "status": "blocked",
+        "declaration": "supported",
+        "failure_domain": "command_execution",
+    }
+    assert rows[1] == {
+        "check_id": "mode.set",
+        "status": "pass",
+        "declaration": "supported",
+    }
+
+
+def test_normalize_is_idempotent() -> None:
+    """Normalizing an already-normalized dict is a no-op (goldens are stored
+    normalized, so the gate must accept both shapes)."""
+    normalized = normalize_artifact(_make_artifact(checks=[_check()]).to_dict())
+    assert normalize_artifact(normalized) == normalized
+
+
+# ---------------------------------------------------------------------------
+# gate_artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_gate_identical_artifacts_ok() -> None:
+    artifact = _make_artifact(checks=[_check()]).to_dict()
+    report = gate_artifacts(artifact, copy.deepcopy(artifact))
+    assert isinstance(report, GateReport)
+    assert report.ok
+    assert report.regressions == []
+    assert report.matched == 1
+
+
+def test_gate_pass_to_fail_is_regression() -> None:
+    golden = _make_artifact(checks=[_check(status=CheckStatus.PASS)]).to_dict()
+    current = _make_artifact(
+        checks=[
+            _check(
+                status=CheckStatus.FAIL,
+                failure_domain=FailureDomain.COMMAND_EXECUTION,
+            )
+        ]
+    ).to_dict()
+    report = gate_artifacts(current, golden)
+    assert not report.ok
+    assert any("freq.set" in line and "fail" in line for line in report.regressions)
+
+
+def test_gate_missing_check_is_regression() -> None:
+    golden = _make_artifact(
+        checks=[_check(check_id="freq.set"), _check(check_id="mode.set")]
+    ).to_dict()
+    current = _make_artifact(checks=[_check(check_id="freq.set")]).to_dict()
+    report = gate_artifacts(current, golden)
+    assert not report.ok
+    assert any("mode.set" in line and "missing" in line for line in report.regressions)
+
+
+def test_gate_new_failing_check_is_regression_but_new_pass_is_addition() -> None:
+    golden = _make_artifact(checks=[_check(check_id="freq.set")]).to_dict()
+    current = _make_artifact(
+        checks=[
+            _check(check_id="freq.set"),
+            _check(
+                check_id="mode.set",
+                status=CheckStatus.FAIL,
+                failure_domain=FailureDomain.READBACK,
+            ),
+            _check(check_id="ptt.set", status=CheckStatus.PASS),
+        ]
+    ).to_dict()
+    report = gate_artifacts(current, golden)
+    assert not report.ok
+    assert any("mode.set" in line for line in report.regressions)
+    assert any("ptt.set" in line for line in report.additions)
+    assert not any("ptt.set" in line for line in report.regressions)
+
+
+def test_gate_declaration_drift_is_regression() -> None:
+    golden = _make_artifact(checks=[_check()]).to_dict()
+    current = _make_artifact(
+        checks=[_check(declaration=CapabilityDeclaration.MANUAL_REQUIRED)]
+    ).to_dict()
+    report = gate_artifacts(current, golden)
+    assert not report.ok
+    assert any("declaration" in line for line in report.regressions)
+
+
+def test_gate_fail_to_pass_is_nonblocking_improvement() -> None:
+    golden = _make_artifact(
+        checks=[
+            _check(
+                status=CheckStatus.FAIL,
+                failure_domain=FailureDomain.COMMAND_EXECUTION,
+            )
+        ]
+    ).to_dict()
+    current = _make_artifact(checks=[_check(status=CheckStatus.PASS)]).to_dict()
+    report = gate_artifacts(current, golden)
+    assert report.ok
+    assert any("freq.set" in line for line in report.improvements)
+
+
+def test_format_gate_report_mentions_verdict() -> None:
+    artifact = _make_artifact(checks=[_check()]).to_dict()
+    ok_text = format_gate_report(
+        gate_artifacts(artifact, copy.deepcopy(artifact)), golden_path="g.json"
+    )
+    assert "PASS" in ok_text
+    bad = gate_artifacts(_make_artifact(checks=[]).to_dict(), copy.deepcopy(artifact))
+    fail_text = format_gate_report(bad, golden_path="g.json")
+    assert "FAIL" in fail_text
+    assert "freq.set" in fail_text
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring: --gate (dry-run, no hardware)
+# ---------------------------------------------------------------------------
+
+
+def _parse(argv: list[str]) -> Any:
+    return _build_parser().parse_args(argv)
+
+
+def _run_validate(argv: list[str], capsys: Any) -> tuple[int, str, str]:
+    rc = _validate.run(_parse(argv))
+    captured = capsys.readouterr()
+    return rc, captured.out, captured.err
+
+
+def _write_dry_run_golden(path: Path, capsys: Any) -> dict[str, Any]:
+    """Run a dry-run, normalize the JSON artifact, write it to *path*."""
+    rc, out, _err = _run_validate(
+        ["--model", MODEL, "validate", "--dry-run", "--json"], capsys
+    )
+    assert rc == 0
+    normalized = normalize_artifact(json.loads(out))
+    path.write_text(json.dumps(normalized, indent=2) + "\n", encoding="utf-8")
+    return normalized
+
+
+def test_cli_gate_against_own_golden_exits_zero(tmp_path: Path, capsys: Any) -> None:
+    golden = tmp_path / "golden.json"
+    _write_dry_run_golden(golden, capsys)
+    rc, _out, err = _run_validate(
+        ["--model", MODEL, "validate", "--dry-run", "--gate", str(golden)],
+        capsys,
+    )
+    assert rc == 0
+    assert "PASS" in err
+
+
+def test_cli_gate_detects_mutated_golden(tmp_path: Path, capsys: Any) -> None:
+    """Mutating one check's status in the golden makes the gate exit non-zero."""
+    golden = tmp_path / "golden.json"
+    data = _write_dry_run_golden(golden, capsys)
+    # Claim a check passed in the golden; the dry-run can never satisfy that.
+    data["checks"][0]["status"] = "pass"
+    golden.write_text(json.dumps(data), encoding="utf-8")
+    rc, _out, err = _run_validate(
+        ["--model", MODEL, "validate", "--dry-run", "--gate", str(golden)],
+        capsys,
+    )
+    assert rc == 1
+    assert "FAIL" in err
+
+
+def test_cli_gate_missing_golden_exits_two(tmp_path: Path, capsys: Any) -> None:
+    rc, _out, err = _run_validate(
+        [
+            "--model",
+            MODEL,
+            "validate",
+            "--dry-run",
+            "--gate",
+            str(tmp_path / "nope.json"),
+        ],
+        capsys,
+    )
+    assert rc == 2
+    assert "cannot load golden" in err


### PR DESCRIPTION
## First vertical slice — golden-gate spine for the regression-validation harness

This is goal-1's spine: **registry → artifact → normalize → golden → gate exit codes**, dry-run only, **no hardware**. It reuses the existing `src/rigplane/validation/` subsystem (schema, registry, runner, comparison) and the `rigplane validate` CLI — no new layers, no registry split, no coverage growth.

### What the slice proves
- **Normalization is the load-bearing piece.** `rigplane.validation.gating.normalize_artifact` projects a `ValidationArtifact` dict down to a stable, status-only comparison key: per-check `(check_id, status, declaration, failure_domain)` rows (sorted) plus radio identity and mode. It strips every volatile field — `core_version`, `core_commit`, `generated_at`/timestamps, evidence, summaries, and the transport host/port — so two equivalent runs serialize byte-identical and goldens never diff spuriously. The projection is idempotent (goldens are stored normalized).
- **Gating classifies regressions vs noise.** `gate_artifacts` diffs current vs golden on that key. **Blocking regressions:** a check missing from the current run, a check that went `pass`→anything, a new `fail`/`blocked` check, or declaration/failure-domain drift. **Non-blocking:** improvements (now-`pass`) and new non-failing checks — both nudge you to regen the golden.
- **Exit codes.** `rigplane validate --gate <golden.json>` prints a concise diff summary to stderr and exits **1** on any regression, **0** otherwise, **2** if the golden is missing/unreadable. Wired at all three emit sites (dry-run, single-provider hardware, both) without refactoring the command; existing non-zero exit codes are preserved.
- **Golden regen + first fixture.** `rigplane validate --regen-golden <path>` writes the normalized artifact (creating parent dirs). The committed `tests/golden/validation/ic7610.dry-run.json` (52 checks) is generated from the live profile-driven matrix, and a test pins it to the live normalized dry-run so it can never silently drift.

### How to regen the golden
```
uv run rigplane --model IC-7610 validate --dry-run \
  --regen-golden tests/golden/validation/ic7610.dry-run.json
```
The fixture test fails with this exact command in its message if the matrix changes.

### Deliberately out of scope
- No hardware run (dry-run path only; the `--hardware` double-gate is untouched).
- No registry split (that is task T0) and no new check rows / coverage growth.
- No changes to the audio byte path, transport, protocol, or `registry.py`.

### Verification (all green)
- `uv run pytest tests/ --ignore=tests/integration` → 7658 passed, 0 failures
- `uv run ruff check` / `ruff format --check` → clean
- `uv run mypy src/` → Success: no issues found
- `uv run lint-imports` → 4 contracts kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
