### PR TITLE
test(#MOR-590): fix 3.11 CI-V-timeout + serial RX failures (B3 + serial B4)

### DIFF
--- a/tests/test_icom_receiver_tier.py
+++ b/tests/test_icom_receiver_tier.py
@@ -308,10 +308,16 @@ class TestSetVfoSlot:
     async def test_ic7610_sub_uses_select_restore_pattern(
         self, ic7610: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        # Dual-RX SUB path: select SUB → emit slot → restore MAIN. Two
-        # set_vfo() calls need ACKs.
-        mock_transport.queue_response(ACK_IC7610)
-        mock_transport.queue_response(ACK_IC7610)
+        # Dual-RX SUB path: select SUB → emit slot → restore MAIN.
+        # Release each ACK only after its own send (1=select SUB, 2=slot
+        # fire-and-forget, 3=restore MAIN). Pre-queueing ACKs upfront lets the
+        # rx pump race them into the wrong consumer (fire-and-forget ACK sink
+        # vs restore waiter); the race winner differs between 3.11 and 3.12+
+        # because pre-3.12 asyncio.wait_for wraps the awaitable in an extra
+        # Task (gh-96764), changing scheduling order.
+        mock_transport.queue_response_on_send(1, ACK_IC7610)
+        mock_transport.queue_response_on_send(2, ACK_IC7610)
+        mock_transport.queue_response_on_send(3, ACK_IC7610)
         await ic7610.set_vfo_slot("B", receiver=1)
         frames = _civ_bytes(mock_transport.sent_packets)
         sel_idx = next((i for i, f in enumerate(frames) if f == SEL_SUB_7610), None)
@@ -340,8 +346,11 @@ class TestSetVfoSlot:
     async def test_ic9700_sub_uses_select_restore_pattern(
         self, ic9700: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        mock_transport.queue_response(ACK_IC9700)
-        mock_transport.queue_response(ACK_IC9700)
+        # Per-send ACK release — see test_ic7610_sub_uses_select_restore_
+        # pattern for the 3.11-vs-3.12+ scheduling rationale.
+        mock_transport.queue_response_on_send(1, ACK_IC9700)
+        mock_transport.queue_response_on_send(2, ACK_IC9700)
+        mock_transport.queue_response_on_send(3, ACK_IC9700)
         await ic9700.set_vfo_slot("A", receiver=1)
         frames = _civ_bytes(mock_transport.sent_packets)
         assert SEL_SUB_9700 in frames

--- a/tests/test_per_receiver_vfo_roundtrip.py
+++ b/tests/test_per_receiver_vfo_roundtrip.py
@@ -111,10 +111,16 @@ class TestPerReceiverFreq:
     async def test_ic7610_set_freq_sub_uses_fallback_select_restore(
         self, ic7610: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        # Fallback path: set_vfo("SUB") → set_freq → set_vfo("MAIN"); two
-        # set_vfo calls each await an ACK.
-        mock_transport.queue_response(ACK_IC7610)
-        mock_transport.queue_response(ACK_IC7610)
+        # Fallback path: set_vfo("SUB") → set_freq → set_vfo("MAIN").
+        # Release each ACK only after its own send (1=select SUB, 2=set-freq
+        # fire-and-forget, 3=restore MAIN). Pre-queueing ACKs upfront lets the
+        # rx pump race them into the wrong consumer (fire-and-forget ACK sink
+        # vs restore waiter); the race winner differs between 3.11 and 3.12+
+        # because pre-3.12 asyncio.wait_for wraps the awaitable in an extra
+        # Task (gh-96764), changing scheduling order.
+        mock_transport.queue_response_on_send(1, ACK_IC7610)
+        mock_transport.queue_response_on_send(2, ACK_IC7610)
+        mock_transport.queue_response_on_send(3, ACK_IC7610)
         await ic7610.set_freq(7_074_000, receiver=1)
         frames = _civ_bytes(mock_transport.sent_packets)
         # Expect: select SUB → 0x05 set-freq → restore MAIN.
@@ -173,8 +179,11 @@ class TestPerReceiverMode:
     async def test_ic7610_set_mode_sub_uses_fallback(
         self, ic7610: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        mock_transport.queue_response(ACK_IC7610)
-        mock_transport.queue_response(ACK_IC7610)
+        # Per-send ACK release — see test_ic7610_set_freq_sub_uses_fallback_
+        # select_restore for the 3.11-vs-3.12+ scheduling rationale.
+        mock_transport.queue_response_on_send(1, ACK_IC7610)
+        mock_transport.queue_response_on_send(2, ACK_IC7610)
+        mock_transport.queue_response_on_send(3, ACK_IC7610)
         await ic7610.set_mode(Mode.LSB, receiver=1)
         frames = _civ_bytes(mock_transport.sent_packets)
         sel_idx = next((i for i, f in enumerate(frames) if f == SEL_SUB), None)

--- a/tests/test_serial_backend_smoke.py
+++ b/tests/test_serial_backend_smoke.py
@@ -141,6 +141,19 @@ def _addr_from_asyncio_server(server: asyncio.Server) -> tuple[str, int]:
     return server.sockets[0].getsockname()
 
 
+async def _yield_until(predicate, timeout: float = 1.0) -> None:  # type: ignore[no-untyped-def]
+    """Yield to the event loop until ``predicate()`` is truthy (or timeout).
+
+    A fixed number of ``asyncio.sleep(0)`` yields is interpreter-sensitive:
+    pre-3.12 ``asyncio.wait_for`` wraps its awaitable in an extra Task
+    (gh-96764), so frame propagation through AudioBus → bridge loops needs
+    more event-loop iterations on 3.11 than on 3.12+.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate() and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0)
+
+
 async def _http_get(
     host: str, port: int, path: str
 ) -> tuple[int, dict[str, str], bytes]:
@@ -417,9 +430,11 @@ async def test_audio_bridge_smoke_with_serial_backend_audio_driver() -> None:
         # Yield once so _rx_loop and _tx_loop tasks actually start running.
         await asyncio.sleep(0)
 
-        # RX path: serial driver → AudioBus → _rx_loop → FakeTxStream
+        # RX path: serial driver → AudioBus → _rx_loop → FakeTxStream.
+        # _yield_until: the number of event-loop hops differs across Python
+        # versions (see helper docstring), so poll instead of a fixed yield.
         serial_audio.emit_rx_pcm(b"\x10\x20" * 960)
-        await asyncio.sleep(0)  # let _rx_loop process the queued packet
+        await _yield_until(lambda: backend.tx_streams[0].written_frames)
         assert backend.tx_streams[0].written_frames, (
             "RX frame did not reach bridge output"
         )
@@ -428,10 +443,9 @@ async def test_audio_bridge_smoke_with_serial_backend_audio_driver() -> None:
         # PCM value 100 (> silence threshold of 10) so it is not filtered.
         pcm_tx = bytes([0, 100] * 960)  # 960 int16 samples, each = 0x6400 = 25600
         backend.rx_streams[0].inject_frame(pcm_tx)
-        # inject_frame calls _on_tx_capture via call_soon_threadsafe; need two
-        # yields: one to run _enqueue_tx, one to let _tx_loop process the frame.
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        # inject_frame calls _on_tx_capture via call_soon_threadsafe, then
+        # _tx_loop must process the queued frame — again hop-count-sensitive.
+        await _yield_until(lambda: serial_audio.tx_frames)
         assert serial_audio.tx_frames, "TX frame did not reach radio"
 
         await bridge.stop()


### PR DESCRIPTION
## Summary

Fixes the Python-3.11-only failures in the CI-V-timeout cluster (MOR-632 / MOR-590-B3) and the `test_serial_backend_smoke.py` half of MOR-650 (B4). Test-only changes — no `src/` modifications were needed.

## Root cause (common mechanism, verified per cluster)

Both clusters are downstream of the same interpreter delta: **pre-3.12 `asyncio.wait_for` wraps its awaitable in an extra `Task`** (rewritten in 3.12 via gh-96764 to await inside `asyncio.timeout`). The extra scheduling hop changes task interleaving on 3.11 versus 3.13.

**This is NOT the B1 (#1800) runtime-Protocol/Mock mechanism.** That was explicitly checked: all test doubles here are real classes (`MockTransport` in `tests/test_radio.py`, `FakeAudioBackend`, `_FakeUsbAudioDriver`, `_FakeSerialCivLink`) — no `MagicMock`/`AsyncMock` is involved, so the 3.11 `hasattr`-based `runtime_checkable` `isinstance` delta (gh-102433) cannot steer any code path. Both failures are genuine async-interleaving test fragility.

## Cluster 1 — CI-V timeout (`test_per_receiver_vfo_roundtrip.py`, `test_icom_receiver_tier.py`)

The select-SUB → op → restore-MAIN fallback tests pre-queued **both** ACKs into `MockTransport` upfront. The CI-V rx pump (`_civ_rx_loop`) then races delivery of the second ACK between two consumers:

- the **fire-and-forget ACK sink** registered by the middle frame (`wait_response=False`, `_civ_rx.py:2698`), and
- the **restore-MAIN ACK waiter** (`_civ_rx.py:2733`).

Evidence from `--log-cli-level=DEBUG` runs of the same test on both interpreters:

- **3.13 (pass):** `Dropped 1 stale ACK sink waiter(s) before blocking command` — the orphan ACK landed in the tracker's ACK backlog (`core/civ.py:372`) before the sink registered; the restore attempt still timed out once and only the **retry** (`_dual_rx_runtime.py:144`) consumed the backlog entry. I.e. the test was marginal even on 3.13 (`set_vfo_slot: timeout restoring VFO receiver to MAIN, retrying once` appears in the *passing* run).
- **3.11 (fail):** no `Dropped … sink` line — the sink registered first (slower pump wake-up due to the extra `wait_for` Task hop) and swallowed the second ACK; both restore attempts then timed out → `rigplane.core.exceptions.TimeoutError: CI-V response timed out`.

**Fix:** release each ACK only after its corresponding send using the existing `MockTransport.queue_response_on_send()` helper (send 1 = select SUB, send 2 = fire-and-forget op frame, send 3 = restore MAIN). Delivery order is now deterministic on every interpreter, each consumer gets its own ACK, and the retry path is no longer load-bearing.

## Cluster 2 — serial smoke (`test_serial_backend_smoke.py::test_audio_bridge_smoke_with_serial_backend_audio_driver`)

Frame propagation runs serial driver → `AudioBus` → `AudioBridge._rx_loop` → `FakeTxStream`. `_rx_loop` iterates `AudioSubscription.__anext__`, which awaits `asyncio.wait_for(self._queue.get(), timeout=1.0)` (`audio/bus.py:270`). On 3.11 the extra Task hop means the test's single `await asyncio.sleep(0)` (and the TX path's two) is not enough event-loop iterations for the frame to arrive → empty `written_frames`.

**Fix:** replace the fixed yield counts with a bounded `_yield_until(predicate, timeout=1.0)` polling helper (local to the test file). The audio byte path itself is untouched and interpreter-correct.

## Verification (both interpreters)

| Check | 3.11 | 3.13 |
|---|---|---|
| Target 3 files (57 tests) | ✅ pass (×4 runs, no flake) | ✅ pass |
| Full suite (`--ignore=tests/integration`) | ✅ B3/B4 clusters gone; only known siblings remain: `test_rigctld_handler.py` (B1/#1800) and the B2 web/audio trio (`test_web_server*.py`, `test_security_headers.py`, `test_audio_rx_tx_transition.py`) — no new failures | ✅ 7608 passed, 0 failed |
| `ruff check` + `ruff format --check` | — | ✅ clean |
| `mypy src/` | — | ✅ Success, 267 files |
| `lint-imports` | — | ✅ 4 kept, 0 broken |

🤖 Generated with [Claude Code](https://claude.com/claude-code)