### PR TITLE
test(#MOR-590): fix 3.11 web-server + audio Protocol/async-mock failures (B2 + audio B4)

### DIFF
--- a/tests/test_audio_rx_tx_transition.py
+++ b/tests/test_audio_rx_tx_transition.py
@@ -374,7 +374,13 @@ class _SingleSlotAudioRadio:
 
     @property
     def audio_codec(self) -> Any:
-        return self.profile.audio_codec
+        # NOTE: must not raise. ``RadioProfile`` has no ``audio_codec``
+        # attribute, so returning ``self.profile.audio_codec`` raised
+        # AttributeError — invisible on Python 3.12+ where the AudioCapable
+        # isinstance() check uses inspect.getattr_static() (gh-102433), but
+        # fatal on 3.11 where the hasattr()-based check invokes this getter
+        # and the AttributeError makes the Protocol check fail.
+        return AudioCodec[self.profile.codec_preference[0]]
 
     @property
     def audio_sample_rate(self) -> int:

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -23,6 +23,14 @@ from rigplane.web.server import WebConfig, WebServer
 
 def _make_radio() -> MagicMock:
     radio = MagicMock(name="radio")
+    # Python 3.11 runtime-checkable Protocol isinstance() uses hasattr(), which
+    # a bare MagicMock always satisfies — start_web_server would then spawn the
+    # auto-generated MagicMock poller.start() as a coroutine (TypeError).
+    # Python 3.12+ uses inspect.getattr_static() (gh-102433) and is immune.
+    # Deleting the factory attrs makes both interpreters take the RadioPoller
+    # branch.
+    del radio.create_observation_poller
+    del radio.create_state_poller
     radio.connected = True
     radio.radio_ready = True
     radio.control_connected = True

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -255,6 +255,22 @@ async def _close_ws(writer: asyncio.StreamWriter) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _del_poller_factory_attrs(radio: MagicMock) -> MagicMock:
+    """Make a MagicMock radio fail ObservationPollable/StatePollable checks.
+
+    Python 3.11's runtime-checkable Protocol ``isinstance()`` uses
+    ``hasattr()``, which a bare MagicMock always satisfies, so
+    ``start_web_server`` would take the observation-poller branch and try to
+    spawn the auto-generated MagicMock ``poller.start()`` as a coroutine
+    (``TypeError: a coroutine was expected``). Python 3.12+ uses
+    ``inspect.getattr_static()`` (gh-102433) and is immune. Deleting the
+    factory attributes makes both interpreters take the RadioPoller branch.
+    """
+    del radio.create_observation_poller
+    del radio.create_state_poller
+    return radio
+
+
 def _add_scope_capable_attrs(radio: MagicMock) -> MagicMock:
     """Explicitly set all ScopeCapable protocol attrs on a MagicMock.
 
@@ -331,6 +347,7 @@ def mock_radio() -> MagicMock:
         "ip_plus",
     }
     _add_scope_capable_attrs(radio)
+    _del_poller_factory_attrs(radio)
     radio.get_freq = AsyncMock(return_value=14_074_000)
     radio.get_mode = AsyncMock(return_value=MagicMock(name="USB"))
     radio.get_mode.return_value.name = "USB"
@@ -2468,6 +2485,7 @@ class TestScopeEnableAtomic:
         config = WebConfig(host="127.0.0.1", port=0, keepalive_interval=9999.0)
         radio = MagicMock()
         _add_scope_capable_attrs(radio)
+        _del_poller_factory_attrs(radio)
         radio.connected = True
         radio.radio_ready = True
 

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -201,6 +201,18 @@ def _scope_radio(*, ready: bool = True, connected: bool = True) -> MagicMock:
 class _StateNotifyRadio(MagicMock):
     """Minimal mock that satisfies StateNotifyCapable so server registers callbacks."""
 
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        # Python 3.11 runtime-checkable Protocol isinstance() uses hasattr(),
+        # which the MagicMock base always satisfies — start_web_server would
+        # then take the observation-poller branch and spawn the auto-generated
+        # MagicMock poller.start() as a coroutine (TypeError). Python 3.12+
+        # uses inspect.getattr_static() (gh-102433) and is immune. Deleting
+        # the factory attrs makes both interpreters take the RadioPoller
+        # branch, which is what this fake's StateNotifyCapable methods test.
+        del self.create_observation_poller
+        del self.create_state_poller
+
     def set_state_change_callback(self, callback: object) -> None:
         self._state_change_callback = callback
 


### PR DESCRIPTION
## Linear

MOR-631 (MOR-590-B2: web-server cluster) + the `test_audio_rx_tx_transition.py` half of MOR-650 (B4). Sibling of #1800 (B1), same root-cause family.

## Diagnosis

On Python 3.11, `isinstance(obj, <runtime_checkable Protocol>)` uses `hasattr()`, which a bare `MagicMock` always satisfies. On 3.12+ (gh-102433) it uses `inspect.getattr_static()`, which does not trigger `Mock.__getattr__`, so the same mock fails the check. This makes 3.11 take a different branch than 3.13 in production glue — the failures were 3.11-only:

1. **`test_web_server.py` (30 errors/failures), `test_web_server_coverage.py` (2), `test_security_headers.py` (6)** — in `src/rigplane/web/web_startup.py:97`, the MagicMock radio falsely satisfies `ObservationPollable` on 3.11, so startup calls the auto-generated `radio.create_observation_poller()` and hands its MagicMock `.start()` to `WebServer._spawn` → `TypeError: a coroutine was expected`. On 3.13 the mock fails `ObservationPollable` *and* `StatePollable` (`web_startup.py:116`) and falls through to the `RadioPoller` branch (`web_startup.py:134`), which these tests were written against. (Deleting only `create_observation_poller` would just shift 3.11 onto the equally broken legacy `StatePollable` branch, hence both markers are removed.)

2. **`test_audio_rx_tx_transition.py` (1)** — the inverse direction: the real fake class `_SingleSlotAudioRadio` *should* satisfy `AudioCapable` but failed on 3.11. Its `audio_codec` property returned `self.profile.audio_codec`, and `RadioProfile` has no `audio_codec` attribute (it has `codec_preference`/`tx_codec`), so the getter raised `AttributeError`. 3.11's `hasattr`-based check invokes the getter → member missing → `isinstance` False; 3.13's `getattr_static` sees the property on the class without calling it → True. A latent bug in the fake, exposed only on 3.11.

## Fix (test layer only)

- `tests/test_web_server.py` — new `_del_poller_factory_attrs()` helper (B1's `make_mock_radio()` philosophy): `del radio.create_observation_poller` / `del radio.create_state_poller` so the mock fails both poller Protocols on both interpreters; applied in the `mock_radio` fixture and the one inline server-starting test.
- `tests/test_security_headers.py` — same two deletions in its local `_make_radio()`.
- `tests/test_web_server_coverage.py` — `_StateNotifyRadio.__init__` deletes the same two markers, so both interpreters reach the `StateNotifyCapable`/`RadioPoller` branch the fake is designed for.
- `tests/test_audio_rx_tx_transition.py` — `_SingleSlotAudioRadio.audio_codec` now returns `AudioCodec[self.profile.codec_preference[0]]` (a real enum value from the resolved IC-7610 profile) instead of raising.

**Production source untouched** — `git diff` is 4 test files, +45/−1.

## Verification

- 3.11 target files: `uv run --python 3.11 pytest tests/test_web_server.py tests/test_web_server_coverage.py tests/test_security_headers.py tests/test_audio_rx_tx_transition.py -q` → **294 passed, 2 skipped, 0 failed** (was 4 failed + 35 errors).
- 3.11 full suite (`--ignore=tests/integration`): the B2/audio clusters are gone; the only remaining failures are the known out-of-scope sibling clusters — `test_rigctld_handler.py` (B1, fixed in open #1800), `test_per_receiver_vfo_roundtrip.py` / `test_icom_receiver_tier.py` (B3), `test_serial_backend_smoke.py` (B4, other agent). No new failures introduced.
- 3.13 full suite: **7608 passed, 0 failed** — no regression.
- `ruff check` + `ruff format` clean, `mypy src/` Success, `lint-imports` 4 contracts kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)