### PR TITLE
ci(#MOR-590): pin CI test interpreter to 3.11 (quick) / matrix (full)

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
+    env:
+      # Pin uv to the matrix interpreter. Without this, `uv run` satisfies
+      # requires-python=">=3.11" with the newest interpreter on the runner
+      # (3.13), so every matrix job silently tested 3.13 (MOR-590).
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -34,6 +34,12 @@ jobs:
     # doc: rigplane-tower/docs/development/mac-mini-self-hosted-runners.md.
     runs-on: [self-hosted, linux, build]
     timeout-minutes: 10
+    env:
+      # Pin uv to the project's minimum Python. Without this, `uv run`
+      # satisfies requires-python=">=3.11" with the newest interpreter on
+      # the runner (3.13), so the "Python 3.11" job silently tested 3.13
+      # (MOR-590).
+      UV_PYTHON: "3.11"
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Why

CI workflows ran `uv python install <ver>` but never **pinned** the interpreter for the test step. With `requires-python = ">=3.11"`, `uv run` picks the newest interpreter installed on the runner (**3.13**). As a result:

- `quick.yml`'s job titled "Set up Python 3.11" actually ran the test suite under **3.13**.
- `full.yml`'s matrix jobs (3.11 / 3.12 / 3.13) **all** ran under 3.13.

So CI silently tested only 3.13 and **masked 136 real failures under Python 3.11** — the stated minimum supported version (MOR-590). Those 3.11 failures have now been fixed on `main` by **B1 (#1800)**, **B2 (#1803)**, **B3 (#1802)**, and **B4**, so it is now safe to make CI actually exercise 3.11.

## What changed

- **`quick.yml`** — added `env: UV_PYTHON: "3.11"` on the `quick` job. `uv run ruff`/`mypy`/`pytest` now run under 3.11, consistent with the `uv python install 3.11` step.
- **`full.yml`** — added `env: UV_PYTHON: ${{ matrix.python-version }}` on the matrix job, so each matrix leg genuinely tests its own interpreter (3.11, 3.12, 3.13).

No `.python-version` file was added — a repo-root `3.11` pin would override and collapse the full matrix to 3.11. Per-job `UV_PYTHON` keeps the matrix honest. No changes to triggers, job structure, caching, or any unrelated step.

## Proof

This PR's **own** `quick` check now runs under Python **3.11** — so a green `Tests (quick)` check on this PR is itself the proof that the pin works and that 3.11 is green.

Locally, the full suite under `uv run --python 3.11` (matching the pin) passes: **7669 passed, 8 skipped, 11 xfailed, 1 xpassed, 0 failed**.

## Merge note

Must merge only **after** B1–B4 are on `main` — they already are (this branch is cut from current `main` containing #1800, #1803, #1802). Otherwise the pin would turn `main` red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)