### PR TITLE
fix(#MOR-549): normalize ALSA device names so Linux USB-audio topology pairing matches

### DIFF
--- a/src/rigplane/audio/_usb_resolve.py
+++ b/src/rigplane/audio/_usb_resolve.py
@@ -82,6 +82,8 @@ import subprocess
 from dataclasses import dataclass
 from typing import Any
 
+from rigplane.audio.backend import _ALSA_HW_RE
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -817,6 +819,32 @@ def _read_sysfs_str(path: str) -> str | None:
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Trailing ALSA decoration PortAudio appends on Linux: " (hw:X,Y)" (or
+# "(plughw:X,Y)"). Anchored variant of backend._ALSA_HW_RE for suffix-stripping.
+_ALSA_NAME_SUFFIX_RE = re.compile(rf"\s*\({_ALSA_HW_RE.pattern}\)\s*$")
+
+
+def _normalize_alsa_device_name(name: str) -> str:
+    """Strip PortAudio's ALSA decoration down to the bare card name (MOR-549).
+
+    On Linux, ``sounddevice.query_devices()`` reports ALSA devices as
+    ``"<card>: <pcm> (hw:X,Y)"`` (e.g. ``"USB Audio CODEC: Audio (hw:2,0)"``),
+    while the sysfs ``product`` attribute — the topology identity key used by
+    :func:`_resolve_linux` — is just ``"<card>"`` (``"USB Audio CODEC"``).
+    Normalising the sounddevice side makes the exact-identity match work.
+
+    Conservative by design: a name without an ``(hw:X,Y)`` suffix is returned
+    unchanged (macOS/Windows names, plain test names, names containing a colon
+    for other reasons). The ``": <pcm>"`` tail is only stripped when the ALSA
+    suffix was present, so legitimate names are never over-stripped.
+    """
+    m = _ALSA_NAME_SUFFIX_RE.search(name)
+    if m is None:
+        return name
+    base = name[: m.start()]
+    head, sep, _ = base.partition(":")
+    return head.strip() if sep else base.strip()
+
 
 def _pair_audio_cluster_by_name_rank(
     devices: list[Any],
@@ -836,7 +864,12 @@ def _pair_audio_cluster_by_name_rank(
     the matched cluster is missing an RX or TX index.
     """
     clusters = _cluster_usb_audio_devices(devices)
-    same_name_clusters = [c for c in clusters if c[0] == audio_name]
+    # Normalise the sounddevice-side name: on Linux/ALSA it carries a
+    # ": <pcm> (hw:X,Y)" decoration absent from the sysfs product string
+    # (MOR-549). A no-op for macOS/Windows names.
+    same_name_clusters = [
+        c for c in clusters if _normalize_alsa_device_name(c[0]) == audio_name
+    ]
     if same_name_rank >= len(same_name_clusters):
         logger.warning(
             "usb-audio-resolve: %r rank %d out of range (%d matching clusters)",

--- a/tests/test_usb_audio_resolve.py
+++ b/tests/test_usb_audio_resolve.py
@@ -17,6 +17,7 @@ from rigplane.usb_audio_resolve import (
     _find_audio_codec_locations,
     _find_serial_location,
     _is_usb_audio_codec,
+    _normalize_alsa_device_name,
     _resolve_linux,
     _resolve_macos,
     _usb_device_node_from_realpath,
@@ -1337,6 +1338,82 @@ class TestResolveLinuxSysfs:
             "/dev/ttyACM0", sounddevice_module=sd, sysfs_root=str(tmp_path)
         )
         assert result is None
+
+
+class TestNormalizeAlsaDeviceName:
+    """MOR-549: strip PortAudio's ALSA decoration down to the card name."""
+
+    def test_full_alsa_form(self) -> None:
+        assert (
+            _normalize_alsa_device_name("USB Audio CODEC: Audio (hw:2,0)")
+            == "USB Audio CODEC"
+        )
+
+    def test_alsa_form_with_pcm_descriptor(self) -> None:
+        assert (
+            _normalize_alsa_device_name("USB Audio Device: USB Audio (hw:1,0)")
+            == "USB Audio Device"
+        )
+
+    def test_plughw_suffix(self) -> None:
+        assert (
+            _normalize_alsa_device_name("USB Audio CODEC: Audio (plughw:2,0)")
+            == "USB Audio CODEC"
+        )
+
+    def test_suffix_without_descriptor(self) -> None:
+        assert _normalize_alsa_device_name("USB Audio CODEC (hw:2,0)") == (
+            "USB Audio CODEC"
+        )
+
+    def test_plain_name_unchanged(self) -> None:
+        assert _normalize_alsa_device_name("USB Audio CODEC") == "USB Audio CODEC"
+
+    def test_macos_name_unchanged(self) -> None:
+        assert _normalize_alsa_device_name("USB Audio Device") == "USB Audio Device"
+
+    def test_colon_without_hw_suffix_unchanged(self) -> None:
+        # Conservative: only strip the ": <descriptor>" tail when the name
+        # carries an ALSA (hw:X,Y) suffix — never over-strip legitimate names.
+        assert (
+            _normalize_alsa_device_name("Radio: Special Edition")
+            == "Radio: Special Edition"
+        )
+
+
+class TestResolveLinuxAlsaDeviceNames:
+    """MOR-549: real ALSA enumerations decorate names as
+    ``"<card>: <pcm> (hw:X,Y)"`` while sysfs ``product`` is the bare card name
+    (``"USB Audio CODEC"``). Topology pairing must match despite the suffix.
+    """
+
+    def test_ftdi_resolves_with_realistic_alsa_names(self, tmp_path: Path) -> None:
+        TestResolveLinuxSysfs._build_tree(tmp_path)
+        sd = _make_mock_sd_two_usb_named(
+            "USB Audio Device: USB Audio (hw:1,0)",
+            "USB Audio CODEC: Audio (hw:2,0)",
+        )
+        result = _resolve_linux(
+            "/dev/ttyUSB0", sounddevice_module=sd, sysfs_root=str(tmp_path)
+        )
+        assert result is not None
+        # sysfs product "USB Audio CODEC" must match the decorated ALSA name
+        # at sounddevice index 2.
+        assert result.rx_device_index == 2
+        assert result.tx_device_index == 2
+
+    def test_x6200_resolves_with_realistic_alsa_names(self, tmp_path: Path) -> None:
+        TestResolveLinuxSysfs._build_tree(tmp_path)
+        sd = _make_mock_sd_two_usb_named(
+            "USB Audio Device: USB Audio (hw:1,0)",
+            "USB Audio CODEC: Audio (hw:2,0)",
+        )
+        result = _resolve_linux(
+            "/dev/ttyACM0", sounddevice_module=sd, sysfs_root=str(tmp_path)
+        )
+        assert result is not None
+        assert result.rx_device_index == 1
+        assert result.tx_device_index == 1
 
 
 class TestResolveLinuxCompositeIdentity:


### PR DESCRIPTION
## Problem (MOR-549)

The Linux no-override topology path `_resolve_linux` in `src/rigplane/audio/_usb_resolve.py` matches the sysfs USB `product` string against `sounddevice` device names with an EXACT string equality (`_pair_audio_cluster_by_name_rank`). But the two sides never agree on real Linux hardware:

- sysfs `product` (via `_sysfs_usb_audio_cards`) yields the bare card name, e.g. `"USB Audio CODEC"`;
- `sounddevice.query_devices()` on ALSA/PortAudio decorates it as `"USB Audio CODEC: Audio (hw:2,0)"`.

So the cluster match always failed, `_resolve_linux` returned `None`, and topology pairing silently fell back — untested because the existing tests mocked plain (undecorated) names.

## Fix

New `_normalize_alsa_device_name()` applied to the sounddevice-side name before the equality check in `_pair_audio_cluster_by_name_rank`:

- strips the trailing ` (hw:X,Y)` / ` (plughw:X,Y)` suffix, reusing the existing `_ALSA_HW_RE` from `rigplane.audio.backend` (anchored variant `_ALSA_NAME_SUFFIX_RE`);
- strips the `": <pcm descriptor>"` tail **only when** the ALSA suffix was present — conservative, never over-strips legitimate names;
- names without the suffix pass through unchanged, so macOS/Windows resolution and existing plain-name behavior are untouched.

No changes to the audio byte path, macOS/Windows resolvers, transport, or protocol.

## Tests (TDD — written first, red → green)

- `TestNormalizeAlsaDeviceName`: full ALSA form, plughw form, suffix without descriptor, plain-name passthrough, colon-without-suffix passthrough (over-strip guard).
- `TestResolveLinuxAlsaDeviceNames`: `_resolve_linux` against the existing sysfs fixture tree with sounddevice mocked using the REALISTIC decorated names (`"USB Audio CODEC: Audio (hw:2,0)"`), asserting each serial port pairs to the correct device — closing the prior test gap. Existing plain-name cases keep passing (no regression).

## Verification

- `uv run pytest tests/ -q --ignore=tests/integration` — 7678 passed, 0 failures
- `uv run ruff check src/ tests/` + `ruff format` — clean
- `uv run mypy src/` — Success: no issues in 267 files
- `uv run lint-imports` — 4 contracts kept, 0 broken

## Note

FINAL acceptance is hardware-gated on a real Linux host with a USB-audio CODEC attached (MOR-549 remains hw-gated); the code fix itself is unit-tested with realistic ALSA enumeration shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)