### PR TITLE
chore(importlinter): pin validation/ layer boundaries (MOR-649)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -42,3 +42,20 @@ modules =
     rigplane.commands
     rigplane.scope
     rigplane.dsp
+
+[importlinter:contract:validation-leaf]
+name = validation is a leaf consumer — no lower layer may import it
+type = forbidden
+source_modules =
+    rigplane.web
+    rigplane.rigctld
+    rigplane.backends
+    rigplane.runtime
+    rigplane.profiles
+    rigplane.audio
+    rigplane.commands
+    rigplane.scope
+    rigplane.dsp
+    rigplane.core
+forbidden_modules =
+    rigplane.validation

--- a/src/rigplane/validation/LAYER.md
+++ b/src/rigplane/validation/LAYER.md
@@ -31,17 +31,20 @@ both opt-in gates are open. No transport, radio, or audio I/O happens here.
 
 ## Dependencies
 
-Imports only `rigplane.core.capabilities` (`KNOWN_CAPABILITIES`) and the
-standard library. It must not import from upper layers (`web/`, `rigctld/`,
-`backends/`, `runtime/`, `cli/`). The `cli._validate` module is the sole
-consumer wiring `validate` into the CLI.
+`validation` is a top-layer consumer (it sits alongside `cli/`): it MAY
+import `core`, `runtime`, `backends` — including `backends.rigctld_client`,
+used by the hamlib-external provider — `profiles`, `audio`, and `commands`.
+Today it imports only `rigplane.core.*` (`capabilities`, `exceptions`,
+`radio_protocol`, `types`) plus the standard library. It must not import
+`web/`, `rigctld/`, or `cli/`; that boundary is enforced by the ruff TID251
+banned-import rule. The `cli._validate` module is the sole consumer wiring
+`validate` into the CLI.
 
-The upward-import boundary (no imports from `web/`, `rigctld/`, `cli/`) is
-governed by this charter and enforced by the ruff TID251 banned-import rule.
-`rigplane.validation` is not currently listed in `.importlinter` — it sits
-outside the layer DAG, mirroring `rigplane.diagnostics`. Adding it to the
-import-linter contract is deferred; do not claim import-linter enforcement
-that does not exist.
+The leaf-consumer boundary is enforced by import-linter: the
+`validation-leaf` forbidden contract in the repo-root `.importlinter` bans
+every lower layer (`web`, `rigctld`, `backends`, `runtime`, `profiles`,
+`audio`, `commands`, `scope`, `dsp`, `core`) from importing
+`rigplane.validation`. Only `cli/` may consume it.
 
 ## Contract
 


### PR DESCRIPTION
## Summary

Adds an explicit import-linter contract for the `validation/` layer (harness epic T14, Linear MOR-649). Until now `rigplane.validation` was not named anywhere in `.importlinter` — its boundaries were governed only by the LAYER.md charter and the ruff TID251 banned-import rule.

## What changed

**`.importlinter`** — new `forbidden` contract, matching the existing config style:

```ini
[importlinter:contract:validation-leaf]
name = validation is a leaf consumer — no lower layer may import it
type = forbidden
source_modules =
    rigplane.web
    rigplane.rigctld
    rigplane.backends
    rigplane.runtime
    rigplane.profiles
    rigplane.audio
    rigplane.commands
    rigplane.scope
    rigplane.dsp
    rigplane.core
forbidden_modules =
    rigplane.validation
```

**`src/rigplane/validation/LAYER.md`** — Dependencies section refreshed:
- documents that `validation` is a top-layer consumer (sits alongside `cli/`) and MAY import `core`, `runtime`, `backends` — including `backends.rigctld_client`, used by the hamlib-external provider — `profiles`, `audio`, and `commands`;
- notes that today it imports only `rigplane.core.*` (`capabilities`, `exceptions`, `radio_protocol`, `types`); the upward ban on `web/`/`rigctld/`/`cli/` remains ruff TID251's job;
- removes the now-obsolete "not currently listed in `.importlinter` / enforcement deferred" caveat.

## Why

`validation/` must stay a leaf consumer: it may depend on the stack below it, but nothing below may grow a dependency on it. A `forbidden` contract pins exactly that invariant without constraining what `validation` itself imports — so the planned hamlib-external provider use of `backends.rigctld_client` stays allowed, and `cli/` (the sole legitimate consumer via `cli._validate`) is deliberately excluded from the source list.

## Verification

- `uv run lint-imports` → **5 contracts kept, 0 broken** (including the new `validation-leaf` contract; 274 files, 750 dependencies analyzed)
- `uv run ruff check src/ tests/` → all checks passed
- `uv run mypy src/` → Success: no issues found in 276 source files
- `git diff` → only `.importlinter` + `validation/LAYER.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)