### PR TITLE
ci(validation): native dry-run golden gate + release-validation runner + docs (MOR-648)

### DIFF
--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -75,6 +75,16 @@ jobs:
       - name: Lint architecture (import-linter)
         run: uv run lint-imports
 
+      - name: Validation dry-run golden gate
+        # Native dry-run matrix vs the committed golden artifact: a
+        # registry/declaration regression fails CI (MOR-648). Dry-run only —
+        # no hardware, sub-second. Regen after an intentional matrix change:
+        #   uv run rigplane --model IC-7610 validate --dry-run \
+        #     --regen-golden tests/golden/validation/ic7610.dry-run.json
+        run: >-
+          uv run rigplane --model IC-7610 validate --provider native --dry-run
+          --gate tests/golden/validation/ic7610.dry-run.json
+
       - name: Set up Node.js
         if: steps.filter.outputs.frontend == 'true'
         uses: actions/setup-node@v6

--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,12 @@ references/
 # Mockups (design artifacts, not runtime)
 mockups/
 
-# Scripts (internal dev tools)
-scripts/
+# Scripts (internal dev tools). `scripts/*` (not `scripts/`) so the
+# release-validation runner below can be un-ignored — git never descends
+# into a directory excluded by a trailing-slash pattern.
+scripts/*
+# But the release-validation runner is tracked (MOR-648).
+!scripts/validate-release.sh
 # But CI scripts under .github/ are tracked.
 !.github/scripts/
 # And frontend tooling scripts (e.g. i18n lint) are tracked.

--- a/docs/validation/running-validation.md
+++ b/docs/validation/running-validation.md
@@ -109,8 +109,97 @@ Global (before the `validate` subcommand):
 | `--tx-allowed` / `--tuner-allowed` | Authorize the TX/tuner checks (still operator-verified, never auto-keyed). |
 | `--provider {native,hamlib}` | `native` = RigPlane's own backend; `hamlib` = via the rigctld bridge. |
 | `--compare <artifact.json>` | Diff this run against a prior artifact. |
+| `--gate <golden.json>` | Gate this run against a golden normalized artifact: exit 1 on any regression. |
+| `--regen-golden <path>` | Write the normalized artifact to `<path>` as a new `--gate` golden baseline. |
 | `--operator-id <id>` | Record the operator in the artifact. |
 | `--json` / `--output <path>` | Emit JSON (to stdout or a file) instead of the human summary. |
+
+---
+
+## Golden gate: dry-run regression protection
+
+A **golden** is a normalized dry-run artifact (volatile fields stripped)
+committed to the repo. Gating a run against it turns the validation matrix into
+a regression check: any check that goes `pass`→`fail`, any new `fail`/`blocked`
+check, any missing check, or any declaration drift exits `1`. Improvements
+never block.
+
+Committed goldens live in `tests/golden/validation/`. Today only the IC-7610
+dry-run golden is committed (`ic7610.dry-run.json`); X6200 and FTX-1 goldens
+are a known loose end.
+
+### Run the dry-run gate
+
+```bash
+uv run rigplane --model IC-7610 validate --provider native --dry-run \
+  --gate tests/golden/validation/ic7610.dry-run.json
+```
+
+Exit `0` = no regression; exit `1` = regression (a diff summary is printed to
+stderr); exit `2` = golden missing/unreadable.
+
+### Regenerate a golden after an intentional matrix change
+
+When you intentionally change the registry, a profile's declared capabilities,
+or an override file, the gate (and
+`tests/test_validation_gating.py::test_committed_ic7610_golden_matches_live_dry_run`)
+will fail until the golden is refreshed:
+
+```bash
+uv run rigplane --model IC-7610 validate --dry-run \
+  --regen-golden tests/golden/validation/ic7610.dry-run.json
+```
+
+Review the resulting diff carefully before committing — the golden is the
+contract; regenerating it to silence a gate failure you do not understand
+defeats the purpose.
+
+### CI
+
+`.github/workflows/quick.yml` runs the IC-7610 native dry-run gate on every
+push/PR that touches `src/**`, `tests/**`, etc. — so a registry or
+profile-declaration regression fails CI without any hardware. It is dry-run
+only and takes under a second.
+
+---
+
+## Pre-release validation runner
+
+`scripts/validate-release.sh` bundles the pre-release validation pass across
+the owned radios (IC-7610, X6200, FTX-1).
+
+**Default (CI-safe, no hardware):**
+
+```bash
+scripts/validate-release.sh
+```
+
+For each radio it runs the native dry-run matrix; where a committed golden
+exists it gates against it, otherwise it notes the missing golden (with the
+exact `--regen-golden` command) and still verifies the matrix generates. Exits
+non-zero on any gate regression or matrix-generation error; skips never fail
+the run.
+
+**Hardware (opt-in, pre-release):**
+
+```bash
+RIGPLANE_VALIDATION_ALLOW_HARDWARE=1 \
+ICOM_HOST=192.168.55.40 ICOM_USER=<user> ICOM_PASS_FILE=/path/to/secret \
+X6200_SERIAL_PORT=/dev/cu.usbmodem58910181093 \
+FTX1_SERIAL_PORT=/dev/cu.usbserial-XXXX \
+scripts/validate-release.sh --hardware
+```
+
+Hardware execution requires **both** the `--hardware` script flag **and**
+`RIGPLANE_VALIDATION_ALLOW_HARDWARE=1` (the script then passes the CLI's own
+`--hardware --allow-hardware` gates through). Each radio additionally needs
+its connection environment — `ICOM_HOST`/`ICOM_USER`/`ICOM_PASS_FILE` for the
+IC-7610, `X6200_SERIAL_PORT` (optionally `X6200_SERIAL_BAUD`, default 19200)
+for the X6200, `FTX1_SERIAL_PORT` (optionally `FTX1_SERIAL_BAUD`, default
+38400) for the FTX-1. Radios without configuration are skipped with a note, so
+you can validate whatever subset is on the bench. Hardware artifacts are
+written to `/tmp/<radio>-hw-<timestamp>.json`; the per-radio invocations match
+the recipes above (RMVR writes with restore, TX/tuner never auto-actuated).
 
 ---
 

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# validate-release.sh — pre-release validation runner (MOR-648).
+#
+# Runs the `rigplane validate` matrix for the owned radios (IC-7610, X6200,
+# FTX-1). The DEFAULT path is CI-safe: native dry-run only, gated against the
+# committed golden artifacts in tests/golden/validation/. No hardware is ever
+# touched unless BOTH the --hardware flag AND the
+# RIGPLANE_VALIDATION_ALLOW_HARDWARE=1 environment variable are present
+# (mirroring the CLI's own triple gate), and the per-radio connection
+# environment is configured.
+#
+# Usage:
+#   scripts/validate-release.sh                 # dry-run gates (CI-safe, default)
+#   scripts/validate-release.sh --hardware      # + hardware runs (opt-in, see below)
+#   scripts/validate-release.sh --help
+#
+# Hardware opt-in (per radio; unconfigured radios are skipped with a note):
+#   RIGPLANE_VALIDATION_ALLOW_HARDWARE=1        required for any hardware run
+#   IC-7610:  ICOM_HOST, ICOM_USER, ICOM_PASS_FILE   (LAN, CI-V 0x98)
+#   X6200:    X6200_SERIAL_PORT                       (serial 19200, CI-V 0xA4)
+#   FTX-1:    FTX1_SERIAL_PORT                        (yaesu-cat 38400)
+#
+# Exit code: non-zero if any executed step fails (golden-gate regression,
+# matrix generation error, or hardware failure). Skips never fail the run.
+#
+# Idempotent: writes only timestamped artifacts under /tmp on hardware runs;
+# never modifies the repository.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+GOLDEN_DIR="tests/golden/validation"
+HARDWARE=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --hardware) HARDWARE=1 ;;
+        --help|-h)
+            sed -n '2,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg (see --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# slug:model pairs — slug names the golden file, model is the --model value.
+RADIOS=(
+    "ic7610:IC-7610"
+    "x6200:X6200"
+    "ftx1:FTX-1"
+)
+
+FAILURES=0
+note() { printf '\n==> %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Phase 1 — native dry-run golden gates (always runs; CI-safe, no hardware)
+# ---------------------------------------------------------------------------
+note "Phase 1: native dry-run golden gates"
+
+for entry in "${RADIOS[@]}"; do
+    slug="${entry%%:*}"
+    model="${entry#*:}"
+    golden="$GOLDEN_DIR/$slug.dry-run.json"
+
+    if [[ -f "$golden" ]]; then
+        note "$model: dry-run gate vs $golden"
+        if uv run rigplane --model "$model" validate --provider native \
+                --dry-run --gate "$golden"; then
+            echo "[$model] gate: PASS"
+        else
+            echo "[$model] gate: FAIL (regression vs golden)" >&2
+            FAILURES=$((FAILURES + 1))
+        fi
+    else
+        # No committed golden yet (only ic7610 is committed today). Still run
+        # the plain dry-run so a matrix-generation error is caught, but skip
+        # the gate. Committing the golden is a separate task — do NOT regen
+        # into the repo from this script.
+        note "$model: no committed golden ($golden) — running ungated dry-run"
+        if uv run rigplane --model "$model" validate --provider native \
+                --dry-run > /dev/null; then
+            echo "[$model] dry-run: OK (gate SKIPPED — no golden committed)"
+            echo "[$model] to create one:" \
+                "uv run rigplane --model $model validate --dry-run" \
+                "--regen-golden $golden"
+        else
+            echo "[$model] dry-run: FAIL (matrix generation error)" >&2
+            FAILURES=$((FAILURES + 1))
+        fi
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Phase 2 — hardware validation (opt-in only; never runs in CI)
+# ---------------------------------------------------------------------------
+if [[ "$HARDWARE" -eq 1 ]]; then
+    if [[ "${RIGPLANE_VALIDATION_ALLOW_HARDWARE:-}" != "1" ]]; then
+        echo "Error: --hardware also requires RIGPLANE_VALIDATION_ALLOW_HARDWARE=1" >&2
+        exit 2
+    fi
+    note "Phase 2: hardware validation (RMVR, no TX/tuner auto-actuation)"
+    STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+
+    # IC-7610 — LAN (CI-V 0x98). Needs ICOM_HOST/ICOM_USER/ICOM_PASS_FILE.
+    if [[ -n "${ICOM_HOST:-}" && -n "${ICOM_USER:-}" && -n "${ICOM_PASS_FILE:-}" ]]; then
+        note "IC-7610: hardware run via LAN ($ICOM_HOST)"
+        if uv run rigplane --backend lan --pass-file "$ICOM_PASS_FILE" \
+                --model IC-7610 --radio-addr 0x98 --timeout 6 \
+                validate --hardware --allow-hardware --provider native \
+                --json --output "/tmp/ic7610-hw-$STAMP.json"; then
+            echo "[IC-7610] hardware: OK (/tmp/ic7610-hw-$STAMP.json)"
+        else
+            echo "[IC-7610] hardware: FAIL" >&2
+            FAILURES=$((FAILURES + 1))
+        fi
+    else
+        echo "[IC-7610] hardware: SKIPPED (set ICOM_HOST, ICOM_USER, ICOM_PASS_FILE)"
+    fi
+
+    # X6200 — serial (19200 baud, CI-V 0xA4). Port is exclusive: close
+    # RigPlane Pro / other clients first.
+    if [[ -n "${X6200_SERIAL_PORT:-}" ]]; then
+        note "X6200: hardware run via serial ($X6200_SERIAL_PORT)"
+        if uv run rigplane --backend serial \
+                --serial-port "$X6200_SERIAL_PORT" \
+                --serial-baud "${X6200_SERIAL_BAUD:-19200}" \
+                --model X6200 --radio-addr 0xA4 --timeout 6 \
+                validate --hardware --allow-hardware --provider native \
+                --json --output "/tmp/x6200-hw-$STAMP.json"; then
+            echo "[X6200] hardware: OK (/tmp/x6200-hw-$STAMP.json)"
+        else
+            echo "[X6200] hardware: FAIL" >&2
+            FAILURES=$((FAILURES + 1))
+        fi
+    else
+        echo "[X6200] hardware: SKIPPED (set X6200_SERIAL_PORT)"
+    fi
+
+    # FTX-1 — Yaesu CAT serial (38400 baud).
+    if [[ -n "${FTX1_SERIAL_PORT:-}" ]]; then
+        note "FTX-1: hardware run via yaesu-cat ($FTX1_SERIAL_PORT)"
+        if uv run rigplane --backend yaesu-cat \
+                --serial-port "$FTX1_SERIAL_PORT" \
+                --serial-baud "${FTX1_SERIAL_BAUD:-38400}" \
+                --model FTX-1 --timeout 6 \
+                validate --hardware --allow-hardware --provider native \
+                --json --output "/tmp/ftx1-hw-$STAMP.json"; then
+            echo "[FTX-1] hardware: OK (/tmp/ftx1-hw-$STAMP.json)"
+        else
+            echo "[FTX-1] hardware: FAIL" >&2
+            FAILURES=$((FAILURES + 1))
+        fi
+    else
+        echo "[FTX-1] hardware: SKIPPED (set FTX1_SERIAL_PORT)"
+    fi
+else
+    note "Phase 2: hardware validation SKIPPED (opt-in: --hardware +" \
+        "RIGPLANE_VALIDATION_ALLOW_HARDWARE=1; see docs/validation/running-validation.md)"
+fi
+
+# ---------------------------------------------------------------------------
+note "Summary"
+if [[ "$FAILURES" -gt 0 ]]; then
+    echo "validate-release: $FAILURES step(s) FAILED" >&2
+    exit 1
+fi
+echo "validate-release: all executed steps passed"


### PR DESCRIPTION
Harness epic T13 (MOR-648) — a CI regression gate + release-validation runner on the shipped golden-gate machinery (MOR-635/636).

## Changes
- **`quick.yml`** — new `Validation dry-run golden gate` step: runs `rigplane --model IC-7610 validate --provider native --dry-run --gate tests/golden/validation/ic7610.dry-run.json` after lint-imports. A registry/declaration regression now fails CI. Dry-run only, no hardware, sub-second. This PR's own `quick` run exercises the gate.
- **`scripts/validate-release.sh`** — pre-release runner. CI-safe default (native dry-run gate per owned radio: ic7610/x6200/ftx1); hardware opt-in via `RIGPLANE_VALIDATION_ALLOW_HARDWARE=1` + `--hardware`. Idempotent; regen-or-skips the not-yet-committed x6200/ftx1 goldens gracefully.
- **`docs/validation/running-validation.md`** — dry-run gate, golden regen, per-radio pre-release hardware recipe with env gating.
- **`.gitignore`** — `scripts/` was fully ignored; narrowed to `scripts/*` + `!scripts/validate-release.sh` so the runner is tracked.

## Verification (local, worktree)
- Gate command → **exit 0** against the committed golden.
- `bash -n scripts/validate-release.sh` clean; both workflow YAMLs parse.
- Only ic7610.dry-run.json is committed today; x6200/ftx1 goldens are a separate loose end (script handles their absence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)