### PR TITLE
feat(validation): automated audio-pipeline probe checks — the GH #1650 audio check-kind (MOR-639/640/641)

### DIFF
--- a/src/rigplane/validation/LAYER.md
+++ b/src/rigplane/validation/LAYER.md
@@ -43,6 +43,38 @@ outside the layer DAG, mirroring `rigplane.diagnostics`. Adding it to the
 import-linter contract is deferred; do not claim import-linter enforcement
 that does not exist.
 
+## Automated audio probes (`audio_checks.py`)
+
+The `AUDIO_PROBE` check kind (GH #1650; MOR-639/640/641) is the CI-automated
+counterpart of the MANUAL `audio.rx` / `scope.capture` operator checks:
+
+- `run_rx_rms_check` — injects a reference tone through
+  `FakeAudioBackend`/`FakeRxStream` and verifies the delivered PCM RMS
+  (`failure_domain=audio`).
+- `run_tx_byte_perfect_check` — pushes captured frames through the REAL
+  `AudioStream` LAN packetization and requires a byte-perfect reassembled
+  payload (`failure_domain=audio`).
+- `run_scope_presence_check` — feeds PCM to the REAL `AudioFftScope` and
+  requires in-band bins above the out-of-band baseline
+  (`failure_domain=scope_waterfall`; MOR-512/528 regression guard).
+
+Integration decision: the pre-existing MANUAL `audio.rx`/`scope.capture`
+entries are KEPT for real-hardware operator confirmation; the probes are
+additive. Generated hardware templates carry `AUDIO_PROBE` checks as
+`MANUAL_REQUIRED` (they are never auto-run on a live radio; `hardware.py`
+SKIPs them defensively), while the CI harness executes them via
+`run_audio_probe_checks()` + `audio_probe_level_results()` and folds the
+results into `build_validation_artifact` → `gate_artifacts`, so audio
+regressions gate exactly like command regressions. `audio.tx.byte_perfect`
+is `tx_adjacent=True` per GH #1650 (TX audio stays behind explicit operator
+safety enablement on real hardware).
+
+This module imports `rigplane.audio` (the deterministic fakes, the LAN audio
+packetizer, the FFT scope) and `rigplane.scope` (`ScopeFrame`) — permitted:
+`validation` is a top-level consumer outside the layer DAG, and only the CI
+harness imports `audio_checks` (the `rigplane.validation` facade does not
+re-export it).
+
 ## Contract
 
 The template and artifact shapes are a public, versioned contract — see

--- a/src/rigplane/validation/audio_checks.py
+++ b/src/rigplane/validation/audio_checks.py
@@ -1,0 +1,252 @@
+"""Automated audio-pipeline probe checks (GH #1650; MOR-639/640/641).
+
+The AUDIO_PROBE check family is the CI-automated counterpart of the MANUAL
+``audio.rx`` / ``scope.capture`` operator checks. Each probe drives the audio
+pipeline through the deterministic test fakes (:class:`FakeAudioBackend` and
+its streams — no PortAudio, no hardware, no network) and emits a real
+:class:`~rigplane.validation.schema.CheckResult`, so audio regressions flow
+into the existing ``ValidationArtifact`` + golden-gate machinery exactly like
+command checks do.
+
+Integration contract:
+
+* The probes' registry rows live in ``registry/_audio.py`` with
+  ``CheckKind.AUDIO_PROBE``. Generated per-radio templates carry them as
+  ``MANUAL_REQUIRED`` (never auto-run on a live radio); the pre-existing
+  MANUAL entries are kept for real-hardware operator confirmation.
+* ``pcm_transform`` on each probe is a fault-injection hook for the probes'
+  own regression tests: it mutates the PCM *as injected into the pipeline*
+  while the expected reference stays pristine, simulating a corrupted
+  pipeline.
+
+Import path: ``from rigplane.validation import audio_checks`` (not re-exported
+by the ``rigplane.validation`` facade — this module imports ``rigplane.audio``
+and is only needed by the CI harness).
+"""
+
+from __future__ import annotations
+
+import datetime
+import math
+from collections.abc import Callable
+
+from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.validation.registry import CheckSpec, get_spec
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CheckResult,
+    CheckStatus,
+)
+
+__all__ = [
+    "PROBE_AMPLITUDE",
+    "PROBE_FRAME_BYTES",
+    "PROBE_FRAME_MS",
+    "PROBE_SAMPLE_RATE",
+    "PROBE_SAMPLES_PER_FRAME",
+    "PROBE_TONE_HZ",
+    "RX_RMS_TOLERANCE",
+    "PcmTransform",
+    "run_rx_rms_check",
+]
+
+# Probe signal parameters. They mirror the audio-bridge PCM contract
+# (48 kHz mono s16le, 20 ms frames = 960 samples = 1920 bytes) without
+# importing the bridge: the probes exercise the fakes' fixed-frame contract,
+# and the byte sizes must match what the managed PCM-TX validator accepts.
+PROBE_SAMPLE_RATE = 48_000
+PROBE_FRAME_MS = 20
+PROBE_SAMPLES_PER_FRAME = PROBE_SAMPLE_RATE * PROBE_FRAME_MS // 1000  # 960
+PROBE_FRAME_BYTES = PROBE_SAMPLES_PER_FRAME * 2  # mono s16le -> 1920
+PROBE_TONE_HZ = 1_000.0
+PROBE_AMPLITUDE = 12_000
+PROBE_FRAME_COUNT = 8
+
+# Relative RMS tolerance band for the RX probe: the fake pipeline delivers
+# byte-identical PCM, so any deviation beyond rounding indicates corruption.
+RX_RMS_TOLERANCE = 0.05
+
+PcmTransform = Callable[[bytes], bytes]
+"""Fault-injection hook: mutates PCM as injected; the reference stays pristine."""
+
+
+# ---------------------------------------------------------------------------
+# Deterministic PCM helpers (stdlib-only; mirror tests/_audio_pipeline_helpers)
+# ---------------------------------------------------------------------------
+
+
+def _sine_pcm16_mono(
+    frequency_hz: float,
+    *,
+    samples: int,
+    sample_rate: int = PROBE_SAMPLE_RATE,
+    amplitude: int = PROBE_AMPLITUDE,
+) -> bytes:
+    """Generate deterministic mono s16le sine PCM."""
+    pcm = bytearray()
+    for index in range(samples):
+        phase = 2.0 * math.pi * frequency_hz * (index / sample_rate)
+        value = int(amplitude * math.sin(phase))
+        pcm += value.to_bytes(2, "little", signed=True)
+    return bytes(pcm)
+
+
+def _pcm_rms(pcm: bytes) -> float:
+    """Return RMS for mono s16le PCM bytes (0.0 for empty input)."""
+    if not pcm:
+        return 0.0
+    if len(pcm) % 2:
+        raise ValueError("PCM byte length must be even for s16le samples.")
+    count = len(pcm) // 2
+    total = 0.0
+    for offset in range(0, len(pcm), 2):
+        sample = int.from_bytes(pcm[offset : offset + 2], "little", signed=True)
+        total += float(sample) * float(sample)
+    return math.sqrt(total / count)
+
+
+def _utcnow_iso() -> str:
+    """Current UTC time as an ISO-8601 millisecond ``...Z`` string."""
+    return (
+        datetime.datetime.now(datetime.UTC)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend / result plumbing
+# ---------------------------------------------------------------------------
+
+
+def _default_backend() -> FakeAudioBackend:
+    """A fresh single-device fake backend (deterministic, dependency-free)."""
+    return FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="Audio Probe Loopback",
+                input_channels=2,
+                output_channels=2,
+            )
+        ]
+    )
+
+
+def _first_device(backend: FakeAudioBackend) -> AudioDeviceId:
+    devices = backend.list_devices()
+    if not devices:
+        raise ValueError("audio probe backend exposes no devices")
+    return devices[0].id
+
+
+def _probe_spec(check_id: str) -> CheckSpec:
+    spec = get_spec(check_id)
+    if spec is None:  # pragma: no cover — registry rows ship with this module
+        raise LookupError(f"audio probe check {check_id!r} missing from REGISTRY")
+    return spec
+
+
+def _probe_result(
+    check_id: str,
+    *,
+    passed: bool,
+    evidence: dict[str, object],
+    error: str | None,
+    started_at: str,
+) -> CheckResult:
+    """Build a :class:`CheckResult` for a probe from its registry spec.
+
+    The probe ran automatically, so the declaration is SUPPORTED; on failure
+    the failure domain comes from the registry spec (``audio`` or
+    ``scope_waterfall``).
+    """
+    spec = _probe_spec(check_id)
+    status = CheckStatus.PASS if passed else CheckStatus.FAIL
+    return CheckResult(
+        check_id=spec.check_id,
+        capability=spec.capability,
+        level=spec.level,
+        status=status,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary=spec.summary,
+        failure_domain=None if passed else spec.failure_domain,
+        evidence=evidence,
+        error=None if passed else error,
+        started_at=started_at,
+        finished_at=_utcnow_iso(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# T4 / MOR-639 — RX-RMS probe
+# ---------------------------------------------------------------------------
+
+
+async def run_rx_rms_check(
+    *,
+    backend: FakeAudioBackend | None = None,
+    frame_count: int = PROBE_FRAME_COUNT,
+    pcm_transform: PcmTransform | None = None,
+) -> CheckResult:
+    """Inject a reference tone through the fake RX pipeline; verify the RMS.
+
+    Opens an RX capture stream on the fake backend, injects ``frame_count``
+    frames of a deterministic 1 kHz sine, and asserts the RMS of the delivered
+    PCM is non-zero and within ``RX_RMS_TOLERANCE`` of the reference tone's
+    RMS. A silent, attenuated, or distorted delivery fails with
+    ``failure_domain="audio"``.
+    """
+    started_at = _utcnow_iso()
+    fake = backend if backend is not None else _default_backend()
+    stream = fake.open_rx(
+        _first_device(fake),
+        sample_rate=PROBE_SAMPLE_RATE,
+        channels=1,
+        frame_ms=PROBE_FRAME_MS,
+    )
+
+    reference = _sine_pcm16_mono(PROBE_TONE_HZ, samples=PROBE_SAMPLES_PER_FRAME)
+    injected = reference if pcm_transform is None else pcm_transform(reference)
+
+    received: list[bytes] = []
+    await stream.start(received.append)
+    try:
+        for _ in range(frame_count):
+            stream.inject_frame(injected)
+    finally:
+        await stream.stop()
+
+    delivered = b"".join(received)
+    expected_rms = _pcm_rms(reference)
+    rms = _pcm_rms(delivered)
+    in_band = (
+        len(delivered) == frame_count * len(reference)
+        and rms > 0.0
+        and abs(rms - expected_rms) <= expected_rms * RX_RMS_TOLERANCE
+    )
+
+    evidence: dict[str, object] = {
+        "tone_hz": PROBE_TONE_HZ,
+        "frames_injected": frame_count,
+        "bytes_delivered": len(delivered),
+        "rms": round(rms, 6),
+        "expected_rms": round(expected_rms, 6),
+        "rms_tolerance": RX_RMS_TOLERANCE,
+    }
+    error = (
+        None
+        if in_band
+        else (
+            f"RX RMS {rms:.3f} outside tolerance band "
+            f"{expected_rms:.3f} +/- {RX_RMS_TOLERANCE * 100:.0f}% "
+            f"({len(delivered)} bytes delivered)"
+        )
+    )
+    return _probe_result(
+        "audio.rx.rms",
+        passed=in_band,
+        evidence=evidence,
+        error=error,
+        started_at=started_at,
+    )

--- a/src/rigplane/validation/audio_checks.py
+++ b/src/rigplane/validation/audio_checks.py
@@ -29,8 +29,16 @@ from __future__ import annotations
 import datetime
 import math
 from collections.abc import Callable
+from typing import cast
 
 from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.audio.lan_stream import (
+    TX_IDENT,
+    AudioPacket,
+    AudioStream,
+    parse_audio_packet,
+)
+from rigplane.core.transport import IcomTransport
 from rigplane.validation.registry import CheckSpec, get_spec
 from rigplane.validation.schema import (
     CapabilityDeclaration,
@@ -48,6 +56,7 @@ __all__ = [
     "RX_RMS_TOLERANCE",
     "PcmTransform",
     "run_rx_rms_check",
+    "run_tx_byte_perfect_check",
 ]
 
 # Probe signal parameters. They mirror the audio-bridge PCM contract
@@ -246,6 +255,123 @@ async def run_rx_rms_check(
     return _probe_result(
         "audio.rx.rms",
         passed=in_band,
+        evidence=evidence,
+        error=error,
+        started_at=started_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T5 / MOR-640 — TX byte-perfect probe
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAudioTransport:
+    """Minimal in-memory audio transport: records every tracked send.
+
+    Duck-types the slice of :class:`IcomTransport` that
+    :meth:`AudioStream.push_tx` uses (``my_id``, ``remote_id``,
+    ``send_tracked``). A plain class, not a mock — signature drift fails
+    loudly instead of being absorbed.
+    """
+
+    my_id = 0xAABBCCDD
+    remote_id = 0x11223344
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+
+    async def send_tracked(self, data: bytes) -> None:
+        self.sent.append(bytes(data))
+
+
+async def run_tx_byte_perfect_check(
+    *,
+    backend: FakeAudioBackend | None = None,
+    frame_count: int = 4,
+    pcm_transform: PcmTransform | None = None,
+) -> CheckResult:
+    """Verify captured TX PCM survives LAN packetization byte-perfect.
+
+    Mirrors the in-process TX harness (``tests/test_audio_pipeline_harness``,
+    real-hardware byte-perfectness proven in MOR-614): a reference tone is
+    injected into the fake capture stream (the bridge's TX source), every
+    delivered frame is pushed through the REAL :class:`AudioStream` TX
+    packetization, and the reassembled packet payload must equal the
+    reference PCM byte-for-byte — with TX idents and contiguous audio-level
+    sequence numbers.
+    """
+    started_at = _utcnow_iso()
+    fake = backend if backend is not None else _default_backend()
+    capture = fake.open_rx(
+        _first_device(fake),
+        sample_rate=PROBE_SAMPLE_RATE,
+        channels=1,
+        frame_ms=PROBE_FRAME_MS,
+    )
+
+    reference = _sine_pcm16_mono(PROBE_TONE_HZ, samples=PROBE_SAMPLES_PER_FRAME)
+    expected_pcm = reference * frame_count
+
+    transport = _RecordingAudioTransport()
+    stream = AudioStream(cast(IcomTransport, transport))
+    await stream.start_tx()
+
+    delivered: list[bytes] = []
+    await capture.start(delivered.append)
+    try:
+        for _ in range(frame_count):
+            frame = reference if pcm_transform is None else pcm_transform(reference)
+            capture.inject_frame(frame)
+        for frame in delivered:
+            await stream.push_tx(frame)
+    finally:
+        await capture.stop()
+        await stream.stop_tx()
+
+    packets: list[AudioPacket] = []
+    for raw in transport.sent:
+        packet = parse_audio_packet(raw)
+        if packet is not None:
+            packets.append(packet)
+
+    payload = b"".join(packet.data for packet in packets)
+    payload_matches = payload == expected_pcm
+    idents = sorted({packet.ident for packet in packets})
+    sequences_contiguous = [packet.send_seq for packet in packets] == list(
+        range(len(packets))
+    )
+    passed = (
+        payload_matches
+        and bool(packets)
+        and idents == [TX_IDENT]
+        and sequences_contiguous
+    )
+
+    evidence: dict[str, object] = {
+        "tone_hz": PROBE_TONE_HZ,
+        "frames_captured": len(delivered),
+        "packets_sent": len(packets),
+        "packet_sizes": [len(packet.data) for packet in packets],
+        "payload_bytes": len(payload),
+        "expected_bytes": len(expected_pcm),
+        "payload_matches": payload_matches,
+        "idents": idents,
+        "sequences_contiguous": sequences_contiguous,
+    }
+    error = (
+        None
+        if passed
+        else (
+            "TX payload is not byte-perfect: "
+            f"{len(payload)}/{len(expected_pcm)} bytes reassembled, "
+            f"match={payload_matches}, idents={idents}, "
+            f"contiguous={sequences_contiguous}"
+        )
+    )
+    return _probe_result(
+        "audio.tx.byte_perfect",
+        passed=passed,
         evidence=evidence,
         error=error,
         started_at=started_at,

--- a/src/rigplane/validation/audio_checks.py
+++ b/src/rigplane/validation/audio_checks.py
@@ -28,7 +28,8 @@ from __future__ import annotations
 
 import datetime
 import math
-from collections.abc import Callable
+import statistics
+from collections.abc import Callable, Sequence
 from typing import cast
 
 from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
@@ -39,11 +40,14 @@ from rigplane.audio.lan_stream import (
     parse_audio_packet,
 )
 from rigplane.core.transport import IcomTransport
+from rigplane.scope import ScopeFrame
 from rigplane.validation.registry import CheckSpec, get_spec
 from rigplane.validation.schema import (
     CapabilityDeclaration,
     CheckResult,
     CheckStatus,
+    LevelResult,
+    ValidationLevel,
 )
 
 __all__ = [
@@ -54,8 +58,13 @@ __all__ = [
     "PROBE_SAMPLES_PER_FRAME",
     "PROBE_TONE_HZ",
     "RX_RMS_TOLERANCE",
+    "SCOPE_MIN_RISE_PIXELS",
+    "SCOPE_MIN_SIGNAL_PIXEL",
     "PcmTransform",
+    "audio_probe_level_results",
+    "run_audio_probe_checks",
     "run_rx_rms_check",
+    "run_scope_presence_check",
     "run_tx_byte_perfect_check",
 ]
 
@@ -74,6 +83,21 @@ PROBE_FRAME_COUNT = 8
 # Relative RMS tolerance band for the RX probe: the fake pipeline delivers
 # byte-identical PCM, so any deviation beyond rounding indicates corruption.
 RX_RMS_TOLERANCE = 0.05
+
+# Scope-presence probe parameters (regression guard for the MOR-512/528
+# adaptive in-band auto-range). The synthetic VFO center is arbitrary —
+# AudioFftScope only needs a positive center frequency for RF mapping.
+SCOPE_CENTER_FREQ_HZ = 14_074_000
+_SCOPE_FFT_SIZE = 2048
+# In-band region inspected for the tone: the audio baseband the adaptive
+# window estimates over (MOR-512's _INBAND_FALLBACK_HI_HZ).
+_SCOPE_INBAND_HZ = 3_500.0
+# Baseline region: bins beyond this audio offset, far outside the passband.
+_SCOPE_BASELINE_MIN_HZ = 8_000.0
+# A real in-band tone must reach this pixel level (0-160 ScopeFrame scale)
+# and rise this far above the out-of-band baseline median.
+SCOPE_MIN_SIGNAL_PIXEL = 80
+SCOPE_MIN_RISE_PIXELS = 40
 
 PcmTransform = Callable[[bytes], bytes]
 """Fault-injection hook: mutates PCM as injected; the reference stays pristine."""
@@ -376,3 +400,164 @@ async def run_tx_byte_perfect_check(
         error=error,
         started_at=started_at,
     )
+
+
+# ---------------------------------------------------------------------------
+# T6 / MOR-641 — scope-presence probe
+# ---------------------------------------------------------------------------
+
+
+async def run_scope_presence_check(
+    *,
+    backend: FakeAudioBackend | None = None,
+    frame_count: int = PROBE_FRAME_COUNT,
+    pcm_transform: PcmTransform | None = None,
+) -> CheckResult:
+    """Feed a reference tone to the audio FFT scope; verify in-band presence.
+
+    Routes the tone through the fake RX capture stream into the REAL
+    :class:`~rigplane.audio.fft_scope.AudioFftScope` (the MOR-512/528
+    adaptive in-band auto-range path) and asserts the in-band pixel peak of
+    the emitted :class:`ScopeFrame` rises above the out-of-band baseline. A
+    silent or missing spectrum fails with ``failure_domain=scope_waterfall``.
+
+    Returns a SKIP result when numpy (the FFT dependency) is unavailable.
+    """
+    started_at = _utcnow_iso()
+    spec = _probe_spec("scope.fft.presence")
+    try:
+        from rigplane.audio.fft_scope import AudioFftScope
+
+        scope = AudioFftScope(
+            fft_size=_SCOPE_FFT_SIZE,
+            fps=1_000,
+            avg_count=1,
+            sample_rate=PROBE_SAMPLE_RATE,
+        )
+    except ImportError as exc:
+        return CheckResult(
+            check_id=spec.check_id,
+            capability=spec.capability,
+            level=spec.level,
+            status=CheckStatus.SKIP,
+            declaration=CapabilityDeclaration.SUPPORTED,
+            summary=spec.summary,
+            evidence={"reason": f"FFT dependency unavailable: {exc}"},
+            started_at=started_at,
+            finished_at=_utcnow_iso(),
+        )
+
+    frames: list[ScopeFrame] = []
+    scope.set_center_freq(SCOPE_CENTER_FREQ_HZ)
+    scope.on_frame(frames.append)
+
+    fake = backend if backend is not None else _default_backend()
+    capture = fake.open_rx(
+        _first_device(fake),
+        sample_rate=PROBE_SAMPLE_RATE,
+        channels=1,
+        frame_ms=PROBE_FRAME_MS,
+    )
+    reference = _sine_pcm16_mono(PROBE_TONE_HZ, samples=PROBE_SAMPLES_PER_FRAME)
+    injected = reference if pcm_transform is None else pcm_transform(reference)
+    await capture.start(scope.feed_audio)
+    try:
+        for _ in range(frame_count):
+            capture.inject_frame(injected)
+    finally:
+        await capture.stop()
+        scope.stop()
+
+    evidence: dict[str, object] = {
+        "tone_hz": PROBE_TONE_HZ,
+        "center_freq_hz": SCOPE_CENTER_FREQ_HZ,
+        "fft_size": _SCOPE_FFT_SIZE,
+        "frames_emitted": len(frames),
+        "min_signal_pixel": SCOPE_MIN_SIGNAL_PIXEL,
+        "min_rise_pixels": SCOPE_MIN_RISE_PIXELS,
+    }
+    if not frames:
+        return _probe_result(
+            "scope.fft.presence",
+            passed=False,
+            evidence=evidence,
+            error=(
+                f"no scope frame emitted from {frame_count} injected "
+                f"frame(s) ({frame_count * PROBE_SAMPLES_PER_FRAME} samples)"
+            ),
+            started_at=started_at,
+        )
+
+    last = frames[-1]
+    pixels = list(last.pixels)
+    span_hz = last.end_freq_hz - last.start_freq_hz
+    bin_hz = span_hz / max(1, len(pixels) - 1)
+    center = len(pixels) // 2
+    inband_half = int(_SCOPE_INBAND_HZ / bin_hz)
+    baseline_from = int(_SCOPE_BASELINE_MIN_HZ / bin_hz)
+
+    inband = pixels[max(0, center - inband_half) : center + inband_half + 1]
+    baseline = (
+        pixels[: max(0, center - baseline_from)] + pixels[center + baseline_from + 1 :]
+    )
+    signal_peak = max(inband) if inband else 0
+    baseline_median = float(statistics.median(baseline)) if baseline else 0.0
+
+    passed = (
+        signal_peak >= SCOPE_MIN_SIGNAL_PIXEL
+        and signal_peak - baseline_median >= SCOPE_MIN_RISE_PIXELS
+    )
+    evidence.update(
+        {
+            "signal_peak": int(signal_peak),
+            "baseline_median": baseline_median,
+            "pixel_bins": len(pixels),
+        }
+    )
+    error = (
+        None
+        if passed
+        else (
+            f"in-band pixel peak {signal_peak} vs baseline median "
+            f"{baseline_median:.1f} below presence thresholds "
+            f"(peak >= {SCOPE_MIN_SIGNAL_PIXEL}, rise >= {SCOPE_MIN_RISE_PIXELS})"
+        )
+    )
+    return _probe_result(
+        "scope.fft.presence",
+        passed=passed,
+        evidence=evidence,
+        error=error,
+        started_at=started_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Aggregation — fold probe results into the artifact/golden-gate machinery
+# ---------------------------------------------------------------------------
+
+
+async def run_audio_probe_checks(
+    *,
+    backend_factory: Callable[[], FakeAudioBackend] = _default_backend,
+) -> list[CheckResult]:
+    """Run the full AUDIO_PROBE family, each probe on a fresh fake backend."""
+    return [
+        await run_rx_rms_check(backend=backend_factory()),
+        await run_tx_byte_perfect_check(backend=backend_factory()),
+        await run_scope_presence_check(backend=backend_factory()),
+    ]
+
+
+def audio_probe_level_results(checks: Sequence[CheckResult]) -> list[LevelResult]:
+    """Group probe results by level for ``build_validation_artifact``.
+
+    Mirrors the runner/hardware grouping: ascending level order, original
+    order preserved within a level, empty levels omitted.
+    """
+    by_level: dict[ValidationLevel, list[CheckResult]] = {}
+    for check in checks:
+        by_level.setdefault(check.level, []).append(check)
+    return [
+        LevelResult(level=level, checks=by_level[level]) for level in sorted(by_level)
+    ]

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1258,6 +1258,23 @@ async def _check_from_spec(
     if spec.kind is CheckKind.MANUAL:
         return _manual_required_result(radio, entry)
 
+    if spec.kind is CheckKind.AUDIO_PROBE:
+        # Automated audio probes run in CI against FakeAudioBackend via
+        # ``rigplane.validation.audio_checks`` — never auto-run on a live
+        # radio. Generated templates declare them MANUAL_REQUIRED (pre-gate 2
+        # above); this branch only fires for custom templates that mark an
+        # AUDIO_PROBE check as supported.
+        return _base_result(
+            entry,
+            CheckStatus.SKIP,
+            evidence={
+                "reason": (
+                    "automated audio probe runs in CI via "
+                    "rigplane.validation.audio_checks"
+                )
+            },
+        )
+
     # CheckKind.TX_ADJACENT_BLOCKED (defensive)
     return _base_result(
         entry,

--- a/src/rigplane/validation/registry/__init__.py
+++ b/src/rigplane/validation/registry/__init__.py
@@ -3,7 +3,7 @@
 Public facade for the ``rigplane.validation.registry`` package.  Defines the
 closed set of check kinds and value-mutation rules, the ``CheckSpec``
 dataclass (pure data, no hardware dependencies), and ``REGISTRY`` — the
-canonical 21-entry tuple that drives every validation run regardless of radio
+canonical check tuple that drives every validation run regardless of radio
 model or backend.
 
 The check rows live in per-domain submodules so coverage-expansion work can
@@ -15,6 +15,7 @@ edit disjoint files (MOR-637):
 - ``_tuning`` — RIT, XIT, squelch (14-16)
 - ``_surfaces`` — audio, scope, meters (17-19)
 - ``_tx`` — tuner, PTT (20-21)
+- ``_audio`` — appended CI-automated audio probes (GH #1650, MOR-639/640/641)
 
 ``_assembly`` concatenates them into ``REGISTRY`` (order-preserving) and runs
 the import-time invariant guard; ``_builders`` holds the template generators.

--- a/src/rigplane/validation/registry/_assembly.py
+++ b/src/rigplane/validation/registry/_assembly.py
@@ -9,6 +9,7 @@ within each level.
 from __future__ import annotations
 
 from rigplane.core.capabilities import KNOWN_CAPABILITIES
+from rigplane.validation.registry._audio import CHECKS as _AUDIO_CHECKS
 from rigplane.validation.registry._dsp import CHECKS as _DSP_CHECKS
 from rigplane.validation.registry._levels import CHECKS as _LEVELS_CHECKS
 from rigplane.validation.registry._structural import CHECKS as _STRUCTURAL_CHECKS
@@ -28,6 +29,10 @@ REGISTRY: tuple[CheckSpec, ...] = (
     + _TUNING_CHECKS  # 14-16: rit, xit, squelch
     + _SURFACES_CHECKS  # 17-19: audio, scope, meters
     + _TX_CHECKS  # 20-21: tuner, tx
+    # ----- append-only anchor: new check families concatenate BELOW the -----
+    # ----- historical 1-21 block. The template generators stable-sort by ----
+    # ----- level, so appended checks slot into their level untouched. -------
+    + _AUDIO_CHECKS  # 22+: automated audio probes (GH #1650, MOR-639/640/641)
 )
 
 

--- a/src/rigplane/validation/registry/_audio.py
+++ b/src/rigplane/validation/registry/_audio.py
@@ -1,0 +1,39 @@
+"""Automated audio-pipeline probe checks (GH #1650; MOR-639/640/641).
+
+Registry positions 22+ (appended after the historical 1-21 block; the
+template generators stable-sort by level, so these COMPATIBILITY_SURFACES
+checks slot in next to the MANUAL ``audio.rx`` / ``scope.capture`` entries).
+
+The AUDIO_PROBE kind is CI-automated: each check executes against the
+deterministic audio fakes via :mod:`rigplane.validation.audio_checks` and is
+never auto-run on a live radio. The pre-existing MANUAL entries are kept for
+real-hardware operator confirmation; these probes are their automated,
+regression-gating counterparts.
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.registry._types import CheckKind, CheckSpec, ValueRule
+from rigplane.validation.schema import FailureDomain, ValidationLevel
+
+CHECKS: tuple[CheckSpec, ...] = (
+    # 22 — audio.rx.rms (T4 / MOR-639)
+    CheckSpec(
+        check_id="audio.rx.rms",
+        capability="audio",
+        kind=CheckKind.AUDIO_PROBE,
+        level=ValidationLevel.COMPATIBILITY_SURFACES,
+        failure_domain=FailureDomain.AUDIO,
+        summary=(
+            "Automated CI probe: inject a reference tone through the RX audio "
+            "pipeline and verify the delivered PCM RMS stays in the expected band."
+        ),
+        protocol="audio",
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+)

--- a/src/rigplane/validation/registry/_audio.py
+++ b/src/rigplane/validation/registry/_audio.py
@@ -58,4 +58,23 @@ CHECKS: tuple[CheckSpec, ...] = (
         # entry stays behind the tx_allowed operator gate like tx.ptt.
         tx_adjacent=True,
     ),
+    # 24 — scope.fft.presence (T6 / MOR-641)
+    CheckSpec(
+        check_id="scope.fft.presence",
+        capability="scope",
+        kind=CheckKind.AUDIO_PROBE,
+        level=ValidationLevel.COMPATIBILITY_SURFACES,
+        failure_domain=FailureDomain.SCOPE_WATERFALL,
+        summary=(
+            "Automated CI probe: feed a reference tone to the audio FFT scope "
+            "and verify in-band bins rise above the out-of-band baseline."
+        ),
+        protocol="scope",
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
 )

--- a/src/rigplane/validation/registry/_audio.py
+++ b/src/rigplane/validation/registry/_audio.py
@@ -36,4 +36,26 @@ CHECKS: tuple[CheckSpec, ...] = (
         hamlib_token=None,
         tx_adjacent=False,
     ),
+    # 23 — audio.tx.byte_perfect (T5 / MOR-640)
+    CheckSpec(
+        check_id="audio.tx.byte_perfect",
+        capability="audio",
+        kind=CheckKind.AUDIO_PROBE,
+        level=ValidationLevel.COMPATIBILITY_SURFACES,
+        failure_domain=FailureDomain.AUDIO,
+        summary=(
+            "Automated CI probe: verify captured TX audio PCM survives the "
+            "LAN audio packetization pipeline byte-perfect."
+        ),
+        protocol="audio",
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        # GH #1650: TX audio requires explicit operator safety enablement on
+        # real hardware. The CI probe never keys anything, but the template
+        # entry stays behind the tx_allowed operator gate like tx.ptt.
+        tx_adjacent=True,
+    ),
 )

--- a/src/rigplane/validation/registry/_builders.py
+++ b/src/rigplane/validation/registry/_builders.py
@@ -28,6 +28,9 @@ _KIND_TO_DECLARATION: dict[CheckKind, CapabilityDeclaration] = {
     CheckKind.WRITE_ONLY_OBSERVE: CapabilityDeclaration.SUPPORTED,
     CheckKind.MANUAL: CapabilityDeclaration.MANUAL_REQUIRED,
     CheckKind.TX_ADJACENT_BLOCKED: CapabilityDeclaration.MANUAL_REQUIRED,
+    # AUDIO_PROBE checks are CI-automated (rigplane.validation.audio_checks);
+    # on a real radio they keep the MANUAL operator-confirmation posture.
+    CheckKind.AUDIO_PROBE: CapabilityDeclaration.MANUAL_REQUIRED,
 }
 
 

--- a/src/rigplane/validation/registry/_types.py
+++ b/src/rigplane/validation/registry/_types.py
@@ -27,6 +27,11 @@ class CheckKind(StrEnum):
     WRITE_ONLY_OBSERVE = "write_only_observe"
     TX_ADJACENT_BLOCKED = "tx_adjacent_blocked"
     MANUAL = "manual"
+    # Automated audio-pipeline probe (GH #1650, MOR-639/640/641): executes in
+    # CI against the deterministic audio fakes via
+    # ``rigplane.validation.audio_checks`` — never auto-run on a live radio
+    # (hardware templates carry these checks as MANUAL_REQUIRED).
+    AUDIO_PROBE = "audio_probe"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -42,6 +42,12 @@
       "declaration": "manual_required"
     },
     {
+      "check_id": "audio.tx.byte_perfect",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
       "check_id": "band_edge.presence",
       "status": "unsupported",
       "declaration": "unsupported_pending_evidence"

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -218,6 +218,11 @@
       "declaration": "manual_required"
     },
     {
+      "check_id": "scope.fft.presence",
+      "status": "manual_required",
+      "declaration": "manual_required"
+    },
+    {
       "check_id": "split.presence",
       "status": "unsupported",
       "declaration": "unsupported_pending_evidence"

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -37,6 +37,11 @@
       "declaration": "manual_required"
     },
     {
+      "check_id": "audio.rx.rms",
+      "status": "manual_required",
+      "declaration": "manual_required"
+    },
+    {
       "check_id": "band_edge.presence",
       "status": "unsupported",
       "declaration": "unsupported_pending_evidence"

--- a/tests/validation/test_audio_checks.py
+++ b/tests/validation/test_audio_checks.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 from array import array
 
 from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.audio.lan_stream import MAX_AUDIO_PAYLOAD, TX_IDENT
 from rigplane.validation.audio_checks import (
+    PROBE_FRAME_BYTES,
     PROBE_SAMPLES_PER_FRAME,
     PROBE_TONE_HZ,
     run_rx_rms_check,
+    run_tx_byte_perfect_check,
 )
 from rigplane.validation.registry import (
     REGISTRY_BY_ID,
@@ -152,3 +155,77 @@ async def test_rx_rms_check_fails_on_attenuated_pipeline() -> None:
     expected_rms = result.evidence["expected_rms"]
     assert isinstance(rms, float) and isinstance(expected_rms, float)
     assert 0.0 < rms < expected_rms
+
+
+# ---------------------------------------------------------------------------
+# T5 / MOR-640 — TX byte-perfect probe
+# ---------------------------------------------------------------------------
+
+
+def test_audio_tx_byte_perfect_spec_registered() -> None:
+    spec = REGISTRY_BY_ID["audio.tx.byte_perfect"]
+    assert spec.kind is CheckKind.AUDIO_PROBE
+    assert spec.capability == "audio"
+    assert spec.level == ValidationLevel.COMPATIBILITY_SURFACES
+    assert spec.failure_domain is FailureDomain.AUDIO
+    assert spec.set_op is None
+    # GH #1650: TX audio stays behind explicit operator safety enablement
+    # on real hardware, exactly like tuner.tune / tx.ptt.
+    assert spec.tx_adjacent is True
+
+
+async def test_tx_byte_perfect_check_passes_on_clean_pipeline() -> None:
+    backend = _backend()
+    frame_count = 4
+    result = await run_tx_byte_perfect_check(backend=backend, frame_count=frame_count)
+
+    assert result.check_id == "audio.tx.byte_perfect"
+    assert result.status is CheckStatus.PASS
+    assert result.failure_domain is None
+    assert result.error is None
+
+    # Mirrors the byte-perfect TX harness contract: each 1920-byte PCM frame
+    # splits into a MAX_AUDIO_PAYLOAD chunk plus the remainder, all packets
+    # carry TX_IDENT, and sequence numbers are contiguous.
+    assert result.evidence["payload_matches"] is True
+    assert result.evidence["payload_bytes"] == frame_count * PROBE_FRAME_BYTES
+    assert result.evidence["packet_sizes"] == [
+        size
+        for _ in range(frame_count)
+        for size in (MAX_AUDIO_PAYLOAD, PROBE_FRAME_BYTES - MAX_AUDIO_PAYLOAD)
+    ]
+    assert result.evidence["idents"] == [TX_IDENT]
+    assert result.evidence["sequences_contiguous"] is True
+
+    # The fake capture stream was started and stopped exactly once.
+    assert len(backend.rx_streams) == 1
+    assert backend.rx_streams[0].stopped_count == 1
+
+
+async def test_tx_byte_perfect_check_fails_on_corrupted_payload() -> None:
+    def corrupt(pcm: bytes) -> bytes:
+        # Flip one byte mid-frame: same length, different payload.
+        mutated = bytearray(pcm)
+        mutated[len(mutated) // 2] ^= 0xFF
+        return bytes(mutated)
+
+    result = await run_tx_byte_perfect_check(backend=_backend(), pcm_transform=corrupt)
+    assert result.status is CheckStatus.FAIL
+    assert result.failure_domain is FailureDomain.AUDIO
+    assert result.error is not None
+    assert result.evidence["payload_matches"] is False
+
+
+async def test_tx_byte_perfect_check_fails_on_dropped_frames() -> None:
+    dropped: dict[str, int] = {"count": 0}
+
+    def drop_every_other(pcm: bytes) -> bytes:
+        dropped["count"] += 1
+        return pcm if dropped["count"] % 2 else b""
+
+    result = await run_tx_byte_perfect_check(
+        backend=_backend(), pcm_transform=drop_every_other
+    )
+    assert result.status is CheckStatus.FAIL
+    assert result.failure_domain is FailureDomain.AUDIO
+    assert result.evidence["payload_matches"] is False

--- a/tests/validation/test_audio_checks.py
+++ b/tests/validation/test_audio_checks.py
@@ -1,0 +1,154 @@
+"""Tests for the automated audio-pipeline probe checks (MOR-639/640/641).
+
+The AUDIO_PROBE check family is the CI-automated counterpart of the MANUAL
+``audio.rx`` / ``scope.capture`` operator checks (GH #1650): each probe
+executes against the real audio fakes (``FakeAudioBackend`` and friends) and
+produces a real :class:`CheckResult` that folds into the existing
+``ValidationArtifact`` + golden-gate machinery.
+"""
+
+from __future__ import annotations
+
+from array import array
+
+from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.validation.audio_checks import (
+    PROBE_SAMPLES_PER_FRAME,
+    PROBE_TONE_HZ,
+    run_rx_rms_check,
+)
+from rigplane.validation.registry import (
+    REGISTRY_BY_ID,
+    CheckKind,
+    build_template_from_capabilities,
+)
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CheckStatus,
+    FailureDomain,
+    ValidationLevel,
+)
+
+from _audio_pipeline_helpers import pcm_rms, sine_pcm16_mono
+
+
+def _backend() -> FakeAudioBackend:
+    return FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="Probe Loopback",
+                input_channels=2,
+                output_channels=2,
+            )
+        ]
+    )
+
+
+def _silence(pcm: bytes) -> bytes:
+    return b"\x00" * len(pcm)
+
+
+def _attenuate_6db(pcm: bytes) -> bytes:
+    samples = array("h")
+    samples.frombytes(pcm)
+    return array("h", (s // 2 for s in samples)).tobytes()
+
+
+# ---------------------------------------------------------------------------
+# Registry integration (T4 — audio.rx.rms)
+# ---------------------------------------------------------------------------
+
+
+def test_audio_rx_rms_spec_registered() -> None:
+    spec = REGISTRY_BY_ID["audio.rx.rms"]
+    assert spec.kind is CheckKind.AUDIO_PROBE
+    assert spec.capability == "audio"
+    assert spec.level == ValidationLevel.COMPATIBILITY_SURFACES
+    assert spec.failure_domain is FailureDomain.AUDIO
+    assert spec.get_op is None
+    assert spec.set_op is None
+    assert spec.tx_adjacent is False
+
+
+def test_manual_audio_rx_check_kept_for_real_hardware() -> None:
+    """The MANUAL audio.rx operator check is kept, not superseded."""
+    spec = REGISTRY_BY_ID["audio.rx"]
+    assert spec.kind is CheckKind.MANUAL
+
+
+def test_audio_probe_declares_manual_required_in_hardware_templates() -> None:
+    """AUDIO_PROBE checks slot into generated templates as MANUAL_REQUIRED.
+
+    On real hardware the probes are never auto-run (they execute in CI via
+    ``rigplane.validation.audio_checks``), so per-radio templates carry them
+    with the same operator-confirmation posture as the MANUAL checks.
+    """
+    template = build_template_from_capabilities(
+        frozenset({"audio"}),
+        model="IC-0000",
+        profile_id="probe_test",
+    )
+    entries = {entry.check_id: entry for entry in template.entries}
+    entry = entries["audio.rx.rms"]
+    assert entry.declaration == CapabilityDeclaration.MANUAL_REQUIRED
+    assert entry.level == ValidationLevel.COMPATIBILITY_SURFACES
+
+
+# ---------------------------------------------------------------------------
+# T4 / MOR-639 — RX-RMS probe
+# ---------------------------------------------------------------------------
+
+
+async def test_rx_rms_check_passes_on_clean_pipeline() -> None:
+    backend = _backend()
+    result = await run_rx_rms_check(backend=backend)
+
+    assert result.check_id == "audio.rx.rms"
+    assert result.capability == "audio"
+    assert result.level == ValidationLevel.COMPATIBILITY_SURFACES
+    assert result.status is CheckStatus.PASS
+    assert result.declaration is CapabilityDeclaration.SUPPORTED
+    assert result.failure_domain is None
+    assert result.error is None
+    assert result.started_at and result.finished_at
+
+    # The delivered RMS matches the reference tone exactly (byte-identical
+    # delivery through FakeRxStream), cross-checked against the shared
+    # test helpers rather than the probe's own math.
+    expected_rms = pcm_rms(
+        sine_pcm16_mono(PROBE_TONE_HZ, samples=PROBE_SAMPLES_PER_FRAME)
+    )
+    rms = result.evidence["rms"]
+    assert isinstance(rms, float)
+    assert rms > 0.0
+    assert abs(rms - expected_rms) < 1e-6
+
+    # Stream lifecycle is clean: started once, stopped once.
+    assert len(backend.rx_streams) == 1
+    assert backend.rx_streams[0].started_count == 1
+    assert backend.rx_streams[0].stopped_count == 1
+
+
+async def test_rx_rms_check_builds_default_backend() -> None:
+    result = await run_rx_rms_check()
+    assert result.status is CheckStatus.PASS
+
+
+async def test_rx_rms_check_fails_on_silent_pipeline() -> None:
+    result = await run_rx_rms_check(backend=_backend(), pcm_transform=_silence)
+    assert result.status is CheckStatus.FAIL
+    assert result.failure_domain is FailureDomain.AUDIO
+    assert result.error is not None
+    assert result.evidence["rms"] == 0.0
+
+
+async def test_rx_rms_check_fails_on_attenuated_pipeline() -> None:
+    """A -6 dB level drop lands outside the RMS tolerance band."""
+    result = await run_rx_rms_check(backend=_backend(), pcm_transform=_attenuate_6db)
+    assert result.status is CheckStatus.FAIL
+    assert result.failure_domain is FailureDomain.AUDIO
+    rms = result.evidence["rms"]
+    expected_rms = result.evidence["expected_rms"]
+    assert isinstance(rms, float) and isinstance(expected_rms, float)
+    assert 0.0 < rms < expected_rms

--- a/tests/validation/test_audio_checks.py
+++ b/tests/validation/test_audio_checks.py
@@ -17,9 +17,15 @@ from rigplane.validation.audio_checks import (
     PROBE_FRAME_BYTES,
     PROBE_SAMPLES_PER_FRAME,
     PROBE_TONE_HZ,
+    audio_probe_level_results,
+    run_audio_probe_checks,
     run_rx_rms_check,
+    run_scope_presence_check,
     run_tx_byte_perfect_check,
 )
+from rigplane.validation.gating import gate_artifacts
+from rigplane.validation.runner import build_validation_artifact
+from rigplane.validation.schema import validate_artifact_dict
 from rigplane.validation.registry import (
     REGISTRY_BY_ID,
     CheckKind,
@@ -29,6 +35,8 @@ from rigplane.validation.schema import (
     CapabilityDeclaration,
     CheckStatus,
     FailureDomain,
+    OperatorSafetyBlock,
+    TransportInfo,
     ValidationLevel,
 )
 
@@ -229,3 +237,122 @@ async def test_tx_byte_perfect_check_fails_on_dropped_frames() -> None:
     assert result.status is CheckStatus.FAIL
     assert result.failure_domain is FailureDomain.AUDIO
     assert result.evidence["payload_matches"] is False
+
+
+# ---------------------------------------------------------------------------
+# T6 / MOR-641 — scope-presence probe
+# ---------------------------------------------------------------------------
+
+
+def test_scope_fft_presence_spec_registered() -> None:
+    spec = REGISTRY_BY_ID["scope.fft.presence"]
+    assert spec.kind is CheckKind.AUDIO_PROBE
+    assert spec.capability == "scope"
+    assert spec.level == ValidationLevel.COMPATIBILITY_SURFACES
+    assert spec.failure_domain is FailureDomain.SCOPE_WATERFALL
+    assert spec.tx_adjacent is False
+
+
+def test_manual_scope_capture_check_kept_for_real_hardware() -> None:
+    spec = REGISTRY_BY_ID["scope.capture"]
+    assert spec.kind is CheckKind.MANUAL
+
+
+async def test_scope_presence_check_passes_on_tone() -> None:
+    """A 1 kHz tone raises in-band FFT bins well above the baseline.
+
+    Regression guard for the MOR-512/528 adaptive in-band auto-range: a
+    clean in-band signal must stand out of the (clipped-low) baseline.
+    """
+    result = await run_scope_presence_check(backend=_backend())
+
+    assert result.check_id == "scope.fft.presence"
+    assert result.status is CheckStatus.PASS
+    assert result.failure_domain is None
+    assert result.error is None
+
+    frames = result.evidence["frames_emitted"]
+    assert isinstance(frames, int) and frames >= 1
+    signal_peak = result.evidence["signal_peak"]
+    baseline = result.evidence["baseline_median"]
+    assert isinstance(signal_peak, int) and isinstance(baseline, (int, float))
+    assert signal_peak > baseline
+
+
+async def test_scope_presence_check_fails_on_silence() -> None:
+    result = await run_scope_presence_check(backend=_backend(), pcm_transform=_silence)
+    assert result.status is CheckStatus.FAIL
+    assert result.failure_domain is FailureDomain.SCOPE_WATERFALL
+    assert result.error is not None
+
+
+async def test_scope_presence_check_fails_when_no_frames_emitted() -> None:
+    """Starving the scope below one FFT window emits no frame at all."""
+    result = await run_scope_presence_check(
+        backend=_backend(),
+        frame_count=1,  # 960 samples < 2048-sample FFT window
+    )
+    assert result.status is CheckStatus.FAIL
+    assert result.failure_domain is FailureDomain.SCOPE_WATERFALL
+    assert result.evidence["frames_emitted"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Aggregation: artifact + golden-gate integration
+# ---------------------------------------------------------------------------
+
+
+async def test_run_audio_probe_checks_runs_all_three() -> None:
+    checks = await run_audio_probe_checks()
+    assert [check.check_id for check in checks] == [
+        "audio.rx.rms",
+        "audio.tx.byte_perfect",
+        "scope.fft.presence",
+    ]
+    assert all(check.status is CheckStatus.PASS for check in checks)
+
+
+async def test_probe_results_flow_into_artifact_and_golden_gate() -> None:
+    """Probe CheckResults assemble into a schema-valid ValidationArtifact and
+    regress through gate_artifacts exactly like command checks."""
+    checks = await run_audio_probe_checks()
+    levels = audio_probe_level_results(checks)
+    assert len(levels) == 1
+    assert levels[0].level == ValidationLevel.COMPATIBILITY_SURFACES
+
+    template = build_template_from_capabilities(
+        frozenset({"audio", "scope"}),
+        model="CI Audio Harness",
+        profile_id="ci_audio_harness",
+    )
+    artifact = build_validation_artifact(
+        template=template,
+        levels=levels,
+        transport=TransportInfo(backend="fake-audio"),
+        safety=OperatorSafetyBlock(),
+        core_version="0.0.0-test",
+        mode="ci-audio-probe",
+    )
+    payload = artifact.to_dict()
+    # Round-trips through the strict schema validator.
+    validate_artifact_dict(payload)
+
+    # An all-PASS run gates clean against itself (the golden).
+    report = gate_artifacts(payload, payload)
+    assert report.ok
+    assert report.matched == 3
+
+    # A regressed probe (silent RX pipeline) is a BLOCKING regression.
+    regressed = await run_rx_rms_check(pcm_transform=_silence)
+    regressed_levels = audio_probe_level_results([regressed, *checks[1:]])
+    regressed_artifact = build_validation_artifact(
+        template=template,
+        levels=regressed_levels,
+        transport=TransportInfo(backend="fake-audio"),
+        safety=OperatorSafetyBlock(),
+        core_version="0.0.0-test",
+        mode="ci-audio-probe",
+    )
+    report = gate_artifacts(regressed_artifact.to_dict(), payload)
+    assert not report.ok
+    assert any("audio.rx.rms" in line for line in report.regressions)

--- a/tests/validation/test_registry.py
+++ b/tests/validation/test_registry.py
@@ -28,8 +28,8 @@ from rigplane.validation.schema import FailureDomain, ValidationLevel
 # ---------------------------------------------------------------------------
 
 
-def test_registry_has_22_entries():
-    assert len(REGISTRY) == 22
+def test_registry_has_23_entries():
+    assert len(REGISTRY) == 23
 
 
 def test_check_ids_unique():
@@ -65,6 +65,7 @@ def test_check_id_set_unchanged_after_domain_split():
         "tx.ptt",
         # Appended audio-probe family (CI-automated, GH #1650):
         "audio.rx.rms",
+        "audio.tx.byte_perfect",
     }
     assert {spec.check_id for spec in REGISTRY} == expected
 
@@ -91,9 +92,10 @@ def test_tx_adjacent_blocked_implies_tx_adjacent():
             assert spec.tx_adjacent is True, (
                 f"{spec.check_id!r}: TX_ADJACENT_BLOCKED but tx_adjacent is False"
             )
-    # ONLY tuner.tune and tx.ptt should have tx_adjacent=True
+    # tuner.tune, tx.ptt, and the TX-audio probe (GH #1650: TX audio stays
+    # behind explicit operator safety enablement) are the only tx_adjacent ids.
     tx_adjacent_ids = {spec.check_id for spec in REGISTRY if spec.tx_adjacent}
-    assert tx_adjacent_ids == {"tuner.tune", "tx.ptt"}
+    assert tx_adjacent_ids == {"tuner.tune", "tx.ptt", "audio.tx.byte_perfect"}
 
 
 def test_manual_and_blocked_have_no_set_op():

--- a/tests/validation/test_registry.py
+++ b/tests/validation/test_registry.py
@@ -28,8 +28,8 @@ from rigplane.validation.schema import FailureDomain, ValidationLevel
 # ---------------------------------------------------------------------------
 
 
-def test_registry_has_23_entries():
-    assert len(REGISTRY) == 23
+def test_registry_has_24_entries():
+    assert len(REGISTRY) == 24
 
 
 def test_check_ids_unique():
@@ -66,6 +66,7 @@ def test_check_id_set_unchanged_after_domain_split():
         # Appended audio-probe family (CI-automated, GH #1650):
         "audio.rx.rms",
         "audio.tx.byte_perfect",
+        "scope.fft.presence",
     }
     assert {spec.check_id for spec in REGISTRY} == expected
 

--- a/tests/validation/test_registry.py
+++ b/tests/validation/test_registry.py
@@ -28,8 +28,8 @@ from rigplane.validation.schema import FailureDomain, ValidationLevel
 # ---------------------------------------------------------------------------
 
 
-def test_registry_has_21_entries():
-    assert len(REGISTRY) == 21
+def test_registry_has_22_entries():
+    assert len(REGISTRY) == 22
 
 
 def test_check_ids_unique():
@@ -39,7 +39,8 @@ def test_check_ids_unique():
 
 def test_check_id_set_unchanged_after_domain_split():
     """MOR-637 guard: the per-domain package split must not lose, duplicate,
-    or rename any check. Frozen snapshot of the pre-split REGISTRY ids."""
+    or rename any check. Frozen snapshot of the pre-split REGISTRY ids, plus
+    the append-only audio-probe family (GH #1650, MOR-639/640/641)."""
     expected = {
         "discovery.identify",
         "freq.write",
@@ -62,6 +63,8 @@ def test_check_id_set_unchanged_after_domain_split():
         "meters.read",
         "tuner.tune",
         "tx.ptt",
+        # Appended audio-probe family (CI-automated, GH #1650):
+        "audio.rx.rms",
     }
     assert {spec.check_id for spec in REGISTRY} == expected
 


### PR DESCRIPTION
## Summary

Implements the net-new **audio check-kind** specified in #1650: an automated, CI-safe AUDIO-pipeline regression suite that produces real `CheckResult`s flowing into the existing `ValidationArtifact` + golden-gate machinery, so audio regressions gate exactly like command regressions.

Three probes, one per Linear task:

| Check | Task | What it guards | Failure domain |
|---|---|---|---|
| `audio.rx.rms` | MOR-639 | Injects a 1 kHz reference tone through `FakeAudioBackend`/`FakeRxStream` and verifies the delivered PCM RMS is non-zero and within a 5% band of the reference | `audio` |
| `audio.tx.byte_perfect` | MOR-640 | Mirrors the in-process TX harness (`tests/test_audio_pipeline_harness`; real-hw byte-perfectness proven in MOR-614): captured frames are pushed through the REAL `AudioStream` LAN packetization and the reassembled payload must equal the reference PCM byte-for-byte, with TX idents and contiguous sequence numbers | `audio` |
| `scope.fft.presence` | MOR-641 | Feeds the tone to the REAL `AudioFftScope` (MOR-512/528 adaptive in-band auto-range path) and requires in-band bins to rise above the out-of-band baseline (observed margins: pixel peak 160 vs baseline 0) | `scope_waterfall` |

## How it integrates

- **New `CheckKind.AUDIO_PROBE`** (`registry/_types.py`) — the #1650 audio check-kind. Registry rows live in a new module `registry/_audio.py`, appended to `REGISTRY` in `_assembly.py` at a clearly-commented append-only anchor below the historical 1-21 block (template generators stable-sort by level, so the entries slot into COMPATIBILITY_SURFACES without reordering anything).
- **CI-safe via `FakeAudioBackend`** — probes live in new `src/rigplane/validation/audio_checks.py` and run against the deterministic audio fakes plus the REAL packetizer/FFT-scope code paths. No PortAudio, no hardware, no network. `pcm_transform` is a documented fault-injection hook for the probes' own regression tests.
- **MANUAL kept for real hardware** — the pre-existing MANUAL `audio.rx`/`scope.capture` operator checks are kept, not superseded; the probes are additive. Generated hardware templates carry AUDIO_PROBE checks as `MANUAL_REQUIRED` (never auto-run on a live radio; `hardware.py` defensively SKIPs them if a custom template declares them supported). Decision documented in `src/rigplane/validation/LAYER.md`.
- **TX safety per #1650** — `audio.tx.byte_perfect` is `tx_adjacent=True`: on real hardware it stays behind the `tx_allowed` operator gate like `tx.ptt` (the CI probe never keys anything).
- **Artifact + golden gate** — `run_audio_probe_checks()` + `audio_probe_level_results()` feed `build_validation_artifact` → `gate_artifacts`; an end-to-end test proves a regressed probe (silent RX pipeline) surfaces as a BLOCKING gate regression.

## Tests

TDD suite `tests/validation/test_audio_checks.py` (18 tests): RX-RMS pass/silent/attenuated, TX byte-perfect pass/corrupted/dropped-frames, scope present/silent/starved, registry + template integration, and the artifact/golden-gate round-trip. Registry guard tests updated (21 → 24 entries, tx_adjacent id set); IC-7610 dry-run golden regenerated via the documented `--regen-golden` command.

## Verification

- `uv run pytest tests/ -q --ignore=tests/integration` — **7702 passed, 0 failed**
- `uv run ruff check src/ tests/` + `ruff format` — clean
- `uv run mypy src/` — Success: no issues found in 278 source files
- `uv run lint-imports` — Contracts: 4 kept, 0 broken

Closes #1650 (Core scope; CI fake-stream checks per its acceptance criteria — hardware runs remain operator-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)