### PR TITLE
feat(validation): command-coverage families T7-T10 — tone, VFO, memory, system (MOR-642..645)

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1065,6 +1065,7 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     ValueRule.AGC_FLIP: int(AgcMode.FAST),
     ValueRule.TONE_FREQ_CYCLE: 88.5,
     ValueRule.VFO_AB_FLIP: "A",
+    ValueRule.KEY_SPEED_WPM: 20,
 }
 
 # Benign value to restore a write-only control to afterwards (best-effort).
@@ -1092,6 +1093,8 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     ValueRule.TONE_FREQ_CYCLE: lambda f: 100.0 if float(f) == 88.5 else 88.5,
     # VFO slot select: "A" <-> "B".
     ValueRule.VFO_AB_FLIP: lambda s: "B" if str(s).upper() == "A" else "A",
+    # CW keyer speed in WPM (real range 6-48): pick a DIFFERENT in-range value.
+    ValueRule.KEY_SPEED_WPM: lambda w: 24 if int(w) != 24 else 20,
 }
 
 

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1063,6 +1063,7 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     ValueRule.NUDGE_FILTER: 2800,
     ValueRule.PREAMP_CYCLE: 1,
     ValueRule.AGC_FLIP: int(AgcMode.FAST),
+    ValueRule.TONE_FREQ_CYCLE: 88.5,
 }
 
 # Benign value to restore a write-only control to afterwards (best-effort).
@@ -1085,6 +1086,9 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
         int(AgcMode.SLOW) if m != AgcMode.SLOW else int(AgcMode.FAST)
     ),
     ValueRule.BUMP_HZ: lambda v: v + 100,
+    # MOR-642..645 command-coverage families.
+    # Flip between two standard CTCSS tones (Hz).
+    ValueRule.TONE_FREQ_CYCLE: lambda f: 100.0 if float(f) == 88.5 else 88.5,
 }
 
 

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1064,6 +1064,7 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     ValueRule.PREAMP_CYCLE: 1,
     ValueRule.AGC_FLIP: int(AgcMode.FAST),
     ValueRule.TONE_FREQ_CYCLE: 88.5,
+    ValueRule.VFO_AB_FLIP: "A",
 }
 
 # Benign value to restore a write-only control to afterwards (best-effort).
@@ -1089,6 +1090,8 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     # MOR-642..645 command-coverage families.
     # Flip between two standard CTCSS tones (Hz).
     ValueRule.TONE_FREQ_CYCLE: lambda f: 100.0 if float(f) == 88.5 else 88.5,
+    # VFO slot select: "A" <-> "B".
+    ValueRule.VFO_AB_FLIP: lambda s: "B" if str(s).upper() == "A" else "A",
 }
 
 

--- a/src/rigplane/validation/registry/__init__.py
+++ b/src/rigplane/validation/registry/__init__.py
@@ -17,6 +17,7 @@ edit disjoint files (MOR-637):
 - ``_tx`` — tuner, PTT (20-21)
 - ``_tone`` — CTCSS repeater tone, TSQL, tone frequencies (MOR-642)
 - ``_vfo`` — split, VFO A/B slot, dual watch (MOR-643)
+- ``_memory`` — band-stack manual check (MOR-644)
 
 ``_assembly`` concatenates them into ``REGISTRY`` (order-preserving) and runs
 the import-time invariant guard; ``_builders`` holds the template generators.

--- a/src/rigplane/validation/registry/__init__.py
+++ b/src/rigplane/validation/registry/__init__.py
@@ -3,7 +3,7 @@
 Public facade for the ``rigplane.validation.registry`` package.  Defines the
 closed set of check kinds and value-mutation rules, the ``CheckSpec``
 dataclass (pure data, no hardware dependencies), and ``REGISTRY`` — the
-canonical 21-entry tuple that drives every validation run regardless of radio
+canonical check tuple that drives every validation run regardless of radio
 model or backend.
 
 The check rows live in per-domain submodules so coverage-expansion work can
@@ -15,6 +15,7 @@ edit disjoint files (MOR-637):
 - ``_tuning`` — RIT, XIT, squelch (14-16)
 - ``_surfaces`` — audio, scope, meters (17-19)
 - ``_tx`` — tuner, PTT (20-21)
+- ``_tone`` — CTCSS repeater tone, TSQL, tone frequencies (MOR-642)
 
 ``_assembly`` concatenates them into ``REGISTRY`` (order-preserving) and runs
 the import-time invariant guard; ``_builders`` holds the template generators.

--- a/src/rigplane/validation/registry/__init__.py
+++ b/src/rigplane/validation/registry/__init__.py
@@ -18,6 +18,7 @@ edit disjoint files (MOR-637):
 - ``_tone`` — CTCSS repeater tone, TSQL, tone frequencies (MOR-642)
 - ``_vfo`` — split, VFO A/B slot, dual watch (MOR-643)
 - ``_memory`` — band-stack manual check (MOR-644)
+- ``_system`` — system clock, CW keyer speed, VOX, dial lock (MOR-645)
 
 ``_assembly`` concatenates them into ``REGISTRY`` (order-preserving) and runs
 the import-time invariant guard; ``_builders`` holds the template generators.

--- a/src/rigplane/validation/registry/__init__.py
+++ b/src/rigplane/validation/registry/__init__.py
@@ -16,6 +16,7 @@ edit disjoint files (MOR-637):
 - ``_surfaces`` — audio, scope, meters (17-19)
 - ``_tx`` — tuner, PTT (20-21)
 - ``_tone`` — CTCSS repeater tone, TSQL, tone frequencies (MOR-642)
+- ``_vfo`` — split, VFO A/B slot, dual watch (MOR-643)
 
 ``_assembly`` concatenates them into ``REGISTRY`` (order-preserving) and runs
 the import-time invariant guard; ``_builders`` holds the template generators.

--- a/src/rigplane/validation/registry/_assembly.py
+++ b/src/rigplane/validation/registry/_assembly.py
@@ -14,6 +14,7 @@ from rigplane.validation.registry._levels import CHECKS as _LEVELS_CHECKS
 from rigplane.validation.registry._memory import CHECKS as _MEMORY_CHECKS
 from rigplane.validation.registry._structural import CHECKS as _STRUCTURAL_CHECKS
 from rigplane.validation.registry._surfaces import CHECKS as _SURFACES_CHECKS
+from rigplane.validation.registry._system import CHECKS as _SYSTEM_CHECKS
 from rigplane.validation.registry._tone import CHECKS as _TONE_CHECKS
 from rigplane.validation.registry._tuning import CHECKS as _TUNING_CHECKS
 from rigplane.validation.registry._tx import CHECKS as _TX_CHECKS
@@ -36,6 +37,7 @@ REGISTRY: tuple[CheckSpec, ...] = (
     + _TONE_CHECKS  # T7: repeater_tone, tone_freq, tsql, tsql_freq
     + _VFO_CHECKS  # T8: split, vfo_slot, dual_watch
     + _MEMORY_CHECKS  # T9: bsr (manual; CI-V memory surface is SET-only)
+    + _SYSTEM_CHECKS  # T10: system clock, key_speed, vox, dial_lock
 )
 
 

--- a/src/rigplane/validation/registry/_assembly.py
+++ b/src/rigplane/validation/registry/_assembly.py
@@ -17,6 +17,7 @@ from rigplane.validation.registry._tone import CHECKS as _TONE_CHECKS
 from rigplane.validation.registry._tuning import CHECKS as _TUNING_CHECKS
 from rigplane.validation.registry._tx import CHECKS as _TX_CHECKS
 from rigplane.validation.registry._types import VALUE_RULES, CheckKind, CheckSpec
+from rigplane.validation.registry._vfo import CHECKS as _VFO_CHECKS
 
 # ---------------------------------------------------------------------------
 # REGISTRY
@@ -32,6 +33,7 @@ REGISTRY: tuple[CheckSpec, ...] = (
     # --- MOR-642..645 command-coverage families (append-only; generators
     # stable-sort by level so new checks slot in without reordering 1-21) ---
     + _TONE_CHECKS  # T7: repeater_tone, tone_freq, tsql, tsql_freq
+    + _VFO_CHECKS  # T8: split, vfo_slot, dual_watch
 )
 
 

--- a/src/rigplane/validation/registry/_assembly.py
+++ b/src/rigplane/validation/registry/_assembly.py
@@ -13,6 +13,7 @@ from rigplane.validation.registry._dsp import CHECKS as _DSP_CHECKS
 from rigplane.validation.registry._levels import CHECKS as _LEVELS_CHECKS
 from rigplane.validation.registry._structural import CHECKS as _STRUCTURAL_CHECKS
 from rigplane.validation.registry._surfaces import CHECKS as _SURFACES_CHECKS
+from rigplane.validation.registry._tone import CHECKS as _TONE_CHECKS
 from rigplane.validation.registry._tuning import CHECKS as _TUNING_CHECKS
 from rigplane.validation.registry._tx import CHECKS as _TX_CHECKS
 from rigplane.validation.registry._types import VALUE_RULES, CheckKind, CheckSpec
@@ -28,6 +29,9 @@ REGISTRY: tuple[CheckSpec, ...] = (
     + _TUNING_CHECKS  # 14-16: rit, xit, squelch
     + _SURFACES_CHECKS  # 17-19: audio, scope, meters
     + _TX_CHECKS  # 20-21: tuner, tx
+    # --- MOR-642..645 command-coverage families (append-only; generators
+    # stable-sort by level so new checks slot in without reordering 1-21) ---
+    + _TONE_CHECKS  # T7: repeater_tone, tone_freq, tsql, tsql_freq
 )
 
 

--- a/src/rigplane/validation/registry/_assembly.py
+++ b/src/rigplane/validation/registry/_assembly.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from rigplane.core.capabilities import KNOWN_CAPABILITIES
 from rigplane.validation.registry._dsp import CHECKS as _DSP_CHECKS
 from rigplane.validation.registry._levels import CHECKS as _LEVELS_CHECKS
+from rigplane.validation.registry._memory import CHECKS as _MEMORY_CHECKS
 from rigplane.validation.registry._structural import CHECKS as _STRUCTURAL_CHECKS
 from rigplane.validation.registry._surfaces import CHECKS as _SURFACES_CHECKS
 from rigplane.validation.registry._tone import CHECKS as _TONE_CHECKS
@@ -34,6 +35,7 @@ REGISTRY: tuple[CheckSpec, ...] = (
     # stable-sort by level so new checks slot in without reordering 1-21) ---
     + _TONE_CHECKS  # T7: repeater_tone, tone_freq, tsql, tsql_freq
     + _VFO_CHECKS  # T8: split, vfo_slot, dual_watch
+    + _MEMORY_CHECKS  # T9: bsr (manual; CI-V memory surface is SET-only)
 )
 
 

--- a/src/rigplane/validation/registry/_memory.py
+++ b/src/rigplane/validation/registry/_memory.py
@@ -1,0 +1,40 @@
+"""Memory / band-stack checks.
+
+Command-coverage family T9 (MOR-644). This family is read-mostly by charter,
+but the Icom CI-V memory surface is SET-only on the IC-7610: ``get_memory_mode``,
+``get_memory_contents`` and ``get_bsr`` exist on the runtime but raise
+``NotImplementedError`` (commands 0x08 / 0x1A 0x00 / 0x1A 0x01 have no GET
+variant per the CI-V Reference Manual), and the write ops (``set_memory_mode``,
+``memory_to_vfo``, ``set_bsr``) cannot be restored without a readback — i.e.
+they are not RMVR-safe. The only honest automated representation is a MANUAL
+check; the rest of the family is deferred until a radio with memory readback
+lands (see PR body).
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.registry._types import CheckKind, CheckSpec, ValueRule
+from rigplane.validation.schema import FailureDomain, ValidationLevel
+
+CHECKS: tuple[CheckSpec, ...] = (
+    # bsr.select — manual: CI-V band-stack write is SET-only (no readback).
+    CheckSpec(
+        check_id="bsr.select",
+        capability="bsr",
+        kind=CheckKind.MANUAL,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.COMMAND_EXECUTION,
+        summary=(
+            "Operator verifies band-stack register select/recall on the rig; "
+            "the CI-V command is SET-only (no GET variant) so automated "
+            "readback is impossible."
+        ),
+        protocol="bsr",
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+)

--- a/src/rigplane/validation/registry/_system.py
+++ b/src/rigplane/validation/registry/_system.py
@@ -1,0 +1,144 @@
+"""System checks: clock read, CW keyer speed, VOX, dial lock.
+
+Command-coverage family T10 (MOR-645). Ops exist on ``SystemControlCapable``
+(``get_system_date``/``get_system_time``, ``get/set_dial_lock``),
+``CwControlCapable`` (``get/set_key_speed``, WPM) and ``VoiceControlCapable``
+(``get_vox``, ``set_vox``, ``set_vox_gain``).
+
+Safety classification:
+
+* ``system_date.read``/``system_time.read`` are READ_ONLY — writing the rig
+  clock is lossy (seconds drift between RMVR write and restore) and
+  ``set_system_date``/``set_system_time`` take multi-argument tuples the
+  generic single-value runner cannot drive; the SET side is deferred.
+* ``vox.set``/``vox_gain.set`` are TX_ADJACENT_BLOCKED: enabling VOX (or
+  raising its gain while the operator has VOX armed) can key the transmitter
+  from ambient microphone audio, so both require explicit operator
+  authorization and are never auto-actuated.
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.registry._types import CheckKind, CheckSpec, ValueRule
+from rigplane.validation.schema import FailureDomain, ValidationLevel
+
+CHECKS: tuple[CheckSpec, ...] = (
+    # system_date.read
+    CheckSpec(
+        check_id="system_date.read",
+        capability="system_settings",
+        kind=CheckKind.READ_ONLY,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Read the rig system date and verify a plausible (year, month, day) result.",
+        protocol="system_settings",
+        get_op="get_system_date",
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # system_time.read
+    CheckSpec(
+        check_id="system_time.read",
+        capability="system_settings",
+        kind=CheckKind.READ_ONLY,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Read the rig system time and verify a plausible (hour, minute) result.",
+        protocol="system_settings",
+        get_op="get_system_time",
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # key_speed.set
+    CheckSpec(
+        check_id="key_speed.set",
+        capability="cw",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Nudge the CW keyer speed (WPM), verify readback, restore original.",
+        protocol="cw",
+        get_op="get_key_speed",
+        set_op="set_key_speed",
+        value_rule=ValueRule.KEY_SPEED_WPM,
+        tolerance=1,
+        hamlib_token="KEYSPD",
+        tx_adjacent=False,
+    ),
+    # vox.read — safe readback of the VOX enable state.
+    CheckSpec(
+        check_id="vox.read",
+        capability="vox",
+        kind=CheckKind.READ_ONLY,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Read the VOX on/off state without actuating it.",
+        protocol="vox",
+        get_op="get_vox",
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # vox.set — TX-adjacent: enabling VOX can key TX from ambient audio.
+    CheckSpec(
+        check_id="vox.set",
+        capability="vox",
+        kind=CheckKind.TX_ADJACENT_BLOCKED,
+        level=ValidationLevel.STRESS_RECOVERY,
+        failure_domain=FailureDomain.COMMAND_EXECUTION,
+        summary=(
+            "Toggle VOX on/off; requires explicit operator authorization "
+            "because an enabled VOX can key TX from ambient microphone audio."
+        ),
+        protocol="vox",
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=True,
+    ),
+    # vox_gain.set — TX-adjacent: raising gain with VOX armed can key TX.
+    CheckSpec(
+        check_id="vox_gain.set",
+        capability="vox",
+        kind=CheckKind.TX_ADJACENT_BLOCKED,
+        level=ValidationLevel.STRESS_RECOVERY,
+        failure_domain=FailureDomain.COMMAND_EXECUTION,
+        summary=(
+            "Adjust VOX gain; requires explicit operator authorization "
+            "because raising the gain while VOX is armed can key TX."
+        ),
+        protocol="vox",
+        get_op=None,
+        set_op=None,
+        value_rule=ValueRule.STEP_LEVEL_255,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=True,
+    ),
+    # dial_lock.set
+    CheckSpec(
+        check_id="dial_lock.set",
+        capability="dial_lock",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle the dial lock on/off and verify readback; restore original.",
+        protocol="dial_lock",
+        get_op="get_dial_lock",
+        set_op="set_dial_lock",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+)

--- a/src/rigplane/validation/registry/_tone.py
+++ b/src/rigplane/validation/registry/_tone.py
@@ -1,0 +1,82 @@
+"""Tone / tone-squelch checks: CTCSS repeater tone, TSQL, tone frequencies.
+
+Command-coverage family T7 (MOR-642). All four checks drive ops that exist on
+``RepeaterControlCapable`` (``runtime/radio.py``): ``get/set_repeater_tone``,
+``get/set_repeater_tsql``, ``get/set_tone_freq``, ``get/set_tsql_freq``.
+
+DTCS/DCS code select is deliberately absent: the Radio protocol has no
+``get_dtcs_code``/``set_dtcs_code`` yet (capability tag ``dtcs`` exists but is
+method-less) — deferred as add-method-then-add-check.
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.registry._types import CheckKind, CheckSpec, ValueRule
+from rigplane.validation.schema import FailureDomain, ValidationLevel
+
+CHECKS: tuple[CheckSpec, ...] = (
+    # repeater_tone.set
+    CheckSpec(
+        check_id="repeater_tone.set",
+        capability="repeater_tone",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle the CTCSS repeater tone on/off and verify readback.",
+        protocol="repeater_tone",
+        get_op="get_repeater_tone",
+        set_op="set_repeater_tone",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # tone_freq.set
+    CheckSpec(
+        check_id="tone_freq.set",
+        capability="repeater_tone",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Cycle the CTCSS tone frequency to another standard tone and verify readback.",
+        protocol="repeater_tone",
+        get_op="get_tone_freq",
+        set_op="set_tone_freq",
+        value_rule=ValueRule.TONE_FREQ_CYCLE,
+        tolerance=1,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # tsql.set
+    CheckSpec(
+        check_id="tsql.set",
+        capability="tsql",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle tone squelch (TSQL) on/off and verify readback.",
+        protocol="tsql",
+        get_op="get_repeater_tsql",
+        set_op="set_repeater_tsql",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # tsql_freq.set
+    CheckSpec(
+        check_id="tsql_freq.set",
+        capability="tsql",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Cycle the TSQL frequency to another standard tone and verify readback.",
+        protocol="tsql",
+        get_op="get_tsql_freq",
+        set_op="set_tsql_freq",
+        value_rule=ValueRule.TONE_FREQ_CYCLE,
+        tolerance=1,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+)

--- a/src/rigplane/validation/registry/_types.py
+++ b/src/rigplane/validation/registry/_types.py
@@ -46,6 +46,7 @@ class ValueRule(StrEnum):
     MODE_CYCLE = "mode_cycle"
     # MOR-642..645 command-coverage families
     TONE_FREQ_CYCLE = "tone_freq_cycle"
+    VFO_AB_FLIP = "vfo_ab_flip"
 
 
 # ---------------------------------------------------------------------------

--- a/src/rigplane/validation/registry/_types.py
+++ b/src/rigplane/validation/registry/_types.py
@@ -47,6 +47,7 @@ class ValueRule(StrEnum):
     # MOR-642..645 command-coverage families
     TONE_FREQ_CYCLE = "tone_freq_cycle"
     VFO_AB_FLIP = "vfo_ab_flip"
+    KEY_SPEED_WPM = "key_speed_wpm"
 
 
 # ---------------------------------------------------------------------------

--- a/src/rigplane/validation/registry/_types.py
+++ b/src/rigplane/validation/registry/_types.py
@@ -44,6 +44,8 @@ class ValueRule(StrEnum):
     PREAMP_CYCLE = "preamp_cycle"
     AGC_FLIP = "agc_flip"
     MODE_CYCLE = "mode_cycle"
+    # MOR-642..645 command-coverage families
+    TONE_FREQ_CYCLE = "tone_freq_cycle"
 
 
 # ---------------------------------------------------------------------------

--- a/src/rigplane/validation/registry/_vfo.py
+++ b/src/rigplane/validation/registry/_vfo.py
@@ -1,0 +1,69 @@
+"""Split / VFO-slot / dual-watch checks.
+
+Command-coverage family T8 (MOR-643). Ops exist on ``SplitCapable``
+(``get/set_split``), ``VfoSlotCapable`` (``get/set_vfo_slot`` — implemented on
+``CoreRadio`` via ``DualRxRuntimeMixin``) and ``SystemControlCapable``
+(``get/set_dual_watch``).
+
+``swap_vfo_ab`` is deliberately absent: it is a zero-argument *action* op and
+the generic runner only drives value-bearing get/set pairs — deferred until a
+runner action-check kind exists. ``vfo_slot.set`` covers A/B select with full
+RMVR readback, which subsumes the swap path's observable effect.
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.registry._types import CheckKind, CheckSpec, ValueRule
+from rigplane.validation.schema import FailureDomain, ValidationLevel
+
+CHECKS: tuple[CheckSpec, ...] = (
+    # split.set
+    CheckSpec(
+        check_id="split.set",
+        capability="split",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle split operation on/off and verify readback; restore original.",
+        protocol="split",
+        get_op="get_split",
+        set_op="set_split",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # vfo_slot.set — structural (capability ""): VFO A/B select is core
+    # control like freq/mode; radios lacking the op resolve UNSUPPORTED.
+    CheckSpec(
+        check_id="vfo_slot.set",
+        capability="",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.BASIC_CONTROL,
+        failure_domain=FailureDomain.READBACK,
+        summary="Flip the active VFO slot (A/B), verify readback, restore original.",
+        protocol=None,
+        get_op="get_vfo_slot",
+        set_op="set_vfo_slot",
+        value_rule=ValueRule.VFO_AB_FLIP,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # dual_watch.set
+    CheckSpec(
+        check_id="dual_watch.set",
+        capability="dual_watch",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Toggle dual watch on/off and verify readback; restore original.",
+        protocol="dual_watch",
+        get_op="get_dual_watch",
+        set_op="set_dual_watch",
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+)

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -47,17 +47,12 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
-      "check_id": "bsr.presence",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "bsr.select",
+      "status": "manual_required",
+      "declaration": "manual_required"
     },
     {
       "check_id": "compressor.presence",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
-    },
-    {
-      "check_id": "cw.presence",
       "status": "unsupported",
       "declaration": "unsupported_pending_evidence"
     },
@@ -67,9 +62,9 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
-      "check_id": "dial_lock.presence",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "dial_lock.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "digisel.presence",
@@ -92,9 +87,9 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
-      "check_id": "dual_watch.presence",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "dual_watch.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "filter_shape.presence",
@@ -120,6 +115,11 @@
       "check_id": "ip_plus.presence",
       "status": "unsupported",
       "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "key_speed.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "lan_dual_rx_audio_routing.presence",
@@ -177,9 +177,9 @@
       "declaration": "supported"
     },
     {
-      "check_id": "repeater_tone.presence",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "repeater_tone.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "rf_gain.set",
@@ -207,9 +207,9 @@
       "declaration": "manual_required"
     },
     {
-      "check_id": "split.presence",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "split.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "squelch.set",
@@ -222,14 +222,29 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
-      "check_id": "system_settings.presence",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "system_date.read",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
-      "check_id": "tsql.presence",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "system_time.read",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "tone_freq.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "tsql.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "tsql_freq.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "tuner.tune",
@@ -254,9 +269,26 @@
       "failure_domain": "command_execution"
     },
     {
-      "check_id": "vox.presence",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "vfo_slot.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "vox.read",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "vox.set",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "vox_gain.set",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
     },
     {
       "check_id": "xfc.presence",

--- a/tests/validation/test_generator.py
+++ b/tests/validation/test_generator.py
@@ -160,13 +160,15 @@ def test_tx_adjacent_blocked():
 
 def test_presence_entries():
     """Capabilities with no registry check get a <cap>.presence entry at STATIC_PROFILE."""
+    # NOTE (MOR-642..645): split/vox/cw now have registry checks, so this test
+    # uses capabilities that still lack one.
     tpl = build_template_from_capabilities(
-        frozenset({"split", "vox", "cw"}),
+        frozenset({"scan", "xfc", "band_edge"}),
         model="IC-7300",
         profile_id="ic7300",
     )
     entries_by_id = {e.check_id: e for e in tpl.entries}
-    for cap in ("split", "vox", "cw"):
+    for cap in ("scan", "xfc", "band_edge"):
         cid = f"{cap}.presence"
         assert cid in entries_by_id, f"Expected {cid!r} in template entries"
         entry = entries_by_id[cid]
@@ -176,8 +178,10 @@ def test_presence_entries():
 
 def test_entries_sorted_by_level():
     """Level sequence is non-decreasing; presence entries (level 0) sort first."""
+    # NOTE (MOR-643): "split" gained a registry check, so "scan" provides the
+    # check-less capability that yields the level-0 presence entry.
     tpl = build_template_from_capabilities(
-        frozenset({"split", "rf_gain"}),
+        frozenset({"scan", "rf_gain"}),
         model="IC-7300",
         profile_id="ic7300",
     )

--- a/tests/validation/test_generator_hamlib.py
+++ b/tests/validation/test_generator_hamlib.py
@@ -164,18 +164,20 @@ def test_template_validates():
 
 def test_entries_sorted_by_level():
     """Level sequence is non-decreasing; presence entries (level 0) sort first."""
-    tpl = _build(caps={"split", "rf_gain"}, tokens={"RF"})
+    # NOTE (MOR-643): "split" gained a registry check, so "scan" provides the
+    # check-less capability that yields the level-0 presence entry.
+    tpl = _build(caps={"scan", "rf_gain"}, tokens={"RF"})
     levels = [int(e.level) for e in tpl.entries]
     assert levels == sorted(levels), "Entries are not sorted by level"
-    # 'split' has no registry check → presence entry at STATIC_PROFILE (0)
+    # 'scan' has no registry check → presence entry at STATIC_PROFILE (0)
     first = tpl.entries[0]
     assert first.level == ValidationLevel.STATIC_PROFILE
 
 
 def test_presence_entries():
     """A declared capability with no registry check gets a <cap>.presence entry."""
-    tpl = _build(caps={"split"}, tokens=frozenset())
-    entry = _entry(tpl, "split.presence")
+    tpl = _build(caps={"scan"}, tokens=frozenset())
+    entry = _entry(tpl, "scan.presence")
     assert entry.level == ValidationLevel.STATIC_PROFILE
     assert entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
 

--- a/tests/validation/test_hardware_command_families.py
+++ b/tests/validation/test_hardware_command_families.py
@@ -241,3 +241,25 @@ async def test_vfo_slot_unsupported_when_radio_lacks_op():
     radio.set_vfo_slot = None
     result = await _run(radio, "vfo_slot.set")
     assert result.status is CheckStatus.UNSUPPORTED
+
+
+# ---------------------------------------------------------------------------
+# T9 / MOR-644 — memory / band-stack
+# ---------------------------------------------------------------------------
+
+
+async def test_bsr_select_is_manual_and_touches_nothing():
+    radio = _bare_radio({"bsr"})
+    radio.set_bsr = AsyncMock()
+    radio.set_memory_mode = AsyncMock()
+    result = await _run(radio, "bsr.select")
+    assert result.status is CheckStatus.MANUAL_REQUIRED
+    radio.set_bsr.assert_not_called()
+    radio.set_memory_mode.assert_not_called()
+
+
+def test_bsr_select_spec_is_manual_with_no_ops():
+    spec = REGISTRY_BY_ID["bsr.select"]
+    assert spec.kind is CheckKind.MANUAL
+    assert spec.get_op is None
+    assert spec.set_op is None

--- a/tests/validation/test_hardware_command_families.py
+++ b/tests/validation/test_hardware_command_families.py
@@ -1,0 +1,175 @@
+"""Hardware-runner tests for the command-coverage families (MOR-642..645).
+
+Drives every new registry check through ``execute_hardware_checks`` against
+stateful fake radios (closures over real values — no MagicMock return-value
+soup), asserting:
+
+* RMVR checks mutate, read back, and restore the original value;
+* READ_ONLY checks pass when the op exists and report UNSUPPORTED when absent;
+* MANUAL checks resolve MANUAL_REQUIRED without touching the radio;
+* TX-adjacent checks stay BLOCKED without operator authorization.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.core.radio_protocol import Radio
+from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.registry import REGISTRY_BY_ID, CheckKind
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckStatus,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    ValidationLevel,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _flatten(levels):
+    return {check.check_id: check for level in levels for check in level.checks}
+
+
+def _template_for(check_id: str) -> MatrixTemplate:
+    """Build a single-entry template straight from the registry spec."""
+    spec = REGISTRY_BY_ID[check_id]
+    if spec.kind in (CheckKind.MANUAL, CheckKind.TX_ADJACENT_BLOCKED):
+        declaration = CapabilityDeclaration.MANUAL_REQUIRED
+    else:
+        declaration = CapabilityDeclaration.SUPPORTED
+    return MatrixTemplate(
+        radio=RadioTarget(model="IC-7610", profile_id="ic7610"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id=spec.check_id,
+                capability=spec.capability,
+                level=spec.level,
+                declaration=declaration,
+                summary=spec.summary,
+                tx_adjacent=spec.tx_adjacent,
+            )
+        ],
+    )
+
+
+def _bare_radio(capabilities: set[str]):
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "IC-7610"
+    radio.capabilities = capabilities
+    return radio
+
+
+def _stateful_value_radio(
+    *, capability: str, get_op: str, set_op: str, start, receiver_kw: bool = True
+):
+    """A fake radio whose ``get_op``/``set_op`` round-trip via a closure."""
+    radio = _bare_radio({capability} if capability else set())
+    store = {"value": start, "writes": []}
+
+    if receiver_kw:
+
+        async def _get(receiver: int = 0):
+            return store["value"]
+
+        async def _set(value, receiver: int = 0) -> None:
+            store["value"] = value
+            store["writes"].append(value)
+
+    else:
+
+        async def _get():  # type: ignore[misc]
+            return store["value"]
+
+        async def _set(value) -> None:  # type: ignore[misc]
+            store["value"] = value
+            store["writes"].append(value)
+
+    setattr(radio, get_op, AsyncMock(side_effect=_get))
+    setattr(radio, set_op, AsyncMock(side_effect=_set))
+    return radio, store
+
+
+async def _run(radio, check_id: str, *, safety: OperatorSafetyBlock | None = None):
+    levels = await execute_hardware_checks(
+        radio,
+        _template_for(check_id),
+        safety or OperatorSafetyBlock(),
+        allow_writes=True,
+    )
+    return _flatten(levels)[check_id]
+
+
+# ---------------------------------------------------------------------------
+# T7 / MOR-642 — tone / TSQL
+# ---------------------------------------------------------------------------
+
+
+async def test_repeater_tone_set_rmvr_roundtrip():
+    radio, store = _stateful_value_radio(
+        capability="repeater_tone",
+        get_op="get_repeater_tone",
+        set_op="set_repeater_tone",
+        start=False,
+    )
+    result = await _run(radio, "repeater_tone.set")
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["restored"] is True
+    assert store["value"] is False  # restored to original
+    assert True in store["writes"]  # toggled on during the check
+
+
+async def test_tsql_set_rmvr_roundtrip():
+    radio, store = _stateful_value_radio(
+        capability="tsql",
+        get_op="get_repeater_tsql",
+        set_op="set_repeater_tsql",
+        start=True,
+    )
+    result = await _run(radio, "tsql.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] is True
+    assert False in store["writes"]
+
+
+async def test_tone_freq_set_cycles_standard_ctcss_tone():
+    radio, store = _stateful_value_radio(
+        capability="repeater_tone",
+        get_op="get_tone_freq",
+        set_op="set_tone_freq",
+        start=88.5,
+    )
+    result = await _run(radio, "tone_freq.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 88.5  # restored
+    # The mutated value must be a DIFFERENT standard CTCSS tone.
+    changed = [v for v in store["writes"] if v != 88.5]
+    assert changed and changed[0] == 100.0
+
+
+async def test_tsql_freq_set_cycles_standard_ctcss_tone():
+    radio, store = _stateful_value_radio(
+        capability="tsql",
+        get_op="get_tsql_freq",
+        set_op="set_tsql_freq",
+        start=123.0,
+    )
+    result = await _run(radio, "tsql_freq.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 123.0
+    changed = [v for v in store["writes"] if v != 123.0]
+    assert changed and changed[0] == 88.5
+
+
+async def test_tone_check_unsupported_when_radio_lacks_op():
+    radio = _bare_radio({"repeater_tone"})
+    radio.get_repeater_tone = None
+    radio.set_repeater_tone = None
+    result = await _run(radio, "repeater_tone.set")
+    assert result.status is CheckStatus.UNSUPPORTED

--- a/tests/validation/test_hardware_command_families.py
+++ b/tests/validation/test_hardware_command_families.py
@@ -173,3 +173,71 @@ async def test_tone_check_unsupported_when_radio_lacks_op():
     radio.set_repeater_tone = None
     result = await _run(radio, "repeater_tone.set")
     assert result.status is CheckStatus.UNSUPPORTED
+
+
+# ---------------------------------------------------------------------------
+# T8 / MOR-643 — split / VFO / dual-watch
+# ---------------------------------------------------------------------------
+
+
+async def test_split_set_rmvr_roundtrip():
+    radio, store = _stateful_value_radio(
+        capability="split",
+        get_op="get_split",
+        set_op="set_split",
+        start=False,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "split.set")
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["restored"] is True
+    assert store["value"] is False
+    assert True in store["writes"]
+
+
+async def test_vfo_slot_set_flips_a_b_and_restores():
+    radio, store = _stateful_value_radio(
+        capability="",
+        get_op="get_vfo_slot",
+        set_op="set_vfo_slot",
+        start="A",
+    )
+    result = await _run(radio, "vfo_slot.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == "A"  # restored
+    assert "B" in store["writes"]
+
+
+async def test_vfo_slot_set_flips_b_to_a():
+    radio, store = _stateful_value_radio(
+        capability="",
+        get_op="get_vfo_slot",
+        set_op="set_vfo_slot",
+        start="B",
+    )
+    result = await _run(radio, "vfo_slot.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == "B"
+    assert "A" in store["writes"]
+
+
+async def test_dual_watch_set_rmvr_roundtrip():
+    radio, store = _stateful_value_radio(
+        capability="dual_watch",
+        get_op="get_dual_watch",
+        set_op="set_dual_watch",
+        start=False,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "dual_watch.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] is False
+    assert True in store["writes"]
+
+
+async def test_vfo_slot_unsupported_when_radio_lacks_op():
+    radio = _bare_radio(set())
+    radio.get_vfo_slot = None
+    radio.set_vfo_slot = None
+    result = await _run(radio, "vfo_slot.set")
+    assert result.status is CheckStatus.UNSUPPORTED

--- a/tests/validation/test_hardware_command_families.py
+++ b/tests/validation/test_hardware_command_families.py
@@ -263,3 +263,135 @@ def test_bsr_select_spec_is_manual_with_no_ops():
     assert spec.kind is CheckKind.MANUAL
     assert spec.get_op is None
     assert spec.set_op is None
+
+
+# ---------------------------------------------------------------------------
+# T10 / MOR-645 — system
+# ---------------------------------------------------------------------------
+
+
+async def test_system_date_read_passes_with_tuple_value():
+    radio = _bare_radio({"system_settings"})
+    radio.get_system_date = AsyncMock(return_value=(2026, 6, 11))
+    result = await _run(radio, "system_date.read")
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["value"] == (2026, 6, 11)
+
+
+async def test_system_time_read_passes_with_tuple_value():
+    radio = _bare_radio({"system_settings"})
+    radio.get_system_time = AsyncMock(return_value=(13, 37))
+    result = await _run(radio, "system_time.read")
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["value"] == (13, 37)
+
+
+async def test_system_date_read_unsupported_when_op_missing():
+    radio = _bare_radio({"system_settings"})
+    radio.get_system_date = None
+    result = await _run(radio, "system_date.read")
+    assert result.status is CheckStatus.UNSUPPORTED
+
+
+async def test_key_speed_set_rmvr_roundtrip_in_wpm():
+    radio, store = _stateful_value_radio(
+        capability="cw",
+        get_op="get_key_speed",
+        set_op="set_key_speed",
+        start=28,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "key_speed.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 28  # restored
+    changed = [v for v in store["writes"] if v != 28]
+    assert changed, "key speed was never mutated"
+    # Mutation must stay inside the keyer's real WPM range (6-48).
+    assert all(6 <= v <= 48 for v in changed)
+
+
+async def test_vox_read_passes():
+    radio = _bare_radio({"vox"})
+    radio.get_vox = AsyncMock(return_value=False)
+    result = await _run(radio, "vox.read")
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["value"] is False
+
+
+async def test_vox_set_blocked_without_authorization():
+    radio = _bare_radio({"vox"})
+    radio.set_vox = AsyncMock()
+    result = await _run(radio, "vox.set")
+    assert result.status is CheckStatus.BLOCKED
+    radio.set_vox.assert_not_called()
+
+
+async def test_vox_gain_set_blocked_without_authorization():
+    radio = _bare_radio({"vox"})
+    radio.set_vox_gain = AsyncMock()
+    result = await _run(radio, "vox_gain.set")
+    assert result.status is CheckStatus.BLOCKED
+    radio.set_vox_gain.assert_not_called()
+
+
+async def test_vox_set_manual_required_when_authorized():
+    """With operator TX authorization the check surfaces as MANUAL_REQUIRED —
+    it still never auto-actuates VOX."""
+    radio = _bare_radio({"vox"})
+    radio.set_vox = AsyncMock()
+    safety = OperatorSafetyBlock(tx_allowed=True, operator_id="test")
+    result = await _run(radio, "vox.set", safety=safety)
+    assert result.status is CheckStatus.MANUAL_REQUIRED
+    radio.set_vox.assert_not_called()
+
+
+async def test_dial_lock_set_rmvr_roundtrip():
+    radio, store = _stateful_value_radio(
+        capability="dial_lock",
+        get_op="get_dial_lock",
+        set_op="set_dial_lock",
+        start=False,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "dial_lock.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] is False
+    assert True in store["writes"]
+
+
+# ---------------------------------------------------------------------------
+# Cross-family registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_new_family_levels_are_correct():
+    matrix = ValidationLevel.CAPABILITY_MATRIX
+    expectations = {
+        "repeater_tone.set": matrix,
+        "tone_freq.set": matrix,
+        "tsql.set": matrix,
+        "tsql_freq.set": matrix,
+        "split.set": matrix,
+        "vfo_slot.set": ValidationLevel.BASIC_CONTROL,
+        "dual_watch.set": matrix,
+        "bsr.select": matrix,
+        "system_date.read": matrix,
+        "system_time.read": matrix,
+        "key_speed.set": matrix,
+        "vox.read": matrix,
+        "vox.set": ValidationLevel.STRESS_RECOVERY,
+        "vox_gain.set": ValidationLevel.STRESS_RECOVERY,
+        "dial_lock.set": matrix,
+    }
+    for check_id, level in expectations.items():
+        spec = REGISTRY_BY_ID[check_id]
+        assert spec.level == level, f"{check_id}: level {spec.level} != {level}"
+
+
+def test_tx_adjacent_vox_checks_have_no_ops():
+    for check_id in ("vox.set", "vox_gain.set"):
+        spec = REGISTRY_BY_ID[check_id]
+        assert spec.kind is CheckKind.TX_ADJACENT_BLOCKED
+        assert spec.tx_adjacent is True
+        assert spec.get_op is None
+        assert spec.set_op is None

--- a/tests/validation/test_registry.py
+++ b/tests/validation/test_registry.py
@@ -28,8 +28,56 @@ from rigplane.validation.schema import FailureDomain, ValidationLevel
 # ---------------------------------------------------------------------------
 
 
-def test_registry_has_21_entries():
-    assert len(REGISTRY) == 21
+# Frozen snapshot of the REGISTRY check ids. Deliberately updated for the
+# MOR-642..645 command-coverage families (tone/TSQL, split/VFO/dual-watch,
+# band-stack, system) on top of the pre-split 21 (MOR-637 guard).
+_EXPECTED_CHECK_IDS = {
+    # Pre-split 21 (MOR-637)
+    "discovery.identify",
+    "freq.write",
+    "freq.reverse_sync",
+    "mode.set",
+    "filter_width.set",
+    "rf_gain.set",
+    "af_level.set",
+    "preamp.set",
+    "attenuator.set",
+    "notch.set",
+    "nb.set",
+    "nr.set",
+    "agc.set",
+    "rit.set",
+    "xit.set",
+    "squelch.set",
+    "audio.rx",
+    "scope.capture",
+    "meters.read",
+    "tuner.tune",
+    "tx.ptt",
+    # T7 / MOR-642 — tone / TSQL
+    "repeater_tone.set",
+    "tone_freq.set",
+    "tsql.set",
+    "tsql_freq.set",
+    # T8 / MOR-643 — split / VFO / dual-watch
+    "split.set",
+    "vfo_slot.set",
+    "dual_watch.set",
+    # T9 / MOR-644 — memory / band-stack
+    "bsr.select",
+    # T10 / MOR-645 — system
+    "system_date.read",
+    "system_time.read",
+    "key_speed.set",
+    "vox.read",
+    "vox.set",
+    "vox_gain.set",
+    "dial_lock.set",
+}
+
+
+def test_registry_has_expected_entry_count():
+    assert len(REGISTRY) == len(_EXPECTED_CHECK_IDS) == 36
 
 
 def test_check_ids_unique():
@@ -38,32 +86,9 @@ def test_check_ids_unique():
 
 
 def test_check_id_set_unchanged_after_domain_split():
-    """MOR-637 guard: the per-domain package split must not lose, duplicate,
-    or rename any check. Frozen snapshot of the pre-split REGISTRY ids."""
-    expected = {
-        "discovery.identify",
-        "freq.write",
-        "freq.reverse_sync",
-        "mode.set",
-        "filter_width.set",
-        "rf_gain.set",
-        "af_level.set",
-        "preamp.set",
-        "attenuator.set",
-        "notch.set",
-        "nb.set",
-        "nr.set",
-        "agc.set",
-        "rit.set",
-        "xit.set",
-        "squelch.set",
-        "audio.rx",
-        "scope.capture",
-        "meters.read",
-        "tuner.tune",
-        "tx.ptt",
-    }
-    assert {spec.check_id for spec in REGISTRY} == expected
+    """Guard: the per-domain package split (MOR-637) and the coverage
+    families (MOR-642..645) must not lose, duplicate, or rename any check."""
+    assert {spec.check_id for spec in REGISTRY} == _EXPECTED_CHECK_IDS
 
 
 def test_all_capabilities_known():
@@ -88,9 +113,10 @@ def test_tx_adjacent_blocked_implies_tx_adjacent():
             assert spec.tx_adjacent is True, (
                 f"{spec.check_id!r}: TX_ADJACENT_BLOCKED but tx_adjacent is False"
             )
-    # ONLY tuner.tune and tx.ptt should have tx_adjacent=True
+    # Closed set of TX-adjacent checks. vox.set / vox_gain.set joined in
+    # MOR-645: an enabled (or gain-boosted) VOX can key TX from ambient audio.
     tx_adjacent_ids = {spec.check_id for spec in REGISTRY if spec.tx_adjacent}
-    assert tx_adjacent_ids == {"tuner.tune", "tx.ptt"}
+    assert tx_adjacent_ids == {"tuner.tune", "tx.ptt", "vox.set", "vox_gain.set"}
 
 
 def test_manual_and_blocked_have_no_set_op():


### PR DESCRIPTION
## Summary

Harness-epic command-coverage tasks T7-T10 (MOR-642, MOR-643, MOR-644, MOR-645): grows the validation REGISTRY from **21 to 36 checks** (+15) across four new per-family registry submodules. Every added check was audited against `core/radio_protocol.py` + `runtime/radio.py` first — a CheckSpec was added only where the underlying `Radio` get/set op actually exists.

## T7 / MOR-642 — tone/TSQL (`registry/_tone.py`, 4 checks)

| check_id | kind | Radio ops |
|---|---|---|
| `repeater_tone.set` | RMVR_SAFE_WRITE (TOGGLE_BOOL) | `get_repeater_tone` / `set_repeater_tone` |
| `tone_freq.set` | RMVR_SAFE_WRITE (new `TONE_FREQ_CYCLE`) | `get_tone_freq` / `set_tone_freq` |
| `tsql.set` | RMVR_SAFE_WRITE (TOGGLE_BOOL) | `get_repeater_tsql` / `set_repeater_tsql` |
| `tsql_freq.set` | RMVR_SAFE_WRITE (`TONE_FREQ_CYCLE`) | `get_tsql_freq` / `set_tsql_freq` |

`TONE_FREQ_CYCLE` flips between standard CTCSS tones 88.5 ↔ 100.0 Hz with tolerance 1.

**Deferred:** DTCS/DCS code select — the Radio protocol has no `get_dtcs_code` / `set_dtcs_code` (capability tag `dtcs` exists but is method-less). Add-method-then-add-check.

## T8 / MOR-643 — split/VFO/dual-watch (`registry/_vfo.py`, 3 checks)

| check_id | kind | Radio ops |
|---|---|---|
| `split.set` | RMVR_SAFE_WRITE (TOGGLE_BOOL) | `get_split` / `set_split` |
| `vfo_slot.set` | RMVR_SAFE_WRITE (new `VFO_AB_FLIP`), structural (capability `""`, BASIC_CONTROL) | `get_vfo_slot` / `set_vfo_slot` |
| `dual_watch.set` | RMVR_SAFE_WRITE (TOGGLE_BOOL) | `get_dual_watch` / `set_dual_watch` |

**Deferred:** `swap_vfo_ab` — a zero-argument *action* op; the generic runner only drives value-bearing get/set pairs. `vfo_slot.set` covers the observable A/B-select effect with full RMVR readback.

## T9 / MOR-644 — memory/band-stack (`registry/_memory.py`, 1 check)

| check_id | kind | Radio ops |
|---|---|---|
| `bsr.select` | MANUAL (no actuation) | — |

**Deferred (most of the family):** the IC-7610 CI-V memory surface is SET-only. `get_memory_mode`, `get_memory_contents`, `get_bsr` exist on the runtime but raise `NotImplementedError` (commands 0x08 / 0x1A 0x00 / 0x1A 0x01 have no GET variant per the CI-V Reference Manual), and the write ops (`set_memory_mode`, `memory_to_vfo`, `set_bsr`) cannot be restored without a readback — not RMVR-safe. A MANUAL check is the only honest automated representation until a radio with memory readback lands.

## T10 / MOR-645 — system (`registry/_system.py`, 7 checks)

| check_id | kind | Radio ops |
|---|---|---|
| `system_date.read` | READ_ONLY | `get_system_date` |
| `system_time.read` | READ_ONLY | `get_system_time` |
| `key_speed.set` | RMVR_SAFE_WRITE (new `KEY_SPEED_WPM`, range 6-48) | `get_key_speed` / `set_key_speed` |
| `vox.read` | READ_ONLY | `get_vox` |
| `vox.set` | TX_ADJACENT_BLOCKED | — (never auto-actuated) |
| `vox_gain.set` | TX_ADJACENT_BLOCKED | — (never auto-actuated) |
| `dial_lock.set` | RMVR_SAFE_WRITE (TOGGLE_BOOL) | `get_dial_lock` / `set_dial_lock` |

Safety calls: enabling VOX (or raising its gain while VOX is armed) can key TX from ambient microphone audio → both write checks are TX-adjacent and require explicit operator authorization, mirroring `tuner.tune`/`tx.ptt`. **Deferred:** `set_system_date`/`set_system_time` — multi-argument signatures the generic single-value runner cannot drive, and clock writes are inherently lossy; SET side needs a bespoke handler if ever wanted.

## Deliberate guard updates (explained)

- `tests/validation/test_registry.py`: frozen check-id snapshot deliberately extended with the 15 new ids (count 21 → 36); the TX-adjacent closed set now reads `{tuner.tune, tx.ptt, vox.set, vox_gain.set}`.
- `tests/validation/test_generator{,_hamlib}.py`: presence-entry tests switched from `split`/`vox`/`cw` (which now have functional checks) to `scan`/`xfc`/`band_edge`.
- `tests/golden/validation/ic7610.dry-run.json`: regenerated via the documented `--regen-golden` command — diff is exactly the expected `<cap>.presence` → functional-check transitions.

## Coexistence with the concurrent `_audio.py` PR

All additions live in this PR's own per-family modules. `_assembly.py` and `__init__.py` were touched append-only at a clearly-commented `MOR-642..645` anchor after the existing 1-21 concatenation; `_surfaces.py` untouched. Worst-case merge conflict with the audio PR is a trivial adjacent-line conflict in `_assembly.py` / the facade docstring / the registry-count assert.

## Runner changes

`validation/hardware.py`: three new entries in `_VALUE_RULE_FNS` (TONE_FREQ_CYCLE, VFO_AB_FLIP, KEY_SPEED_WPM) and matching `_WRITE_ONLY_TEST_VALUES`; no dispatch-logic changes — all new checks ride the existing generic `_check_from_spec` path.

## Testing

- New `tests/validation/test_hardware_command_families.py` (23 tests): every new check driven through `execute_hardware_checks` against stateful fake radios — RMVR mutate/readback/restore assertions, UNSUPPORTED on missing ops, MANUAL without actuation, BLOCKED without operator authorization (and MANUAL_REQUIRED with it).
- Full suite: **7707 passed, 0 failed** (integration excluded) · `ruff check` clean · `mypy src/` Success (280 files) · `lint-imports` 4 contracts kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
