### PR TITLE
test(validation): mock integration dry-run matrix per owned profile + validation_hardware marker (MOR-647)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -175,6 +175,39 @@ async def radio(radio_config: dict) -> AsyncGenerator[IcomRadio, None]:
         await r.disconnect()
 
 
+# ---------------------------------------------------------------------------
+# Owned-profile enumeration (MOR-647 mock validation matrix)
+# ---------------------------------------------------------------------------
+
+_RIGS_DIR = Path(__file__).resolve().parent.parent.parent / "rigs"
+
+
+def owned_profile_models() -> list[str]:
+    """Model names of every radio profile shipped in ``rigs/``.
+
+    These are the "owned" profiles for the validation matrix: the native
+    dry-run template generator (``build_template_from_capabilities``) only
+    needs ``profile.capabilities``, so it can build a full matrix for any
+    profile the rig loader discovers. Enumerated dynamically — a new rig
+    TOML automatically joins the mock integration matrix.
+    """
+    from rigplane.profiles.rig_loader import discover_rigs
+
+    return sorted(discover_rigs(_RIGS_DIR).keys())
+
+
+@pytest.fixture(scope="session")
+def all_owned_profile_models() -> list[str]:
+    """Session-scoped list of all owned profile model names."""
+    return owned_profile_models()
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Parametrize any test requesting ``owned_profile_model`` per owned rig."""
+    if "owned_profile_model" in metafunc.fixturenames:
+        metafunc.parametrize("owned_profile_model", owned_profile_models())
+
+
 # Pytest configuration
 def pytest_configure(config: pytest.Config) -> None:
     """Register integration marker."""

--- a/tests/integration/test_validation_matrix_integration.py
+++ b/tests/integration/test_validation_matrix_integration.py
@@ -1,0 +1,198 @@
+"""Mock integration: full validation dry-run matrix per owned profile (MOR-647).
+
+Runs the COMPLETE registry-driven validation matrix through the native dry-run
+provider (``rigplane validate --model <M> --dry-run``) for every radio profile
+shipped in ``rigs/`` — fully offline, no hardware. A global change that breaks
+the validation pipeline (registry assembly, template generation, dry-run
+gating, artifact schema) for ANY owned profile fails here.
+
+Invariants asserted per profile:
+
+* the dry-run exits 0 and emits a schema-valid ``ValidationArtifact``;
+* every ``REGISTRY`` check appears in the artifact (iterated dynamically —
+  never a hardcoded count or id list, so concurrent registry edits stay safe);
+* no check carries an ``error`` and every status is a legal *planned* dry-run
+  status (dry-run executes nothing, so ``pass``/``fail`` must not appear);
+* TX-adjacent / registry-safety-gated checks are BLOCKED without operator
+  authorization; manual + audio-probe checks are MANUAL_REQUIRED;
+* the dry-run never constructs a radio backend (no connection attempt).
+
+Marker policy: these tests are ``mock_integration`` — they RUN in the
+integration job without hardware (see ``conftest.pytest_collection_modifyitems``).
+Genuinely hardware-requiring validation tests carry the ``validation_hardware``
+marker (registered in ``pyproject.toml``) instead, so the two sets can be
+selected independently via ``-m validation_hardware`` / ``-m "not
+validation_hardware"``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from rigplane.cli import _build_parser, _validate
+from rigplane.profiles import get_radio_profile
+from rigplane.validation.registry import REGISTRY, CheckKind
+from rigplane.validation.schema import CheckStatus, validate_artifact_dict
+
+pytestmark = [pytest.mark.integration, pytest.mark.mock_integration]
+
+# Dry-run plans checks; it never executes them. Anything outside this set
+# (notably pass/fail) means the dry-run path actually ran a check.
+_DRY_RUN_LEGAL_STATUSES = {
+    CheckStatus.SKIP.value,
+    CheckStatus.UNSUPPORTED.value,
+    CheckStatus.MANUAL_REQUIRED.value,
+    CheckStatus.BLOCKED.value,
+}
+
+
+@pytest.fixture(autouse=True)
+def _forbid_real_connections(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail loudly if the dry-run path ever tries to build a radio backend."""
+    import rigplane.backends.factory as factory
+
+    def _fail(config: Any) -> Any:
+        raise AssertionError(
+            "dry-run validation must never construct a radio backend "
+            f"(create_radio called with {config!r})"
+        )
+
+    monkeypatch.setattr(factory, "create_radio", _fail)
+
+
+def _dry_run_artifact(
+    model: str, capsys: pytest.CaptureFixture[str], *extra: str
+) -> dict[str, Any]:
+    """Run ``rigplane validate --dry-run --json`` for *model*, return the artifact."""
+    argv = ["--model", model, "validate", "--dry-run", "--json", *extra]
+    rc = _validate.run(_build_parser().parse_args(argv))
+    out, err = capsys.readouterr()
+    assert rc == 0, f"dry-run for {model} exited {rc}; stderr:\n{err}"
+    artifact = json.loads(out)
+    # Schema round-trip: the emitted JSON must be a valid ValidationArtifact.
+    validate_artifact_dict(artifact)
+    return artifact
+
+
+def _checks_by_id(artifact: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Flatten artifact levels into a ``check_id`` → check-dict map."""
+    return {
+        check["check_id"]: check
+        for level in artifact["levels"]
+        for check in level["checks"]
+    }
+
+
+def _is_safety_gated(spec: Any) -> bool:
+    """Registry-side safety classification mirrored by the dry-run runner."""
+    return spec.tx_adjacent or spec.kind is CheckKind.TX_ADJACENT_BLOCKED
+
+
+def test_owned_profile_set_is_sane(all_owned_profile_models: list[str]) -> None:
+    """Discovery yields a non-empty owned set including the reference rig."""
+    assert all_owned_profile_models, "no owned rig profiles discovered in rigs/"
+    assert "IC-7610" in all_owned_profile_models
+    # Guard against vacuous per-spec loops below: the registry must contain
+    # checks, including at least one safety-gated one.
+    assert REGISTRY
+    assert any(_is_safety_gated(spec) for spec in REGISTRY)
+
+
+def test_full_registry_matrix_covers_every_check(
+    owned_profile_model: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Every REGISTRY check appears in the dry-run artifact; nothing leaks in."""
+    artifact = _dry_run_artifact(owned_profile_model, capsys, "--no-overrides")
+    checks = _checks_by_id(artifact)
+
+    missing = [spec.check_id for spec in REGISTRY if spec.check_id not in checks]
+    assert not missing, f"{owned_profile_model}: registry checks missing: {missing}"
+
+    # Anything beyond the registry must be a synthetic <cap>.presence entry.
+    registry_ids = {spec.check_id for spec in REGISTRY}
+    unexpected = [
+        check_id
+        for check_id in checks
+        if check_id not in registry_ids and not check_id.endswith(".presence")
+    ]
+    assert not unexpected, (
+        f"{owned_profile_model}: unexpected non-registry checks: {unexpected}"
+    )
+
+
+def test_dry_run_statuses_are_planned_and_error_free(
+    owned_profile_model: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No check errors out and no check claims execution in a dry-run."""
+    artifact = _dry_run_artifact(owned_profile_model, capsys, "--no-overrides")
+    for check_id, check in _checks_by_id(artifact).items():
+        assert check.get("error") is None, (
+            f"{owned_profile_model}: {check_id} carries an error: {check['error']}"
+        )
+        assert check["status"] in _DRY_RUN_LEGAL_STATUSES, (
+            f"{owned_profile_model}: {check_id} has non-dry-run status "
+            f"{check['status']!r}"
+        )
+
+
+def test_safety_gated_checks_blocked_without_authorization(
+    owned_profile_model: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """TX-adjacent / registry-gated checks are BLOCKED; manual checks are
+    MANUAL_REQUIRED for declared capabilities."""
+    artifact = _dry_run_artifact(owned_profile_model, capsys, "--no-overrides")
+    checks = _checks_by_id(artifact)
+    capabilities = get_radio_profile(owned_profile_model).capabilities
+
+    for spec in REGISTRY:
+        status = checks[spec.check_id]["status"]
+        if _is_safety_gated(spec):
+            # Fail-closed: blocked regardless of capability declaration.
+            assert status == CheckStatus.BLOCKED.value, (
+                f"{owned_profile_model}: safety-gated {spec.check_id} is "
+                f"{status!r}, expected blocked"
+            )
+        elif (
+            spec.kind in (CheckKind.MANUAL, CheckKind.AUDIO_PROBE)
+            and spec.capability
+            and spec.capability in capabilities
+        ):
+            assert status == CheckStatus.MANUAL_REQUIRED.value, (
+                f"{owned_profile_model}: manual {spec.check_id} is "
+                f"{status!r}, expected manual_required"
+            )
+
+
+def test_default_pipeline_with_overrides_completes(
+    owned_profile_model: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The DEFAULT pipeline (per-profile overrides auto-applied) stays green.
+
+    Override files may legitimately exclude or append checks, so registry
+    coverage here is asserted modulo the artifact's own override audit.
+    """
+    artifact = _dry_run_artifact(owned_profile_model, capsys)
+    checks = _checks_by_id(artifact)
+    audit = artifact.get("metadata", {}).get("overrides") or {}
+    excluded = set(audit.get("excluded", []))
+
+    missing = [
+        spec.check_id
+        for spec in REGISTRY
+        if spec.check_id not in checks and spec.check_id not in excluded
+    ]
+    assert not missing, (
+        f"{owned_profile_model}: registry checks neither present nor "
+        f"override-excluded: {missing}"
+    )
+
+    # The summary in metadata must agree with a recount of the levels.
+    recount: dict[str, int] = {}
+    for check in checks.values():
+        recount[check["status"]] = recount.get(check["status"], 0) + 1
+    summary = artifact["metadata"]["summary"]
+    nonzero_summary = {status: n for status, n in summary.items() if n}
+    assert nonzero_summary == recount


### PR DESCRIPTION
## Summary

MOR-647 (T12, harness epic MOR-634): pytest mock-integration coverage that runs the FULL validation dry-run matrix (the whole `REGISTRY`) against each owned radio profile via the native provider — completely offline — so any global change that breaks the validation pipeline for any owned profile is caught without hardware.

## Profiles covered (and how they are discovered)

The owned set is enumerated **dynamically** at collection time via `rigplane.profiles.rig_loader.discover_rigs(rigs/)` — never hardcoded. The native dry-run template generator (`build_template_from_capabilities`) only needs `profile.capabilities`, so every discovered rig qualifies. Currently that is 8 profiles:

`FTX-1`, `IC-705`, `IC-7300`, `IC-7610`, `IC-9700`, `TX-500`, `X6100`, `X6200`

A new rig TOML automatically joins the matrix. A sanity test guards against silent empty discovery (set non-empty, contains IC-7610, REGISTRY non-empty with at least one safety-gated check, so the per-spec loops can never go vacuous).

## Invariants asserted (per profile, 4 tests x 8 profiles + 1 sanity = 33 tests)

Each test drives the real CLI path (`rigplane validate --model <M> --dry-run --json` via `_build_parser` + `_validate.run`) and asserts:

1. **Registry coverage** (`--no-overrides`): every `REGISTRY` check_id appears in the artifact; any extra ids must be synthetic `<cap>.presence` entries. REGISTRY is iterated dynamically — no hardcoded check counts or ids, so the sibling registry PR (MOR-646) cannot conflict.
2. **Planned-only, error-free**: exit code 0, artifact passes `validate_artifact_dict`, no check carries `error`, and every status is in the planned dry-run set (`skip`/`unsupported`/`manual_required`/`blocked`) — `pass`/`fail` would mean the dry-run actually executed something.
3. **Safety gating**: every spec with `tx_adjacent=True` or kind `TX_ADJACENT_BLOCKED` is `blocked` (fail-closed, regardless of capability declaration); `MANUAL`/`AUDIO_PROBE` specs on declared capabilities are `manual_required`.
4. **Default pipeline with overrides**: the default run (per-profile override files auto-applied) also exits 0; registry coverage is asserted modulo the artifact's own `metadata.overrides.excluded` audit, and `metadata.summary` agrees with a recount of the levels.
5. **No connection attempts**: an autouse fixture monkeypatches `rigplane.backends.factory.create_radio` to raise, proving the dry-run path never constructs a radio backend.

## Marker usage

- The suite is marked `integration` + `mock_integration`: the existing `tests/integration/conftest.py` collection hook lets `mock_integration` tests RUN without `ICOM_HOST`/credentials, so these execute in any integration job, CI or local.
- `validation_hardware` (deliverable 3) was found **already registered** in `pyproject.toml` `[tool.pytest.ini_options].markers` ("real-radio validation runs; requires explicit env opt-in") — no change needed. It remains reserved for true-hardware validation runs; this suite deliberately does NOT carry it, so `-m validation_hardware` / `-m "not validation_hardware"` cleanly separate hardware vs mock-matrix sets. Verified: `-m "not validation_hardware"` collects all 33, `-m validation_hardware` deselects all 33, with `-W error::pytest.PytestUnknownMarkWarning` raising nothing.

## Changes

- `tests/integration/test_validation_matrix_integration.py` (new) — the matrix suite.
- `tests/integration/conftest.py` — extended (not overwritten) with `owned_profile_models()`, a session-scoped `all_owned_profile_models` fixture, and a `pytest_generate_tests` hook that parametrizes any test requesting `owned_profile_model`.
- No `src/` changes; registry modules, `_assembly.py`, golden JSONs, and CI workflows untouched.

## Verification

- `uv run pytest tests/integration/test_validation_matrix_integration.py -q` — **33 passed** in 0.27s
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — **7725 passed, 8 skipped, 3 deselected, 11 xfailed, 1 xpassed** (single warning is third-party opuslib SyntaxWarning; no unknown-marker warnings)
- `uv run ruff check src/ tests/` — All checks passed; `ruff format` — 597 files unchanged
- `uv run lint-imports` — Contracts: 5 kept, 0 broken
- mypy skipped (no `src/` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)