### PR TITLE
feat(validation): scope-control SET command-coverage checks (MOR-646)

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1066,6 +1066,11 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     ValueRule.TONE_FREQ_CYCLE: 88.5,
     ValueRule.VFO_AB_FLIP: "A",
     ValueRule.KEY_SPEED_WPM: 20,
+    # T11 / MOR-646 — scope controls: index 1 and edge 1 are valid for every
+    # scope preset surface; 0.0 dB is the neutral scope reference level.
+    ValueRule.SCOPE_INDEX_FLIP: 1,
+    ValueRule.SCOPE_EDGE_CYCLE: 1,
+    ValueRule.SCOPE_REF_DB: 0.0,
 }
 
 # Benign value to restore a write-only control to afterwards (best-effort).
@@ -1095,6 +1100,15 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     ValueRule.VFO_AB_FLIP: lambda s: "B" if str(s).upper() == "A" else "A",
     # CW keyer speed in WPM (real range 6-48): pick a DIFFERENT in-range value.
     ValueRule.KEY_SPEED_WPM: lambda w: 24 if int(w) != 24 else 20,
+    # T11 / MOR-646 — scope controls.
+    # Small 0-based preset/enum (receiver 0-1, mode 0-3, span 0-7, speed 0-2,
+    # center_type 0-2, rbw 0-2): flip 0 <-> 1, in range for ALL of them.
+    ValueRule.SCOPE_INDEX_FLIP: lambda v: 1 if int(v) == 0 else 0,
+    # Fixed-edge selection is 1-BASED (1..4): cycle 1 <-> 2, never write 0.
+    ValueRule.SCOPE_EDGE_CYCLE: lambda e: 2 if int(e) != 2 else 1,
+    # Reference level in dB on the radio's 0.5 dB grid: hop between two
+    # exact grid values so the readback comparison can stay exact.
+    ValueRule.SCOPE_REF_DB: lambda r: 5.0 if float(r) != 5.0 else 0.0,
 }
 
 

--- a/src/rigplane/validation/registry/_assembly.py
+++ b/src/rigplane/validation/registry/_assembly.py
@@ -13,6 +13,7 @@ from rigplane.validation.registry._audio import CHECKS as _AUDIO_CHECKS
 from rigplane.validation.registry._dsp import CHECKS as _DSP_CHECKS
 from rigplane.validation.registry._levels import CHECKS as _LEVELS_CHECKS
 from rigplane.validation.registry._memory import CHECKS as _MEMORY_CHECKS
+from rigplane.validation.registry._scope import CHECKS as _SCOPE_CHECKS
 from rigplane.validation.registry._structural import CHECKS as _STRUCTURAL_CHECKS
 from rigplane.validation.registry._surfaces import CHECKS as _SURFACES_CHECKS
 from rigplane.validation.registry._system import CHECKS as _SYSTEM_CHECKS
@@ -43,6 +44,7 @@ REGISTRY: tuple[CheckSpec, ...] = (
     + _VFO_CHECKS  # T8: split, vfo_slot, dual_watch
     + _MEMORY_CHECKS  # T9: bsr (manual; CI-V memory surface is SET-only)
     + _SYSTEM_CHECKS  # T10: system clock, key_speed, vox, dial_lock
+    + _SCOPE_CHECKS  # T11 (MOR-646): scope-control SET commands (cmd 0x27)
 )
 
 

--- a/src/rigplane/validation/registry/_scope.py
+++ b/src/rigplane/validation/registry/_scope.py
@@ -1,0 +1,156 @@
+"""Scope-control SET-command checks: the Command 0x27 control surface.
+
+Command-coverage family T11 (MOR-646). All ops live on ``ScopeCapable``
+(``rigplane.core.radio_protocol``) and are implemented for the IC-7610 in
+``rigplane.runtime._scope_runtime``.
+
+Safety classification:
+
+* Every SET here only changes what the spectrum scope DISPLAYS — receiver
+  selection, display mode, span/edge presets, reference level, sweep speed,
+  hold, RBW/VBW, dual display, and the during-TX display flag. None can key
+  the transmitter, so none is TX-adjacent. All are RMVR-safe: each setter has
+  a matching getter, so the runner reads the original, writes a test value,
+  verifies the readback, and restores.
+* ``scope_fixed_edge.read`` is READ_ONLY: ``set_scope_fixed_edge`` exists but
+  takes multi-keyword arguments (``edge``, ``start_hz``, ``end_hz``) the
+  generic single-value runner cannot drive, so its SET side is deferred.
+* ``enable_scope``/``disable_scope`` are stream-lifecycle ops, not SET-value
+  commands; the scope surface itself is covered by ``scope.capture``.
+
+Value encodings (IC-7610 runtime):
+
+* receiver: 0=MAIN, 1=SUB · mode: 0=center, 1=fixed, 2/3=scroll
+* span: preset index 0..7 · edge: 1..4 (1-based) · speed: 0..2 · rbw: 0..2
+* center_type: 0..2 · ref: dB float on a 0.5 dB grid · the rest are bools
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.registry._types import CheckKind, CheckSpec, ValueRule
+from rigplane.validation.schema import FailureDomain, ValidationLevel
+
+
+def _rmvr(check_id: str, op: str, summary: str, value_rule: ValueRule) -> CheckSpec:
+    """Build one RMVR scope-control spec; only the op stem and rule vary."""
+    return CheckSpec(
+        check_id=check_id,
+        capability="scope",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary=summary,
+        protocol="scope",
+        get_op=f"get_{op}",
+        set_op=f"set_{op}",
+        value_rule=value_rule,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    )
+
+
+CHECKS: tuple[CheckSpec, ...] = (
+    # scope_receiver.set — MAIN/SUB scope source selection (0/1).
+    _rmvr(
+        "scope_receiver.set",
+        "scope_receiver",
+        "Flip the scope receiver MAIN/SUB, verify readback, restore original.",
+        ValueRule.SCOPE_INDEX_FLIP,
+    ),
+    # scope_dual.set — single/dual scope display.
+    _rmvr(
+        "scope_dual.set",
+        "scope_dual",
+        "Toggle dual scope display on/off and verify readback; restore original.",
+        ValueRule.TOGGLE_BOOL,
+    ),
+    # scope_mode.set — center/fixed display mode (flips 0<->1).
+    _rmvr(
+        "scope_mode.set",
+        "scope_mode",
+        "Flip the scope mode center/fixed, verify readback, restore original.",
+        ValueRule.SCOPE_INDEX_FLIP,
+    ),
+    # scope_span.set — span preset index 0..7 (flips 0<->1, always in range).
+    _rmvr(
+        "scope_span.set",
+        "scope_span",
+        "Nudge the scope span preset index, verify readback, restore original.",
+        ValueRule.SCOPE_INDEX_FLIP,
+    ),
+    # scope_edge.set — fixed-edge selection, 1-based (cycles within 1..4).
+    _rmvr(
+        "scope_edge.set",
+        "scope_edge",
+        "Cycle the fixed-edge selection (1..4), verify readback, restore original.",
+        ValueRule.SCOPE_EDGE_CYCLE,
+    ),
+    # scope_hold.set — scope hold on/off.
+    _rmvr(
+        "scope_hold.set",
+        "scope_hold",
+        "Toggle scope hold on/off and verify readback; restore original.",
+        ValueRule.TOGGLE_BOOL,
+    ),
+    # scope_ref.set — reference level in dB on a 0.5 dB grid.
+    _rmvr(
+        "scope_ref.set",
+        "scope_ref",
+        "Move the scope reference level (dB), verify readback, restore original.",
+        ValueRule.SCOPE_REF_DB,
+    ),
+    # scope_speed.set — sweep speed preset 0..2 (flips 0<->1, always in range).
+    _rmvr(
+        "scope_speed.set",
+        "scope_speed",
+        "Flip the scope sweep-speed preset, verify readback, restore original.",
+        ValueRule.SCOPE_INDEX_FLIP,
+    ),
+    # scope_during_tx.set — display-only flag; never keys TX, not TX-adjacent.
+    _rmvr(
+        "scope_during_tx.set",
+        "scope_during_tx",
+        "Toggle the scope-during-TX display flag and verify readback; restore.",
+        ValueRule.TOGGLE_BOOL,
+    ),
+    # scope_center_type.set — center display type 0..2 (flips 0<->1).
+    _rmvr(
+        "scope_center_type.set",
+        "scope_center_type",
+        "Flip the scope center display type, verify readback, restore original.",
+        ValueRule.SCOPE_INDEX_FLIP,
+    ),
+    # scope_vbw.set — narrow video bandwidth on/off.
+    _rmvr(
+        "scope_vbw.set",
+        "scope_vbw",
+        "Toggle narrow scope VBW on/off and verify readback; restore original.",
+        ValueRule.TOGGLE_BOOL,
+    ),
+    # scope_rbw.set — resolution bandwidth preset 0..2 (flips 0<->1).
+    _rmvr(
+        "scope_rbw.set",
+        "scope_rbw",
+        "Flip the scope RBW preset, verify readback, restore original.",
+        ValueRule.SCOPE_INDEX_FLIP,
+    ),
+    # scope_fixed_edge.read — READ_ONLY: set_scope_fixed_edge takes multi-kwarg
+    # (edge, start_hz, end_hz) the generic single-value runner cannot drive;
+    # the SET side is deferred (cf. system_date/system_time in _system.py).
+    CheckSpec(
+        check_id="scope_fixed_edge.read",
+        capability="scope",
+        kind=CheckKind.READ_ONLY,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Read the fixed-edge scope bounds and verify a parsed result.",
+        protocol="scope",
+        get_op="get_scope_fixed_edge",
+        set_op=None,
+        value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+)

--- a/src/rigplane/validation/registry/_types.py
+++ b/src/rigplane/validation/registry/_types.py
@@ -53,6 +53,10 @@ class ValueRule(StrEnum):
     TONE_FREQ_CYCLE = "tone_freq_cycle"
     VFO_AB_FLIP = "vfo_ab_flip"
     KEY_SPEED_WPM = "key_speed_wpm"
+    # T11 / MOR-646 — scope-control SET commands
+    SCOPE_INDEX_FLIP = "scope_index_flip"
+    SCOPE_EDGE_CYCLE = "scope_edge_cycle"
+    SCOPE_REF_DB = "scope_ref_db"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -223,6 +223,71 @@
       "declaration": "manual_required"
     },
     {
+      "check_id": "scope_center_type.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_dual.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_during_tx.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_edge.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_fixed_edge.read",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_hold.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_mode.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_rbw.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_receiver.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_ref.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_span.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_speed.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope_vbw.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
       "check_id": "split.set",
       "status": "skip",
       "declaration": "supported"

--- a/tests/validation/test_hardware_command_families.py
+++ b/tests/validation/test_hardware_command_families.py
@@ -360,6 +360,269 @@ async def test_dial_lock_set_rmvr_roundtrip():
 
 
 # ---------------------------------------------------------------------------
+# T11 / MOR-646 — scope-control SET commands
+# ---------------------------------------------------------------------------
+
+
+async def test_scope_dual_set_rmvr_roundtrip():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_dual",
+        set_op="set_scope_dual",
+        start=False,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_dual.set")
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["restored"] is True
+    assert store["value"] is False  # restored to original
+    assert True in store["writes"]  # toggled on during the check
+
+
+async def test_scope_hold_set_rmvr_roundtrip():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_hold",
+        set_op="set_scope_hold",
+        start=True,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_hold.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] is True
+    assert False in store["writes"]
+
+
+async def test_scope_mode_set_flips_index_and_restores():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_mode",
+        set_op="set_scope_mode",
+        start=0,  # center mode
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_mode.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 0  # restored
+    changed = [v for v in store["writes"] if v != 0]
+    assert changed and changed[0] == 1  # flipped to fixed mode
+
+
+async def test_scope_mode_set_flips_nonzero_index_to_zero():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_mode",
+        set_op="set_scope_mode",
+        start=3,  # scroll-F
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_mode.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 3
+    assert 0 in store["writes"]
+
+
+async def test_scope_span_set_stays_in_preset_range():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_span",
+        set_op="set_scope_span",
+        start=4,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_span.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 4  # restored
+    # All written values must be valid preset indexes (0..7).
+    assert all(0 <= v <= 7 for v in store["writes"])
+
+
+async def test_scope_speed_set_stays_in_preset_range():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_speed",
+        set_op="set_scope_speed",
+        start=2,  # slow
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_speed.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 2
+    assert all(0 <= v <= 2 for v in store["writes"])
+
+
+async def test_scope_receiver_set_flips_main_sub():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_receiver",
+        set_op="set_scope_receiver",
+        start=0,  # MAIN
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_receiver.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 0  # restored to MAIN
+    assert 1 in store["writes"]  # flipped to SUB during the check
+
+
+async def test_scope_edge_set_cycles_within_valid_edges():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_edge",
+        set_op="set_scope_edge",
+        start=1,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_edge.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 1  # restored
+    changed = [v for v in store["writes"] if v != 1]
+    assert changed, "edge was never mutated"
+    # Edge selection is 1-based (1..4) — 0 is never a valid write.
+    assert all(1 <= v <= 4 for v in store["writes"])
+
+
+async def test_scope_edge_set_mutates_edge_two_to_one():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_edge",
+        set_op="set_scope_edge",
+        start=2,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_edge.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 2
+    assert 1 in store["writes"]
+
+
+async def test_scope_ref_set_moves_on_half_db_grid_and_restores():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_ref",
+        set_op="set_scope_ref",
+        start=-10.0,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_ref.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == -10.0  # restored
+    changed = [v for v in store["writes"] if v != -10.0]
+    assert changed, "ref level was never mutated"
+    # The mutated value must sit on the radio's 0.5 dB grid.
+    assert all(float(v) * 2 == int(float(v) * 2) for v in store["writes"])
+
+
+async def test_scope_during_tx_set_rmvr_roundtrip():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_during_tx",
+        set_op="set_scope_during_tx",
+        start=False,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_during_tx.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] is False
+    assert True in store["writes"]
+
+
+async def test_scope_center_type_set_flips_and_restores():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_center_type",
+        set_op="set_scope_center_type",
+        start=0,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_center_type.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 0
+    assert all(0 <= v <= 2 for v in store["writes"])
+
+
+async def test_scope_vbw_set_rmvr_roundtrip():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_vbw",
+        set_op="set_scope_vbw",
+        start=False,
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_vbw.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] is False
+    assert True in store["writes"]
+
+
+async def test_scope_rbw_set_stays_in_preset_range():
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_rbw",
+        set_op="set_scope_rbw",
+        start=1,  # mid
+        receiver_kw=False,
+    )
+    result = await _run(radio, "scope_rbw.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 1
+    assert all(0 <= v <= 2 for v in store["writes"])
+
+
+async def test_scope_fixed_edge_read_passes_with_value():
+    radio = _bare_radio({"scope"})
+    fixed_edge = MagicMock()  # stand-in for the ScopeFixedEdge dataclass
+    radio.get_scope_fixed_edge = AsyncMock(return_value=fixed_edge)
+    result = await _run(radio, "scope_fixed_edge.read")
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["value"] is fixed_edge
+
+
+async def test_scope_fixed_edge_read_unsupported_when_op_missing():
+    radio = _bare_radio({"scope"})
+    radio.get_scope_fixed_edge = None
+    result = await _run(radio, "scope_fixed_edge.read")
+    assert result.status is CheckStatus.UNSUPPORTED
+
+
+async def test_scope_check_unsupported_when_radio_lacks_op():
+    radio = _bare_radio({"scope"})
+    radio.get_scope_span = None
+    radio.set_scope_span = None
+    result = await _run(radio, "scope_span.set")
+    assert result.status is CheckStatus.UNSUPPORTED
+
+
+def test_scope_family_levels_and_safety():
+    """All scope-control checks live in CAPABILITY_MATRIX and none is
+    TX-adjacent: they only change what the scope DISPLAYS (including the
+    during-TX display flag) and can never key the transmitter."""
+    scope_ids = [
+        "scope_receiver.set",
+        "scope_dual.set",
+        "scope_mode.set",
+        "scope_span.set",
+        "scope_edge.set",
+        "scope_hold.set",
+        "scope_ref.set",
+        "scope_speed.set",
+        "scope_during_tx.set",
+        "scope_center_type.set",
+        "scope_vbw.set",
+        "scope_rbw.set",
+        "scope_fixed_edge.read",
+    ]
+    for check_id in scope_ids:
+        spec = REGISTRY_BY_ID[check_id]
+        assert spec.level is ValidationLevel.CAPABILITY_MATRIX, check_id
+        assert spec.tx_adjacent is False, check_id
+        assert spec.capability == "scope", check_id
+    read_only = REGISTRY_BY_ID["scope_fixed_edge.read"]
+    assert read_only.kind is CheckKind.READ_ONLY
+    assert read_only.set_op is None
+
+
+# ---------------------------------------------------------------------------
 # Cross-family registry wiring
 # ---------------------------------------------------------------------------
 

--- a/tests/validation/test_registry.py
+++ b/tests/validation/test_registry.py
@@ -30,8 +30,8 @@ from rigplane.validation.schema import FailureDomain, ValidationLevel
 
 # Frozen snapshot of the REGISTRY check ids. Deliberately updated for the
 # append-only audio-probe family (GH #1650, MOR-639/640/641) and the
-# MOR-642..645 command-coverage families (tone/TSQL, split/VFO/dual-watch,
-# band-stack, system) on top of the pre-split 21 (MOR-637 guard).
+# MOR-642..646 command-coverage families (tone/TSQL, split/VFO/dual-watch,
+# band-stack, system, scope controls) on top of the pre-split 21 (MOR-637 guard).
 _EXPECTED_CHECK_IDS = {
     # Pre-split 21 (MOR-637)
     "discovery.identify",
@@ -78,11 +78,25 @@ _EXPECTED_CHECK_IDS = {
     "vox.set",
     "vox_gain.set",
     "dial_lock.set",
+    # T11 / MOR-646 — scope-control SET commands
+    "scope_receiver.set",
+    "scope_dual.set",
+    "scope_mode.set",
+    "scope_span.set",
+    "scope_edge.set",
+    "scope_hold.set",
+    "scope_ref.set",
+    "scope_speed.set",
+    "scope_during_tx.set",
+    "scope_center_type.set",
+    "scope_vbw.set",
+    "scope_rbw.set",
+    "scope_fixed_edge.read",
 }
 
 
 def test_registry_has_expected_entry_count():
-    assert len(REGISTRY) == len(_EXPECTED_CHECK_IDS) == 39
+    assert len(REGISTRY) == len(_EXPECTED_CHECK_IDS) == 52
 
 
 def test_check_ids_unique():


### PR DESCRIPTION
## Summary

T11 of the harness epic MOR-634: command-coverage expansion for the scope-control SET surface. Adds a new per-domain registry module `src/rigplane/validation/registry/_scope.py` (13 checks, REGISTRY 39 -> 52), wired append-only into `_assembly.py` below `_SYSTEM_CHECKS`.

The family was audited against `core.radio_protocol.ScopeCapable` (CI-V command 0x27 sub-commands) and the IC-7610 implementation in `runtime/_scope_runtime.py` before any check row was written — every check maps to a real, implemented protocol op.

## RMVR checks (12) — full read-modify-verify-restore

Every get/set pair `ScopeCapable` exposes:

| check_id | ops | value rule |
|---|---|---|
| `scope_receiver.set` | `get/set_scope_receiver` (0=MAIN, 1=SUB) | `scope_index_flip` |
| `scope_dual.set` | `get/set_scope_dual` (bool) | `toggle_bool` |
| `scope_mode.set` | `get/set_scope_mode` (0=center, 1=fixed, 2/3=scroll) | `scope_index_flip` |
| `scope_span.set` | `get/set_scope_span` (preset index 0..7) | `scope_index_flip` |
| `scope_edge.set` | `get/set_scope_edge` (1..4, 1-based) | `scope_edge_cycle` |
| `scope_hold.set` | `get/set_scope_hold` (bool) | `toggle_bool` |
| `scope_ref.set` | `get/set_scope_ref` (dB, 0.5 dB grid) | `scope_ref_db` |
| `scope_speed.set` | `get/set_scope_speed` (0..2) | `scope_index_flip` |
| `scope_during_tx.set` | `get/set_scope_during_tx` (bool) | `toggle_bool` |
| `scope_center_type.set` | `get/set_scope_center_type` (0..2) | `scope_index_flip` |
| `scope_vbw.set` | `get/set_scope_vbw` (bool) | `toggle_bool` |
| `scope_rbw.set` | `get/set_scope_rbw` (0..2) | `scope_index_flip` |

None is TX-adjacent: every one of these only changes what the scope *displays* (including the during-TX display flag) and can never key the transmitter. The frozen `tx_adjacent` closed set in `test_registry.py` is unchanged.

## READ_ONLY (1) and deferred

- `scope_fixed_edge.read` — `get_scope_fixed_edge` is verified readable; `set_scope_fixed_edge` exists but takes multi-keyword args (`edge`, `start_hz`, `end_hz`) the generic single-value RMVR runner cannot drive, so its SET side is **deferred** (same posture as `system_date`/`system_time` in T10).
- `enable_scope`/`disable_scope` are stream-lifecycle ops, not SET-value commands — intentionally not check rows; the scope surface itself remains covered by `scope.capture`.

## New ValueRules (3)

Each gets the full triple (enum member in `_types.py`, `_WRITE_ONLY_TEST_VALUES` entry, mutation lambda in `hardware.py`):

- `SCOPE_INDEX_FLIP` — flips 0 <-> 1; in range for every 0-based scope preset/enum above. Test value 1.
- `SCOPE_EDGE_CYCLE` — cycles 1 <-> 2; edge selection is 1-based, so 0 is never written. Test value 1.
- `SCOPE_REF_DB` — hops 0.0 <-> 5.0 dB, both exact values on the radio's 0.5 dB grid so readback comparison stays exact. Test value 0.0 (neutral ref).

## Tests & golden

- TDD: 18 new tests in `test_hardware_command_families.py` (stateful fake-radio RMVR roundtrips incl. restore + in-range write assertions, READ_ONLY pass/UNSUPPORTED, missing-op UNSUPPORTED, family level/safety wiring) were written and confirmed failing before implementation.
- `test_registry.py`: count 39 -> 52, frozen check-id set extended with the 13 new ids.
- `tests/golden/validation/ic7610.dry-run.json` regenerated via the CLI regen command (not hand-edited); gate passes with 74 matching checks, 0 regressions.

## Verification (all foreground, to completion)

1. `uv run pytest tests/ -q --ignore=tests/integration` — **7743 passed**, 8 skipped, 11 xfailed, 0 failures
2. `uv run mypy src/` — Success: no issues found in 283 source files
3. `uv run ruff check src/ tests/` + `ruff format` — All checks passed, 597 files unchanged
4. `uv run lint-imports` — Contracts: 5 kept, 0 broken
5. dry-run golden gate — PASS (74 checks match, 0 regressions), exit 0

Scope of change is confined to `src/rigplane/validation/` + tests + golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)