### PR TITLE
ci(validation): X6200 + FTX-1 dry-run goldens + gates (MOR-636)

### DIFF
--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -75,15 +75,26 @@ jobs:
       - name: Lint architecture (import-linter)
         run: uv run lint-imports
 
-      - name: Validation dry-run golden gate
+      - name: Validation dry-run golden gate (IC-7610)
         # Native dry-run matrix vs the committed golden artifact: a
         # registry/declaration regression fails CI (MOR-648). Dry-run only —
         # no hardware, sub-second. Regen after an intentional matrix change:
         #   uv run rigplane --model IC-7610 validate --dry-run \
         #     --regen-golden tests/golden/validation/ic7610.dry-run.json
+        # (same for X6200 / FTX-1 below — MOR-636.)
         run: >-
           uv run rigplane --model IC-7610 validate --provider native --dry-run
           --gate tests/golden/validation/ic7610.dry-run.json
+
+      - name: Validation dry-run golden gate (X6200)
+        run: >-
+          uv run rigplane --model X6200 validate --provider native --dry-run
+          --gate tests/golden/validation/x6200.dry-run.json
+
+      - name: Validation dry-run golden gate (FTX-1)
+        run: >-
+          uv run rigplane --model FTX-1 validate --provider native --dry-run
+          --gate tests/golden/validation/ftx1.dry-run.json
 
       - name: Set up Node.js
         if: steps.filter.outputs.frontend == 'true'

--- a/tests/golden/validation/ftx1.dry-run.json
+++ b/tests/golden/validation/ftx1.dry-run.json
@@ -1,0 +1,305 @@
+{
+  "schema_version": 1,
+  "radio": {
+    "model": "FTX-1",
+    "profile_id": "yaesu_ftx1"
+  },
+  "mode": "dry-run",
+  "checks": [
+    {
+      "check_id": "af_level.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "agc.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "attenuator.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "audio.rx",
+      "status": "manual_required",
+      "declaration": "manual_required"
+    },
+    {
+      "check_id": "audio.rx.rms",
+      "status": "manual_required",
+      "declaration": "manual_required"
+    },
+    {
+      "check_id": "audio.tx.byte_perfect",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "break_in.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "bsr.select",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "compressor.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "contour.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "dial_lock.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "discovery.identify",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "dual_rx.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "dual_watch.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "filter_width.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "freq.reverse_sync",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "freq.write",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "if_shift.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "key_speed.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "meters.read",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "mode.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "nb.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "notch.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "nr.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "preamp.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "repeater_tone.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "rf_gain.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "rit.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scope.capture",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope.fft.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_center_type.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_dual.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_during_tx.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_edge.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_fixed_edge.read",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_hold.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_mode.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_rbw.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_receiver.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_ref.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_span.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_speed.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_vbw.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "split.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "sql_type.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "squelch.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "system_date.read",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "system_time.read",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "tone_freq.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "tsql.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "tsql_freq.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "tuner.tune",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "tx.ptt",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "vfo_slot.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "vox.read",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "vox.set",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "vox_gain.set",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "xit.set",
+      "status": "skip",
+      "declaration": "supported"
+    }
+  ]
+}

--- a/tests/golden/validation/x6200.dry-run.json
+++ b/tests/golden/validation/x6200.dry-run.json
@@ -1,0 +1,300 @@
+{
+  "schema_version": 1,
+  "radio": {
+    "model": "X6200",
+    "profile_id": "xiegu_x6200"
+  },
+  "mode": "dry-run",
+  "checks": [
+    {
+      "check_id": "af_level.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "agc.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "attenuator.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "audio.rx",
+      "status": "manual_required",
+      "declaration": "manual_required"
+    },
+    {
+      "check_id": "audio.rx.rms",
+      "status": "manual_required",
+      "declaration": "manual_required"
+    },
+    {
+      "check_id": "audio.tx.byte_perfect",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "break_in.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "bsr.select",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "compressor.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "data_mode.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "dial_lock.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "discovery.identify",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "dual_watch.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "filter_width.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "freq.reverse_sync",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "freq.write",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "key_speed.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "meters.read",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "mode.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "nb.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "notch.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "nr.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "pbt.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "preamp.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "repeater_tone.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "rf_gain.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "rit.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "scan.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope.capture",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope.fft.presence",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_center_type.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_dual.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_during_tx.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_edge.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_fixed_edge.read",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_hold.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_mode.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_rbw.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_receiver.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_ref.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_span.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_speed.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "scope_vbw.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "split.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "squelch.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "system_date.read",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "system_time.read",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "tone_freq.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "tsql.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "tsql_freq.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "tuner.tune",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "tx.ptt",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "vfo_slot.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "vox.read",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "vox.set",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "vox_gain.set",
+      "status": "blocked",
+      "declaration": "manual_required",
+      "failure_domain": "command_execution"
+    },
+    {
+      "check_id": "xit.set",
+      "status": "skip",
+      "declaration": "supported"
+    }
+  ]
+}


### PR DESCRIPTION
## What

T2/MOR-636 originally scoped dry-run goldens for **ic7610/x6200/ftx1**, but only `ic7610.dry-run.json` was committed and only IC-7610 was gated in `quick.yml`. This closes that gap:

- Commit normalized native dry-run goldens for **X6200** and **FTX-1** (`tests/golden/validation/{x6200,ftx1}.dry-run.json`), generated via the canonical `--regen-golden` CLI (no hand edits).
- Add two `quick.yml` gate steps mirroring the IC-7610 one, so a registry/declaration regression that only manifests on those profiles fails CI.

Dry-run only — no hardware, sub-second per gate. Complements the MOR-647 mock-integration matrix (which exercises the dry-run pipeline per profile but does not pin a regression golden).

## Verification (local)
- X6200 gate → exit 0
- FTX-1 gate → exit 0
- IC-7610 gate (regression guard) → exit 0
- `quick.yml` parses (yaml.safe_load OK)

## Scope
`tests/golden/validation/x6200.dry-run.json`, `tests/golden/validation/ftx1.dry-run.json` (new), `.github/workflows/quick.yml` (+2 gate steps). No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)