### PR TITLE
fix(scope): send range+edge selector in get_scope_fixed_edge (MOR-662)

### DIFF
--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -694,13 +694,32 @@ def scope_set_vbw(
 
 
 def get_scope_fixed_edge(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    cmd_map: CommandMap | None = None,
+    *,
+    range_index: int = 1,
+    edge: int = 1,
 ) -> bytes:
+    # The IC-7610 NAKs (0xFA) a bare 0x27 0x1E query — it requires a
+    # <range_index><edge> selector (1-byte BCD each). Mirror the setter's
+    # encoding so the radio answers with the fixed-edge start/end (MOR-662).
+    _validate_scope_range("scope fixed edge range", range_index, 1, 99)
+    _validate_scope_range("scope fixed edge", edge, 1, 4)
+    selector = bcd_encode_value(range_index, byte_count=1) + bcd_encode_value(
+        edge, byte_count=1
+    )
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_scope_fixed_edge", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_scope_fixed_edge",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            data=selector,
         )
-    return _scope_query(_SUB_SCOPE_FIXED_EDGE, to_addr=to_addr, from_addr=from_addr)
+    return build_civ_frame(
+        to_addr, from_addr, _CMD_SCOPE, sub=_SUB_SCOPE_FIXED_EDGE, data=selector
+    )
 
 
 def scope_set_fixed_edge(

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -2639,7 +2639,7 @@ class CivRuntime:
             # Scope-control GETs for subs 0x14, 0x15, 0x16, 0x17, 0x19, 0x1A,
             # 0x1D, 0x1F may carry a single receiver-prefix byte (00=MAIN,
             # 01=SUB) and still expect a data response. Subs without prefix
-            # (0x12, 0x13, 0x1B, 0x1C, 0x1E) keep the empty-data heuristic.
+            # (0x12, 0x13, 0x1B, 0x1C) keep the empty-data heuristic.
             _SCOPE_GET_WITH_RX_PREFIX = (
                 0x14,
                 0x15,
@@ -2652,6 +2652,10 @@ class CivRuntime:
             )
             if frame.sub in _SCOPE_GET_WITH_RX_PREFIX:
                 return len(frame.data) <= 1
+            if frame.sub == 0x1E:
+                # Fixed-edge GET requires a 2-byte <range><edge> selector
+                # (MOR-662); the SET carries the 12-byte bounds payload.
+                return len(frame.data) <= 2
             return len(frame.data) == 0
         return len(frame.data) == 0
 

--- a/src/rigplane/runtime/_scope_runtime.py
+++ b/src/rigplane/runtime/_scope_runtime.py
@@ -433,7 +433,9 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
         """Read the fixed-edge scope bounds."""
         self._check_connected()
         resp = await self._send_civ_expect(
-            _get_scope_fixed_edge_cmd(to_addr=self._radio_addr),
+            # IC-7610 requires a <range><edge> selector or it NAKs the read
+            # (MOR-662). Use range 1, edge 1.
+            _get_scope_fixed_edge_cmd(to_addr=self._radio_addr, range_index=1, edge=1),
             label="get_scope_fixed_edge",
         )
         fixed_edge = parse_scope_fixed_edge_response(resp)

--- a/tests/integration/test_scope_advanced_integration.py
+++ b/tests/integration/test_scope_advanced_integration.py
@@ -148,14 +148,14 @@ class ScopeMockRadio(MockIcomRadio):
 
         # --- 0x27 0x1E: scope fixed edge ---
         if sub == _SUB_SCOPE_FIXED_EDGE:
-            if rest:  # SET: 12-byte payload
-                if len(rest) >= 12:
-                    self._fixed_range_index = _bcd_byte_decode(rest[0])
-                    self._fixed_edge = _bcd_byte_decode(rest[1])
-                    self._fixed_start_hz = _bcd_decode_freq(rest[2:7])
-                    self._fixed_end_hz = _bcd_decode_freq(rest[7:12])
+            if len(rest) >= 12:  # SET: <range><edge> + start(5) + end(5)
+                self._fixed_range_index = _bcd_byte_decode(rest[0])
+                self._fixed_edge = _bcd_byte_decode(rest[1])
+                self._fixed_start_hz = _bcd_decode_freq(rest[2:7])
+                self._fixed_end_hz = _bcd_decode_freq(rest[7:12])
                 return self._civ_ack(to, frm)
-            # GET: 12-byte response
+            # GET: a <range><edge> selector (2 bytes) is required by the
+            # IC-7610 (MOR-662); respond with the 12-byte fixed-edge bounds.
             data = (
                 bytes([_bcd_byte(self._fixed_range_index)])
                 + bytes([_bcd_byte(self._fixed_edge)])

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1249,6 +1249,25 @@ class TestAdvancedScopeParsers:
         assert bounds.start_hz == 14_000_000
         assert bounds.end_hz == 14_350_000
 
+    def test_parse_scope_fixed_edge_response_captured_ic7610(self) -> None:
+        # Raw CI-V captured on the live IC-7610 (MOR-662):
+        #   RX fe fe e0 98 27 1e 01 01 00 00 50 00 00 00 00 50 01 00 fd
+        # Payload after 27 1e: range=01 edge=01 start(5B BCD) end(5B BCD).
+        from rigplane.commands import parse_scope_fixed_edge_response
+
+        frame = CivFrame(
+            0xE0,
+            0x98,
+            0x27,
+            0x1E,
+            bytes.fromhex("0101" + "0000500000" + "0000500100"),
+        )
+        bounds = parse_scope_fixed_edge_response(frame)
+        assert bounds.range_index == 1
+        assert bounds.edge == 1
+        assert bounds.start_hz == 500_000
+        assert bounds.end_hz == 1_500_000
+
     def test_parse_scope_span_response_from_single_byte_index(self) -> None:
         from rigplane.commands import parse_scope_span_response
 

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -838,8 +838,20 @@ class TestScopeCommandBuilders:
         assert frame == b"\xfe\xfe\x98\xe0\x27\x1d\xfd"
 
     def test_get_scope_fixed_edge(self) -> None:
+        # IC-7610 NAKs a bare 0x27 0x1E query; it requires a <range><edge>
+        # selector. Defaults are range=1, edge=1 (MOR-662).
         frame = get_scope_fixed_edge()
-        assert frame == b"\xfe\xfe\x98\xe0\x27\x1e\xfd"
+        assert frame == b"\xfe\xfe\x98\xe0\x27\x1e\x01\x01\xfd"
+
+    def test_get_scope_fixed_edge_selector(self) -> None:
+        frame = get_scope_fixed_edge(range_index=6, edge=4)
+        assert frame == b"\xfe\xfe\x98\xe0\x27\x1e\x06\x04\xfd"
+
+    def test_get_scope_fixed_edge_rejects_bad_edge(self) -> None:
+        with pytest.raises(ValueError):
+            get_scope_fixed_edge(edge=5)
+        with pytest.raises(ValueError):
+            get_scope_fixed_edge(edge=0)
 
     def test_scope_set_fixed_edge(self) -> None:
         frame = scope_set_fixed_edge(edge=4, start_hz=14_000_000, end_hz=14_350_000)


### PR DESCRIPTION
## What
Live IC-7610 validation FAILed `scope_fixed_edge.read` with `timeout after 8.0s`. Raw CI-V trace root-caused it: `get_scope_fixed_edge` sent a **bare** `0x27 0x1E` query, which the radio **NAKs (0xFA)**; `_send_civ_expect` then waited 8s for a data frame that never came. The IC-7610 requires a `<range><edge>` selector (same keying as `scope_set_fixed_edge`):

```
TX fe fe 98 e0 27 1e fd        -> RX fe fe e0 98 FA fd                              (NAK — bare rejected)
TX fe fe 98 e0 27 1e 01 01 fd  -> RX fe fe e0 98 27 1e 01 01 00 00 50 00 00 00 00 50 01 00 fd  (data)
TX fe fe 98 e0 27 1e 01 fd     -> RX fe fe e0 98 FA fd                              (NAK — edge-only rejected)
```

## Fix
- `commands/scope.py::get_scope_fixed_edge` — add `range_index: int = 1`, `edge: int = 1` kwargs; emit the 2-byte BCD selector so the frame is `... 27 1e <range> <edge> fd`.
- `runtime/_scope_runtime.py::get_scope_fixed_edge` — pass the selector.
- `runtime/_civ_rx.py` — the GET/SET frame-classification heuristic for sub `0x1E` now treats a `<=2`-byte payload as the GET (the SET carries the 12-byte bounds payload), so the outgoing selector-bearing GET is classified correctly.

## Verification
- pytest (xdist, no integration): **7754 passed, 0 failed**
- mypy: Success (283 files) · ruff: clean · lint-imports: 5 kept, 0 broken
- All three dry-run golden gates exit 0; **no golden changed** (read-path only — dry-run does not execute reads)
- New unit tests: builder emits `... 27 1e 01 01 fd`; parser decodes the real captured response; out-of-range edge raises.

## Scope
`commands/scope.py`, `runtime/_scope_runtime.py`, `runtime/_civ_rx.py`, tests. No overlap with the sibling MOR-660/661 PR (hardware.py / ic7610.toml / goldens).

Will be confirmed on hardware in the post-merge live IC-7610 re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)