### PR TITLE
fix(validation): coerce non-primitive check evidence to JSON-safe types so artifact emission never crashes (MOR-663)

### DIFF
--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -543,6 +543,19 @@ async def _run_hardware_both(
     return _apply_golden_flags(art_n, args, rc_n if rc_n else rc_h)
 
 
+def _json_default(obj: object) -> object:
+    """Last-resort JSON coercion so artifact emission can never crash.
+
+    ``CheckResult.to_dict`` already coerces evidence to JSON-safe types; this
+    is belt-and-suspenders for any unforeseen object that still reaches
+    ``json.dumps`` (mirrors the "always produce output" principle): a
+    dataclass becomes its ``asdict``, anything else its ``str``.
+    """
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    return str(obj)
+
+
 def _apply_golden_flags(
     artifact: ValidationArtifact, args: argparse.Namespace, exit_code: int
 ) -> int:
@@ -560,7 +573,10 @@ def _apply_golden_flags(
         normalized = normalize_artifact(artifact.to_dict())
         path = Path(regen_path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(normalized, indent=2) + "\n", encoding="utf-8")
+        path.write_text(
+            json.dumps(normalized, indent=2, default=_json_default) + "\n",
+            encoding="utf-8",
+        )
         print(f"Golden written to: {regen_path}", file=sys.stderr)
 
     gate_path = getattr(args, "gate", None)
@@ -597,11 +613,11 @@ def _stamp_overrides(
 def _emit_artifact(artifact: ValidationArtifact, args: argparse.Namespace) -> None:
     """Render the artifact: file on --output, JSON on --json, else human text."""
     if args.output:
-        text = json.dumps(artifact.to_dict(), indent=2)
+        text = json.dumps(artifact.to_dict(), indent=2, default=_json_default)
         Path(args.output).write_text(text + "\n", encoding="utf-8")
         print(f"Artifact written to: {args.output}", file=sys.stderr)
     elif args.json:
-        print(json.dumps(artifact.to_dict(), indent=2))
+        print(json.dumps(artifact.to_dict(), indent=2, default=_json_default))
     else:
         print(human_summary(artifact))
 

--- a/src/rigplane/validation/schema.py
+++ b/src/rigplane/validation/schema.py
@@ -13,13 +13,50 @@ indexing so the public API stays type-safe without ``type: ignore``.
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass, field
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 
 from rigplane.core.capabilities import KNOWN_CAPABILITIES
 
 SCHEMA_VERSION = 1
 TOOL_NAME = "rigplane-validation-matrix"
+
+
+def _jsonify(value: object) -> object:
+    """Recursively coerce ``value`` into JSON-serializable types.
+
+    Evidence dicts can hold non-primitive objects (a ``ScopeFixedEdge``
+    dataclass, an ``Enum``, ``bytes``) that ``json.dumps`` cannot encode.
+    This walker normalizes them so the artifact can ALWAYS be emitted:
+
+    - dataclass instance -> its ``to_dict()`` if present, else ``asdict`` (recurse);
+    - ``Enum`` -> its ``.value``;
+    - ``bytes``/``bytearray`` -> hex string;
+    - ``set``/``tuple`` -> list of recursed elements;
+    - ``dict`` -> recursed values (non-str keys coerced via ``str``);
+    - ``list`` -> recursed elements;
+    - primitives (str/int/float/bool/None) -> unchanged.
+    """
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    if isinstance(value, Enum):
+        return _jsonify(value.value)
+    if isinstance(value, (bytes, bytearray)):
+        return value.hex()
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        to_dict = getattr(value, "to_dict", None)
+        if callable(to_dict):
+            return _jsonify(to_dict())
+        return _jsonify(dataclasses.asdict(value))
+    if isinstance(value, dict):
+        return {
+            (key if isinstance(key, str) else str(key)): _jsonify(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_jsonify(item) for item in value]
+    return value
 
 
 class CheckStatus(StrEnum):
@@ -94,7 +131,9 @@ class CheckResult:
         if self.failure_domain is not None:
             payload["failure_domain"] = self.failure_domain.value
         if self.evidence:
-            payload["evidence"] = dict(self.evidence)
+            payload["evidence"] = {
+                key: _jsonify(value) for key, value in self.evidence.items()
+            }
         if self.error:
             payload["error"] = self.error
         if self.started_at is not None:

--- a/tests/validation/test_schema_jsonify.py
+++ b/tests/validation/test_schema_jsonify.py
@@ -1,0 +1,137 @@
+"""Regression tests for JSON-safe coercion of check evidence (MOR-663).
+
+The live IC-7610 matrix crashed when writing its artifact because a
+``ScopeFixedEdge`` dataclass landed in a check's ``evidence`` dict and
+``json.dumps(artifact.to_dict())`` had no way to serialize it. These tests
+pin the recursive coercion in ``CheckResult.to_dict`` (and confirm the whole
+``ValidationArtifact`` round-trips through ``json.dumps``), while guarding
+that primitive-only evidence keeps its exact prior shape so goldens do not
+shift.
+"""
+
+from __future__ import annotations
+
+import json
+
+from rigplane.core.types import AgcMode, ScopeFixedEdge
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CheckResult,
+    CheckStatus,
+    LevelResult,
+    OperatorSafetyBlock,
+    RadioTarget,
+    TransportInfo,
+    ValidationArtifact,
+    ValidationLevel,
+)
+
+
+def _make_check(evidence: dict[str, object]) -> CheckResult:
+    return CheckResult(
+        check_id="scope.fixed_edge.read",
+        capability="scope",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        status=CheckStatus.PASS,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="scope fixed-edge read",
+        evidence=evidence,
+    )
+
+
+def test_to_dict_coerces_dataclass_enum_and_bytes() -> None:
+    edge = ScopeFixedEdge(range_index=1, edge=2, start_hz=14_000_000, end_hz=14_350_000)
+    check = _make_check(
+        {
+            "edge": edge,
+            "mode": AgcMode.FAST,
+            "raw": b"\xab\xcd",
+        }
+    )
+
+    payload = check.to_dict()
+    evidence = payload["evidence"]
+    assert isinstance(evidence, dict)
+
+    # dataclass -> plain dict of its fields (exact keys/values).
+    assert evidence["edge"] == {
+        "range_index": 1,
+        "edge": 2,
+        "start_hz": 14_000_000,
+        "end_hz": 14_350_000,
+    }
+    # Enum -> its .value.
+    assert evidence["mode"] == AgcMode.FAST.value
+    # bytes -> hex string.
+    assert evidence["raw"] == b"\xab\xcd".hex()
+
+    # The whole payload must be JSON-serializable without a default= handler.
+    json.dumps(payload)
+
+
+def test_to_dict_coerces_nested_containers() -> None:
+    edge = ScopeFixedEdge(range_index=0, edge=1, start_hz=1, end_hz=2)
+    check = _make_check(
+        {
+            "edges": [edge, {"nested_bytes": b"\x01"}],
+            "tags": {"a", "b"},
+            "pair": (1, AgcMode.SLOW),
+        }
+    )
+
+    evidence = check.to_dict()["evidence"]
+    assert isinstance(evidence, dict)
+
+    assert evidence["edges"][0] == {
+        "range_index": 0,
+        "edge": 1,
+        "start_hz": 1,
+        "end_hz": 2,
+    }
+    assert evidence["edges"][1] == {"nested_bytes": b"\x01".hex()}
+    # set -> list; order is not guaranteed, so compare as a set.
+    assert isinstance(evidence["tags"], list)
+    assert set(evidence["tags"]) == {"a", "b"}
+    # tuple -> list, with elements recursed (Enum -> value).
+    assert evidence["pair"] == [1, AgcMode.SLOW.value]
+
+    json.dumps(check.to_dict())
+
+
+def test_artifact_with_dataclass_evidence_is_json_serializable() -> None:
+    edge = ScopeFixedEdge(range_index=1, edge=2, start_hz=10, end_hz=20)
+    check = _make_check({"edge": edge})
+    artifact = ValidationArtifact(
+        radio=RadioTarget(model="IC-7610", profile_id="ic7610"),
+        transport=TransportInfo(backend="udp", host="192.168.55.40", port=50001),
+        safety=OperatorSafetyBlock(),
+        levels=[LevelResult(level=ValidationLevel.CAPABILITY_MATRIX, checks=[check])],
+        core_version="2.9.0",
+    )
+
+    # The live-run crash was here: this must not raise.
+    text = json.dumps(artifact.to_dict())
+    assert "start_hz" in text
+
+
+def test_primitive_evidence_shape_is_unchanged() -> None:
+    """Primitive-only evidence must serialize identically to a plain dict copy.
+
+    Guards against goldens shifting: only non-primitive values change shape.
+    """
+    evidence: dict[str, object] = {
+        "freq_hz": 14_074_000,
+        "mode": "USB",
+        "ok": True,
+        "ratio": 1.5,
+        "missing": None,
+        "list": [1, 2, 3],
+        "nested": {"k": "v", "n": 7},
+    }
+    check = _make_check(dict(evidence))
+
+    assert check.to_dict()["evidence"] == evidence
+    # Byte-identical JSON to a direct dump of the original primitive evidence.
+    assert json.dumps(check.to_dict()["evidence"], sort_keys=True) == json.dumps(
+        evidence, sort_keys=True
+    )


### PR DESCRIPTION
## The bug (live IC-7610 run, epic MOR-634)

The full live IC-7610 matrix ran all 70 checks but **crashed while writing the artifact**:

```
TypeError: Object of type ScopeFixedEdge is not JSON serializable
```

The MOR-662 fix made `scope_fixed_edge.read` return a real `ScopeFixedEdge` dataclass (instead of timing out). That object lands in the check's `evidence` dict, and the final `json.dumps(artifact.to_dict())` had no `default=` handler — so it raised and aborted artifact emission **after the whole matrix had already run**.

## Root cause

`CheckResult.to_dict()` in `src/rigplane/validation/schema.py` did `payload["evidence"] = dict(self.evidence)` — a **shallow** copy. Non-JSON-primitive evidence values (a dataclass like `ScopeFixedEdge`, an `Enum`, `bytes`) passed through unconverted, so `json.dumps` could not encode them.

## Fix (defense in depth — the harness must ALWAYS be able to emit its artifact)

1. **Recursive `_jsonify()` helper** in `schema.py`, applied per evidence value in `CheckResult.to_dict()`:
   - dataclass → `to_dict()` if present, else `dataclasses.asdict` (then recurse);
   - `Enum` → `.value`;
   - `bytes`/`bytearray` → hex string;
   - `set`/`tuple`/`frozenset` → list (recurse elements);
   - `dict` → recurse values (non-str keys coerced via `str`);
   - `list` → recurse elements;
   - primitives (str/int/float/bool/None) → **unchanged** (so primitive-only evidence keeps its exact prior shape and goldens do not move).
2. **Belt-and-suspenders**: the three `json.dumps(...)` calls in `cli/_validate.py` (regen-golden write, `--output`, `--json`) now pass `default=_json_default` (dataclass → `asdict`, else `str`), so an unforeseen object can never again abort emission (mirrors MOR-659's "always produce output" principle).
3. `scope_fixed_edge.read` itself is **unchanged** — the general coercion is the fix.

## Tests (`tests/validation/test_schema_jsonify.py`, TDD)

- `CheckResult` evidence with a real `ScopeFixedEdge` + `Enum` + `bytes` → `to_dict()` is `json.dumps`-able; ScopeFixedEdge becomes a dict of its exact fields, Enum its `.value`, bytes its `.hex()`.
- Nested containers (list/set/tuple, nested dataclass/bytes) recurse correctly.
- A full `ValidationArtifact` carrying such a check → `json.dumps(artifact.to_dict())` does not raise (the exact live-run path).
- Regression: primitive-only evidence is byte-identical to the previous shallow-copy output.

## Verification (all foreground, to completion)

- `pytest tests/ --ignore=tests/integration -n auto` → **7763 passed, 8 skipped, 11 xfailed, 1 xpassed**
- `mypy src/` → **Success: no issues found in 283 source files**
- `ruff check` → **All checks passed!**; `ruff format` → 600 files unchanged
- `lint-imports` → **5 kept, 0 broken**
- Dry-run golden gates IC-7610 / X6200 / FTX-1 each **exit 0**; **no golden changed** (`git diff tests/golden/` empty) — dry-run produces no non-primitive evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)