### PR TITLE
fix(validation): preamp.set clears and restores the DIGI-SEL prerequisite before testing PREAMP (MOR-665)

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -958,24 +958,32 @@ async def _check_preamp_set(
     try:
         result = await _preamp_rmvr(radio, entry, per_check_timeout=per_check_timeout)
     finally:
+        # Best-effort restore that must never raise (mirrors
+        # ``_read_modify_verify_restore``): ``_guard`` maps the rig-error family,
+        # and the surrounding ``except _RESTORE_ERRORS`` additionally contains a
+        # bare ``OSError`` from the UDP send path so a mid-restore LAN drop can
+        # never escape and leave DIGI-SEL in the wrong state.
         restored = False
-        _, restore_fail = await _guard(
-            cast(Awaitable[None], set_digisel(True)),
-            entry,
-            per_check_timeout=per_check_timeout,
-        )
-        if restore_fail is not None:
-            extra["digisel_restore_error"] = restore_fail.error
-        else:
-            ctrl, ctrl_fail = await _guard(
-                cast(Awaitable[bool], get_digisel()),
+        try:
+            _, restore_fail = await _guard(
+                cast(Awaitable[None], set_digisel(True)),
                 entry,
                 per_check_timeout=per_check_timeout,
             )
-            if ctrl_fail is not None:
-                extra["digisel_restore_read_error"] = ctrl_fail.error
+            if restore_fail is not None:
+                extra["digisel_restore_error"] = restore_fail.error
             else:
-                restored = bool(ctrl)
+                ctrl, ctrl_fail = await _guard(
+                    cast(Awaitable[bool], get_digisel()),
+                    entry,
+                    per_check_timeout=per_check_timeout,
+                )
+                if ctrl_fail is not None:
+                    extra["digisel_restore_read_error"] = ctrl_fail.error
+                else:
+                    restored = bool(ctrl)
+        except _RESTORE_ERRORS as exc:
+            extra["digisel_restore_error"] = str(exc)
         extra["digisel_restored"] = restored
 
     return _merge_evidence(result, extra)

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -871,16 +871,22 @@ async def _check_af_level_set(
     )
 
 
-async def _check_preamp_set(
+def _merge_evidence(result: CheckResult, extra: dict[str, object]) -> CheckResult:
+    """Return ``result`` with ``extra`` merged into its evidence dict."""
+    if not extra:
+        return result
+    merged = dict(result.evidence)
+    merged.update(extra)
+    return dataclasses.replace(result, evidence=merged)
+
+
+async def _preamp_rmvr(
     radio: Radio,
     entry: CapabilityDeclarationEntry,
     *,
-    allow_writes: bool,
     per_check_timeout: float,
 ) -> CheckResult:
-    gate = _write_gate(radio, entry, allow_writes=allow_writes)
-    if gate is not None:
-        return gate
+    """The plain PREAMP read-modify-verify-restore cycle (no prerequisites)."""
     antenna = cast(AntennaControlCapable, radio)
     return await _read_modify_verify_restore(
         radio,
@@ -890,6 +896,89 @@ async def _check_preamp_set(
         make_changed=lambda v: 1 if v == 0 else 0,
         per_check_timeout=per_check_timeout,
     )
+
+
+async def _check_preamp_set(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    allow_writes: bool,
+    per_check_timeout: float,
+) -> CheckResult:
+    """RMVR the PREAMP, clearing the DIGI-SEL prerequisite first (MOR-665).
+
+    The IC-7610 enforces PREAMP/DIGI-SEL mutual exclusion: setting PREAMP while
+    DIGI-SEL (IP+) is ON raises ``CommandError``. When DIGI-SEL is ON the
+    harness temporarily disables it, runs the normal PREAMP RMVR, then restores
+    DIGI-SEL to its original ON state in a best-effort step that never raises.
+    If DIGI-SEL is already OFF — or the radio does not support reading it —
+    behaviour is identical to the plain RMVR.
+    """
+    gate = _write_gate(radio, entry, allow_writes=allow_writes)
+    if gate is not None:
+        return gate
+
+    get_digisel = getattr(radio, "get_digisel", None)
+    set_digisel = getattr(radio, "set_digisel", None)
+    if not callable(get_digisel) or not callable(set_digisel):
+        # Radio cannot report DIGI-SEL state — fall back to today's behaviour.
+        return await _preamp_rmvr(radio, entry, per_check_timeout=per_check_timeout)
+
+    digisel_on: bool | None = None
+    ds_fail: CheckResult | None = None
+    try:
+        digisel_on, ds_fail = await _guard(
+            cast(Awaitable[bool], get_digisel()),
+            entry,
+            per_check_timeout=per_check_timeout,
+        )
+    except Exception:  # noqa: BLE001 — any DIGI-SEL read error -> safe fallback.
+        ds_fail = _base_result(entry, CheckStatus.FAIL)
+    if ds_fail is not None:
+        # DIGI-SEL read unsupported/failed — fall back, don't crash the check.
+        return await _preamp_rmvr(radio, entry, per_check_timeout=per_check_timeout)
+
+    if not digisel_on:
+        result = await _preamp_rmvr(radio, entry, per_check_timeout=per_check_timeout)
+        return _merge_evidence(result, {"digisel_was_on": False})
+
+    # DIGI-SEL is ON: clear it, run the PREAMP RMVR, then always restore it.
+    extra: dict[str, object] = {"digisel_was_on": True}
+    _, clear_fail = await _guard(
+        cast(Awaitable[None], set_digisel(False)),
+        entry,
+        per_check_timeout=per_check_timeout,
+    )
+    if clear_fail is not None:
+        # Could not clear the prerequisite — fall back so PREAMP still runs.
+        extra["digisel_clear_error"] = clear_fail.error
+        result = await _preamp_rmvr(radio, entry, per_check_timeout=per_check_timeout)
+        return _merge_evidence(result, extra)
+
+    try:
+        result = await _preamp_rmvr(radio, entry, per_check_timeout=per_check_timeout)
+    finally:
+        restored = False
+        _, restore_fail = await _guard(
+            cast(Awaitable[None], set_digisel(True)),
+            entry,
+            per_check_timeout=per_check_timeout,
+        )
+        if restore_fail is not None:
+            extra["digisel_restore_error"] = restore_fail.error
+        else:
+            ctrl, ctrl_fail = await _guard(
+                cast(Awaitable[bool], get_digisel()),
+                entry,
+                per_check_timeout=per_check_timeout,
+            )
+            if ctrl_fail is not None:
+                extra["digisel_restore_read_error"] = ctrl_fail.error
+            else:
+                restored = bool(ctrl)
+        extra["digisel_restored"] = restored
+
+    return _merge_evidence(result, extra)
 
 
 async def _check_attenuator_set(

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -116,6 +116,29 @@ def _stateful_preamp_mock(*, start: int = 0):
     return radio, store
 
 
+def _digisel_preamp_mock(*, preamp_start: int = 0, digisel_on: bool = True):
+    """A stateful preamp mock that ALSO exposes get/set_digisel.
+
+    ``get_digisel`` is not part of the Radio protocol, so a ``spec=Radio`` mock
+    would not auto-provide it; attach it explicitly so the preamp handler's
+    DIGI-SEL prerequisite path (MOR-665) can be exercised. Returns the radio
+    plus the preamp and digisel state stores.
+    """
+    radio, preamp_store = _stateful_preamp_mock(start=preamp_start)
+    radio.capabilities = {"preamp", "digisel"}
+    digisel_store = {"on": digisel_on}
+
+    async def _get_digisel(receiver: int = 0) -> bool:
+        return digisel_store["on"]
+
+    async def _set_digisel(on: bool, receiver: int = 0) -> None:
+        digisel_store["on"] = on
+
+    radio.get_digisel = AsyncMock(side_effect=_get_digisel)
+    radio.set_digisel = AsyncMock(side_effect=_set_digisel)
+    return radio, preamp_store, digisel_store
+
+
 async def test_default_run_produces_artifact_with_expected_statuses(connected_radio):
     template = _x6200_template()
     safety = OperatorSafetyBlock()
@@ -330,6 +353,111 @@ async def test_rmvr_restore_failure_is_recorded():
     assert check.status is CheckStatus.FAIL
     assert check.failure_domain is FailureDomain.READBACK
     assert "restore_error" in check.evidence
+
+
+# ---------------------------------------------------------------------------
+# MOR-665: preamp.set clears the DIGI-SEL prerequisite, then restores it.
+# The IC-7610 enforces PREAMP/DIGI-SEL mutual exclusion, so when DIGI-SEL is
+# ON the harness must temporarily disable it, run the PREAMP RMVR, then restore
+# DIGI-SEL to its original state.
+# ---------------------------------------------------------------------------
+
+
+async def test_preamp_clears_and_restores_digisel_when_on():
+    radio, _preamp_store, digisel_store = _digisel_preamp_mock(
+        preamp_start=0, digisel_on=True
+    )
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["digisel_was_on"] is True
+    assert check.evidence["digisel_restored"] is True
+    # PREAMP RMVR still ran and reacted/restored.
+    assert check.evidence["original"] == 0
+    assert check.evidence["changed"] == 1
+    assert check.evidence["restored"] is True
+    # DIGI-SEL ended back ON.
+    assert digisel_store["on"] is True
+    # set_digisel called False (clear) then True (restore), in that order.
+    calls = [c.args[0] for c in radio.set_digisel.call_args_list]
+    assert calls == [False, True]
+
+
+async def test_preamp_no_toggle_when_digisel_off():
+    radio, _preamp_store, digisel_store = _digisel_preamp_mock(
+        preamp_start=0, digisel_on=False
+    )
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["digisel_was_on"] is False
+    # No prerequisite toggle when DIGI-SEL was already off.
+    assert "digisel_restored" not in check.evidence
+    radio.set_digisel.assert_not_called()
+    assert digisel_store["on"] is False
+    # PREAMP RMVR ran as today.
+    assert check.evidence["original"] == 0
+    assert check.evidence["changed"] == 1
+
+
+async def test_preamp_restores_digisel_even_when_rmvr_fails():
+    """If the PREAMP write/readback fails mid-check, DIGI-SEL is STILL restored."""
+    radio, _preamp_store, digisel_store = _digisel_preamp_mock(
+        preamp_start=0, digisel_on=True
+    )
+    # Make PREAMP a no-op write so the readback never reacts -> FAIL/READBACK.
+    radio.set_preamp = AsyncMock(return_value=None)
+    radio.get_preamp = AsyncMock(return_value=0)
+
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+
+    assert check.status is CheckStatus.FAIL
+    assert check.failure_domain is FailureDomain.READBACK
+    assert check.evidence["digisel_was_on"] is True
+    assert check.evidence["digisel_restored"] is True
+    assert digisel_store["on"] is True
+    calls = [c.args[0] for c in radio.set_digisel.call_args_list]
+    assert calls == [False, True]
+
+
+async def test_preamp_falls_back_when_get_digisel_unsupported():
+    """A radio without get_digisel (or whose read raises) falls back to plain
+    RMVR with no DIGI-SEL evidence and no crash."""
+    # No get_digisel attached at all (spec=Radio does not provide it).
+    radio, _store = _stateful_preamp_mock(start=0)
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+
+    assert check.status is CheckStatus.PASS
+    assert "digisel_was_on" not in check.evidence
+    assert "digisel_restored" not in check.evidence
+
+    # And the case where get_digisel exists but raises -> same fallback.
+    radio2, _store2 = _stateful_preamp_mock(start=0)
+    radio2.get_digisel = AsyncMock(side_effect=RuntimeError("not implemented"))
+    radio2.set_digisel = AsyncMock(return_value=None)
+    levels2 = await execute_hardware_checks(
+        radio2, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check2 = _flatten(levels2)["preamp.set"]
+    assert check2.status is CheckStatus.PASS
+    assert "digisel_was_on" not in check2.evidence
+    radio2.set_digisel.assert_not_called()
 
 
 async def test_read_only_skips_write_checks():

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -432,6 +432,34 @@ async def test_preamp_restores_digisel_even_when_rmvr_fails():
     assert calls == [False, True]
 
 
+async def test_preamp_digisel_restore_oserror_never_escapes():
+    """A bare OSError from the UDP send path during the DIGI-SEL restore must be
+    contained (it is in _RESTORE_ERRORS), not escape and abort the run."""
+    radio, _preamp_store, _digisel_store = _digisel_preamp_mock(
+        preamp_start=0, digisel_on=True
+    )
+    calls: list[bool] = []
+
+    async def _set_digisel(on: bool, receiver: int = 0) -> None:
+        calls.append(on)
+        if on:  # the restore call -> simulate a mid-restore LAN drop
+            raise OSError("sendto: network is down")
+
+    radio.set_digisel = AsyncMock(side_effect=_set_digisel)
+
+    template = _single_entry_template(check_id="preamp.set", capability="preamp")
+    # Must not raise despite the OSError in the finally restore.
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["preamp.set"]
+
+    assert check.evidence["digisel_was_on"] is True
+    assert check.evidence["digisel_restored"] is False
+    assert "digisel_restore_error" in check.evidence
+    assert calls == [False, True]  # cleared, then restore attempted
+
+
 async def test_preamp_falls_back_when_get_digisel_unsupported():
     """A radio without get_digisel (or whose read raises) falls back to plain
     RMVR with no DIGI-SEL evidence and no crash."""


### PR DESCRIPTION
## MOR-665 — preamp.set clears and restores the DIGI-SEL prerequisite

### The live FAIL
The live IC-7610 validation run (epic MOR-634) FAILed `preamp.set`:

> `Cannot set preamp level 1: DIGI-SEL (IP+) is ON. PREAMP and DIGI-SEL are mutually exclusive`

The radio's preflight in `runtime/radio.py` correctly enforces PREAMP/DIGI-SEL mutual exclusion (setting PREAMP while DIGI-SEL is ON raises `CommandError`). So the **harness**, not the radio, must adapt: it should temporarily clear the blocking prerequisite, test PREAMP, then restore it — rather than just reporting FAIL.

### Clear-and-restore approach
`preamp.set` (the named handler in `_SUPPORTED_HANDLERS`) is now prerequisite-aware, localized to that one check:

- Before the PREAMP read-modify-verify-restore, read DIGI-SEL via `radio.get_digisel()`.
- **DIGI-SEL ON** → `set_digisel(False)`, run the normal PREAMP RMVR, then restore `set_digisel(True)` in a `finally` that **never raises** (best-effort, same spirit as the RMVR restore); the restore is verified by re-reading.
- **DIGI-SEL OFF** → no toggle; behaviour is exactly as before.
- **Unsupported/erroring** `get_digisel`/`set_digisel` (missing attr, raises, NAK) → fall back to today's plain RMVR; no crash (MOR-659 containment still applies, but this is a clean handled path).

No generic precondition framework was added (preamp/DIGI-SEL is the only known case), and **`runtime/radio.py`'s preflight is untouched** — that mutual-exclusion is correct radio behaviour.

### Evidence keys
- `digisel_was_on: <bool>` — always recorded.
- `digisel_restored: <bool>` — recorded only when DIGI-SEL was toggled, verified by re-read.
- Best-effort error breadcrumbs when relevant: `digisel_clear_error`, `digisel_restore_error`, `digisel_restore_read_error`.

### Tests (TDD, `tests/validation/test_hardware.py`)
- DIGI-SEL ON → clears it, PREAMP RMVR PASSes, DIGI-SEL restored ON; evidence `digisel_was_on: true`, `digisel_restored: true`; `set_digisel` called `False` then `True`.
- DIGI-SEL OFF → no toggle (`set_digisel` not called), RMVR runs as today; evidence `digisel_was_on: false`.
- Restore-on-failure → PREAMP write/readback fails mid-check, DIGI-SEL is STILL restored to ON (`False` then `True`).
- Unsupported `get_digisel` (absent, and raising) → graceful fallback, no crash, no DIGI-SEL evidence, `set_digisel` not called.

### Verification (all green)
1. `pytest tests/ --ignore=tests/integration -n auto` — **7763 passed**, 8 skipped, 11 xfailed, 1 xpassed
2. `mypy src/` — Success (283 files)
3. `ruff check` + `ruff format` — clean (599 files)
4. `lint-imports` — 5 kept, 0 broken
5. Dry-run golden gates (`tests/test_validation_gating.py`, incl. IC-7610/X6200/FTX-1 exit-zero + committed IC-7610 golden) — 18 passed

### No golden changed
This affects **live execution only** — dry-run does not actuate, so no golden should change. Confirmed: `git diff tests/golden/` is empty. Only `src/rigplane/validation/hardware.py` and `tests/validation/test_hardware.py` changed (no overlap with the sibling MOR-663 PR's `schema.py`/`_validate.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
