### PR TITLE
feat(validation): --interactive operator-confirmed manual-perception checks + confirm primitive (MOR-667)

### DIFF
--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 from rigplane import __version__
 from rigplane.validation import (
     HARDWARE_OPT_IN_ENV,
+    InteractivePrompter,
     MatrixTemplate,
     OperatorSafetyBlock,
     TransportInfo,
@@ -168,6 +169,28 @@ def _utcnow_iso() -> str:
         .isoformat(timespec="milliseconds")
         .replace("+00:00", "Z")
     )
+
+
+def _build_prompter(args: argparse.Namespace) -> InteractivePrompter | None:
+    """Construct an :class:`InteractivePrompter` for ``--interactive`` runs.
+
+    Returns ``None`` (→ unchanged MANUAL_REQUIRED behaviour) unless ``--interactive``
+    is set AND stdin is a real TTY. The TTY guard is the no-hang safeguard
+    (MOR-667): a CI/piped run must never block on ``input()``, so without a TTY
+    the perception checks stay MANUAL_REQUIRED. ``--assume-yes`` only auto-answers
+    perception prompts; it never satisfies the prompter's ``confirm`` gate (used by
+    the MOR-666 TX prompt), which always reads a real answer.
+    """
+    if not getattr(args, "interactive", False):
+        return None
+    if not sys.stdin.isatty():
+        print(
+            "Warning: --interactive ignored (stdin is not a TTY); "
+            "manual-perception checks stay MANUAL_REQUIRED.",
+            file=sys.stderr,
+        )
+        return None
+    return InteractivePrompter(assume_yes=bool(getattr(args, "assume_yes", False)))
 
 
 def add_subparser(sub: Any) -> argparse.ArgumentParser:
@@ -308,6 +331,26 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
             "Skip auto-applying the per-profile override file "
             "(docs/validation/templates/<profile_id>.json). Escape hatch for "
             "deterministic CI runs. No effect when --template is given."
+        ),
+    )
+    p.add_argument(
+        "--interactive",
+        action="store_true",
+        help=(
+            "Prompt the operator for the manual-perception checks "
+            "(audio.rx, scope.capture, bsr.select) and record their y/n answer "
+            "as PASS/FAIL instead of MANUAL_REQUIRED. Requires a TTY on stdin; "
+            "with no TTY (CI/piped) these stay MANUAL_REQUIRED and never block."
+        ),
+    )
+    p.add_argument(
+        "--assume-yes",
+        dest="assume_yes",
+        action="store_true",
+        help=(
+            "With --interactive, auto-answer YES to non-TX perception prompts "
+            "for unattended runs. Does NOT apply to any TX-transmit gate, which "
+            "always requires a real interactive YES."
         ),
     )
     p.add_argument(
@@ -722,6 +765,7 @@ async def _run_hardware(
                 allow_writes=not bool(getattr(args, "read_only", False)),
                 per_check_timeout=getattr(args, "timeout", 5.0) or 5.0,
                 write_only_capabilities=write_only_capabilities,
+                prompter=_build_prompter(args),
             )
     except (RigConnectionError, AuthenticationError, OSError, RigplaneError) as exc:
         levels = _transport_failure_levels(template, exc)
@@ -911,6 +955,7 @@ async def _run_hardware_hamlib(
                         write_only_capabilities=(
                             profile.write_only_controls if profile else frozenset()
                         ),
+                        prompter=_build_prompter(args),
                     )
             finally:
                 await bridge.stop()
@@ -1024,6 +1069,7 @@ async def _run_hardware_hamlib_external(
                 safety,
                 allow_writes=not bool(getattr(args, "read_only", False)),
                 per_check_timeout=timeout,
+                prompter=_build_prompter(args),
             )
     except (RigConnectionError, AuthenticationError, OSError, RigplaneError) as exc:
         template = build_template_from_capabilities(

--- a/src/rigplane/validation/__init__.py
+++ b/src/rigplane/validation/__init__.py
@@ -16,6 +16,7 @@ from rigplane.validation.gating import (
     normalize_artifact,
 )
 from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.interactive import InteractivePrompter, is_affirmative
 from rigplane.validation.overrides import (
     EXCLUDED,
     MergeReport,
@@ -79,6 +80,8 @@ __all__ = [
     "build_validation_artifact",
     "human_summary",
     "execute_hardware_checks",
+    "InteractivePrompter",
+    "is_affirmative",
     "compute_comparison_dimensions",
     "GateReport",
     "format_gate_report",

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -49,6 +49,7 @@ from rigplane.core.radio_protocol import (
     UsbAudioCapable,
 )
 from rigplane.core.types import AgcMode
+from rigplane.validation.interactive import InteractivePrompter
 from rigplane.validation.registry import CheckKind, CheckSpec, ValueRule, get_spec
 from rigplane.validation.runner import _is_authorized, _is_safety_gated
 from rigplane.validation.schema import (
@@ -113,6 +114,27 @@ _CAP_PROTOCOL: dict[str, type] = {
 }
 
 
+# Operator-perception prompts (MOR-667). These checks have NO software readback
+# — only a human watching the rig can confirm them — so in ``--interactive`` mode
+# the harness asks the operator a yes/no question and records PASS/FAIL instead of
+# the default MANUAL_REQUIRED. A check_id without an entry here keeps
+# MANUAL_REQUIRED even under ``--interactive``.
+_PERCEPTION_PROMPTS: dict[str, str] = {
+    "audio.rx": (
+        "Listen to the radio's RX audio (speaker/headphones). "
+        "Do you hear receive audio? [y/N] "
+    ),
+    "scope.capture": (
+        "Look at the radio's panadapter/spectrum scope. "
+        "Do you see the spectrum sweeping? [y/N] "
+    ),
+    "bsr.select": (
+        "Trigger the band-stack select on the rig and watch the band display. "
+        "Did the band change as expected? [y/N] "
+    ),
+}
+
+
 def _utcnow_iso() -> str:
     """Return the current UTC time as an ISO-8601 millisecond ``...Z`` string."""
     return (
@@ -130,6 +152,7 @@ async def execute_hardware_checks(
     allow_writes: bool,
     per_check_timeout: float = DEFAULT_PER_CHECK_TIMEOUT,
     write_only_capabilities: frozenset[str] = frozenset(),
+    prompter: InteractivePrompter | None = None,
 ) -> list[LevelResult]:
     """Run a template's checks against an already-connected ``radio``.
 
@@ -151,6 +174,7 @@ async def execute_hardware_checks(
                 allow_writes=allow_writes,
                 per_check_timeout=per_check_timeout,
                 write_only_capabilities=write_only_capabilities,
+                prompter=prompter,
             )
         except Exception as exc:
             # Backstop (MOR-659): one raising check must never abort the
@@ -226,6 +250,7 @@ async def _run_one_check(
     allow_writes: bool,
     per_check_timeout: float,
     write_only_capabilities: frozenset[str] = frozenset(),
+    prompter: InteractivePrompter | None = None,
 ) -> CheckResult:
     """Execute a single template entry, applying universal pre-gates first."""
     # Pre-gate 1: authorization for TX-adjacent checks.
@@ -239,7 +264,7 @@ async def _run_one_check(
 
     # Pre-gate 2: manual-required (authorized / non-TX-adjacent).
     if entry.declaration == CapabilityDeclaration.MANUAL_REQUIRED:
-        return _manual_required_result(radio, entry)
+        return _manual_required_result(radio, entry, prompter=prompter)
 
     # Pre-gate 3: declared unsupported pending evidence.
     if entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE:
@@ -278,6 +303,7 @@ async def _run_one_check(
                 spec,
                 allow_writes=allow_writes,
                 per_check_timeout=per_check_timeout,
+                prompter=prompter,
             )
         return _base_result(
             entry,
@@ -292,14 +318,46 @@ async def _run_one_check(
     )
 
 
+def _interactive_perception_result(
+    entry: CapabilityDeclarationEntry, prompter: InteractivePrompter, prompt: str
+) -> CheckResult:
+    """Resolve a manual-perception check via an operator yes/no prompt (MOR-667).
+
+    Asks the operator the perception question and records PASS (yes) or FAIL
+    (no) with ``{operator_confirmed: <bool>, prompt: <text>}`` evidence. Performs
+    NO actuation itself — the operator triggers and observes the rig; the harness
+    only collects the verdict.
+    """
+    confirmed = prompter.ask(prompt)
+    return _base_result(
+        entry,
+        CheckStatus.PASS if confirmed else CheckStatus.FAIL,
+        failure_domain=None if confirmed else FailureDomain.COMMAND_EXECUTION,
+        evidence={"operator_confirmed": confirmed, "prompt": prompt.strip()},
+    )
+
+
 def _manual_required_result(
-    radio: Radio, entry: CapabilityDeclarationEntry
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    prompter: InteractivePrompter | None = None,
 ) -> CheckResult:
     """Build a MANUAL_REQUIRED result with read-only evidence enrichment.
 
     Performs NO actuation: never keys TX, never triggers a tune cycle, never
-    starts a stream.
+    starts a stream. When a *prompter* is supplied and this check has a
+    perception prompt (``audio.rx``/``scope.capture``/``bsr.select``), resolve it
+    to PASS/FAIL from the operator's answer instead of MANUAL_REQUIRED (MOR-667).
     """
+    # MOR-667: operator-confirmed perception checks. TX-adjacent checks
+    # (``tx.ptt``/``tuner.tune``) deliberately have NO perception prompt, so they
+    # never become an auto-yes target and fall through to MANUAL_REQUIRED below.
+    if prompter is not None:
+        prompt = _PERCEPTION_PROMPTS.get(entry.check_id)
+        if prompt is not None:
+            return _interactive_perception_result(entry, prompter, prompt)
+
     if entry.check_id == "audio.rx":
         present = (
             isinstance(radio, AudioCapable | UsbAudioCapable)
@@ -1348,6 +1406,7 @@ async def _check_from_spec(
     *,
     allow_writes: bool,
     per_check_timeout: float,
+    prompter: InteractivePrompter | None = None,
 ) -> CheckResult:
     """Execute a check using a registry CheckSpec when no named handler exists."""
     if spec.kind is CheckKind.READ_ONLY:
@@ -1435,7 +1494,7 @@ async def _check_from_spec(
         )
 
     if spec.kind is CheckKind.MANUAL:
-        return _manual_required_result(radio, entry)
+        return _manual_required_result(radio, entry, prompter=prompter)
 
     if spec.kind is CheckKind.AUDIO_PROBE:
         # Automated audio probes run in CI against FakeAudioBackend via

--- a/src/rigplane/validation/interactive.py
+++ b/src/rigplane/validation/interactive.py
@@ -1,0 +1,107 @@
+"""Interactive operator prompting for the ``rigplane validate`` harness.
+
+The validation harness has a class of *manual-perception* checks — ``audio.rx``,
+``scope.capture``, ``bsr.select`` — that no software readback can confirm: only
+a human watching the rig can say whether RX audio is audible, the scope is
+sweeping, or the band display changed. Without an operator these resolve to
+``MANUAL_REQUIRED`` (an honest "not verified") and never PASS/FAIL.
+
+:class:`InteractivePrompter` turns those into a real PASS/FAIL by asking the
+operator a yes/no question on the terminal and recording the answer. It is a
+thin, dependency-free wrapper around an injectable ``input`` callable so tests
+can feed canned answers without touching real stdin.
+
+Two methods, deliberately:
+
+* :meth:`InteractivePrompter.ask` — the general perception prompt. It honours
+  ``assume_yes`` (auto-answer YES for unattended perception runs).
+* :meth:`InteractivePrompter.confirm` — a stricter yes/no *gate* primitive that
+  ALWAYS reads a real answer and IGNORES ``assume_yes``. MOR-666 reuses this for
+  the pre-TX "type YES to transmit" gate, where an unattended auto-yes must
+  never be able to key the transmitter. Keeping ``confirm`` immune to
+  ``assume_yes`` is the safety boundary between perception checks and actuation.
+
+This module imports only the standard library — it lives in the ``validation``
+leaf layer and must not reach into the CLI, backends, or runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+__all__ = ["InteractivePrompter", "is_affirmative"]
+
+# Inputs that count as an explicit "yes". Everything else (including an empty
+# line) is "no": the prompts are phrased ``[y/N]`` so the safe default is no.
+_AFFIRMATIVE = frozenset({"y", "yes"})
+
+
+def is_affirmative(answer: str) -> bool:
+    """Return ``True`` only for an explicit yes (``y``/``yes``, any case).
+
+    Empty input, ``n``/``no``, or anything else is ``False`` — the perception
+    prompts default to "no" so an ambiguous or blank answer never falsely PASSes
+    a check or (via :meth:`InteractivePrompter.confirm`) authorizes an action.
+    """
+    return answer.strip().lower() in _AFFIRMATIVE
+
+
+class InteractivePrompter:
+    """Ask the operator yes/no questions on the terminal.
+
+    Parameters
+    ----------
+    input_fn:
+        The line-reader used to collect an answer. Defaults to the builtin
+        :func:`input`; tests inject a callable returning canned strings so no
+        real stdin is consumed.
+    output_fn:
+        Where the prompt text is written. Defaults to :func:`print`.
+    assume_yes:
+        When ``True``, :meth:`ask` returns ``True`` WITHOUT reading input —
+        for unattended perception runs (``--assume-yes``). :meth:`confirm`
+        ignores this flag and always reads a real answer, so it can never
+        auto-authorize a TX/actuation gate.
+    """
+
+    def __init__(
+        self,
+        *,
+        input_fn: Callable[[str], str] = input,
+        output_fn: Callable[[str], None] = print,
+        assume_yes: bool = False,
+    ) -> None:
+        self._input = input_fn
+        self._output = output_fn
+        self.assume_yes = assume_yes
+
+    def ask(self, prompt: str) -> bool:
+        """Print *prompt*, read one line, return ``True`` on an affirmative.
+
+        With ``assume_yes`` set, returns ``True`` immediately without reading
+        input (the prompt is still echoed so the run log shows what was
+        auto-confirmed). Use this for perception checks only.
+        """
+        if self.assume_yes:
+            self._output(prompt + " [auto-yes]")
+            return True
+        return is_affirmative(self._read(prompt))
+
+    def confirm(self, prompt: str) -> bool:
+        """Yes/no gate that ALWAYS reads a real answer (ignores ``assume_yes``).
+
+        This is the reusable primitive for explicit-affirmative gates such as
+        the MOR-666 pre-TX "type YES to transmit" confirmation: it returns
+        ``True`` only when the operator types an affirmative, and ``--assume-yes``
+        can never satisfy it.
+        """
+        return is_affirmative(self._read(prompt))
+
+    def _read(self, prompt: str) -> str:
+        """Echo *prompt* then read a line via the injected input function."""
+        try:
+            return self._input(prompt)
+        except EOFError:
+            # No more input (e.g. closed pipe): treat as a declined answer
+            # rather than letting EOFError abort the whole validation run.
+            return ""

--- a/tests/test_validation_gating.py
+++ b/tests/test_validation_gating.py
@@ -405,3 +405,42 @@ def test_cli_gate_against_committed_golden_exits_zero(capsys: Any) -> None:
     )
     assert rc == 0
     assert "PASS" in err
+
+
+# ---------------------------------------------------------------------------
+# MOR-667: --interactive prompter construction (TTY gate, no-hang)
+# ---------------------------------------------------------------------------
+
+
+def test_build_prompter_none_without_interactive_flag() -> None:
+    args = _parse(["--model", MODEL, "validate", "--hardware"])
+    assert _validate._build_prompter(args) is None
+
+
+def test_build_prompter_none_when_stdin_not_a_tty(
+    monkeypatch: Any, capsys: Any
+) -> None:
+    """--interactive without a TTY must NOT build a prompter (no stdin hang)."""
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    args = _parse(["--model", MODEL, "validate", "--hardware", "--interactive"])
+    assert _validate._build_prompter(args) is None
+    err = capsys.readouterr().err
+    assert "not a TTY" in err
+
+
+def test_build_prompter_built_when_interactive_and_tty(monkeypatch: Any) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    args = _parse(["--model", MODEL, "validate", "--hardware", "--interactive"])
+    prompter = _validate._build_prompter(args)
+    assert prompter is not None
+    assert prompter.assume_yes is False
+
+
+def test_build_prompter_assume_yes_propagates(monkeypatch: Any) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    args = _parse(
+        ["--model", MODEL, "validate", "--hardware", "--interactive", "--assume-yes"]
+    )
+    prompter = _validate._build_prompter(args)
+    assert prompter is not None
+    assert prompter.assume_yes is True

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -761,6 +761,155 @@ async def test_artifact_round_trips():
 
 
 # ---------------------------------------------------------------------------
+# MOR-667: interactive operator-confirmed manual-perception checks
+# ---------------------------------------------------------------------------
+
+
+def _perception_template(check_id: str, capability: str) -> MatrixTemplate:
+    return _single_entry_template(
+        check_id=check_id,
+        capability=capability,
+        declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+        summary="perception",
+    )
+
+
+def _canned_prompter(answer: bool):
+    """Build an InteractivePrompter returning *answer*, recording prompts seen."""
+    from rigplane.validation.interactive import InteractivePrompter
+
+    seen: list[str] = []
+
+    def _input(prompt: str) -> str:
+        seen.append(prompt)
+        return "y" if answer else "n"
+
+    return (
+        InteractivePrompter(input_fn=_input, output_fn=lambda _msg: None),
+        seen,
+    )
+
+
+async def test_interactive_audio_rx_yes_passes():
+    radio = _make_mock_radio()
+    prompter, seen = _canned_prompter(True)
+    levels = await execute_hardware_checks(
+        radio,
+        _perception_template("audio.rx", "audio"),
+        OperatorSafetyBlock(),
+        allow_writes=False,
+        prompter=prompter,
+    )
+    check = _flatten(levels)["audio.rx"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["operator_confirmed"] is True
+    assert "RX audio" in check.evidence["prompt"]
+    assert len(seen) == 1  # exactly one prompt read
+
+
+async def test_interactive_scope_capture_no_fails():
+    radio = _make_mock_radio()
+    prompter, _ = _canned_prompter(False)
+    levels = await execute_hardware_checks(
+        radio,
+        _perception_template("scope.capture", "scope"),
+        OperatorSafetyBlock(),
+        allow_writes=False,
+        prompter=prompter,
+    )
+    check = _flatten(levels)["scope.capture"]
+    assert check.status is CheckStatus.FAIL
+    assert check.evidence["operator_confirmed"] is False
+    assert check.failure_domain is FailureDomain.COMMAND_EXECUTION
+
+
+async def test_interactive_bsr_select_yes_passes():
+    radio = _make_mock_radio()
+    prompter, _ = _canned_prompter(True)
+    levels = await execute_hardware_checks(
+        radio,
+        _perception_template("bsr.select", "bsr"),
+        OperatorSafetyBlock(),
+        allow_writes=False,
+        prompter=prompter,
+    )
+    check = _flatten(levels)["bsr.select"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["operator_confirmed"] is True
+
+
+async def test_no_prompter_keeps_manual_required_and_reads_no_stdin():
+    """Regression guard: without a prompter, perception checks stay
+    MANUAL_REQUIRED and nothing ever reads stdin (no hang)."""
+    radio = _make_mock_radio()
+    levels = await execute_hardware_checks(
+        radio,
+        _perception_template("audio.rx", "audio"),
+        OperatorSafetyBlock(),
+        allow_writes=False,
+    )
+    check = _flatten(levels)["audio.rx"]
+    assert check.status is CheckStatus.MANUAL_REQUIRED
+    assert "operator_confirmed" not in check.evidence
+
+
+async def test_assume_yes_auto_passes_without_reading_stdin():
+    """``--assume-yes`` (assume_yes prompter) PASSes a perception check without
+    ever calling input — proves an unattended run never blocks on stdin."""
+    from rigplane.validation.interactive import InteractivePrompter
+
+    def _input(_prompt: str) -> str:  # pragma: no cover - must never run
+        raise AssertionError("stdin must not be read under assume_yes")
+
+    prompter = InteractivePrompter(
+        input_fn=_input, output_fn=lambda _msg: None, assume_yes=True
+    )
+    radio = _make_mock_radio()
+    levels = await execute_hardware_checks(
+        radio,
+        _perception_template("audio.rx", "audio"),
+        OperatorSafetyBlock(),
+        allow_writes=False,
+        prompter=prompter,
+    )
+    check = _flatten(levels)["audio.rx"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["operator_confirmed"] is True
+
+
+async def test_interactive_does_not_actuate_tx_or_tuner():
+    """Perception interactivity must not turn TX/tuner manual checks into a
+    prompt — they have no perception entry and stay MANUAL_REQUIRED (authorized)
+    or BLOCKED, never auto-yes-able and never actuated."""
+    radio = _make_mock_radio()
+    prompter, seen = _canned_prompter(True)
+    template = MatrixTemplate(
+        radio=RadioTarget(model="X6200", profile_id="x6200"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id="tx.ptt",
+                capability="tx",
+                level=ValidationLevel.STRESS_RECOVERY,
+                declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+                summary="ptt",
+                tx_adjacent=True,
+            ),
+        ],
+    )
+    levels = await execute_hardware_checks(
+        radio,
+        template,
+        OperatorSafetyBlock(tx_allowed=True),
+        allow_writes=False,
+        prompter=prompter,
+    )
+    check = _flatten(levels)["tx.ptt"]
+    assert check.status is CheckStatus.MANUAL_REQUIRED
+    assert seen == []  # no perception prompt for tx.ptt
+    radio.set_ptt.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # MOR-199: generic _check_from_spec dispatch tests
 # ---------------------------------------------------------------------------
 

--- a/tests/validation/test_interactive.py
+++ b/tests/validation/test_interactive.py
@@ -1,0 +1,84 @@
+"""Tests for the interactive operator-prompt primitive (MOR-667).
+
+``InteractivePrompter`` wraps an injectable ``input`` callable so these tests
+feed canned answers — no real stdin is ever consumed.
+"""
+
+from __future__ import annotations
+
+from rigplane.validation.interactive import InteractivePrompter, is_affirmative
+
+
+def _prompter(answers: list[str], *, assume_yes: bool = False):
+    """Build a prompter that returns *answers* in order and records prompts."""
+    seen: list[str] = []
+
+    def _input(prompt: str) -> str:
+        seen.append(prompt)
+        return answers.pop(0)
+
+    return (
+        InteractivePrompter(
+            input_fn=_input, output_fn=lambda _msg: None, assume_yes=assume_yes
+        ),
+        seen,
+    )
+
+
+def test_is_affirmative_only_on_yes() -> None:
+    for yes in ("y", "Y", "yes", "YES", " Yes ", "yEs"):
+        assert is_affirmative(yes) is True
+    for no in ("", " ", "n", "no", "NO", "nope", "maybe", "1", "0"):
+        assert is_affirmative(no) is False
+
+
+def test_ask_true_on_yes() -> None:
+    prompter, seen = _prompter(["y"])
+    assert prompter.ask("hear audio? [y/N] ") is True
+    assert seen == ["hear audio? [y/N] "]
+
+
+def test_ask_false_on_no_and_empty() -> None:
+    prompter, _ = _prompter(["n"])
+    assert prompter.ask("hear audio? [y/N] ") is False
+    prompter, _ = _prompter([""])
+    assert prompter.ask("hear audio? [y/N] ") is False
+
+
+def test_assume_yes_auto_answers_ask_without_reading_input() -> None:
+    answers: list[str] = []  # popping would IndexError if input were read
+
+    def _input(_prompt: str) -> str:  # pragma: no cover - must never run
+        raise AssertionError("input must not be read under assume_yes")
+
+    prompter = InteractivePrompter(
+        input_fn=_input, output_fn=lambda _msg: None, assume_yes=True
+    )
+    assert prompter.ask("hear audio? [y/N] ") is True
+    assert answers == []
+
+
+def test_confirm_true_only_on_affirmative() -> None:
+    prompter, _ = _prompter(["yes"])
+    assert prompter.confirm("type yes to transmit: ") is True
+    prompter, _ = _prompter(["n"])
+    assert prompter.confirm("type yes to transmit: ") is False
+    prompter, _ = _prompter([""])
+    assert prompter.confirm("type yes to transmit: ") is False
+
+
+def test_confirm_ignores_assume_yes_and_reads_real_answer() -> None:
+    """The TX gate primitive (MOR-666) must never be satisfied by --assume-yes."""
+    prompter, _ = _prompter(["n"], assume_yes=True)
+    # assume_yes is set, but confirm still reads the canned "n" → False.
+    assert prompter.confirm("type yes to transmit: ") is False
+    prompter, _ = _prompter(["yes"], assume_yes=True)
+    assert prompter.confirm("type yes to transmit: ") is True
+
+
+def test_read_returns_no_on_eof() -> None:
+    def _input(_prompt: str) -> str:
+        raise EOFError
+
+    prompter = InteractivePrompter(input_fn=_input, output_fn=lambda _msg: None)
+    assert prompter.ask("hear audio? [y/N] ") is False


### PR DESCRIPTION
## What

Adds an **interactive mode** to `rigplane validate` so the manual-perception checks — `audio.rx`, `scope.capture`, `bsr.select` — prompt the operator and record their y/n answer as the check result (PASS/FAIL) instead of always `MANUAL_REQUIRED`. Linear: **MOR-667** (epic MOR-634).

## The flag

- `--interactive` — enables operator prompting. Builds a prompter **only when `sys.stdin.isatty()`**. With no TTY (CI/piped) it prints a warning and falls back to `MANUAL_REQUIRED` — it NEVER reads stdin and never hangs.
- `--assume-yes` — auto-answers YES to non-TX **perception** prompts for unattended runs. It is scoped to `ask()` only; it can never satisfy the TX gate (see below).

## Prompter / `confirm` primitive

New `rigplane.validation.interactive.InteractivePrompter` (validation leaf layer, stdlib-only, injectable `input_fn` so tests feed canned answers):

- `ask(prompt) -> bool` — perception prompt; honours `assume_yes`.
- `confirm(prompt) -> bool` — a stricter yes/no **gate** that ALWAYS reads a real answer and **ignores `assume_yes`**. This is the reusable primitive **MOR-666** will use for the pre-TX "type YES to transmit" gate: keeping `confirm` immune to `--assume-yes` is the safety boundary so an unattended auto-yes can never key the transmitter.

## Per-check prompts

A small `_PERCEPTION_PROMPTS` map in `hardware.py`:

- `audio.rx` → "Listen to the radio's RX audio … Do you hear receive audio? [y/N]"
- `scope.capture` → "Look at the radio's panadapter/spectrum scope … Do you see the spectrum sweeping? [y/N]"
- `bsr.select` → "Trigger the band-stack select on the rig and watch the band display. Did the band change as expected? [y/N]"

Answer → `PASS` (yes) / `FAIL` (no) with evidence `{operator_confirmed: <bool>, prompt: "<text>"}`. Checks without a prompt entry keep `MANUAL_REQUIRED`. `bsr.select` does **not** auto-actuate (no safe zero-arg selector exists; `set_bsr` needs a constructed `BandStackRegister`), so the operator triggers it and the harness only records the verdict.

## Safety / no-hang

- Without `--interactive` (no prompter): behaviour **unchanged** — `MANUAL_REQUIRED`, no stdin read.
- `--interactive` + non-TTY: `MANUAL_REQUIRED`, no `input()` call, no block.
- TX-adjacent checks (`tx.ptt`, `tuner.tune`) have **no** perception prompt → never auto-yes-able, never actuated.

## Tests

- `tests/validation/test_interactive.py` — `is_affirmative`, `ask` yes/no/empty, `assume_yes` auto-answers without reading stdin, `confirm` true only on affirmative and ignores `assume_yes`, EOF → no.
- `tests/validation/test_hardware.py` — yes→PASS / no→FAIL for audio.rx, scope.capture, bsr.select; no-prompter regression guard (MANUAL_REQUIRED, no stdin); assume_yes auto-pass without reading stdin; tx.ptt not prompted/actuated under a prompter.
- `tests/test_validation_gating.py` — `_build_prompter` TTY gate: None without flag, None on non-TTY (warning), built on TTY, `assume_yes` propagates.

## No golden change

Dry-run/CI is non-interactive, so `--interactive` only affects the live manual checks. `git diff tests/golden/` is empty and the IC-7610 / X6200 / FTX-1 dry-run gates exit 0 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)