### PR TITLE
feat(validation): --tx-actuate keys PTT + tuner tune-cycle behind full gate + confirm (MOR-666)

### DIFF
--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -193,6 +193,27 @@ def _build_prompter(args: argparse.Namespace) -> InteractivePrompter | None:
     return InteractivePrompter(assume_yes=bool(getattr(args, "assume_yes", False)))
 
 
+def _tx_actuate_enabled(args: argparse.Namespace) -> bool:
+    """Whether the TX checks may ACTUALLY transmit (MOR-666).
+
+    Returns ``True`` only when EVERY gate in the opt-in stack is open:
+    ``--tx-actuate`` AND ``--tx-allowed`` AND ``--allow-hardware`` AND
+    ``RIGPLANE_VALIDATION_ALLOW_HARDWARE=1`` AND ``--hardware`` (running on real
+    hardware). Missing ANY gate → ``False`` → today's behaviour (the TX checks
+    stay MANUAL_REQUIRED/BLOCKED and never key the transmitter). This is only the
+    *static* gate stack; the actuating handlers additionally require an explicit
+    interactive ``confirm()`` YES at runtime before any transmission, so even an
+    all-gates-open unattended run cannot transmit.
+    """
+    return (
+        bool(getattr(args, "tx_actuate", False))
+        and bool(getattr(args, "tx_allowed", False))
+        and bool(getattr(args, "allow_hardware", False))
+        and bool(getattr(args, "hardware", False))
+        and os.environ.get(HARDWARE_OPT_IN_ENV) == "1"
+    )
+
+
 def add_subparser(sub: Any) -> argparse.ArgumentParser:
     """Register the ``validate`` subparser on ``sub`` (an ``_SubParsersAction``).
 
@@ -239,6 +260,19 @@ def add_subparser(sub: Any) -> argparse.ArgumentParser:
         dest="tuner_allowed",
         action="store_true",
         help="Authorize tuner tune-cycle checks.",
+    )
+    p.add_argument(
+        "--tx-actuate",
+        dest="tx_actuate",
+        action="store_true",
+        help=(
+            "ACTUALLY exercise the TX checks (tx.ptt keys PTT at MINIMUM power "
+            "for ~1s then unkeys/restores; tuner.tune runs a tune-cycle). "
+            "Quadruple-gated: also requires --tx-allowed, --allow-hardware, "
+            f"{HARDWARE_OPT_IN_ENV}=1, and --hardware, PLUS an explicit "
+            "interactive confirm YES at runtime. Missing any → MANUAL_REQUIRED "
+            "(no transmission). VOX stays manual."
+        ),
     )
     p.add_argument(
         "--read-only",
@@ -766,6 +800,7 @@ async def _run_hardware(
                 per_check_timeout=getattr(args, "timeout", 5.0) or 5.0,
                 write_only_capabilities=write_only_capabilities,
                 prompter=_build_prompter(args),
+                tx_actuate=_tx_actuate_enabled(args),
             )
     except (RigConnectionError, AuthenticationError, OSError, RigplaneError) as exc:
         levels = _transport_failure_levels(template, exc)
@@ -956,6 +991,7 @@ async def _run_hardware_hamlib(
                             profile.write_only_controls if profile else frozenset()
                         ),
                         prompter=_build_prompter(args),
+                        tx_actuate=_tx_actuate_enabled(args),
                     )
             finally:
                 await bridge.stop()
@@ -1070,6 +1106,7 @@ async def _run_hardware_hamlib_external(
                 allow_writes=not bool(getattr(args, "read_only", False)),
                 per_check_timeout=timeout,
                 prompter=_build_prompter(args),
+                tx_actuate=_tx_actuate_enabled(args),
             )
     except (RigConnectionError, AuthenticationError, OSError, RigplaneError) as exc:
         template = build_template_from_capabilities(

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -521,6 +521,20 @@ async def _actuate_tx_ptt(
             if fail is not None:
                 evidence["power_read_error"] = fail.error
 
+    # Harm reduction: if the radio HAS power control but we could not confirm
+    # it is at minimum (read or set failed), refuse to transmit at an unknown
+    # (possibly full) power. Minimum-power-first is part of the TX-actuate
+    # safety contract, not just best-effort. (A radio with no power API at all
+    # still actuates — power can't be controlled there; the operator opted in.)
+    if has_power and not power_set_to_min:
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.COMMAND_EXECUTION,
+            evidence=evidence,
+            error="refusing to transmit: could not set TX power to minimum",
+        )
+
     try:
         # Key the transmitter.
         await asyncio.wait_for(set_ptt(True), timeout=per_check_timeout)

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -135,6 +135,36 @@ _PERCEPTION_PROMPTS: dict[str, str] = {
 }
 
 
+# MOR-666 — TX actuation. The pre-TX gate prompt is asked ONCE per run via the
+# MOR-667 ``confirm()`` primitive, which ALWAYS reads a real answer and IGNORES
+# ``--assume-yes`` — an unattended run can therefore never key the transmitter.
+_TX_ACTUATE_CONFIRM_PROMPT = (
+    "About to TRANSMIT on the connected antenna/dummy load at MINIMUM power "
+    "for ~1-2s (PTT key + tuner tune-cycle). Type YES to proceed: "
+)
+# Minimum TX power on the normalised 0-255 scale (lowest practical key).
+_TX_MIN_POWER = 0
+# Brief PTT key duration (seconds) — shortest practical key for a valid check.
+_TX_PTT_KEY_SECONDS = 1.0
+# Tuner status codes (mirror ``commands/system.py``): 0=off, 1=on, 2=tune.
+_TUNER_STATUS_TUNE = 2
+# Bounded wait for the tune-cycle to settle before reading status back.
+_TUNER_SETTLE_SECONDS = 1.0
+
+# The check_ids whose actuation transmits; gated by ``--tx-actuate`` + confirm.
+# VOX is deliberately excluded (stays MANUAL — out of MOR-666 scope).
+_TX_ACTUATE_CHECK_IDS = frozenset({"tx.ptt", "tuner.tune"})
+
+
+def _template_has_tx_check(template: MatrixTemplate) -> bool:
+    """True if the template contains a TX-actuatable check (tx.ptt/tuner.tune).
+
+    Used to decide whether to ask the single pre-TX confirm at all — a run with
+    no TX check never prompts the operator.
+    """
+    return any(entry.check_id in _TX_ACTUATE_CHECK_IDS for entry in template.entries)
+
+
 def _utcnow_iso() -> str:
     """Return the current UTC time as an ISO-8601 millisecond ``...Z`` string."""
     return (
@@ -153,6 +183,7 @@ async def execute_hardware_checks(
     per_check_timeout: float = DEFAULT_PER_CHECK_TIMEOUT,
     write_only_capabilities: frozenset[str] = frozenset(),
     prompter: InteractivePrompter | None = None,
+    tx_actuate: bool = False,
 ) -> list[LevelResult]:
     """Run a template's checks against an already-connected ``radio``.
 
@@ -162,7 +193,22 @@ async def execute_hardware_checks(
     stamped with ISO-8601 ``started_at``/``finished_at`` timestamps and a single
     INFO log line is emitted per check. The radio is assumed connected; this
     function neither connects nor disconnects.
+
+    When *tx_actuate* is ``True`` (the caller has already verified the full
+    opt-in gate stack, MOR-666) AND a *prompter* is supplied, the TX checks
+    (``tx.ptt``/``tuner.tune``) may ACTUALLY transmit — but only after the
+    operator types YES to a single pre-TX ``confirm()`` gate asked ONCE here,
+    before any check runs. Without ``tx_actuate``, without a prompter, or on a
+    declined confirm, the TX checks keep their MANUAL_REQUIRED behaviour and
+    NEVER key the transmitter.
     """
+    # MOR-666: resolve the single pre-TX confirmation up front so it is asked at
+    # most once per run (not per check). ``confirm()`` ignores ``--assume-yes``,
+    # so an unattended run can never authorise transmission.
+    tx_actuate_confirmed = False
+    if tx_actuate and prompter is not None and _template_has_tx_check(template):
+        tx_actuate_confirmed = prompter.confirm(_TX_ACTUATE_CONFIRM_PROMPT)
+
     by_level: dict[ValidationLevel, list[CheckResult]] = {}
     for entry in template.entries:
         started = _utcnow_iso()
@@ -175,6 +221,7 @@ async def execute_hardware_checks(
                 per_check_timeout=per_check_timeout,
                 write_only_capabilities=write_only_capabilities,
                 prompter=prompter,
+                tx_actuate_confirmed=tx_actuate_confirmed,
             )
         except Exception as exc:
             # Backstop (MOR-659): one raising check must never abort the
@@ -251,6 +298,7 @@ async def _run_one_check(
     per_check_timeout: float,
     write_only_capabilities: frozenset[str] = frozenset(),
     prompter: InteractivePrompter | None = None,
+    tx_actuate_confirmed: bool = False,
 ) -> CheckResult:
     """Execute a single template entry, applying universal pre-gates first."""
     # Pre-gate 1: authorization for TX-adjacent checks.
@@ -261,6 +309,22 @@ async def _run_one_check(
             failure_domain=FailureDomain.COMMAND_EXECUTION,
             evidence={"reason": "operator authorization required"},
         )
+
+    # MOR-666: TX actuation. ONLY when the operator affirmatively confirmed the
+    # pre-TX gate AND this is a TX-actuatable check, ACTUALLY transmit (key PTT
+    # at minimum power / run a tune-cycle). This runs AFTER pre-gate 1, so the
+    # operator must STILL be authorized (tx_allowed/tuner_allowed). Without an
+    # affirmative confirm this branch is skipped and the check falls through to
+    # MANUAL_REQUIRED below — the transmitter is never keyed.
+    if tx_actuate_confirmed and entry.check_id in _TX_ACTUATE_CHECK_IDS:
+        if entry.check_id == "tx.ptt":
+            return await _actuate_tx_ptt(
+                radio, entry, per_check_timeout=per_check_timeout
+            )
+        if entry.check_id == "tuner.tune":
+            return await _actuate_tuner_tune(
+                radio, entry, per_check_timeout=per_check_timeout
+            )
 
     # Pre-gate 2: manual-required (authorized / non-TX-adjacent).
     if entry.declaration == CapabilityDeclaration.MANUAL_REQUIRED:
@@ -393,6 +457,182 @@ def _manual_required_result(
             evidence["scope_capability_present"] = scope_present
         return _base_result(entry, CheckStatus.MANUAL_REQUIRED, evidence=evidence)
     return _base_result(entry, CheckStatus.MANUAL_REQUIRED)
+
+
+# ---------------------------------------------------------------------------
+# TX actuation handlers (MOR-666) — reached ONLY after the full gate stack and
+# an explicit interactive confirm() YES. Each guarantees the radio is left in a
+# safe (un-keyed, power-restored) state via a finally that never raises.
+# ---------------------------------------------------------------------------
+
+
+async def _actuate_tx_ptt(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    per_check_timeout: float,
+) -> CheckResult:
+    """ACTUALLY key PTT briefly at minimum power, verify, then always unkey.
+
+    Sequence: read original TX power → set power to MINIMUM → key PTT → brief
+    wait → read ``radio_state.ptt`` to verify it keyed → unkey → restore power.
+    The unkey AND power-restore run in a ``finally`` that ALWAYS executes and
+    never raises (contained by ``_RESTORE_ERRORS``, which includes ``OSError``),
+    so a mid-check exception/timeout/LAN drop can never leave the radio keyed or
+    at the wrong power.
+    """
+    _set_ptt_attr = getattr(radio, "set_ptt", None)
+    if not callable(_set_ptt_attr):
+        return _base_result(
+            entry,
+            CheckStatus.UNSUPPORTED,
+            evidence={"reason": "radio has no set_ptt op"},
+        )
+    set_ptt = cast(Callable[[bool], Awaitable[None]], _set_ptt_attr)
+
+    _get_power_attr = getattr(radio, "get_rf_power", None)
+    _set_power_attr = getattr(radio, "set_rf_power", None)
+    has_power = callable(_get_power_attr) and callable(_set_power_attr)
+    get_power = cast(Callable[[], Awaitable[int]], _get_power_attr)
+    set_power = cast(Callable[[int], Awaitable[None]], _set_power_attr)
+
+    evidence: dict[str, object] = {"tx_actuated": True, "keyed": False}
+    original_power: int | None = None
+    power_set_to_min = False
+    keyed = False
+    verify_error: str | None = None
+
+    if has_power:
+        original_power, fail = await _guard(
+            get_power(), entry, per_check_timeout=per_check_timeout
+        )
+        if fail is None and original_power is not None:
+            evidence["original_power"] = original_power
+            _, pf = await _guard(
+                set_power(_TX_MIN_POWER),
+                entry,
+                per_check_timeout=per_check_timeout,
+            )
+            power_set_to_min = pf is None
+            evidence["power_set_to_min"] = power_set_to_min
+            if pf is not None:
+                evidence["power_set_error"] = pf.error
+        else:
+            if fail is not None:
+                evidence["power_read_error"] = fail.error
+
+    try:
+        # Key the transmitter.
+        await asyncio.wait_for(set_ptt(True), timeout=per_check_timeout)
+        keyed = True
+        # Brief, bounded key window.
+        await asyncio.sleep(_TX_PTT_KEY_SECONDS)
+        # Verify the keyed state from published radio state (best-effort).
+        evidence["ptt_state"] = bool(radio.radio_state.ptt)
+        keyed = bool(radio.radio_state.ptt)
+        evidence["keyed"] = keyed
+    except _RESTORE_ERRORS as exc:
+        verify_error = str(exc)
+        evidence["actuate_error"] = verify_error
+    finally:
+        # ALWAYS unkey, no matter what — the radio must never be left keyed.
+        unkeyed = False
+        try:
+            await asyncio.wait_for(set_ptt(False), timeout=per_check_timeout)
+            unkeyed = True
+        except _RESTORE_ERRORS as exc:
+            evidence["unkey_error"] = str(exc)
+        evidence["unkeyed"] = unkeyed
+        # ALWAYS restore the original power if we lowered it.
+        power_restored = not power_set_to_min
+        if has_power and power_set_to_min and original_power is not None:
+            try:
+                _, rf = await _guard(
+                    set_power(original_power),
+                    entry,
+                    per_check_timeout=per_check_timeout,
+                )
+                power_restored = rf is None
+                if rf is not None:
+                    evidence["power_restore_error"] = rf.error
+            except _RESTORE_ERRORS as exc:
+                evidence["power_restore_error"] = str(exc)
+        evidence["power_restored"] = power_restored
+
+    if verify_error is not None:
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.COMMAND_EXECUTION,
+            evidence=evidence,
+            error=f"tx actuation failed: {verify_error}",
+        )
+    if keyed and bool(evidence.get("unkeyed")):
+        return _base_result(entry, CheckStatus.PASS, evidence=evidence)
+    return _base_result(
+        entry,
+        CheckStatus.FAIL,
+        failure_domain=FailureDomain.COMMAND_EXECUTION,
+        evidence=evidence,
+        error="PTT did not key/unkey cleanly",
+    )
+
+
+async def _actuate_tuner_tune(
+    radio: Radio,
+    entry: CapabilityDeclarationEntry,
+    *,
+    per_check_timeout: float,
+) -> CheckResult:
+    """ACTUALLY run a tuner tune-cycle (``set_tuner_status(2)``) and verify.
+
+    The tuner keys TX into the connected load; this is gated behind the same
+    pre-TX confirm as ``tx.ptt``. After triggering the cycle we wait a bounded
+    settle window, read the tuner status back (best-effort), and record it. A
+    NAK/timeout-free trigger is the PASS signal — the radio's own readback can
+    report transient/idle states once the cycle completes.
+    """
+    _set_tuner_attr = getattr(radio, "set_tuner_status", None)
+    if not callable(_set_tuner_attr):
+        return _base_result(
+            entry,
+            CheckStatus.UNSUPPORTED,
+            evidence={"reason": "radio has no set_tuner_status op"},
+        )
+    set_tuner = cast(Callable[[int], Awaitable[None]], _set_tuner_attr)
+
+    evidence: dict[str, object] = {"tx_actuated": True}
+    _, fail = await _guard(
+        set_tuner(_TUNER_STATUS_TUNE),
+        entry,
+        per_check_timeout=per_check_timeout,
+    )
+    if fail is not None:
+        evidence["tune_error"] = fail.error
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=fail.failure_domain,
+            evidence=evidence,
+            error=fail.error,
+        )
+    evidence["tune_triggered"] = True
+
+    # Bounded settle, then best-effort readback (never the pass/fail driver).
+    await asyncio.sleep(_TUNER_SETTLE_SECONDS)
+    _get_tuner_attr = getattr(radio, "get_tuner_status", None)
+    if callable(_get_tuner_attr):
+        get_tuner = cast(Callable[[], Awaitable[int]], _get_tuner_attr)
+        status, sf = await _guard(
+            get_tuner(),
+            entry,
+            per_check_timeout=per_check_timeout,
+        )
+        if sf is None:
+            evidence["tuner_status_readback"] = status
+        else:
+            evidence["tuner_status_read_error"] = sf.error
+    return _base_result(entry, CheckStatus.PASS, evidence=evidence)
 
 
 async def _guard(

--- a/tests/test_validation_gating.py
+++ b/tests/test_validation_gating.py
@@ -444,3 +444,60 @@ def test_build_prompter_assume_yes_propagates(monkeypatch: Any) -> None:
     prompter = _validate._build_prompter(args)
     assert prompter is not None
     assert prompter.assume_yes is True
+
+
+# ---------------------------------------------------------------------------
+# MOR-666: --tx-actuate gate stack (no hardware; pure flag/env logic)
+# ---------------------------------------------------------------------------
+
+_OPT_IN_ENV = "RIGPLANE_VALIDATION_ALLOW_HARDWARE"
+
+
+def _actuate_args(*flags: str) -> Any:
+    return _parse(["--model", MODEL, "validate", "--hardware", *flags])
+
+
+def test_tx_actuate_enabled_full_stack(monkeypatch: Any) -> None:
+    monkeypatch.setenv(_OPT_IN_ENV, "1")
+    args = _actuate_args("--allow-hardware", "--tx-allowed", "--tx-actuate")
+    assert _validate._tx_actuate_enabled(args) is True
+
+
+def test_tx_actuate_disabled_without_flag(monkeypatch: Any) -> None:
+    monkeypatch.setenv(_OPT_IN_ENV, "1")
+    args = _actuate_args("--allow-hardware", "--tx-allowed")
+    assert _validate._tx_actuate_enabled(args) is False
+
+
+def test_tx_actuate_disabled_without_tx_allowed(monkeypatch: Any) -> None:
+    monkeypatch.setenv(_OPT_IN_ENV, "1")
+    args = _actuate_args("--allow-hardware", "--tx-actuate")
+    assert _validate._tx_actuate_enabled(args) is False
+
+
+def test_tx_actuate_disabled_without_allow_hardware(monkeypatch: Any) -> None:
+    monkeypatch.setenv(_OPT_IN_ENV, "1")
+    args = _actuate_args("--tx-allowed", "--tx-actuate")
+    assert _validate._tx_actuate_enabled(args) is False
+
+
+def test_tx_actuate_disabled_without_env(monkeypatch: Any) -> None:
+    monkeypatch.delenv(_OPT_IN_ENV, raising=False)
+    args = _actuate_args("--allow-hardware", "--tx-allowed", "--tx-actuate")
+    assert _validate._tx_actuate_enabled(args) is False
+
+
+def test_tx_actuate_disabled_without_hardware(monkeypatch: Any) -> None:
+    monkeypatch.setenv(_OPT_IN_ENV, "1")
+    # No --hardware: not running against real hardware.
+    args = _parse(
+        [
+            "--model",
+            MODEL,
+            "validate",
+            "--allow-hardware",
+            "--tx-allowed",
+            "--tx-actuate",
+        ]
+    )
+    assert _validate._tx_actuate_enabled(args) is False

--- a/tests/validation/test_tx_actuate.py
+++ b/tests/validation/test_tx_actuate.py
@@ -1,0 +1,265 @@
+"""Tests for ``validate --tx-actuate`` (MOR-666).
+
+Under a full opt-in gate stack plus an explicit interactive ``confirm()`` YES,
+the harness ACTUALLY exercises the TX checks: it keys PTT at minimum power for a
+brief moment (then unkeys and restores power) and runs a tuner tune-cycle.
+Missing ANY gate — or a declined/absent confirm — keeps today's behaviour
+(MANUAL_REQUIRED, never actuated). These tests use stateful fake radios; they
+never touch real hardware.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.core.radio_protocol import Radio
+from rigplane.core.radio_state import RadioState
+from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.interactive import InteractivePrompter
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckStatus,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    ValidationLevel,
+)
+
+
+def _flatten(levels):
+    return {check.check_id: check for level in levels for check in level.checks}
+
+
+def _tx_template() -> MatrixTemplate:
+    return MatrixTemplate(
+        radio=RadioTarget(model="X6200", profile_id="x6200"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id="tx.ptt",
+                capability="tx",
+                level=ValidationLevel.STRESS_RECOVERY,
+                declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+                summary="ptt",
+                tx_adjacent=True,
+            ),
+            CapabilityDeclarationEntry(
+                check_id="tuner.tune",
+                capability="tuner",
+                level=ValidationLevel.STRESS_RECOVERY,
+                declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+                summary="tuner tune",
+                tx_adjacent=True,
+            ),
+        ],
+    )
+
+
+def _tx_radio(*, start_power: int = 200):
+    """A MagicMock(spec=Radio) whose PTT/power/tuner round-trip via a closure.
+
+    ``set_ptt(True/False)`` mirrors into ``radio_state.ptt`` so the actuating
+    handler's readback verification observes the keyed state. RF power and the
+    tuner status are likewise stateful.
+    """
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"tx", "tuner"}
+    state = RadioState()
+    radio.radio_state = state
+
+    power = {"value": start_power}
+
+    async def _set_ptt(on: bool) -> None:
+        state.ptt = bool(on)
+
+    async def _get_rf_power() -> int:
+        return power["value"]
+
+    async def _set_rf_power(level: int) -> None:
+        power["value"] = int(level)
+
+    async def _set_tuner_status(value: int) -> None:
+        state.tuner_status = int(value)
+
+    async def _get_tuner_status() -> int:
+        return state.tuner_status
+
+    radio.set_ptt = AsyncMock(side_effect=_set_ptt)
+    radio.get_rf_power = AsyncMock(side_effect=_get_rf_power)
+    radio.set_rf_power = AsyncMock(side_effect=_set_rf_power)
+    radio.set_tuner_status = AsyncMock(side_effect=_set_tuner_status)
+    radio.get_tuner_status = AsyncMock(side_effect=_get_tuner_status)
+    return radio, power
+
+
+def _confirm_prompter(answer: bool):
+    """Prompter whose ``confirm()`` returns *answer*, recording prompts seen."""
+    seen: list[str] = []
+
+    def _input(prompt: str) -> str:
+        seen.append(prompt)
+        return "YES" if answer else "no"
+
+    return InteractivePrompter(input_fn=_input, output_fn=lambda _msg: None), seen
+
+
+async def _run(radio, *, safety, tx_actuate, prompter):
+    return await execute_hardware_checks(
+        radio,
+        _tx_template(),
+        safety,
+        allow_writes=True,
+        tx_actuate=tx_actuate,
+        prompter=prompter,
+    )
+
+
+_FULL_SAFETY = OperatorSafetyBlock(tx_allowed=True, tuner_allowed=True)
+
+
+async def test_full_gate_stack_and_confirm_yes_keys_ptt_and_tunes():
+    radio, power = _tx_radio(start_power=200)
+    prompter, seen = _confirm_prompter(True)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    checks = _flatten(levels)
+
+    # The confirm gate was asked exactly once for the whole TX-actuate session.
+    assert len(seen) == 1
+    assert "YES" in seen[0]
+
+    # tx.ptt actuated: keyed True then False (in order), PASS, evidence recorded.
+    ptt = checks["tx.ptt"]
+    assert ptt.status is CheckStatus.PASS
+    assert ptt.evidence["tx_actuated"] is True
+    assert ptt.evidence["keyed"] is True
+    assert ptt.evidence["power_restored"] is True
+    ptt_calls = [c.args[0] for c in radio.set_ptt.call_args_list]
+    assert ptt_calls == [True, False]
+
+    # Power was set to minimum (0) then restored to the original (200).
+    power_calls = [c.args[0] for c in radio.set_rf_power.call_args_list]
+    assert power_calls[0] == 0
+    assert power_calls[-1] == 200
+    assert power["value"] == 200
+
+    # Radio is NOT left transmitting.
+    assert radio.radio_state.ptt is False
+
+    # tuner.tune actuated: tune-cycle (status 2) triggered, PASS.
+    tune = checks["tuner.tune"]
+    assert tune.status is CheckStatus.PASS
+    assert tune.evidence["tx_actuated"] is True
+    tuner_set_calls = [c.args[0] for c in radio.set_tuner_status.call_args_list]
+    assert 2 in tuner_set_calls
+
+
+async def test_confirm_declined_no_transmission():
+    radio, _ = _tx_radio()
+    prompter, seen = _confirm_prompter(False)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    checks = _flatten(levels)
+
+    assert len(seen) == 1  # confirm asked once
+    assert checks["tx.ptt"].status is CheckStatus.MANUAL_REQUIRED
+    assert checks["tuner.tune"].status is CheckStatus.MANUAL_REQUIRED
+    radio.set_ptt.assert_not_called()
+    radio.set_tuner_status.assert_not_called()
+
+
+async def test_no_tx_actuate_flag_no_transmission():
+    radio, _ = _tx_radio()
+    prompter, _ = _confirm_prompter(True)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=False, prompter=prompter)
+    checks = _flatten(levels)
+
+    assert checks["tx.ptt"].status is CheckStatus.MANUAL_REQUIRED
+    assert checks["tuner.tune"].status is CheckStatus.MANUAL_REQUIRED
+    radio.set_ptt.assert_not_called()
+
+
+async def test_no_prompter_no_transmission():
+    """tx_actuate set but no prompter (non-interactive) → never transmit."""
+    radio, _ = _tx_radio()
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=None)
+    checks = _flatten(levels)
+
+    assert checks["tx.ptt"].status is CheckStatus.MANUAL_REQUIRED
+    assert checks["tuner.tune"].status is CheckStatus.MANUAL_REQUIRED
+    radio.set_ptt.assert_not_called()
+
+
+async def test_assume_yes_alone_does_not_authorize_transmission():
+    """``--assume-yes`` (assume_yes prompter) must NOT satisfy the confirm gate —
+    confirm() always reads a real answer; a 'no' input keeps it MANUAL_REQUIRED."""
+    seen: list[str] = []
+
+    def _input(prompt: str) -> str:
+        seen.append(prompt)
+        return ""  # blank == declined
+
+    prompter = InteractivePrompter(
+        input_fn=_input, output_fn=lambda _msg: None, assume_yes=True
+    )
+    radio, _ = _tx_radio()
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    checks = _flatten(levels)
+
+    # confirm() ignored assume_yes and actually read stdin, which declined.
+    assert len(seen) == 1
+    assert checks["tx.ptt"].status is CheckStatus.MANUAL_REQUIRED
+    radio.set_ptt.assert_not_called()
+
+
+async def test_unkey_and_restore_even_if_verify_raises():
+    """The most important safety test: if the mid-check verify/readback raises
+    AFTER keying, the ``finally`` still unkeys PTT and restores power."""
+    radio, power = _tx_radio(start_power=200)
+    prompter, _ = _confirm_prompter(True)
+
+    state = radio.radio_state
+    calls = {"n": 0}
+
+    async def _exploding_set_ptt(on: bool) -> None:
+        calls["n"] += 1
+        if on:
+            # Key succeeds (mirror state) but the post-key verify path explodes.
+            state.ptt = True
+            raise RuntimeError("injected mid-check failure after keying")
+        # Unkey path (the finally) must still run and clear PTT.
+        state.ptt = False
+
+    radio.set_ptt = AsyncMock(side_effect=_exploding_set_ptt)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    checks = _flatten(levels)
+
+    # Whatever the verdict, the radio must NOT be left transmitting and power
+    # must be restored.
+    assert state.ptt is False
+    ptt_calls = [c.args[0] for c in radio.set_ptt.call_args_list]
+    assert ptt_calls[0] is True
+    assert False in ptt_calls  # finally unkeyed
+    assert power["value"] == 200  # power restored
+    assert checks["tx.ptt"].status is CheckStatus.FAIL
+
+
+async def test_tx_allowed_missing_keeps_manual_required():
+    """Even with --tx-actuate + confirm, tx.ptt requires tx_allowed authorization;
+    without it the pre-gate BLOCKS and nothing transmits."""
+    radio, _ = _tx_radio()
+    prompter, _ = _confirm_prompter(True)
+
+    # tuner_allowed only — tx.ptt gated solely by tx_allowed remains BLOCKED.
+    safety = OperatorSafetyBlock(tx_allowed=False, tuner_allowed=True)
+    levels = await _run(radio, safety=safety, tx_actuate=True, prompter=prompter)
+    checks = _flatten(levels)
+
+    assert checks["tx.ptt"].status is CheckStatus.BLOCKED
+    radio.set_ptt.assert_not_called()

--- a/tests/validation/test_tx_actuate.py
+++ b/tests/validation/test_tx_actuate.py
@@ -156,6 +156,27 @@ async def test_full_gate_stack_and_confirm_yes_keys_ptt_and_tunes():
     assert 2 in tuner_set_calls
 
 
+async def test_refuses_to_transmit_when_min_power_set_fails():
+    """If the radio HAS power control but lowering to minimum fails, the handler
+    must NOT key the transmitter (harm reduction: never TX at unknown power)."""
+    from rigplane.core.exceptions import CommandError
+
+    radio, power = _tx_radio(start_power=200)
+    # get_rf_power succeeds, but set_rf_power(min) fails -> can't confirm minimum.
+    radio.set_rf_power = AsyncMock(side_effect=CommandError("power set NAK"))
+    prompter, seen = _confirm_prompter(True)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    ptt = _flatten(levels)["tx.ptt"]
+
+    assert ptt.status is CheckStatus.FAIL
+    assert "minimum" in (ptt.error or "")
+    assert ptt.evidence.get("power_set_to_min") is False
+    # Crucially: the transmitter was NEVER keyed.
+    radio.set_ptt.assert_not_called()
+    assert radio.radio_state.ptt is False
+
+
 async def test_confirm_declined_no_transmission():
     radio, _ = _tx_radio()
     prompter, seen = _confirm_prompter(False)


### PR DESCRIPTION
## MOR-666 — `validate --tx-actuate`

Adds a strong opt-in that ACTUALLY exercises the TX checks `tx.ptt` and `tuner.tune` (today these are MANUAL_REQUIRED even with `--tx-allowed`). VOX stays MANUAL (out of scope). Epic MOR-634.

### Gate stack (ALL required to transmit)
`--tx-actuate` **AND** `--tx-allowed` **AND** `--allow-hardware` **AND** `RIGPLANE_VALIDATION_ALLOW_HARDWARE=1` **AND** `--hardware` (real hardware). Missing ANY → today's behavior (MANUAL_REQUIRED / BLOCKED, no actuation). Computed by `_tx_actuate_enabled(args)` in `cli/_validate.py`; the pre-gate-1 authorization check still applies (tx.ptt needs `tx_allowed`, tuner.tune needs `tuner_allowed`).

### confirm() reuse (MOR-667)
Before ANY transmission, a single `confirm()` ("About to TRANSMIT … type YES to proceed") is asked ONCE per run in `execute_hardware_checks`. `confirm()` ALWAYS reads a real answer and IGNORES `--assume-yes`, so an unattended/auto-yes run can never key TX. No prompter / non-TTY / declined → the TX checks stay MANUAL_REQUIRED, no transmission. Not re-prompted per check.

### Guaranteed unkey/restore
`tx.ptt`: read original TX power → set MINIMUM (0) → key PTT → brief ~1s key → verify `radio_state.ptt` → unkey → restore power. The unkey AND power-restore run in a `finally` that ALWAYS executes and is contained by `_RESTORE_ERRORS` (incl. `OSError`), so a mid-check exception/timeout/LAN drop can never leave the radio keyed or at the wrong power. `tuner.tune`: `set_tuner_status(2)` trigger + bounded settle + best-effort readback. Evidence records `tx_actuated`, `keyed`, `power_restored`, `unkeyed`, etc.

### Tests (`tests/validation/test_tx_actuate.py` + CLI gate tests)
- Full gate + confirm YES → tx.ptt keys (`set_ptt` True then False asserted in order), power set to min then restored to original, PASS, `keyed: true`; tuner.tune runs (status 2).
- Missing any gate (no `--tx-actuate` / no prompter), declined confirm, `--assume-yes`-only → no transmission, `set_ptt` NEVER called, MANUAL_REQUIRED.
- **Unkey/restore even if the mid-check verify raises** (inject error after keying → `finally` still unkeys + restores; radio not left transmitting).
- `tx_allowed` missing → BLOCKED, never actuated.
- `_tx_actuate_enabled` unit tests for each missing-gate combination.

### Verification
- `pytest tests/ -q --ignore=tests/integration -n auto` → **7798 passed, 8 skipped, 11 xfailed, 1 xpassed**, 0 failures.
- `mypy src/` → Success (284 files).
- `ruff check` clean + `ruff format` applied.
- `lint-imports` → 5 kept, 0 broken.
- Three dry-run golden gates (IC-7610 / X6200 / FTX-1) exit 0; `git diff tests/golden/` empty (dry-run never actuates).

Files: `src/rigplane/cli/_validate.py`, `src/rigplane/validation/hardware.py`, tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)