### PR TITLE
docs(validation): CAT-manual vs implementation gap audits for 5 radios

### DIFF
--- a/docs/validation/cat-audits/.gitignore
+++ b/docs/validation/cat-audits/.gitignore
@@ -1,0 +1,3 @@
+# Copyrighted vendor manuals (Icom / Yaesu / Xiegu / lab599) — kept locally only,
+# never committed to this public repo. Each audit .md cites the source URL instead.
+manuals/

--- a/docs/validation/cat-audits/README.md
+++ b/docs/validation/cat-audits/README.md
@@ -1,0 +1,38 @@
+# CAT manual vs implementation — gap audits
+
+Per-radio comparison of each transceiver's **official CAT/CI-V reference manual**
+against what rigplane-core actually implements, across three surfaces:
+
+1. **Backend** — does a method exist (`src/rigplane/backends/<driver>/`)?
+2. **Profile** — does `rigs/<radio>.toml` declare the capability + command strings?
+3. **Validation** — does `src/rigplane/validation/registry/` have a round-trip
+   (RMVR) check, and what is its live status?
+
+Each audit produces a **5-column command matrix** (CAT cmd · Documented · Backend ·
+Profile · Validation+live) plus **four gap lists**:
+
+- **A. Under-declared** — backend implements it, but profile/registry can't see it.
+- **B. Validation gaps** — implemented + declared, but no round-trip check (presence-only or nothing).
+- **C. Missing backend** — documented operator command, no backend method at all.
+- **D. Mismatch / wrong** — declared/checked but behaves differently, or a live FAIL tracing to a real mismatch.
+
+Each gap row cross-references an existing or NEW Linear ticket (team RigPlane, key `MOR`).
+
+## Audits
+
+| Radio | Driver | Manual | Status |
+|---|---|---|---|
+| FTX-1 (Yaesu) | `yaesu_cat` | CAT OM v2507-B | ✅ [ftx1.md](ftx1.md) — done, live-validated |
+| IC-7610 (Icom) | `icom_civ` | CI-V Reference Guide rev 1a | ✅ [ic7610.md](ic7610.md) — done, live-validated (3 scope FAILs → MOR-664) |
+| IC-7300 (Icom) | `icom_civ` (shared) | Full Manual v6 §19 | ✅ [ic7300.md](ic7300.md) — done, static/template (no live run) |
+| Xiegu X6200 | `ic705` serial (CI-V-like) | Radioddity CI-V V1.0.6 | ✅ [x6200.md](x6200.md) — done, doc-vs-code (live not run) |
+| Discovery TX-500 (lab599) | **none** (Kenwood-CAT, unimplemented) | Lab599 CAT Protocol rev.2 | ✅ [tx500.md](tx500.md) — done, doc-vs-code (no backend, no hw) |
+
+## Source manuals
+
+Downloaded vendor PDFs and their extracted `.txt` are kept locally under `manuals/`,
+which is **git-ignored** — these are copyrighted Icom / Yaesu / Xiegu / lab599
+documents and this is a public repo, so we do not redistribute them. Each audit
+`.md` cites the exact manual revision + source URL so anyone can re-fetch it.
+Command mnemonics / opcodes referenced in the audits are interface facts, not
+reproductions of the manuals.

--- a/docs/validation/cat-audits/ftx1.md
+++ b/docs/validation/cat-audits/ftx1.md
@@ -1,0 +1,64 @@
+# FTX-1 (Yaesu) — CAT manual vs implementation
+
+**Manual:** Yaesu FTX-1 CAT Operation Reference Manual **v2507-B** (67-command index + detail).
+**Driver:** `src/rigplane/backends/yaesu_cat/radio.py` (146 `async def`).
+**Profile:** `rigs/ftx1.toml`. **Validation:** `src/rigplane/validation/registry/*`.
+**Live run:** `/tmp/ftx1.live.json` — 58 checks: 30 pass · 1 **fail** (`vfo_slot.set`) · 21 unsupported · 6 manual_required. (core 2.9.0, mode=hardware, tx_allowed, USB + antenna.)
+
+Protocol: Yaesu ASCII CAT, `;`-terminated (NOT CI-V). CP2105 dual-UART.
+
+---
+
+## Gap lists (priority-ordered)
+
+### A. UNDER-DECLARED — backend implements, profile/registry can't see it
+
+| CAT | rigplane symbol | Fix | Ticket |
+|---|---|---|---|
+| **CN** CTCSS tone freq (+ **CT** type) | backend `get_sql_type`/`set_sql_type`, `get_ctcss_tone` (read-only) exist; registry tone round-trips resolve to `get_/set_repeater_tone`, `_tsql`, `_tone_freq`, `_tsql_freq` — **none exist on the backend** → 4 tone checks `unsupported` | Repoint registry tone checks at `get_sql_type`/`set_sql_type`+`get_ctcss_tone`, mark tone-freq read-only | **MOR-672** |
+| **DT** Date & Time | `get/set_system_date`/`time` exist; **no `DT` command string** in `ftx1.toml` → `system_date/time.read` unsupported | Add `DT0;`/`DT1;` strings to `[commands]` | **MOR-672** |
+| **VG** VOX Gain | `get/set_vox_gain` **raise NotImplementedError**, no `VG` string | Implement + add strings | **MOR-674** |
+| **NA** Narrow | `get/set_narrow` work, folded into `filter_width` | Low — optional `narrow.set` | — |
+
+### B. VALIDATION GAPS — implemented + declared, but no round-trip (presence-only)
+
+| CAT | rigplane symbol | Live | Ticket |
+|---|---|---|---|
+| **IS** IF Shift | `get/set_if_shift` — only `if_shift.presence` | pass | **MOR-671** |
+| **CO** Contour | `get/set_contour` (+apf) — only `contour.presence` | pass | **MOR-671** |
+| **BI** Break-in | `get/set_break_in` — only `break_in.presence` | pass | **MOR-673** |
+| **PR/PL** Compressor | `get/set_processor`(+level) — only `compressor.presence` | pass | **MOR-673** |
+| **CT** SQL type | `get/set_sql_type` — only `sql_type.presence` | pass | **MOR-673** |
+| **FR** Dual RX | `get/set_rx_func` — only `dual_rx.presence` | pass | — (low) |
+
+### C. MISSING BACKEND — documented operator command, no backend method
+
+| CAT | Function | Value | Ticket |
+|---|---|---|---|
+| **MX** | MOX SET (manual TX-on) | Med — alt TX trigger | **MOR-675** |
+| **OS** | Repeater Offset/Shift | Med — FM repeater | **MOR-675** |
+| **TS** | TXW (TX watch, split) | Med — operating | **MOR-675** |
+| **VD** | VOX delay (methods exist, no `VD` string) | Med | **MOR-674** |
+| MD/MC/MA/MB/MW/MR/MT/MS memory family | memory ops | Feature | **MOR-676** |
+| KM / PB / LM | CW + voice message keyer | Feature | **MOR-676** |
+
+### D. MISMATCH / WRONG — declared/checked but behaves differently
+
+| CAT | rigplane symbol | Issue | Ticket |
+|---|---|---|---|
+| **VS** | `vfo_slot.set` (**FAIL**) | `set_vfo_slot` raises NotImplementedError on `vfo.scheme="ab_shared"`; backend DOES implement `VS` via `set_vfo_select` (MAIN/SUB) — harness calls wrong abstraction. The one red FAIL. | **MOR-670** (NotImplementedError→unsupported) |
+| **ML** | `get/set_monitor` raise NIE | Correctly NOT declared (real radio returns `?;` — manual column optimistic vs hardware). No gap. | (note) |
+| **CT** | `set_sql_type` writes `CT0{type:02d}`, live answers `CT0;` single-digit | Asymmetric width; flagged in-profile as "unconfirmed residual" | MOR-473 (open) |
+
+### Intentionally OUT OF SCOPE (device front panel — nothing to mirror into browser UI)
+- **DA** TFT contrast/brightness/LED · **SF** FUNC knob assignment · **EX** settings menu (Table 3, hundreds of params) · **MS** Meter SW (UI reads meters directly).
+
+---
+
+## Ticket coverage summary
+
+- 1 red FAIL (`vfo_slot.set`) → **MOR-670**.
+- presence-only IS/CO → **MOR-671**; BI/PR/CT → **MOR-673**.
+- tone (CN/CT) + clock (DT) under-declaration → **MOR-672**.
+- VG impl + VD wiring → **MOR-674**; MX/OS/TS missing backend → **MOR-675**.
+- memory + keyer UI feature → **MOR-676**.

--- a/docs/validation/cat-audits/ic7300.md
+++ b/docs/validation/cat-audits/ic7300.md
@@ -1,0 +1,175 @@
+# IC-7300 (Icom) — CI-V manual vs implementation
+
+**Manual:** Icom IC-7300 **Full Manual (English) v6**, §19 CONTROL COMMAND command table (`manuals/ic7300.txt`, extracted from the official Icom UK PDF). The standalone "CI-V Reference Guide" PDF that Icom now ships only covers the **IC-7300MK2**; the original IC-7300 CI-V table is published inside the Full Manual §19 — that is the authoritative source used here. (The profile header cites "IC-7300MK2 CI-V Reference Guide" + wfview `IC-7300.rig`; sub-command numbering matches the original §19 table.)
+**Driver:** shared Icom CI-V core — `src/rigplane/backends/ic7300/{serial,core}.py` are 22-line shims over `backends/_icom_serial_base._IcomSerialRadioBase` + `runtime/radio.CoreRadio` (185 `get_/set_`) + `_scope_runtime` mixin (26) + `_dual_rx_runtime` (3). **Zero IC-7300-specific command code** — every method is shared with IC-7610 / IC-705 / IC-9700 / X6200 and routed by `rigs/ic7300.toml`.
+**Profile:** `rigs/ic7300.toml`. **Validation:** `src/rigplane/validation/registry/*` (capability-gated template; see `_builders.py`).
+**Live run:** none — this is a **template/static audit**. No `/tmp/ic7300.live.json` hardware run was performed; "Validation" column reflects the generated matrix declaration, not observed pass/fail.
+
+Protocol: Icom CI-V, `FE FE 94 E0 … FD`, transceiver address **0x94**. Default baud 115200 (required for serial scope data).
+
+### IC-7300 vs IC-7610 divergence (7300-specific)
+- **Single receiver** — no dual-watch, no MAIN/SUB band select, no `0x29` (cmd29). Scope is `27 12`=Main-only, `27 13`=Single-only.
+- **Single antenna + ATU** — `0x12` is a 1-of-1 selector; **no RX antenna**, no ANT1/ANT2 (profile `has_rx_ant=false`, `tx_count=1`).
+- **APF is a plain ON/OFF toggle** (`16 32`, 0/1) — *not* the IC-7610 WIDE/MID/NAR 3-level. Profile maps `audio_peak_filter`→`16 32`; the 3-level `apf_type_level`→`14 05` is flagged `NOT_IMPLEMENTED` in-profile.
+- **2 preamp levels** (`16 02`: 0/1/2), no DIGI-SEL, no drive_gain, single DATA sub-mode.
+
+---
+
+## Command matrix (operator-facing)
+
+Legend — Backend: method name or `—`. Profile: `[commands]` key or cap. Validation: `check_id` + declaration (`RMVR`=round-trip / `PRESENCE`=synthetic `.presence` only / `MANUAL`/`TX-ADJ` / `READ` / `—`=none).
+
+| CI-V cmd | Documented S/R | Backend method | Profile cap / cmd | Validation |
+|---|---|---|---|---|
+| `03` / `05` | freq read/set | `get_freq`/`set_freq` | `get_freq`/`set_freq` | `freq.write` **RMVR** (structural) |
+| `04` / `06` | mode read/set | `get_mode`/`set_mode` | `get_mode`/`set_mode` | `mode.set` **RMVR** (structural) |
+| `02` | band-edge freqs | `get_band_edge_freq` | `band_edge` | — |
+| `25` / `26` | sel/unsel VFO freq+mode | `get_selected_freq`… | `get_selected_*` | (structural reads) |
+| `07` | VFO A/B, swap, equalize | `get_vfo`/`set_vfo` | `get_vfo`/`set_vfo`, vfo scheme `ab` | (via VFO scheme) |
+| `0F` | split read/set | `set_split`/`get_split` | `get_split`/`set_split` | `split.set` **RMVR** |
+| `10` | tuning step | `get_/set_tuning_step` | `tuning_step` | — (declared, presence only) |
+| `11` | attenuator 0/20dB | `get_/set_attenuator` | `attenuator` | `attenuator.set` **RMVR** |
+| `14 01` | AF level | `get_/set_af_level` | `af_level` | `af_level.set` **RMVR** |
+| `14 02` | RF gain | `get_/set_rf_gain` | `rf_gain` | `rf_gain.set` **RMVR** |
+| `14 03` | squelch | `get_/set_squelch` | `squelch` | `squelch.set` **RMVR** |
+| `14 06` | NR level | `get_/set_nr_level` | `nr` | (covered by `nr.set`) |
+| `14 07`/`08` | TWIN PBT inner/outer | `get_/set_pbt_inner`/`_outer` | `pbt` | `pbt.presence` **—** |
+| `14 09` | CW pitch | `get_/set_cw_pitch` | `cw` | — (cw check = key_speed only) |
+| `14 0A` | RF power | `get_/set_rf_power` | `power_control` | `power_control.presence` **—** |
+| `14 0B` | MIC gain | `get_/set_mic_gain` | `power_control` | `power_control.presence` **—** |
+| `14 0C` | KEY SPEED | `get_/set_key_speed` | `cw` | `key_speed.set` **RMVR** |
+| `14 0D` | NOTCH position | `get_/set_notch_filter` | `notch` | (covered by `notch.set`) |
+| `14 0E` | COMP level | `get_/set_compressor_level` | `compressor` | `compressor.presence` **—** |
+| `14 0F` | break-in delay | `get_/set_break_in_delay` | `break_in` | `break_in.presence` **—** |
+| `14 12` | NB level | `get_/set_nb_level` | `nb` | (covered by `nb.set`) |
+| `14 15` | monitor gain | `get_/set_monitor_gain` | `monitor` | `monitor.presence` **—** |
+| `14 16` | VOX gain | `get_/set_vox_gain` | `vox` | `vox_gain.set` **TX-ADJ** |
+| `14 17` | anti-VOX gain | `get_/set_anti_vox_gain` | `vox` | — |
+| `15 02` | S-meter | `get_s_meter` | `meters` | `meters.read` **READ** |
+| `15 11`/`12`/`13`/`14`/`15`/`16` | PO/SWR/ALC/COMP/Vd/Id meters | `get_power_meter`…`get_id_meter` | `meters` | (covered by `meters.read`) |
+| `16 02` | preamp 0/1/2 | `get_/set_preamp` | `preamp` | `preamp.set` **RMVR** |
+| `16 12` | AGC FAST/MID/SLOW | `get_/set_agc` | `agc` | `agc.set` **RMVR** |
+| `16 22` | NB on/off | `get_/set_nb` | `nb` | `nb.set` **RMVR** |
+| `16 40` | NR on/off | `get_/set_nr` | `nr` | `nr.set` **RMVR** |
+| `16 41` | auto-notch | `get_/set_auto_notch` | `notch` | (covered by `notch.set`) |
+| `16 42` | repeater tone | `get_/set_repeater_tone` | `repeater_tone` | `repeater_tone.set` **RMVR** |
+| `16 43` | tone squelch | `get_/set_repeater_tsql` | `tsql` | `tsql.set` **RMVR** |
+| `16 44` | compressor on/off | `get_/set_compressor` | `compressor` | `compressor.presence` **—** |
+| `16 45` | monitor on/off | `get_/set_monitor` | `monitor` | `monitor.presence` **—** |
+| `16 46` | VOX on/off | `get_/set_vox` | `vox` | `vox.read` **READ** + `vox.set` **PRESENCE** |
+| `16 47` | BK-IN OFF/SEMI/FULL | `get_/set_break_in` | `break_in` | `break_in.presence` **—** |
+| `16 48` | manual notch on/off | `get_/set_manual_notch` | `notch` | `notch.set` **RMVR** |
+| `16 4F` | Twin Peak Filter | `get_/set_twin_peak_filter` | `twin_peak` | `twin_peak.presence` **—** |
+| `16 50` | dial lock | `get_/set_dial_lock` | `dial_lock` | `dial_lock.set` **RMVR** |
+| `16 56` | DSP filter type | `get_/set_filter_shape` | `filter_shape` | `filter_shape.presence` **—** |
+| `16 57` | manual notch width | `get_/set_manual_notch_width` | `notch` | (covered by `notch.set`) |
+| `16 58` | SSB TX bandwidth | `get_/set_ssb_tx_bandwidth` | `ssb_tx_bw` | `ssb_tx_bw.presence` **—** |
+| `16 32` | APF ON/OFF (7300: toggle) | `get_/set_audio_peak_filter` | `apf` | `apf.presence` **—** |
+| `16 65` | IP+ | `get_/set_ip_plus` | `ip_plus` | `ip_plus.presence` **—** |
+| `17` | send/stop CW msg | `send_cw`/`stop_cw` | `send_cw`/`stop_cw` | — (feature) |
+| `18` | power on/off | `get_/set_powerstat` | `power_control` | `power_control.presence` **—** |
+| `19 00` | transceiver ID | `get_transceiver_id` | `get_transceiver_id` | `discovery.identify` (structural) |
+| `1A 01` | band-stack register | `set_bsr` (`get_bsr` **NIE**) | `bsr` | `bsr.select` **MANUAL** (set-only) |
+| `1A 03` | filter width (BCD idx) | `get_/set_filter_width` | `filter_width` | `filter_width.set` **RMVR** |
+| `1A 04` | AGC time constant | `get_/set_agc_time_constant` | `agc` | (covered by `agc.set`) |
+| `1A 05 …` EQ (RX/TX bass/treble, HPF/LPF) | `get_/set_*_rx_bass`… | `[commands.overrides]` | `system_settings` | — |
+| `1A 05 0064/0065` | ACC/USB MOD level | `get_/set_acc1_mod_level`, `_usb_mod_level` | mod cmds | — (audio path) |
+| `1A 05 0066/0067` | MOD input (DATA OFF / DATA) | `get_/set_data_off_mod_input`, `_data1_mod_input` | data inputs | — (audio path) |
+| `1A 05 0071` | CI-V transceive | `get_/set_civ_transceive` | civ cmds | — |
+| `1A 05 0073` | CI-V output (for ANT) | `get_/set_civ_output_ant` | civ cmds | — |
+| `1A 05 0094/0095/0096` | date / time / UTC offset | `get_/set_system_date`/`_time`/`_utc_offset` | system cmds | `system_date.read`/`system_time.read` **READ** |
+| `1A 05 0189/0190` | NB depth / width | `get_/set_nb_depth`/`_width` | nb cmds | — (covered loosely by `nb.set`) |
+| `1A 05 0191/0192` | VOX delay / voice delay | `get_/set_vox_delay` | vox cmds | — |
+| `1A 06` | DATA mode | `get_/set_data_mode` | `data_mode` | `data_mode.presence` **—** |
+| `1B 00`/`01` | repeater-tone freq / TSQL freq | `get_/set_tone_freq`/`_tsql_freq` | tone cmds | `tone_freq.set` / `tsql_freq.set` **RMVR** |
+| `1C 00` | PTT TX/RX | `set_ptt` | `ptt_on`/`ptt_off` | `tx.ptt` **TX-ADJ** |
+| `1C 01` | antenna tuner OFF/ON/tune | `get_/set_tuner_status` | `tuner` | `tuner.tune` **TX-ADJ** |
+| `1C 02` | TX freq monitor (XFC) | `get_/set_xfc_status` | `xfc` | `xfc.presence` **—** |
+| `1C 03` | read TX freq | `get_/set_tx_freq_monitor` | tx cmds | — |
+| `21 00` | RIT freq | `get_/set_rit_frequency` | `rit` | `rit.set` **RMVR** |
+| `21 01` | RIT on/off | `get_/set_rit_status` | `rit` | (covered by `rit.set`) |
+| `21 02` | ∂TX (XIT) on/off | `get_/set_rit_tx_status` | `xit` | `xit.set` **RMVR** |
+| `27 00` | scope waveform data | `get_/set_scope_wave` | scope cmds | (audio/scope surface) |
+| `27 10`/`11` | scope on/off, data output | `scope_on`/`scope_data_output` | scope cmds | `scope.capture` **MANUAL** |
+| `27 14` | center/fixed mode | `get_/set_scope_mode` | scope cmds | `scope_mode.set` **RMVR** |
+| `27 15` | span | `get_/set_scope_span` | scope cmds | `scope_span.set` **RMVR** |
+| `27 16` | edge number | `get_/set_scope_edge` | scope cmds | `scope_edge.set` **RMVR** |
+| `27 17` | hold | `get_/set_scope_hold` | scope cmds | `scope_hold.set` **RMVR** |
+| `27 19` | reference level | `get_/set_scope_ref` | scope cmds | `scope_ref.set` **RMVR** |
+| `27 1A` | sweep speed | `get_/set_scope_speed` | scope cmds | `scope_speed.set` **RMVR** |
+| `27 1B` | scope-during-TX | `get_/set_scope_during_tx` | scope cmds | `scope_during_tx.set` **RMVR** |
+| `27 1C` | center type | `get_/set_scope_center_type` | scope cmds | `scope_center_type.set` **RMVR** |
+| `27 1D` | VBW | `get_/set_scope_vbw` | scope cmds | `scope_vbw.set` **RMVR** |
+| `27 1E` | fixed-edge freqs | `get_/set_scope_fixed_edge` | scope cmds | `scope_fixed_edge.read` **READ** |
+| `27 1F` | RBW | `get_/set_scope_rbw` | scope cmds | `scope_rbw.set` **RMVR** |
+| `27 12`/`13` | main/sub, single/dual | `get_scope_single_dual` | scope cmds | `scope_dual.set`/`scope_receiver.set` (no-op on 7300, single-RX) |
+| `0E` | scan start/stop | `scan_start`/`scan_stop` | `scan` | `scan.presence` **—** |
+| `13` | speech synthesizer | `get_speech` | `set_speech` | — (device front-panel) |
+
+### Intentionally OUT OF SCOPE (device front panel / menu — nothing to mirror into browser UI)
+- **`08`/`09`/`0A`/`0B` + `1A 00`/`1A 02` memory & memory-keyer family** — memory ops, feature, not an operator real-time control.
+- **`1A 05 0021…0197` settings-menu mass** (beep, screen capture, fonts, RTTY decode, QSO recorder, contest number, keyboard layout, screen saver, colors, waterfall styling) — device settings menu (hundreds of params); only the audio-path (mod level/input), clock, NB depth/width, VOX delay, and per-band scope edges are surfaced.
+- **`1E`** user-set TX band edges · **`1A 05 0072` CI-V address** · **`0081` LCD backlight** — config, not operating controls.
+- **`28 00` Voice TX memory** — voice keyer (feature, same class as CW keyer).
+
+---
+
+## Gap lists (priority-ordered)
+
+### A. UNDER-DECLARED — backend implements, profile/registry can't see it
+
+| CI-V | rigplane symbol | Fix | Ticket |
+|---|---|---|---|
+| `1B 00`/`01` repeater-tone freq + TSQL freq | `get_/set_tone_freq`, `get_/set_tsql_freq` exist + `tone_freq`/`tsql_freq` registry checks **RMVR** — but they are gated on `capability="repeater_tone"`/`"tsql"`; the 7300 declares both, so they DO run. **No gap** (listed to confirm parity with FTX-1 audit). | none | — |
+| `14 16`/`17` VOX gain + anti-VOX | `get_/set_vox_gain` (REAL), `get_/set_anti_vox_gain` (REAL) — backend + profile present, but only `vox_gain.set` is checked (TX-adjacent, manual); anti-VOX has no check_id | Add `anti_vox_gain.set` RMVR (or fold under vox) | **NEW** |
+| `1A 05 0191/0192` VOX delay / voice delay | `get_/set_vox_delay` (REAL) + `get_vox_delay`/`set_vox_delay` cmd strings present — no registry check at all | Add `vox_delay.set` RMVR | **NEW** |
+| `1A 05 0189/0190` NB depth / width | `get_/set_nb_depth`/`_width` (REAL) + cmd strings present — no dedicated check (only generic `nb.set` toggle) | Add `nb_depth.set` RMVR | **NEW** |
+
+### B. VALIDATION GAPS — implemented + declared, but no round-trip (synthetic `.presence` only)
+
+Per `_builders.py`, a declared capability with **no registry CheckSpec** gets only a synthetic `<cap>.presence` entry at `UNSUPPORTED_PENDING_EVIDENCE`. These 7300 features have a **REAL backend method** + profile declaration but **no functional check** — so the matrix can never go green for them:
+
+| Capability | CI-V | Backend (REAL) | Fix | Ticket |
+|---|---|---|---|---|
+| `pbt` | `14 07`/`08` | `get_/set_pbt_inner`/`_outer` | Add `pbt.set` RMVR (raw 0/128/255) | **NEW** |
+| `compressor` (+level) | `16 44` / `14 0E` | `get_/set_compressor`(+`_level`) | Add `compressor.set` RMVR | **NEW** |
+| `monitor` (+gain) | `16 45` / `14 15` | `get_/set_monitor`(+`_gain`) | Add `monitor.set` RMVR | **NEW** |
+| `break_in` (+delay) | `16 47` / `14 0F` | `get_/set_break_in`(+`_delay`) | Add `break_in.set` RMVR | **NEW** |
+| `twin_peak` | `16 4F` | `get_/set_twin_peak_filter` | Add `twin_peak.set` RMVR | **NEW** |
+| `apf` (7300 toggle) | `16 32` | `get_/set_audio_peak_filter` | Add `apf.set` RMVR (0/1) | **NEW** |
+| `ip_plus` | `16 65` | `get_/set_ip_plus` | Add `ip_plus.set` RMVR | **NEW** |
+| `filter_shape` | `16 56` | `get_/set_filter_shape` | Add `filter_shape.set` RMVR (SHARP/SOFT) | **NEW** |
+| `ssb_tx_bw` | `16 58` | `get_/set_ssb_tx_bandwidth` | Add `ssb_tx_bw.set` RMVR | **NEW** |
+| `data_mode` | `1A 06` | `get_/set_data_mode` | Add `data_mode.set` RMVR | **NEW** |
+| `tuning_step` | `10` | `get_/set_tuning_step` | Add `tuning_step.set` RMVR | **NEW** |
+| `xfc` | `1C 02` | `get_/set_xfc_status` | Add `xfc.set` RMVR | **NEW** |
+| `power_control` (rf_power/mic_gain) | `14 0A`/`0B`, `18` | `get_/set_rf_power`/`_mic_gain`/`powerstat` | Split `rf_power.set`+`mic_gain.set` RMVR | **NEW** |
+| `cw_pitch` (under `cw`) | `14 09` | `get_/set_cw_pitch` | Add `cw_pitch.set` RMVR (cw check currently = key_speed only) | **NEW** |
+
+> All RMVR-able level/toggle controls above are shared with IC-7610; one registry CheckSpec per capability fixes every Icom rig at once (`_levels.py`/`_dsp.py`/`_tx.py`).
+
+### C. MISSING BACKEND — documented operator command, no backend method
+
+| CI-V | Function | Value | Ticket |
+|---|---|---|---|
+| `1A 01` (read) band-stack register | `get_bsr` **raises NotImplementedError** for all Icom — only `set_bsr` works; `bsr.select` is set-only/manual | Med — implement BSR read (firmware DOES answer `1A 01`); the NIE is a stale IC-7610-era assumption | **NEW** |
+| `1A 05 0030` quick split | no `get_quick_split`/`set_quick_split` method (profile has the cmd string `get_/set_quick_split`, no backend `async def`) | Low — operating convenience | **NEW** |
+| `0E A1–A7` ∂F scan span / select-scan variants | `scan_set_df_span`/`scan_set_resume` exist; the select-memory-scan + ∂F-span enumerations are not surfaced | Low — feature (scan family) | — |
+| `1A 02` / `17` memory & CW message keyer | memory ops + CW keyer text | Feature (out of scope, see above) | — |
+
+### D. MISMATCH / WRONG — declared/checked but behaves differently
+
+| CI-V | rigplane symbol | Issue | Ticket |
+|---|---|---|---|
+| `14 05` APF type/level | `get_/set_apf_type_level` | Method sends `0x14` (REAL on IC-7610's 3-level APF), but the **IC-7300 has no `14 05` APF position** — it is a plain `16 32` toggle. Profile correctly maps `apf`→`16 32` and flags `get_apf_type_level=[0x14,0x05]` as `NOT_IMPLEMENTED`. Calling `apf_type_level` on a 7300 would emit a command the radio ignores. Cosmetic (method unreachable via 7300 UI) but the cmd string should be removed, not just commented. | **NEW** (low) |
+| `1A 01` `get_bsr` | band-stack read | `get_bsr` `raise NotImplementedError(...)` cites "IC-7610 does not support reading band stack" — inherited verbatim by the 7300 even though the 7300 §19 table documents `1A 01` as **Send/read**. Driver-wide stale assumption (see list C). | **NEW** |
+| header provenance | `rigs/ic7300.toml` | Header & two `[commands]` comments cite **"IC-7300MK2 CI-V Reference Guide"** as source, but the profile targets the **original IC-7300** (addr 0x94, 2-level preamp, single DATA). MK2 has a different command set. Update provenance to the IC-7300 Full Manual §19 to avoid future mis-merges. | **NEW** (doc) |
+
+---
+
+## Summary
+
+- **No live hardware validation** was run for the IC-7300 — this is a static/template audit. Recommend an `/tmp/ic7300.live.json` run to confirm the ~26 RMVR checks and resolve list-B presence-only items.
+- The IC-7300 is **100% shared-backend** with the IC-7610 — every gap in lists A/B is also an IC-7610/IC-705/IC-9700 gap; fixes are one CheckSpec per capability, rig-agnostic.
+- **Biggest single lever:** list B — ~14 declared+implemented capabilities (pbt, compressor, monitor, break_in, twin_peak, apf, ip_plus, filter_shape, ssb_tx_bw, data_mode, tuning_step, xfc, power_control, cw_pitch) have a working backend method but only a synthetic `.presence` stub, so they can never validate green. Add functional `_levels`/`_dsp`/`_tx` CheckSpecs.
+- **Real bugs:** `get_bsr` NIE blocks `1A 01` read on hardware that supports it (lists C+D); `apf_type_level`→`14 05` is a dead command on the 7300 (list D).

--- a/docs/validation/cat-audits/ic7610.md
+++ b/docs/validation/cat-audits/ic7610.md
@@ -1,0 +1,195 @@
+# IC-7610 (Icom) — CI-V manual vs implementation
+
+**Manual:** Icom IC-7610 **CI-V Reference Guide** rev **1a** (2021 printing) — full command table (cmds `00`–`27`, `1A 05 00xx` menu) + command formats. Source: `docs/validation/cat-audits/manuals/ic7610.txt` (extracted from the official Icom Japan PDF `IC-7610_ENG_CI-V_1a.pdf`, retrieved via the radiomanual.info mirror — Icom's own download endpoint serves an HTML/JS shell to `curl`, not the PDF; the mirror's bytes are the official document).
+**Driver:** `src/rigplane/runtime/radio.py` (IcomRadio + mixins) · scope in `src/rigplane/runtime/_scope_runtime.py` · dual-RX in `src/rigplane/runtime/_dual_rx_runtime.py`. Backend assembly `src/rigplane/backends/icom7610/`.
+**Profile:** `rigs/ic7610.toml`. **Validation:** `src/rigplane/validation/registry/*`.
+**Live run:** `/tmp/ic7610.live.json` — 70 checks: **59 pass · 3 fail** (`scope_dual.set`, `scope_vbw.set`, `scope_rbw.set`) · 8 manual_required. (core 2.9.0, mode=hardware, tx_allowed, LAN `192.168.55.40:50001`.)
+
+Protocol: Icom CI-V, `FE FE 98 E0 … FD` framing (transceiver addr `0x98`). `@9` in the manual = "**Command 29 supported**" → dual-RX targeting via the `0x29 <00|01>` prefix; the profile's `[cmd29]` block routes 26 commands this way. Set-then-read round-trips (RMVR) are the harness's strongest signal; many implemented controls only get a `*.presence` check because no RMVR is registered.
+
+---
+
+## Command matrix (operator-facing set)
+
+CI-V cmd · Documented S(et)/R(ead) · Backend method (or —) · Profile cap/cmd · Validation check_id + live status.
+
+| CI-V cmd | Doc | Backend method | Profile | Validation (live) |
+|---|---|---|---|---|
+| `03` read freq / `05` set freq | S/R | `get_freq`/`set_freq` | `get_freq`/`set_freq` | `freq.write` RMVR ✅ · `freq.reverse_sync` ✅ · `discovery.identify` ✅ |
+| `04` read mode / `06` set mode | S/R | `get_mode`/`set_mode` | `get_mode`/`set_mode` | `mode.set` RMVR ✅ |
+| `02` band edge | R | `get_band_edge_freq` | `band_edge` cap | `band_edge.presence` ✅ |
+| `07 B0/B1` swap/equalize | S | `swap_main_sub`/`equalize_main_sub` | `[vfo]` | (via `vfo_slot.set` RMVR ✅) |
+| `07 C0/C1/C2` dualwatch | S/R | `get_dual_watch`/`set_dual_watch` | `dual_watch` cap | `dual_watch.set` RMVR ✅ |
+| `07 D0/D1/D2` main/sub select | S/R | `select_receiver`/`get_active_receiver` | `[vfo]` main/sub | `vfo_slot.set` RMVR ✅ |
+| `0F` split | S/R | `get_split`/`set_split` | `split` cap | `split.set` RMVR ✅ |
+| `10` tuning step | S/R | `get_tuning_step`/`set_tuning_step` | `tuning_step` cap | `tuning_step.presence` ✅ |
+| `11` attenuator | S/R | `get_attenuator`/`set_attenuator` | `attenuator` cap | `attenuator.set` RMVR ✅ |
+| `12 00/01` ANT 1/2 + RX-ANT | S/R | `get/set_antenna_1/2`, `get/set_rx_antenna_*` | `antenna`,`rx_antenna` | `antenna.presence` ✅ · `rx_antenna.presence` ✅ |
+| `13` speech synth | R | `get_speech` | — | (front-panel; not checked) |
+| `14 01` AF / `14 02` RF gain / `14 03` SQL | S/R | `get/set_af_level`, `…rf_gain`, `…squelch` | yes | `af_level.set`✅ `rf_gain.set`✅ `squelch.set`✅ (RMVR) |
+| `14 05` APF pos | S/R | `get/set_apf_type_level` | `apf` cap | `apf.presence` ✅ |
+| `14 06` NR level | S/R | `get/set_nr_level` | `[commands]` | (none — NR level not round-tripped) |
+| `14 07/08` inner/outer PBT | S/R | `get/set_pbt_inner/outer` | `pbt` cap | `pbt.presence` ✅ |
+| `14 09` CW pitch | S/R | `get/set_cw_pitch` | `cw` | (none — pitch not round-tripped) |
+| `14 0A` RF power | S/R | `get/set_rf_power` | `[commands]` | (none) |
+| `14 0B` MIC gain | S/R | `get/set_mic_gain` | `[commands]` | (none) |
+| `14 0C` keying speed | S/R | `get/set_key_speed` | `cw` | `key_speed.set` RMVR ✅ |
+| `14 0D` notch filter pos | S/R | `get/set_notch_filter` | `[commands]` | (none) |
+| `14 0E` COMP level | S/R | `get/set_compressor_level` | `[commands]` | (none — see `compressor.presence`) |
+| `14 0F` break-in delay | S/R | `get/set_break_in_delay` | `[commands]` | (none) |
+| `14 12` NB level | S/R | `get/set_nb_level` | `[commands]` | (none) |
+| `14 13` DIGI-SEL shift | S/R | `get/set_digisel_shift` | `[commands]` | (none) |
+| `14 14` DRIVE gain | S/R | `get/set_drive_gain` | `drive_gain` cap | `drive_gain.presence` ✅ |
+| `14 15` MONI level | S/R | `get/set_monitor_gain` | `[commands]` | (none) |
+| `14 16` VOX gain | S/R | `get/set_vox_gain` | `[commands]` | `vox_gain.set` manual_required (TX-gated) |
+| `14 17` Anti-VOX gain | S/R | `get/set_anti_vox_gain` | `[commands]` | (none) |
+| `14 19` LCD backlight | S/R | — | — | (device front panel) |
+| `15 01` SQL status | R | `get_s_meter_sql_status` | meters | `meters.read` ✅ (S-meter) |
+| `15 02` S-meter | R | `get_s_meter` | meters | `meters.read` READ ✅ |
+| `15 05` various SQL | R | `get_various_squelch` | meters | — |
+| `15 07` OVF | R | `get_overflow_status` | meters | — |
+| `15 11/12/13/14/15/16` PO/SWR/ALC/COMP/Vd/Id | R | `get_power_meter`/`get_swr`/`get_alc_meter`/`get_comp_meter`/`get_vd_meter`/`get_id_meter` | meters | (streamed; not individually checked) |
+| `16 02` preamp | S/R | `get/set_preamp` | `preamp` cap | `preamp.set` RMVR ✅ |
+| `16 12` AGC time const | S/R | `get/set_agc` (speed) | `agc` cap | `agc.set` RMVR ✅ |
+| `16 22` NB | S/R | `get/set_nb` | `nb` cap | `nb.set` RMVR ✅ |
+| `16 32` audio peak filter | S/R | `get/set_audio_peak_filter` | `[commands]` | (none — polled only) |
+| `16 40` NR | S/R | `get/set_nr` | `nr` cap | `nr.set` RMVR ✅ |
+| `16 41` auto notch | S/R | `get/set_auto_notch` | `[commands]` | (polled; no check) |
+| `16 42/43` repeater tone / TSQL | S/R | `get/set_repeater_tone`/`…tsql` | `[commands]` | (cap not declared — see Gap D) |
+| `16 44` compressor | S/R | `get/set_compressor` | `compressor` cap | `compressor.presence` ✅ |
+| `16 45` monitor | S/R | `get/set_monitor` | `monitor` cap | `monitor.presence` ✅ |
+| `16 46` VOX | S/R | `get/set_vox` | `vox` cap | `vox.read` ✅ · `vox.set` manual_required |
+| `16 47` break-in | S/R | `get/set_break_in` | `break_in` cap | `break_in.presence` ✅ |
+| `16 48` manual notch | S/R | `get/set_manual_notch` | `notch` cap | `notch.set` RMVR ✅ |
+| `16 4E` DIGI-SEL | S/R | `get/set_digisel` | `digisel` cap | `digisel.presence` ✅ |
+| `16 4F` twin peak filter | S/R | `get/set_twin_peak_filter` | `twin_peak` cap | `twin_peak.presence` ✅ |
+| `16 50` dial lock | S/R | `get/set_dial_lock` | `dial_lock` cap | `dial_lock.set` RMVR ✅ |
+| `16 53` ANT-RX I/O | S/R | `get/set_rx_antenna_*` | `rx_antenna` | `rx_antenna.presence` ✅ |
+| `16 56` DSP IF filter type | S/R | `get/set_filter_shape` | `filter_shape` cap | `filter_shape.presence` ✅ |
+| `16 57` manual notch width | S/R | `get/set_manual_notch_width` | `[commands]` | (none) |
+| `16 58` SSB TX bandwidth | S/R | `get/set_ssb_tx_bandwidth` | `ssb_tx_bw` cap | `ssb_tx_bw.presence` ✅ |
+| `16 5E` MAIN/SUB tracking | S/R | `get/set_main_sub_tracking` | `main_sub_tracking` | `main_sub_tracking.presence` ✅ |
+| `16 65` IP+ | S/R | `get/set_ip_plus` | `ip_plus` cap | `ip_plus.presence` ✅ |
+| `17` send CW message | S | `send_cw_text`/`stop_cw_text` | `send_cw` | (TX-gated; not checked) |
+| `18 00/01` power off/on | S | `set_powerstat`/`get_powerstat` | `power_on/off` | `power_control.presence` ✅ |
+| `19` transceiver ID | R | `get_transceiver_id` | `[commands]` | (used at discovery) |
+| `1A 00` memory contents | S/R | `get/set_memory_contents` | — | (memory family — see Gap C note) |
+| `1A 01` band stacking reg | S/R | `get/set_bsr` | `bsr` cap | `bsr.select` manual_required (set-only) |
+| `1A 03` IF filter width | S/R | `get/set_filter_width` | `filter_width` cap | `filter_width.set` RMVR ✅ |
+| `1A 04` AGC time const | S/R | `get/set_agc_time_constant` | `[commands]` | (none) |
+| `1A 05 0070` REF adjust | S/R | `get/set_ref_adjust` | `[commands]` | (none) |
+| `1A 05 0089/0090` USB/LAN MOD lvl | S/R | `get/set_usb_mod_level`/`…lan_mod_level` | `[commands]` | (none — audio-path; see memory note) |
+| `1A 05 0091-0094` DATA OFF/1/2/3 MOD | S/R | `get/set_data_off_mod_input` … `data3` | `[commands]` | (none; live-critical, see MEMORY.md) |
+| `1A 05 0112` CI-V Transceive | S/R | `get/set_civ_transceive` | `[commands]` | (config; not checked) |
+| `1A 05 0114` CI-V Output (ANT) | S/R | `get/set_civ_output_ant` | `[commands]` | (config) |
+| `1A 05 0158/0159/0162` date/time/UTC | S/R | `get/set_system_date`/`…time`/`…utc_offset` | `system_settings` | `system_date.read`✅ `system_time.read`✅ (READ-only) |
+| `1A 05 0290/0291` NB depth/width | S/R | `get/set_nb_depth`/`…nb_width` | `[commands]` | (none) |
+| `1A 05 0292` VOX delay | S/R | `get/set_vox_delay` | `[commands]` | (none) |
+| `1A 05 0228` dot/dash ratio | S/R | `get/set_dash_ratio` | `[commands]` | (none) |
+| `1A 06` DATA mode w/ filter | S/R | `get/set_data_mode` | `data_mode` cap | `data_mode.presence` ✅ |
+| `1A 09` AF mute | S/R | `get/set_af_mute` | `[commands]` | (none) |
+| `1B 00/01` repeater/TSQL tone freq | S/R | `get/set_tone_freq`/`…tsql_freq` | `[commands]` | (cap not declared — Gap D) |
+| `1C 00` PTT (RX/TX) | S/R | `set_ptt` | `ptt_on/off` | `tx.ptt` manual_required (TX-gated) |
+| `1C 01` antenna tuner | S/R | `get/set_tuner_status` | `tuner` cap | `tuner.tune` manual_required (TX-gated) |
+| `1C 02` XFC (TX freq monitor) | S/R | `get/set_xfc_status` | `xfc` cap | `xfc.presence` ✅ |
+| `1C 03` read TX freq | R | `get_tx_freq_monitor` | `[commands]` | (none) |
+| `0E` scan start/stop/resume | S | `scan_start`/`scan_stop`/`scan_set_*` | `scan` cap | `scan.presence` ✅ |
+| `21 00/01/02` RIT freq/on/ΔTX | S/R | `get/set_rit_frequency`/`…rit_status`/`…rit_tx_status` | `rit`,`xit` | `rit.set` RMVR ✅ · `xit.set` RMVR ✅ |
+| `25` main/sub band freq | S/R | (via `_dual_rx_runtime`) `get_selected_freq`/`unselected` | `[commands]` | (covered by `vfo_slot.set`) |
+| `26` operating mode+filter (both) | S/R | (via dual_rx) `get_selected_mode`/`unselected` | `[commands]` | — |
+| `27 10` scope ON/OFF | S/R | `enable_scope`/`disable_scope` | `scope` cap | `scope.capture` manual_required |
+| `27 11` scope data output | S/R | `scope_stream` | `[commands]` | (streamed) |
+| `27 12` main/sub scope | S/R | `get/set_scope_receiver` | scope | `scope_receiver.set` RMVR ✅ |
+| `27 13` single/dual scope | S/R | `get/set_scope_dual` | scope | **`scope_dual.set` RMVR ❌ FAIL** |
+| `27 14` scope mode | S/R | `get/set_scope_mode` | scope | `scope_mode.set` RMVR ✅ |
+| `27 15` span | S/R | `get/set_scope_span` | scope | `scope_span.set` RMVR ✅ |
+| `27 16` edge number | S/R | `get/set_scope_edge` | scope | `scope_edge.set` RMVR ✅ |
+| `27 17` scope hold | S/R | `get/set_scope_hold` | scope | `scope_hold.set` RMVR ✅ |
+| `27 19` reference level | S/R | `get/set_scope_ref` | scope `[scope]` | `scope_ref.set` RMVR ✅ |
+| `27 1A` sweep speed | S/R | `get/set_scope_speed` | scope | `scope_speed.set` RMVR ✅ |
+| `27 1B` scope during TX | S/R | `get/set_scope_during_tx` | scope | `scope_during_tx.set` RMVR ✅ |
+| `27 1C` center type | S/R | `get/set_scope_center_type` | scope | `scope_center_type.set` RMVR ✅ |
+| `27 1D` VBW | S/R | `get/set_scope_vbw` | scope | **`scope_vbw.set` RMVR ❌ FAIL** |
+| `27 1E` fixed edge freqs | S/R | `get/set_scope_fixed_edge` | scope | `scope_fixed_edge.read` READ ✅ |
+| `27 1F` RBW | S/R | `get/set_scope_rbw` | scope | **`scope_rbw.set` RMVR ❌ FAIL** |
+| `27 20` marker position | S/R | — | — | (NEW — see Gap C) |
+
+### Intentionally OUT OF SCOPE (device front panel / non-operator — nothing to mirror into a browser UI)
+- **`13` speech synthesizer** (voice readout — front panel), **`14 19` LCD backlight**, **`1A 02` memory keyer contents** (CW message store — feature, not a live control).
+- **`1A 05` menu tail** (`0022`–`0309`, hundreds of params): beep/tone-control EQ, RTTY/PSK decode, recorder, keyboard/mouse, network (DHCP/IP/ports), display (LCD/LED/meter type/screen saver), scope cosmetics (waterfall colour/size/averaging/fixed-edge memory), antenna memory, USB SEND/keying routing. These are Set-mode configuration, not operator controls — out of harness scope by design (same policy as FTX-1's EX menu / Table 3).
+- **`1E`** TX band-edge enumeration (regulatory band table — read-only metadata).
+- Memory channel family (`08`/`09`/`0A`/`0B`/`1A 00`) — backend methods exist (`get/set_memory_mode`, `memory_write/to_vfo/clear`, `get/set_memory_contents`) but memory ops are a deferred UI feature, not a CAT round-trip surface.
+
+---
+
+## Gap lists (priority-ordered)
+
+### A. UNDER-DECLARED — backend implements, profile/registry can't round-trip it
+
+The IC-7610 driver is *very* complete (≈150 `get_/set_` methods). The recurring gap: a method exists **and** the profile declares either a `[capabilities]` feature or a `[commands]` string, but no RMVR check is registered — so the control is invisible to validation beyond, at best, a `*.presence` ping. Highest-value missing RMVRs (all backend + profile present, just no registry entry):
+
+| Control | Backend (verified) | Why it matters | Ticket |
+|---|---|---|---|
+| **RF power** `14 0A` | `get/set_rf_power` | core TX control, fully readable/writable, zero round-trip | **NEW** |
+| **MIC gain** `14 0B` | `get/set_mic_gain` | primary TX-audio control | **NEW** |
+| **COMP level** `14 0E` | `get/set_compressor_level` | only `compressor.presence` exists (on/off), level unchecked | **NEW** |
+| **NR level / NB level** `14 06`/`14 12` | `get/set_nr_level`/`…nb_level` | on/off has RMVR; the *level* (the operator-visible slider) does not | **NEW** |
+| **CW pitch** `14 09` | `get/set_cw_pitch` | RMVR-friendly (300–900 Hz), CW op control | **NEW** |
+| **notch filter pos / manual-notch width** `14 0D`/`16 57` | `get/set_notch_filter`, `…manual_notch_width` | `notch.set` only round-trips the on/off, not position/width | **NEW** |
+| **monitor / drive / anti-VOX gain** `14 15`/`14 14`/`14 17` | resp. methods | `drive_gain` only `*.presence`; monitor/anti-VOX no check | **NEW** |
+| **PBT inner/outer** `14 07/08` | `get/set_pbt_inner/outer` | `pbt.presence` only; pos is RMVR-able (0–255) | **NEW** |
+| **AGC time constant** `16 12`/`1A 04` | `get/set_agc`, `get/set_agc_time_constant` | `agc.set` round-trips speed; the `1A 04` selected-filter time-constant path is unchecked | **NEW** |
+| **AF mute** `1A 09` | `get/set_af_mute` | clean boolean RMVR, declared in `[commands]`, no check | **NEW** |
+| **USB/LAN/DATA MOD inputs** `1A 05 0089-0094` | `get/set_usb_mod_level`,`…lan_mod_level`,`…data_off/1/2/3_mod_input` | **live-critical** — DATA-OFF MOD=LAN is the documented fix for the "web TX = noise" class of bug (see MEMORY.md); these have methods + `[commands]` strings but no round-trip guard | **NEW** |
+| **tuning step / band edge** `10`/`02` | `get/set_tuning_step`, `get_band_edge_freq` | `tuning_step.presence`/`band_edge.presence` only — step is a clean RMVR | **NEW** (low) |
+
+Recommended fix (one ticket per cluster): add `RMVR_SAFE_WRITE` checks to the registry (`_levels.py`/`_dsp.py`/`_tx.py`/`_audio.py`) gated on the already-declared capabilities; for the MOD-input cluster, a dedicated `_audio`/`_system` round-trip since it guards a known field-failure mode.
+
+### B. VALIDATION GAPS — implemented + declared, but presence-only (no round-trip)
+
+These have a capability **and** a registered check, but the check is `*.presence` (confirms the command answers) rather than set-then-verify. All pass live; upgrading to RMVR would catch silent write-failures.
+
+| Capability | Backend | Live | Recommendation | Ticket |
+|---|---|---|---|---|
+| `compressor` `16 44` | `get/set_compressor` | `compressor.presence` ✅ | RMVR (toggle on/off) | **NEW** |
+| `break_in` `16 47` | `get/set_break_in` | `break_in.presence` ✅ | RMVR (OFF/SEMI/FULL) | **NEW** |
+| `filter_shape` `16 56` | `get/set_filter_shape` | `filter_shape.presence` ✅ | RMVR (SHARP/SOFT) | **NEW** |
+| `ssb_tx_bw` `16 58` | `get/set_ssb_tx_bandwidth` | `ssb_tx_bw.presence` ✅ | RMVR (WIDE/MID/NAR) | **NEW** |
+| `twin_peak` `16 4F` | `get/set_twin_peak_filter` | `twin_peak.presence` ✅ | RMVR (guarded: only valid in RTTY 2125/170) | **NEW** (low) |
+| `digisel`/`ip_plus` `16 4E`/`16 65` | resp. | `*.presence` ✅ | RMVR booleans | **NEW** (low) |
+| `apf`/`pbt`/`drive_gain` | resp. | `*.presence` ✅ | level RMVR (folds into Gap A) | **NEW** |
+| `data_mode` `1A 06` | `get/set_data_mode` | `data_mode.presence` ✅ | RMVR | **NEW** (low) |
+| `main_sub_tracking` `16 5E` | `get/set_main_sub_tracking` | `*.presence` ✅ | RMVR boolean | **NEW** (low) |
+| `xfc` `1C 02` | `get/set_xfc_status` | `xfc.presence` ✅ | RMVR boolean | **NEW** (low) |
+| `monitor` `16 45` | `get/set_monitor` | `monitor.presence` ✅ | RMVR boolean | **NEW** (low) |
+
+### C. MISSING BACKEND — documented operator command, no backend method
+
+The driver is near-complete; genuinely-missing *operator-facing* commands are few. The rest of the manual's unimplemented commands are device-front-panel/config (listed OUT OF SCOPE above).
+
+| CI-V cmd | Function | Value | Ticket |
+|---|---|---|---|
+| **`27 20`** | Scope **marker position** (Filter-center vs Carrier-point) | Low — scope cosmetic but a live-changeable scope control, not a Set-mode-only param | **NEW** (low) |
+| `13` speech / `1A 02` memory keyer / memory channel family | voice readout · CW keyer store · memory ch | Feature/front-panel — track as a UI feature, not a CAT gap | — (out of scope) |
+
+### D. MISMATCH / WRONG — declared/checked but behaves differently (the live FAILs)
+
+| CI-V cmd | check_id | Issue | Ticket |
+|---|---|---|---|
+| **`27 13`** single/dual | **`scope_dual.set` ❌** | Set does not round-trip on the IC-7610. Per MOR-664 the dual-scope write needs the **dual-RX precondition** (the radio rejects/ignores the single→dual flip unless the second receiver is active), so read-back never matches the requested value. | **MOR-664** |
+| **`27 1D`** VBW | **`scope_vbw.set` ❌** | Verified asymmetry: `get_scope_vbw` passes `receiver=` into `_get_scope_vbw_cmd` (`runtime/_scope_runtime.py:410-421`), but `set_scope_vbw` calls `_scope_set_vbw_cmd(narrow, …)` with **no receiver** (`:423-429`). When the scope source is SUB the set lands on the wrong RX and read-back mismatches. | **MOR-664** |
+| **`27 1F`** RBW | **`scope_rbw.set` ❌** | Same receiver-prefix asymmetry: `get_scope_rbw` takes `receiver=` (`:473-484`) while `set_scope_rbw` (`:486-492`) omits it. | **MOR-664** |
+| (note) `27 1E` fixed edge | `scope_fixed_edge.read` ✅ | Already mitigated for the read path — `get_scope_fixed_edge` injects a `<range><edge>` selector (range 1, edge 1) or the IC-7610 NAKs the read (fixed by **MOR-662**). Documented here so the pattern (selector/receiver-prefix on `0x27` sub-reads) is visible. | — (fixed) |
+| (note) `16 42/43`, `1B 00/01` tone | — | Repeater-tone / TSQL / tone-freq have **backend methods + `[commands]` strings** but the `repeater_tone`/`tsql` **capabilities are NOT declared** in `[capabilities].features` (IC-7610 is HF/6m, no FM-repeater CTCSS surfaced) — so no tone check runs. Correct intent, but the dangling `[commands]` entries are dead weight; either drop them or gate behind an explicit "no FM repeater" note. | **NEW** (doc/cleanup, low) |
+
+The 3 red FAILs all trace to **MOR-664** (already filed). MOR-659/660/661/662/663/665 were the live-found-and-fixed scope/read issues from the same session and are not re-filed.
+
+---
+
+## Ticket coverage summary
+
+- **3 live FAILs** (`scope_dual.set` / `scope_vbw.set` / `scope_rbw.set`) → **MOR-664** (receiver-prefix on `0x27 1D/1F` set + dual-RX precondition on `0x27 13`). Verified in code (set-path omits the `receiver=` the get-path uses).
+- **Gap A** (under-declared, no RMVR): ~12 clusters of fully-implemented controls — headline = **RF power / MIC gain / COMP level / NR+NB level / CW pitch / MOD-input routing**. All **NEW**.
+- **Gap B** (presence-only → RMVR upgrade): ~11 capabilities, headline = **compressor / break_in / filter_shape / ssb_tx_bw**. All **NEW**.
+- **Gap C** (missing backend): only **`27 20` marker position** is a real (low-value) operator gap. **NEW**. Everything else is front-panel/feature, out of scope.
+- **Gap D** (mismatch): the 3 FAILs (MOR-664) + a doc-cleanup note on the dead tone `[commands]` entries (**NEW**, low).

--- a/docs/validation/cat-audits/tx500.md
+++ b/docs/validation/cat-audits/tx500.md
@@ -1,0 +1,110 @@
+# Discovery TX-500 (Lab599) — CAT manual vs implementation
+
+**Manual:** Lab599 **CAT Protocol rev. 2** (official) — full per-command parameter tables; cross-checked against TX-500 User Manual v1.12.08 (04.2022) and the Ham Radio Deluxe support note. Sources + SHA in `manuals/tx500.txt`.
+**Protocol family (CONFIRMED):** Kenwood-style **ASCII CAT**, `;`-terminated (`FA`/`MD`/`IF`/…), modeled on the Kenwood **TS-2000** set with Lab599 extensions — **NOT** Icom CI-V. `ID;` → `ID019` (TS-2000 compat) or `ID500`/`ID505` (native Lab599). PL2303 USB-serial cable, 38400 baud.
+**Driver:** **NONE.** No `kenwood_cat` backend exists. `backends/factory.py` has no Kenwood path; `create_radio(SerialBackendConfig(model="TX-500"))` **raises `ValueError: Unsupported serial model`** (asserted by `tests/test_backend_factory.py:143`). `probe_serial_kenwood_cat()` in `discovery.py:540` is a stub that **always returns `None`** ("reserved for future use"). The `yaesu_cat` backend is Yaesu-specific ASCII CAT and does not speak the Kenwood wire shape.
+**Profile:** `rigs/tx500.toml` (`protocol.type = "kenwood_cat"`, minimal — empty `[commands]`). A richer reference profile exists at `rigs/examples/lab599_tx500.toml` (not loaded by default).
+**Validation:** `src/rigplane/validation/registry/*` — capability-driven; the matrix template is derived from `[capabilities] features` (`_builders.build_template_from_capabilities`), so checks are emitted for the TX-500's declared features **regardless of backend existence**. With no backend, every functional check would resolve `unsupported`/error at runtime.
+**Live run:** **not run** — no hardware, and there is no instantiable backend to run against. All live cells below are `n/a (no backend)`.
+
+> Bottom line: the TX-500 is a **profile-only, no-backend radio**. This audit therefore reads differently from `ftx1.md`: the dominant gap is **C (missing backend)** — the entire operator command surface — not scattered per-command gaps. Lists A/B/D are mostly N/A until a Kenwood backend exists, and are filled with the profile-level mismatches that already exist on disk.
+
+---
+
+## Command matrix (operator-facing)
+
+Documented = present in Lab599 CAT Protocol rev. 2. Backend = method on a real TX-500 driver (none exists → always `—`). Profile cap/cmd = `rigs/tx500.toml` `[capabilities]` / `[commands]`. Validation = registry `check_id` that *would* be emitted from the declared capability + its status.
+
+| CAT | Documented (Lab599 rev.2) | Backend method | Profile cap / cmd | Validation check_id · status |
+|---|---|---|---|---|
+| **FA/FB** | VFO A/B freq, 11-digit Hz | — (no driver) | `tx` implies; example has `get/set_freq_a/b` strings, **`tx500.toml` has none** | `freq.*` · n/a (no backend) |
+| **MD** | Mode (1=LSB 2=USB 3=CW 4=FM 5=AM **6=DIG** 7=CW-R) | — | modes list declared | `mode.*` · n/a |
+| **IF** | Full status (freq+RIT/XIT+mode+split+tone) | — | — (no `get_info` string) | (feeds freq/mode/rit) · n/a |
+| **FR/FT** | VFO/Memory select (0=A 1=B 2=Mem) | — | `split` implies; no string | `vfo_select` · n/a |
+| **SP** | Split ON/OFF (TX500) | — | `split` | `split.presence` · n/a |
+| **RX/TX** | Set RX / Set TX (PTT) | — | `tx` | `ptt.*` (manual/tx-adjacent) · n/a |
+| **PT** | Read PTT (0=RX 1=TX) | — | `tx` | `ptt` read · n/a |
+| **PS** | Power ON/OFF | — | not in `tx500.toml` (example: `power_control`) | `powerstat` · n/a |
+| **AG** | AF gain 000–250 | — | `af_level` | `af_level.*` · n/a |
+| **RG** | RF gain 000–100 | — | `rf_gain` | `rf_gain.*` · n/a |
+| **SQ** | Squelch 000–255 | — | `squelch` | `squelch.*` · n/a |
+| **PA** | Preamp ON/OFF | — | `preamp` (+`PA;` string in example) | `preamp.*` · n/a |
+| **RA** | RF attenuator ON/OFF | — | `attenuator` (+`RA;` string in example) | `attenuator.*` · n/a |
+| **FL** | Filter select (RX 0-3 / TX 0-1) | — | `filter_width` | `filter_width.*` · n/a |
+| **IS** | DSP IF set (0/1) | — | not declared | — |
+| **NB** / **NL** | Noise blanker ON/OFF / level 030–100 | — | `nb` | `nb.*` · n/a |
+| **NR** / **RL** | Noise reduction ON/OFF / level 01–100 | — | `nr` | `nr.*` · n/a |
+| **NT** | Notch (0=OFF 1=Auto) | — | not in `tx500.toml` (example: `notch`) | `notch.*` (only if declared) · n/a |
+| **GT** | AGC time constant 01–10 | — | not declared | `agc.*` (not declared) |
+| **RT** | RIT ON/OFF | — | `rit` | `rit.*` · n/a |
+| **XT** | XIT ON/OFF (TX-500) | — | not in `tx500.toml` (example: `xit`) | `xit.*` (only if declared) · n/a |
+| **PC** | Output power 010–100 | — | not declared (example notes "NOT via CAT" — **contradicted by rev.2**) | — |
+| **TP** | TX-Tune output power 005–050 | — | not declared | — |
+| **AC** | Internal antenna tuner (TX500MP) | — | `tuner` | `tuner.*` · n/a |
+| **PR** / **PL** | Speech compressor ON/OFF / level 001–100 | — | not declared | — |
+| **VX** / **VG** / **VD** | VOX ON/OFF / gain 000–100 / delay 0–5000ms | — | not in `tx500.toml` (example: `vox`) | `vox.*` (only if declared) · n/a |
+| **KS** | CW keyer speed 004–060 | — | `cw` declared, no keyer cap | `cw` keyer · n/a |
+| **MG** | Mic gain 000–100 | — | not declared | — |
+| **MA** | DIG (data) gain 000–100 | — | not declared (example: `data_mode`) | — |
+| **ML** / **MO** | TX-Monitor level 000–250 / mute | — | not declared | — |
+| **LK** | Lock (dial lock) | — | `dial_lock` | `dial_lock.*` · n/a |
+| **SM** | Read S-meter / TX power (0000–0030) | — | `meters` | `meters`/`s_meter` · n/a |
+| **RM** | Meter select (POWER/SWR/MIC/ALC) + value | — | `meters` | `meters` · n/a |
+| **VL** | Read supply voltage (Lab599) | — | not declared | — |
+| **BY** | Read busy/squelch-open | — | not declared | — |
+| **AL** | NF (noise-floor) type 1/2 (Lab599) | — | not declared | — |
+| **CG** | Carrier/TUNE-TONE level 10–100 | — | not declared | — |
+| **AI** | Auto-information on/off (per HRD note) | — | not declared | — |
+
+### Intentionally OUT OF SCOPE (memory / scan / tone / band-step — not browser-operator surface)
+- **MC / MR / MW** memory channel read/write · **VV** VFO copy (A=B) · **BD/BU** band up/down · **CN / CT / TO** CTCSS/Tone (TX500MP only; TX-500 has no repeater FM use case in scope) · **SC** scan (referenced by IF P11, no standalone row in rev.2).
+
+---
+
+## Gap lists (priority-ordered)
+
+### C. MISSING BACKEND — documented operator command, no backend method *(dominant list for this radio)*
+
+The TX-500 has **no driver at all**; the single root fix dwarfs every per-command row.
+
+| Item | Function | Value | Ticket |
+|---|---|---|---|
+| **Kenwood-CAT backend (root)** | A `backends/kenwood_cat/` ASCII-CAT driver (transport + `get_/set_` surface), wired into `factory.create_radio` for `protocol.type="kenwood_cat"` / `model="TX-500"`. Today instantiation **raises `ValueError`** (`factory.py:100-107`, asserted `test_backend_factory.py:143`). Without it, **the entire matrix above is dead.** | **Critical** — unblocks the radio entirely | **NEW** |
+| **`probe_serial_kenwood_cat`** | Real probe (currently `return None`, `discovery.py:558`) so the TX-500 is auto-discoverable; `ID;`→`ID019/500/505` is the natural fingerprint. | High — discovery/setup | **NEW** |
+| FA/FB · MD · IF · FR/FT · RX/TX/PT | Core tuning + mode + PTT methods on the new driver | High (operating) | **NEW** (sub-tasks of root) |
+| AG · RG · SQ · PA · RA · FL | Level + front-end + filter methods | High | **NEW** |
+| NB/NL · NR/RL · NT · GT | DSP methods | Med | **NEW** |
+| RT · XT · SP | RIT / XIT / split | Med | **NEW** |
+| PC · TP · AC · PR/PL · VX/VG/VD · KS · MG · ML/MO | Power, tuner, compressor, VOX, keyer, mic, TX-monitor | Med (operating) | **NEW** |
+| SM · RM · VL · BY | Meters + voltage + busy readback | Med (UI meters) | **NEW** |
+| Hamlib-bridge raw-byte seam | `hamlib_bridge.py` only carries CI-V bytes; non-CI-V ASCII rigs (Yaesu/Kenwood, TX-500) need a raw-*byte* pipe seam (noted as follow-up in the module docstring). | Low — rigctld interop | **NEW** |
+
+### D. MISMATCH / WRONG — profile declares/implies something the doc contradicts
+
+These are **on-disk profile bugs** in `rigs/tx500.toml` / `rigs/examples/lab599_tx500.toml` that will mislead the future backend + the validation matrix.
+
+| Where | Item | Issue | Ticket |
+|---|---|---|---|
+| `examples/lab599_tx500.toml:117-123` | `rf_power` "NOT controllable via CAT (TS-2000 PA/RA only)" | **Wrong per rev.2** — `PC` (010–100) and `TP` (005–050) DO set power. Comment is based on the stale HRD/TS-2000 subset. | **NEW** |
+| `examples/lab599_tx500.toml:37,186` & `tx500.toml` modes | `set_mode` comment `6=FSK … 9=FSK-R`; modes list includes `RTTY/RTTY-R` | **Wrong per rev.2** — TX-500 map is `6=DIG`, `7=CW-R`; no FSK/RTTY/9 register. `tx500.toml` modes (`DIGI`, `CW-R`) are closer but label is `DIGI` vs doc `DIG`. | **NEW** |
+| `tx500.toml` vs `examples/` | Two divergent profiles, different feature sets (`tx500.toml` drops `notch/xit/vox/power_control/data_mode/memory_channels` that the example declares) | Decide the canonical profile before backend work; the loaded one (`tx500.toml`) under-declares vs the documented radio. | **NEW** |
+| `tx500.toml:121-123` | `[commands]` is an empty comment stub (`# ID FA FB MD FR FT PA RA`) | No CAT strings wired; the example's `[protocol.commands]` block is the usable starting point but lives in `examples/`. | **NEW** |
+| profile attenuator label | `attenuator.values=[0,1]` "20dB" | rev.2 `RA` is `00/01` ON/OFF (2-char) — value mapping fine, but width (2-char) must be honored by the backend. | note |
+
+### A. UNDER-DECLARED — backend implements, profile/registry can't see it
+
+**N/A** — there is no backend, so nothing is implemented-but-hidden. (Revisit after the Kenwood backend lands: e.g. if it implements `VL` voltage / `RM` meter-select but the profile omits the cap, those become real A-rows.)
+
+### B. VALIDATION GAPS — implemented + declared, but presence-only (no round-trip)
+
+**N/A today** (no backend → no round-trips to downgrade). After the backend lands, the capability-driven registry will emit standard checks; expect the usual presence-only suspects to need RMVR round-trips: **`split` (SP)**, **`tuner` (AC)**, **`dial_lock` (LK)**, **`vox` (VX/VG/VD)** — same pattern as the FTX-1 B-list. Pre-flagged **NEW** for when they apply.
+
+---
+
+## Documentation quality note
+
+- **HIGH confidence** on the mnemonic set, parameter widths, and the mode map — source [1] is Lab599's own protocol PDF (rev. 2) with per-command parameter tables.
+- **Variant ambiguity (needs live capture):** rev.2 annotates some rows for a specific variant — `AC`/`CN`/`CT`/`MA`-ish rows marked **TX500MP**, `SP`/`BD`/`BU`/`VV`/`XT` marked **TX500**, and several `Lab599`/`LAB599` extension rows (`FL`, `IS`, `RM`, `VL`, `AL`, `MR`/`MW`). Which of these answer on a **plain TX-500** at a given firmware is **unconfirmed** — a `;`-terminated read sweep (`ID;`, `AG;`, `PC;`, `KS;`, `NT;`, `VL;`, `RM0;`) on real hardware is required before declaring caps.
+- **`MD` label:** doc says `DIG`; `tx500.toml` says `DIGI` — confirm the exact answer byte map live.
+- **Stale third-party docs:** the HRD support note (source [3]) lists only the legacy TS-2000-compat subset and wrongly says AF/power/keyer are unsupported; **do not** scope the backend from it — rev.2 supersedes it.
+- **Live status:** every cell in this audit is **doc-vs-code only**; no hardware was driven. Mark all live results "not run / no backend" until the Kenwood backend + a real TX-500 capture exist.

--- a/docs/validation/cat-audits/x6200.md
+++ b/docs/validation/cat-audits/x6200.md
@@ -1,0 +1,132 @@
+# Xiegu X6200 — CAT (CI-V) reference vs implementation
+
+**Manual:** Radioddity **"XIEGU X6200 CI-V implementation V1.0.6"** (Firmware V1.0.6, dated 2025-06-20, 13 pp.) — official, tabular, **CONFIRMED** for its documented subset. Cross-referenced against Hamlib `rigs/icom/xiegu.c` (`x6100_priv_caps`, reused by X6200; `RIG_MODEL_X6200 = 3091`). Sources + verbatim extract: `manuals/x6200.txt` (+ committed `manuals/x6200_civ_v1.0.6.pdf`). **Confidence: high** for documented opcodes; Hamlib `X108G_LEVELS/FUNCS` over-advertise — the Radioddity table wins.
+**Driver:** no `x6200/` dir — X6200 routes through `Ic705SerialRadio` (`src/rigplane/backends/ic705/serial.py`) → `_IcomSerialRadioBase` → **`CoreRadio`** (`src/rigplane/runtime/radio.py`, all `get_/set_` live here). Factory: `backends/factory.py:85` maps `model in ("IC-705","X6200")` to `Ic705SerialRadio`; personality comes from `rigs/x6200.toml` (`model="X6200"`), not a distinct class.
+**Profile:** `rigs/x6200.toml` (CI-V addr `0xA4`, 19200 bps SERIAL-B). **Validation:** `src/rigplane/validation/registry/*`.
+**Live run:** **not run** — live serial access unavailable to this audit. All statuses are doc-vs-code; every "live" column is `not run`.
+
+Protocol: CI-V-derived (FE FE A4 00 .. FD), narrower than Icom. Disambiguated from IC-705 (same 0xA4) by Xiegu-only `0x1D 0x19` model-ID → `6200`. CH342 dual-UART. **0x18 power on/off intentionally absent** (the documented wedge trigger — MOR-170).
+
+> **Routing fact that drives the gaps below:** `CoreRadio` setters/getters build CI-V frames from **hardcoded opcodes in `commands/*` builders**, *not* from the profile `[commands]` map (the `cmd_map=` path is never passed for these). The profile gate is `_require_capability(<feature>)`. So a declared `[capabilities] feature` activates a method whose opcode is fixed in code — which may not match a Xiegu-documented opcode. The `[commands]` opcode table in `x6200.toml` is largely **descriptive, not wired** for the legacy freq/mode/func paths.
+
+---
+
+## Command matrix (operator-facing)
+
+Legend — Documented: ✅ in Radioddity V1.0.6 table · ⚠️ narrative-only / uncertain · ❌ absent.
+Validation: RMVR = round-trip readback check · presence = `<cap>.presence` only · — = no check / cap absent · structural = `capability=""`.
+
+| CAT (X6200 opcode) | Documented | Backend method (CoreRadio) | Profile cap / cmd | Validation check_id · live |
+|---|---|---|---|---|
+| `0x25 0x00/0x01` selected/unselected freq | ✅ | `get_selected_freq`/`set_selected_freq`/`_unselected_` (dual-RX mixin) | `get/set_selected_freq`, `get/set_unselected_freq` | `freq.write`,`freq.reverse_sync` (structural) · not run |
+| `0x03`/`0x05` freq (legacy) | ⚠️ narrative only | `get_freq`/`set_freq` → **main RX path uses hardcoded `0x03/0x05`** | `get_freq=[0x03]`,`set_freq=[0x05]` (declared, not wired) | via `freq.*` structural · not run |
+| `0x26 0x00/0x01` selected/unselected mode | ✅ | `get_selected_mode`/`set_selected_mode`/`_unselected_` | `get/set_selected_mode`,`get/set_unselected_mode` | `mode.set` (structural) · not run |
+| `0x04`/`0x06` mode (legacy) | ❌ (not in table) | `get_mode`/`set_mode` → **main path hardcoded `0x04/0x06`** | `get_mode=[0x04]`,`set_mode=[0x06]` (declared, not wired) | `mode.set` · not run |
+| `0x02` RX freq range | ✅ | `get_band_edge_freq` | `get_band_edge_freq=[0x02]` | — |
+| `0x07 0x00/0x01` VFO A/B select; `0x07 0xB0` swap | ✅ | `get/set_vfo_slot` (DualRxRuntimeMixin), `swap_vfo_ab` | `get/set_vfo=[0x07]`; `[vfo] scheme="ab"` | `vfo_slot.set` (structural RMVR) · not run |
+| `0x0F 0x00/0x01` split | ✅ (set only) | `set_split`/`get_split` (hardcoded `0x0F`) | `split`; `set_split=[0x0F]` | `split.set` RMVR · not run |
+| `0x11` attenuator on/off | ✅ | `get/set_attenuator` | `attenuator`; `get/set_attenuator=[0x11]` | `attenuator.set` RMVR · not run |
+| `0x16 0x02` preamp | ✅ | `get/set_preamp` | `preamp`; `get/set_preamp=[0x16,0x02]` | `preamp.set` RMVR · not run |
+| `0x16 0x12` AGC | ✅ | `get/set_agc` | `agc`; `get/set_agc=[0x16,0x12]` | `agc.set` RMVR · not run |
+| `0x16 0x22` noise blanker | ✅ | `get/set_nb` | `nb`; `get/set_nb=[0x16,0x22]` | `nb.set` RMVR · not run |
+| `0x16 0x40` NR on/off | ✅ | `get/set_nr` (hardcoded `0x16 0x40`) | `nr` | `nr.set` RMVR · not run |
+| `0x16 0x44` COMP on/off | ✅ | `get/set_compressor` (hardcoded `0x16 0x44`) | `compressor` | presence-only · not run |
+| `0x16 0x50` key/dial lock | ✅ | `get/set_dial_lock` | `dial_lock`; `get/set_dial_lock=[0x16,0x50]` | `dial_lock.set` RMVR · not run |
+| `0x14 0x01` AF | ✅ | `get/set_af_level` | `af_level`; `[0x14,0x01]` | `af_level.set` RMVR · not run |
+| `0x14 0x02` RF gain | ✅ | `get/set_rf_gain` | `rf_gain`; `[0x14,0x02]` | `rf_gain.set` RMVR · not run |
+| `0x14 0x03` squelch | ✅ | `get/set_squelch` | `squelch`; `[0x14,0x03]` | `squelch.set` RMVR · not run |
+| `0x14 0x06` NR level | ✅ | `get/set_nr_level` | `nr`; `[0x14,0x06]` | — (cap `nr` covered by `nr.set` on/off only) |
+| `0x14 0x09` CW pitch | ✅ | `get/set_cw_pitch` | `cw`; `[0x14,0x09]` | — |
+| `0x14 0x0A` TX power | ✅ | `get/set_rf_power` | `tx`; `[0x14,0x0A]` | — (no `rf_power` RMVR check) |
+| `0x14 0x0B` mic gain | ✅ | `get/set_mic_gain` | `[0x14,0x0B]` | — |
+| `0x14 0x0C` keyer speed | ✅ | `get/set_key_speed` | `cw`; `[0x14,0x0C]` | `key_speed.set` RMVR · not run |
+| `0x14 0x0D` DNF/notch FC | ✅ | `get/set_notch_filter` (hardcoded `0x14 0x0D`) | `notch` (no cmd string) | (see notch row below) |
+| `0x14 0x0F` QSK hang | ✅ | `get/set_break_in_delay` (Icom uses `0x14 0x10`?) | `break_in` (no cmd string) | — |
+| `0x14 0x12` NB level | ✅ | `get/set_nb_level` | `nb`; `[0x14,0x12]` | — |
+| `0x14 0x15` MONI level | ✅ | `get/set_monitor_gain` | `[0x14,0x15]` | — |
+| `0x15 0x02/0x11/0x12/0x15` S/pwr/SWR/Vd meters | ✅ | `get_s_meter`/`get_power_meter`/`get_swr`/`get_vd_meter` | `meters`; `[0x15,..]` | `meters.read` RO · not run |
+| `0x1A 0x01` band/spectrum + band-stacking set | ✅ | `get_band_spectrum_display` / `set_bsr` | `get_band_spectrum_display=[0x1A,0x01]` | `bsr.select` (cap `bsr` **not declared** → resolves UNSUPPORTED) · not run |
+| `0x1A 0x03` IF filter width (read) | ✅ | `get_filter_width` (`set_filter_width` exists) | `get_filter_width=[0x1A,0x03]`; cap `filter_width` **not declared** | — (`filter_width.set` skipped: cap absent) |
+| `0x1A 0x05 (00 62)` LCD/key LOCK | ✅ | (no dedicated method; overlaps `dial_lock` 0x16 0x50) | — | — |
+| `0x1C 0x00` PTT | ✅ | `set_ptt`/`get_transceiver_status` | `tx`; `ptt_on/off=[0x1C,0x00]` | `tx.ptt` (MANUAL) · not run |
+| `0x1C 0x01` ATU (off/on/auto-tune) | ✅ | `get/set_tuner_status` | `tuner`; `get/set_tuner_status=[0x1C,0x01]` | `tuner.tune` (MANUAL) · not run |
+| `0x19 0x00` radio ID | ✅ | `get_transceiver_id` | `get_transceiver_id=[0x19,0x00]` | `discovery.identify` (structural) · not run |
+| `0x1D 0x19` Xiegu model ID → 6200 | ✅ | (discovery probe `probe_xiegu_model_id`) | `get_xiegu_model_id=[0x1D,0x19]` | discovery-only · not run |
+| **DNF on/off `0x16 0x41`** | ✅ | **no method** — `notch` cap routes to `set_manual_notch` (`0x16 0x48`, NOT X6200) | `notch` declared | `notch.set` RMVR → **wrong opcode** (D) |
+| **break-in (QSK) on/off** | ✅ only as `0x14 0x0F` hang time | `get/set_break_in` → hardcoded **`0x16 0x47`** (NOT X6200) | `break_in` declared | presence-only · not run (D) |
+| **VOX** | ❌ no CI-V | `get/set_vox` → hardcoded **`0x16 0x46`** (NOT X6200) | `vox` declared | `vox.read`/`vox.set`(TX-blocked) · not run (D) |
+| **repeater tone / TSQL / tone freq** | ❌ no `0x1B`/`0x16 0x42-43` | `get/set_repeater_tone`/`_tsql`/`_tone_freq` → `0x16 0x42/43`, `0x1B 0x00` (NOT X6200) | `repeater_tone`,`tsql` declared | `repeater_tone.set`,`tone_freq.set`,`tsql.set`,`tsql_freq.set` RMVR → **all wrong opcode** (D) |
+| RIT / XIT `0x21` | ❌ no CI-V | `get/set_rit_frequency`/`_tx_status` → hardcoded `0x21` | `rit`,`xit`; `[validation] write_only_controls=["rit","xit","notch"]` | `rit.set`,`xit.set` RMVR (write-only) · not run (D) |
+| scope `0x27` | ❌ no CI-V | scope mixin (gated) | cap `scope` **not declared** (intentional) | `scope.*` resolve UNSUPPORTED · correct |
+| `pbt` (PBT 0x14 0x08/0x09) | ❌ no CI-V | `get/set_pbt_inner/outer` (hardcoded `0x14 0x08/09`) | `pbt` declared; `[controls.pbt_inner/outer]` | no registry check → presence-only (D) |
+| `data_mode` `0x26` data-flag / `0x1A 0x06` | partial (via 0x26 byte) | `get/set_data_mode` (hardcoded `0x1A 0x06`) | `data_mode` declared | no registry check → presence-only |
+| `scan` | ❌ no CI-V | none | `scan` declared | no registry check → presence-only |
+
+### Intentionally skipped (memory / scan / menu / display — nothing to mirror into the browser UI)
+- **Band-stacking register set** (`0x1A 0x01 D0+D1`) — band-recall UI, not a control round-trip (registry `bsr` exists but cap undeclared).
+- **LCD backlight** (`0x14 0x19`) and **`0x1A 0x05` LOCK** — front-panel display state.
+- **No memory family, no scan-table CI-V** documented for X6200 — nothing to audit.
+
+---
+
+## Gap lists (priority-ordered)
+
+### A. UNDER-DECLARED — backend implements + opcode is X6200-documented, but profile/registry can't see it
+
+| CAT (X6200) | rigplane symbol | Fix | Ticket |
+|---|---|---|---|
+| `0x1A 0x03` filter width | `get/set_filter_width` exist + `get_filter_width=[0x1A,0x03]` in toml, but `filter_width` is **not** a declared capability → `filter_width.set` check skipped entirely | Declare `filter_width` cap once the segmented BCD index tables (Table 2-4) are confirmed on hardware; the profile comment already flags this as deferred pending HW. Until then: keep as-is. | **NEW** (low) |
+| `0x14 0x0A` TX power · `0x14 0x0B` mic gain · `0x14 0x09` CW pitch · `0x14 0x15` MONI | methods exist, opcodes documented & in toml, but no RMVR registry check for `rf_power`/`mic_gain`/`cw_pitch`/`monitor` | Optional: add level RMVR checks (these are clean read/set BCD-255 pairs). Low — operator-visible but already wired. | **NEW** (low) |
+| `0x16 0x40` NR on/off · `0x16 0x44` COMP on/off | `set_nr`/`set_compressor` use exactly the documented opcodes; `compressor` is presence-only and `nr.set` covers NR | Add `compressor.set` RMVR (`get/set_compressor`, opcode is correct for X6200). | **NEW** (med) |
+
+### B. VALIDATION GAPS — implemented + declared + opcode-correct, but presence-only (no round-trip)
+
+| CAT (X6200) | rigplane symbol | Why presence-only | Ticket |
+|---|---|---|---|
+| `0x16 0x44` COMP | `get/set_compressor` | `compressor` cap has no registry check → `compressor.presence` | **NEW** (med) — opcode is X6200-correct, safe to RMVR |
+| `0x14 0x08/0x09` PBT | `get/set_pbt_inner`/`_outer` | `pbt` cap has no registry check; opcodes are generic-Icom and **not in the X6200 table** → presence masks a likely-unsupported control | **NEW** (med) — verify PBT on HW before promoting; may belong in C/D |
+| `0x1A 0x06` data mode | `get/set_data_mode` | `data_mode` cap has no registry check → presence | **NEW** (low) |
+| (n/a) scan | — | `scan` cap declared, no method, no CI-V | **NEW** (low) — drop cap or implement |
+
+### C. MISSING BACKEND — X6200-documented operator command, no (correct) backend method
+
+| CAT (X6200) | Function | Value | Ticket |
+|---|---|---|---|
+| **`0x16 0x41`** DNF on/off | Digital notch toggle — the X6200's real notch. No method binds it; `notch` cap mis-binds to `0x16 0x48` (manual notch, Icom-only). | Med — primary noise-reduction control | **NEW** (med) → see D |
+| **`0x14 0x0D`** DNF centre freq | Notch FC 100-3000 Hz. `get/set_notch_filter` exists at `0x14 0x0D` (correct!) but is not surfaced via the `notch` cap path. | Low | **NEW** (low) |
+| **`0x1A 0x05` (00 62)** key/LCD LOCK | Distinct from `0x16 0x50` dial lock; documented separately. | Low — overlaps dial_lock | **NEW** (low) |
+| **`0x1C 0x01 0x02`** ATU auto-tune | `set_tuner_status` likely only sends on/off; the `0x02` auto-tune action value may be unreached. | Med — verify auto-tune value path | **NEW** (med) |
+
+### D. MISMATCH / WRONG — declared/checked but the opcode is NOT in the X6200 documented set
+
+> These are the high-value finds: a capability is declared, a registry RMVR check is generated (and would run on live HW), but the hardcoded backend opcode is one the X6200 firmware does not document → the check would likely time out / NAK, or worse, silently hit an unrelated register. **All need a live capture to confirm true behavior.**
+
+| CAT path | rigplane symbol | Issue | Ticket |
+|---|---|---|---|
+| tone/CTCSS family | `repeater_tone.set`,`tone_freq.set`,`tsql.set`,`tsql_freq.set` RMVR checks (caps `repeater_tone`,`tsql` declared) | Backend sends `0x16 0x42/0x43` + `0x1B 0x00`. **None are in the X6200 table** — no `0x1B`, no tone funcs. 4 RMVR checks point at undocumented opcodes. | **NEW** (high) — drop `repeater_tone`/`tsql` caps from `x6200.toml` (or gate behind HW confirm) |
+| manual notch | `notch.set` RMVR (cap `notch`) | Routes to `set_manual_notch` = **`0x16 0x48`** (Icom manual notch). X6200's notch is **DNF `0x16 0x41`** + FC `0x14 0x0D`. Check targets the wrong register. | **NEW** (high) — repoint `notch` to DNF `0x16 0x41`; add `get/set` DNF methods |
+| VOX | `vox.read`/`vox.set`/`vox_gain.set` (cap `vox`) | `get/set_vox` = **`0x16 0x46`**, vox-gain `0x14 0x16` — **neither documented** for X6200. | **NEW** (med) — drop `vox` cap, or confirm on HW |
+| break-in | `break_in` cap (presence-only) | `get/set_break_in` = **`0x16 0x47`** (Icom CW BK-IN mode). X6200 documents only QSK *hang time* `0x14 0x0F`, not a BK-IN-mode register. | **NEW** (med) — remap to QSK-hang or drop cap |
+| RIT/XIT | `rit.set`,`xit.set` write-only checks (caps `rit`,`xit`) | `0x21` RIT/XIT — **not in the X6200 table**. Already partly hedged via `[validation] write_only_controls=["rit","xit","notch"]` ("SET accepted but GET times out", MOR-179/207 — those were raw-CIV-confirmed on **other** Icoms, not X6200). For X6200 the SET itself is undocumented. | **NEW** (med) — confirm `0x21` on X6200 HW; if absent, drop `rit`/`xit` caps |
+| legacy mode `0x04`/`0x06` | `get_mode`/`set_mode` main path (hardcoded `0x04/0x06`) | X6200 table documents mode **only** via `0x26`. Main RX mode read/write may not answer on `0x04/0x06`. The dual-RX `0x26` path is correct; the legacy main path is the risk. | **NEW** (high) — confirm `0x04` responds on HW; if not, route main mode through `0x26 0x00` |
+| legacy freq `0x03`/`0x05` | `get_freq`/`set_freq` main path (hardcoded `0x03/0x05`) | `0x03` appears only in the page-4 narrative example, not Table 1. Likely works (example is explicit) but unconfirmed; `0x25 0x00` is the table-blessed path. | **NEW** (med) — confirm; prefer `0x25 0x00` for main if `0x03` is flaky |
+| `pbt` | `get/set_pbt_inner`/`_outer` (`0x14 0x08/0x09`) | Generic-Icom PBT opcodes, **absent** from X6200 table; cap declared with `[controls.pbt_inner/outer]` ranges. | **NEW** (med) — confirm PBT on HW; drop cap if unsupported |
+
+### Correctly handled (no gap)
+- **`0x18` power on/off** — intentionally omitted from `x6200.toml` (MOR-170 wedge). `power_control` cap undeclared → no `powerstat` path. ✅
+- **`0x27` scope** — `scope` cap undeclared; all `scope.*` checks resolve UNSUPPORTED. Matches doc (no scope CI-V). ✅
+- **NB `0x16 0x22`, NR `0x16 0x40`, AGC `0x16 0x12`, preamp `0x16 0x02`, ATT `0x11`, AF/RF/SQL `0x14 0x01/02/03`, key-lock `0x16 0x50`, meters `0x15`, PTT/ATU `0x1C`** — opcodes match the X6200 table; checks are sound. ✅
+
+---
+
+## Documentation quality note
+
+The Radioddity V1.0.6 PDF is the single authoritative source and is **high quality for what it covers**: every opcode above marked ✅ is verbatim from Table 1. The audit's confidence is therefore high on **presence/absence of opcodes** but the following need a **live X6200 capture** before acting on the D-list:
+
+1. **Legacy `0x03`/`0x04` (main freq/mode):** `0x03` is narrative-only; `0x04` is fully absent. Does the firmware still answer them (Icom-compat), or only `0x25`/`0x26`? This decides whether the legacy main paths are silently broken.
+2. **`0x16 0x41` DNF vs `0x16 0x48` manual-notch:** confirm the X6200 NAKs `0x48` (so the `notch.set` check is a real failure, not a coincidental hit).
+3. **Tone/CTCSS, VOX, break-in, RIT/XIT (`0x1B`, `0x16 0x42/43/46/47`, `0x21`):** confirmed *doc-absent*; a live NAK capture would let us safely drop the four caps (`repeater_tone`, `tsql`, `vox`, plus `break_in`/`rit`/`xit` review) from `x6200.toml`.
+4. **PBT `0x14 0x08/0x09`:** doc-absent but cap-declared with full control ranges — most likely a copied-from-IC-705 over-declaration.
+5. **`0x1A 0x03` filter width + `0x1C 0x01 0x02` ATU auto-tune:** documented but un-surfaced / partially wired; capture to confirm the segmented BCD index and the auto-tune action value.
+
+**Headline:** the X6200 profile is **over-declared** — it inherited several IC-705-class capabilities (`repeater_tone`, `tsql`, `vox`, `break_in`, `rit`, `xit`, `notch`→manual, `pbt`) whose hardcoded backend opcodes are **not in the X6200 CI-V table**. On live hardware these generate RMVR checks that would target undocumented registers. The fix is profile-side (drop/remap caps) once a single live capture confirms the NAKs — no backend changes are needed for the correctly-wired majority.


### PR DESCRIPTION
## What

New `docs/validation/cat-audits/` — for each owned/supported radio, a structured comparison of its **official CAT/CI-V reference manual** against what rigplane-core actually implements, across three surfaces: backend method · profile (`rigs/*.toml`) declaration · validation-registry round-trip check.

Each audit = a 5-column command matrix + four gap lists:
- **A** under-declared (backend has it, profile/registry can't see it)
- **B** validation gaps (implemented + declared, but no round-trip — presence-only)
- **C** missing backend (documented operator command, no method)
- **D** mismatch / wrong (declared/checked but behaves differently, or a live FAIL)

Every gap row cross-references a Linear ticket (existing or NEW).

## Radios

| Radio | Protocol | Status |
|---|---|---|
| FTX-1 (Yaesu) | ASCII CAT | live-validated |
| IC-7610 (Icom) | CI-V | live-validated (3 scope FAILs → MOR-664) |
| IC-7300 (Icom) | CI-V (shared 22-line shim) | static/template |
| Xiegu X6200 | CI-V-like (via `ic705` serial) | doc-vs-code |
| Discovery TX-500 (lab599) | Kenwood ASCII CAT | doc-vs-code — **no backend exists** |

## Notes

- Vendor manuals (Icom/Yaesu/Xiegu/lab599 PDFs + text extracts) are **git-ignored** under `manuals/` — copyrighted, public repo, not redistributed. Each audit cites the source URL + revision so they can be re-fetched.
- Docs only — no source/test/CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)