### PR TITLE
feat(#MOR-671): add if_shift.set + contour.set RMVR validation checks

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -808,6 +808,26 @@ def _nudge_filter(width: int) -> int:
     return width + 200 if width <= 2600 else width - 200
 
 
+# MOR-671 — IF-shift offset is signed Hz with a symmetric settable band of
+# roughly +/-1200 Hz on the FTX-1. The RMVR mutation must stay inside that band
+# so the written test value is always restorable and never out of range.
+_IF_SHIFT_LIMIT_HZ = 1200
+_IF_SHIFT_NUDGE_HZ = 200
+
+
+def _nudge_if_shift(offset: int) -> int:
+    """Mutate an IF-shift offset to a DIFFERENT in-range value.
+
+    Nudge by +200 Hz, but if that would exceed the +1200 Hz ceiling, step the
+    other way (-200 Hz) instead. The original is assumed in-band (|offset| <=
+    1200), so the result is always within +/-1200 Hz and always differs from
+    the original. NEVER writes out of range.
+    """
+    if int(offset) + _IF_SHIFT_NUDGE_HZ <= _IF_SHIFT_LIMIT_HZ:
+        return int(offset) + _IF_SHIFT_NUDGE_HZ
+    return int(offset) - _IF_SHIFT_NUDGE_HZ
+
+
 def _filter_width_equal(a: int, b: int) -> bool:
     """Encoding-aware filter-width comparator.
 
@@ -1591,6 +1611,9 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     ValueRule.SCOPE_INDEX_FLIP: 1,
     ValueRule.SCOPE_EDGE_CYCLE: 1,
     ValueRule.SCOPE_REF_DB: 0.0,
+    # MOR-671 — IF-shift in-band test value; contour on-state.
+    ValueRule.SHIFT_HZ: 600,
+    ValueRule.CONTOUR_FLIP: 1,
 }
 
 # Benign value to restore a write-only control to afterwards (best-effort).
@@ -1629,6 +1652,10 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     # Reference level in dB on the radio's 0.5 dB grid: hop between two
     # exact grid values so the readback comparison can stay exact.
     ValueRule.SCOPE_REF_DB: lambda r: 5.0 if float(r) != 5.0 else 0.0,
+    # MOR-671 — IF-shift: nudge +/-200 Hz, clamped to +/-1200 (never OOR).
+    ValueRule.SHIFT_HZ: _nudge_if_shift,
+    # MOR-671 — contour on/off: flip 0 <-> 1 (off <-> a valid on level).
+    ValueRule.CONTOUR_FLIP: lambda v: 1 if int(v) == 0 else 0,
 }
 
 # Restore-safety predicates (MOR-659): when the CURRENT value of an RMVR

--- a/src/rigplane/validation/registry/_dsp.py
+++ b/src/rigplane/validation/registry/_dsp.py
@@ -1,6 +1,7 @@
-"""DSP and noise-processing checks: notch, NB, NR, AGC.
+"""DSP and noise-processing checks: notch, NB, NR, AGC, IF-shift, contour.
 
-Registry positions 10-13.
+Registry positions 10-13 (notch/nb/nr/agc) plus the appended MOR-671
+FTX-1 DSP RMVR checks (if_shift, contour).
 """
 
 from __future__ import annotations
@@ -69,6 +70,38 @@ CHECKS: tuple[CheckSpec, ...] = (
         get_op="get_agc",
         set_op="set_agc",
         value_rule=ValueRule.AGC_FLIP,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # MOR-671 — if_shift.set (FTX-1 / Yaesu-CAT only; generic RMVR dispatch).
+    CheckSpec(
+        check_id="if_shift.set",
+        capability="if_shift",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Nudge the IF-shift offset (signed Hz) and verify readback.",
+        protocol="if_shift",
+        get_op="get_if_shift",
+        set_op="set_if_shift",
+        value_rule=ValueRule.SHIFT_HZ,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # MOR-671 — contour.set (FTX-1 / Yaesu-CAT only; generic RMVR dispatch).
+    CheckSpec(
+        check_id="contour.set",
+        capability="contour",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Flip the contour (S-DX) DSP off/on and verify readback.",
+        protocol="contour",
+        get_op="get_contour",
+        set_op="set_contour",
+        value_rule=ValueRule.CONTOUR_FLIP,
         tolerance=0,
         hamlib_token=None,
         tx_adjacent=False,

--- a/src/rigplane/validation/registry/_types.py
+++ b/src/rigplane/validation/registry/_types.py
@@ -57,6 +57,9 @@ class ValueRule(StrEnum):
     SCOPE_INDEX_FLIP = "scope_index_flip"
     SCOPE_EDGE_CYCLE = "scope_edge_cycle"
     SCOPE_REF_DB = "scope_ref_db"
+    # MOR-671 — FTX-1 DSP RMVR checks
+    SHIFT_HZ = "shift_hz"
+    CONTOUR_FLIP = "contour_flip"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/golden/validation/ftx1.dry-run.json
+++ b/tests/golden/validation/ftx1.dry-run.json
@@ -53,9 +53,9 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
-      "check_id": "contour.presence",
-      "status": "pass",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "contour.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "dial_lock.set",
@@ -93,9 +93,9 @@
       "declaration": "supported"
     },
     {
-      "check_id": "if_shift.presence",
-      "status": "pass",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "if_shift.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "key_speed.set",

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -68,6 +68,11 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
+      "check_id": "contour.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
       "check_id": "data_mode.presence",
       "status": "pass",
       "declaration": "unsupported_pending_evidence"
@@ -121,6 +126,11 @@
       "check_id": "freq.write",
       "status": "skip",
       "declaration": "supported"
+    },
+    {
+      "check_id": "if_shift.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
     },
     {
       "check_id": "ip_plus.presence",

--- a/tests/golden/validation/x6200.dry-run.json
+++ b/tests/golden/validation/x6200.dry-run.json
@@ -53,6 +53,11 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
+      "check_id": "contour.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
       "check_id": "data_mode.presence",
       "status": "pass",
       "declaration": "unsupported_pending_evidence"
@@ -86,6 +91,11 @@
       "check_id": "freq.write",
       "status": "skip",
       "declaration": "supported"
+    },
+    {
+      "check_id": "if_shift.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
     },
     {
       "check_id": "key_speed.set",

--- a/tests/validation/test_hardware_dsp_shift_contour.py
+++ b/tests/validation/test_hardware_dsp_shift_contour.py
@@ -1,0 +1,198 @@
+"""RMVR validation for FTX-1 IF-shift and contour DSP controls (MOR-671).
+
+``if_shift.set`` and ``contour.set`` previously had only synthetic
+``<cap>.presence`` entries. These tests lock the new read-modify-verify-restore
+behaviour driven entirely by the generic registry dispatch:
+
+* ``if_shift.set`` nudges the signed-Hz offset by a clamped delta that NEVER
+  leaves the +/-1200 Hz band, verifies the readback reacted, and restores.
+* ``contour.set`` flips the on/off (0 / >0) DSP state, verifies, and restores.
+
+A radio that *declares* the capability but lacks the get/set op must degrade to
+UNSUPPORTED (not crash / FAIL), cross-radio-safe for Icom radios that share the
+DSP surface but never expose these Yaesu-only ops.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.core.radio_protocol import Radio
+from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckStatus,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    ValidationLevel,
+)
+
+
+def _flatten(levels):
+    return {check.check_id: check for level in levels for check in level.checks}
+
+
+def _single_entry_template(*, check_id: str, capability: str) -> MatrixTemplate:
+    return MatrixTemplate(
+        radio=RadioTarget(model="FTX-1", profile_id="ftx1"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id=check_id,
+                capability=capability,
+                level=ValidationLevel.CAPABILITY_MATRIX,
+                declaration=CapabilityDeclaration.SUPPORTED,
+                summary="single",
+            )
+        ],
+    )
+
+
+async def _run(radio, *, check_id: str, capability: str):
+    template = _single_entry_template(check_id=check_id, capability=capability)
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    return _flatten(levels)[check_id]
+
+
+# ---------------------------------------------------------------------------
+# if_shift.set — signed Hz, clamped RMVR
+# ---------------------------------------------------------------------------
+
+
+def _stateful_if_shift_mock(*, start: int):
+    """FTX-1-shaped IF-shift: round-trips any value in the +/-1200 Hz band."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"if_shift"}
+    store = {"value": start}
+    writes: list[int] = []
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(offset: int, receiver: int = 0) -> None:
+        writes.append(offset)
+        store["value"] = offset
+
+    radio.get_if_shift = AsyncMock(side_effect=_get)
+    radio.set_if_shift = AsyncMock(side_effect=_set)
+    return radio, store, writes
+
+
+async def test_if_shift_rmvr_passes_and_restores():
+    """A mid-band offset nudges to a DIFFERENT in-range value, reacts, restores."""
+    radio, store, writes = _stateful_if_shift_mock(start=0)
+    check = await _run(radio, check_id="if_shift.set", capability="if_shift")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 0
+    assert check.evidence["changed"] == 200
+    assert check.evidence["readback"] == 200
+    assert check.evidence["restored"] is True
+    # Restored to the original value.
+    assert store["value"] == 0
+    # Every written value stayed strictly inside the +/-1200 Hz band.
+    assert all(-1200 <= w <= 1200 for w in writes)
+
+
+async def test_if_shift_rmvr_clamps_near_upper_bound():
+    """Near the +1200 ceiling the nudge must flip downward, never exceeding it."""
+    radio, store, writes = _stateful_if_shift_mock(start=1100)
+    check = await _run(radio, check_id="if_shift.set", capability="if_shift")
+    assert check.status is CheckStatus.PASS
+    # +200 would overshoot 1200, so the rule steps -200 instead.
+    assert check.evidence["changed"] == 900
+    assert check.evidence["changed"] != 1100
+    assert store["value"] == 1100
+    # NEVER write out of range, even at the boundary.
+    assert all(-1200 <= w <= 1200 for w in writes)
+    assert max(writes) <= 1200
+
+
+async def test_if_shift_rmvr_at_ceiling_clamps_down():
+    """Exactly at +1200 the rule still produces an in-range, different value."""
+    radio, _store, writes = _stateful_if_shift_mock(start=1200)
+    check = await _run(radio, check_id="if_shift.set", capability="if_shift")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["changed"] == 1000
+    assert all(-1200 <= w <= 1200 for w in writes)
+
+
+# ---------------------------------------------------------------------------
+# contour.set — off <-> on RMVR
+# ---------------------------------------------------------------------------
+
+
+def _stateful_contour_mock(*, start: int):
+    """FTX-1-shaped contour: 0=off, >0=on; round-trips any value."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"contour"}
+    store = {"value": start}
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(val: int, receiver: int = 0) -> None:
+        store["value"] = val
+
+    radio.get_contour = AsyncMock(side_effect=_get)
+    radio.set_contour = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_contour_rmvr_off_to_on_passes_and_restores():
+    """Contour off (0) flips to a valid on level (1), reacts, restores to 0."""
+    radio, store = _stateful_contour_mock(start=0)
+    check = await _run(radio, check_id="contour.set", capability="contour")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 0
+    assert check.evidence["changed"] == 1
+    assert check.evidence["readback"] == 1
+    assert check.evidence["restored"] is True
+    assert store["value"] == 0
+
+
+async def test_contour_rmvr_on_to_off_passes_and_restores():
+    """Contour on (1) flips to off (0), reacts, restores to the original on value."""
+    radio, store = _stateful_contour_mock(start=1)
+    check = await _run(radio, check_id="contour.set", capability="contour")
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 1
+    assert check.evidence["changed"] == 0
+    assert check.evidence["readback"] == 0
+    assert check.evidence["restored"] is True
+    assert store["value"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-radio safety: declares the cap but lacks the op -> UNSUPPORTED
+# ---------------------------------------------------------------------------
+
+
+async def test_if_shift_declared_but_missing_op_is_unsupported():
+    """A radio declaring ``if_shift`` but exposing no get/set op degrades to
+    UNSUPPORTED, never crashing or FAILing (Icom shares the DSP surface but has
+    no IF-shift op)."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "IC-7610"
+    radio.capabilities = {"if_shift"}
+    # No get_if_shift / set_if_shift: spec(Radio) excludes the Yaesu-only ops.
+    check = await _run(radio, check_id="if_shift.set", capability="if_shift")
+    assert check.status is CheckStatus.UNSUPPORTED
+
+
+async def test_contour_declared_but_missing_op_is_unsupported():
+    """A radio declaring ``contour`` but exposing no get/set op degrades to
+    UNSUPPORTED, never crashing or FAILing."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "IC-7610"
+    radio.capabilities = {"contour"}
+    check = await _run(radio, check_id="contour.set", capability="contour")
+    assert check.status is CheckStatus.UNSUPPORTED

--- a/tests/validation/test_registry.py
+++ b/tests/validation/test_registry.py
@@ -47,6 +47,9 @@ _EXPECTED_CHECK_IDS = {
     "nb.set",
     "nr.set",
     "agc.set",
+    # MOR-671 — FTX-1 DSP RMVR checks (appended to the DSP family)
+    "if_shift.set",
+    "contour.set",
     "rit.set",
     "xit.set",
     "squelch.set",
@@ -96,7 +99,7 @@ _EXPECTED_CHECK_IDS = {
 
 
 def test_registry_has_expected_entry_count():
-    assert len(REGISTRY) == len(_EXPECTED_CHECK_IDS) == 52
+    assert len(REGISTRY) == len(_EXPECTED_CHECK_IDS) == 54
 
 
 def test_check_ids_unique():


### PR DESCRIPTION
## What

Adds two RMVR (read-modify-verify-restore) validation checks for FTX-1 DSP capabilities that previously had only synthetic `<cap>.presence` entries:

- **`if_shift.set`** — signed Hz (`radio_state.if_shift`, ±1200). New `SHIFT_HZ` value rule: `_nudge_if_shift` nudges +200 Hz, clamped to ±1200 (steps −200 near the ceiling), never writes out of range.
- **`contour.set`** — 0=off / >0=on. New `CONTOUR_FLIP` value rule: flip off↔on.

Both run through the existing generic RMVR dispatch (`_check_from_spec`) — no named handlers.

## Found by

Live FTX-1 validation run (MOR-634). Operator-requested coverage (SHIFT/CONTOUR confirmed in FTX-1 CAT OM `IS`/`CO`). Builds on MOR-670 (NotImplementedError→UNSUPPORTED).

## Cross-radio safety

`get/set_if_shift` and `get/set_contour` exist on Yaesu-CAT but not IcomRadio. Checks are capability-gated. A profile declaring the cap but lacking the op → `getattr` None → UNSUPPORTED (two dedicated tests); `NotImplementedError` → UNSUPPORTED via `_guard` (MOR-670).

## Goldens

- **ftx1**: `contour/if_shift.presence` → `contour/if_shift.set` (supported).
- **ic7610 / x6200**: gain `contour.set` + `if_shift.set` as **UNSUPPORTED** rows (caps undeclared) — every functional registry check emits an entry on every profile, so all three goldens regenerate. Only the new rows changed.

## Changes (8 files, +293/−9)

`registry/_types.py` (+2 ValueRule), `registry/_dsp.py` (+2 CheckSpec), `hardware.py` (+`_nudge_if_shift` + wiring), `tests/validation/test_registry.py` (count 52→54 + 2 frozen ids), `tests/validation/test_hardware_dsp_shift_contour.py` (new, 7 tests), 3 regenerated goldens.

## Validation

- `pytest tests/ --ignore=tests/integration` → 7820 passed, 12 skipped, 11 xfailed
- `ruff check` + `format --check` → clean
- `mypy src/` → no issues (zero new)

Closes MOR-671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)