### PR TITLE
fix(#MOR-681): implement IC-7300 get_bsr band-stack read + drop dead apf 14 05 + fix profile citation

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -2,7 +2,9 @@
 # This file defines the IC-7300 radio profile in TOML format.
 # See _schema.md for field documentation.
 #
-# Source: IC-7300MK2 CI-V Reference Guide (PDF)
+# Source: IC-7300 Full Manual (English) v6, §19 CONTROL COMMAND
+#         (original IC-7300, CI-V addr 0x94 — NOT the IC-7300MK2, which has a
+#         different command set)
 #         wfview IC-7300.rig
 #         Hardware testing
 
@@ -335,7 +337,7 @@ bsr_code = 0x0A
 
 # ── CI-V Commands ────────────────────────────────────────────────
 # Grouped by capability area. Wire bytes as integer arrays.
-# Source: IC-7300MK2 CI-V Reference Guide
+# Source: IC-7300 Full Manual (English) v6, §19 CONTROL COMMAND (original IC-7300)
 #
 # IC-7300 has NO Command29 support (single receiver).
 
@@ -405,8 +407,10 @@ get_manual_notch_width = [0x16, 0x57]     # 0=WIDE, 1=MID, 2=NAR
 set_manual_notch_width = [0x16, 0x57]
 get_audio_peak_filter = [0x16, 0x32]      # IC-7300: 0=OFF, 1=ON only
 set_audio_peak_filter = [0x16, 0x32]
-get_apf_type_level = [0x14, 0x05]         # NOT_IMPLEMENTED — APF position (not in 7300 wfview)
-set_apf_type_level = [0x14, 0x05]
+# NOTE: no apf_type_level on the IC-7300. The 7300 APF is a plain 0x16 0x32
+# ON/OFF toggle (above); there is no 0x14 0x05 APF position like the IC-7610's
+# WIDE/MID/NAR 3-level control. The dead 0x14 0x05 command string was removed
+# (MOR-681) so it cannot be emitted to a radio that ignores it.
 get_twin_peak_filter = [0x16, 0x4F]
 set_twin_peak_filter = [0x16, 0x4F]
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -68,6 +68,7 @@ from rigplane.commands import (
     build_civ_frame,
     filter_hz_to_index,
     filter_index_to_hz,
+    build_band_stack_get,
     build_memory_clear,
     build_memory_contents_set,
     build_memory_mode_set,
@@ -156,6 +157,7 @@ from rigplane.commands import (
     get_vox_gain,
     get_xfc_status,
     parse_ack_nak,
+    parse_band_stack_response,
     parse_bool_response,
     parse_data_mode_response,
     parse_frequency_response,
@@ -3900,23 +3902,26 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_bsr(self, band: int, register: int) -> BandStackRegister:
         """Read band stacking register (band 0-24, register 1-3).
 
+        Issues CI-V ``0x1A 0x01 <band> <register>`` and parses the band-stack
+        response (frequency / mode / filter). Icom firmware (IC-7300,
+        IC-7610, IC-705, IC-9700, X6200, ...) answers this read; the historic
+        ``NotImplementedError`` was a stale IC-7610-era assumption.
+
         Args:
             band: Band number (0-24).
             register: Register number (1-3).
 
-        Raises:
-            NotImplementedError: IC-7610 does not support reading band
-                stacking registers. Command 0x1A 0x01 GET is not documented
-                in the official CI-V Reference Manual.
+        Returns:
+            The decoded band-stack register entry.
         """
         if not 0 <= band <= 24:
             raise ValueError(f"Band must be 0-24, got {band}")
         if not 1 <= register <= 3:
             raise ValueError(f"Register must be 1-3, got {register}")
-        raise NotImplementedError(
-            f"IC-7610 does not support reading band stack register (band={band}, reg={register}). "
-            "Command 0x1A 0x01 GET is not documented in the CI-V Reference Manual."
-        )
+        self._check_connected()
+        civ = build_band_stack_get(band, register, to_addr=self._radio_addr)
+        resp = await self._send_civ_expect(civ, label="get_bsr")
+        return parse_band_stack_response(resp)
 
     async def set_bsr(self, bsr: BandStackRegister) -> None:
         """Write band stacking register."""

--- a/tests/test_memory_commands.py
+++ b/tests/test_memory_commands.py
@@ -354,6 +354,112 @@ class TestIcomRadioMemoryMethods:
 
 
 # ---------------------------------------------------------------------------
+# Band-stack READ (get_bsr) — MOR-681
+# ---------------------------------------------------------------------------
+
+
+class TestIcomRadioGetBsr:
+    """Verify IcomRadio.get_bsr issues 0x1A 0x01 and parses the response.
+
+    The IC-7300 (and other Icom rigs) firmware DOES answer a band-stack read;
+    the previous NotImplementedError was a stale IC-7610-era assumption.
+    get_bsr is shared backend code, so it must behave identically for both
+    the IC-7300 (addr 0x94) and the IC-7610 (addr 0x98).
+    """
+
+    IC7300_ADDR = 0x94
+    IC7610_ADDR = 0x98
+
+    def _make_radio(self, radio_addr: int) -> MagicMock:
+        radio = MagicMock()
+        radio._radio_addr = radio_addr
+        radio._check_connected = MagicMock()
+        radio._send_civ_expect = AsyncMock()
+        return radio
+
+    def _band_stack_frame(self, radio_addr: int) -> CivFrame:
+        from rigplane.types import bcd_encode
+
+        # Band 5 / register 1 / 14.074 MHz / mode USB(0x01) / filter 1.
+        data = bytes([0x05, 0x01])
+        data += bcd_encode(14_074_000)
+        data += bcd_encode_value(0x01, byte_count=1)
+        data += bcd_encode_value(0x01, byte_count=1)
+        return CivFrame(
+            to_addr=CONTROLLER_ADDR,
+            from_addr=radio_addr,
+            command=0x1A,
+            sub=0x01,
+            data=data,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_bsr_ic7300_parses_band_stack_entry(self) -> None:
+        from rigplane.radio import IcomRadio
+
+        radio = self._make_radio(self.IC7300_ADDR)
+        radio._send_civ_expect.return_value = self._band_stack_frame(self.IC7300_ADDR)
+        bound = IcomRadio.get_bsr.__get__(radio, type(radio))
+
+        result = await bound(5, 1)
+
+        assert isinstance(result, BandStackRegister)
+        assert result.band == 5
+        assert result.register == 1
+        assert result.frequency_hz == 14_074_000
+        assert result.mode == 0x01
+        assert result.filter == 1
+        # It must actually issue a 0x1A 0x01 read frame.
+        radio._send_civ_expect.assert_awaited_once()
+        sent_frame = radio._send_civ_expect.call_args[0][0]
+        assert sent_frame[4] == 0x1A
+        assert sent_frame[5] == 0x01
+
+    @pytest.mark.asyncio
+    async def test_get_bsr_ic7610_still_works(self) -> None:
+        """Regression: shared path must not break the IC-7610."""
+        from rigplane.radio import IcomRadio
+
+        radio = self._make_radio(self.IC7610_ADDR)
+        radio._send_civ_expect.return_value = self._band_stack_frame(self.IC7610_ADDR)
+        bound = IcomRadio.get_bsr.__get__(radio, type(radio))
+
+        result = await bound(5, 1)
+
+        assert isinstance(result, BandStackRegister)
+        assert result.frequency_hz == 14_074_000
+        radio._send_civ_expect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_bsr_no_longer_raises_not_implemented(self) -> None:
+        from rigplane.radio import IcomRadio
+
+        radio = self._make_radio(self.IC7300_ADDR)
+        radio._send_civ_expect.return_value = self._band_stack_frame(self.IC7300_ADDR)
+        bound = IcomRadio.get_bsr.__get__(radio, type(radio))
+        # Must not raise NotImplementedError anymore.
+        await bound(5, 1)
+
+    @pytest.mark.asyncio
+    async def test_get_bsr_rejects_invalid_band(self) -> None:
+        from rigplane.radio import IcomRadio
+
+        radio = self._make_radio(self.IC7300_ADDR)
+        bound = IcomRadio.get_bsr.__get__(radio, type(radio))
+        with pytest.raises(ValueError, match="Band must be 0-24"):
+            await bound(25, 1)
+
+    @pytest.mark.asyncio
+    async def test_get_bsr_rejects_invalid_register(self) -> None:
+        from rigplane.radio import IcomRadio
+
+        radio = self._make_radio(self.IC7300_ADDR)
+        bound = IcomRadio.get_bsr.__get__(radio, type(radio))
+        with pytest.raises(ValueError, match="Register must be 1-3"):
+            await bound(5, 4)
+
+
+# ---------------------------------------------------------------------------
 # Web handler dispatch tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Three IC-7300 corrections from the CAT audit (`docs/validation/cat-audits/ic7300.md`, gap-lists C + D):

1. **`get_bsr` band-stack read (gap C)** — was `NotImplementedError` (stale "IC-7610 doesn't support" assumption). The CI-V builder (`build_band_stack_get`) and parser (`parse_band_stack_response`) already existed in `commands/memory.py`; only the runtime method was stubbed. Wired `CoreRadio.get_bsr` (`runtime/radio.py`) to build `0x1A 0x01 <band> <register>`, send, and decode into `BandStackRegister`, following the existing `get_data_mode` read pattern. Shared Icom path → works for all CoreRadio rigs.
2. **Dead `apf_type_level → 14 05` cmd (gap D)** — removed from `rigs/ic7300.toml` (no such position on the 7300; working `16 32` APF toggle untouched).
3. **Profile mis-citation (gap D)** — corrected header + `[commands]` citations from "IC-7300MK2 CI-V Reference Guide" to "IC-7300 Full Manual (English) v6, §19 (original IC-7300, addr 0x94)".

## Regression + goldens

- `test_get_bsr_ic7610_still_works` — shared path returns a parsed entry for 0x98 identically to 0x94. No 7610 regression.
- No committed `ic7300` golden; the 3 committed goldens (`ftx1/ic7610/x6200`) are **unchanged**.

## Tests (`tests/test_memory_commands.py`, `TestIcomRadioGetBsr`)

`test_get_bsr_ic7300_parses_band_stack_entry`, `test_get_bsr_ic7610_still_works`, `test_get_bsr_no_longer_raises_not_implemented`, `test_get_bsr_rejects_invalid_band`, `test_get_bsr_rejects_invalid_register`.

## Validation

- `pytest tests/ --ignore=tests/integration` → 7825 passed, 12 skipped, 11 xfailed
- `ruff check` + `format --check` → clean
- `mypy src/` → no issues

Closes MOR-681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)