### PR TITLE
feat(#MOR-678): add IC-7610 MOD-input routing (1A 05 0089-0094) RMVR validation guard

### DIFF
--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -100,6 +100,10 @@ features = [
     # repeater-tone / TSQL family is intentionally NOT declared (MOR-661).
     # Data
     "data_mode",
+    # Modulation input routing — USB/LAN/DATA MOD source select (1A 05
+    # 0089-0094). Gates the mod_input.set RMVR guard behind the "web voice
+    # TX = noise" surface (DATA-OFF MOD must be LAN, not MIC; MOR-678).
+    "mod_input_routing",
     # AGC
     "agc",
     # System

--- a/src/rigplane/core/capabilities.py
+++ b/src/rigplane/core/capabilities.py
@@ -51,6 +51,7 @@ __all__ = [
     "CAP_SQL_TYPE",
     "CAP_VOICE_TX",
     "CAP_DATA_MODE",
+    "CAP_MOD_INPUT_ROUTING",
     "CAP_AGC",
     "CAP_POWER_CONTROL",
     "CAP_DIAL_LOCK",
@@ -155,6 +156,11 @@ CAP_SQL_TYPE = "sql_type"
 # Data
 CAP_DATA_MODE = "data_mode"
 
+# Modulation input routing — USB/LAN/DATA MOD source select (Icom 1A 05
+# 0089-0094). Guards the TX-audio routing surface behind the "web voice TX =
+# noise" failure mode (the documented fix is DATA-OFF MOD = LAN; MOR-678).
+CAP_MOD_INPUT_ROUTING = "mod_input_routing"
+
 # AGC
 CAP_AGC = "agc"
 
@@ -235,6 +241,8 @@ KNOWN_CAPABILITIES: frozenset[str] = frozenset(
         CAP_VOICE_TX,
         # Data
         CAP_DATA_MODE,
+        # Modulation input routing
+        CAP_MOD_INPUT_ROUTING,
         # AGC
         CAP_AGC,
         # System

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1614,6 +1614,9 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     # MOR-671 — IF-shift in-band test value; contour on-state.
     ValueRule.SHIFT_HZ: 600,
     ValueRule.CONTOUR_FLIP: 1,
+    # MOR-678 — MOD-input routing: LAN (index 3) is the documented digital
+    # source and always a valid setting on DATA-OFF/1/2/3.
+    ValueRule.MOD_SRC_FLIP: 3,
 }
 
 # Benign value to restore a write-only control to afterwards (best-effort).
@@ -1656,6 +1659,10 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     ValueRule.SHIFT_HZ: _nudge_if_shift,
     # MOR-671 — contour on/off: flip 0 <-> 1 (off <-> a valid on level).
     ValueRule.CONTOUR_FLIP: lambda v: 1 if int(v) == 0 else 0,
+    # MOR-678 — MOD-input routing source select (enumerated, range 0-5).
+    # Flip between two always-valid digital sources: USB (2) <-> LAN (3).
+    # Never writes an invalid source; restores the original afterwards.
+    ValueRule.MOD_SRC_FLIP: lambda v: 3 if int(v) != 3 else 2,
 }
 
 # Restore-safety predicates (MOR-659): when the CURRENT value of an RMVR

--- a/src/rigplane/validation/registry/_system.py
+++ b/src/rigplane/validation/registry/_system.py
@@ -15,6 +15,13 @@ Safety classification:
   raising its gain while the operator has VOX armed) can key the transmitter
   from ambient microphone audio, so both require explicit operator
   authorization and are never auto-actuated.
+* ``mod_input.set`` (MOR-678) is an RMVR round-trip over the DATA-OFF
+  modulation-input source select (Icom ``1A 05 0091``). It guards the
+  TX-audio routing surface behind the "web voice TX = noise" failure mode
+  (the documented fix is DATA-OFF MOD = LAN): a regression that silently
+  flipped the source back to MIC would otherwise be invisible. The flip stays
+  between two always-valid digital sources (USB <-> LAN) and restores the
+  original; it does NOT key the transmitter, so it is a safe RMVR write.
 """
 
 from __future__ import annotations
@@ -137,6 +144,30 @@ CHECKS: tuple[CheckSpec, ...] = (
         get_op="get_dial_lock",
         set_op="set_dial_lock",
         value_rule=ValueRule.TOGGLE_BOOL,
+        tolerance=0,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # mod_input.set (MOR-678) — DATA-OFF MOD-input routing source select
+    # (Icom 1A 05 0091). RMVR over an enumerated source; the flip stays between
+    # two always-valid digital sources (USB <-> LAN) and restores the original.
+    # Guards the "web voice TX = noise" regression (DATA-OFF MOD must be LAN,
+    # not MIC). Does not key the transmitter — safe RMVR write.
+    CheckSpec(
+        check_id="mod_input.set",
+        capability="mod_input_routing",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.AUDIO,
+        summary=(
+            "Flip the DATA-OFF MOD-input routing source (USB <-> LAN), verify "
+            "readback, and restore the original; guards the TX-audio routing "
+            "regression behind the 'web voice TX = noise' failure mode."
+        ),
+        protocol="mod_input_routing",
+        get_op="get_data_off_mod_input",
+        set_op="set_data_off_mod_input",
+        value_rule=ValueRule.MOD_SRC_FLIP,
         tolerance=0,
         hamlib_token=None,
         tx_adjacent=False,

--- a/src/rigplane/validation/registry/_types.py
+++ b/src/rigplane/validation/registry/_types.py
@@ -60,6 +60,8 @@ class ValueRule(StrEnum):
     # MOR-671 — FTX-1 DSP RMVR checks
     SHIFT_HZ = "shift_hz"
     CONTOUR_FLIP = "contour_flip"
+    # MOR-678 — IC-7610 MOD-input routing source select (enumerated 0-5)
+    MOD_SRC_FLIP = "mod_src_flip"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/golden/validation/ftx1.dry-run.json
+++ b/tests/golden/validation/ftx1.dry-run.json
@@ -108,6 +108,11 @@
       "declaration": "supported"
     },
     {
+      "check_id": "mod_input.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
       "check_id": "mode.set",
       "status": "skip",
       "declaration": "supported"

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -158,6 +158,11 @@
       "declaration": "supported"
     },
     {
+      "check_id": "mod_input.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
       "check_id": "mode.set",
       "status": "skip",
       "declaration": "supported"

--- a/tests/golden/validation/x6200.dry-run.json
+++ b/tests/golden/validation/x6200.dry-run.json
@@ -108,6 +108,11 @@
       "declaration": "supported"
     },
     {
+      "check_id": "mod_input.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
       "check_id": "mode.set",
       "status": "skip",
       "declaration": "supported"

--- a/tests/test_rig_ic7610.py
+++ b/tests/test_rig_ic7610.py
@@ -105,6 +105,8 @@ class TestProfileParity:
                 # (MOR-661).
                 # Data / System
                 "data_mode",
+                # MOR-678: USB/LAN/DATA MOD-input routing source-select guard.
+                "mod_input_routing",
                 "power_control",
                 "dial_lock",
                 "scan",
@@ -123,7 +125,8 @@ class TestProfileParity:
 
     def test_capabilities_count(self, profile):
         # MOR-661: dropped repeater_tone + tsql (48 → 46).
-        assert len(profile.capabilities) == 46
+        # MOR-678: added mod_input_routing (46 → 47).
+        assert len(profile.capabilities) == 47
 
     def test_cmd29_routes_exact(self, profile):
         expected = frozenset(

--- a/tests/validation/test_generator.py
+++ b/tests/validation/test_generator.py
@@ -121,6 +121,30 @@ def test_undeclared_functional_pending():
     )
 
 
+def test_mod_input_supported_when_cap_declared():
+    """MOR-678: mod_input.set is SUPPORTED when mod_input_routing is declared
+    (IC-7610), and UNSUPPORTED_PENDING_EVIDENCE otherwise (X6200/FTX-1)."""
+    declared = build_template_from_capabilities(
+        frozenset({"mod_input_routing"}),
+        model="IC-7610",
+        profile_id="ic7610",
+    )
+    by_id = {e.check_id: e for e in declared.entries}
+    assert by_id["mod_input.set"].declaration == CapabilityDeclaration.SUPPORTED
+
+    undeclared = build_template_from_capabilities(
+        frozenset(),
+        model="X6200",
+        profile_id="x6200",
+    )
+    by_id2 = {e.check_id: e for e in undeclared.entries}
+    assert "mod_input.set" in by_id2
+    assert (
+        by_id2["mod_input.set"].declaration
+        == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+    )
+
+
 def test_manual_kind_manual_required():
     """MANUAL checks map to CapabilityDeclaration.MANUAL_REQUIRED when capability declared.
 

--- a/tests/validation/test_hardware_command_families.py
+++ b/tests/validation/test_hardware_command_families.py
@@ -360,6 +360,57 @@ async def test_dial_lock_set_rmvr_roundtrip():
 
 
 # ---------------------------------------------------------------------------
+# MOR-678 — IC-7610 MOD-input routing (1A 05 0089-0094) RMVR guard
+# ---------------------------------------------------------------------------
+
+
+async def test_mod_input_set_rmvr_roundtrip_flips_and_restores():
+    """RMVR over the DATA-OFF MOD-input source: flip USB(2) -> LAN(3),
+    verify readback, restore the original."""
+    radio, store = _stateful_value_radio(
+        capability="mod_input_routing",
+        get_op="get_data_off_mod_input",
+        set_op="set_data_off_mod_input",
+        start=2,  # USB
+        receiver_kw=False,
+    )
+    result = await _run(radio, "mod_input.set")
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["restored"] is True
+    assert store["value"] == 2  # restored to original USB
+    assert 3 in store["writes"]  # flipped to LAN during the check
+
+
+async def test_mod_input_set_flips_away_from_lan_when_already_lan():
+    """When the source is already LAN(3), the flip must pick a DIFFERENT valid
+    source (USB=2) — never write an invalid value and never write the same one."""
+    radio, store = _stateful_value_radio(
+        capability="mod_input_routing",
+        get_op="get_data_off_mod_input",
+        set_op="set_data_off_mod_input",
+        start=3,  # LAN
+        receiver_kw=False,
+    )
+    result = await _run(radio, "mod_input.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 3  # restored to original LAN
+    changed = [v for v in store["writes"] if v != 3]
+    assert changed and changed[0] == 2  # flipped to USB
+    # never writes an out-of-range source
+    assert all(0 <= v <= 5 for v in store["writes"])
+
+
+async def test_mod_input_check_unsupported_when_radio_lacks_op():
+    """A radio that declares the cap but lacks the get/set op reports
+    UNSUPPORTED without crashing."""
+    radio = _bare_radio({"mod_input_routing"})
+    radio.get_data_off_mod_input = None
+    radio.set_data_off_mod_input = None
+    result = await _run(radio, "mod_input.set")
+    assert result.status is CheckStatus.UNSUPPORTED
+
+
+# ---------------------------------------------------------------------------
 # T11 / MOR-646 — scope-control SET commands
 # ---------------------------------------------------------------------------
 
@@ -645,6 +696,7 @@ def test_new_family_levels_are_correct():
         "vox.set": ValidationLevel.STRESS_RECOVERY,
         "vox_gain.set": ValidationLevel.STRESS_RECOVERY,
         "dial_lock.set": matrix,
+        "mod_input.set": matrix,
     }
     for check_id, level in expectations.items():
         spec = REGISTRY_BY_ID[check_id]

--- a/tests/validation/test_registry.py
+++ b/tests/validation/test_registry.py
@@ -81,6 +81,8 @@ _EXPECTED_CHECK_IDS = {
     "vox.set",
     "vox_gain.set",
     "dial_lock.set",
+    # MOR-678 — IC-7610 MOD-input routing RMVR guard (1A 05 0089-0094)
+    "mod_input.set",
     # T11 / MOR-646 — scope-control SET commands
     "scope_receiver.set",
     "scope_dual.set",
@@ -99,7 +101,7 @@ _EXPECTED_CHECK_IDS = {
 
 
 def test_registry_has_expected_entry_count():
-    assert len(REGISTRY) == len(_EXPECTED_CHECK_IDS) == 54
+    assert len(REGISTRY) == len(_EXPECTED_CHECK_IDS) == 55
 
 
 def test_check_ids_unique():
@@ -237,6 +239,22 @@ def test_import_guard_runs():
 # ---------------------------------------------------------------------------
 
 _EXPECTED: list[tuple[str, dict]] = [
+    (
+        "mod_input.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "capability": "mod_input_routing",
+            "get_op": "get_data_off_mod_input",
+            "set_op": "set_data_off_mod_input",
+            "value_rule": ValueRule.MOD_SRC_FLIP,
+            "tolerance": 0,
+            "hamlib_token": None,
+            "protocol": "mod_input_routing",
+            "failure_domain": FailureDomain.AUDIO,
+            "tx_adjacent": False,
+        },
+    ),
     (
         "freq.write",
         {


### PR DESCRIPTION
## What

Adds an RMVR round-trip validation check for the **IC-7610 DATA-OFF MOD-input routing** (CI-V `1A 05 0091-0094`) — the surface behind "web voice TX = noise/squeal" (documented fix: DATA-OFF MOD=LAN). A regression that silently flipped MOD back to MIC was invisible to the harness; now it round-trips and restores.

Backend already exposes `get/set_data_off_mod_input` — this is pure registry wiring (no backend gap).

## Check

- id `mod_input.set` — `RMVR_SAFE_WRITE`, capability `mod_input_routing`, ops `get/set_data_off_mod_input`, `FailureDomain.AUDIO`.
- New value rule `MOD_SRC_FLIP` = flip USB(2) ↔ LAN(3) (two always-valid digital sources), restore original; write-only test value = 3 (LAN, the documented fix). Never writes out of the 0–5 source range.

## Changes (12 files, +166/-2)

`core/capabilities.py` (new `CAP_MOD_INPUT_ROUTING`), `validation/registry/_types.py` (ValueRule), `validation/hardware.py` (mutation + test value), `validation/registry/_system.py` (CheckSpec), `rigs/ic7610.toml` (declare cap), 3 regenerated goldens, registry/generator/IC-7610 guard tests.

## Goldens (only the new row added per profile, +5 each; all `--gate` exit 0)

- `ic7610`: `mod_input.set` → supported (skip in dry-run)
- `x6200` / `ftx1`: `mod_input.set` → unsupported_pending_evidence (cap undeclared)

## Tests (tests/validation/)

`test_mod_input_set_rmvr_roundtrip_flips_and_restores`, `test_mod_input_set_flips_away_from_lan_when_already_lan` (asserts every write in-range 0–5), `test_mod_input_check_unsupported_when_radio_lacks_op`, `test_mod_input_supported_when_cap_declared`. Registry guards updated (count 54→55, frozen id-set, IC-7610 cap parity 46→47).

## Validation

- `pytest tests/ --ignore=tests/integration` → 7825 passed, 12 skipped, 11 xfailed
- `ruff check` + `format --check` → clean
- `mypy src/` → no issues

## Note

Live IC-7610 round-trip verification not run (no hardware in worktree) — dry-run goldens + fake-radio RMVR tests green. Live check pending hardware.

Closes MOR-678.

🤖 Generated with [Claude Code](https://claude.com/claude-code)