### PR TITLE
fix(#MOR-664): correct scope vbw/rbw/dual receiver-prefix on SET (live-proven IC-7610 round-trip)

### DIFF
--- a/src/rigplane/runtime/_scope_runtime.py
+++ b/src/rigplane/runtime/_scope_runtime.py
@@ -221,9 +221,11 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def set_scope_dual(self, dual: bool) -> None:
         """Enable or disable dual scope mode."""
         self._check_connected()
-        receiver = self._scope_controls().receiver
+        # Single/dual is a GLOBAL scope setting — get_scope_dual sends no
+        # receiver prefix, so the setter must not either (MOR-664). A stray
+        # receiver byte malforms the write and the radio ignores it.
         await self._send_civ_raw(
-            _scope_single_dual_cmd(dual, to_addr=self._radio_addr, receiver=receiver),
+            _scope_single_dual_cmd(dual, to_addr=self._radio_addr),
             wait_response=False,
         )
         self._scope_controls().dual = dual
@@ -423,8 +425,12 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def set_scope_vbw(self, narrow: bool) -> None:
         """Enable or disable narrow scope VBW."""
         self._check_connected()
+        # get_scope_vbw reads the selected receiver (sends a receiver prefix),
+        # so the setter must address the same receiver or the write never
+        # reflects back (MOR-664).
+        receiver = self._scope_controls().receiver
         await self._send_civ_raw(
-            _scope_set_vbw_cmd(narrow, to_addr=self._radio_addr),
+            _scope_set_vbw_cmd(narrow, to_addr=self._radio_addr, receiver=receiver),
             wait_response=False,
         )
         self._scope_controls().vbw_narrow = narrow
@@ -486,8 +492,12 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def set_scope_rbw(self, rbw: int) -> None:
         """Set the scope RBW preset (0=wide, 1=mid, 2=narrow)."""
         self._check_connected()
+        # get_scope_rbw reads the selected receiver (sends a receiver prefix),
+        # so the setter must address the same receiver or the write never
+        # reflects back (MOR-664).
+        receiver = self._scope_controls().receiver
         await self._send_civ_raw(
-            _scope_set_rbw_cmd(rbw, to_addr=self._radio_addr),
+            _scope_set_rbw_cmd(rbw, to_addr=self._radio_addr, receiver=receiver),
             wait_response=False,
         )
         self._scope_controls().rbw = rbw

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1081,6 +1081,64 @@ class TestAdvancedScopeControls:
         assert len(mock_transport.sent_packets) > 0
 
 
+class TestScopeSetterReceiverPrefix:
+    """MOR-664: SET receiver-prefix must mirror the matching GETTER.
+
+    Live-proven on the real IC-7610 (raw CI-V traces): vbw/rbw GET reads the
+    selected receiver (sends a receiver-prefix byte) while the SET wrote WITHOUT
+    the prefix — so the radio never reflected the write ("did not react"). The
+    fix adds the receiver prefix to set_scope_vbw / set_scope_rbw. Conversely,
+    single/dual is a GLOBAL scope setting: get_scope_dual sends NO prefix, but
+    the SET was sending one, malforming the write — the fix drops the prefix
+    from set_scope_dual so it matches the getter.
+
+    These assertions pin the EXACT CI-V frame bytes (cmd 0x27, sub, optional
+    receiver prefix, value) embedded in the UDP-wrapped packet.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("receiver", [0, 1])
+    async def test_set_scope_vbw_includes_receiver_prefix(
+        self, radio: IcomRadio, mock_transport: MockTransport, receiver: int
+    ) -> None:
+        """set_scope_vbw sends sub 0x1D with the receiver-prefix byte then value
+        (mirrors get_scope_vbw, which passes receiver=)."""
+        radio.radio_state.scope_controls.receiver = receiver
+        await radio.set_scope_vbw(narrow=True)
+        sent = bytes(mock_transport.sent_packets[-1])
+        # 0x27 0x1D <receiver> 0x01 0xFD — prefix byte present, value last.
+        assert bytes([0x27, 0x1D, receiver, 0x01, 0xFD]) in sent
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("receiver", [0, 1])
+    async def test_set_scope_rbw_includes_receiver_prefix(
+        self, radio: IcomRadio, mock_transport: MockTransport, receiver: int
+    ) -> None:
+        """set_scope_rbw sends sub 0x1F with the receiver-prefix byte then value
+        (mirrors get_scope_rbw, which passes receiver=)."""
+        radio.radio_state.scope_controls.receiver = receiver
+        await radio.set_scope_rbw(2)
+        sent = bytes(mock_transport.sent_packets[-1])
+        # 0x27 0x1F <receiver> 0x02 0xFD — prefix byte present, value last.
+        assert bytes([0x27, 0x1F, receiver, 0x02, 0xFD]) in sent
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("receiver", [0, 1])
+    async def test_set_scope_dual_omits_receiver_prefix(
+        self, radio: IcomRadio, mock_transport: MockTransport, receiver: int
+    ) -> None:
+        """set_scope_dual sends sub 0x13 with NO receiver prefix regardless of
+        the selected receiver (single/dual is global; matches get_scope_dual's
+        prefix-less frame shape)."""
+        radio.radio_state.scope_controls.receiver = receiver
+        await radio.set_scope_dual(True)
+        sent = bytes(mock_transport.sent_packets[-1])
+        # Corrected frame: 0x27 0x13 0x01 0xFD (no receiver byte between sub and
+        # value). The old buggy frame was 0x27 0x13 <receiver> 0x01.
+        assert bytes([0x27, 0x13, 0x01, 0xFD]) in sent
+        assert bytes([0x27, 0x13, receiver, 0x01, 0xFD]) not in sent
+
+
 # ---------------------------------------------------------------------------
 # set_mode fire-and-forget (IC-7610 ACK quirk fix)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Backend-only fix in `runtime/_scope_runtime.py` for the GET/SET receiver-prefix mismatch that made three scope `.set` checks fail to round-trip on the live IC-7610 (MOR-664, found by the harness):

- **`set_scope_vbw`** (`0x27 0x1D`) — getter passes `receiver=`, setter didn't → **added** it.
- **`set_scope_rbw`** (`0x27 0x1F`) — same → **added** it.
- **`set_scope_dual`** (`0x27 0x13`) — getter uses no receiver (global setting), setter wrongly added one → **removed** it (frame is now `0x27 0x13 0x01`, not `0x27 0x13 0x00 0x01`).

## Live-proven root cause

Raw CI-V traces on the real IC-7610 (2026-06-11): vbw/rbw with the receiver prefix → readback == written value (REACTED); dual WITHOUT the receiver prefix → REACTED (dual_watch state irrelevant). Builders already accept `receiver=None`; only the runtime call sites changed.

## Tests

`TestScopeSetterReceiverPrefix` in `tests/test_radio.py` (real `MockTransport`, no MagicMock) asserts exact CI-V frame bytes, parametrized over scope receiver 0/1: vbw/rbw include the receiver byte; dual has NO receiver byte. Confirmed failing before / passing after.

## Validation

- `pytest tests/ --ignore=tests/integration` → 7839 passed, 12 skipped, 11 xfailed
- `ruff check` + `format --check` → clean · `mypy src/` → no issues
- Goldens UNCHANGED (backend-only, dry-run-inert).

**Live verification:** re-running the IC-7610 hardware validation from this branch (in progress) — expect `scope_dual/vbw/rbw.set` to move FAIL → PASS.

Closes MOR-664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)