### PR TITLE
feat(#MOR-679): add Icom level RMVR checks (rf_power, mic_gain, comp, nr/nb, cw_pitch)

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -815,6 +815,29 @@ _IF_SHIFT_LIMIT_HZ = 1200
 _IF_SHIFT_NUDGE_HZ = 200
 
 
+# MOR-679 — CW pitch is a sidetone frequency in Hz, NOT a 0-255 level. The Icom
+# encoder (``commands/levels.py::_cw_pitch_to_level``) raises ValueError outside
+# 300-900 Hz, and the getter snaps the readback to the nearest 5 Hz. The RMVR
+# mutation must stay inside that band so the written test value is always
+# restorable and never out of range.
+_CW_PITCH_MIN_HZ = 300
+_CW_PITCH_MAX_HZ = 900
+_CW_PITCH_NUDGE_HZ = 50
+
+
+def _nudge_cw_pitch(pitch_hz: int) -> int:
+    """Mutate a CW pitch (Hz) to a DIFFERENT in-range value on the 5 Hz grid.
+
+    Nudge by +50 Hz, but if that would exceed the 900 Hz ceiling, step the other
+    way (-50 Hz) instead. The original is assumed in-band (300-900 Hz), so the
+    result is always within 300-900 Hz, on the radio's 5 Hz grid, and always
+    differs from the original. NEVER writes out of range.
+    """
+    if int(pitch_hz) + _CW_PITCH_NUDGE_HZ <= _CW_PITCH_MAX_HZ:
+        return int(pitch_hz) + _CW_PITCH_NUDGE_HZ
+    return int(pitch_hz) - _CW_PITCH_NUDGE_HZ
+
+
 def _nudge_if_shift(offset: int) -> int:
     """Mutate an IF-shift offset to a DIFFERENT in-range value.
 
@@ -1617,6 +1640,8 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     # MOR-678 — MOD-input routing: LAN (index 3) is the documented digital
     # source and always a valid setting on DATA-OFF/1/2/3.
     ValueRule.MOD_SRC_FLIP: 3,
+    # MOR-679 — CW pitch: a mid-band 600 Hz is always in 300-900 and on-grid.
+    ValueRule.CW_PITCH_HZ: 600,
 }
 
 # Benign value to restore a write-only control to afterwards (best-effort).
@@ -1663,6 +1688,8 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     # Flip between two always-valid digital sources: USB (2) <-> LAN (3).
     # Never writes an invalid source; restores the original afterwards.
     ValueRule.MOD_SRC_FLIP: lambda v: 3 if int(v) != 3 else 2,
+    # MOR-679 — CW pitch: nudge +/-50 Hz, clamped to 300-900 (never OOR).
+    ValueRule.CW_PITCH_HZ: _nudge_cw_pitch,
 }
 
 # Restore-safety predicates (MOR-659): when the CURRENT value of an RMVR

--- a/src/rigplane/validation/registry/_levels.py
+++ b/src/rigplane/validation/registry/_levels.py
@@ -1,6 +1,8 @@
 """Front-end gain and level checks: filter width, gains, preamp, attenuator.
 
-Registry positions 5-9.
+Registry positions 5-9, plus the MOR-679 Icom level RMVR cluster (rf_power,
+mic_gain, comp_level, nr_level, nb_level, cw_pitch) appended below the
+historical block.
 """
 
 from __future__ import annotations
@@ -87,6 +89,107 @@ CHECKS: tuple[CheckSpec, ...] = (
         value_rule=ValueRule.TOGGLE_BOOL,
         tolerance=0,
         hamlib_token="ATT",
+        tx_adjacent=False,
+    ),
+    # ----- MOR-679: Icom level RMVR cluster (shared CoreRadio; serves both -----
+    # ----- IC-7610 and IC-7300). Append-only; the template generators ----------
+    # ----- stable-sort by level so these slot into CAPABILITY_MATRIX in --------
+    # ----- registry order without disturbing positions 5-9. All ranges are -----
+    # ----- 0-255 (STEP_LEVEL_255) except CW pitch (300-900 Hz, CW_PITCH_HZ). ---
+    # rf_power.set — RF power 14 0A
+    CheckSpec(
+        check_id="rf_power.set",
+        capability="power_control",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Step the RF output power level and confirm readback within tolerance.",
+        protocol="power_control",
+        get_op="get_rf_power",
+        set_op="set_rf_power",
+        value_rule=ValueRule.STEP_LEVEL_255,
+        tolerance=3,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # mic_gain.set — MIC gain 14 0B
+    CheckSpec(
+        check_id="mic_gain.set",
+        capability="power_control",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Step the microphone gain level and confirm readback within tolerance.",
+        protocol="power_control",
+        get_op="get_mic_gain",
+        set_op="set_mic_gain",
+        value_rule=ValueRule.STEP_LEVEL_255,
+        tolerance=3,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # comp_level.set — speech compressor level 14 0E
+    CheckSpec(
+        check_id="comp_level.set",
+        capability="compressor",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Step the speech-compressor level and confirm readback within tolerance.",
+        protocol="compressor",
+        get_op="get_compressor_level",
+        set_op="set_compressor_level",
+        value_rule=ValueRule.STEP_LEVEL_255,
+        tolerance=3,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # nr_level.set — noise-reduction level 14 06
+    CheckSpec(
+        check_id="nr_level.set",
+        capability="nr",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Step the noise-reduction level and confirm readback within tolerance.",
+        protocol="nr",
+        get_op="get_nr_level",
+        set_op="set_nr_level",
+        value_rule=ValueRule.STEP_LEVEL_255,
+        tolerance=3,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # nb_level.set — noise-blanker level 14 12
+    CheckSpec(
+        check_id="nb_level.set",
+        capability="nb",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Step the noise-blanker level and confirm readback within tolerance.",
+        protocol="nb",
+        get_op="get_nb_level",
+        set_op="set_nb_level",
+        value_rule=ValueRule.STEP_LEVEL_255,
+        tolerance=3,
+        hamlib_token=None,
+        tx_adjacent=False,
+    ),
+    # cw_pitch.set — CW sidetone pitch 14 09 (300-900 Hz)
+    CheckSpec(
+        check_id="cw_pitch.set",
+        capability="cw",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="Nudge the CW pitch in Hz and confirm readback within tolerance.",
+        protocol="cw",
+        get_op="get_cw_pitch",
+        set_op="set_cw_pitch",
+        value_rule=ValueRule.CW_PITCH_HZ,
+        tolerance=5,
+        hamlib_token=None,
         tx_adjacent=False,
     ),
 )

--- a/src/rigplane/validation/registry/_types.py
+++ b/src/rigplane/validation/registry/_types.py
@@ -62,6 +62,9 @@ class ValueRule(StrEnum):
     CONTOUR_FLIP = "contour_flip"
     # MOR-678 — IC-7610 MOD-input routing source select (enumerated 0-5)
     MOD_SRC_FLIP = "mod_src_flip"
+    # MOR-679 — CW pitch is Hz (300-900), not a 0-255 level; nudge on the 5 Hz
+    # grid inside the documented band so the write is always restorable.
+    CW_PITCH_HZ = "cw_pitch_hz"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/golden/validation/ftx1.dry-run.json
+++ b/tests/golden/validation/ftx1.dry-run.json
@@ -48,12 +48,17 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
-      "check_id": "compressor.presence",
-      "status": "pass",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "comp_level.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "contour.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "cw_pitch.set",
       "status": "skip",
       "declaration": "supported"
     },
@@ -108,6 +113,11 @@
       "declaration": "supported"
     },
     {
+      "check_id": "mic_gain.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
       "check_id": "mod_input.set",
       "status": "unsupported",
       "declaration": "unsupported_pending_evidence"
@@ -123,12 +133,22 @@
       "declaration": "supported"
     },
     {
+      "check_id": "nb_level.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
       "check_id": "notch.set",
       "status": "skip",
       "declaration": "supported"
     },
     {
       "check_id": "nr.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "nr_level.set",
       "status": "skip",
       "declaration": "supported"
     },
@@ -146,6 +166,11 @@
       "check_id": "rf_gain.set",
       "status": "skip",
       "declaration": "supported"
+    },
+    {
+      "check_id": "rf_power.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
     },
     {
       "check_id": "rit.set",

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -63,14 +63,19 @@
       "declaration": "manual_required"
     },
     {
-      "check_id": "compressor.presence",
-      "status": "pass",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "comp_level.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "contour.set",
       "status": "unsupported",
       "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "cw_pitch.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "data_mode.presence",
@@ -158,6 +163,11 @@
       "declaration": "supported"
     },
     {
+      "check_id": "mic_gain.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
       "check_id": "mod_input.set",
       "status": "skip",
       "declaration": "supported"
@@ -178,6 +188,11 @@
       "declaration": "supported"
     },
     {
+      "check_id": "nb_level.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
       "check_id": "notch.set",
       "status": "skip",
       "declaration": "supported"
@@ -188,12 +203,12 @@
       "declaration": "supported"
     },
     {
-      "check_id": "pbt.presence",
-      "status": "pass",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "nr_level.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
-      "check_id": "power_control.presence",
+      "check_id": "pbt.presence",
       "status": "pass",
       "declaration": "unsupported_pending_evidence"
     },
@@ -204,6 +219,11 @@
     },
     {
       "check_id": "rf_gain.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "rf_power.set",
       "status": "skip",
       "declaration": "supported"
     },

--- a/tests/golden/validation/x6200.dry-run.json
+++ b/tests/golden/validation/x6200.dry-run.json
@@ -48,14 +48,19 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
-      "check_id": "compressor.presence",
-      "status": "pass",
-      "declaration": "unsupported_pending_evidence"
+      "check_id": "comp_level.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "contour.set",
       "status": "unsupported",
       "declaration": "unsupported_pending_evidence"
+    },
+    {
+      "check_id": "cw_pitch.set",
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "data_mode.presence",
@@ -108,6 +113,11 @@
       "declaration": "supported"
     },
     {
+      "check_id": "mic_gain.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
       "check_id": "mod_input.set",
       "status": "unsupported",
       "declaration": "unsupported_pending_evidence"
@@ -123,12 +133,22 @@
       "declaration": "supported"
     },
     {
+      "check_id": "nb_level.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
       "check_id": "notch.set",
       "status": "skip",
       "declaration": "supported"
     },
     {
       "check_id": "nr.set",
+      "status": "skip",
+      "declaration": "supported"
+    },
+    {
+      "check_id": "nr_level.set",
       "status": "skip",
       "declaration": "supported"
     },
@@ -151,6 +171,11 @@
       "check_id": "rf_gain.set",
       "status": "skip",
       "declaration": "supported"
+    },
+    {
+      "check_id": "rf_power.set",
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
     },
     {
       "check_id": "rit.set",

--- a/tests/validation/test_hardware_icom_levels.py
+++ b/tests/validation/test_hardware_icom_levels.py
@@ -1,0 +1,212 @@
+"""MOR-679: RMVR checks for Icom level controls.
+
+Covers the six level RMVR checks added by MOR-679 — rf_power, mic_gain,
+comp_level, nr_level, nb_level, cw_pitch — which share the CoreRadio backend
+(serving both IC-7610 and IC-7300). Each check is exercised against a stateful
+in-process fake that round-trips set->get, asserting it:
+
+* PASSes (the readback reacts and the original is restored),
+* restores the original value, and
+* never writes a value outside the control's documented range.
+
+A profile that does NOT declare the gating capability resolves the check to
+UNSUPPORTED without crashing.
+"""
+
+from __future__ import annotations
+
+from rigplane.core.radio_state import RadioState
+from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckStatus,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    ValidationLevel,
+)
+
+
+def _flatten(levels):
+    return {check.check_id: check for level in levels for check in level.checks}
+
+
+def _single_entry_template(
+    *,
+    check_id: str,
+    capability: str,
+    declaration: CapabilityDeclaration = CapabilityDeclaration.SUPPORTED,
+) -> MatrixTemplate:
+    return MatrixTemplate(
+        radio=RadioTarget(model="IC-7610", profile_id="icom_ic7610"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id=check_id,
+                capability=capability,
+                level=ValidationLevel.CAPABILITY_MATRIX,
+                declaration=declaration,
+                summary="single",
+            )
+        ],
+    )
+
+
+class _StatefulIcomLevelRadio:
+    """Stateful fake that round-trips set->get for the six MOR-679 controls.
+
+    Mirrors the shared CoreRadio surface: 0-255 levels for rf_power/mic_gain/
+    compressor/nr/nb plus CW pitch in Hz snapped to a 5 Hz grid (matching the
+    real decode). Records every written value so a test can assert nothing was
+    ever written out of range. ``capabilities`` is parameterised so the
+    cap-undeclared path can be exercised.
+    """
+
+    def __init__(self, capabilities: set[str]) -> None:
+        self.connected = True
+        self.model = "IC-7610"
+        self.capabilities = capabilities
+        self.radio_state = RadioState()
+        self._rf_power = 100
+        self._mic_gain = 100
+        self._comp_level = 100
+        self._nr_level = 100
+        self._nb_level = 100
+        self._cw_pitch = 600
+        self.rf_power_writes: list[int] = []
+        self.mic_gain_writes: list[int] = []
+        self.comp_writes: list[int] = []
+        self.nr_writes: list[int] = []
+        self.nb_writes: list[int] = []
+        self.cw_pitch_writes: list[int] = []
+
+    async def get_rf_power(self) -> int:
+        return self._rf_power
+
+    async def set_rf_power(self, level: int) -> None:
+        assert 0 <= level <= 255, f"rf_power out of range: {level}"
+        self.rf_power_writes.append(level)
+        self._rf_power = level
+
+    async def get_mic_gain(self) -> int:
+        return self._mic_gain
+
+    async def set_mic_gain(self, level: int) -> None:
+        assert 0 <= level <= 255, f"mic_gain out of range: {level}"
+        self.mic_gain_writes.append(level)
+        self._mic_gain = level
+
+    async def get_compressor_level(self) -> int:
+        return self._comp_level
+
+    async def set_compressor_level(self, level: int) -> None:
+        assert 0 <= level <= 255, f"comp_level out of range: {level}"
+        self.comp_writes.append(level)
+        self._comp_level = level
+
+    async def get_nr_level(self, receiver: int = 0) -> int:
+        return self._nr_level
+
+    async def set_nr_level(self, level: int, receiver: int = 0) -> None:
+        assert 0 <= level <= 255, f"nr_level out of range: {level}"
+        self.nr_writes.append(level)
+        self._nr_level = level
+
+    async def get_nb_level(self, receiver: int = 0) -> int:
+        return self._nb_level
+
+    async def set_nb_level(self, level: int, receiver: int = 0) -> None:
+        assert 0 <= level <= 255, f"nb_level out of range: {level}"
+        self.nb_writes.append(level)
+        self._nb_level = level
+
+    async def get_cw_pitch(self) -> int:
+        # Real decode snaps to the nearest 5 Hz; the fake stores on-grid values.
+        return self._cw_pitch
+
+    async def set_cw_pitch(self, pitch_hz: int) -> None:
+        assert 300 <= pitch_hz <= 900, f"cw_pitch out of range: {pitch_hz}"
+        self.cw_pitch_writes.append(pitch_hz)
+        self._cw_pitch = pitch_hz
+
+
+_ALL_CAPS = {"power_control", "compressor", "nr", "nb", "cw"}
+
+# (check_id, capability, writes-attr, original-value)
+_CASES = [
+    ("rf_power.set", "power_control", "rf_power_writes", 100),
+    ("mic_gain.set", "power_control", "mic_gain_writes", 100),
+    ("comp_level.set", "compressor", "comp_writes", 100),
+    ("nr_level.set", "nr", "nr_writes", 100),
+    ("nb_level.set", "nb", "nb_writes", 100),
+    ("cw_pitch.set", "cw", "cw_pitch_writes", 600),
+]
+
+
+async def test_icom_level_rmvr_pass_and_restore():
+    """Each level RMVR PASSes, reacts, and restores the original value."""
+    for check_id, capability, writes_attr, original in _CASES:
+        radio = _StatefulIcomLevelRadio(_ALL_CAPS)
+        template = _single_entry_template(check_id=check_id, capability=capability)
+        levels = await execute_hardware_checks(
+            radio, template, OperatorSafetyBlock(), allow_writes=True
+        )
+        check = _flatten(levels)[check_id]
+        assert check.status is CheckStatus.PASS, (
+            f"{check_id}: expected PASS, got {check.status} ({check.error})"
+        )
+        assert check.evidence["original"] == original
+        assert check.evidence["restored"] is True
+        # The control must end the run back at its original value.
+        writes = getattr(radio, writes_attr)
+        assert writes[-1] == original, (
+            f"{check_id}: last write {writes[-1]} != original {original}"
+        )
+
+
+async def test_icom_level_rmvr_never_writes_out_of_range():
+    """No level RMVR ever writes a value outside the control's documented band."""
+    for check_id, capability, writes_attr, _original in _CASES:
+        radio = _StatefulIcomLevelRadio(_ALL_CAPS)
+        template = _single_entry_template(check_id=check_id, capability=capability)
+        await execute_hardware_checks(
+            radio, template, OperatorSafetyBlock(), allow_writes=True
+        )
+        writes = getattr(radio, writes_attr)
+        assert writes, f"{check_id}: expected at least one write"
+        if check_id == "cw_pitch.set":
+            lo, hi = 300, 900
+        else:
+            lo, hi = 0, 255
+        for value in writes:
+            assert lo <= value <= hi, f"{check_id}: wrote {value} outside [{lo}, {hi}]"
+
+
+async def test_icom_level_rmvr_unsupported_when_cap_undeclared():
+    """A profile not declaring the gating capability resolves UNSUPPORTED."""
+    for check_id, capability, _writes_attr, _original in _CASES:
+        # Radio declares NO capabilities at all — gate resolves not-present.
+        radio = _StatefulIcomLevelRadio(set())
+        template = _single_entry_template(check_id=check_id, capability=capability)
+        levels = await execute_hardware_checks(
+            radio, template, OperatorSafetyBlock(), allow_writes=True
+        )
+        check = _flatten(levels)[check_id]
+        assert check.status is CheckStatus.UNSUPPORTED, (
+            f"{check_id}: expected UNSUPPORTED, got {check.status}"
+        )
+        assert check.evidence.get("capability_present") is False
+
+
+async def test_cw_pitch_nudge_stays_on_grid_at_ceiling():
+    """CW pitch near the 900 Hz ceiling nudges DOWN, never out of range."""
+    radio = _StatefulIcomLevelRadio(_ALL_CAPS)
+    radio._cw_pitch = 900
+    template = _single_entry_template(check_id="cw_pitch.set", capability="cw")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["cw_pitch.set"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["changed"] == 850  # 900 - 50, stepped away from ceiling
+    assert radio.cw_pitch_writes[-1] == 900  # restored

--- a/tests/validation/test_registry.py
+++ b/tests/validation/test_registry.py
@@ -97,11 +97,18 @@ _EXPECTED_CHECK_IDS = {
     "scope_vbw.set",
     "scope_rbw.set",
     "scope_fixed_edge.read",
+    # MOR-679 — Icom level RMVR cluster (shared CoreRadio: IC-7610 + IC-7300)
+    "rf_power.set",
+    "mic_gain.set",
+    "comp_level.set",
+    "nr_level.set",
+    "nb_level.set",
+    "cw_pitch.set",
 }
 
 
 def test_registry_has_expected_entry_count():
-    assert len(REGISTRY) == len(_EXPECTED_CHECK_IDS) == 55
+    assert len(REGISTRY) == len(_EXPECTED_CHECK_IDS) == 61
 
 
 def test_check_ids_unique():
@@ -388,6 +395,91 @@ _EXPECTED: list[tuple[str, dict]] = [
             "protocol": None,
             "failure_domain": FailureDomain.COMMAND_EXECUTION,
             "tx_adjacent": True,
+        },
+    ),
+    # MOR-679 — Icom level RMVR cluster
+    (
+        "rf_power.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "capability": "power_control",
+            "get_op": "get_rf_power",
+            "set_op": "set_rf_power",
+            "value_rule": ValueRule.STEP_LEVEL_255,
+            "tolerance": 3,
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "mic_gain.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "capability": "power_control",
+            "get_op": "get_mic_gain",
+            "set_op": "set_mic_gain",
+            "value_rule": ValueRule.STEP_LEVEL_255,
+            "tolerance": 3,
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "comp_level.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "capability": "compressor",
+            "get_op": "get_compressor_level",
+            "set_op": "set_compressor_level",
+            "value_rule": ValueRule.STEP_LEVEL_255,
+            "tolerance": 3,
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "nr_level.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "capability": "nr",
+            "get_op": "get_nr_level",
+            "set_op": "set_nr_level",
+            "value_rule": ValueRule.STEP_LEVEL_255,
+            "tolerance": 3,
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "nb_level.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "capability": "nb",
+            "get_op": "get_nb_level",
+            "set_op": "set_nb_level",
+            "value_rule": ValueRule.STEP_LEVEL_255,
+            "tolerance": 3,
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
+        },
+    ),
+    (
+        "cw_pitch.set",
+        {
+            "kind": CheckKind.RMVR_SAFE_WRITE,
+            "level": ValidationLevel.CAPABILITY_MATRIX,
+            "capability": "cw",
+            "get_op": "get_cw_pitch",
+            "set_op": "set_cw_pitch",
+            "value_rule": ValueRule.CW_PITCH_HZ,
+            "tolerance": 5,
+            "failure_domain": FailureDomain.READBACK,
+            "tx_adjacent": False,
         },
     ),
 ]


### PR DESCRIPTION
## What

Adds 6 RMVR round-trip validation checks for Icom level controls that had no round-trip check (gap-list A, `docs/validation/cat-audits/{ic7610,ic7300}.md`). Shared CoreRadio → covers IC-7610 + IC-7300.

| check_id | cap | get/set | range |
|---|---|---|---|
| `rf_power.set` | power_control | get/set_rf_power | 0-255 |
| `mic_gain.set` | power_control | get/set_mic_gain | 0-255 |
| `comp_level.set` | compressor | get/set_compressor_level | 0-255 |
| `nr_level.set` | nr | get/set_nr_level | 0-255 |
| `nb_level.set` | nb | get/set_nb_level | 0-255 |
| `cw_pitch.set` | cw | get/set_cw_pitch | 300-900 Hz |

Value rules: reused `STEP_LEVEL_255` (tol 3) for the five 0-255 levels (mirrors `af_level.set`); new `CW_PITCH_HZ` (tol 5, `_nudge_cw_pitch` +50 Hz on the 5 Hz grid, steps down near 900). No caps added to any profile.

## Goldens (only the 6 new rows + presence→functional swaps)

- **ic7610** 73→77: +6 `*.set` supported; `compressor.presence` + `power_control.presence` synthetic stubs removed (now functional).
- **x6200** 60→65 / **ftx1** 59→64: +6 rows; rf_power/mic_gain = unsupported_pending_evidence (no `power_control` cap). Existing rows untouched. All `--gate` exit 0.

## Tests (`tests/validation/test_hardware_icom_levels.py`, parametrized over 6 levels)

pass+restore; never-writes-out-of-range; unsupported-when-cap-undeclared; cw_pitch ceiling step-down. Registry guards count 55→61 + frozen id-set.

## Validation

- `pytest tests/ --ignore=tests/integration` → 7843 passed, 12 skipped, 11 xfailed
- `ruff check` + `format --check` → clean · `mypy src/` → no issues · `lint-imports` → 5 kept, 0 broken

**Live verification:** running the IC-7610 hardware validation from this branch (in progress) — expect the 6 level checks to PASS (RMVR, no TX).

Closes MOR-679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)