### PR TITLE
fix(MOR-683): X6200 — drop tone family (live-confirmed), defer filter_width

### DIFF
--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -62,11 +62,13 @@ codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
 #     RMVR checks (repeater_tone/tone_freq/tsql/tsql_freq) time out, so the
 #     caps are dropped — the checks now resolve UNSUPPORTED, not FAIL
 #     (MOR-683, supersedes the audit's gap-list D tone row).
-#   - ``filter_width`` IS declared: ``0x1A 0x03`` is wired
-#     (``get/set_filter_width``) and the live X6200 capture confirmed the
-#     radio answers it (MOR-683 — the earlier "deferred until tables
-#     confirmed on hardware" stance from x6100.toml/#1159 is now resolved
-#     for the X6200).
+#   - no ``filter_width`` SET: a live X6200 capture (CI-V 0xA4) showed
+#     ``0x1A 0x03`` cannot be round-tripped by the harness — ``get`` reads
+#     back a passband index (live: 27) while the USB setter guards
+#     50-9999 Hz, so the nudge produces an out-of-range write (units
+#     mismatch), and Hamlib marks ``x1ax03_supported = 0``. The cap stays
+#     UNDECLARED pending a setter units fix + a clean live round-trip
+#     (MOR-683 defers; tracked as a filter_width follow-up).
 features = [
     "audio",
     "af_level",
@@ -88,7 +90,6 @@ features = [
     "xit",
     "tuner",
     "meters",
-    "filter_width",
     "data_mode",
     "scan",
     "dial_lock",
@@ -390,7 +391,6 @@ get_transceiver_id = [0x19, 0x00]
 # 0x1A family — PDF pages 8-9 (band/spectrum, filter width)
 get_band_spectrum_display = [0x1A, 0x01]
 get_filter_width          = [0x1A, 0x03]
-set_filter_width          = [0x1A, 0x03]
 
 # PTT / tuner — PDF page 9 (0x1C family)
 ptt_on           = [0x1C, 0x00]

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -56,10 +56,17 @@ codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
 # narrower than the IC-705 envelope:
 #   - no ``power_control`` (no documented CI-V 0x18)
 #   - no ``scope`` (no documented 0x27 family)
-#   - no ``filter_width`` SET (PDF table 5 documents widths but encoding
-#     is the segmented BCD index family; mirror x6100.toml's "feature not
-#     advertised until tables are confirmed on hardware" stance — see
-#     issue #1159 referenced in x6100.toml)
+#   - no tone family (``repeater_tone`` / ``tsql``): the backend would send
+#     ``0x16 0x42/0x43`` + ``0x1B 0x00``, none of which the X6200 firmware
+#     answers. A live X6200 capture (CI-V 0xA4) confirmed all four tone
+#     RMVR checks (repeater_tone/tone_freq/tsql/tsql_freq) time out, so the
+#     caps are dropped — the checks now resolve UNSUPPORTED, not FAIL
+#     (MOR-683, supersedes the audit's gap-list D tone row).
+#   - ``filter_width`` IS declared: ``0x1A 0x03`` is wired
+#     (``get/set_filter_width``) and the live X6200 capture confirmed the
+#     radio answers it (MOR-683 — the earlier "deferred until tables
+#     confirmed on hardware" stance from x6100.toml/#1159 is now resolved
+#     for the X6200).
 features = [
     "audio",
     "af_level",
@@ -81,8 +88,7 @@ features = [
     "xit",
     "tuner",
     "meters",
-    "repeater_tone",
-    "tsql",
+    "filter_width",
     "data_mode",
     "scan",
     "dial_lock",
@@ -384,6 +390,7 @@ get_transceiver_id = [0x19, 0x00]
 # 0x1A family — PDF pages 8-9 (band/spectrum, filter width)
 get_band_spectrum_display = [0x1A, 0x01]
 get_filter_width          = [0x1A, 0x03]
+set_filter_width          = [0x1A, 0x03]
 
 # PTT / tuner — PDF page 9 (0x1C family)
 ptt_on           = [0x1C, 0x00]

--- a/tests/golden/validation/x6200.dry-run.json
+++ b/tests/golden/validation/x6200.dry-run.json
@@ -89,8 +89,8 @@
     },
     {
       "check_id": "filter_width.set",
-      "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "freq.reverse_sync",
@@ -169,8 +169,8 @@
     },
     {
       "check_id": "repeater_tone.set",
-      "status": "skip",
-      "declaration": "supported"
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
     },
     {
       "check_id": "rf_gain.set",
@@ -294,18 +294,18 @@
     },
     {
       "check_id": "tone_freq.set",
-      "status": "skip",
-      "declaration": "supported"
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
     },
     {
       "check_id": "tsql.set",
-      "status": "skip",
-      "declaration": "supported"
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
     },
     {
       "check_id": "tsql_freq.set",
-      "status": "skip",
-      "declaration": "supported"
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
     },
     {
       "check_id": "tuner.tune",

--- a/tests/golden/validation/x6200.dry-run.json
+++ b/tests/golden/validation/x6200.dry-run.json
@@ -89,8 +89,8 @@
     },
     {
       "check_id": "filter_width.set",
-      "status": "skip",
-      "declaration": "supported"
+      "status": "unsupported",
+      "declaration": "unsupported_pending_evidence"
     },
     {
       "check_id": "freq.reverse_sync",

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -807,3 +807,16 @@ class TestWriteOnlyControls:
     def test_x6200_declares_rit_xit_notch_write_only(self):
         profile = get_radio_profile("X6200")
         assert profile.write_only_controls >= {"rit", "xit", "notch"}
+
+    def test_x6200_drops_tone_family_keeps_filter_width(self):
+        # MOR-683: a live X6200 capture (CI-V 0xA4) confirmed the tone family
+        # (repeater_tone / tsql, driving 0x16 0x42/0x43 + 0x1B) times out, so
+        # those caps are dropped → the four tone RMVR checks resolve
+        # UNSUPPORTED instead of FAIL. filter_width (0x1A 0x03) is
+        # live-confirmed and now declared. rit/xit/notch and the DSP toggles
+        # stay untouched.
+        caps = get_radio_profile("X6200").capabilities
+        assert "repeater_tone" not in caps
+        assert "tsql" not in caps
+        assert "filter_width" in caps
+        assert {"rit", "xit", "notch", "nr", "nb", "compressor"} <= caps

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -808,15 +808,16 @@ class TestWriteOnlyControls:
         profile = get_radio_profile("X6200")
         assert profile.write_only_controls >= {"rit", "xit", "notch"}
 
-    def test_x6200_drops_tone_family_keeps_filter_width(self):
+    def test_x6200_drops_tone_family_and_does_not_declare_filter_width(self):
         # MOR-683: a live X6200 capture (CI-V 0xA4) confirmed the tone family
         # (repeater_tone / tsql, driving 0x16 0x42/0x43 + 0x1B) times out, so
         # those caps are dropped → the four tone RMVR checks resolve
-        # UNSUPPORTED instead of FAIL. filter_width (0x1A 0x03) is
-        # live-confirmed and now declared. rit/xit/notch and the DSP toggles
-        # stay untouched.
+        # UNSUPPORTED instead of FAIL. filter_width stays UNDECLARED: the same
+        # live capture showed 0x1A 0x03 cannot be round-tripped (get reads a
+        # passband index, the USB setter guards 50-9999 Hz) and Hamlib marks
+        # x1ax03_supported=0. rit/xit/notch and the DSP toggles stay untouched.
         caps = get_radio_profile("X6200").capabilities
         assert "repeater_tone" not in caps
         assert "tsql" not in caps
-        assert "filter_width" in caps
+        assert "filter_width" not in caps
         assert {"rit", "xit", "notch", "nr", "nb", "compressor"} <= caps


### PR DESCRIPTION
## MOR-683 — X6200 profile alignment to live hardware

Aligns the X6200 rig profile to a **live X6200 capture** (USB serial, CI-V `0xA4`),
under the MOR-634 validation-harness epic. Two profile changes, both driven by
what the connected radio actually does:

### 1. Drop the tone family (live-confirmed unsupported)
`repeater_tone` / `tsql` caps removed. The backend would send `0x16 0x42/0x43`
+ `0x1B 0x00`; live capture showed all four tone RMVR checks
(`repeater_tone`/`tone_freq`/`tsql`/`tsql_freq`) **time out**. They now resolve
**UNSUPPORTED** instead of FAIL. Corroborated by Hamlib `xiegu.c` (the X6200 caps
struct over-declares these — Hamlib never round-trip-verified them).

### 2. Defer `filter_width` (cap undeclared → `unsupported_pending_evidence`)
The first cut of this PR added `filter_width` (`0x1A 0x03`). Live capture proved
that's premature: the check FAILED — not a radio timeout, but a backend
encoding mismatch. `get_filter_width` returned a **raw passband index** the
BCD path mis-handles, and the radio uses a **raw-hex, two-segment codec with a
~1100 Hz breakpoint** — unlike the BCD+segments path IC-705/IC-7610 use. So the
cap is **left undeclared** (`set_filter_width` command removed; golden row reverts
to `unsupported_pending_evidence`). Implementing real X6200 filter_width support
(custom codec, live-derived) is a separate MOR-634 follow-up.

### Live evidence
- Tone: 4 checks TIMEOUT → drop.
- rit/xit/notch/nr/nb: PASS live → kept (Hamlib & the doc-only audit wrongly
  predicted some of these would fail).
- filter_width: radio answers `0x1A 0x03` reads, but width codec is raw-hex
  `Hz=(b-10)*100` (≥1200) / `Hz=b*50+50` (≤1100), AM/FM off-register — needs a
  dedicated implementation, not a profile flag.

### Tests / verification
- New `test_x6200_drops_tone_family_and_does_not_declare_filter_width`.
- Golden `x6200.dry-run.json` regenerated; ftx1/ic7610 goldens byte-identical.
- `pytest` (excl. integration), `ruff`, `ruff format`, `mypy src/`,
  `lint-imports`, and all 3 `--gate` runs: green.

### Note — pre-existing, unrelated
`tests/integration/test_validation_matrix_integration.py::test_dry_run_statuses_are_planned_and_error_free`
fails for **all 8 owned profiles** on `main` too (HEAD `3d8c29ae`): `*.presence`
checks return `pass` in dry-run. That's MOR-680 territory, not introduced here,
and outside the `quick.yml` gate (which excludes integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)