### PR TITLE
fix(MOR-699): X6200 — drop over-declared pbt cap (live 0x14 07/08 timeout)

### DIFF
--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -62,6 +62,12 @@ codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
 #     RMVR checks (repeater_tone/tone_freq/tsql/tsql_freq) time out, so the
 #     caps are dropped — the checks now resolve UNSUPPORTED, not FAIL
 #     (MOR-683, supersedes the audit's gap-list D tone row).
+#   - no ``pbt`` (twin passband tuning): the front panel HAS PBT, but a live
+#     X6200 probe (CI-V 0xA4) showed ``get_pbt_inner`` (0x14 0x07) and
+#     ``get_pbt_outer`` (0x14 0x08) both TIME OUT in BOTH AM and USB modes —
+#     the firmware does not expose PBT over CI-V. Hamlib xiegu.c over-declares
+#     it without a round-trip, so the cap is dropped → the pbt.presence check
+#     now resolves UNSUPPORTED, not a spurious presence-pass (MOR-699).
 #   - no ``filter_width`` SET: a live X6200 capture (CI-V 0xA4) showed
 #     ``0x1A 0x03`` cannot be round-tripped by the harness — ``get`` reads
 #     back a passband index (live: 27) while the USB setter guards
@@ -79,7 +85,6 @@ features = [
     "nb",
     "nr",
     "notch",
-    "pbt",
     "tx",
     "split",
     "vox",
@@ -183,22 +188,6 @@ style = "toggle"
 # Level control ranges — CI-V compatible (Xiegu X6200).
 # Every "raw_min/raw_max" pair below is documented in the PDF as
 # "BCD format 0-255" (pages 6-7).
-[controls.pbt_inner]
-raw_min = 0
-raw_max = 255
-raw_center = 128
-display_min = -1200
-display_max = 1200
-display_unit = "Hz"
-
-[controls.pbt_outer]
-raw_min = 0
-raw_max = 255
-raw_center = 128
-display_min = -1200
-display_max = 1200
-display_unit = "Hz"
-
 [controls.af_level]
 raw_min = 0
 raw_max = 255

--- a/tests/golden/validation/x6200.dry-run.json
+++ b/tests/golden/validation/x6200.dry-run.json
@@ -158,11 +158,6 @@
       "declaration": "supported"
     },
     {
-      "check_id": "pbt.presence",
-      "status": "pass",
-      "declaration": "unsupported_pending_evidence"
-    },
-    {
       "check_id": "preamp.set",
       "status": "skip",
       "declaration": "supported"

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -821,3 +821,14 @@ class TestWriteOnlyControls:
         assert "tsql" not in caps
         assert "filter_width" not in caps
         assert {"rit", "xit", "notch", "nr", "nb", "compressor"} <= caps
+
+    def test_x6200_drops_over_declared_pbt(self):
+        # MOR-699: a live X6200 probe (CI-V 0xA4) showed twin-PBT (get_pbt_inner
+        # 0x14 0x07 and get_pbt_outer 0x14 0x08) time out in BOTH AM and USB
+        # modes — the front-panel PBT is not exposed over CI-V. The cap is
+        # over-declared (Hamlib xiegu.c declares it without a round-trip), so it
+        # is dropped → the pbt.presence check resolves UNSUPPORTED instead of a
+        # spurious presence-pass. The kept controls stay untouched.
+        caps = get_radio_profile("X6200").capabilities
+        assert "pbt" not in caps
+        assert {"rit", "xit", "notch", "nr", "nb", "compressor"} <= caps


### PR DESCRIPTION
## MOR-699 (part) — X6200 drop over-declared twin-PBT

Live-probed on a connected X6200 (CI-V `0xA4`) under the MOR-634 validation-harness epic:
- `get_pbt_inner` (`0x14 0x07`) → **TimeoutError** in BOTH AM and USB.
- `get_pbt_outer` (`0x14 0x08`) → **TimeoutError** in BOTH AM and USB.

The radio has twin-PBT on the front panel, but the firmware does **not** expose it over CI-V — same over-declaration class as the tone family (MOR-683 / PR #1833) and the nr/nb/comp levels (rest of MOR-699). Hamlib `xiegu.c` over-advertises the same controls without round-trip-verifying them.

### Change (profile-data only)
- Remove `pbt` from `[capabilities] features`.
- Remove `[controls.pbt_inner]` / `[controls.pbt_outer]`.
- Capability comment records the live rationale.
- Regenerated x6200 golden: the spurious `pbt.presence` `pass`-in-dry-run row is gone (cap undeclared → no pbt check generated). ftx1/ic7610 goldens byte-identical.
- New test `test_x6200_drops_over_declared_pbt` (pbt absent; rit/xit/notch/nr/nb/compressor retained).

### Verification
pytest (excl. integration): 7868 passed / 0 failed · ruff check + format · mypy clean · lint-imports 5/0 · golden gates FTX-1/IC-7610/X6200 exit 0.

### Note — pre-existing, unrelated
The 8 `*.presence` `test_dry_run_statuses_are_planned_and_error_free` integration failures reproduce on `main` (MOR-680) and are outside the `quick.yml` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)