### PR TITLE
fix(MOR-634): X6100 — drop over-declared tone+pbt (X6200 shared-firmware inference)

### DIFF
--- a/rigs/x6100.toml
+++ b/rigs/x6100.toml
@@ -26,6 +26,23 @@ address = 0x70
 # undocumented in wfview and unverified on hardware. Until segment tables
 # are confirmed against an X6100, the capability stays disabled to avoid
 # silently sending wrong indices (CI-V SET is fire-and-forget). Issue #1159.
+#
+# NOTE: the tone family (``repeater_tone`` / ``tsql``) and ``pbt`` are
+# intentionally NOT advertised — dropped by X6100/X6200 shared-firmware
+# inference, PENDING direct X6100 hardware confirmation (we have NO X6100
+# to capture). Rationale (MOR-634):
+#   - Hamlib ``rigs/icom/xiegu.c`` builds the X6200 (``RIG_MODEL_X6200`` =
+#     3091) from the same ``x6100_priv_caps`` struct it uses for the X6100,
+#     i.e. the two radios share one CI-V personality / firmware lineage.
+#   - A live X6200 capture (CI-V 0xA4) then disproved these caps on real
+#     hardware: the tone family's ``0x16 0x42/0x43`` + ``0x1B`` time out
+#     (dropped in MOR-683 / PR #1833), and ``pbt``'s ``0x14 0x07/0x08``
+#     time out in both AM and USB (dropped in MOR-699).
+# By the shared-firmware inference the X6100 almost certainly behaves the
+# same way, so advertising caps we cannot validate is exactly the
+# over-declaration the validation harness exists to catch. These three are
+# dropped here BY INFERENCE, not by a direct X6100 capture — do NOT relabel
+# them "live confirmed" for the X6100 until a real X6100 is actually probed.
 features = [
     "audio",
     "af_level",
@@ -36,7 +53,6 @@ features = [
     "nb",
     "nr",
     "notch",
-    "pbt",
     "tx",
     "split",
     "vox",
@@ -47,8 +63,6 @@ features = [
     "xit",
     "tuner",
     "meters",
-    "repeater_tone",
-    "tsql",
     "data_mode",
     "scan",
     "dial_lock",
@@ -73,22 +87,6 @@ values = [0, 1]
 style = "toggle"
 
 # Level control ranges — CI-V compatible (Xiegu X6100)
-[controls.pbt_inner]
-raw_min = 0
-raw_max = 255
-raw_center = 128
-display_min = -1200
-display_max = 1200
-display_unit = "Hz"
-
-[controls.pbt_outer]
-raw_min = 0
-raw_max = 255
-raw_center = 128
-display_min = -1200
-display_max = 1200
-display_unit = "Hz"
-
 [controls.af_level]
 raw_min = 0
 raw_max = 255

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -821,3 +821,22 @@ class TestWriteOnlyControls:
         assert "tsql" not in caps
         assert "filter_width" not in caps
         assert {"rit", "xit", "notch", "nr", "nb", "compressor"} <= caps
+
+    def test_x6100_drops_unsupported_tone_and_pbt(self):
+        # MOR-634: the X6100 over-declared repeater_tone / tsql / pbt. By the
+        # X6100/X6200 shared-firmware inference (Hamlib xiegu.c reuses the same
+        # x6100_priv_caps struct for RIG_MODEL_X6200=3091) plus live X6200
+        # evidence — tone 0x16 0x42/0x43 + 0x1B (MOR-683) and pbt 0x14 07/08
+        # (MOR-699) both time out on real hardware — these caps are dropped.
+        # NOT live-confirmed on an X6100 (no X6100 hardware exists to capture);
+        # this is a conservative by-inference alignment pending direct
+        # confirmation. The profile must still load and keep its other caps.
+        profile = get_radio_profile("X6100")
+        caps = profile.capabilities
+        assert "repeater_tone" not in caps
+        assert "tsql" not in caps
+        assert "pbt" not in caps
+        # filter_width is already (correctly) not advertised — keep it so.
+        assert "filter_width" not in caps
+        # Unrelated caps stay untouched.
+        assert {"rit", "xit", "notch", "nr", "nb", "compressor"} <= caps


### PR DESCRIPTION
## MOR-634 — align X6100 profile to corrected X6200 reality

`rigs/x6100.toml` over-declared the same capabilities just live-disproven on the X6200. Hamlib `xiegu.c` shows `RIG_MODEL_X6200=3091` reuses the X6100 caps struct (`x6100_priv_caps`) verbatim — shared firmware — so the X6200 live evidence transfers. We have **no X6100 hardware**, so this is a by-inference alignment, documented honestly (NOT labeled "live confirmed" for the X6100).

### Change (profile-data only)
- Drop `repeater_tone`, `tsql`, `pbt` from `[capabilities] features`.
- Remove dangling `[controls.pbt_inner]`/`[controls.pbt_outer]` (only served `pbt`).
- Capability comment records the inference: hamlib shared struct + X6200 live (tone `0x16 42/43`+`0x1B` MOR-683/#1833; pbt `0x14 07/08` MOR-699), **PENDING** X6100 hardware confirmation.
- `filter_width` stays undeclared (unchanged).
- No committed x6100 golden exists; none added (out of scope).

### Test
`test_x6100_drops_unsupported_tone_and_pbt` — the three caps absent, profile still loads, unrelated caps retained.

### Verification
pytest (excl. integration): 7868 passed / 0 failed · ruff check + format · mypy clean · lint-imports 5/0.

### Note — pre-existing, unrelated
The 8 `*.presence` integration failures reproduce on `main` (MOR-680), outside the `quick.yml` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)