### PR TITLE
test(MOR-611): reset connection store before each test (kill order-dependent flake)

### DIFF
--- a/frontend/src/lib/stores/connection.test.ts
+++ b/frontend/src/lib/stores/connection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   setRigConnected,
   getRigConnected,
@@ -12,6 +12,16 @@ import {
 } from './connection.svelte';
 
 describe('connection readiness fields', () => {
+  beforeEach(() => {
+    // The store is a module-level singleton shared across tests; reset it to a
+    // known baseline so per-test "defaults to false/null" assertions hold
+    // regardless of execution order (vitest shuffle/parallelism). See MOR-611.
+    setRigConnected(false);
+    setRadioReady(false);
+    setControlConnected(false);
+    setRadioHealth(null);
+  });
+
   it('rigConnected defaults to false and can be set', () => {
     expect(getRigConnected()).toBe(false);
     setRigConnected(true);


### PR DESCRIPTION
## MOR-611 — frontend test flake

`frontend/src/lib/stores/connection.test.ts` drives the module-singleton `connection.svelte` store with no per-test reset, so its "defaults to false/null" assertions leaked state under vitest CI ordering/parallelism → spurious `expected true to be false`. Surfaces on any `web/**` PR that triggers the `quick.yml` frontend block.

### Fix (test-only, no production change)
Added `beforeEach` resetting the store to baseline (`setRigConnected/​setRadioReady/​setControlConnected(false)`, `setRadioHealth(null)`).

### Verification
- `npx vitest run --sequence.shuffle src/lib/stores/connection.test.ts` ×3 — all green.
- Full frontend suite: 124 files / 2137 tests pass.
- `grep -L beforeEach` over store tests → only this file lacked it (no siblings need it).

No Python/`src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)