### PR TITLE
fix(MOR-561): FTX-1 — suppress repeated sub.s_meter SM1 parse warning (radio answers SM0000)

### DIFF
--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -920,18 +920,42 @@ class YaesuObservationAdapter:
         ``CatTimeoutError`` both subclass ``CatTransportError``, so the SPECIFIC
         ``CatCommandRejected`` (a ``?;`` reject = unsupported command on this
         radio) is caught while the base/timeout propagates.
+
+        MOR-561: a permanently unsupported field (e.g. the FTX-1 answering the
+        SUB ``SM1;`` query with a main-form ``SM0000;`` frame) fails identically
+        every poll cycle, several times a second. The FIRST failure for a given
+        field warns; every repeat is demoted to DEBUG so the log is not flooded.
         """
         try:
             return True, await read
         except (CatParseError, CatFormatError, ValueError, KeyError) as exc:
             # ValueError covers _read_meter / int() malformed-frame failures;
             # CatParse/FormatError subclass ValueError but are listed for clarity.
-            logger.warning("Skipping field %s — malformed CAT response: %s", label, exc)
+            self._log_field_skip(
+                label, "Skipping field %s — malformed CAT response: %s", exc
+            )
             return False, None
         except CatCommandRejected as exc:
             # ``?;`` reject = command unsupported on this radio -> skip the field.
-            logger.warning("Skipping field %s — command rejected (?;): %s", label, exc)
+            self._log_field_skip(
+                label, "Skipping field %s — command rejected (?;): %s", exc
+            )
             return False, None
+
+    def _log_field_skip(self, label: str, message: str, exc: Exception) -> None:
+        """Warn once per field, then demote repeats to DEBUG (MOR-561).
+
+        The warned-field set lives on the radio (persistent across poll cycles)
+        rather than the adapter (rebuilt every cycle). A non-``set`` attribute —
+        e.g. a ``MagicMock`` test double — falls back to always-warn.
+        """
+        warned = getattr(self.radio, "_poll_warned_fields", None)
+        if isinstance(warned, set):
+            if label in warned:
+                logger.debug(message, label, exc)
+                return
+            warned.add(label)
+        logger.warning(message, label, exc)
 
     def _adapter(self) -> ProviderObservationAdapter:
         return ProviderObservationAdapter(

--- a/src/rigplane/backends/yaesu_cat/parser.py
+++ b/src/rigplane/backends/yaesu_cat/parser.py
@@ -116,7 +116,11 @@ _PLACEHOLDER_REGEX: dict[str, tuple[str, Any]] = {
     "wpm:03d": (r"(?P<wpm>\d{3})", int),
     "code:03d": (r"(?P<code>\d{3})", int),
     "idx:02d": (r"(?P<idx>\d{2})", int),
-    "delay:04d": (r"(?P<delay>\d{4})", int),
+    # MOR-561: the FTX-1 answers ``SD;`` with a short ``SD09;`` (2-digit) form
+    # while the template is the canonical ``SD{delay:04d};`` (4-digit). Accept
+    # 2–4 digits so the QSK-delay read parses instead of warning every cycle.
+    # ``delay`` is FTX-1-only, so this does not affect any other radio.
+    "delay:04d": (r"(?P<delay>\d{2,4})", int),
     "head": (r"(?P<head>.)", str),
     "watts:03d": (r"(?P<watts>\d{3})", int),
     "model:04d": (r"(?P<model>\d{4})", int),

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -238,6 +238,13 @@ class YaesuCatRadio:
             self._code_to_mode[code] = name
             self._mode_to_code[name] = code
 
+        # MOR-561: poll-lane fields whose field-level CAT failure has already
+        # been warned about once. Persists across poll cycles (the observation
+        # adapter is rebuilt every cycle, the radio is not), so a permanently
+        # unsupported field — e.g. the FTX-1 answering ``SM1;`` with a main-form
+        # ``SM0000;`` — warns once and then demotes repeats to DEBUG.
+        self._poll_warned_fields: set[str] = set()
+
         # Compile response parsers once at init time (keyed by command name).
         # Commands with unsupported placeholders (e.g. {vfo}, {band}) are skipped.
         self._parsers: dict[str, CatCommandParser] = {}

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -1657,5 +1657,73 @@ async def test_happy_path_slow_poll_unchanged_when_all_reads_succeed() -> None:
     ]
 
 
+# ---------------------------------------------------------------------------
+# MOR-561: once-then-suppress for repeated field-level CAT parse failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sub_s_meter_parse_warning_logged_once_then_suppressed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MOR-561: the FTX-1 answers ``SM1;`` (sub) with a main-form ``SM0000;``.
+
+    That well-formed-but-wrong-form frame raises ``CatParseError`` every poll
+    cycle. The poller queries it several times per second, so a per-cycle
+    WARNING floods the log. The first occurrence must WARN once; every repeat
+    for the same field must demote to DEBUG (no repeated WARNING).
+    """
+    radio = _make_radio()
+    # The real YaesuCatRadio owns this persistent set; the MagicMock double
+    # must too, so the once-then-suppress dedup has somewhere to record the
+    # already-warned field across poll cycles (MOR-561).
+    radio._poll_warned_fields = set()
+    radio.read_s_meter = AsyncMock(
+        side_effect=lambda receiver=0: (
+            120
+            if receiver == 0
+            else _raise(
+                CatParseError(
+                    "SM1{raw:03d};",
+                    "SM0000;",
+                    "Response does not match pattern",
+                )
+            )
+        )
+    )
+
+    def _poll_meters() -> "object":
+        # Fresh adapter per cycle (matches the poller, which rebuilds the
+        # adapter every poll cycle via YaesuObservationAdapter.from_radio).
+        return YaesuObservationAdapter(
+            radio,
+            profile=_profile_state_acquisition(),
+            clock=_clock,
+        ).poll_rx_meters()
+
+    with caplog.at_level("DEBUG"):
+        for _ in range(5):
+            await _poll_meters()
+
+    sub_warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelname == "WARNING" and "sub.s_meter" in rec.getMessage()
+    ]
+    sub_debugs = [
+        rec
+        for rec in caplog.records
+        if rec.levelname == "DEBUG" and "sub.s_meter" in rec.getMessage()
+    ]
+    # Exactly one WARNING across all five cycles; repeats demoted to DEBUG.
+    assert len(sub_warnings) == 1
+    assert len(sub_debugs) == 4
+    # The MAIN meter still emits every cycle (sub failure is isolated).
+    observations = await _poll_meters()
+    assert ("receiver.main.meters.s_meter", 120) in [
+        (str(item.path), item.value) for item in observations
+    ]
+
+
 def _raise(exc: Exception) -> object:
     raise exc

--- a/tests/test_yaesu_cat_parser.py
+++ b/tests/test_yaesu_cat_parser.py
@@ -135,6 +135,20 @@ class TestCatCommandParser:
         result = parser.parse("SM0000;")
         assert isinstance(result["raw"], int)
 
+    def test_parse_break_in_delay_two_digit(self):
+        # MOR-561: the FTX-1 answers ``SD;`` with a 2-digit ``SD09;`` form
+        # while the template is ``SD{delay:04d};`` (4-digit). The delay regex
+        # must accept 2–4 digits so the startup read parses without warning.
+        parser = CatCommandParser("SD{delay:04d};")
+        assert parser.parse("SD09;") == {"delay": 9}
+
+    def test_parse_break_in_delay_four_digit_still_parses(self):
+        # MOR-561 regression: the widened delay regex must still accept the
+        # canonical 4-digit ``SD0300;`` form (no behaviour change for radios
+        # that answer in full width).
+        parser = CatCommandParser("SD{delay:04d};")
+        assert parser.parse("SD0300;") == {"delay": 300}
+
     def test_parse_rit_clarifier(self):
         # CF001+0500; — func=1, sign=+, offset=500
         parser = CatCommandParser("CF001{sign}{offset:04d};")


### PR DESCRIPTION
## MOR-561 — FTX-1 poller log spam

The FTX-1 web poller flooded the log every cycle (several/sec) with `Skipping field sub.s_meter — malformed CAT response: ... 'SM1...' against 'SM0000;'`: the radio answers the SUB `SM1;` query in main-meter form (`SM0000;`), i.e. it doesn't support the sub S-meter read. Also a one-shot `break_in_delay` warning (`SD09;` 2-digit vs the 4-digit template).

### Fix — log-hygiene (once-then-suppress); NO dual-RX remodeling
Per the ticket's preferred path and to avoid disturbing FTX-1 dual-receiver modeling (under separate review, MOR-558):
- `_safe_read` warns once per field then demotes repeats to DEBUG. The warned-field set lives on the **radio** (persistent) because the observation adapter is rebuilt every poll cycle. Covers both parse-error and command-rejected paths.
- `break_in_delay`: widened the `delay` parse regex `\d{4}` → `\d{2,4}` (FTX-1 returns 2-digit; `delay` is FTX-1-only across all profiles; write template stays `04d`).

### Files (3 production + 2 test)
`backends/yaesu_cat/observations.py`, `radio.py`, `parser.py` + tests. No profile/golden change (goldens byte-identical).

### Tests
- `test_sub_s_meter_parse_warning_logged_once_then_suppressed` — 5 cycles → 1 WARNING + 4 DEBUG; MAIN meter unaffected.
- `test_parse_break_in_delay_two_digit` / `..._four_digit_still_parses` (regression).

### Verification
pytest (excl. integration): 7809 passed / 0 failed · ruff · mypy · lint-imports all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)