### PR TITLE
fix(MOR-682): IC-7610 — remove dead [commands] tone entries (no declared capability)

### DIFF
--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -1088,14 +1088,12 @@ get_vd_meter = [0x15, 0x15]
 get_id_meter = [0x15, 0x16]
 
 # ── Tone / TSQL ──
-get_repeater_tone = [0x16, 0x42]          # 0=OFF, 1=ON
-set_repeater_tone = [0x16, 0x42]
-get_repeater_tsql = [0x16, 0x43]          # 0=OFF, 1=ON
-set_repeater_tsql = [0x16, 0x43]
-get_tone_freq = [0x1B, 0x00]
-set_tone_freq = [0x1B, 0x00]
-get_tsql_freq = [0x1B, 0x01]
-set_tsql_freq = [0x1B, 0x01]
+# Intentionally absent: the IC-7610 (HF/6m) has no FM-repeater CTCSS tone
+# feature, so the repeater-tone / TSQL family is NOT declared as a capability
+# (MOR-660/661). With no declared capability and no registry check referencing
+# them, the get/set_repeater_tone, get/set_repeater_tsql, get/set_tone_freq,
+# and get/set_tsql_freq command entries were dead/orphaned and were removed
+# (MOR-682). Do not re-add them without first declaring the capability.
 
 # ── Data Mode ──
 get_data_mode = [0x1A, 0x06]

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -545,6 +545,22 @@ class TestToCommandMap:
         cm = load_rig(TEMPLATE_PATH).to_command_map()
         assert len(cm) > 50  # template has ~100 commands
 
+    def test_ic7610_drops_dead_tone_commands(self):
+        """MOR-682: IC-7610 has no FM-repeater tone capability, so the
+        repeater-tone / TSQL command entries must not be in the command map."""
+        cm = load_rig(TEMPLATE_PATH).to_command_map()
+        for key in (
+            "get_repeater_tone",
+            "set_repeater_tone",
+            "get_repeater_tsql",
+            "set_repeater_tsql",
+            "get_tone_freq",
+            "set_tone_freq",
+            "get_tsql_freq",
+            "set_tsql_freq",
+        ):
+            assert not cm.has(key), f"dead tone command {key!r} still present"
+
 
 # ── discover_rigs ────────────────────────────────────────────────
 


### PR DESCRIPTION
## MOR-682 — IC-7610 dead tone command cleanup (MOR-634 / CAT audit gap-list D)

`rigs/ic7610.toml` `[commands]` carried tone/TSQL entries (`0x16 0x42`/`0x43`, `0x1B 0x00`/`0x01`) whose capabilities are NOT declared — the IC-7610 repeater-tone family was intentionally dropped (MOR-660/661), so these are orphan command strings. Removed.

### Change
Removed 8 dead command keys (`get/set_repeater_tone`, `get/set_repeater_tsql`, `get/set_tone_freq`, `get/set_tsql_freq`), replaced with an explanatory comment. The `[cmd29]` routes were left untouched (out of scope — `[commands]` only). Confirmed orphaned: the validation registry tone checks are gated on the (absent) caps, so none ran.

### Golden
UNCHANGED — dead commands generate no checks; regen produced a byte-identical golden (reverted). FTX-1/X6200 untouched; all 3 `--gate` runs exit 0.

### Test
`test_ic7610_drops_dead_tone_commands` — asserts all 8 keys absent from the command map.

### Verification
pytest (excl. integration): 7869 passed / 0 failed · ruff · mypy · lint-imports clean. (Branch merged up to current `main`; `test_rig_loader.py` auto-merged cleanly with the X6200/X6100 tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)