### PR TITLE
fix(MOR-699): exclude X6200 NR/NB level validation

### DIFF
--- a/docs/validation/templates/xiegu_x6200.json
+++ b/docs/validation/templates/xiegu_x6200.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "override": true,
+  "radio": {
+    "model": "X6200",
+    "profile_id": "xiegu_x6200"
+  },
+  "entries": [
+    {
+      "check_id": "nr_level.set",
+      "declaration": "excluded"
+    },
+    {
+      "check_id": "nb_level.set",
+      "declaration": "excluded"
+    }
+  ]
+}

--- a/tests/golden/validation/x6200.dry-run.json
+++ b/tests/golden/validation/x6200.dry-run.json
@@ -138,22 +138,12 @@
       "declaration": "supported"
     },
     {
-      "check_id": "nb_level.set",
-      "status": "skip",
-      "declaration": "supported"
-    },
-    {
       "check_id": "notch.set",
       "status": "skip",
       "declaration": "supported"
     },
     {
       "check_id": "nr.set",
-      "status": "skip",
-      "declaration": "supported"
-    },
-    {
-      "check_id": "nr_level.set",
       "status": "skip",
       "declaration": "supported"
     },

--- a/tests/test_validate_overrides.py
+++ b/tests/test_validate_overrides.py
@@ -102,6 +102,28 @@ def test_no_override_file_leaves_matrix_unchanged(
     assert "filter_width.set" in checks
 
 
+def test_shipped_x6200_override_excludes_dead_nr_nb_level_checks(
+    capsys: Any,
+) -> None:
+    """The X6200 shipped override drops dead level registers, not toggles."""
+    args = _parse(["--model", "X6200", "validate", "--json"])
+    rc = _validate.run(args)
+    assert rc == 0
+    artifact = json.loads(capsys.readouterr().out)
+
+    overrides = artifact["metadata"].get("overrides")
+    assert overrides is not None
+    assert "nr_level.set" in overrides["excluded"]
+    assert "nb_level.set" in overrides["excluded"]
+
+    checks = {c["check_id"] for level in artifact["levels"] for c in level["checks"]}
+    assert "nr_level.set" not in checks
+    assert "nb_level.set" not in checks
+    assert "nr.set" in checks
+    assert "nb.set" in checks
+    assert "comp_level.set" in checks
+
+
 def test_full_template_without_flag_is_not_applied(
     tmp_path: Any, monkeypatch: Any, capsys: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- add the shipped `xiegu_x6200` validation override to exclude `nr_level.set` and `nb_level.set`
- regenerate the X6200 dry-run golden so those two dead level checks are absent
- add a dry-run wiring test proving the level checks are excluded while `nr.set`, `nb.set`, and `comp_level.set` remain present

## Evidence
Live X6200 validation on 2026-06-11T20:26Z (CI-V 0xA4) showed `nr_level.set` (`0x14 06`) and `nb_level.set` (`0x14 12`) timing out after 8s with no response, while the NR/NB toggles passed. This mirrors the existing IC-7610 tone-family override precedent and keeps `comp_level.set` untouched for the remaining hardware-gated MOR-699 scope.

## Verification
- RED: `uv run pytest tests/test_validate_overrides.py::test_shipped_x6200_override_excludes_dead_nr_nb_level_checks -q --tb=short` failed before the override with `assert None is not None`
- GREEN: `uv run pytest tests/test_validate_overrides.py::test_shipped_x6200_override_excludes_dead_nr_nb_level_checks -q --tb=short`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`
- `uv run ruff check src/ tests/ && uv run ruff format src/ tests/`
- `uv run lint-imports`
- `uv run rigplane --model X6200 validate --provider native --dry-run --gate tests/golden/validation/x6200.dry-run.json`
- `python3 -c "import json;c={x['check_id'] for x in json.load(open('tests/golden/validation/x6200.dry-run.json'))['checks']};print('nr_level.set' in c, 'nb_level.set' in c, 'nr.set' in c, 'comp_level.set' in c)"` -> `False False True True`