### PR TITLE
fix(MOR-690): firm unsupported for absent validation caps

### DIFF
--- a/docs/contracts/validation-matrix-v1.md
+++ b/docs/contracts/validation-matrix-v1.md
@@ -99,8 +99,9 @@ Each `levels[].checks[]` object:
 
 | Declaration                    | Meaning                                                |
 | ------------------------------ | ------------------------------------------------------ |
-| `supported`                    | Capability is declared in the radio profile.           |
-| `unsupported_pending_evidence` | Not declared; absence pending evidence to confirm.     |
+| `supported`                    | Capability is declared and planned for this radio.     |
+| `unsupported`                  | Registry-backed capability is absent from the radio.   |
+| `unsupported_pending_evidence` | Declared support lacks enough provider/live evidence.  |
 | `manual_required`              | Requires manual/operator verification.                 |
 
 ## Levels

--- a/docs/plans/2026-05-28-universal-validation-matrix.md
+++ b/docs/plans/2026-05-28-universal-validation-matrix.md
@@ -246,7 +246,7 @@ this ADR fixes the structure, not the final coverage.)
    - If `capability in capabilities` → emit `CapabilityDeclarationEntry` with
      `declaration = SUPPORTED` (or `MANUAL_REQUIRED` when `kind == MANUAL`,
      mirroring the shipped `audio.rx`/`tuner.tune` templates).
-   - Else → emit with `declaration = UNSUPPORTED_PENDING_EVIDENCE`.
+   - Else → emit with firm `declaration = UNSUPPORTED`.
 3. For every `KNOWN_CAPABILITIES` tag declared on the radio but with **no**
    registered functional `CheckSpec`, emit the level-0 presence entry (§2.6).
 4. `tx_adjacent` is copied from the `CheckSpec`; `TX_ADJACENT_BLOCKED` and
@@ -262,11 +262,9 @@ this ADR fixes the structure, not the final coverage.)
 - A capability tag the registry does not know is **impossible** — `RadioProfile`
   rejects unknown tags at load (`rig_loader.py:544`), and the registry keys on
   `KNOWN_CAPABILITIES`. No defensive branch needed.
-- A registered capability the radio does **not** declare → emitted as
-  `UNSUPPORTED_PENDING_EVIDENCE`, which `execute_hardware_checks` already turns
-  into a `UNSUPPORTED` `CheckResult` with `capability_present` evidence
-  (`hardware.py:225`). The matrix stays exhaustive; absence is recorded, not
-  hidden.
+- A registered capability the radio does **not** declare → emitted as firm
+  `UNSUPPORTED`. The matrix stays exhaustive; absence is recorded as
+  capability-not-applicable, not hidden.
 
 ### 3.3 Ordering
 
@@ -400,6 +398,8 @@ everything else is `None` ⇒ N/A on the Hamlib provider (D6).
 
 1. Walk the same registry as Generator A.
 2. For each functional `CheckSpec`:
+   - If the rigplane radio does **not** declare the capability →
+     emit firm `UNSUPPORTED`, even when Hamlib reports a matching token.
    - `hamlib_token is None` → emit `declaration = UNSUPPORTED_PENDING_EVIDENCE`
      with evidence `{"hamlib": "no_token_map"}`. This becomes a `UNSUPPORTED`
      `CheckResult` (N/A), **never** `FAIL` (D6).

--- a/src/rigplane/validation/comparison.py
+++ b/src/rigplane/validation/comparison.py
@@ -25,6 +25,7 @@ _MANUAL_REQUIRED_STATUS = CheckStatus.MANUAL_REQUIRED.value
 _BLOCKED = CheckStatus.BLOCKED.value
 
 _SUPPORTED = CapabilityDeclaration.SUPPORTED.value
+_UNSUPPORTED_DECL = CapabilityDeclaration.UNSUPPORTED.value
 _UNSUPPORTED_PENDING = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE.value
 _MANUAL_REQUIRED_DECL = CapabilityDeclaration.MANUAL_REQUIRED.value
 
@@ -79,8 +80,8 @@ def _classify_pvr(declaration: str, status: str) -> str:
     Rules (ADR §7.1):
     - SUPPORTED + pass          → agree
     - SUPPORTED + {fail|unsupported} → differ
-    - UNSUPPORTED_PENDING + unsupported → agree
-    - UNSUPPORTED_PENDING + pass        → differ
+    - UNSUPPORTED or UNSUPPORTED_PENDING + unsupported → agree
+    - UNSUPPORTED or UNSUPPORTED_PENDING + pass        → differ
     - everything else (manual_required decl, manual_required/skip/blocked
       status, UNSUPPORTED_PENDING+fail) → na
     """
@@ -91,7 +92,7 @@ def _classify_pvr(declaration: str, status: str) -> str:
             return "differ"
         # skip / manual_required / blocked → na
         return "na"
-    if declaration == _UNSUPPORTED_PENDING:
+    if declaration in (_UNSUPPORTED_DECL, _UNSUPPORTED_PENDING):
         if status == _UNSUPPORTED:
             return "agree"
         if status == _PASS:

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -167,7 +167,11 @@ def _template_has_tx_check(template: MatrixTemplate) -> bool:
     Used to decide whether to ask the single pre-TX confirm at all — a run with
     no TX check never prompts the operator.
     """
-    return any(entry.check_id in _TX_ACTUATE_CHECK_IDS for entry in template.entries)
+    return any(
+        entry.check_id in _TX_ACTUATE_CHECK_IDS
+        and entry.declaration is not CapabilityDeclaration.UNSUPPORTED
+        for entry in template.entries
+    )
 
 
 def _utcnow_iso() -> str:
@@ -318,6 +322,15 @@ async def _run_one_check(
     audio_probe_frames: Sequence[bytes | None] | None = None,
 ) -> CheckResult:
     """Execute a single template entry, applying universal pre-gates first."""
+    # Pre-gate 0: firm unsupported means the capability is absent from the
+    # radio profile. Do not block it on TX authorization and do not touch radio I/O.
+    if entry.declaration == CapabilityDeclaration.UNSUPPORTED:
+        return _base_result(
+            entry,
+            CheckStatus.UNSUPPORTED,
+            evidence={"declared": "unsupported"},
+        )
+
     # Pre-gate 1: authorization for TX-adjacent checks.
     if _is_safety_gated(entry) and not _is_authorized(entry, safety):
         return _base_result(

--- a/src/rigplane/validation/registry/_builders.py
+++ b/src/rigplane/validation/registry/_builders.py
@@ -81,9 +81,9 @@ def build_template_from_capabilities(
        the signature for forward-compatibility; do not branch on it.
     2. Every registry entry with ``capability == ""`` (structural) is always emitted
        with ``CapabilityDeclaration.SUPPORTED``.
-    3. Functional entries are emitted with a declaration derived from
-       ``_KIND_TO_DECLARATION`` when the capability is declared, or
-       ``UNSUPPORTED_PENDING_EVIDENCE`` otherwise.
+    3. Registry-backed functional entries are emitted with a declaration derived
+       from ``_KIND_TO_DECLARATION`` when the capability is declared, or
+       firm ``UNSUPPORTED`` otherwise.
     4. Capabilities that appear in *capabilities* but have no registry check receive
        a synthetic ``<cap>.presence`` entry at ``ValidationLevel.STATIC_PROFILE`` with
        ``UNSUPPORTED_PENDING_EVIDENCE`` (they are declared but not yet exercised).
@@ -106,7 +106,7 @@ def build_template_from_capabilities(
             if spec.capability in capabilities:
                 declaration = _KIND_TO_DECLARATION[spec.kind]
             else:
-                declaration = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+                declaration = CapabilityDeclaration.UNSUPPORTED
 
         entries.append(
             CapabilityDeclarationEntry(
@@ -163,15 +163,13 @@ def build_hamlib_template_from_capabilities(
     Algorithm (ADR §6):
 
     1. Walk REGISTRY in order.  For each ``CheckSpec``:
-       - If ``spec.hamlib_token is None`` → ``UNSUPPORTED_PENDING_EVIDENCE``.
-       - elif ``spec.hamlib_token not in available_hamlib_tokens`` →
+       - If ``spec.capability`` is non-empty and absent from ``capabilities`` →
+         firm ``UNSUPPORTED``.
+       - Else if ``spec.hamlib_token is None`` → ``UNSUPPORTED_PENDING_EVIDENCE``.
+       - Else if ``spec.hamlib_token not in available_hamlib_tokens`` →
          ``UNSUPPORTED_PENDING_EVIDENCE``.
-       - else (token present):
-         - If ``spec.capability == ""`` (structural) → ``SUPPORTED``.
-         - elif ``spec.capability in capabilities`` →
-           ``_KIND_TO_DECLARATION[spec.kind]``.
-         - else (token present but cap not declared) →
-           ``UNSUPPORTED_PENDING_EVIDENCE``.
+       - Else if ``spec.capability == ""`` (structural) → ``SUPPORTED``.
+       - Else → ``_KIND_TO_DECLARATION[spec.kind]``.
     2. Track functional caps (non-empty capability) for presence-entry exclusion.
     3. Append ``_presence_entries(capabilities, functional_caps)``.
     4. Stable-sort by level; return ``MatrixTemplate``.
@@ -184,7 +182,9 @@ def build_hamlib_template_from_capabilities(
         if spec.capability:
             functional_caps.add(spec.capability)
 
-        if spec.hamlib_token is None:
+        if spec.capability and spec.capability not in capabilities:
+            declaration = CapabilityDeclaration.UNSUPPORTED
+        elif spec.hamlib_token is None:
             declaration = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
         elif spec.hamlib_token not in available_hamlib_tokens:
             declaration = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
@@ -192,10 +192,8 @@ def build_hamlib_template_from_capabilities(
             # Token is present — now check structural vs functional.
             if spec.capability == "":
                 declaration = CapabilityDeclaration.SUPPORTED
-            elif spec.capability in capabilities:
-                declaration = _KIND_TO_DECLARATION[spec.kind]
             else:
-                declaration = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+                declaration = _KIND_TO_DECLARATION[spec.kind]
 
         entries.append(
             CapabilityDeclarationEntry(

--- a/src/rigplane/validation/runner.py
+++ b/src/rigplane/validation/runner.py
@@ -40,6 +40,7 @@ class HardwareExecutionBlocked(RuntimeError):
 
 _DECLARATION_TO_STATUS: dict[CapabilityDeclaration, CheckStatus] = {
     CapabilityDeclaration.SUPPORTED: CheckStatus.SKIP,
+    CapabilityDeclaration.UNSUPPORTED: CheckStatus.UNSUPPORTED,
     CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE: CheckStatus.UNSUPPORTED,
     CapabilityDeclaration.MANUAL_REQUIRED: CheckStatus.MANUAL_REQUIRED,
 }
@@ -101,6 +102,11 @@ def _is_authorized(
     return safety.tx_allowed
 
 
+def _is_capability_absent(check: CheckResult) -> bool:
+    """True when a result is firm unsupported because the capability is absent."""
+    return check.declaration is CapabilityDeclaration.UNSUPPORTED
+
+
 def dry_run_results(
     template: MatrixTemplate, safety: OperatorSafetyBlock
 ) -> list[LevelResult]:
@@ -127,7 +133,11 @@ def dry_run_results(
         ):
             status = CheckStatus.PASS
         failure_domain: FailureDomain | None = None
-        if _is_safety_gated(entry) and not _is_authorized(entry, safety):
+        if (
+            entry.declaration is not CapabilityDeclaration.UNSUPPORTED
+            and _is_safety_gated(entry)
+            and not _is_authorized(entry, safety)
+        ):
             status = CheckStatus.BLOCKED
             failure_domain = FailureDomain.COMMAND_EXECUTION
         result = CheckResult(
@@ -193,13 +203,25 @@ def human_summary(artifact: ValidationArtifact) -> str:
     blocked: list[str] = []
     for level in artifact.levels:
         counts: dict[str, int] = {}
+        capability_absent = 0
         for check in level.checks:
+            if _is_capability_absent(check):
+                capability_absent += 1
+                continue
             counts[check.status.value] = counts.get(check.status.value, 0) + 1
             if check.status is CheckStatus.BLOCKED:
                 blocked.append(check.check_id)
         count_str = ", ".join(
             f"{status}={count}" for status, count in sorted(counts.items())
         )
+        if capability_absent:
+            if count_str:
+                count_str = (
+                    f"{count_str}, not applicable (capability absent): "
+                    f"{capability_absent}"
+                )
+            else:
+                count_str = f"not applicable (capability absent): {capability_absent}"
         lines.append(f"  L{int(level.level)} {level.level.name.lower()}: {count_str}")
     if blocked:
         lines.append("Blocked checks (authorization required):")

--- a/src/rigplane/validation/schema.py
+++ b/src/rigplane/validation/schema.py
@@ -74,6 +74,7 @@ class CapabilityDeclaration(StrEnum):
     """Declared support posture for a capability in a template."""
 
     SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
     UNSUPPORTED_PENDING_EVIDENCE = "unsupported_pending_evidence"
     MANUAL_REQUIRED = "manual_required"
 

--- a/tests/golden/validation/ftx1.dry-run.json
+++ b/tests/golden/validation/ftx1.dry-run.json
@@ -45,7 +45,7 @@
     {
       "check_id": "bsr.select",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "comp_level.set",
@@ -85,7 +85,7 @@
     {
       "check_id": "dual_watch.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "filter_width.set",
@@ -120,12 +120,12 @@
     {
       "check_id": "mic_gain.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "mod_input.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "mode.set",
@@ -165,7 +165,7 @@
     {
       "check_id": "repeater_tone.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "rf_gain.set",
@@ -175,7 +175,7 @@
     {
       "check_id": "rf_power.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "rit.set",
@@ -185,77 +185,77 @@
     {
       "check_id": "scope.capture",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope.fft.presence",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_center_type.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_dual.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_during_tx.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_edge.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_fixed_edge.read",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_hold.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_mode.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_rbw.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_receiver.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_ref.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_span.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_speed.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_vbw.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "split.set",
@@ -275,27 +275,27 @@
     {
       "check_id": "system_date.read",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "system_time.read",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "tone_freq.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "tsql.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "tsql_freq.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "tuner.tune",

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -70,12 +70,12 @@
     {
       "check_id": "contour.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "ctcss_tone.read",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "cw_pitch.set",
@@ -140,7 +140,7 @@
     {
       "check_id": "if_shift.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "ip_plus.presence",
@@ -330,7 +330,7 @@
     {
       "check_id": "sql_type.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "squelch.set",

--- a/tests/golden/validation/x6200.dry-run.json
+++ b/tests/golden/validation/x6200.dry-run.json
@@ -45,7 +45,7 @@
     {
       "check_id": "bsr.select",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "comp_level.set",
@@ -55,12 +55,12 @@
     {
       "check_id": "contour.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "ctcss_tone.read",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "cw_pitch.set",
@@ -85,12 +85,12 @@
     {
       "check_id": "dual_watch.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "filter_width.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "freq.reverse_sync",
@@ -105,7 +105,7 @@
     {
       "check_id": "if_shift.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "key_speed.set",
@@ -120,12 +120,12 @@
     {
       "check_id": "mic_gain.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "mod_input.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "mode.set",
@@ -155,7 +155,7 @@
     {
       "check_id": "repeater_tone.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "rf_gain.set",
@@ -165,7 +165,7 @@
     {
       "check_id": "rf_power.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "rit.set",
@@ -180,77 +180,77 @@
     {
       "check_id": "scope.capture",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope.fft.presence",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_center_type.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_dual.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_during_tx.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_edge.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_fixed_edge.read",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_hold.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_mode.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_rbw.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_receiver.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_ref.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_span.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_speed.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "scope_vbw.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "split.set",
@@ -260,7 +260,7 @@
     {
       "check_id": "sql_type.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "squelch.set",
@@ -270,27 +270,27 @@
     {
       "check_id": "system_date.read",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "system_time.read",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "tone_freq.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "tsql.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "tsql_freq.set",
       "status": "unsupported",
-      "declaration": "unsupported_pending_evidence"
+      "declaration": "unsupported"
     },
     {
       "check_id": "tuner.tune",

--- a/tests/test_validate_hamlib_provider.py
+++ b/tests/test_validate_hamlib_provider.py
@@ -965,7 +965,8 @@ def _build_level_results(
 ) -> list[Any]:
     """Build a list of LevelResult from (check_id, declaration, status) tuples.
 
-    declaration strings: "supported", "unsupported_pending_evidence", "manual_required"
+    declaration strings: "supported", "unsupported",
+    "unsupported_pending_evidence", "manual_required"
     status strings: "pass", "fail", "skip", "unsupported", "blocked", "manual_required"
     """
     from rigplane.validation.schema import (
@@ -979,6 +980,7 @@ def _build_level_results(
 
     decl_map = {
         "supported": CapabilityDeclaration.SUPPORTED,
+        "unsupported": CapabilityDeclaration.UNSUPPORTED,
         "unsupported_pending_evidence": CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE,
         "manual_required": CapabilityDeclaration.MANUAL_REQUIRED,
     }

--- a/tests/test_validation_comparison.py
+++ b/tests/test_validation_comparison.py
@@ -15,6 +15,7 @@ from rigplane.validation.schema import CapabilityDeclaration, CheckStatus
 # ---------------------------------------------------------------------------
 
 _SUPPORTED = CapabilityDeclaration.SUPPORTED.value
+_UNSUPPORTED_DECL = CapabilityDeclaration.UNSUPPORTED.value
 _UNSUPPORTED_PENDING = CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE.value
 _MANUAL_REQUIRED_DECL = CapabilityDeclaration.MANUAL_REQUIRED.value
 
@@ -92,6 +93,18 @@ class TestProfileVsReality:
         dim = self._get([("ext.feature", _UNSUPPORTED_PENDING, _PASS)])
         assert dim["differ"] == 1
         assert "ext.feature" in dim["differing"]
+
+    def test_unsupported_unsupported_counts_agree(self):
+        dim = self._get([("absent.feature", _UNSUPPORTED_DECL, _UNSUPPORTED)])
+        assert dim["agree"] == 1
+        assert dim["differ"] == 0
+        assert dim["differing"] == []
+
+    def test_unsupported_pass_counts_differ(self):
+        dim = self._get([("absent.feature", _UNSUPPORTED_DECL, _PASS)])
+        assert dim["agree"] == 0
+        assert dim["differ"] == 1
+        assert "absent.feature" in dim["differing"]
 
     def test_manual_required_status_is_na(self):
         """manual_required status → na (not counted in agree/differ)."""
@@ -176,6 +189,18 @@ class TestHamlibVsReality:
         dim = self._get([("rf_gain", _SUPPORTED, _PASS)])
         assert dim["agree"] == 1
         assert dim["differ"] == 0
+
+    def test_unsupported_unsupported_counts_agree(self):
+        dim = self._get([("rf_gain", _UNSUPPORTED_DECL, _UNSUPPORTED)])
+        assert dim["agree"] == 1
+        assert dim["differ"] == 0
+        assert dim["na"] == 0
+
+    def test_unsupported_pass_counts_differ(self):
+        dim = self._get([("rf_gain", _UNSUPPORTED_DECL, _PASS)])
+        assert dim["agree"] == 0
+        assert dim["differ"] == 1
+        assert dim["na"] == 0
 
     def test_supported_fail_counts_differ(self):
         dim = self._get([("mode.set", _SUPPORTED, _FAIL)])

--- a/tests/test_validation_runner.py
+++ b/tests/test_validation_runner.py
@@ -82,6 +82,26 @@ def test_dry_run_presence_check_resolves_pass() -> None:
     assert checks["bsr.select"].status is CheckStatus.UNSUPPORTED
 
 
+def test_dry_run_firm_unsupported_maps_to_unsupported_without_safety_block() -> None:
+    template = MatrixTemplate(
+        radio=RadioTarget(model="Test Radio", profile_id="test"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id="tx.ptt",
+                capability="tx",
+                level=ValidationLevel.CAPABILITY_MATRIX,
+                declaration=CapabilityDeclaration.UNSUPPORTED,
+                summary="absent tx",
+                tx_adjacent=True,
+            ),
+        ],
+    )
+    levels = dry_run_results(template, OperatorSafetyBlock())
+    check = _checks_by_id(levels)["tx.ptt"]
+    assert check.status is CheckStatus.UNSUPPORTED
+    assert check.failure_domain is None
+
+
 def test_tx_adjacent_blocked_without_authorization() -> None:
     template = load_template(_TEMPLATE)
     levels = dry_run_results(template, OperatorSafetyBlock())
@@ -131,6 +151,39 @@ def test_human_summary_lists_blocked_items() -> None:
     assert text
     assert "tuner.tune" in text
     assert "tx.ptt" in text
+
+
+def test_human_summary_excludes_capability_na_from_main_counts() -> None:
+    template = MatrixTemplate(
+        radio=RadioTarget(model="Test Radio", profile_id="test"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id="rf_gain.set",
+                capability="rf_gain",
+                level=ValidationLevel.CAPABILITY_MATRIX,
+                declaration=CapabilityDeclaration.UNSUPPORTED,
+                summary="absent rf gain",
+            ),
+            CapabilityDeclarationEntry(
+                check_id="agc.set",
+                capability="agc",
+                level=ValidationLevel.CAPABILITY_MATRIX,
+                declaration=CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE,
+                summary="pending agc evidence",
+            ),
+        ],
+    )
+    levels = dry_run_results(template, OperatorSafetyBlock())
+    artifact = build_validation_artifact(
+        template=template,
+        levels=levels,
+        transport=TransportInfo(backend="fixture"),
+        safety=OperatorSafetyBlock(),
+        core_version="2.5.1",
+    )
+    text = human_summary(artifact)
+    assert "L3 capability_matrix: unsupported=1" in text
+    assert "not applicable (capability absent): 1" in text
 
 
 def _make_split_template() -> MatrixTemplate:

--- a/tests/test_validation_schema.py
+++ b/tests/test_validation_schema.py
@@ -8,10 +8,18 @@ from pathlib import Path
 import pytest
 
 from rigplane.validation import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckResult,
     CheckStatus,
     FailureDomain,
+    LevelResult,
     MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
     SchemaValidationError,
+    TransportInfo,
+    ValidationLevel,
     ValidationArtifact,
     validate_artifact_dict,
     validate_template_dict,
@@ -40,6 +48,49 @@ def test_invalid_capability_tag_raises() -> None:
     entries[0]["capability"] = "not_a_real_capability"
     with pytest.raises(SchemaValidationError):
         validate_template_dict(data)
+
+
+def test_template_accepts_firm_unsupported_declaration() -> None:
+    template = MatrixTemplate(
+        radio=RadioTarget(model="IC-TEST", profile_id="ic_test"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id="rf_gain.set",
+                capability="rf_gain",
+                level=ValidationLevel.CAPABILITY_MATRIX,
+                declaration=CapabilityDeclaration.UNSUPPORTED,
+                summary="Absent RF gain control.",
+            )
+        ],
+    )
+    parsed = validate_template_dict(template.to_dict())
+    assert parsed.entries[0].declaration is CapabilityDeclaration.UNSUPPORTED
+
+
+def test_artifact_accepts_firm_unsupported_declaration() -> None:
+    artifact = ValidationArtifact(
+        radio=RadioTarget(model="IC-TEST", profile_id="ic_test"),
+        transport=TransportInfo(backend="fixture"),
+        safety=OperatorSafetyBlock(),
+        levels=[
+            LevelResult(
+                level=ValidationLevel.CAPABILITY_MATRIX,
+                checks=[
+                    CheckResult(
+                        check_id="rf_gain.set",
+                        capability="rf_gain",
+                        level=ValidationLevel.CAPABILITY_MATRIX,
+                        status=CheckStatus.UNSUPPORTED,
+                        declaration=CapabilityDeclaration.UNSUPPORTED,
+                        summary="Absent RF gain control.",
+                    )
+                ],
+            )
+        ],
+        core_version="test",
+    )
+    parsed = validate_artifact_dict(artifact.to_dict())
+    assert parsed.levels[0].checks[0].declaration is CapabilityDeclaration.UNSUPPORTED
 
 
 def test_mixed_artifact_fixture_validates() -> None:

--- a/tests/validation/test_generator.py
+++ b/tests/validation/test_generator.py
@@ -106,8 +106,8 @@ def test_declared_functional_supported():
     assert entries_by_id["rf_gain.set"].declaration == CapabilityDeclaration.SUPPORTED
 
 
-def test_undeclared_functional_pending():
-    """A functional check whose capability is absent maps to UNSUPPORTED_PENDING_EVIDENCE."""
+def test_undeclared_functional_unsupported():
+    """A registry-backed functional check with an absent cap is firm UNSUPPORTED."""
     tpl = build_template_from_capabilities(
         frozenset(),
         model="IC-7300",
@@ -115,15 +115,12 @@ def test_undeclared_functional_pending():
     )
     entries_by_id = {e.check_id: e for e in tpl.entries}
     assert "rf_gain.set" in entries_by_id
-    assert (
-        entries_by_id["rf_gain.set"].declaration
-        == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
-    )
+    assert entries_by_id["rf_gain.set"].declaration == CapabilityDeclaration.UNSUPPORTED
 
 
 def test_mod_input_supported_when_cap_declared():
     """MOR-678: mod_input.set is SUPPORTED when mod_input_routing is declared
-    (IC-7610), and UNSUPPORTED_PENDING_EVIDENCE otherwise (X6200/FTX-1)."""
+    (IC-7610), and firm UNSUPPORTED otherwise (X6200/FTX-1)."""
     declared = build_template_from_capabilities(
         frozenset({"mod_input_routing"}),
         model="IC-7610",
@@ -139,10 +136,7 @@ def test_mod_input_supported_when_cap_declared():
     )
     by_id2 = {e.check_id: e for e in undeclared.entries}
     assert "mod_input.set" in by_id2
-    assert (
-        by_id2["mod_input.set"].declaration
-        == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
-    )
+    assert by_id2["mod_input.set"].declaration == CapabilityDeclaration.UNSUPPORTED
 
 
 def test_manual_kind_manual_required():
@@ -262,7 +256,7 @@ def test_realistic_ic7300():
     else:
         assert (
             entries_by_id["filter_width.set"].declaration
-            == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+            == CapabilityDeclaration.UNSUPPORTED
         )
 
 

--- a/tests/validation/test_generator_hamlib.py
+++ b/tests/validation/test_generator_hamlib.py
@@ -61,11 +61,18 @@ def test_token_absent_from_available_unsupported():
     assert entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
 
 
-def test_undeclared_but_token_present_unsupported():
-    """'RF' token present but rf_gain not in caps → rf_gain.set == UNSUPPORTED_PENDING_EVIDENCE."""
-    tpl = _build(caps=frozenset(), tokens={"RF"})
+def test_declared_cap_with_missing_hamlib_token_stays_pending():
+    """Declared cap without Hamlib evidence remains pending, not firm unsupported."""
+    tpl = _build(caps={"rf_gain"}, tokens={"AF"})
     entry = _entry(tpl, "rf_gain.set")
     assert entry.declaration == CapabilityDeclaration.UNSUPPORTED_PENDING_EVIDENCE
+
+
+def test_undeclared_but_token_present_unsupported():
+    """'RF' token present but rf_gain not in caps → rf_gain.set == UNSUPPORTED."""
+    tpl = _build(caps=frozenset(), tokens={"RF"})
+    entry = _entry(tpl, "rf_gain.set")
+    assert entry.declaration == CapabilityDeclaration.UNSUPPORTED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -230,6 +230,30 @@ async def test_write_only_cap_routes_to_set_observe():
     assert radio.set_rit_frequency.call_count == 2
 
 
+async def test_firm_unsupported_pre_gates_before_tx_authorization():
+    radio = _make_mock_radio()
+    template = MatrixTemplate(
+        radio=RadioTarget(model="X6200", profile_id="x6200"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id="tx.ptt",
+                capability="tx",
+                level=ValidationLevel.CAPABILITY_MATRIX,
+                declaration=CapabilityDeclaration.UNSUPPORTED,
+                summary="absent tx",
+                tx_adjacent=True,
+            )
+        ],
+    )
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["tx.ptt"]
+    assert check.status is CheckStatus.UNSUPPORTED
+    assert check.failure_domain is None
+    radio.set_ptt.assert_not_called()
+
+
 async def test_non_write_only_cap_still_uses_rmvr():
     """A cap NOT in write_only_capabilities keeps the RMVR read-modify-verify
     path even when other caps are classified write-only."""


### PR DESCRIPTION
## Summary
- add firm `unsupported` as a narrow validation declaration for known absent capabilities
- emit firm unsupported in native/hamlib template generation when a registry-backed functional check capability is absent from the radio capability set
- keep synthetic `.presence` and Hamlib token-missing cases as `unsupported_pending_evidence`
- keep JSON/golden rows intact while human summaries move capability-N/A rows out of normal unsupported counts
- update validation contract/ADR docs and regenerate IC-7610, X6200, and FTX-1 dry-run goldens

## Architecture
The semantic lives in template generation. Runner, hardware, comparison, and human summary consume declaration semantics; they do not import profile metadata or re-infer capabilities. Human summary uses declaration-based capability-absent filtering, not a raw `status == unsupported` shortcut.

## Verification
Implementer:
- RED: targeted generator tests failed on missing `CapabilityDeclaration.UNSUPPORTED` before production code
- `uv run pytest tests/validation/test_generator.py tests/validation/test_generator_hamlib.py -q --tb=short`
- `uv run pytest tests/test_validation_schema.py tests/test_validation_runner.py tests/test_validation_comparison.py tests/validation/test_hardware.py tests/test_validation_gating.py -q --tb=short` -> 143 passed
- dry-run + golden gates for IC-7610, X6200, FTX-1
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` -> 7824 passed, 73 skipped, 3 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/ && uv run ruff format src/ tests/`
- `uv run lint-imports` -> 5 contracts kept, 0 broken

Reviewers:
- Spec review: PASS, no MOR-690 blockers
- Quality/architecture review: PASS, no blocking quality findings

Golden diff summary:
- `ic7610`: 4 declaration flips
- `ftx1`: 26 declaration flips
- `x6200`: 31 declaration flips
- structured check confirmed 0 row ID/status/failure_domain changes for all three

Known unrelated note:
- `uv run mypy src/rigplane/validation` still fails on pre-existing `audio_checks.py:482` (`Returning Any from function declared to return object | None`), not introduced by this PR.