### PR TITLE
fix(MOR-588): honor adaptive egress degradation thresholds

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncIterator, Awaitable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 
 from rigplane.audio._codecs import decode_ulaw_to_pcm16
@@ -53,6 +53,8 @@ _TX_CLEANUP_STOP_TIMEOUT_SECONDS = 2.0
 DEGRADE_WINDOW_S = 3.0
 CLEAN_WINDOW_S = 30.0
 DWELL_S = 10.0
+DEGRADE_UNDERRUN_THRESHOLD = 3
+DEGRADE_QUEUE_DROP_THRESHOLD = 5
 
 # Fixed Opus egress frame duration (MOR-596).  Radio RX packets are not
 # Opus-frame-aligned (IC-7610 LAN @48k stereo ≈1280 B ≈6.67 ms), while
@@ -84,6 +86,10 @@ class _AdaptiveEgressState:
     # rising past its mark is one unit of degradation evidence.
     seen_underruns: int = 0
     seen_queue_drops: int = 0
+    # Rolling degradation evidence samples: (monotonic time,
+    # underrun delta, ws_queue_drops delta).
+    degrade_samples: list[tuple[float, int, int]] = field(default_factory=list)
+    degrade_threshold_met: bool = False
 
 
 def _is_benign_tx_restart(exc: RuntimeError) -> bool:
@@ -580,9 +586,10 @@ class AudioBroadcaster:
         Evidence = either MOR-585 cumulative counter rising (client
         playback ``underruns``, server ``ws_queue_drops``). A degradation
         episode is continuous evidence with gaps shorter than the degrade
-        window; PCM16→Opus fires once an episode spans the window, Opus→
-        PCM16 once no evidence arrives for the clean window — both gated
-        by the dwell since the previous switch.
+        window; PCM16→Opus fires once the rolling window contains the ADR
+        §3.6 threshold (>= 3 underruns OR >= 5 queue drops), Opus→PCM16
+        once no evidence arrives for the clean window — both gated by the
+        dwell since the previous switch.
         """
         state = self._client_adaptive.get(client_id)
         if state is None:
@@ -593,21 +600,51 @@ class AudioBroadcaster:
         stats = self._client_link_quality.get(client_id, {})
         underruns = int(stats.get("underruns", 0))
         queue_drops = self._client_queue_drops.get(client_id, 0)
-        evidence = (
-            underruns > state.seen_underruns or queue_drops > state.seen_queue_drops
-        )
+        underrun_delta = max(0, underruns - state.seen_underruns)
+        queue_drop_delta = max(0, queue_drops - state.seen_queue_drops)
+        evidence = underrun_delta > 0 or queue_drop_delta > 0
         state.seen_underruns = max(state.seen_underruns, underruns)
         state.seen_queue_drops = max(state.seen_queue_drops, queue_drops)
         if evidence:
             state.last_evidence = now
             if state.degrade_since is None:
                 state.degrade_since = now
+            state.degrade_samples.append((now, underrun_delta, queue_drop_delta))
+            threshold_cutoff = now - self._adaptive_degrade_window_s
+            threshold_samples = [
+                sample
+                for sample in state.degrade_samples
+                if sample[0] >= threshold_cutoff
+            ]
+            rolling_underruns = sum(sample[1] for sample in threshold_samples)
+            rolling_queue_drops = sum(sample[2] for sample in threshold_samples)
+            if (
+                rolling_underruns >= DEGRADE_UNDERRUN_THRESHOLD
+                or rolling_queue_drops >= DEGRADE_QUEUE_DROP_THRESHOLD
+            ):
+                state.degrade_threshold_met = True
         elif (
             state.degrade_since is not None
             and state.last_evidence is not None
             and now - state.last_evidence > self._adaptive_degrade_window_s
         ):
             state.degrade_since = None  # episode over — evidence stopped
+            state.degrade_samples.clear()
+            state.degrade_threshold_met = False
+
+        cutoff = now - self._adaptive_degrade_window_s
+        state.degrade_samples = [
+            sample for sample in state.degrade_samples if sample[0] >= cutoff
+        ]
+        if (
+            not state.degrade_samples
+            and state.degrade_since is not None
+            and (
+                state.last_evidence is None
+                or now - state.last_evidence > self._adaptive_degrade_window_s
+            )
+        ):
+            state.degrade_since = None
 
         dwell_ok = (
             state.last_switch is None
@@ -618,6 +655,7 @@ class AudioBroadcaster:
             and dwell_ok
             and state.degrade_since is not None
             and now - state.degrade_since >= self._adaptive_degrade_window_s
+            and state.degrade_threshold_met
         ):
             self._adaptive_switch(client_id, state, AUDIO_CODEC_OPUS, now)
         elif (
@@ -644,6 +682,8 @@ class AudioBroadcaster:
         state.codec = codec
         state.last_switch = now
         state.degrade_since = None
+        state.degrade_samples.clear()
+        state.degrade_threshold_met = False
         if codec != AUDIO_CODEC_OPUS:
             self._client_opus_transcoders.pop(client_id, None)
             self._client_opus_pcm_buffers.pop(client_id, None)

--- a/tests/test_web_audio_adaptive_egress.py
+++ b/tests/test_web_audio_adaptive_egress.py
@@ -178,6 +178,69 @@ class TestAdaptiveDegrade:
         )
         assert [a["codec"] for a in _acks(ws)] == ["pcm16", "opus"]
 
+    async def test_threshold_underruns_flip_with_scheduler_jitter(self) -> None:
+        """Once the threshold is met during a continuous episode, normal
+        scheduler jitter after DEGRADE_WINDOW_S must not miss the switch."""
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        with patch(_TRANSCODER_PATCH, return_value=_FakeTranscoder()):
+            await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+            await _report(handler, 1)
+            clock.advance(1.0)
+            await _report(handler, 2)
+            clock.advance(1.0)
+            await _report(handler, 3)
+            clock.advance(DEGRADE_WINDOW_S - 2.0 + 0.1)
+            await _report(handler, 3)
+            await _inject(bus)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_OPUS
+        state = broadcaster._client_adaptive[id(handler._frame_queue)]
+        assert state.codec == AUDIO_CODEC_OPUS
+
+    async def test_sustained_underruns_below_threshold_do_not_flip(self) -> None:
+        """ADR §3.6 requires >= 3 underruns inside the rolling window;
+        sustained evidence below that threshold must remain PCM16."""
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+
+        await _report(handler, 1)
+        clock.advance(DEGRADE_WINDOW_S / 2)
+        await _report(handler, 2)
+        clock.advance(DEGRADE_WINDOW_S)
+        await _report(handler, 2)
+        await _inject(bus)
+
+        frame = handler._frame_queue.get_nowait()
+        assert frame[1] == AUDIO_CODEC_PCM16
+        state = broadcaster._client_adaptive[id(handler._frame_queue)]
+        assert state.codec == AUDIO_CODEC_PCM16
+        assert broadcaster._client_opus_transcoders == {}
+
+    async def test_sustained_queue_drops_below_threshold_do_not_flip(self) -> None:
+        """ADR §3.6 requires >= 5 ws_queue_drops inside the rolling window;
+        sustained evidence below that threshold must remain PCM16."""
+        radio, bus = _make_radio()
+        broadcaster, clock = _make_adaptive(radio)
+        broadcaster.HIGH_WATERMARK = 1
+        handler = AudioHandler(_make_ws(), radio, broadcaster)
+        await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
+
+        for _ in range(4):
+            await _inject(bus)
+            clock.advance(DEGRADE_WINDOW_S / 4)
+        clock.advance(DEGRADE_WINDOW_S)
+        await _inject(bus)
+
+        state = broadcaster._client_adaptive[id(handler._frame_queue)]
+        assert state.codec == AUDIO_CODEC_PCM16
+        assert set(_drain_codecs(handler)) == {AUDIO_CODEC_PCM16}
+        assert broadcaster._client_opus_transcoders == {}
+
     async def test_isolated_burst_does_not_flip(self) -> None:
         """A single evidence burst that is NOT sustained (episode gap >
         DEGRADE_WINDOW_S) must not engage Opus."""
@@ -222,9 +285,9 @@ class TestAdaptiveDegrade:
             await handler._start_rx(preferred_rx_codec=AUDIO_CODEC_OPUS)
             # Nobody drains the queue: each relay iteration past the
             # watermark evicts-oldest and increments ws_queue_drops.
-            for _ in range(8):
+            for _ in range(10):
                 await _inject(bus)
-                clock.advance(1.0)
+                clock.advance(0.5)
 
         state = broadcaster._client_adaptive[id(handler._frame_queue)]
         assert state.codec == AUDIO_CODEC_OPUS, (


### PR DESCRIPTION
## Summary
- enforce ADR §3.6 adaptive egress thresholds before switching PCM16 -> Opus
- track rolling underrun / queue-drop evidence per adaptive client
- add regressions for below-threshold sustained evidence and scheduler jitter after the degrade window

## Root Cause
The MOR-588 controller treated any increase in client underruns or server `ws_queue_drops` as degradation evidence. A single underrun/drop could therefore switch a client to Opus after `DEGRADE_WINDOW_S`, even though ADR §3.6 requires `>= 3` underruns or `>= 5` queue drops within the degradation window.

## Validation
- `uv run pytest tests/test_web_audio_adaptive_egress.py tests/contracts/test_adaptive_egress_conformance.py -q --tb=short`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run lint-imports`

## Review
- Spec review: PASS
- Code quality re-review: Agent Review: PASS
