### PR TITLE
fix(MOR-558): drop dead VFO fieldStatus parents

### DIFF
--- a/docs/internals/radio-state-pipeline-contracts.md
+++ b/docs/internals/radio-state-pipeline-contracts.md
@@ -63,6 +63,16 @@ frequency, mode, active slot, S-meter, NR/NB, AF level, RF gain, and PBT, plus
 global TX and meter paths. It is intentionally not a complete `RadioState`
 field map yet; later lanes should extend it as field families migrate.
 
+### FTX-1 `ab_shared` VFO topology note
+
+The FTX-1 profile uses `[vfo] scheme = "ab_shared"`. In this topology there is
+no per-receiver A/B slot concept: `FA` and `FB` are the MAIN and SUB receive
+frequencies, `VS` selects the active receiver focus, `FR` controls dual/single
+RX, and `FT` selects the TX source. The dynamic HF-vs-U/VHF collapse observed
+on the radio is not currently modeled in Core. MOR-558 therefore only removes
+dead Web `fieldStatus` parent seeds for bare `main/sub.vfoA/vfoB`; it keeps the
+existing per-leaf VFO status seeds unchanged.
+
 ## Observation
 
 `Observation` represents one decoded state-bearing sample from CI-V, CAT,

--- a/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
+++ b/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
@@ -419,12 +419,6 @@
     "observed": false,
     "storePath": "receiver.main.operator_toggles.twin_peak_filter"
   },
-  "main.vfoA": {
-    "availability": "missing",
-    "freshness": "unknown",
-    "observed": false,
-    "storePath": "receiver.main.slow_state.vfo_a"
-  },
   "main.vfoA.dataMode": {
     "availability": "missing",
     "freshness": "unknown",
@@ -448,12 +442,6 @@
     "freshness": "unknown",
     "observed": false,
     "storePath": "receiver.main.slot.A.freq_mode.mode"
-  },
-  "main.vfoB": {
-    "availability": "missing",
-    "freshness": "unknown",
-    "observed": false,
-    "storePath": "receiver.main.slow_state.vfo_b"
   },
   "main.vfoB.dataMode": {
     "availability": "missing",
@@ -977,12 +965,6 @@
     "observed": false,
     "storePath": "receiver.sub.operator_toggles.twin_peak_filter"
   },
-  "sub.vfoA": {
-    "availability": "missing",
-    "freshness": "unknown",
-    "observed": false,
-    "storePath": "receiver.sub.slow_state.vfo_a"
-  },
   "sub.vfoA.dataMode": {
     "availability": "missing",
     "freshness": "unknown",
@@ -1006,12 +988,6 @@
     "freshness": "unknown",
     "observed": false,
     "storePath": "receiver.sub.slot.A.freq_mode.mode"
-  },
-  "sub.vfoB": {
-    "availability": "missing",
-    "freshness": "unknown",
-    "observed": false,
-    "storePath": "receiver.sub.slow_state.vfo_b"
   },
   "sub.vfoB.dataMode": {
     "availability": "missing",

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -381,6 +381,12 @@ def _default_receiver_field_status(
                 FieldPath.receiver(receiver_key, "operator_toggles", "dcd"),
             )
     for name in _RECEIVER_SLOW_STATE_FIELDS:
+        if name in {"vfo_a", "vfo_b"}:
+            # Slot observations project to ``<receiver>.vfoA/B.<leaf>``.
+            # No store writer emits the bare slow-state group paths, so
+            # seeding them would let the frontend parent-veto hide real leaves
+            # (MOR-558). Keep the leaf seeds above as the actual gate.
+            continue
         _set_missing_field_status(
             statuses,
             _public_field_path(receiver_key, _receiver_public_key(name)),

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -399,6 +399,13 @@ _SCOPE_TOOLBAR_SUFFIXES = (
     "dual",
     "receiver",
 )
+_VFO_GROUP_PATHS = ("main.vfoA", "main.vfoB", "sub.vfoA", "sub.vfoB")
+_VFO_LEAF_PATHS = (
+    "main.vfoA.freqHz",
+    "main.vfoB.mode",
+    "sub.vfoA.freqHz",
+    "sub.vfoB.mode",
+)
 
 
 def _frontend_availability(field_status: dict[str, dict[str, Any]], path: str) -> str:
@@ -431,6 +438,44 @@ def test_default_field_status_has_no_scope_controls_group_entry() -> None:
         status = field_status[f"scopeControls.{suffix}"]
         assert status["availability"] == "missing", suffix
         assert status["observed"] is False, suffix
+
+
+def test_default_field_status_has_no_vfo_group_entries() -> None:
+    """MOR-558: slow-state ``vfo_a``/``vfo_b`` group entries are never written.
+
+    Keep the real per-leaf VFO status entries seeded missing, but do not seed
+    bare ``main/sub.vfoA/vfoB`` parents that would veto observed leaves.
+    """
+    payload = build_public_state_payload_from_snapshot(
+        StateSnapshot.empty(), radio=None, receiver_count=2
+    )
+    field_status = payload["fieldStatus"]
+    for path in _VFO_GROUP_PATHS:
+        assert path not in field_status
+    for path in _VFO_LEAF_PATHS:
+        status = field_status[path]
+        assert status["availability"] == "missing", path
+        assert status["observed"] is False, path
+
+
+def test_observed_vfo_slot_leaf_survives_frontend_parent_veto() -> None:
+    """MOR-558: an observed slot leaf must not be hidden by a missing parent."""
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.apply(
+        _observation(
+            FieldPath.vfo_slot("0", "A", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=clock.now(),
+        )
+    )
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=2
+    )
+    field_status = payload["fieldStatus"]
+    assert payload["main"]["vfoA"]["freqHz"] == 14_074_000
+    assert _frontend_availability(field_status, "main.vfoA.freqHz") == "available"
 
 
 def test_observed_scope_control_leaves_survive_frontend_parent_veto() -> None:


### PR DESCRIPTION
## Summary
- stop seeding bare `main/sub.vfoA/vfoB` fieldStatus parent entries from never-written slow-state paths
- preserve per-leaf VFO fieldStatus seeds and update the shared frontend fixture
- document the FTX-1 `ab_shared` topology caveat before the mechanical fieldStatus cleanup

## Root Cause
`_default_snapshot_field_status` seeded `main.vfoA`, `main.vfoB`, `sub.vfoA`, and `sub.vfoB` from `receiver.<rx>.slow_state.vfo_a/vfo_b`. No observation writer emits those store paths. The frontend MOR-429 parent-veto rule means those missing parent entries would override available VFO leaves if a consumer gated on `main.vfoA.*` / `main.vfoB.*`.

## Notes
FTX-1 uses `ab_shared`, not per-receiver A/B VFO slots. This PR documents that `FA/FB` are MAIN/SUB receive frequencies, `VS` selects active receiver focus, `FR` controls dual/single RX, and the dynamic HF-vs-U/VHF collapse is not modeled here. MOR-558 only removes the dead web fieldStatus parents.

## Validation
- `uv run pytest tests/test_web_runtime_helpers.py tests/test_field_status_frontend_fixture.py -q --tb=short`
- `npm test -- --run src/lib/state/__tests__/field-status.test.ts src/components-v2/panels/lcd/__tests__/lcd-availability.test.ts`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run lint-imports`

## Review
- Spec review: PASS
- Code quality review: PASS
