### PR TITLE
fix(MOR-706): read X6200 filter width raw index

### DIFF
--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -341,7 +341,7 @@ Additional optional fields:
 | Field            | Type   | Required | Description                                      |
 |------------------|--------|----------|--------------------------------------------------|
 | `style`          | string | no       | `"named_slots"` (default) or `"per_mode"`        |
-| `encoding`       | string | no       | `"segmented_bcd_index"` (default, all Icom rigs) or `"table_index"` (Yaesu) |
+| `encoding`       | string | no       | `"segmented_bcd_index"` (default, Icom BCD index), `"raw_byte_index"` (raw byte index), or `"table_index"` (Yaesu) |
 | `width_min_hz`   | int    | no       | Minimum IF filter width in Hz                    |
 | `width_max_hz`   | int    | no       | Maximum IF filter width in Hz                    |
 

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -124,6 +124,7 @@ stream_like_meters = [
 command_response_observable = [
     "receiver.main.active.freq_mode.freq_hz",
     "receiver.main.active.freq_mode.mode",
+    "receiver.main.active.freq_mode.filter_width",
 ]
 supported_controls = [
     "receiver.main.active.freq_mode.freq_hz",
@@ -158,6 +159,58 @@ list = ["USB", "LSB", "CW", "CW-R", "AM", "FM", "RTTY", "DIGI"]
 
 [filters]
 list = ["FIL1", "FIL2", "FIL3"]
+# MOR-706 live USB CI-V 0xA4 evidence: 0x1A/0x03 returns one raw byte for the
+# active selected FIL slot width, not packed BCD. Examples: 0x1c -> 1800 Hz,
+# 0x22 -> 2400 Hz, 0x27 -> 2900 Hz. The observed formula is:
+#   byte <= 21: Hz = byte * 50 + 50
+#   byte >= 22: Hz = (byte - 10) * 100
+# Keep max_hz at 3600 to match the established Icom SSB/CW/RTTY profile bound;
+# higher X6200 values are not proven by current live evidence.
+encoding = "raw_byte_index"
+width_min_hz = 50
+width_max_hz = 3600
+
+[filters.width.SSB]
+min_hz = 50
+max_hz = 3600
+defaults = [2900, 2400, 1800]
+segments = [
+    { hz_min = 50, hz_max = 1100, step_hz = 50, index_min = 0 },
+    { hz_min = 1200, hz_max = 3600, step_hz = 100, index_min = 22 },
+]
+
+[filters.width.CW]
+min_hz = 50
+max_hz = 3600
+defaults = [2900, 2400, 1800]
+segments = [
+    { hz_min = 50, hz_max = 1100, step_hz = 50, index_min = 0 },
+    { hz_min = 1200, hz_max = 3600, step_hz = 100, index_min = 22 },
+]
+
+[filters.width.RTTY]
+min_hz = 50
+max_hz = 3600
+defaults = [2900, 2400, 1800]
+segments = [
+    { hz_min = 50, hz_max = 1100, step_hz = 50, index_min = 0 },
+    { hz_min = 1200, hz_max = 3600, step_hz = 100, index_min = 22 },
+]
+
+[filters.width.DIGI]
+min_hz = 50
+max_hz = 3600
+defaults = [2900, 2400, 1800]
+segments = [
+    { hz_min = 50, hz_max = 1100, step_hz = 50, index_min = 0 },
+    { hz_min = 1200, hz_max = 3600, step_hz = 100, index_min = 22 },
+]
+
+[filters.width.AM]
+fixed = true
+
+[filters.width.FM]
+fixed = true
 
 [vfo]
 scheme = "ab"

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -158,6 +158,7 @@ class RadioProfile:
     freq_ranges: tuple[FreqRangeInfo, ...] = ()
     modes: tuple[str, ...] = ()
     filters: tuple[str, ...] = ()
+    command_names: frozenset[str] = frozenset()
     filter_width_min: int = 50
     filter_width_max: int = 9999
     filter_width_encoding: str = "segmented_bcd_index"
@@ -240,6 +241,9 @@ class RadioProfile:
             command,
             None,
         ) in self.cmd29_routes
+
+    def supports_command(self, command_name: str) -> bool:
+        return command_name in self.command_names
 
     def resolve_filter_rule(
         self, mode: str | None, *, data_mode: int = 0

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -180,6 +180,7 @@ class RigConfig:
             freq_ranges=ranges,
             modes=tuple(self.modes),
             filters=tuple(self.filters),
+            command_names=frozenset(self.commands),
             filter_width_min=self.filter_width_min,
             filter_width_max=self.filter_width_max,
             filter_width_encoding=self.filter_width_encoding,

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -1908,22 +1908,26 @@ class CivRuntime:
     def _decode_filter_width(self, frame: CivFrame) -> int:
         """Decode a 0x1A/0x03 filter-width frame to Hz.
 
-        Profile-dependent: when the active profile encodes filter width as a
-        ``segmented_bcd_index``, the BCD index is mapped to Hz via the
-        mode/data-mode filter rule; otherwise the raw index is returned. Shared
-        by ``_observations_from_frame`` and ``_handle_1a`` so both produce a
-        byte-for-byte identical value (MOR-437).
+        Profile-dependent: ``segmented_bcd_index`` BCD-decodes the response
+        byte, while ``raw_byte_index`` uses the first data byte directly. The
+        resulting index is mapped to Hz via the mode/data-mode filter rule.
+        Shared by ``_observations_from_frame`` and ``_handle_1a`` so both
+        produce a byte-for-byte identical value (MOR-437).
         """
 
         from rigplane.commands import _bcd_decode_value, filter_index_to_hz
 
-        filter_index = _bcd_decode_value(frame.data)
         profile = getattr(self._host, "_profile", None)
+        encoding = getattr(profile, "filter_width_encoding", None)
+        if encoding == "raw_byte_index":
+            filter_index = frame.data[0]
+        else:
+            filter_index = _bcd_decode_value(frame.data)
         rx = self._resolve_filter_width_receiver(frame)
-        if (
-            profile is not None
-            and getattr(profile, "filter_width_encoding", None) == "segmented_bcd_index"
-        ):
+        if profile is not None and encoding in {
+            "segmented_bcd_index",
+            "raw_byte_index",
+        }:
             rule = profile.resolve_filter_rule(
                 getattr(rx, "mode", None),
                 data_mode=int(getattr(rx, "data_mode", 0) or 0),

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -1637,10 +1637,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def set_filter_width(self, width_hz: int, receiver: int = 0) -> None:
         """Set DSP IF filter width in Hz (CI-V 0x1A 0x03).
 
-        Hz is translated to a profile-defined 1-byte BCD index (wfview's
-        ``funcFilterWidth`` segmented formula — see ``icomcommander.cpp:1131``)
-        and wrapped via cmd29 only when the profile lists ``[0x1A, 0x03]`` in
-        its cmd29 routes (IC-7610). IC-705 and IC-9700 send the frame directly.
+        Hz is translated to a profile-defined index and wrapped via cmd29 only
+        when the profile lists ``[0x1A, 0x03]`` in its cmd29 routes
+        (IC-7610). The profile must declare a ``set_filter_width`` command
+        before the runtime sends a write.
 
         Args:
             width_hz: Filter width in Hz. Bounds and step depend on the
@@ -1649,6 +1649,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """
         self._check_connected()
         self._require_receiver(receiver, operation="set_filter_width")
+        if not self._profile.supports_command("set_filter_width"):
+            raise CommandError(
+                f"set_filter_width is unsupported by profile {self._profile.model}"
+            )
 
         target = self._radio_state.receiver("SUB" if receiver else "MAIN")
         mode_name = getattr(target, "mode", None)
@@ -1699,12 +1703,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_filter_width(self, receiver: int = 0) -> int:
         """Get DSP IF filter width in Hz (CI-V 0x1A 0x03).
 
-        Per wfview's ``funcFilterWidth`` handler (``icomcommander.cpp:1131``),
-        all Icom rigs return a 1-byte BCD segmented index. The request is
-        cmd29-wrapped only when the profile lists ``[0x1A, 0x03]`` in its
-        cmd29 routes (IC-7610). IC-705 and IC-9700 send the request directly
-        and the response is decoded with the same segmented formula
-        (issue #1156).
+        The response encoding is profile-driven. Icom profiles use a 1-byte
+        BCD segmented index; Xiegu X6200 uses a single raw byte index. The
+        request is cmd29-wrapped only when the profile lists ``[0x1A, 0x03]``
+        in its cmd29 routes.
 
         Args:
             receiver: 0=MAIN, 1=SUB.
@@ -1723,13 +1725,29 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         else:
             civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1A, sub=0x03)
 
-        value = await self._get_bcd_level(
+        resp = await self._send_civ_expect(
             civ,
             key=f"get_filter_width:{receiver}",
-            command=0x1A,
-            sub=0x03,
-            bcd_bytes=1,
+            dedupe=True,
+            label="get_filter_width",
         )
+        if resp.command != 0x1A or resp.sub != 0x03:
+            raise ValueError(
+                f"Not a filter-width response: command 0x{resp.command:02x} "
+                f"sub 0x{0 if resp.sub is None else resp.sub:02x}"
+            )
+
+        if self._profile.filter_width_encoding == "raw_byte_index":
+            if not resp.data:
+                raise ValueError("Filter-width response payload too short")
+            value = resp.data[0]
+        else:
+            value = parse_level_response(
+                resp,
+                command=0x1A,
+                sub=0x03,
+                bcd_bytes=1,
+            )
 
         target = self._radio_state.receiver("SUB" if receiver else "MAIN")
         mode_name = getattr(target, "mode", None)

--- a/tests/integration/test_validation_matrix_integration.py
+++ b/tests/integration/test_validation_matrix_integration.py
@@ -128,10 +128,20 @@ def test_dry_run_statuses_are_planned_and_error_free(
 ) -> None:
     """No check errors out and no check claims execution in a dry-run."""
     artifact = _dry_run_artifact(owned_profile_model, capsys, "--no-overrides")
+    registry_ids = {spec.check_id for spec in REGISTRY}
     for check_id, check in _checks_by_id(artifact).items():
         assert check.get("error") is None, (
             f"{owned_profile_model}: {check_id} carries an error: {check['error']}"
         )
+        if (
+            check_id.endswith(".presence")
+            and check_id not in registry_ids
+            and check["status"] == CheckStatus.PASS.value
+        ):
+            # MOR-660: synthetic capability-presence entries are static profile
+            # evidence, not executed probes. Registry-backed checks still must
+            # not PASS/FAIL in dry-run.
+            continue
         assert check["status"] in _DRY_RUN_LEGAL_STATUSES, (
             f"{owned_profile_model}: {check_id} has non-dry-run status "
             f"{check['status']!r}"

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -777,6 +777,28 @@ def test_update_state_cache_filter_width_decodes_index_to_hz(radio: IcomRadio) -
     assert radio._state_cache.filter_width == 1500
 
 
+def test_update_state_cache_x6200_filter_width_decodes_raw_byte_index() -> None:
+    """X6200 raw 0x1c maps to 1800 Hz; it must not be BCD-decoded."""
+    radio = IcomRadio("192.168.1.100", model="X6200")
+    radio._radio_state = RadioState()
+    radio._radio_state.main.mode = "USB"
+    frame = _make_frame(
+        cmd=0x1A,
+        sub=0x03,
+        data=b"\x1c",
+        from_addr=0xA4,
+        receiver=0x00,
+    )
+
+    radio._civ_runtime._update_state_cache_from_frame(frame)
+
+    field = radio._state_store.snapshot().field(
+        "receiver.0.active.freq_mode.filter_width"
+    )
+    assert field.value == 1800
+    assert radio._state_cache.filter_width == 1800
+
+
 def test_update_state_cache_exception_suppressed(radio: IcomRadio) -> None:
     """Exception in cache update is suppressed (lines 456-457)."""
     # StateCache uses slots=True, so replace the whole object with a MagicMock

--- a/tests/test_dsp_filter_family.py
+++ b/tests/test_dsp_filter_family.py
@@ -186,6 +186,45 @@ async def test_icom_set_filter_width_rejects_out_of_range() -> None:
     radio.send_civ.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("payload", "expected_hz"), [(b"\x22", 2400), (b"\x1c", 1800)])
+async def test_x6200_get_filter_width_decodes_raw_byte_index(
+    payload: bytes, expected_hz: int
+) -> None:
+    """X6200 returns a raw byte width index, not packed BCD."""
+    radio = _connected_icom(model="X6200")
+
+    async def fake_expect(civ: bytes, **_: object) -> CivFrame:
+        assert civ.hex() == "fefea4e01a03fd"
+        return CivFrame(
+            to_addr=0xE0,
+            from_addr=0xA4,
+            command=0x1A,
+            sub=0x03,
+            data=payload,
+        )
+
+    radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+    radio._radio_state.main.mode = "USB"
+
+    assert await radio.get_filter_width(receiver=0) == expected_hz
+
+
+@pytest.mark.asyncio
+async def test_x6200_set_filter_width_requires_profile_setter_command() -> None:
+    """X6200 has no live-proven Hz setter; runtime must not send 0x1A/0x03."""
+    from rigplane.exceptions import CommandError
+
+    radio = _connected_icom(model="X6200")
+    radio.send_civ = AsyncMock()  # type: ignore[method-assign]
+    radio._radio_state.main.mode = "USB"
+
+    with pytest.raises(CommandError, match="unsupported by profile"):
+        await radio.set_filter_width(2400, receiver=0)
+
+    radio.send_civ.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # get_filter_width — unified 1-byte BCD segmented index per wfview (issue #1156)
 # ---------------------------------------------------------------------------

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -838,6 +838,27 @@ class TestWriteOnlyControls:
         assert "filter_width" not in caps
         assert {"rit", "xit", "notch", "nr", "nb", "compressor"} <= caps
 
+    def test_x6200_filter_width_is_read_only_raw_byte_profile_mapping(self):
+        # MOR-706: X6200 0x1A/0x03 returns a single raw byte index for the
+        # active FIL slot width. Keep the public capability undeclared because
+        # the Hz setter is not live-proven, but preserve the GET command so
+        # runtime reads can use the profile mapping.
+        rig = load_rig(RIGS_DIR / "x6200.toml")
+        profile = rig.to_profile()
+
+        assert profile.filter_width_encoding == "raw_byte_index"
+        assert "filter_width" not in profile.capabilities
+        assert "get_filter_width" in profile.command_names
+        assert "set_filter_width" not in profile.command_names
+
+        rule = profile.resolve_filter_rule("USB")
+        assert rule is not None
+        assert rule.segments
+        for fixed_mode in ("AM", "FM"):
+            fixed_rule = profile.resolve_filter_rule(fixed_mode)
+            assert fixed_rule is not None
+            assert fixed_rule.fixed is True
+
     def test_x6200_drops_over_declared_pbt(self):
         # MOR-699: a live X6200 probe (CI-V 0xA4) showed twin-PBT (get_pbt_inner
         # 0x14 0x07 and get_pbt_outer 0x14 0x08) time out in BOTH AM and USB


### PR DESCRIPTION
## Summary
- add X6200 raw-byte filter_width READ decoding for CI-V 0x1A/0x03 and expose it as command-response-observable state
- keep X6200 filter_width read-only by requiring a declared set_filter_width command before writes
- mark X6200 AM/FM filter width rules fixed and allow synthetic dry-run presence PASS entries per MOR-660 semantics

## Test Plan
- uv run pytest tests/ -q --tb=short
- uv run ruff check src/ tests/
- uv run mypy src/

Linear: MOR-706