### PR TITLE
test(MOR-474): cover FTX-1 two-digit break-in delay

### DIFF
--- a/docs/internals/backend-neutral-readiness-gap-register.md
+++ b/docs/internals/backend-neutral-readiness-gap-register.md
@@ -36,7 +36,7 @@ evidence stays outside this open-core repository.
 | Limitation class | Tracking decision | Current state |
 |---|---|---|
 | FTX-1 observation backing for legacy-only field families | Split into implementation tasks instead of treating MOR-424 as a hidden code bucket. | MOR-443, MOR-444, MOR-445, MOR-446, MOR-447, MOR-448, MOR-449, MOR-452, MOR-458, MOR-460, MOR-461, MOR-462, and MOR-463 are completed. |
-| FTX-1 live parser/poll resilience defects | File only deterministic CAT/backend defects found by live validation. | MOR-473 is completed; MOR-474 remains open for the non-blocking `break_in_delay` SD parse-width follow-up. |
+| FTX-1 live parser/poll resilience defects | File only deterministic CAT/backend defects found by live validation. | MOR-473 and MOR-474 are completed; `break_in_delay` now accepts the live `SD09;` reply fixture. |
 | Public naming / semantic cleanup | Track as compatibility work, not release blockers. | MOR-465 remains open for RIT/XIT field naming/re-home compatibility. |
 | IC-7610 front-panel readback audit | Treat as model-specific readback coverage, not a broad backend-neutral readiness claim. | MOR-488 remains the audit umbrella; completed child issues are reflected in the project board. |
 | External rigctld power and VFO-slot gaps | Declare unsupported in the provider acquisition profile instead of filing generic code defects. | Implemented in `backends/rigctld_client/observations.py`; no extra code issue is required unless a supported rigctld command misbehaves. |

--- a/docs/internals/radio-state-pipeline-validation.md
+++ b/docs/internals/radio-state-pipeline-validation.md
@@ -536,7 +536,8 @@ log shows exactly two distinct field-level skip WARNs, repeated each poll cycle
 - `sub.sMeter` — degrades cleanly (see above); SUB has no independent s-meter on
   this single-RX firmware state (`SM1;` echoes a MAIN `SM0` frame).
 - `breakInDelay` — a residual parser-width mismatch (`SD09;` is 2 digits, parse
-  wants 4). A follow-up `SD` 2-digit parse fix would recover it; non-blocking.
+  wanted 4 in the original run). MOR-474 closes this residual: the parser
+  accepts the live `SD09;` form and the FTX-1 radio fixture covers it.
 - The per-VFO nested slots (`main.vfoA/vfoB.*`, `sub.vfoA/vfoB.*`) remain
   default/stale (freqHz 0, USB) and `missing` — only the ACTIVE-slot projection
   (`main.freqHz`/`main.mode`) is observed. Meters other than s-meter

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -910,8 +910,9 @@ async def test_send_cw(connected_radio):
 
 @pytest.mark.asyncio
 async def test_get_break_in_delay(connected_radio):
-    connected_radio._transport.query = AsyncMock(return_value="SD0300")
-    assert await connected_radio.get_break_in_delay() == 300
+    # Transport strips the trailing semicolon; live FTX-1 frame is ``SD09;``.
+    connected_radio._transport.query = AsyncMock(return_value="SD09")
+    assert await connected_radio.get_break_in_delay() == 9
     connected_radio._transport.query.assert_called_once_with("SD;")
 
 


### PR DESCRIPTION
## Summary
- update the FTX-1 `get_break_in_delay` regression fixture to the live two-digit `SD09;` reply form
- keep the write-side fixture on the canonical four-digit `SD0500;` command
- refresh internal readiness/validation docs now that the MOR-474 residual is closed

## Notes
The production parser already accepts `delay:04d` as 2-4 digits, so this PR does not need another runtime parser change. It pins the radio-level fixture to the live FTX-1 response that originally surfaced the gap.

## Validation
- `uv run pytest tests/test_ftx1_radio.py::test_get_break_in_delay tests/test_ftx1_radio.py::test_set_break_in_delay tests/test_yaesu_cat_parser.py::TestCatCommandParser::test_parse_break_in_delay_two_digit tests/test_yaesu_cat_parser.py::TestCatCommandParser::test_parse_break_in_delay_four_digit_still_parses tests/test_docs_runtime_sync.py -q --tb=short`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -q --tb=short`
