### PR TITLE
fix(MOR-486): route digisel preflight by receiver

### DIFF
--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3282,17 +3282,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
 
         # Pre-flight: check DIGI-SEL / PREAMP mutual exclusion
-        if level > 0:
+        if level > 0 and "digisel" in self.capabilities:
             try:
-                if await self.get_digisel():
+                if await self.get_digisel(receiver=receiver):
                     raise CommandError(
                         f"Cannot set preamp level {level}: DIGI-SEL (IP+) is ON. "
                         "PREAMP and DIGI-SEL are mutually exclusive — disable DIGI-SEL first."
                     )
-            except CommandError as exc:
-                if "DIGI-SEL" in str(exc) and "mutually exclusive" in str(exc):
-                    raise  # Our own error — propagate
-                # get_digisel() failed (radio doesn't support it, timeout, etc.) — ignore
+            except CommandError:
+                raise
             except Exception:
                 logger.debug(
                     "set_preamp: unexpected error checking DIGI-SEL, proceeding",
@@ -3306,16 +3304,23 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         await self._send_civ_raw(civ, wait_response=False)
         self._preamp_level = level
 
-    async def get_digisel(self) -> bool:
+    async def get_digisel(self, receiver: int = RECEIVER_MAIN) -> bool:
         """Read DIGI-SEL status (IC-7610 frontend selector)."""
         self._check_connected()
         self._require_capability("digisel", operation="get_digisel")
+        self._require_receiver(receiver, operation="get_digisel")
+        self._require_cmd29_route(
+            0x16,
+            0x4E,
+            receiver=receiver,
+            operation="get_digisel",
+        )
         if not self._profile.supports_cmd29(0x16, 0x4E):
             raise CommandError(
                 f"get_digisel is unsupported by profile {self._profile.model}: "
                 "no cmd29 route for command 0x16/0x4E"
             )
-        civ = get_digisel(to_addr=self._radio_addr)
+        civ = get_digisel(to_addr=self._radio_addr, receiver=receiver)
         resp = await self._send_civ_expect(civ, label="get_digisel")
         if not resp.data:
             raise CommandError("Radio returned empty DIGI-SEL response")

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -36,7 +36,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from rigplane import IC_7610_ADDR
-from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
+from rigplane.commands import CONTROLLER_ADDR, build_civ_frame, build_cmd29_frame
 from rigplane.exceptions import CommandError, ConnectionError, TimeoutError
 from rigplane.radio import IcomRadio
 from rigplane.scope import ScopeFrame
@@ -86,11 +86,23 @@ def _level_response(cmd: int, sub: int, level: int) -> bytes:
     return _wrap_civ_in_udp(civ)
 
 
-def _raw_byte_response(cmd: int, sub: int | None, raw: int) -> bytes:
+def _raw_byte_response(
+    cmd: int, sub: int | None, raw: int, *, receiver: int | None = None
+) -> bytes:
     """CI-V response with a single raw byte (attenuator, preamp, digisel)."""
-    civ = build_civ_frame(
-        CONTROLLER_ADDR, IC_7610_ADDR, cmd, sub=sub, data=bytes([raw])
-    )
+    if receiver is None:
+        civ = build_civ_frame(
+            CONTROLLER_ADDR, IC_7610_ADDR, cmd, sub=sub, data=bytes([raw])
+        )
+    else:
+        civ = build_cmd29_frame(
+            CONTROLLER_ADDR,
+            IC_7610_ADDR,
+            cmd,
+            sub=sub,
+            data=bytes([raw]),
+            receiver=receiver,
+        )
     return _wrap_civ_in_udp(civ)
 
 
@@ -577,6 +589,18 @@ async def test_get_digisel_raises_on_empty_response(
     mock_transport.queue_response(_wrap_civ_in_udp(empty_civ))
     with pytest.raises(CommandError, match="empty DIGI-SEL response"):
         await radio.get_digisel()
+
+
+async def test_get_digisel_sub_routes_to_sub_receiver(
+    radio: IcomRadio, mock_transport: MockTransport
+) -> None:
+    """get_digisel(receiver=1) must query the SUB Command29 receiver route."""
+    mock_transport.queue_response(_raw_byte_response(0x16, 0x4E, 0x01, receiver=1))
+
+    assert await radio.get_digisel(receiver=1) is True
+
+    sent = mock_transport.sent_packets[-1]
+    assert sent.endswith(b"\x29\x01\x16\x4e\xfd")
 
 
 # ---------------------------------------------------------------------------
@@ -1958,20 +1982,29 @@ async def test_set_preamp_propagates_own_digi_sel_error(
             await radio.set_preamp(1)
 
 
-async def test_set_preamp_ignores_unrelated_command_error(
+async def test_set_preamp_propagates_preflight_command_error(
     radio: IcomRadio,
 ) -> None:
-    """set_preamp() ignores CommandError that isn't its own DIGI-SEL error."""
+    """set_preamp() surfaces get_digisel() failures instead of silently writing."""
     from rigplane.exceptions import CommandError
 
-    # Mock get_digisel to raise a different CommandError
     with patch.object(
         radio,
         "get_digisel",
         new=AsyncMock(side_effect=CommandError("radio unreachable")),
     ):
-        # Should NOT raise — it's a different CommandError, not DIGI-SEL
-        await radio.set_preamp(1)
+        with pytest.raises(CommandError, match="radio unreachable"):
+            await radio.set_preamp(1)
+
+
+async def test_set_preamp_checks_digisel_on_target_receiver(
+    radio: IcomRadio,
+) -> None:
+    """set_preamp(receiver=1) must preflight DIGI-SEL on SUB, not MAIN."""
+    with patch.object(radio, "get_digisel", new=AsyncMock(return_value=False)) as check:
+        await radio.set_preamp(1, receiver=1)
+
+    check.assert_awaited_once_with(receiver=1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `get_digisel(receiver=...)` receiver-aware and validate the target receiver route
- make `set_preamp(receiver=...)` run the DIGI-SEL mutex preflight against the same receiver
- stop swallowing `CommandError` from supported DIGI-SEL preflight failures, while preserving preamp behavior on profiles that do not advertise `digisel`

## Root Cause
`set_preamp(receiver=1)` called `get_digisel()` without forwarding `receiver`, so dual-RX preflight checked MAIN instead of SUB. The same preflight also swallowed non-mutual-exclusion `CommandError`s, causing backend errors to disappear instead of surfacing to command/UI paths.

## Validation
- `uv run pytest tests/test_radio_coverage.py::test_get_digisel_sub_routes_to_sub_receiver tests/test_radio_coverage.py::test_set_preamp_propagates_preflight_command_error tests/test_radio_coverage.py::test_set_preamp_checks_digisel_on_target_receiver -q --tb=short`
- `uv run pytest tests/test_single_rx_plain_routing.py tests/test_radio_coverage.py::test_get_digisel_sub_routes_to_sub_receiver tests/test_radio_coverage.py::test_set_preamp_propagates_preflight_command_error tests/test_radio_coverage.py::test_set_preamp_checks_digisel_on_target_receiver -q --tb=short`
- `uv run pytest tests/test_radio_coverage.py tests/test_single_rx_plain_routing.py tests/test_commands.py::TestCmd29ReceiverRouting tests/test_command_map_integration.py::TestCmd29Parity::test_get_digisel -q --tb=short`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -q --tb=short`
