### PR TITLE
fix(MOR-511): use platform cache for daemon logs

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -3651,6 +3651,20 @@ async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
     return 0
 
 
+def _default_daemon_log_file(*, managed_runtime: bool) -> Path:
+    filename = "rigplane-managed.log" if managed_runtime else "rigplane.log"
+    log_dir = os.environ.get("RIGPLANE_LOG_DIR", "").strip()
+    if log_dir:
+        return Path(log_dir).expanduser() / filename
+
+    import platformdirs
+
+    from rigplane._platformdirs_migration import migrate_legacy_platformdirs
+
+    migrate_legacy_platformdirs()
+    return Path(platformdirs.user_cache_path("rigplane")) / "logs" / filename
+
+
 def main() -> None:
     import logging
 
@@ -3658,7 +3672,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # Enable debug logging with ICOM_DEBUG=1 or any truthy value
-    # ICOM_LOG_FILE=/path/to/file.log — log to file (default: logs/rigplane.log)
+    # ICOM_LOG_FILE=/path/to/file.log — log to file (default: platform cache logs)
     # ICOM_LOG_MAX_BYTES=50000000 — rotate when file reaches this size (default: 50 MB)
     # ICOM_LOG_BACKUP_COUNT=5 — keep N rotated backups (default: 5; 0 disables rotation)
     # Set ICOM_LOG_FILE=off to disable the default file log on daemon commands.
@@ -3698,10 +3712,10 @@ def main() -> None:
 
     # File handler (if log_file specified, debug mode, or daemon command)
     if (debug_mode or is_daemon) and not log_file and not log_file_disabled:
-        log_file = (
-            "logs/rigplane-managed.log"
-            if getattr(args, "managed_runtime", False)
-            else "logs/rigplane.log"
+        log_file = str(
+            _default_daemon_log_file(
+                managed_runtime=bool(getattr(args, "managed_runtime", False))
+            )
         )
 
     if log_file:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,11 @@
 
 import argparse
 import io
+import logging
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import platformdirs
 import pytest
 
 from rigplane.cli import (
@@ -539,6 +542,76 @@ def _run_main_serve(env_overrides: dict[str, str] | None = None) -> int:
                     with pytest.raises(SystemExit):
                         main()
     return exit_code
+
+
+def _capture_main_serve_log_path(
+    env_overrides: dict[str, str] | None = None,
+) -> Path | None:
+    captured: dict[str, Path] = {}
+
+    class _Handler(logging.NullHandler):
+        def __init__(self, filename: Path, *args: object, **kwargs: object) -> None:
+            super().__init__()
+            captured["path"] = Path(filename)
+
+    env = {"ICOM_PID_FILE": "", "ICOM_LOG_FILE": "", **(env_overrides or {})}
+    with patch.dict("os.environ", env, clear=False):
+        with patch("sys.argv", ["rigplane", "--host", "127.0.0.1", "serve"]):
+            with patch("rigplane.cli._run", new_callable=AsyncMock, return_value=0):
+                with patch(
+                    "rigplane.cli.os._exit",
+                    side_effect=lambda code: (_ for _ in ()).throw(SystemExit(code)),
+                ):
+                    with patch("rigplane.cli.RotatingFileHandler", _Handler):
+                        with pytest.raises(SystemExit):
+                            main()
+    return captured.get("path")
+
+
+class TestDaemonLogDefaults:
+    def test_daemon_log_default_uses_platform_cache_not_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        cache_root = tmp_path / "cache"
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            platformdirs,
+            "user_cache_path",
+            lambda app: cache_root / app,
+        )
+
+        log_path = _capture_main_serve_log_path()
+
+        assert log_path == cache_root / "rigplane" / "logs" / "rigplane.log"
+
+    def test_daemon_log_default_honors_rigplane_log_dir(self, tmp_path):
+        log_dir = tmp_path / "custom-logs"
+
+        log_path = _capture_main_serve_log_path({"RIGPLANE_LOG_DIR": str(log_dir)})
+
+        assert log_path == log_dir / "rigplane.log"
+
+    def test_daemon_log_explicit_icom_log_file_still_wins(self, tmp_path):
+        explicit = tmp_path / "explicit.log"
+
+        log_path = _capture_main_serve_log_path(
+            {
+                "RIGPLANE_LOG_DIR": str(tmp_path / "ignored"),
+                "ICOM_LOG_FILE": str(explicit),
+            }
+        )
+
+        assert log_path == explicit
+
+    def test_daemon_log_off_still_disables_file_handler(self, tmp_path):
+        log_path = _capture_main_serve_log_path(
+            {
+                "RIGPLANE_LOG_DIR": str(tmp_path / "ignored"),
+                "ICOM_LOG_FILE": "off",
+            }
+        )
+
+        assert log_path is None
 
 
 class TestPidFile:


### PR DESCRIPTION
## Summary
- move daemon default runtime logs out of CWD-relative `logs/` and into `platformdirs.user_cache_path("rigplane") / "logs"`
- honor `RIGPLANE_LOG_DIR` for daemon default log placement
- preserve explicit `ICOM_LOG_FILE` and `ICOM_LOG_FILE=off` behavior

## Tests
- `uv run pytest tests/test_cli.py::TestDaemonLogDefaults -q --tb=short`
- `uv run pytest tests/test_cli.py tests/test_cli_async.py tests/test_cli_coverage.py tests/test_diagnostics_logging.py tests/test_platformdirs_migration.py -q --tb=short`
- `uv run ruff format --check src/ tests/ && uv run ruff check src/ tests/`
- `uv run pytest tests/ -q --tb=short`

Refs MOR-511