### PR TITLE
fix(MOR-726): centralize core log directory resolution

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -3653,16 +3653,11 @@ async def _cmd_discover(_radio: Radio | None, args: argparse.Namespace) -> int:
 
 def _default_daemon_log_file(*, managed_runtime: bool) -> Path:
     filename = "rigplane-managed.log" if managed_runtime else "rigplane.log"
-    log_dir = os.environ.get("RIGPLANE_LOG_DIR", "").strip()
-    if log_dir:
-        return Path(log_dir).expanduser() / filename
-
-    import platformdirs
-
     from rigplane._platformdirs_migration import migrate_legacy_platformdirs
+    from rigplane.diagnostics._log_paths import resolve_core_log_dir
 
     migrate_legacy_platformdirs()
-    return Path(platformdirs.user_cache_path("rigplane")) / "logs" / filename
+    return resolve_core_log_dir() / filename
 
 
 def main() -> None:

--- a/src/rigplane/cli/_diagnose.py
+++ b/src/rigplane/cli/_diagnose.py
@@ -139,9 +139,10 @@ def _default_log_dir() -> Path:
     # entry point that bypasses that path (or runs before logging init) still
     # benefits from the migration. The helper is idempotent.
     from rigplane._platformdirs_migration import migrate_legacy_platformdirs
+    from rigplane.diagnostics._log_paths import resolve_core_log_dir
 
     migrate_legacy_platformdirs()
-    return Path(platformdirs.user_cache_path("rigplane")) / "logs"
+    return resolve_core_log_dir()
 
 
 def _default_config_dir() -> Path:

--- a/src/rigplane/diagnostics/_log_paths.py
+++ b/src/rigplane/diagnostics/_log_paths.py
@@ -1,0 +1,18 @@
+"""Shared Core log directory resolution."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import platformdirs
+
+__all__ = ["resolve_core_log_dir"]
+
+
+def resolve_core_log_dir() -> Path:
+    """Return the directory Core should use for file logs."""
+    log_dir = os.environ.get("RIGPLANE_LOG_DIR", "").strip()
+    if log_dir:
+        return Path(log_dir).expanduser()
+    return Path(platformdirs.user_cache_path("rigplane")) / "logs"

--- a/src/rigplane/diagnostics/_logging.py
+++ b/src/rigplane/diagnostics/_logging.py
@@ -16,7 +16,7 @@ import os
 import sys
 from logging.handlers import RotatingFileHandler
 
-import platformdirs
+from rigplane.diagnostics._log_paths import resolve_core_log_dir
 
 _DIAGNOSTIC_FORMATTER = logging.Formatter(
     "%(asctime)s %(levelname)s %(name)s %(message)s"
@@ -63,7 +63,7 @@ def configure_diagnostic_logging() -> None:
     except Exception:  # noqa: BLE001 — best-effort, swallow all
         pass
     try:
-        log_dir = platformdirs.user_cache_path("rigplane") / "logs"
+        log_dir = resolve_core_log_dir()
         log_dir.mkdir(parents=True, exist_ok=True)
         handler = SafeRotatingFileHandler(
             log_dir / _LOG_FILE_NAME,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -4476,7 +4476,9 @@ class WebServer:
         migrate_legacy_platformdirs()
 
         config_dir = pathlib.Path(platformdirs.user_config_path("rigplane"))
-        log_dir = pathlib.Path(platformdirs.user_cache_path("rigplane")) / "logs"
+        from rigplane.diagnostics._log_paths import resolve_core_log_dir
+
+        log_dir = resolve_core_log_dir()
         return config_dir, log_dir
 
     async def _handle_diagnose_preview(

--- a/tests/test_cli_diagnose.py
+++ b/tests/test_cli_diagnose.py
@@ -157,6 +157,18 @@ class TestSaveOnly:
         out = capsys.readouterr().out
         assert "Bundle saved to" in out
 
+    def test_context_log_dir_honors_rigplane_log_dir(
+        self, parsed, fake_build_bundle, fake_upload, monkeypatch, tmp_path
+    ):
+        log_dir = tmp_path / "ram-logs"
+        monkeypatch.setenv("RIGPLANE_LOG_DIR", str(log_dir))
+
+        rc = _diagnose.run(parsed())
+
+        assert rc == 0
+        assert fake_build_bundle["ctx"].log_dir == log_dir
+        fake_upload.assert_not_awaited()
+
     def test_no_upload_never_prompts(
         self, parsed, fake_build_bundle, fake_upload, monkeypatch, force_tty
     ):

--- a/tests/test_diagnostics_logging.py
+++ b/tests/test_diagnostics_logging.py
@@ -138,6 +138,23 @@ def test_log_file_writes_to_platformdirs_cache(
     assert "hello" in log_file.read_text(encoding="utf-8")
 
 
+def test_log_file_honors_rigplane_log_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    log_dir = tmp_path / "ram-logs"
+    monkeypatch.setenv("RIGPLANE_LOG_DIR", str(log_dir))
+    monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path / "cache")
+
+    configure_diagnostic_logging()
+    logger = logging.getLogger("rigplane.test")
+    logger.debug("hello from env")
+
+    log_file = log_dir / "rigplane.log"
+    assert log_file.exists()
+    assert "hello from env" in log_file.read_text(encoding="utf-8")
+    assert not (tmp_path / "cache" / "logs" / "rigplane.log").exists()
+
+
 def test_preset_logger_level_preserved(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_web_diagnostics.py
+++ b/tests/test_web_diagnostics.py
@@ -141,6 +141,18 @@ def _register_test_contributor() -> None:
     _discovery._BUILT_IN_CONTRIBUTORS.append(_OkContributor)
 
 
+def test_resolve_diagnostic_dirs_honors_rigplane_log_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    log_dir = tmp_path / "ram-logs"
+    monkeypatch.setenv("RIGPLANE_LOG_DIR", str(log_dir))
+    srv = _make_server()
+
+    _config_dir, resolved_log_dir = srv._resolve_diagnostic_dirs()  # noqa: SLF001
+
+    assert resolved_log_dir == log_dir
+
+
 def _stub_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Replace WebServer._resolve_diagnostic_dirs with a tmp-path version."""
     cfg = tmp_path / "config"


### PR DESCRIPTION
## Summary
- add a shared Core log directory resolver for `RIGPLANE_LOG_DIR` with platformdirs cache fallback
- use it for daemon runtime logs, always-on diagnostic logging, CLI diagnose bundle context, and web diagnostic bundle paths
- preserve `ICOM_LOG_FILE` / `ICOM_LOG_FILE=off` daemon runtime semantics

## Tests
- `uv run pytest tests/test_diagnostics_logging.py::test_log_file_honors_rigplane_log_dir tests/test_cli_diagnose.py::TestSaveOnly::test_context_log_dir_honors_rigplane_log_dir tests/test_web_diagnostics.py::test_resolve_diagnostic_dirs_honors_rigplane_log_dir -q --tb=short`
- `uv run pytest tests/test_diagnostics_logging.py tests/test_cli_diagnose.py tests/test_web_diagnostics.py tests/test_diagnostics_bundle.py tests/test_diagnostics_contributors_batch1.py tests/test_diagnostics_contributors_batch2.py tests/test_diagnostics_contributors_batch3.py tests/test_platformdirs_migration.py tests/test_cli.py::TestDaemonLogDefaults -q --tb=short`
- `uv run ruff format --check src/ tests/ && uv run ruff check src/ tests/`
- `uv run pytest tests/ -q --tb=short`

Refs MOR-726