### PR TITLE
MOR-728: add generic browser audio route model

### DIFF
--- a/frontend/src/lib/audio/__tests__/browser-audio-route.test.ts
+++ b/frontend/src/lib/audio/__tests__/browser-audio-route.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  resolveBrowserAudioRoute,
+  type BrowserAudioRouteDescriptor,
+  type BrowserMediaDeviceInfo,
+} from '../browser-audio-route';
+
+const descriptor: BrowserAudioRouteDescriptor = {
+  routeId: 'example-loopback',
+  input: { labelIncludes: ['Example Bridge Capture'] },
+  output: { labelIncludes: ['Example Bridge Playback'] },
+  preferExplicitOutput: true,
+};
+
+const neutralFixtures = [
+  'Example Bridge Capture',
+  'Example Bridge Playback',
+  'Laptop Microphone',
+  'USB Headphones',
+];
+
+function device(
+  kind: BrowserMediaDeviceInfo['kind'],
+  label: string,
+  scopedDeviceId: string,
+): BrowserMediaDeviceInfo {
+  return {
+    kind,
+    label,
+    deviceId: scopedDeviceId,
+    groupId: `group-${scopedDeviceId}`,
+  };
+}
+
+function mediaDevices(options: {
+  beforePermission?: BrowserMediaDeviceInfo[];
+  afterPermission?: BrowserMediaDeviceInfo[];
+  rejectPermission?: boolean;
+}) {
+  let permissionGranted = false;
+  const stream = {
+    getTracks: () => [{ stop: vi.fn() }],
+  } as unknown as MediaStream;
+
+  return {
+    getUserMedia: vi.fn(async () => {
+      if (options.rejectPermission) {
+        throw new DOMException('denied', 'NotAllowedError');
+      }
+      permissionGranted = true;
+      return stream;
+    }),
+    enumerateDevices: vi.fn(async () => (
+      permissionGranted
+        ? (options.afterPermission ?? [])
+        : (options.beforePermission ?? [])
+    )),
+  };
+}
+
+describe('browser audio route model', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requests microphone permission before relying on labels, then selects matched endpoints', async () => {
+    const media = mediaDevices({
+      beforePermission: [
+        device('audioinput', '', 'scoped-input-before'),
+        device('audiooutput', '', 'scoped-output-before'),
+      ],
+      afterPermission: [
+        device('audioinput', 'Example Bridge Capture', 'scoped-input-after'),
+        device('audiooutput', 'Example Bridge Playback', 'scoped-output-after'),
+      ],
+    });
+    const sinkTarget = { setSinkId: vi.fn(async () => undefined) };
+
+    const route = await resolveBrowserAudioRoute({
+      descriptor,
+      mediaDevices: media,
+      sinkTarget,
+    });
+
+    expect(media.getUserMedia).toHaveBeenCalledBefore(media.enumerateDevices);
+    expect(route.status).toBe('selected');
+    if (route.status !== 'selected') throw new Error('expected selected route');
+    expect(route.input.label).toBe('Example Bridge Capture');
+    expect(route.output.label).toBe('Example Bridge Playback');
+    expect(route.input.scopedDeviceId).toBe('scoped-input-after');
+    expect(route.output.scopedDeviceId).toBe('scoped-output-after');
+  });
+
+  it('prefers explicit output devices over default and communications aliases', async () => {
+    const media = mediaDevices({
+      afterPermission: [
+        device('audioinput', 'Example Bridge Capture', 'scoped-input'),
+        device('audiooutput', 'Example Bridge Playback', 'default'),
+        device('audiooutput', 'Example Bridge Playback', 'communications'),
+        device('audiooutput', 'Example Bridge Playback', 'scoped-output-explicit'),
+      ],
+    });
+
+    const route = await resolveBrowserAudioRoute({
+      descriptor,
+      mediaDevices: media,
+      sinkTarget: { setSinkId: vi.fn(async () => undefined) },
+    });
+
+    expect(route.status).toBe('selected');
+    if (route.status !== 'selected') throw new Error('expected selected route');
+    expect(route.output.scopedDeviceId).toBe('scoped-output-explicit');
+  });
+
+  it('returns unsupported-output-selection when a requested output route cannot use setSinkId', async () => {
+    const media = mediaDevices({
+      afterPermission: [
+        device('audioinput', 'Example Bridge Capture', 'scoped-input'),
+        device('audiooutput', 'Example Bridge Playback', 'scoped-output'),
+      ],
+    });
+
+    const route = await resolveBrowserAudioRoute({
+      descriptor,
+      mediaDevices: media,
+      sinkTarget: {},
+    });
+
+    expect(route).toMatchObject({
+      status: 'unsupported-output-selection',
+      outputSelectionSupported: false,
+    });
+  });
+
+  it('feature-detects output selection support from the media element prototype', async () => {
+    vi.stubGlobal('HTMLMediaElement', class {
+      setSinkId() {
+        return Promise.resolve();
+      }
+    });
+    const media = mediaDevices({
+      afterPermission: [
+        device('audioinput', 'Example Bridge Capture', 'scoped-input'),
+        device('audiooutput', 'Example Bridge Playback', 'scoped-output'),
+      ],
+    });
+
+    const route = await resolveBrowserAudioRoute({
+      descriptor,
+      mediaDevices: media,
+    });
+
+    expect(route.status).toBe('selected');
+  });
+
+  it('returns permission-denied when microphone permission is rejected', async () => {
+    const media = mediaDevices({ rejectPermission: true });
+
+    const route = await resolveBrowserAudioRoute({
+      descriptor,
+      mediaDevices: media,
+      sinkTarget: { setSinkId: vi.fn(async () => undefined) },
+    });
+
+    expect(route).toMatchObject({
+      status: 'permission-denied',
+      permissionState: 'denied',
+    });
+    expect(media.enumerateDevices).not.toHaveBeenCalled();
+  });
+
+  it('returns missing-endpoints with explicit missing directions', async () => {
+    const media = mediaDevices({
+      afterPermission: [
+        device('audioinput', 'Laptop Microphone', 'scoped-input'),
+        device('audiooutput', 'USB Headphones', 'scoped-output'),
+      ],
+    });
+
+    const route = await resolveBrowserAudioRoute({
+      descriptor,
+      mediaDevices: media,
+      sinkTarget: { setSinkId: vi.fn(async () => undefined) },
+    });
+
+    expect(route).toMatchObject({
+      status: 'missing-endpoints',
+      missing: ['input', 'output'],
+      permissionState: 'granted',
+    });
+  });
+
+  it('keeps anonymized fixtures and ignores productMode descriptor data', async () => {
+    for (const fixture of neutralFixtures) {
+      expect(fixture).toMatch(/^(Example|Laptop|USB) /);
+    }
+
+    const media = mediaDevices({
+      afterPermission: [
+        device('audioinput', 'Example Bridge Capture', 'scoped-input'),
+        device('audiooutput', 'Example Bridge Playback', 'scoped-output'),
+      ],
+    });
+    const route = await resolveBrowserAudioRoute({
+      descriptor: { ...descriptor, productMode: 'ignored-host-mode' } as BrowserAudioRouteDescriptor,
+      mediaDevices: media,
+      sinkTarget: { setSinkId: vi.fn(async () => undefined) },
+    });
+
+    expect(route.status).toBe('selected');
+  });
+
+  it('treats malformed host descriptors as untrusted data without throwing', async () => {
+    const media = mediaDevices({
+      afterPermission: [
+        device('audioinput', 'Example Bridge Capture', 'scoped-input'),
+        device('audiooutput', 'Example Bridge Playback', 'scoped-output'),
+      ],
+    });
+
+    const route = await resolveBrowserAudioRoute({
+      descriptor: {
+        routeId: 123,
+        input: { labelIncludes: [null, {}, ''] },
+        output: { labelIncludes: 'Example Bridge Playback' },
+      } as unknown as BrowserAudioRouteDescriptor,
+      mediaDevices: media,
+      sinkTarget: { setSinkId: vi.fn(async () => undefined) },
+    });
+
+    expect(route).toMatchObject({
+      status: 'missing-endpoints',
+      missing: ['input', 'output'],
+    });
+  });
+});

--- a/frontend/src/lib/audio/browser-audio-route.ts
+++ b/frontend/src/lib/audio/browser-audio-route.ts
@@ -1,0 +1,224 @@
+export type BrowserAudioDeviceKind = 'audioinput' | 'audiooutput';
+
+export interface BrowserMediaDeviceInfo {
+  kind: BrowserAudioDeviceKind;
+  deviceId: string;
+  label: string;
+  groupId?: string;
+}
+
+export interface BrowserAudioDeviceMatcher {
+  labelIncludes?: readonly string[];
+  groupId?: string;
+}
+
+export interface BrowserAudioRouteDescriptor {
+  routeId: string;
+  input?: BrowserAudioDeviceMatcher;
+  output?: BrowserAudioDeviceMatcher;
+  preferExplicitOutput?: boolean;
+  [key: string]: unknown;
+}
+
+export interface BrowserAudioRouteEndpoint {
+  kind: BrowserAudioDeviceKind;
+  label: string;
+  groupId?: string;
+  /**
+   * Browser-scoped id for immediate getUserMedia/setSinkId use.
+   * Do not persist this as a stable OS or product identity.
+   */
+  scopedDeviceId: string;
+  isAlias: boolean;
+}
+
+export type BrowserAudioRouteState =
+  | {
+      status: 'unsupported-output-selection';
+      outputSelectionSupported: false;
+      permissionState: 'prompt';
+    }
+  | {
+      status: 'permission-denied';
+      outputSelectionSupported: boolean;
+      permissionState: 'denied';
+    }
+  | {
+      status: 'missing-endpoints';
+      outputSelectionSupported: boolean;
+      permissionState: 'granted';
+      missing: Array<'input' | 'output'>;
+      input?: BrowserAudioRouteEndpoint;
+      output?: BrowserAudioRouteEndpoint;
+    }
+  | {
+      status: 'selected';
+      outputSelectionSupported: boolean;
+      permissionState: 'granted';
+      routeId: string;
+      input: BrowserAudioRouteEndpoint;
+      output: BrowserAudioRouteEndpoint;
+    };
+
+export interface BrowserAudioRouteResolveOptions {
+  descriptor: BrowserAudioRouteDescriptor;
+  mediaDevices: {
+    getUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream>;
+    enumerateDevices(): Promise<readonly BrowserMediaDeviceInfo[]>;
+  };
+  sinkTarget?: unknown;
+}
+
+const DEVICE_ID_ALIASES = new Set(['default', 'communications']);
+const MAX_MATCH_TERMS = 8;
+const MAX_TERM_LENGTH = 160;
+const MAX_ROUTE_ID_LENGTH = 120;
+
+function hasOutputSelectionSupport(target: unknown): boolean {
+  if (
+    typeof target === 'object'
+    && target !== null
+    && typeof (target as { setSinkId?: unknown }).setSinkId === 'function'
+  ) {
+    return true;
+  }
+
+  return (
+    typeof HTMLMediaElement !== 'undefined'
+    && typeof HTMLMediaElement.prototype.setSinkId === 'function'
+  );
+}
+
+function safeText(value: unknown, maxLength = MAX_TERM_LENGTH): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, maxLength);
+}
+
+function normalize(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+function safeMatcher(value: unknown): Required<Pick<BrowserAudioDeviceMatcher, 'labelIncludes'>> & {
+  groupId?: string;
+} {
+  if (typeof value !== 'object' || value === null) return { labelIncludes: [] };
+  const raw = value as BrowserAudioDeviceMatcher;
+  const labelIncludes = Array.isArray(raw.labelIncludes)
+    ? raw.labelIncludes
+      .slice(0, MAX_MATCH_TERMS)
+      .map((term) => safeText(term))
+      .filter((term): term is string => term !== null)
+      .map(normalize)
+    : [];
+  const groupId = safeText(raw.groupId);
+  return groupId ? { labelIncludes, groupId } : { labelIncludes };
+}
+
+function safeRouteId(descriptor: BrowserAudioRouteDescriptor): string {
+  return safeText(descriptor.routeId, MAX_ROUTE_ID_LENGTH) ?? 'browser-audio-route';
+}
+
+function deviceMatches(
+  device: BrowserMediaDeviceInfo,
+  matcher: ReturnType<typeof safeMatcher>,
+): boolean {
+  if (matcher.groupId && device.groupId !== matcher.groupId) return false;
+  if (matcher.labelIncludes.length === 0) return false;
+  const label = normalize(device.label);
+  if (!label) return false;
+  return matcher.labelIncludes.every((term) => label.includes(term));
+}
+
+function toEndpoint(device: BrowserMediaDeviceInfo): BrowserAudioRouteEndpoint {
+  return {
+    kind: device.kind,
+    label: device.label,
+    groupId: device.groupId,
+    scopedDeviceId: device.deviceId,
+    isAlias: DEVICE_ID_ALIASES.has(device.deviceId),
+  };
+}
+
+function chooseDevice(
+  devices: readonly BrowserMediaDeviceInfo[],
+  kind: BrowserAudioDeviceKind,
+  matcher: ReturnType<typeof safeMatcher>,
+  preferExplicit: boolean,
+): BrowserMediaDeviceInfo | undefined {
+  const candidates = devices.filter((device) => (
+    device.kind === kind && deviceMatches(device, matcher)
+  ));
+  if (!preferExplicit) return candidates[0];
+  return candidates.find((device) => !DEVICE_ID_ALIASES.has(device.deviceId)) ?? candidates[0];
+}
+
+function stopTracks(stream: MediaStream): void {
+  for (const track of stream.getTracks()) {
+    track.stop();
+  }
+}
+
+export async function resolveBrowserAudioRoute(
+  options: BrowserAudioRouteResolveOptions,
+): Promise<BrowserAudioRouteState> {
+  const outputSelectionSupported = hasOutputSelectionSupport(options.sinkTarget);
+  if (options.descriptor.output && !outputSelectionSupported) {
+    return {
+      status: 'unsupported-output-selection',
+      outputSelectionSupported: false,
+      permissionState: 'prompt',
+    };
+  }
+
+  let stream: MediaStream;
+  try {
+    stream = await options.mediaDevices.getUserMedia({ audio: true });
+  } catch {
+    return {
+      status: 'permission-denied',
+      outputSelectionSupported,
+      permissionState: 'denied',
+    };
+  }
+
+  stopTracks(stream);
+
+  const devices = await options.mediaDevices.enumerateDevices();
+  const inputMatcher = safeMatcher(options.descriptor.input);
+  const outputMatcher = safeMatcher(options.descriptor.output);
+  const inputDevice = chooseDevice(devices, 'audioinput', inputMatcher, false);
+  const outputDevice = chooseDevice(
+    devices,
+    'audiooutput',
+    outputMatcher,
+    options.descriptor.preferExplicitOutput === true,
+  );
+  const input = inputDevice ? toEndpoint(inputDevice) : undefined;
+  const output = outputDevice ? toEndpoint(outputDevice) : undefined;
+  const missing: Array<'input' | 'output'> = [];
+
+  if (!input) missing.push('input');
+  if (!output) missing.push('output');
+
+  if (missing.length > 0 || !input || !output) {
+    return {
+      status: 'missing-endpoints',
+      outputSelectionSupported,
+      permissionState: 'granted',
+      missing,
+      input,
+      output,
+    };
+  }
+
+  return {
+    status: 'selected',
+    outputSelectionSupported,
+    permissionState: 'granted',
+    routeId: safeRouteId(options.descriptor),
+    input,
+    output,
+  };
+}


### PR DESCRIPTION
## Summary
- Add a product-neutral browser audio route model for browser permission, enumeration, route matching, and selected/missing/denied/unsupported states.
- Add anonymized fixture tests for descriptor-driven audioinput/audiooutput matching and explicit output alias preference.
- Keep RigPlane-specific endpoint labels, install policy, driver identity, and private evidence out of `rigplane-core`.

## Boundary
- Open-core candidate: generic browser route state and descriptor matching only.
- No concrete RigPlane Virtual Cable labels, Windows driver details, registry/hardware IDs, IOCTLs, install/repair policy, entitlement, or private adapter imports.
- Generic model ignores private `productMode`; product behavior must arrive through descriptor route policies.

## Verification
- `npm run test -- --run src/lib/audio/__tests__/browser-audio-route.test.ts`
- `npm run check`
- `git diff --check origin/main...HEAD`
- Subagent review: PASS, no Critical/Important/Minor findings

Linear: MOR-728