### PR TITLE
fix(MOR-467): add normalized-control rigctld safety layer

### DIFF
--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -938,11 +938,13 @@ def _receiver_specs(receiver_id: str) -> tuple[FieldSpec, ...]:
             FieldPath.receiver(receiver_id, "operator_controls", "af_level"),
             "int",
             writable=True,
+            unit="normalized",
         ),
         spec(
             FieldPath.receiver(receiver_id, "operator_controls", "rf_gain"),
             "int",
             writable=True,
+            unit="normalized",
         ),
         spec(
             FieldPath.receiver(receiver_id, "operator_controls", "pbt_inner"),
@@ -958,6 +960,7 @@ def _receiver_specs(receiver_id: str) -> tuple[FieldSpec, ...]:
             FieldPath.receiver(receiver_id, "operator_controls", "squelch"),
             "int",
             writable=True,
+            unit="normalized",
         ),
         spec(
             FieldPath.receiver(receiver_id, "operator_controls", "att"),

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -56,7 +56,8 @@ if TYPE_CHECKING:
 
 from ..capabilities import CAP_METERS, CAP_RIT
 from .routing import (  # noqa: TID251
-    _format_raw_or_normalized_float,
+    _format_normalized_or_raw_float,
+    _format_raw_scaled_float,
     _format_strength,
     create_routing,
 )
@@ -1673,21 +1674,14 @@ class RigctldHandler:
             if projected is not None:
                 if level == "STRENGTH":
                     if "calibrated" in projected.quality:
-                        value = projected.value
-                        if (
-                            isinstance(value, float)
-                            and not isinstance(value, bool)
-                            and 0.0 <= value <= 1.0
-                        ):
-                            return RigctldResponse(values=[f"{value:.6f}"])
-                        return RigctldResponse(values=[str(int(value))])
+                        return RigctldResponse(values=[str(int(projected.value))])
                     return RigctldResponse(
                         values=[_format_strength(projected.value, raw_divisor=241.0)]
                     )
                 if level == "RFPOWER":
                     return RigctldResponse(
                         values=[
-                            _format_raw_or_normalized_float(
+                            _format_normalized_or_raw_float(
                                 projected.value,
                                 raw_divisor=255.0,
                             )
@@ -1698,7 +1692,16 @@ class RigctldHandler:
                 if level in {"RFPOWER_METER", "COMP_METER", "ID_METER", "VD_METER"}:
                     return RigctldResponse(
                         values=[
-                            _format_raw_or_normalized_float(
+                            _format_raw_scaled_float(
+                                projected.value,
+                                raw_divisor=255.0,
+                            )
+                        ]
+                    )
+                if level in {"AF", "RF", "SQL"}:
+                    return RigctldResponse(
+                        values=[
+                            _format_normalized_or_raw_float(
                                 projected.value,
                                 raw_divisor=255.0,
                             )
@@ -1707,7 +1710,7 @@ class RigctldHandler:
                 if level in _GET_LEVEL_FLOAT:
                     return RigctldResponse(
                         values=[
-                            _format_raw_or_normalized_float(
+                            _format_raw_scaled_float(
                                 projected.value,
                                 raw_divisor=255.0,
                             )

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -668,11 +668,11 @@ class RigctldHandler:
         if level == "RFPOWER_METER":
             return FieldPath.global_("meters", "power")
         if level == "COMP_METER":
-            return FieldPath.global_("meters", "comp_meter")
+            return FieldPath.global_("meters", "comp")
         if level == "ID_METER":
-            return FieldPath.global_("meters", "id_meter")
+            return FieldPath.global_("meters", "id")
         if level == "VD_METER":
-            return FieldPath.global_("meters", "vd_meter")
+            return FieldPath.global_("meters", "vd")
         names = {
             "AF": "af_level",
             "RF": "rf_gain",

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -55,7 +55,11 @@ if TYPE_CHECKING:
     from ..radio_protocol import Radio
 
 from ..capabilities import CAP_METERS, CAP_RIT
-from .routing import create_routing  # noqa: TID251
+from .routing import (  # noqa: TID251
+    _format_raw_or_normalized_float,
+    _format_strength,
+    create_routing,
+)
 
 __all__ = ["RigctldHandler"]
 
@@ -1669,24 +1673,45 @@ class RigctldHandler:
             if projected is not None:
                 if level == "STRENGTH":
                     if "calibrated" in projected.quality:
-                        return RigctldResponse(values=[str(int(projected.value))])
-                    raw = int(projected.value)
+                        value = projected.value
+                        if (
+                            isinstance(value, float)
+                            and not isinstance(value, bool)
+                            and 0.0 <= value <= 1.0
+                        ):
+                            return RigctldResponse(values=[f"{value:.6f}"])
+                        return RigctldResponse(values=[str(int(value))])
                     return RigctldResponse(
-                        values=[str(round((raw / 241.0) * 114.0 - 54.0))]
+                        values=[_format_strength(projected.value, raw_divisor=241.0)]
                     )
                 if level == "RFPOWER":
                     return RigctldResponse(
-                        values=[f"{int(projected.value) / 255.0:.6f}"]
+                        values=[
+                            _format_raw_or_normalized_float(
+                                projected.value,
+                                raw_divisor=255.0,
+                            )
+                        ]
                     )
                 if level == "SWR":
                     return RigctldResponse(values=[f"{float(projected.value):.6f}"])
                 if level in {"RFPOWER_METER", "COMP_METER", "ID_METER", "VD_METER"}:
                     return RigctldResponse(
-                        values=[f"{int(projected.value) / 255.0:.6f}"]
+                        values=[
+                            _format_raw_or_normalized_float(
+                                projected.value,
+                                raw_divisor=255.0,
+                            )
+                        ]
                     )
                 if level in _GET_LEVEL_FLOAT:
                     return RigctldResponse(
-                        values=[f"{int(projected.value) / 255.0:.6f}"]
+                        values=[
+                            _format_raw_or_normalized_float(
+                                projected.value,
+                                raw_divisor=255.0,
+                            )
+                        ]
                     )
                 return RigctldResponse(values=[str(projected.value)])
         main_state = self._main_receiver_state()

--- a/src/rigplane/rigctld/routing.py
+++ b/src/rigplane/rigctld/routing.py
@@ -50,15 +50,17 @@ def _is_normalized_float(value: Any) -> bool:
     )
 
 
-def _format_raw_or_normalized_float(value: Any, *, raw_divisor: float) -> str:
+def _format_normalized_or_raw_float(value: Any, *, raw_divisor: float) -> str:
     if _is_normalized_float(value):
         return f"{value:.6f}"
+    return _format_raw_scaled_float(value, raw_divisor=raw_divisor)
+
+
+def _format_raw_scaled_float(value: Any, *, raw_divisor: float) -> str:
     return f"{int(value) / raw_divisor:.6f}"
 
 
 def _format_strength(value: Any, *, raw_divisor: float) -> str:
-    if _is_normalized_float(value):
-        return f"{value:.6f}"
     raw = int(value)
     return str(round((raw / raw_divisor) * 114.0 - 54.0))
 
@@ -190,15 +192,15 @@ class YaesuRouting:
                 return RigctldResponse(values=[str(int(value))])
             if level in ("AF", "RF", "SQL"):
                 return RigctldResponse(
-                    values=[_format_raw_or_normalized_float(value, raw_divisor=255.0)]
+                    values=[_format_normalized_or_raw_float(value, raw_divisor=255.0)]
                 )
             if level == "NB":
                 return RigctldResponse(
-                    values=[_format_raw_or_normalized_float(value, raw_divisor=10.0)]
+                    values=[_format_raw_scaled_float(value, raw_divisor=10.0)]
                 )
             if level == "NR":
                 return RigctldResponse(
-                    values=[_format_raw_or_normalized_float(value, raw_divisor=15.0)]
+                    values=[_format_raw_scaled_float(value, raw_divisor=15.0)]
                 )
             if level == "PREAMP":
                 return RigctldResponse(values=[str(int(value))])

--- a/src/rigplane/rigctld/routing.py
+++ b/src/rigplane/rigctld/routing.py
@@ -44,6 +44,25 @@ def _err(code: HamlibError) -> RigctldResponse:
     return RigctldResponse(error=int(code))
 
 
+def _is_normalized_float(value: Any) -> bool:
+    return (
+        isinstance(value, float) and not isinstance(value, bool) and 0.0 <= value <= 1.0
+    )
+
+
+def _format_raw_or_normalized_float(value: Any, *, raw_divisor: float) -> str:
+    if _is_normalized_float(value):
+        return f"{value:.6f}"
+    return f"{int(value) / raw_divisor:.6f}"
+
+
+def _format_strength(value: Any, *, raw_divisor: float) -> str:
+    if _is_normalized_float(value):
+        return f"{value:.6f}"
+    raw = int(value)
+    return str(round((raw / raw_divisor) * 114.0 - 54.0))
+
+
 # ---------------------------------------------------------------------------
 # Protocol
 # ---------------------------------------------------------------------------
@@ -164,18 +183,23 @@ class YaesuRouting:
 
         try:
             if level == "STRENGTH":
-                raw = int(value)
                 return RigctldResponse(
-                    values=[str(round((raw / 255.0) * 114.0 - 54.0))]
+                    values=[_format_strength(value, raw_divisor=255.0)]
                 )
             if level == "RAWSTR":
                 return RigctldResponse(values=[str(int(value))])
             if level in ("AF", "RF", "SQL"):
-                return RigctldResponse(values=[f"{int(value) / 255.0:.6f}"])
+                return RigctldResponse(
+                    values=[_format_raw_or_normalized_float(value, raw_divisor=255.0)]
+                )
             if level == "NB":
-                return RigctldResponse(values=[f"{int(value) / 10.0:.6f}"])
+                return RigctldResponse(
+                    values=[_format_raw_or_normalized_float(value, raw_divisor=10.0)]
+                )
             if level == "NR":
-                return RigctldResponse(values=[f"{int(value) / 15.0:.6f}"])
+                return RigctldResponse(
+                    values=[_format_raw_or_normalized_float(value, raw_divisor=15.0)]
+                )
             if level == "PREAMP":
                 return RigctldResponse(values=[str(int(value))])
             if level == "ATT":

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1154,6 +1154,42 @@ def test_command_intent_targets_observable_production_write_paths(
     assert observation.value == expected_value
 
 
+@pytest.mark.asyncio
+async def test_set_level_command_overlay_keeps_raw_byte_value_for_current_contract() -> (
+    None
+):
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(),
+    )
+    intent = command_intent_from_request(
+        "set_level",
+        {"level": "AF", "value": 0.5},
+        source="rigctld",
+        command_id="rigctld-set-af",
+        session_id="client-a",
+    )
+    path = FieldPath.receiver("0", "operator_controls", "af_level")
+
+    assert intent.params["af_level"] == 128
+    assert (
+        command_response_observation(
+            intent,
+            timestamp_monotonic=70.0,
+            provider="test",
+        ).value
+        == 128
+    )
+
+    await service.execute(intent)
+
+    assert service.project_pending_values(
+        source="rigctld",
+        session_id="client-a",
+        paths=(path,),
+    ) == {path: 128}
+
+
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("name", "params", "expected"),
     [

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1220,7 +1220,7 @@ async def test_get_level_strength_projects_state_store_snapshot(
 
 
 @pytest.mark.asyncio
-async def test_get_level_strength_projected_normalized_float_passes_through(
+async def test_get_level_strength_projected_fractional_raw_value_uses_strength_scale(
     mock_radio: AsyncMock,
 ) -> None:
     store = StateStore()
@@ -1231,7 +1231,7 @@ async def test_get_level_strength_projected_normalized_float_passes_through(
     resp = await handler.execute(get_cmd("get_level", "STRENGTH"))
 
     assert resp.ok
-    assert resp.values == ["0.500000"]
+    assert resp.values == ["-54"]
     mock_radio.get_s_meter.assert_not_awaited()
 
 
@@ -1253,6 +1253,48 @@ async def test_get_level_strength_projects_calibrated_state_store_snapshot(
 
     assert resp.ok
     assert int(resp.values[0]) == 0
+    mock_radio.get_s_meter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_level_strength_projected_fractional_calibrated_db_is_not_normalized(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(
+        store,
+        "receiver.0.meters.s_meter",
+        0.5,
+        quality=("confirmed", "calibrated"),
+    )
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", "STRENGTH"))
+
+    assert resp.ok
+    assert resp.values == ["0"]
+    mock_radio.get_s_meter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_level_strength_projected_calibrated_db_float_truncates_to_db(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(
+        store,
+        "receiver.0.meters.s_meter",
+        -12.5,
+        quality=("confirmed", "calibrated"),
+    )
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", "STRENGTH"))
+
+    assert resp.ok
+    assert resp.values == ["-12"]
     mock_radio.get_s_meter.assert_not_awaited()
 
 
@@ -1310,19 +1352,43 @@ async def test_get_level_af_projects_state_store_snapshot(
 
 
 @pytest.mark.asyncio
-async def test_get_level_af_projected_normalized_float_passes_through(
+@pytest.mark.parametrize(
+    ("level", "path"),
+    [
+        ("AF", "receiver.main.operator_controls.af_level"),
+        ("RF", "receiver.main.operator_controls.rf_gain"),
+        ("SQL", "receiver.main.operator_controls.squelch"),
+    ],
+)
+async def test_get_level_operator_control_projected_normalized_float_passes_through(
+    mock_radio: AsyncMock,
+    level: str,
+    path: str,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(store, path, 0.5)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", level))
+
+    assert resp.ok
+    assert resp.values == ["0.500000"]
+
+
+@pytest.mark.asyncio
+async def test_get_level_non_normalized_operator_control_fractional_float_keeps_raw_format(
     mock_radio: AsyncMock,
 ) -> None:
     store = StateStore()
     mock_radio.state_store = store
-    _apply_store_value(store, "receiver.main.operator_controls.af_level", 0.5)
+    _apply_store_value(store, "receiver.main.operator_controls.nb_level", 0.5)
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
-    resp = await handler.execute(get_cmd("get_level", "AF"))
+    resp = await handler.execute(get_cmd("get_level", "NB"))
 
     assert resp.ok
-    assert resp.values == ["0.500000"]
-    mock_radio.get_af_level.assert_not_called()
+    assert resp.values == ["0.000000"]
 
 
 @pytest.mark.asyncio
@@ -1355,6 +1421,32 @@ async def test_get_level_rfpower_projected_normalized_float_passes_through(
     assert resp.ok
     assert resp.values == ["0.500000"]
     mock_radio.get_rf_power.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("level", "path"),
+    [
+        ("RFPOWER_METER", "global.meters.power"),
+        ("COMP_METER", "global.meters.comp_meter"),
+        ("ID_METER", "global.meters.id_meter"),
+        ("VD_METER", "global.meters.vd_meter"),
+    ],
+)
+async def test_get_level_physical_meter_projected_fractional_float_keeps_raw_format(
+    mock_radio: AsyncMock,
+    level: str,
+    path: str,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(store, path, 0.5)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", level))
+
+    assert resp.ok
+    assert resp.values == ["0.000000"]
 
 
 @pytest.mark.asyncio
@@ -3099,6 +3191,22 @@ async def test_yaesu_get_level_af_prefers_state_store(
     assert resp.ok
     assert float(resp.values[0]) == pytest.approx(64 / 255.0, abs=0.001)
     yaesu_radio.get_af_level.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_yaesu_get_level_strength_projected_fractional_raw_uses_strength_scale(
+    yaesu_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    _apply_store_value(store, "receiver.main.meters.s_meter", 0.5)
+    yaesu_radio.get_s_meter.return_value = 128
+    handler = RigctldHandler(yaesu_radio, RigctldConfig(), state_store=store)
+
+    resp = await handler.execute(get_cmd("get_level", "STRENGTH"))
+
+    assert resp.ok
+    assert resp.values == ["-54"]
+    yaesu_radio.get_s_meter.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1425,28 +1425,87 @@ async def test_get_level_rfpower_projected_normalized_float_passes_through(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("level", "path"),
+    ("level", "path", "getter"),
     [
-        ("RFPOWER_METER", "global.meters.power"),
-        ("COMP_METER", "global.meters.comp_meter"),
-        ("ID_METER", "global.meters.id_meter"),
-        ("VD_METER", "global.meters.vd_meter"),
+        ("RFPOWER_METER", "global.meters.power", "get_power_meter"),
+        ("COMP_METER", "global.meters.comp", "get_comp_meter"),
+        ("ID_METER", "global.meters.id", "get_id_meter"),
+        ("VD_METER", "global.meters.vd", "get_vd_meter"),
     ],
 )
 async def test_get_level_physical_meter_projected_fractional_float_keeps_raw_format(
     mock_radio: AsyncMock,
     level: str,
     path: str,
+    getter: str,
 ) -> None:
     store = StateStore()
     mock_radio.state_store = store
     _apply_store_value(store, path, 0.5)
+    getattr(mock_radio, getter).return_value = 255
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(get_cmd("get_level", level))
 
     assert resp.ok
     assert resp.values == ["0.000000"]
+    getattr(mock_radio, getter).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("level", "path", "getter"),
+    [
+        ("COMP_METER", "global.meters.comp", "get_comp_meter"),
+        ("ID_METER", "global.meters.id", "get_id_meter"),
+        ("VD_METER", "global.meters.vd", "get_vd_meter"),
+    ],
+)
+async def test_get_level_physical_meter_uses_canonical_projected_path(
+    mock_radio: AsyncMock,
+    level: str,
+    path: str,
+    getter: str,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(store, path, 128)
+    getattr(mock_radio, getter).return_value = 255
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", level))
+
+    assert resp.ok
+    assert resp.values == [f"{128 / 255.0:.6f}"]
+    getattr(mock_radio, getter).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("level", "legacy_path", "getter"),
+    [
+        ("COMP_METER", "global.meters.comp_meter", "get_comp_meter"),
+        ("ID_METER", "global.meters.id_meter", "get_id_meter"),
+        ("VD_METER", "global.meters.vd_meter", "get_vd_meter"),
+    ],
+)
+async def test_get_level_physical_meter_ignores_legacy_projected_path_and_falls_back(
+    mock_radio: AsyncMock,
+    level: str,
+    legacy_path: str,
+    getter: str,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(store, legacy_path, 128)
+    getattr(mock_radio, getter).return_value = 255
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", level))
+
+    assert resp.ok
+    assert resp.values == ["1.000000"]
+    getattr(mock_radio, getter).assert_awaited_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1220,6 +1220,22 @@ async def test_get_level_strength_projects_state_store_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_get_level_strength_projected_normalized_float_passes_through(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(store, "receiver.0.meters.s_meter", 0.5)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", "STRENGTH"))
+
+    assert resp.ok
+    assert resp.values == ["0.500000"]
+    mock_radio.get_s_meter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_level_strength_projects_calibrated_state_store_snapshot(
     mock_radio: AsyncMock,
 ) -> None:
@@ -1291,6 +1307,54 @@ async def test_get_level_af_projects_state_store_snapshot(
     assert resp.ok
     assert float(resp.values[0]) == pytest.approx(128 / 255.0, rel=1e-6)
     mock_radio.get_af_level.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_level_af_projected_normalized_float_passes_through(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(store, "receiver.main.operator_controls.af_level", 0.5)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", "AF"))
+
+    assert resp.ok
+    assert resp.values == ["0.500000"]
+    mock_radio.get_af_level.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_level_rfpower_projects_raw_int_state_store_snapshot(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(store, "global.operator_controls.power_level", 128)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", "RFPOWER"))
+
+    assert resp.ok
+    assert resp.values == [f"{128 / 255.0:.6f}"]
+    mock_radio.get_rf_power.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_level_rfpower_projected_normalized_float_passes_through(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio.state_store = store
+    _apply_store_value(store, "global.operator_controls.power_level", 0.5)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", "RFPOWER"))
+
+    assert resp.ok
+    assert resp.values == ["0.500000"]
+    mock_radio.get_rf_power.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -3034,6 +3098,22 @@ async def test_yaesu_get_level_af_prefers_state_store(
 
     assert resp.ok
     assert float(resp.values[0]) == pytest.approx(64 / 255.0, abs=0.001)
+    yaesu_radio.get_af_level.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_yaesu_get_level_af_projected_normalized_float_passes_through(
+    yaesu_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    _apply_store_value(store, "receiver.main.operator_controls.af_level", 0.25)
+    yaesu_radio.get_af_level.return_value = 128
+    handler = RigctldHandler(yaesu_radio, RigctldConfig(), state_store=store)
+
+    resp = await handler.execute(get_cmd("get_level", "AF"))
+
+    assert resp.ok
+    assert resp.values == ["0.250000"]
     yaesu_radio.get_af_level.assert_not_awaited()
 
 

--- a/tests/test_server_wire.py
+++ b/tests/test_server_wire.py
@@ -22,6 +22,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from _caps import FULL_ICOM_CAPS
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
 from rigplane.radio_protocol import MetersCapable
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
@@ -617,6 +623,40 @@ class TestLevelWire:
         data = await _read(r)
         assert data == b"1.000000\n"
         await _close(w)
+
+    async def test_get_level_af_projected_normalized_float_wire(self) -> None:
+        """'l AF' with projected normalized 0.5 returns '0.500000\\n'."""
+        from rigplane.rigctld.handler import RigctldHandler
+
+        radio = _make_mock_radio()
+        poller = _make_mock_poller()
+        store = StateStore()
+        store.apply(
+            Observation(
+                path=FieldPath.receiver("main", "operator_controls", "af_level"),
+                value=0.5,
+                source=SourceMetadata(source="test", provider="tests"),
+                timestamp_monotonic=1.0,
+            )
+        )
+        cfg = RigctldConfig(
+            host="127.0.0.1",
+            port=0,
+            client_timeout=2.0,
+            command_timeout=1.0,
+            cache_ttl=0.0,
+        )
+        handler = RigctldHandler(radio, cfg, state_store=store)
+        srv = RigctldServer(radio, cfg, _handler=handler, _poller=poller)
+
+        async with srv:
+            r, w = await _connect(srv)
+            w.write(b"l AF\n")
+            await w.drain()
+
+            data = await _read(r)
+            assert data == b"0.500000\n"
+            await _close(w)
 
     async def test_get_level_swr_wire(self, wire_server: RigctldServer) -> None:
         """'l SWR' with calibrated ratio 1.0 → '1.000000\\n'."""

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -1109,6 +1109,20 @@ def test_power_level_unit_is_normalized() -> None:
     assert spec.value_type == "int"
 
 
+@pytest.mark.parametrize("receiver_id", ["main", "sub"])
+@pytest.mark.parametrize("field", ["af_level", "rf_gain", "squelch"])
+def test_receiver_raw_byte_operator_controls_declare_transitional_normalized_unit(
+    receiver_id: str,
+    field: str,
+) -> None:
+    """Raw-byte operator controls declare normalized units while staying int."""
+    spec = DEFAULT_FIELD_REGISTRY.require(
+        FieldPath.receiver(receiver_id, "operator_controls", field)
+    )
+    assert spec.unit == "normalized"
+    assert spec.value_type == "int"
+
+
 @pytest.mark.parametrize(
     "name,expected_unit",
     [


### PR DESCRIPTION
## Summary
- add type-sensitive rigctld level formatting so future normalized float operator-control values pass through without double scaling
- preserve legacy raw-int GET/SET behavior for AF/RF/SQL/RFPOWER and wire responses
- add canonical StateStore projected meter paths for COMP/ID/VD while keeping physical meters out of normalized-control passthrough
- mark normalized operator-control contract units where safe without flipping provider observations yet

## Scope
This is the MOR-467 safety/contract pre-slice. It does not flip Icom, Yaesu, rigctld_client, or frontend values to normalized controls. That provider/frontend migration remains follow-up work for MOR-467 once consumers are protected.

## Tests
- `uv run pytest tests/test_state_pipeline_contracts.py tests/test_rigctld_handler.py tests/test_server_wire.py tests/test_command_service.py -q --tb=short` -> 661 passed
- `uv run pytest tests/ -q --tb=short` -> 8147 passed, 129 skipped, 3 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

## Reviews
- Spec review PASS
- Code quality review PASS after fixes
- Final combined review PASS
