### PR TITLE
MOR-732: add browser audio self-test model

### DIFF
--- a/frontend/src/lib/audio/__tests__/browser-audio-self-test.test.ts
+++ b/frontend/src/lib/audio/__tests__/browser-audio-self-test.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateBrowserAudioSelfTest,
+  type BrowserAudioSelfTestAnalyzerInput,
+} from '../browser-audio-self-test';
+import type { BrowserAudioRouteState } from '../browser-audio-route';
+
+const selectedRoute: BrowserAudioRouteState = {
+  status: 'selected',
+  outputSelectionSupported: true,
+  permissionState: 'granted',
+  routeId: 'example-loopback',
+  input: {
+    kind: 'audioinput',
+    label: 'Example Bridge Capture',
+    scopedDeviceId: 'scoped-input',
+    isAlias: false,
+  },
+  output: {
+    kind: 'audiooutput',
+    label: 'Example Bridge Playback',
+    scopedDeviceId: 'scoped-output',
+    isAlias: false,
+  },
+};
+
+const missingRoute: BrowserAudioRouteState = {
+  status: 'missing-endpoints',
+  outputSelectionSupported: true,
+  permissionState: 'granted',
+  missing: ['input'],
+};
+
+const passingAnalyzer: BrowserAudioSelfTestAnalyzerInput = {
+  knownTone: {
+    detected: true,
+    frequencyHz: 1000,
+    confidence: 0.96,
+  },
+  level: {
+    measured: true,
+    rmsDbfs: -18,
+    peakDbfs: -6,
+    silenceDetected: false,
+    clippingDetected: false,
+    usableRmsDbfs: {
+      min: -42,
+      max: -8,
+    },
+  },
+  latency: {
+    measured: false,
+  },
+};
+
+describe('browser audio self-test model', () => {
+  it('passes receive readiness from known-tone, non-silent, non-clipping input in the usable level range', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: passingAnalyzer,
+    });
+
+    expect(state.route.status).toBe('selected');
+    expect(state.knownTone.status).toBe('detected');
+    expect(state.level.status).toBe('usable');
+    expect(state.receive.ready).toBe(true);
+    expect(state.receive.verdict).toBe('pass');
+    expect(state.receive.blockers).toEqual([]);
+    expect(state.tx.ready).toBe(false);
+    expect(state.tx.blockers).toContain('safe-tx-validation-required');
+  });
+
+  it('fails receive readiness when analyzer marks the input as silence', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: {
+        ...passingAnalyzer,
+        level: {
+          ...passingAnalyzer.level,
+          rmsDbfs: -80,
+          peakDbfs: -72,
+          silenceDetected: true,
+        },
+      },
+    });
+
+    expect(state.level.status).toBe('silence');
+    expect(state.receive.ready).toBe(false);
+    expect(state.receive.verdict).toBe('fail');
+    expect(state.receive.blockers).toContain('silence');
+  });
+
+  it('fails receive readiness when analyzer marks clipping', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: {
+        ...passingAnalyzer,
+        level: {
+          ...passingAnalyzer.level,
+          peakDbfs: 0,
+          clippingDetected: true,
+        },
+      },
+    });
+
+    expect(state.level.status).toBe('clipping');
+    expect(state.receive.ready).toBe(false);
+    expect(state.receive.blockers).toContain('clipping');
+  });
+
+  it('fails receive readiness when the route is wrong or missing', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: missingRoute,
+      analyzer: passingAnalyzer,
+    });
+
+    expect(state.route.status).toBe('wrong-or-missing');
+    expect(state.route.sourceStatus).toBe('missing-endpoints');
+    expect(state.receive.ready).toBe(false);
+    expect(state.receive.blockers).toContain('wrong-or-missing-route');
+  });
+
+  it('keeps unmeasured latency as a caveated non-blocking receive status', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: passingAnalyzer,
+    });
+
+    expect(state.latency).toMatchObject({
+      status: 'not-measured',
+      blockingReceive: false,
+      unit: 'ms',
+    });
+    expect(state.receive.ready).toBe(true);
+    expect(state.receive.caveats).toContain('latency-not-measured');
+  });
+
+  it('reports measured latency in milliseconds with analyzer caveats', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: {
+        ...passingAnalyzer,
+        latency: {
+          measured: true,
+          milliseconds: 37.4,
+          caveats: ['single-run-estimate'],
+        },
+      },
+    });
+
+    expect(state.latency).toEqual({
+      status: 'measured',
+      milliseconds: 37.4,
+      unit: 'ms',
+      blockingReceive: false,
+      caveats: ['single-run-estimate'],
+    });
+  });
+
+  it('fails receive readiness when the known tone is missing', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: {
+        ...passingAnalyzer,
+        knownTone: {
+          detected: false,
+        },
+      },
+    });
+
+    expect(state.knownTone.status).toBe('missing');
+    expect(state.receive.ready).toBe(false);
+    expect(state.receive.blockers).toContain('known-tone-missing');
+  });
+
+  it('fails receive readiness when measured level is outside the usable range', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: {
+        ...passingAnalyzer,
+        level: {
+          ...passingAnalyzer.level,
+          rmsDbfs: -4,
+        },
+      },
+    });
+
+    expect(state.level.status).toBe('out-of-range');
+    expect(state.receive.ready).toBe(false);
+    expect(state.receive.blockers).toContain('level-out-of-range');
+  });
+
+  it('keeps transmit readiness false by default even when receive passes', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: passingAnalyzer,
+    });
+
+    expect(state.receive.ready).toBe(true);
+    expect(state.tx).toEqual({
+      ready: false,
+      verdict: 'blocked',
+      blockers: ['safe-tx-validation-required'],
+      caveats: [],
+    });
+  });
+
+  it('keeps new self-test files free of product endpoint labels and platform policy words', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const files = [
+      path.resolve(__dirname, '../browser-audio-self-test.ts'),
+      path.resolve(__dirname, './browser-audio-self-test.test.ts'),
+    ];
+    const blocked = [
+      ['Rig', 'Plane'].join(''),
+      ['Win', 'dows'].join(''),
+      ['SYS', 'VAD'].join(''),
+      ['reg', 'istry'].join(''),
+      ['hard', 'ware ID'].join(''),
+      ['IOC', 'TL'].join(''),
+      ['ins', 'tall'].join(''),
+      ['re', 'pair'].join(''),
+      ['entitle', 'ment'].join(''),
+    ];
+
+    for (const file of files) {
+      const content = await fs.readFile(file, 'utf8');
+      const relative = path.relative(process.cwd(), file);
+      for (const term of blocked) {
+        expect(content, `${relative} contains ${term}`).not.toContain(term);
+      }
+    }
+  });
+});

--- a/frontend/src/lib/audio/__tests__/browser-audio-self-test.test.ts
+++ b/frontend/src/lib/audio/__tests__/browser-audio-self-test.test.ts
@@ -30,6 +30,24 @@ const missingRoute: BrowserAudioRouteState = {
   outputSelectionSupported: true,
   permissionState: 'granted',
   missing: ['input'],
+  output: {
+    kind: 'audiooutput',
+    label: 'Example Bridge Playback',
+    scopedDeviceId: 'scoped-output',
+    isAlias: false,
+  },
+};
+
+const permissionDeniedRoute: BrowserAudioRouteState = {
+  status: 'permission-denied',
+  outputSelectionSupported: true,
+  permissionState: 'denied',
+};
+
+const unsupportedOutputSelectionRoute: BrowserAudioRouteState = {
+  status: 'unsupported-output-selection',
+  outputSelectionSupported: false,
+  permissionState: 'prompt',
 };
 
 const passingAnalyzer: BrowserAudioSelfTestAnalyzerInput = {
@@ -109,14 +127,54 @@ describe('browser audio self-test model', () => {
     expect(state.receive.blockers).toContain('clipping');
   });
 
-  it('fails receive readiness when the route is wrong or missing', () => {
+  it('preserves partial missing endpoint route details', () => {
     const state = evaluateBrowserAudioSelfTest({
       route: missingRoute,
       analyzer: passingAnalyzer,
     });
 
-    expect(state.route.status).toBe('wrong-or-missing');
-    expect(state.route.sourceStatus).toBe('missing-endpoints');
+    expect(state.route).toEqual({
+      status: 'missing-endpoints',
+      outputSelectionSupported: true,
+      permissionState: 'granted',
+      missing: ['input'],
+      output: {
+        kind: 'audiooutput',
+        label: 'Example Bridge Playback',
+        scopedDeviceId: 'scoped-output',
+        isAlias: false,
+      },
+    });
+    expect(state.receive.ready).toBe(false);
+    expect(state.receive.blockers).toContain('wrong-or-missing-route');
+  });
+
+  it('preserves permission-denied as the route cause', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: permissionDeniedRoute,
+      analyzer: passingAnalyzer,
+    });
+
+    expect(state.route).toEqual({
+      status: 'permission-denied',
+      outputSelectionSupported: true,
+      permissionState: 'denied',
+    });
+    expect(state.receive.ready).toBe(false);
+    expect(state.receive.blockers).toContain('wrong-or-missing-route');
+  });
+
+  it('preserves unsupported output selection as the route cause', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: unsupportedOutputSelectionRoute,
+      analyzer: passingAnalyzer,
+    });
+
+    expect(state.route).toEqual({
+      status: 'unsupported-output-selection',
+      outputSelectionSupported: false,
+      permissionState: 'prompt',
+    });
     expect(state.receive.ready).toBe(false);
     expect(state.receive.blockers).toContain('wrong-or-missing-route');
   });
@@ -189,6 +247,49 @@ describe('browser audio self-test model', () => {
     expect(state.level.status).toBe('out-of-range');
     expect(state.receive.ready).toBe(false);
     expect(state.receive.blockers).toContain('level-out-of-range');
+  });
+
+  it('fails receive readiness when level was not measured', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: {
+        ...passingAnalyzer,
+        level: {
+          measured: false,
+        },
+      },
+    });
+
+    expect(state.level).toEqual({
+      status: 'not-measured',
+    });
+    expect(state.receive.ready).toBe(false);
+    expect(state.receive.blockers).toContain('level-not-measured');
+  });
+
+  it('does not treat measured level without a usable range as out-of-range', () => {
+    const state = evaluateBrowserAudioSelfTest({
+      route: selectedRoute,
+      analyzer: {
+        ...passingAnalyzer,
+        level: {
+          measured: true,
+          rmsDbfs: -18,
+          peakDbfs: -6,
+          silenceDetected: false,
+          clippingDetected: false,
+        },
+      },
+    });
+
+    expect(state.level).toEqual({
+      status: 'range-not-available',
+      rmsDbfs: -18,
+      peakDbfs: -6,
+    });
+    expect(state.receive.ready).toBe(false);
+    expect(state.receive.blockers).toContain('level-range-not-available');
+    expect(state.receive.blockers).not.toContain('level-out-of-range');
   });
 
   it('keeps transmit readiness false by default even when receive passes', () => {

--- a/frontend/src/lib/audio/browser-audio-self-test.ts
+++ b/frontend/src/lib/audio/browser-audio-self-test.ts
@@ -1,0 +1,246 @@
+import type { BrowserAudioRouteEndpoint, BrowserAudioRouteState } from './browser-audio-route';
+
+export type BrowserAudioSelfTestVerdict = 'pass' | 'fail' | 'blocked';
+
+export type BrowserAudioReceiveBlocker =
+  | 'wrong-or-missing-route'
+  | 'known-tone-missing'
+  | 'silence'
+  | 'clipping'
+  | 'level-out-of-range'
+  | 'level-not-measured';
+
+export type BrowserAudioReceiveCaveat = 'latency-not-measured';
+
+export type BrowserAudioTxBlocker = 'safe-tx-validation-required';
+
+export interface BrowserAudioKnownToneInput {
+  detected: boolean;
+  frequencyHz?: number;
+  confidence?: number;
+}
+
+export interface BrowserAudioLevelInput {
+  measured: boolean;
+  rmsDbfs?: number;
+  peakDbfs?: number;
+  silenceDetected?: boolean;
+  clippingDetected?: boolean;
+  usableRmsDbfs?: {
+    min: number;
+    max: number;
+  };
+}
+
+export type BrowserAudioLatencyInput =
+  | {
+      measured: true;
+      milliseconds: number;
+      caveats?: readonly string[];
+    }
+  | {
+      measured: false;
+      caveats?: readonly string[];
+    };
+
+export interface BrowserAudioSelfTestAnalyzerInput {
+  knownTone: BrowserAudioKnownToneInput;
+  level: BrowserAudioLevelInput;
+  latency: BrowserAudioLatencyInput;
+}
+
+export interface BrowserAudioSelfTestInput {
+  route: BrowserAudioRouteState;
+  analyzer: BrowserAudioSelfTestAnalyzerInput;
+}
+
+export type BrowserAudioSelfTestRouteResult =
+  | {
+      status: 'selected';
+      sourceStatus: 'selected';
+      routeId: string;
+      input: BrowserAudioRouteEndpoint;
+      output: BrowserAudioRouteEndpoint;
+    }
+  | {
+      status: 'wrong-or-missing';
+      sourceStatus: Exclude<BrowserAudioRouteState['status'], 'selected'>;
+      missing: Array<'input' | 'output'>;
+    };
+
+export interface BrowserAudioKnownToneResult {
+  status: 'detected' | 'missing';
+  frequencyHz?: number;
+  confidence?: number;
+}
+
+export interface BrowserAudioLevelResult {
+  status: 'usable' | 'silence' | 'clipping' | 'out-of-range' | 'not-measured';
+  rmsDbfs?: number;
+  peakDbfs?: number;
+  usableRmsDbfs?: {
+    min: number;
+    max: number;
+  };
+}
+
+export type BrowserAudioLatencyResult =
+  | {
+      status: 'measured';
+      milliseconds: number;
+      unit: 'ms';
+      blockingReceive: false;
+      caveats: string[];
+    }
+  | {
+      status: 'not-measured';
+      unit: 'ms';
+      blockingReceive: false;
+      caveats: string[];
+    };
+
+export interface BrowserAudioReadinessResult<TBlocker extends string, TCaveat extends string> {
+  ready: boolean;
+  verdict: BrowserAudioSelfTestVerdict;
+  blockers: TBlocker[];
+  caveats: TCaveat[];
+}
+
+export interface BrowserAudioSelfTestState {
+  route: BrowserAudioSelfTestRouteResult;
+  knownTone: BrowserAudioKnownToneResult;
+  level: BrowserAudioLevelResult;
+  latency: BrowserAudioLatencyResult;
+  receive: BrowserAudioReadinessResult<BrowserAudioReceiveBlocker, BrowserAudioReceiveCaveat>;
+  tx: BrowserAudioReadinessResult<BrowserAudioTxBlocker, never>;
+}
+
+function finite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function evaluateRoute(route: BrowserAudioRouteState): BrowserAudioSelfTestRouteResult {
+  if (route.status === 'selected') {
+    return {
+      status: 'selected',
+      sourceStatus: route.status,
+      routeId: route.routeId,
+      input: route.input,
+      output: route.output,
+    };
+  }
+
+  return {
+    status: 'wrong-or-missing',
+    sourceStatus: route.status,
+    missing: route.status === 'missing-endpoints' ? route.missing : ['input', 'output'],
+  };
+}
+
+function evaluateKnownTone(input: BrowserAudioKnownToneInput): BrowserAudioKnownToneResult {
+  const result: BrowserAudioKnownToneResult = {
+    status: input.detected ? 'detected' : 'missing',
+  };
+  if (finite(input.frequencyHz)) result.frequencyHz = input.frequencyHz;
+  if (finite(input.confidence)) result.confidence = input.confidence;
+  return result;
+}
+
+function evaluateLevel(input: BrowserAudioLevelInput): BrowserAudioLevelResult {
+  const result: BrowserAudioLevelResult = {
+    status: 'not-measured',
+  };
+  if (finite(input.rmsDbfs)) result.rmsDbfs = input.rmsDbfs;
+  if (finite(input.peakDbfs)) result.peakDbfs = input.peakDbfs;
+  if (input.usableRmsDbfs) {
+    result.usableRmsDbfs = {
+      min: input.usableRmsDbfs.min,
+      max: input.usableRmsDbfs.max,
+    };
+  }
+
+  if (!input.measured || !finite(input.rmsDbfs)) return result;
+  if (input.clippingDetected === true) return { ...result, status: 'clipping' };
+  if (input.silenceDetected === true) return { ...result, status: 'silence' };
+
+  const range = input.usableRmsDbfs;
+  if (!range || input.rmsDbfs < range.min || input.rmsDbfs > range.max) {
+    return { ...result, status: 'out-of-range' };
+  }
+
+  return { ...result, status: 'usable' };
+}
+
+function evaluateLatency(input: BrowserAudioLatencyInput): BrowserAudioLatencyResult {
+  if (input.measured && finite(input.milliseconds)) {
+    return {
+      status: 'measured',
+      milliseconds: input.milliseconds,
+      unit: 'ms',
+      blockingReceive: false,
+      caveats: [...(input.caveats ?? [])],
+    };
+  }
+
+  return {
+    status: 'not-measured',
+    unit: 'ms',
+    blockingReceive: false,
+    caveats: ['latency-not-measured', ...(input.caveats ?? [])],
+  };
+}
+
+function receiveBlockerForLevel(
+  status: BrowserAudioLevelResult['status'],
+): BrowserAudioReceiveBlocker | null {
+  switch (status) {
+    case 'usable':
+      return null;
+    case 'silence':
+      return 'silence';
+    case 'clipping':
+      return 'clipping';
+    case 'out-of-range':
+      return 'level-out-of-range';
+    case 'not-measured':
+      return 'level-not-measured';
+  }
+}
+
+export function evaluateBrowserAudioSelfTest(
+  input: BrowserAudioSelfTestInput,
+): BrowserAudioSelfTestState {
+  const route = evaluateRoute(input.route);
+  const knownTone = evaluateKnownTone(input.analyzer.knownTone);
+  const level = evaluateLevel(input.analyzer.level);
+  const latency = evaluateLatency(input.analyzer.latency);
+  const receiveBlockers: BrowserAudioReceiveBlocker[] = [];
+
+  if (route.status !== 'selected') receiveBlockers.push('wrong-or-missing-route');
+  if (knownTone.status !== 'detected') receiveBlockers.push('known-tone-missing');
+  const levelBlocker = receiveBlockerForLevel(level.status);
+  if (levelBlocker) receiveBlockers.push(levelBlocker);
+
+  const receiveCaveats: BrowserAudioReceiveCaveat[] = latency.status === 'not-measured'
+    ? ['latency-not-measured']
+    : [];
+
+  return {
+    route,
+    knownTone,
+    level,
+    latency,
+    receive: {
+      ready: receiveBlockers.length === 0,
+      verdict: receiveBlockers.length === 0 ? 'pass' : 'fail',
+      blockers: receiveBlockers,
+      caveats: receiveCaveats,
+    },
+    tx: {
+      ready: false,
+      verdict: 'blocked',
+      blockers: ['safe-tx-validation-required'],
+      caveats: [],
+    },
+  };
+}

--- a/frontend/src/lib/audio/browser-audio-self-test.ts
+++ b/frontend/src/lib/audio/browser-audio-self-test.ts
@@ -1,4 +1,4 @@
-import type { BrowserAudioRouteEndpoint, BrowserAudioRouteState } from './browser-audio-route';
+import type { BrowserAudioRouteState } from './browser-audio-route';
 
 export type BrowserAudioSelfTestVerdict = 'pass' | 'fail' | 'blocked';
 
@@ -8,6 +8,7 @@ export type BrowserAudioReceiveBlocker =
   | 'silence'
   | 'clipping'
   | 'level-out-of-range'
+  | 'level-range-not-available'
   | 'level-not-measured';
 
 export type BrowserAudioReceiveCaveat = 'latency-not-measured';
@@ -54,19 +55,7 @@ export interface BrowserAudioSelfTestInput {
   analyzer: BrowserAudioSelfTestAnalyzerInput;
 }
 
-export type BrowserAudioSelfTestRouteResult =
-  | {
-      status: 'selected';
-      sourceStatus: 'selected';
-      routeId: string;
-      input: BrowserAudioRouteEndpoint;
-      output: BrowserAudioRouteEndpoint;
-    }
-  | {
-      status: 'wrong-or-missing';
-      sourceStatus: Exclude<BrowserAudioRouteState['status'], 'selected'>;
-      missing: Array<'input' | 'output'>;
-    };
+export type BrowserAudioSelfTestRouteResult = BrowserAudioRouteState;
 
 export interface BrowserAudioKnownToneResult {
   status: 'detected' | 'missing';
@@ -75,7 +64,13 @@ export interface BrowserAudioKnownToneResult {
 }
 
 export interface BrowserAudioLevelResult {
-  status: 'usable' | 'silence' | 'clipping' | 'out-of-range' | 'not-measured';
+  status:
+    | 'usable'
+    | 'silence'
+    | 'clipping'
+    | 'out-of-range'
+    | 'range-not-available'
+    | 'not-measured';
   rmsDbfs?: number;
   peakDbfs?: number;
   usableRmsDbfs?: {
@@ -120,21 +115,24 @@ function finite(value: unknown): value is number {
 }
 
 function evaluateRoute(route: BrowserAudioRouteState): BrowserAudioSelfTestRouteResult {
-  if (route.status === 'selected') {
-    return {
-      status: 'selected',
-      sourceStatus: route.status,
-      routeId: route.routeId,
-      input: route.input,
-      output: route.output,
-    };
+  switch (route.status) {
+    case 'selected':
+      return {
+        ...route,
+        input: { ...route.input },
+        output: { ...route.output },
+      };
+    case 'missing-endpoints':
+      return {
+        ...route,
+        missing: [...route.missing],
+        ...(route.input ? { input: { ...route.input } } : {}),
+        ...(route.output ? { output: { ...route.output } } : {}),
+      };
+    case 'permission-denied':
+    case 'unsupported-output-selection':
+      return { ...route };
   }
-
-  return {
-    status: 'wrong-or-missing',
-    sourceStatus: route.status,
-    missing: route.status === 'missing-endpoints' ? route.missing : ['input', 'output'],
-  };
 }
 
 function evaluateKnownTone(input: BrowserAudioKnownToneInput): BrowserAudioKnownToneResult {
@@ -164,7 +162,11 @@ function evaluateLevel(input: BrowserAudioLevelInput): BrowserAudioLevelResult {
   if (input.silenceDetected === true) return { ...result, status: 'silence' };
 
   const range = input.usableRmsDbfs;
-  if (!range || input.rmsDbfs < range.min || input.rmsDbfs > range.max) {
+  if (!range || !finite(range.min) || !finite(range.max)) {
+    return { ...result, status: 'range-not-available' };
+  }
+
+  if (input.rmsDbfs < range.min || input.rmsDbfs > range.max) {
     return { ...result, status: 'out-of-range' };
   }
 
@@ -202,6 +204,8 @@ function receiveBlockerForLevel(
       return 'clipping';
     case 'out-of-range':
       return 'level-out-of-range';
+    case 'range-not-available':
+      return 'level-range-not-available';
     case 'not-measured':
       return 'level-not-measured';
   }


### PR DESCRIPTION
## Summary
- Add a product-neutral browser audio self-test evaluator for route, tone, level, latency, RX readiness, and TX safety state.
- Preserve distinct route failure causes and level range availability so downstream UI/adapters do not misreport state.
- Add focused regression coverage for pass/fail and edge-case self-test states.

## Test Plan
- npm --prefix frontend exec vitest run src/lib/audio/__tests__/browser-audio-self-test.test.ts
- npm --prefix frontend run check
- npm --prefix frontend run lint
- git diff --check origin/main...HEAD
- rg -n \"RigPlane Pro|proprietary|Windows driver|gtr7|BWS|ACCESS_TOKEN|PRIVATE KEY|BEGIN .*KEY|password|token|secret\" frontend/src/lib/audio/browser-audio-self-test.ts frontend/src/lib/audio/__tests__/browser-audio-self-test.test.ts || true

## Boundary
- open-core candidate
- no proprietary driver/product details