### PR TITLE
feat(MOR-467): expose profile max_watts metadata

### DIFF
--- a/docs/capabilities-matrix.md
+++ b/docs/capabilities-matrix.md
@@ -198,7 +198,7 @@ main_sub_tracking, tx_inhibit, dpd, lcd_backlight
 | NR style | toggle+level | toggle+level | level_is_toggle | — | — | `[controls.nr]` |
 | TX antennas | 2 | 1 | 1 | 1 | 1 | `[antenna] tx_count` |
 | RX antenna | yes | no | no | no | no | `[antenna] has_rx_ant` |
-| Max power W | 100 | 100 | 5-20 | 8 | 10 | `[power] max_watts` |
+| Max power W | 100 | 100 | 100 | 8 | 10 | `[power] max_watts` |
 | Modes | 10 | 9 | 17 | 8 | 7 | `[modes]` |
 | Receivers | 2 | 1 | 2 | 1 | 1 | `[radio] receiver_count` |
 | VFO scheme | main_sub | ab | ab_shared | ab | ab | `[vfo] scheme` |

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -25,6 +25,9 @@ type = "yaesu_cat"
 # (MOR-508). Other rigs omit this and keep the default "mix" average.
 rx_audio_channel = "left"
 
+[power]
+max_watts = 100
+
 [capabilities]
 features = [
     "audio",

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -163,6 +163,7 @@ class RadioProfile:
     filter_width_max: int = 9999
     filter_width_encoding: str = "segmented_bcd_index"
     filter_config: dict[str, FilterWidthRule] | None = None
+    max_watts: int | None = None
     att_values: tuple[int, ...] | None = None
     att_labels: dict[str, str] | None = None
     pre_values: tuple[int, ...] | None = None

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -99,6 +99,7 @@ class RigConfig:
     filter_width_max: int = 9999
     filter_width_encoding: str = "segmented_bcd_index"
     filter_config: dict[str, FilterWidthRule] | None = None
+    max_watts: int | None = None
     data_mode_count: int = 0
     data_mode_labels: dict[str, str] | None = None
     protocol_type: str = "civ"
@@ -185,6 +186,7 @@ class RigConfig:
             filter_width_max=self.filter_width_max,
             filter_width_encoding=self.filter_width_encoding,
             filter_config=self.filter_config,
+            max_watts=self.max_watts,
             att_values=self.att_values,
             att_labels=self.att_labels,
             pre_values=self.pre_values,
@@ -1345,6 +1347,19 @@ def load_rig(path: Path) -> RigConfig:
                 )
             rx_audio_channel = rx_channel_raw
 
+    max_watts: int | None = None
+    power_section = data.get("power")
+    if power_section is not None:
+        if not isinstance(power_section, dict):
+            raise RigLoadError(f"{filename}: [power] must be a table")
+        if "max_watts" in power_section:
+            max_watts_raw = power_section["max_watts"]
+            if not isinstance(max_watts_raw, int) or isinstance(max_watts_raw, bool):
+                raise RigLoadError(f"{filename}: [power].max_watts must be an integer")
+            if max_watts_raw <= 0:
+                raise RigLoadError(f"{filename}: [power].max_watts must be > 0")
+            max_watts = max_watts_raw
+
     state_acquisition = _parse_state_acquisition(
         filename,
         data.get("state_acquisition"),
@@ -1367,6 +1382,7 @@ def load_rig(path: Path) -> RigConfig:
         filter_width_max=filter_width_max,
         filter_width_encoding=filter_width_encoding,
         filter_config=filter_config,
+        max_watts=max_watts,
         vfo_scheme=scheme,
         vfo_main_select=vfo_main,
         vfo_sub_select=vfo_sub,

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -86,6 +86,23 @@ class TestLoadRig:
         rig = load_rig(p)
         assert rig.model == "IC-7300"
 
+    def test_load_minimal_power_max_watts(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[power]
+max_watts = 100
+""",
+        )
+
+        rig = load_rig(p)
+        profile = rig.to_profile()
+
+        assert rig.max_watts == 100
+        assert profile.max_watts == 100
+
     def test_state_acquisition_provider_must_be_string(self, tmp_path):
         p = _write_toml(
             tmp_path,

--- a/tests/test_rig_multi_vendor.py
+++ b/tests/test_rig_multi_vendor.py
@@ -351,6 +351,10 @@ class TestMultiVendorProfiles:
         assert rig.controls is not None
         assert rig.controls["nb"]["style"] == "level_is_toggle"
 
+    def test_ftx1_profile_exposes_power_max_watts(self):
+        profile = load_rig(RIGS_DIR / "ftx1.toml").to_profile()
+        assert profile.max_watts == 100
+
     def test_ic7610_mutex_rule(self):
         rig = load_rig(RIGS_DIR / "ic7610.toml")
         mutex_rules = [r for r in rig.rules if r["kind"] == "mutex"]
@@ -420,6 +424,11 @@ class TestMultiVendorProfiles:
         ic7300 = load_rig(RIGS_DIR / "ic7300.toml")
         assert ic7610.civ_addr == 0x98
         assert ic7300.civ_addr == 0x94
+
+    def test_tx500_profile_without_power_section_still_loads(self):
+        """Backward compat: profiles without ``[power].max_watts`` still load."""
+        profile = load_rig(RIGS_DIR / "tx500.toml").to_profile()
+        assert profile.max_watts is None
 
 
 class TestProfileBuilding:


### PR DESCRIPTION
## Summary
- parse optional `[power].max_watts` from rig TOML into `RigConfig` and `RadioProfile`
- add explicit FTX-1 `[power] max_watts = 100` metadata for later MOR-467 power-level normalization
- update capabilities matrix to match the new FTX-1 profile metadata
- keep profiles without `[power]` metadata loading as before

## Scope
This is a MOR-467 metadata slice only. It does not normalize provider observations.

## Tests
- `uv run pytest tests/test_rig_loader.py tests/test_rig_multi_vendor.py tests/test_ftx1_radio.py -q --tb=short` -> 398 passed
- `uv run pytest tests/ -q --tb=short` -> 8150 passed, 129 skipped, 3 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

## Reviews
- POWER-METADATA REVIEW PASS after docs fix
