### PR TITLE
fix(MOR-467): normalize web control projections

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -38,6 +38,12 @@ __all__ = [
 _UNSET = object()
 _MAX_READBACK_EXPECTATIONS = 128
 _READBACK_EXPECTATION_GRACE_SECONDS = 2.0
+_NORMALIZED_LEVEL_EXPECTATION_COMMANDS = {
+    "set_af_level": "af_level",
+    "set_rf_gain": "rf_gain",
+    "set_squelch": "squelch",
+    "set_rf_power": "power_level",
+}
 
 
 Clock = Callable[[], float]
@@ -412,7 +418,7 @@ class CommandService:
         session_id = _session_id(intent)
         for path in paths:
             try:
-                value = _pending_value_for_path(intent.params, path)
+                value = _expected_value_for_path(intent, path)
             except KeyError:
                 continue
             self.record_pending_overlay(
@@ -591,6 +597,25 @@ class CommandService:
 def _pending_value_for_intent(intent: CommandIntent) -> Any:
     assert intent.target is not None
     return _pending_value_for_path(intent.params, intent.target)
+
+
+def _expected_value_for_path(intent: CommandIntent, path: FieldPath) -> Any:
+    value = _pending_value_for_path(intent.params, path)
+    if _should_normalize_level_expectation(intent.name, path):
+        return _normalize_raw_level_value(value)
+    return value
+
+
+def _should_normalize_level_expectation(name: str, path: FieldPath) -> bool:
+    return _NORMALIZED_LEVEL_EXPECTATION_COMMANDS.get(name) == path.name
+
+
+def _normalize_raw_level_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return float(value) / 255
+    return value
 
 
 def _observable_paths_for_intent(intent: CommandIntent) -> tuple[FieldPath, ...]:

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Protocol
 
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
@@ -176,6 +176,7 @@ class CommandService:
     def apply_observation(self, observation: Observation) -> ChangeSet:
         """Apply a confirmed observation and reconcile matching overlays."""
 
+        observation = self._normalize_correlated_readback_observation(observation)
         changeset = self._state_store.apply(observation)
         self._reconcile_observation(observation, changeset)
         return changeset
@@ -566,6 +567,26 @@ class CommandService:
             )
         ]
 
+    def _normalize_correlated_readback_observation(
+        self,
+        observation: Observation,
+    ) -> Observation:
+        if observation.correlation_id is None:
+            return observation
+        if observation.source.command_source is None:
+            return observation
+        self._purge_expired()
+        for expectation in self._readback_expectations:
+            if not _observation_matches_readback_scope(observation, expectation):
+                continue
+            normalized = _normalized_observation_value_for_expectation(
+                observation,
+                expectation,
+            )
+            if normalized is not _UNSET:
+                return replace(observation, value=normalized)
+        return observation
+
     def _purge_expired(self) -> None:
         now = self._clock()
         self._overlays = [
@@ -616,6 +637,42 @@ def _normalize_raw_level_value(value: Any) -> Any:
     if isinstance(value, (int, float)):
         return float(value) / 255
     return value
+
+
+def _normalize_observed_level_value(value: Any) -> Any:
+    if isinstance(value, float) and 0.0 <= value <= 1.0:
+        return value
+    return _normalize_raw_level_value(value)
+
+
+def _is_normalized_level_value(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and 0.0 <= float(value) <= 1.0
+    )
+
+
+def _path_uses_normalized_level_value(path: FieldPath) -> bool:
+    if path.family.value != "operator_controls":
+        return False
+    if path.scope.value == "receiver":
+        return path.name in {"af_level", "rf_gain", "squelch"}
+    return path.scope.value == "global" and path.name == "power_level"
+
+
+def _normalized_observation_value_for_expectation(
+    observation: Observation,
+    expectation: PendingOverlay,
+) -> Any:
+    if not _path_uses_normalized_level_value(expectation.path):
+        return _UNSET
+    if not _is_normalized_level_value(expectation.value):
+        return _UNSET
+    if observation.value == expectation.value:
+        return observation.value
+    normalized = _normalize_observed_level_value(observation.value)
+    return normalized if normalized == expectation.value else _UNSET
 
 
 def _observable_paths_for_intent(intent: CommandIntent) -> tuple[FieldPath, ...]:
@@ -696,6 +753,19 @@ def _observation_reconciles_overlay(
         and observation.correlation_id == overlay.command_id
         and _paths_reconcile(observation, overlay.path)
         and overlay.value == observation.value
+    )
+
+
+def _observation_matches_readback_scope(
+    observation: Observation,
+    overlay: PendingOverlay,
+) -> bool:
+    observed_source = observation.source.command_source
+    return (
+        observed_source == overlay.source
+        and observation.source.session_id == overlay.session_id
+        and observation.correlation_id == overlay.command_id
+        and _paths_reconcile(observation, overlay.path)
     )
 
 
@@ -873,7 +943,11 @@ def command_response_observation(
 
     if intent.target is None:
         raise ValueError(f"command {intent.name!r} has no observable target")
-    observed_value = _value_for_observable_intent(intent) if value is None else value
+    observed_value = (
+        _expected_value_for_path(intent, intent.target)
+        if value is None
+        else _normalize_explicit_command_response_value(intent, value)
+    )
     return Observation(
         path=intent.target,
         value=observed_value,
@@ -973,17 +1047,15 @@ def _command_expected_observations(
     return () if target is None else (target,)
 
 
-def _value_for_observable_intent(intent: CommandIntent) -> Any:
-    if intent.target is None:
-        raise ValueError(f"command {intent.name!r} has no observable target")
-    params = intent.params
-    if intent.target.name in params:
-        return params[intent.target.name]
-    if intent.target.name == "freq_hz" and "freq" in params:
-        return params["freq"]
-    if "value" in params:
-        return params["value"]
-    raise KeyError(intent.target.name)
+def _normalize_explicit_command_response_value(
+    intent: CommandIntent, value: Any
+) -> Any:
+    if intent.target is not None and _should_normalize_level_expectation(
+        intent.name,
+        intent.target,
+    ):
+        return _normalize_observed_level_value(value)
+    return value
 
 
 def _ptt_value(name: str, params: Mapping[str, Any]) -> bool:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -82,6 +82,11 @@ _RECEIVER_OPERATOR_CONTROL_FIELDS = {
     "anti_vox_gain",
     "vox_delay",
 }
+_NORMALIZED_RECEIVER_OPERATOR_CONTROL_FIELDS = {
+    "af_level",
+    "rf_gain",
+    "squelch",
+}
 _RECEIVER_OPERATOR_TOGGLE_FIELDS = {
     "nb",
     "nr",
@@ -142,6 +147,7 @@ _GLOBAL_OPERATOR_CONTROL_FIELDS = {
     "nb_width",
     "tx_antenna",
 }
+_NORMALIZED_GLOBAL_OPERATOR_CONTROL_FIELDS = {"power_level"}
 _GLOBAL_METER_FIELDS = {
     "alc",
     "power",
@@ -750,6 +756,16 @@ def _set_receiver_value(
     receiver[name] = value
 
 
+def _normalize_public_level_snapshot_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float) and 0.0 <= value <= 1.0:
+        return value
+    if isinstance(value, (int, float)):
+        return float(value) / 255
+    return value
+
+
 def _apply_snapshot_field(
     state: dict[str, Any],
     path: FieldPath,
@@ -788,6 +804,8 @@ def _apply_snapshot_field(
             path.family is FieldFamily.OPERATOR_CONTROLS
             and path.name in _RECEIVER_OPERATOR_CONTROL_FIELDS
         ):
+            if path.name in _NORMALIZED_RECEIVER_OPERATOR_CONTROL_FIELDS:
+                value = _normalize_public_level_snapshot_value(value)
             _set_receiver_value(state, receiver_key, path.name, value)
             return
         if (
@@ -827,6 +845,8 @@ def _apply_snapshot_field(
             path.family is FieldFamily.OPERATOR_CONTROLS
             and path.name in _GLOBAL_OPERATOR_CONTROL_FIELDS
         ):
+            if path.name in _NORMALIZED_GLOBAL_OPERATOR_CONTROL_FIELDS:
+                value = _normalize_public_level_snapshot_value(value)
             state[path.name] = value
             return
         if path.family is FieldFamily.METERS and path.name in _GLOBAL_METER_FIELDS:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -756,21 +756,37 @@ def _set_receiver_value(
     receiver[name] = value
 
 
-def _normalize_public_level_snapshot_value(value: Any) -> Any:
+def _normalize_public_level_snapshot_value(
+    value: Any, *, max_value: float = 255.0
+) -> Any:
     if isinstance(value, bool):
         return value
     if isinstance(value, float) and 0.0 <= value <= 1.0:
         return value
     if isinstance(value, (int, float)):
-        return float(value) / 255
+        return float(value) / max_value
     return value
+
+
+def _power_level_max_value(field: FieldSnapshot, radio: "Radio | None") -> float:
+    if field.source.provider != "yaesu_cat":
+        return 255.0
+    profile = getattr(radio, "profile", None) if radio is not None else None
+    max_watts = getattr(profile, "max_watts", None)
+    if isinstance(max_watts, (int, float)) and not isinstance(max_watts, bool):
+        if max_watts > 0:
+            return float(max_watts)
+    return 255.0
 
 
 def _apply_snapshot_field(
     state: dict[str, Any],
-    path: FieldPath,
-    value: Any,
+    field: FieldSnapshot,
+    *,
+    radio: "Radio | None",
 ) -> None:
+    path = field.path
+    value = field.value
     if path.scope is FieldScope.RECEIVER:
         receiver_key = _snapshot_receiver_key(path.receiver_id)
         if receiver_key is None:
@@ -846,7 +862,10 @@ def _apply_snapshot_field(
             and path.name in _GLOBAL_OPERATOR_CONTROL_FIELDS
         ):
             if path.name in _NORMALIZED_GLOBAL_OPERATOR_CONTROL_FIELDS:
-                value = _normalize_public_level_snapshot_value(value)
+                value = _normalize_public_level_snapshot_value(
+                    value,
+                    max_value=_power_level_max_value(field, radio),
+                )
             state[path.name] = value
             return
         if path.family is FieldFamily.METERS and path.name in _GLOBAL_METER_FIELDS:
@@ -873,10 +892,14 @@ def _apply_snapshot_field(
             scope_controls[path.name] = value
 
 
-def _project_snapshot_state_dict(snapshot: StateSnapshot) -> dict[str, Any]:
+def _project_snapshot_state_dict(
+    snapshot: StateSnapshot,
+    *,
+    radio: "Radio | None",
+) -> dict[str, Any]:
     state = copy.deepcopy(_EMPTY_STATE_DICT)
     for field in snapshot.fields:
-        _apply_snapshot_field(state, field.path, field.value)
+        _apply_snapshot_field(state, field, radio=radio)
     return cast(dict[str, Any], state)
 
 
@@ -991,7 +1014,7 @@ def build_public_state_payload_from_snapshot(
 ) -> dict[str, Any]:
     """Build the public web payload from one StateStore snapshot."""
 
-    state = _project_snapshot_state_dict(snapshot)
+    state = _project_snapshot_state_dict(snapshot, radio=radio)
     state["field_status"] = _build_snapshot_field_status(
         snapshot,
         receiver_count=receiver_count,

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -1383,6 +1383,13 @@ _VALUE_CONTROL_CASES = (
 )
 
 
+def _public_value_control_expected(public_path: str, value: object) -> object:
+    if public_path in {"main.afLevel", "main.rfGain", "main.squelch", "powerLevel"}:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return value / 255
+    return value
+
+
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("frame", "store_path", "public_path", "expected"),
     _VALUE_CONTROL_CASES,
@@ -1467,7 +1474,7 @@ def test_value_control_projects_available(
     node: Any = payload
     for segment in public_path.split("."):
         node = node[segment]
-    assert node == expected
+    assert node == _public_value_control_expected(public_path, expected)
 
 
 def test_civ_projected_active_rit_xit_fields_become_stale(

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1190,6 +1190,73 @@ async def test_set_level_command_overlay_keeps_raw_byte_value_for_current_contra
     ) == {path: 128}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params", "path"),
+    [
+        (
+            "set_af_level",
+            {"level": 128, "receiver": 0},
+            FieldPath.receiver("0", "operator_controls", "af_level"),
+        ),
+        (
+            "set_rf_gain",
+            {"level": 64, "receiver": 1},
+            FieldPath.receiver("1", "operator_controls", "rf_gain"),
+        ),
+        (
+            "set_squelch",
+            {"level": 32, "receiver": 0},
+            FieldPath.receiver("0", "operator_controls", "squelch"),
+        ),
+        (
+            "set_rf_power",
+            {"level": 255},
+            FieldPath.global_("operator_controls", "power_level"),
+        ),
+    ],
+)
+async def test_level_command_readback_expectations_are_normalized_but_params_stay_raw(
+    name: str,
+    params: dict[str, object],
+    path: FieldPath,
+) -> None:
+    executor = FakeExecutor()
+    clock = FreshnessClock(start=0.0)
+    service = CommandService(
+        executor=executor,
+        state_store=StateStore(),
+        clock=clock.now,
+    )
+    intent = command_intent_from_request(
+        name,
+        params,
+        source="websocket",
+        command_id=f"ws-{name}",
+        session_id="client-a",
+    )
+
+    await service.execute(intent)
+
+    assert executor.intents == [intent]
+    assert executor.intents[0].params["level"] == params["level"]
+    assert executor.intents[0].params[path.name] == params["level"]
+    assert service.readback_expectations(
+        source="websocket",
+        session_id="client-a",
+        command_id=f"ws-{name}",
+    ) == (
+        PendingOverlay(
+            source="websocket",
+            session_id="client-a",
+            command_id=f"ws-{name}",
+            path=path,
+            value=cast(int, params["level"]) / 255,
+            expires_at_monotonic=4.0,
+        ),
+    )
+
+
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("name", "params", "expected"),
     [

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1078,9 +1078,24 @@ def test_command_response_observation_carries_session_metadata() -> None:
         ("ptt", {"state": True}, "global.tx_state.ptt", True),
         ("ptt_on", {}, "global.tx_state.ptt", True),
         ("ptt_off", {}, "global.tx_state.ptt", False),
-        ("set_rf_gain", {"level": 111}, "receiver.0.operator_controls.rf_gain", 111),
-        ("set_af_level", {"level": 87}, "receiver.0.operator_controls.af_level", 87),
-        ("set_squelch", {"level": 42}, "receiver.0.operator_controls.squelch", 42),
+        (
+            "set_rf_gain",
+            {"level": 111},
+            "receiver.0.operator_controls.rf_gain",
+            111 / 255,
+        ),
+        (
+            "set_af_level",
+            {"level": 87},
+            "receiver.0.operator_controls.af_level",
+            87 / 255,
+        ),
+        (
+            "set_squelch",
+            {"level": 42},
+            "receiver.0.operator_controls.squelch",
+            42 / 255,
+        ),
         ("set_att", {"db": 12}, "receiver.0.operator_controls.att", 12),
         ("set_attenuator", {"level": 18}, "receiver.0.operator_controls.att", 18),
         ("set_preamp", {"level": 2}, "receiver.0.operator_controls.preamp", 2),
@@ -1111,7 +1126,12 @@ def test_command_response_observation_carries_session_metadata() -> None:
             116,
         ),
         ("set_powerstat", {"on": False}, "global.tx_state.power_on", False),
-        ("set_rf_power", {"level": 88}, "global.operator_controls.power_level", 88),
+        (
+            "set_rf_power",
+            {"level": 88},
+            "global.operator_controls.power_level",
+            88 / 255,
+        ),
         ("set_power", {"level": 77}, "global.operator_controls.power_level", 77),
         (
             "set_filter_width",
@@ -1255,6 +1275,124 @@ async def test_level_command_readback_expectations_are_normalized_but_params_sta
             expires_at_monotonic=4.0,
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_set_squelch_command_response_reconciles_normalized_overlay() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    intent = command_intent_from_request(
+        "set_squelch",
+        {"level": 128, "receiver": 0},
+        source="websocket",
+        command_id="ws-squelch",
+        session_id="client-a",
+    )
+    path = FieldPath.receiver("0", "operator_controls", "squelch")
+    observation = command_response_observation(
+        intent,
+        timestamp_monotonic=10.0,
+        provider="test",
+    )
+    service = CommandService(
+        executor=FakeExecutor(observations=(observation,)),
+        state_store=store,
+        clock=clock.now,
+    )
+
+    result = await service.execute(intent)
+
+    assert intent.params["level"] == 128
+    assert intent.params["squelch"] == 128
+    assert observation.value == 128 / 255
+    assert store.snapshot().field(path).value == 128 / 255
+    assert (
+        service.pending_overlays(
+            source="websocket",
+            session_id="client-a",
+            command_id="ws-squelch",
+        )
+        == ()
+    )
+    assert (
+        service.readback_expectations(
+            source="websocket",
+            session_id="client-a",
+            command_id="ws-squelch",
+        )
+        == ()
+    )
+    assert _states(result.lifecycle_events) == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+        "reconciled",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_raw_external_rigctld_level_readback_normalizes_before_reconcile() -> (
+    None
+):
+    clock = FreshnessClock(start=20.0)
+    store = StateStore(freshness_clock=clock)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=store,
+        clock=clock.now,
+    )
+    intent = command_intent_from_request(
+        "set_rf_power",
+        {"level": 64},
+        source="rigctld",
+        command_id="rigctld-rf-power",
+        session_id="client-a",
+    )
+    path = FieldPath.global_("operator_controls", "power_level")
+
+    await service.execute(intent)
+    assert intent.params["level"] == 64
+    assert intent.params["power_level"] == 64
+
+    service.apply_observation(
+        Observation(
+            path=path,
+            value=64,
+            source=SourceMetadata(
+                source="hamlib_response",
+                provider="external_rigctld",
+                transport="rigctld",
+                command_source="rigctld",
+                session_id="client-a",
+            ),
+            timestamp_monotonic=20.1,
+            correlation_id="rigctld-rf-power",
+        )
+    )
+
+    assert store.snapshot().field(path).value == 64 / 255
+    assert (
+        service.pending_overlays(
+            source="rigctld",
+            session_id="client-a",
+            command_id="rigctld-rf-power",
+        )
+        == ()
+    )
+    assert (
+        service.readback_expectations(
+            source="rigctld",
+            session_id="client-a",
+            command_id="rigctld-rf-power",
+        )
+        == ()
+    )
+    assert _states(
+        event
+        for event in service.lifecycle_events()
+        if event.command_id == "rigctld-rf-power"
+    ) == ["accepted", "queued", "sent", "acknowledged", "reconciled"]
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]

--- a/tests/test_serial_backend_smoke.py
+++ b/tests/test_serial_backend_smoke.py
@@ -533,7 +533,7 @@ async def test_serial_mock_observation_backs_all_v2_fields() -> None:
 
         # Sensible IC-7610 defaults reach the public state (not RadioState
         # defaults masquerading as missing).
-        assert state["main"]["rfGain"] == 200
+        assert state["main"]["rfGain"] == 200 / 255
         assert state["main"]["agc"] == 2  # MID
         assert state["main"]["preamp"] == 1
         assert state["main"]["filterWidth"] == 2400
@@ -551,7 +551,7 @@ async def test_serial_mock_observation_backs_all_v2_fields() -> None:
         await asyncio.wait_for(future, timeout=2.0)
         await asyncio.sleep(0.1)
         updated = server.build_public_state()
-        assert updated["main"]["rfGain"] == 42
+        assert updated["main"]["rfGain"] == 42 / 255
         assert updated["fieldStatus"]["main.rfGain"]["availability"] == "available"
     finally:
         await server.stop()

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -795,8 +795,18 @@ def test_web_state_change_callback_broadcasts_snapshot_without_revision_path() -
 # leaves or ``None`` for top-level global leaves.
 _ICOM_V2_FIELD_FAMILIES: tuple[tuple[FieldPath, str, str | None, Any], ...] = (
     # receiver operator_controls
-    (FieldPath.receiver("main", "operator_controls", "rf_gain"), "rfGain", "main", 7),
-    (FieldPath.receiver("main", "operator_controls", "squelch"), "squelch", "main", 7),
+    (
+        FieldPath.receiver("main", "operator_controls", "rf_gain"),
+        "rfGain",
+        "main",
+        7 / 255,
+    ),
+    (
+        FieldPath.receiver("main", "operator_controls", "squelch"),
+        "squelch",
+        "main",
+        7 / 255,
+    ),
     (FieldPath.receiver("main", "operator_controls", "att"), "att", "main", 6),
     (FieldPath.receiver("main", "operator_controls", "preamp"), "preamp", "main", 1),
     (FieldPath.receiver("main", "operator_controls", "agc"), "agc", "main", 2),

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -220,7 +220,7 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
     )
     assert (
         r._state_store.snapshot().field("receiver.1.operator_controls.squelch").value  # noqa: SLF001
-        == 100
+        == 100 / 255
     )
     r._loop.close()
 

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -69,10 +69,10 @@ class _FakeRadio:
         self.civ_stats = None
 
 
-def _source() -> SourceMetadata:
+def _source(*, provider: str = "test") -> SourceMetadata:
     return SourceMetadata(
         source="poll_response",
-        provider="test",
+        provider=provider,
         transport="fake",
         native_id="test",
     )
@@ -85,11 +85,12 @@ def _observation(
     at: float,
     max_age: float | None = None,
     quality: tuple[str, ...] = ("confirmed",),
+    provider: str = "test",
 ) -> Observation:
     return Observation(
         path=path,
         value=value,
-        source=_source(),
+        source=_source(provider=provider),
         timestamp_monotonic=at,
         max_age=max_age,
         quality=quality,
@@ -408,6 +409,33 @@ def test_public_state_projection_passes_through_normalized_level_controls() -> N
     assert payload["main"]["rfGain"] == 0.25
     assert payload["sub"]["squelch"] == 0.75
     assert payload["powerLevel"] == 0.8
+
+
+def test_public_power_level_projection_keeps_icom_raw_byte_scale_with_profile() -> None:
+    class _Profile:
+        max_watts = 100
+
+    class _Radio:
+        profile = _Profile()
+
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.apply(
+        _observation(
+            FieldPath.global_("operator_controls", "power_level"),
+            128,
+            at=clock.now(),
+            provider="icom_civ",
+        )
+    )
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(),
+        radio=_Radio(),  # type: ignore[arg-type]
+        receiver_count=1,
+    )
+
+    assert payload["powerLevel"] == 128 / 255
 
 
 def test_public_state_projection_keeps_unrelated_operator_controls_raw() -> None:

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -364,6 +364,73 @@ def test_public_field_status_exposes_quality_flags() -> None:
     ]
 
 
+def test_public_state_projection_normalizes_raw_level_control_snapshots() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    for path, value in (
+        (FieldPath.receiver("0", "operator_controls", "af_level"), 128),
+        (FieldPath.receiver("0", "operator_controls", "rf_gain"), 64),
+        (FieldPath.receiver("1", "operator_controls", "squelch"), 32),
+        (FieldPath.global_("operator_controls", "power_level"), 255),
+    ):
+        store.apply(_observation(path, value, at=clock.now()))
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(),
+        radio=None,
+        receiver_count=2,
+    )
+
+    assert payload["main"]["afLevel"] == 128 / 255
+    assert payload["main"]["rfGain"] == 64 / 255
+    assert payload["sub"]["squelch"] == 32 / 255
+    assert payload["powerLevel"] == 1.0
+
+
+def test_public_state_projection_passes_through_normalized_level_controls() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    for path, value in (
+        (FieldPath.receiver("0", "operator_controls", "af_level"), 0.5),
+        (FieldPath.receiver("0", "operator_controls", "rf_gain"), 0.25),
+        (FieldPath.receiver("1", "operator_controls", "squelch"), 0.75),
+        (FieldPath.global_("operator_controls", "power_level"), 0.8),
+    ):
+        store.apply(_observation(path, value, at=clock.now()))
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(),
+        radio=None,
+        receiver_count=2,
+    )
+
+    assert payload["main"]["afLevel"] == 0.5
+    assert payload["main"]["rfGain"] == 0.25
+    assert payload["sub"]["squelch"] == 0.75
+    assert payload["powerLevel"] == 0.8
+
+
+def test_public_state_projection_keeps_unrelated_operator_controls_raw() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    for path, value in (
+        (FieldPath.receiver("0", "operator_controls", "mic_gain"), 180),
+        (FieldPath.receiver("1", "operator_controls", "compressor_level"), 150),
+        (FieldPath.global_("operator_controls", "monitor_gain"), 90),
+    ):
+        store.apply(_observation(path, value, at=clock.now()))
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(),
+        radio=None,
+        receiver_count=2,
+    )
+
+    assert payload["main"]["micGain"] == 180
+    assert payload["sub"]["compressorLevel"] == 150
+    assert payload["monitorGain"] == 90
+
+
 def test_public_state_projection_covers_all_scope_control_leaves() -> None:
     """MOR-557: every scope_controls.global.display leaf must project.
 

--- a/tests/test_yaesu_web_projection.py
+++ b/tests/test_yaesu_web_projection.py
@@ -337,6 +337,24 @@ async def test_tx_controls_project_available() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tx_power_level_projects_watts_against_profile_max() -> None:
+    store = StateStore()
+    radio = _make_radio()
+    radio.profile = get_radio_profile("FTX-1")
+
+    await _apply_tx_controls(store, radio)
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(),
+        radio=radio,
+        receiver_count=2,
+    )
+
+    assert store.snapshot().field("global.operator_controls.power_level").value == 55
+    assert radio.profile.max_watts == 100
+    assert payload["powerLevel"] == 0.55
+
+
+@pytest.mark.asyncio
 async def test_rf_front_end_observation_value() -> None:
     store = StateStore()
     radio = _make_radio()


### PR DESCRIPTION
## Summary
- normalize public web/state compatibility projection for level-like operator controls while preserving raw command/wire payloads
- reconcile normalized command readbacks against raw backend command responses
- make `powerLevel` unit-aware: Yaesu watt setpoints scale by `profile.max_watts`; raw-byte providers still use `/255`
- add regression coverage for Yaesu `55W / 100W = 0.55` and raw-byte Icom fallback

## Scope
MOR-467 web compatibility slice only. Provider observation normalization is intentionally deferred to follow-up slices.

## Tests
- `uv run pytest tests/test_yaesu_web_projection.py tests/test_web_runtime_helpers.py tests/test_civ_rx_coverage.py::test_value_control_projects_available tests/test_serial_backend_smoke.py::test_serial_mock_observation_backs_all_v2_fields tests/test_state_pipeline_contracts.py::test_icom_v2_field_family_projects_observed tests/test_sync_coverage.py::test_sync_wrappers_delegate_and_return_values -q --tb=short` -> 128 passed
- `uv run pytest tests/test_civ_rx_coverage.py tests/test_serial_backend_smoke.py tests/test_state_pipeline_contracts.py tests/test_sync_coverage.py tests/test_web_api_contract.py tests/test_web_server.py tests/test_web_server_coverage.py tests/test_yaesu_web_projection.py tests/test_web_runtime_helpers.py tests/test_state_store.py tests/test_state_queries.py tests/test_sync.py -q --tb=short` -> 910 passed, 2 skipped
- `uv run pytest tests/ -q --tb=short` -> 8161 passed, 129 skipped, 3 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

## Review
- WEB-COMPAT REVIEW PASS on final head after unit-aware `powerLevel` fix
