### PR TITLE
feat(MOR-467): normalize Yaesu CAT provider observations

### DIFF
--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -401,6 +401,39 @@ class YaesuObservationAdapter:
             value = value / 100.0
         return value, ("confirmed", "calibrated")
 
+    def _normalize_level_255(self, value: object) -> object:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return float(value) / 255.0
+        return value
+
+    def _normalize_power_level(self, watts: object) -> float | None:
+        profile = getattr(self.radio, "profile", None)
+        max_watts = getattr(profile, "max_watts", None)
+        if isinstance(max_watts, bool) or not isinstance(max_watts, (int, float)):
+            self._log_field_skip(
+                "power_level",
+                "Skipping field %s — invalid power metadata: %s",
+                ValueError(f"max_watts must be a positive number, got {max_watts!r}"),
+            )
+            return None
+        if max_watts <= 0:
+            self._log_field_skip(
+                "power_level",
+                "Skipping field %s — invalid power metadata: %s",
+                ValueError(f"max_watts must be > 0, got {max_watts!r}"),
+            )
+            return None
+        if isinstance(watts, bool) or not isinstance(watts, (int, float)):
+            self._log_field_skip(
+                "power_level",
+                "Skipping field %s — invalid CAT value: %s",
+                ValueError(f"watts must be numeric, got {watts!r}"),
+            )
+            return None
+        return float(watts) / float(max_watts)
+
     async def poll_tx_meters(self) -> tuple[Observation, ...]:
         adapter = self._adapter()
         observations: list[Observation] = []
@@ -467,7 +500,11 @@ class YaesuObservationAdapter:
             )
             if ok:
                 observations.append(
-                    adapter.observation(_MAIN_AF, value, native_id="read_af_level")
+                    adapter.observation(
+                        _MAIN_AF,
+                        self._normalize_level_255(value),
+                        native_id="read_af_level",
+                    )
                 )
         if self._has_runtime_capability("rf_gain") and self._can_poll(_MAIN_RF):
             ok, value = await self._safe_read(
@@ -475,7 +512,11 @@ class YaesuObservationAdapter:
             )
             if ok:
                 observations.append(
-                    adapter.observation(_MAIN_RF, value, native_id="read_rf_gain")
+                    adapter.observation(
+                        _MAIN_RF,
+                        self._normalize_level_255(value),
+                        native_id="read_rf_gain",
+                    )
                 )
         if self._has_runtime_capability("squelch") and self._can_poll(_MAIN_SQL):
             ok, value = await self._safe_read(
@@ -483,7 +524,11 @@ class YaesuObservationAdapter:
             )
             if ok:
                 observations.append(
-                    adapter.observation(_MAIN_SQL, value, native_id="read_squelch")
+                    adapter.observation(
+                        _MAIN_SQL,
+                        self._normalize_level_255(value),
+                        native_id="read_squelch",
+                    )
                 )
         if (
             self._has_runtime_capability("dual_rx")
@@ -495,7 +540,11 @@ class YaesuObservationAdapter:
             )
             if ok:
                 observations.append(
-                    adapter.observation(_SUB_AF, value, native_id="read_af_level")
+                    adapter.observation(
+                        _SUB_AF,
+                        self._normalize_level_255(value),
+                        native_id="read_af_level",
+                    )
                 )
         if (
             self._has_runtime_capability("dual_rx")
@@ -505,7 +554,11 @@ class YaesuObservationAdapter:
             ok, value = await self._safe_read("sub.rf_gain", self.radio.read_rf_gain(1))
             if ok:
                 observations.append(
-                    adapter.observation(_SUB_RF, value, native_id="read_rf_gain")
+                    adapter.observation(
+                        _SUB_RF,
+                        self._normalize_level_255(value),
+                        native_id="read_rf_gain",
+                    )
                 )
         if (
             self._has_runtime_capability("dual_rx")
@@ -515,7 +568,11 @@ class YaesuObservationAdapter:
             ok, value = await self._safe_read("sub.squelch", self.radio.read_squelch(1))
             if ok:
                 observations.append(
-                    adapter.observation(_SUB_SQL, value, native_id="read_squelch")
+                    adapter.observation(
+                        _SUB_SQL,
+                        self._normalize_level_255(value),
+                        native_id="read_squelch",
+                    )
                 )
         # RF front-end + AGC (MOR-443) — MAIN-only. ATT/preamp gate on their
         # runtime capabilities (matching the legacy poller's ``attenuator`` /
@@ -775,13 +832,15 @@ class YaesuObservationAdapter:
         if self._has_runtime_capability("tx") and self._can_poll(_POWER_LEVEL):
             ok, result = await self._safe_read("power_level", self.radio.read_power())
             if ok and result is not None:
-                observations.append(
-                    adapter.observation(
-                        _POWER_LEVEL,
-                        result[1],
-                        native_id="read_power",
+                normalized = self._normalize_power_level(result[1])
+                if normalized is not None:
+                    observations.append(
+                        adapter.observation(
+                            _POWER_LEVEL,
+                            normalized,
+                            native_id="read_power",
+                        )
                     )
-                )
         if self._can_poll(_MIC_GAIN):
             ok, value = await self._safe_read("mic_gain", self.radio.read_mic_gain())
             if ok:

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -19,6 +21,14 @@ from rigplane.backends.yaesu_cat.radio import RadioConnectionError, YaesuCatRadi
 
 def _clock() -> float:
     return 123.456
+
+
+def _normalized_255(raw: int) -> float:
+    return raw / 255.0
+
+
+def _normalized_power(raw_watts: int, *, max_watts: int = 100) -> float:
+    return raw_watts / max_watts
 
 
 def _make_radio() -> MagicMock:
@@ -203,6 +213,7 @@ class _SideEffectingYaesuRadio:
     }
 
     def __init__(self) -> None:
+        self.profile = SimpleNamespace(max_watts=100)
         self.radio_state = RadioState()
         self.radio_state.main.freq = 1
         self.radio_state.main.mode = "INIT-MAIN"
@@ -605,12 +616,18 @@ async def test_slow_poll_emits_declared_control_observations_only() -> None:
     # The nb/nr toggles are derived from the level read in the same cycle
     # (``level > 0``); a non-zero level → toggle ON, a single read each.
     assert [(str(item.path), item.value) for item in observations] == [
-        ("receiver.main.operator_controls.af_level", 128),
-        ("receiver.main.operator_controls.rf_gain", 180),
-        ("receiver.main.operator_controls.squelch", 12),
-        ("receiver.sub.operator_controls.af_level", 64),
-        ("receiver.sub.operator_controls.rf_gain", 90),
-        ("receiver.sub.operator_controls.squelch", 8),
+        (
+            "receiver.main.operator_controls.af_level",
+            pytest.approx(_normalized_255(128)),
+        ),
+        (
+            "receiver.main.operator_controls.rf_gain",
+            pytest.approx(_normalized_255(180)),
+        ),
+        ("receiver.main.operator_controls.squelch", pytest.approx(_normalized_255(12))),
+        ("receiver.sub.operator_controls.af_level", pytest.approx(_normalized_255(64))),
+        ("receiver.sub.operator_controls.rf_gain", pytest.approx(_normalized_255(90))),
+        ("receiver.sub.operator_controls.squelch", pytest.approx(_normalized_255(8))),
         ("receiver.main.operator_controls.att", 1),
         ("receiver.main.operator_controls.preamp", 2),
         ("receiver.main.operator_controls.agc", 3),
@@ -704,8 +721,11 @@ async def test_slow_poll_skips_sub_controls_without_matching_runtime_capability(
     # here); AGC and narrow have no FTX-1 capability tag and mirror the legacy
     # poller's unconditional poll, so they still emit when policy is pollable.
     assert [(str(item.path), item.value) for item in observations] == [
-        ("receiver.main.operator_controls.af_level", 128),
-        ("receiver.sub.operator_controls.af_level", 64),
+        (
+            "receiver.main.operator_controls.af_level",
+            pytest.approx(_normalized_255(128)),
+        ),
+        ("receiver.sub.operator_controls.af_level", pytest.approx(_normalized_255(64))),
         ("receiver.main.operator_controls.agc", 3),
         ("receiver.main.operator_toggles.narrow", True),
         # active-slot is unconditional (like AGC/narrow), so it still emits when
@@ -890,7 +910,10 @@ async def test_tx_controls_poll_emits_global_setpoints() -> None:
     observations = await adapter.poll_tx_controls()
 
     assert [(str(item.path), item.value) for item in observations] == [
-        ("global.operator_controls.power_level", 55),
+        (
+            "global.operator_controls.power_level",
+            pytest.approx(_normalized_power(55)),
+        ),
         ("global.operator_controls.mic_gain", 40),
         ("global.tx_state.compressor_on", True),
         ("global.operator_controls.compressor_level", 25),
@@ -960,6 +983,39 @@ async def test_tx_controls_poll_emits_global_setpoints() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tx_controls_poll_skips_power_level_without_valid_profile_max_watts() -> (
+    None
+):
+    radio = _make_radio()
+    radio.profile = replace(radio.profile, max_watts=None)
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    observations = await adapter.poll_tx_controls()
+
+    assert [(str(item.path), item.value) for item in observations] == [
+        ("global.operator_controls.mic_gain", 40),
+        ("global.tx_state.compressor_on", True),
+        ("global.operator_controls.compressor_level", 25),
+        ("global.tx_state.vox_on", True),
+        ("global.tx_state.split", True),
+        ("global.tx_state.rit_on", True),
+        ("global.tx_state.rit_tx", False),
+        ("global.operator_controls.rit_freq", -250),
+        ("global.operator_controls.tuner_status", 2),
+        ("global.tx_state.dial_lock", True),
+        ("global.operator_controls.key_speed", 24),
+        ("global.operator_controls.cw_pitch", 600),
+        ("global.operator_controls.break_in", 1),
+        ("global.operator_controls.break_in_delay", 300),
+    ]
+    radio.read_power.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_tx_controls_poll_skips_fields_without_matching_runtime_capability() -> (
     None
 ):
@@ -1025,12 +1081,30 @@ async def test_adapter_uses_read_only_yaesu_paths_when_getters_mutate_state() ->
         ("global.meters.power", 180),
         ("global.meters.swr", 120),
         ("global.meters.comp", 90),
-        ("receiver.main.operator_controls.af_level", 128),
-        ("receiver.main.operator_controls.rf_gain", 180),
-        ("receiver.main.operator_controls.squelch", 12),
-        ("receiver.sub.operator_controls.af_level", 64),
-        ("receiver.sub.operator_controls.rf_gain", 90),
-        ("receiver.sub.operator_controls.squelch", 8),
+        (
+            "receiver.main.operator_controls.af_level",
+            pytest.approx(_normalized_255(128)),
+        ),
+        (
+            "receiver.main.operator_controls.rf_gain",
+            pytest.approx(_normalized_255(180)),
+        ),
+        (
+            "receiver.main.operator_controls.squelch",
+            pytest.approx(_normalized_255(12)),
+        ),
+        (
+            "receiver.sub.operator_controls.af_level",
+            pytest.approx(_normalized_255(64)),
+        ),
+        (
+            "receiver.sub.operator_controls.rf_gain",
+            pytest.approx(_normalized_255(90)),
+        ),
+        (
+            "receiver.sub.operator_controls.squelch",
+            pytest.approx(_normalized_255(8)),
+        ),
         # AGC has no FTX-1 capability tag → unconditional, MAIN-only; ATT and
         # preamp are skipped because this radio lacks those runtime caps.
         ("receiver.main.operator_controls.agc", 3),
@@ -1055,7 +1129,10 @@ async def test_adapter_uses_read_only_yaesu_paths_when_getters_mutate_state() ->
         # cw_spot (MOR-456) — global slow_state bool, gated on the ``cw`` cap
         # (present here); ``read_cw_spot`` does not mutate legacy state.
         ("global.slow_state.cw_spot", True),
-        ("global.operator_controls.power_level", 55),
+        (
+            "global.operator_controls.power_level",
+            pytest.approx(_normalized_power(55)),
+        ),
         ("global.operator_controls.mic_gain", 40),
         ("global.tx_state.compressor_on", True),
         ("global.operator_controls.compressor_level", 25),
@@ -1660,12 +1737,18 @@ async def test_happy_path_slow_poll_unchanged_when_all_reads_succeed() -> None:
     observations = await adapter.poll_slow_controls()
 
     assert [(str(item.path), item.value) for item in observations] == [
-        ("receiver.main.operator_controls.af_level", 128),
-        ("receiver.main.operator_controls.rf_gain", 180),
-        ("receiver.main.operator_controls.squelch", 12),
-        ("receiver.sub.operator_controls.af_level", 64),
-        ("receiver.sub.operator_controls.rf_gain", 90),
-        ("receiver.sub.operator_controls.squelch", 8),
+        (
+            "receiver.main.operator_controls.af_level",
+            pytest.approx(_normalized_255(128)),
+        ),
+        (
+            "receiver.main.operator_controls.rf_gain",
+            pytest.approx(_normalized_255(180)),
+        ),
+        ("receiver.main.operator_controls.squelch", pytest.approx(_normalized_255(12))),
+        ("receiver.sub.operator_controls.af_level", pytest.approx(_normalized_255(64))),
+        ("receiver.sub.operator_controls.rf_gain", pytest.approx(_normalized_255(90))),
+        ("receiver.sub.operator_controls.squelch", pytest.approx(_normalized_255(8))),
         ("receiver.main.operator_controls.att", 1),
         ("receiver.main.operator_controls.preamp", 2),
         ("receiver.main.operator_controls.agc", 3),

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -134,6 +134,14 @@ def make_radio(
     return radio
 
 
+def _normalized_255(raw: int) -> float:
+    return raw / 255.0
+
+
+def _normalized_power(raw_watts: int, *, max_watts: int = 100) -> float:
+    return raw_watts / max_watts
+
+
 class _SideEffectingYaesuRadio:
     capabilities = {
         "dual_rx",
@@ -658,12 +666,30 @@ async def test_observation_poller_uses_read_only_paths_when_getters_mutate_state
         ("global.tx_state.ptt", False),
         ("receiver.main.meters.s_meter", 6),
         ("receiver.sub.meters.s_meter", -37),
-        ("receiver.main.operator_controls.af_level", 128),
-        ("receiver.main.operator_controls.rf_gain", 180),
-        ("receiver.main.operator_controls.squelch", 12),
-        ("receiver.sub.operator_controls.af_level", 64),
-        ("receiver.sub.operator_controls.rf_gain", 90),
-        ("receiver.sub.operator_controls.squelch", 8),
+        (
+            "receiver.main.operator_controls.af_level",
+            pytest.approx(_normalized_255(128)),
+        ),
+        (
+            "receiver.main.operator_controls.rf_gain",
+            pytest.approx(_normalized_255(180)),
+        ),
+        (
+            "receiver.main.operator_controls.squelch",
+            pytest.approx(_normalized_255(12)),
+        ),
+        (
+            "receiver.sub.operator_controls.af_level",
+            pytest.approx(_normalized_255(64)),
+        ),
+        (
+            "receiver.sub.operator_controls.rf_gain",
+            pytest.approx(_normalized_255(90)),
+        ),
+        (
+            "receiver.sub.operator_controls.squelch",
+            pytest.approx(_normalized_255(8)),
+        ),
         # ATT/preamp need their runtime caps (absent here); AGC is
         # unconditional and MAIN-only, mirroring the legacy poller.
         ("receiver.main.operator_controls.agc", 3),
@@ -674,7 +700,10 @@ async def test_observation_poller_uses_read_only_paths_when_getters_mutate_state
         # AGC/narrow, the SUB index coerces to the neutral "SUB" str. split is
         # skipped: this radio lacks the ``split`` runtime cap.
         ("global.slow_state.active", "SUB"),
-        ("global.operator_controls.power_level", 55),
+        (
+            "global.operator_controls.power_level",
+            pytest.approx(_normalized_power(55)),
+        ),
         ("global.operator_controls.mic_gain", 40),
         ("global.tx_state.compressor_on", True),
         ("global.operator_controls.compressor_level", 25),

--- a/tests/test_yaesu_web_projection.py
+++ b/tests/test_yaesu_web_projection.py
@@ -26,7 +26,7 @@ from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
 
 # (store path, public fieldStatus key, expected value) for the five TX controls.
 _TX_CONTROL_CASES = (
-    ("global.operator_controls.power_level", "powerLevel", 55),
+    ("global.operator_controls.power_level", "powerLevel", 0.55),
     ("global.operator_controls.mic_gain", "micGain", 40),
     ("global.tx_state.compressor_on", "compressorOn", True),
     ("global.operator_controls.compressor_level", "compressorLevel", 25),
@@ -164,6 +164,7 @@ def _profile_state_acquisition() -> RadioAcquisitionProfile:
 
 def _make_radio() -> MagicMock:
     radio = MagicMock()
+    radio.profile = get_radio_profile("FTX-1")
     radio.capabilities = {
         "dual_rx",
         "meters",
@@ -340,7 +341,6 @@ async def test_tx_controls_project_available() -> None:
 async def test_tx_power_level_projects_watts_against_profile_max() -> None:
     store = StateStore()
     radio = _make_radio()
-    radio.profile = get_radio_profile("FTX-1")
 
     await _apply_tx_controls(store, radio)
     payload = build_public_state_payload_from_snapshot(
@@ -349,7 +349,7 @@ async def test_tx_power_level_projects_watts_against_profile_max() -> None:
         receiver_count=2,
     )
 
-    assert store.snapshot().field("global.operator_controls.power_level").value == 55
+    assert store.snapshot().field("global.operator_controls.power_level").value == 0.55
     assert radio.profile.max_watts == 100
     assert payload["powerLevel"] == 0.55
 


### PR DESCRIPTION
## Summary
- normalize Yaesu CAT provider observations for AF/RF/SQL from raw 0..255 to normalized floats
- normalize Yaesu `power_level` observations from watts by `profile.max_watts`
- fail closed when `max_watts` is missing or invalid instead of emitting raw watts into a normalized field
- preserve raw CAT readers/writers, `SetPower(unit="watts")`, command payloads, and legacy raw poller state writes

## Scope
MOR-467 Yaesu CAT provider-normalization slice only.

## Tests
- `uv run pytest tests/test_yaesu_cat_observation_adapter.py tests/test_yaesu_cat_poller.py tests/test_rigctld_handler.py tests/test_rig_loader.py tests/test_rig_multi_vendor.py tests/test_yaesu_web_projection.py -q --tb=short` -> 618 passed
- `uv run pytest tests/test_yaesu_*.py -q --tb=short` -> 235 passed
- `uv run pytest tests/ -q --tb=short` -> 8164 passed, 129 skipped, 3 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

## Review
- YAESU REVIEW PASS

Refs MOR-467
