### PR TITLE
feat(MOR-467): normalize Icom CI-V provider observations

### DIFF
--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -936,13 +936,13 @@ def _receiver_specs(receiver_id: str) -> tuple[FieldSpec, ...]:
         ),
         spec(
             FieldPath.receiver(receiver_id, "operator_controls", "af_level"),
-            "int",
+            "float",
             writable=True,
             unit="normalized",
         ),
         spec(
             FieldPath.receiver(receiver_id, "operator_controls", "rf_gain"),
-            "int",
+            "float",
             writable=True,
             unit="normalized",
         ),
@@ -958,7 +958,7 @@ def _receiver_specs(receiver_id: str) -> tuple[FieldSpec, ...]:
         ),
         spec(
             FieldPath.receiver(receiver_id, "operator_controls", "squelch"),
-            "int",
+            "float",
             writable=True,
             unit="normalized",
         ),
@@ -1123,7 +1123,7 @@ def _global_specs() -> tuple[FieldSpec, ...]:
         spec(FieldPath.global_("tx_state", "tx_freq_monitor"), "bool", writable=True),
         spec(
             FieldPath.global_("operator_controls", "power_level"),
-            "int",
+            "float",
             writable=True,
             unit="normalized",
         ),

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -254,6 +254,7 @@ _OBSERVABLE_CMD14_FIELDS = {
     0x16: ("global", "operator_controls", "vox_gain"),
     0x17: ("global", "operator_controls", "anti_vox_gain"),
 }
+_NORMALIZED_CMD14_OBSERVATION_SUBS = frozenset({0x01, 0x02, 0x03, 0x0A})
 
 # 0x14 cw_pitch (sub 0x09) is observation-backed too, but its raw level → Hz
 # mapping is non-linear, so it is decoded via ``_cw_pitch_from_level`` rather
@@ -1575,10 +1576,14 @@ class CivRuntime:
             else:
                 mapping = _OBSERVABLE_CMD14_FIELDS.get(sub14)
                 if mapping is not None:
+                    raw_value = self._decode_level(frame.data)
+                    value: int | float = raw_value
+                    if sub14 in _NORMALIZED_CMD14_OBSERVATION_SUBS:
+                        value = raw_value / 255.0
                     observations.append(
                         self._observation(
                             self._field_path(mapping, receiver_id=receiver_id),
-                            self._decode_level(frame.data),
+                            value,
                             frame=frame,
                         )
                     )

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -914,13 +914,19 @@ def test_update_state_cache_exception_suppressed(radio: IcomRadio) -> None:
         (
             _make_frame(cmd=0x14, sub=0x01, data=_bcd2(87), receiver=0x01),
             "receiver.1.operator_controls.af_level",
-            87,
+            87 / 255.0,
             "command_response",
         ),
         (
             _make_frame(cmd=0x14, sub=0x02, data=_bcd2(111), receiver=0x01),
             "receiver.1.operator_controls.rf_gain",
-            111,
+            111 / 255.0,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x14, sub=0x03, data=_bcd2(45), receiver=0x01),
+            "receiver.1.operator_controls.squelch",
+            45 / 255.0,
             "command_response",
         ),
         (
@@ -1244,7 +1250,25 @@ _VALUE_CONTROL_CASES = (
         _make_frame(cmd=0x14, sub=0x03, data=_bcd2(50), receiver=0x00),
         "receiver.0.operator_controls.squelch",
         "main.squelch",
-        50,
+        50 / 255.0,
+    ),
+    (
+        _make_frame(cmd=0x14, sub=0x01, data=_bcd2(128), receiver=0x00),
+        "receiver.0.operator_controls.af_level",
+        "main.afLevel",
+        128 / 255.0,
+    ),
+    (
+        _make_frame(cmd=0x14, sub=0x02, data=_bcd2(64), receiver=0x00),
+        "receiver.0.operator_controls.rf_gain",
+        "main.rfGain",
+        64 / 255.0,
+    ),
+    (
+        _make_frame(cmd=0x14, sub=0x0A, data=_bcd2(128)),
+        "global.operator_controls.power_level",
+        "powerLevel",
+        128 / 255.0,
     ),
     (
         _make_frame(cmd=0x14, sub=0x06, data=_bcd2(91), receiver=0x00),
@@ -1385,9 +1409,17 @@ _VALUE_CONTROL_CASES = (
 
 def _public_value_control_expected(public_path: str, value: object) -> object:
     if public_path in {"main.afLevel", "main.rfGain", "main.squelch", "powerLevel"}:
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if isinstance(value, int) and not isinstance(value, bool):
             return value / 255
     return value
+
+
+def _expected_value_control_max_age(store_path: str) -> float | None:
+    if store_path.endswith(".af_level") or store_path.endswith(".rf_gain"):
+        return 10.0
+    if store_path == "global.operator_controls.power_level":
+        return 30.0
+    return None
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
@@ -1409,9 +1441,7 @@ def test_value_control_observation_value(
 
     field = radio_with_state._state_store.snapshot().field(store_path)
     assert field.value == expected
-    # These level/value families never expire — no max_age, so the freshness
-    # service cannot re-gate them ``missing`` (MOR-437).
-    assert field.max_age is None
+    assert field.max_age == _expected_value_control_max_age(store_path)
     assert field.freshness is FreshnessState.FRESH
 
 
@@ -2051,7 +2081,7 @@ def test_update_radio_state_cmd14_rf_gain(radio_with_state: IcomRadio) -> None:
     field = radio_with_state._state_store.snapshot().field(
         "receiver.0.operator_controls.rf_gain"
     )
-    assert field.value == 180
+    assert field.value == pytest.approx(180 / 255.0)
 
 
 def test_update_radio_state_cmd14_squelch(radio_with_state: IcomRadio) -> None:
@@ -2063,15 +2093,48 @@ def test_update_radio_state_cmd14_squelch(radio_with_state: IcomRadio) -> None:
     field = radio_with_state._state_store.snapshot().field(
         "receiver.0.operator_controls.squelch"
     )
-    assert field.value == 50
+    assert field.value == pytest.approx(50 / 255.0)
 
 
 def test_update_radio_state_cmd14_power_level(radio_with_state: IcomRadio) -> None:
-    """cmd 0x14 sub 0x0A updates global power level (line 545-546)."""
+    """cmd 0x14 sub 0x0A keeps the raw mirror and stores normalized state."""
     rs = radio_with_state._radio_state
     frame = _make_frame(cmd=0x14, sub=0x0A, data=_bcd2(128))
-    radio_with_state._civ_runtime._update_radio_state_from_frame(frame)
+    radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
     assert rs.power_level == 128
+    field = radio_with_state._state_store.snapshot().field(
+        "global.operator_controls.power_level"
+    )
+    assert field.value == pytest.approx(128 / 255.0)
+
+
+@pytest.mark.parametrize(
+    ("frame", "expected_path", "expected_value"),
+    [
+        (
+            _make_frame(cmd=0x14, sub=0x03, data=_bcd2(45), receiver=0x01),
+            "receiver.1.operator_controls.squelch",
+            45 / 255.0,
+        ),
+        (
+            _make_frame(cmd=0x14, sub=0x0A, data=_bcd2(128)),
+            "global.operator_controls.power_level",
+            128 / 255.0,
+        ),
+    ],
+)
+def test_observations_from_frame_normalizes_selected_cmd14_controls(
+    radio: IcomRadio,
+    frame: CivFrame,
+    expected_path: str,
+    expected_value: float,
+) -> None:
+    observations = radio._civ_runtime._observations_from_frame(frame)
+
+    assert len(observations) == 1
+    observation = observations[0]
+    assert str(observation.path) == expected_path
+    assert observation.value == pytest.approx(expected_value)
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1341,7 +1341,7 @@ async def test_get_level_af_projects_state_store_snapshot(
 ) -> None:
     store = StateStore()
     mock_radio.state_store = store
-    _apply_store_value(store, "receiver.main.operator_controls.af_level", 128)
+    _apply_store_value(store, "receiver.main.operator_controls.af_level", 128 / 255.0)
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(get_cmd("get_level", "AF"))
@@ -1408,19 +1408,29 @@ async def test_get_level_rfpower_projects_raw_int_state_store_snapshot(
 
 
 @pytest.mark.asyncio
-async def test_get_level_rfpower_projected_normalized_float_passes_through(
+@pytest.mark.parametrize(
+    ("level", "path", "value"),
+    [
+        ("RF", "receiver.main.operator_controls.rf_gain", 0.25),
+        ("SQL", "receiver.main.operator_controls.squelch", 0.75),
+        ("RFPOWER", "global.operator_controls.power_level", 0.5),
+    ],
+)
+async def test_get_level_icom_projected_normalized_float_passes_through(
     mock_radio: AsyncMock,
+    level: str,
+    path: str,
+    value: float,
 ) -> None:
     store = StateStore()
     mock_radio.state_store = store
-    _apply_store_value(store, "global.operator_controls.power_level", 0.5)
+    _apply_store_value(store, path, value)
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
-    resp = await handler.execute(get_cmd("get_level", "RFPOWER"))
+    resp = await handler.execute(get_cmd("get_level", level))
 
     assert resp.ok
-    assert resp.values == ["0.500000"]
-    mock_radio.get_rf_power.assert_not_awaited()
+    assert resp.values == [f"{value:.6f}"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -1111,12 +1111,12 @@ def test_tone_and_tsql_freq_units_are_centihz(receiver_id: str, field: str) -> N
 
 
 def test_power_level_unit_is_normalized() -> None:
-    """``power_level`` declares ``normalized`` and stays ``value_type='int'``."""
+    """``power_level`` declares ``normalized`` with float observation values."""
     spec = DEFAULT_FIELD_REGISTRY.require(
         FieldPath.global_("operator_controls", "power_level")
     )
     assert spec.unit == "normalized"
-    assert spec.value_type == "int"
+    assert spec.value_type == "float"
 
 
 @pytest.mark.parametrize("receiver_id", ["main", "sub"])
@@ -1125,12 +1125,12 @@ def test_receiver_raw_byte_operator_controls_declare_transitional_normalized_uni
     receiver_id: str,
     field: str,
 ) -> None:
-    """Raw-byte operator controls declare normalized units while staying int."""
+    """Normalized receiver controls declare normalized units with float values."""
     spec = DEFAULT_FIELD_REGISTRY.require(
         FieldPath.receiver(receiver_id, "operator_controls", field)
     )
     assert spec.unit == "normalized"
-    assert spec.value_type == "int"
+    assert spec.value_type == "float"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- normalize Icom CI-V 0x14 provider observations for AF/RF/SQL/power controls to backend-neutral floats (`raw / 255.0`)
- update state pipeline metadata for these controls to float/normalized
- preserve raw CI-V command builders/parsers and `IcomRadio` getter/setter API behavior
- add rigctld projection coverage for normalized store floats vs raw pending integer overlays

## Scope
MOR-467 Icom CI-V provider-normalization slice only.

## Tests
- `uv run pytest tests/test_civ_rx_coverage.py tests/test_state_pipeline_contracts.py tests/test_rigctld_handler.py tests/test_radio.py tests/test_radio_coverage.py tests/test_command_service.py tests/test_yaesu_cat_observation_adapter.py tests/test_yaesu_web_projection.py -q --tb=short` -> 1399 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` -> 7914 passed, 73 skipped, 3 deselected, 11 xfailed, 1 xpassed before rebase
- `uv run pytest tests/ -q --tb=short` -> 8178 passed, 129 skipped, 3 deselected, 11 xfailed, 1 xpassed after rebase on Yaesu slice
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

## Review
- ICOM REVIEW PASS

Refs MOR-467
