### PR TITLE
feat(#1863): expose RX capture stream health

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -143,6 +143,26 @@ class TxStreamHealth:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class RxStreamHealth:
+    """Snapshot of capture callback delivery and input-side health."""
+
+    frames_delivered: int = 0
+    input_overflow_events: int = 0
+    input_underflow_events: int = 0
+    callback_errors: int = 0
+    callback_status_flags: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "frames_delivered": self.frames_delivered,
+            "input_overflow_events": self.input_overflow_events,
+            "input_underflow_events": self.input_underflow_events,
+            "callback_errors": self.callback_errors,
+            "callback_status_flags": dict(self.callback_status_flags),
+        }
+
+
 # ---------------------------------------------------------------------------
 # Stream protocols
 # ---------------------------------------------------------------------------
@@ -372,6 +392,97 @@ def _downmix_stereo_to_mono_s16le(pcm: bytes, *, channel: str = "mix") -> bytes:
     return mono.tobytes()
 
 
+def _callback_status_flag_names(status: Any) -> tuple[str, ...]:
+    if status is None:
+        return ()
+    try:
+        if not bool(status):
+            return ()
+    except Exception:
+        pass
+    flags: list[str] = []
+    for name in (
+        "input_underflow",
+        "input_overflow",
+        "output_underflow",
+        "output_overflow",
+        "priming_output",
+    ):
+        try:
+            if bool(getattr(status, name, False)):
+                flags.append(name)
+        except Exception:
+            continue
+    if flags:
+        return tuple(flags)
+    try:
+        label = str(status).strip()
+    except Exception:
+        label = type(status).__name__
+    return (label or type(status).__name__,)
+
+
+@dataclass(slots=True)
+class _RxFeedResult:
+    frames_delivered: int = 0
+    callback_errors: int = 0
+
+
+class _CaptureHealthTracker:
+    """Mutable capture-side counters with snapshot export."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._frames_delivered = 0
+        self._input_overflow_events = 0
+        self._input_underflow_events = 0
+        self._callback_errors = 0
+        self._callback_status_flags: dict[str, int] = {}
+
+    def record_status(self, status: Any, *, input_only: bool) -> None:
+        flags = _callback_status_flag_names(status)
+        if input_only:
+            flags = tuple(
+                flag
+                for flag in flags
+                if flag.startswith("input_")
+                or flag not in {"output_underflow", "output_overflow", "priming_output"}
+            )
+        if not flags:
+            return
+        with self._lock:
+            for flag in flags:
+                self._callback_status_flags[flag] = (
+                    self._callback_status_flags.get(flag, 0) + 1
+                )
+                if flag == "input_overflow":
+                    self._input_overflow_events += 1
+                elif flag == "input_underflow":
+                    self._input_underflow_events += 1
+
+    def record_frames_delivered(self, count: int) -> None:
+        if count <= 0:
+            return
+        with self._lock:
+            self._frames_delivered += count
+
+    def record_callback_errors(self, count: int) -> None:
+        if count <= 0:
+            return
+        with self._lock:
+            self._callback_errors += count
+
+    def snapshot(self) -> RxStreamHealth:
+        with self._lock:
+            return RxStreamHealth(
+                frames_delivered=self._frames_delivered,
+                input_overflow_events=self._input_overflow_events,
+                input_underflow_events=self._input_underflow_events,
+                callback_errors=self._callback_errors,
+                callback_status_flags=dict(self._callback_status_flags),
+            )
+
+
 class _RxFramer:
     """Shared RX data-path: downmix → accumulate → re-chunk into fixed frames.
 
@@ -407,7 +518,7 @@ class _RxFramer:
     def reset(self) -> None:
         self._accumulator = bytearray()
 
-    def feed(self, indata: Any, callback: Callable[[bytes], None]) -> None:
+    def feed(self, indata: Any, callback: Callable[[bytes], None]) -> _RxFeedResult:
         """Downmix + re-chunk *indata*; deliver each whole frame to *callback*.
 
         Runs on PortAudio's audio thread: keep it non-blocking. Copies the PCM
@@ -416,15 +527,17 @@ class _RxFramer:
         hands each to the consumer. Re-chunking a continuous callback stream is
         lossless and adds no scheduling seam.
         """
+        result = _RxFeedResult()
         try:
             pcm = (
                 bytes(indata.tobytes()) if hasattr(indata, "tobytes") else bytes(indata)
             )
         except Exception:
             logger.warning("portaudio-rx: capture copy failed", exc_info=True)
-            return
+            result.callback_errors += 1
+            return result
         if not pcm:
-            return
+            return result
         if self._downmix_stereo_to_mono:
             # Device opened at 2 ch (native) but consumer wants mono (MOR-504):
             # collapse interleaved L/R → mono BEFORE chunking, so the
@@ -436,9 +549,10 @@ class _RxFramer:
                 logger.warning(
                     "portaudio-rx: stereo→mono downmix failed", exc_info=True
                 )
-                return
+                result.callback_errors += 1
+                return result
             if not pcm:
-                return
+                return result
         acc = self._accumulator
         acc.extend(pcm)
         frame_bytes = self._frame_bytes
@@ -447,8 +561,11 @@ class _RxFramer:
                 frame = bytes(acc[:frame_bytes])
                 del acc[:frame_bytes]
                 callback(frame)
+                result.frames_delivered += 1
         except Exception:
             logger.warning("portaudio-rx: consumer callback failed", exc_info=True)
+            result.callback_errors += 1
+        return result
 
 
 class _PortAudioRxStream:
@@ -517,10 +634,15 @@ class _PortAudioRxStream:
         self._stream: Any = None
         self._running = False
         self._callback: Callable[[bytes], None] | None = None
+        self._capture_health = _CaptureHealthTracker()
 
     @property
     def running(self) -> bool:
         return self._running
+
+    @property
+    def capture_health(self) -> RxStreamHealth:
+        return self._capture_health.snapshot()
 
     async def start(self, callback: Callable[[bytes], None]) -> None:
         if self.running:
@@ -576,7 +698,10 @@ class _PortAudioRxStream:
         cb = self._callback
         if cb is None:
             return
-        self._framer.feed(indata, cb)
+        self._capture_health.record_status(_status, input_only=True)
+        result = self._framer.feed(indata, cb)
+        self._capture_health.record_frames_delivered(result.frames_delivered)
+        self._capture_health.record_callback_errors(result.callback_errors)
 
 
 class _PortAudioTxStream:
@@ -907,33 +1032,7 @@ class _PortAudioTxStream:
             pass
 
     def _status_flag_names(self, status: Any) -> tuple[str, ...]:
-        if status is None:
-            return ()
-        try:
-            if not bool(status):
-                return ()
-        except Exception:
-            pass
-        flags: list[str] = []
-        for name in (
-            "input_underflow",
-            "input_overflow",
-            "output_underflow",
-            "output_overflow",
-            "priming_output",
-        ):
-            try:
-                if bool(getattr(status, name, False)):
-                    flags.append(name)
-            except Exception:
-                continue
-        if flags:
-            return tuple(flags)
-        try:
-            label = str(status).strip()
-        except Exception:
-            label = type(status).__name__
-        return (label or type(status).__name__,)
+        return _callback_status_flag_names(status)
 
     def _track_write_rate_locked(self) -> None:
         observed_at = time.monotonic()
@@ -1036,6 +1135,7 @@ class _PortAudioDuplexStream:
         self._stream: Any = None
         self._running = False
         self._callback: Callable[[bytes], None] | None = None
+        self._capture_health = _CaptureHealthTracker()
 
     @property
     def running(self) -> bool:
@@ -1044,6 +1144,10 @@ class _PortAudioDuplexStream:
     @property
     def write_health(self) -> TxStreamHealth:
         return self._tx.write_health
+
+    @property
+    def capture_health(self) -> RxStreamHealth:
+        return self._capture_health.snapshot()
 
     async def start(self, callback: Callable[[bytes], None]) -> None:
         if self.running:
@@ -1107,7 +1211,10 @@ class _PortAudioDuplexStream:
         #      the producer is behind), reusing the TX stream's output callback.
         cb = self._callback
         if cb is not None:
-            self._framer.feed(indata, cb)
+            self._capture_health.record_status(status, input_only=True)
+            result = self._framer.feed(indata, cb)
+            self._capture_health.record_frames_delivered(result.frames_delivered)
+            self._capture_health.record_callback_errors(result.callback_errors)
         self._tx._output_callback(outdata, frames, _time_info, status)
 
 
@@ -1348,10 +1455,15 @@ class FakeRxStream:
         self.stopped_count = 0
         self.heartbeat_count = 0
         self.fail_on_inject: Exception | None = None
+        self._capture_health = _CaptureHealthTracker()
 
     @property
     def running(self) -> bool:
         return self._running
+
+    @property
+    def capture_health(self) -> RxStreamHealth:
+        return self._capture_health.snapshot()
 
     async def start(self, callback: Callable[[bytes], None]) -> None:
         if self._running:
@@ -1377,7 +1489,12 @@ class FakeRxStream:
             self.fail_on_inject = None
             raise exc
         if self._callback is not None:
-            self._callback(frame)
+            try:
+                self._callback(frame)
+            except Exception:
+                self._capture_health.record_callback_errors(1)
+                raise
+            self._capture_health.record_frames_delivered(1)
 
     def inject_heartbeat(self, frame: bytes = b"\x00\x00") -> None:
         """Advance RX liveness by one synthetic capture tick (MOR-566).
@@ -1389,7 +1506,12 @@ class FakeRxStream:
         """
         self.heartbeat_count += 1
         if self._callback is not None:
-            self._callback(frame)
+            try:
+                self._callback(frame)
+            except Exception:
+                self._capture_health.record_callback_errors(1)
+                raise
+            self._capture_health.record_frames_delivered(1)
 
 
 class FakeTxStream:
@@ -1472,10 +1594,15 @@ class FakeDuplexStream:
         self.started_count = 0
         self.stopped_count = 0
         self.written_frames: list[bytes] = []
+        self._capture_health = _CaptureHealthTracker()
 
     @property
     def running(self) -> bool:
         return self._running
+
+    @property
+    def capture_health(self) -> RxStreamHealth:
+        return self._capture_health.snapshot()
 
     @property
     def write_health(self) -> TxStreamHealth:
@@ -1506,7 +1633,12 @@ class FakeDuplexStream:
     def inject_frame(self, frame: bytes) -> None:
         """Push an RX capture frame to the registered callback (test helper)."""
         if self._callback is not None:
-            self._callback(frame)
+            try:
+                self._callback(frame)
+            except Exception:
+                self._capture_health.record_callback_errors(1)
+                raise
+            self._capture_health.record_frames_delivered(1)
 
 
 class FakeAudioBackend:
@@ -1647,6 +1779,7 @@ __all__ = [
     "FakeRxStream",
     "FakeTxStream",
     "PortAudioBackend",
+    "RxStreamHealth",
     "RxStream",
     "TxStream",
     "TxStreamHealth",

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -15,6 +15,7 @@ from rigplane.audio.backend import (
     FakeRxStream,
     FakeTxStream,
     PortAudioBackend,
+    RxStreamHealth,
     RxStream,
     TxStream,
     TxStreamHealth,
@@ -107,6 +108,14 @@ class TestProtocolConformance:
         assert health["overrun_events"] == 0
         assert health["underrun_events"] == 0
 
+    def test_rx_stream_health_is_exported(self) -> None:
+        health = RxStreamHealth().to_dict()
+        assert health["frames_delivered"] == 0
+        assert health["input_overflow_events"] == 0
+        assert health["input_underflow_events"] == 0
+        assert health["callback_errors"] == 0
+        assert health["callback_status_flags"] == {}
+
     def test_portaudio_backend_is_audio_backend(self) -> None:
         # PortAudioBackend satisfies the protocol structurally (deps not needed here)
         backend = PortAudioBackend(dependency_loader=lambda: (None, None))
@@ -176,11 +185,14 @@ class TestFakeRxStreamLifecycle:
         received: list[bytes] = []
         await stream.start(received.append)
 
+        assert stream.capture_health.frames_delivered == 0
         stream.inject_frame(b"\x00\x01\x02\x03")
         assert received == [b"\x00\x01\x02\x03"]
+        assert stream.capture_health.frames_delivered == 1
 
         stream.inject_frame(b"\xff")
         assert len(received) == 2
+        assert stream.capture_health.frames_delivered == 2
 
         await stream.stop()
 
@@ -201,6 +213,30 @@ class TestFakeRxStreamLifecycle:
         s1 = fake_backend.open_rx(DUPLEX_DEVICE.id)
         s2 = fake_backend.open_rx(INPUT_ONLY_DEVICE.id)
         assert fake_backend.rx_streams == [s1, s2]
+
+
+# ---------------------------------------------------------------------------
+# FakeDuplexStream capture health
+# ---------------------------------------------------------------------------
+
+
+class TestFakeDuplexStreamCaptureHealth:
+    @pytest.mark.asyncio()
+    async def test_inject_frame_updates_capture_health(
+        self, fake_backend: FakeAudioBackend
+    ) -> None:
+        stream = fake_backend.open_duplex(DUPLEX_DEVICE.id)
+        received: list[bytes] = []
+        await stream.start(received.append)
+
+        assert stream.capture_health.frames_delivered == 0
+        stream.inject_frame(b"\x10\x20")
+        assert received == [b"\x10\x20"]
+        assert stream.capture_health.frames_delivered == 1
+        assert stream.capture_health.input_overflow_events == 0
+        assert stream.capture_health.input_underflow_events == 0
+
+        await stream.stop()
 
 
 # ---------------------------------------------------------------------------
@@ -579,6 +615,161 @@ class TestPortAudioBackendDeps:
         assert len(received) == 2
         for frame in received:
             assert len(frame) == 480 * 2  # 960 bytes / 10 ms each
+
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_open_rx_capture_health_records_input_overflow(self) -> None:
+        class FakeIndata:
+            def __init__(self, payload: bytes) -> None:
+                self._payload = payload
+
+            def tobytes(self) -> bytes:
+                return self._payload
+
+        captured_cb: dict[str, object] = {}
+
+        class FakeSd:
+            class InputStream:
+                def __init__(self, **kw: object) -> None:
+                    captured_cb["cb"] = kw["callback"]
+
+                def start(self) -> None:
+                    pass
+
+                def stop(self) -> None:
+                    pass
+
+                def close(self) -> None:
+                    pass
+
+        class Status:
+            input_overflow = True
+
+            def __bool__(self) -> bool:
+                return True
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        stream = backend.open_rx(
+            AudioDeviceId(0), sample_rate=48_000, channels=1, frame_ms=20
+        )
+        received: list[bytes] = []
+        await stream.start(received.append)
+
+        cb = captured_cb["cb"]
+        frame = b"\x01\x02" * 960
+        cb(FakeIndata(frame), 960, None, Status())  # type: ignore[operator]
+
+        assert received == [frame]
+        assert stream.capture_health.frames_delivered == 1
+        assert stream.capture_health.input_overflow_events == 1
+        assert stream.capture_health.callback_status_flags == {"input_overflow": 1}
+
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_open_rx_capture_health_records_input_underflow(self) -> None:
+        class FakeIndata:
+            def __init__(self, payload: bytes) -> None:
+                self._payload = payload
+
+            def tobytes(self) -> bytes:
+                return self._payload
+
+        captured_cb: dict[str, object] = {}
+
+        class FakeSd:
+            class InputStream:
+                def __init__(self, **kw: object) -> None:
+                    captured_cb["cb"] = kw["callback"]
+
+                def start(self) -> None:
+                    pass
+
+                def stop(self) -> None:
+                    pass
+
+                def close(self) -> None:
+                    pass
+
+        class Status:
+            input_underflow = True
+
+            def __bool__(self) -> bool:
+                return True
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        stream = backend.open_rx(
+            AudioDeviceId(0), sample_rate=48_000, channels=1, frame_ms=20
+        )
+        received: list[bytes] = []
+        await stream.start(received.append)
+
+        cb = captured_cb["cb"]
+        frame = b"\x03\x04" * 960
+        cb(FakeIndata(frame), 960, None, Status())  # type: ignore[operator]
+
+        assert received == [frame]
+        assert stream.capture_health.frames_delivered == 1
+        assert stream.capture_health.input_underflow_events == 1
+        assert stream.capture_health.callback_status_flags == {"input_underflow": 1}
+
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_open_duplex_capture_health_records_input_overflow_separately(
+        self,
+    ) -> None:
+        class FakeIndata:
+            def __init__(self, payload: bytes) -> None:
+                self._payload = payload
+
+            def tobytes(self) -> bytes:
+                return self._payload
+
+        captured: dict[str, object] = {}
+
+        class FakeSd:
+            class Stream:
+                def __init__(self, **kw: object) -> None:
+                    captured["cb"] = kw["callback"]
+
+                def start(self) -> None:
+                    pass
+
+                def stop(self) -> None:
+                    pass
+
+                def close(self) -> None:
+                    pass
+
+        class Status:
+            input_overflow = True
+
+            def __bool__(self) -> bool:
+                return True
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        stream = backend.open_duplex(
+            AudioDeviceId(0),
+            sample_rate=48_000,
+            channels=1,
+            frame_ms=20,
+            tx_channels=1,
+        )
+        received: list[bytes] = []
+        await stream.start(received.append)
+
+        cb = captured["cb"]
+        frame = b"\x05\x06" * 960
+        outdata = bytearray(960 * 2)
+        cb(FakeIndata(frame), outdata, 960, None, Status())  # type: ignore[operator]
+
+        assert received == [frame]
+        assert stream.capture_health.frames_delivered == 1
+        assert stream.capture_health.input_overflow_events == 1
+        assert stream.capture_health.callback_status_flags == {"input_overflow": 1}
+        assert stream.write_health.callback_status_flags["input_overflow"] == 1
 
         await stream.stop()
 


### PR DESCRIPTION
## Summary
- add additive `RxStreamHealth` with `to_dict()` for capture-side stream diagnostics
- expose `capture_health` on concrete PortAudio RX, duplex, and fake streams without changing `RxStream` / `DuplexStream` protocols
- count PortAudio callback input overflow/underflow status flags for RX-only and duplex capture paths
- keep duplex capture health separate from existing TX `write_health` while preserving playback health behavior

## TDD / RED
- Missing `RxStreamHealth` import failed before implementation
- Missing `FakeDuplexStream.capture_health` failed before fake stream support

## Tests
- `uv run pytest tests/test_audio_backend.py tests/test_audio_duplex.py tests/test_audio_bridge.py tests/test_audio_bridge_stereo.py -q --tb=short` -> 126 passed, 2 skipped
- `uv run pytest tests/ -q --tb=short` -> 8183 passed, 129 skipped, 3 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

## Review
- RX-CAPTURE-HEALTH REVIEW PASS

Refs #1863
Refs #1563
