### PR TITLE
feat(#1864): surface bridge capture health metrics

### DIFF
--- a/src/rigplane/audio/_bridge_metrics.py
+++ b/src/rigplane/audio/_bridge_metrics.py
@@ -25,10 +25,16 @@ class BridgeMetrics:
     rx_frames: int = 0
     tx_frames: int = 0
     rx_drops: int = 0
+    tx_silence_suppressed: int = 0
 
     # Underrun / overrun
     rx_underruns: int = 0
     tx_overruns: int = 0
+    capture_input_overflows: int = 0
+    capture_input_underflows: int = 0
+    capture_callback_status_flags: dict[str, int] = dataclasses.field(
+        default_factory=dict
+    )
 
     # Timing
     uptime_seconds: float = 0.0

--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -1479,7 +1479,13 @@ class FakeRxStream:
         self._callback = None
         self.stopped_count += 1
 
-    def inject_frame(self, frame: bytes) -> None:
+    def inject_frame(
+        self,
+        frame: bytes,
+        *,
+        input_overflow: bool = False,
+        input_underflow: bool = False,
+    ) -> None:
         """Push a frame to the registered callback (test helper).
 
         If *fail_on_inject* is set, raises it once and clears the flag.
@@ -1488,6 +1494,13 @@ class FakeRxStream:
         if exc is not None:
             self.fail_on_inject = None
             raise exc
+        if input_overflow or input_underflow:
+            status = type("_Status", (), {})()
+            if input_overflow:
+                status.input_overflow = True
+            if input_underflow:
+                status.input_underflow = True
+            self._capture_health.record_status(status, input_only=True)
         if self._callback is not None:
             try:
                 self._callback(frame)
@@ -1630,8 +1643,21 @@ class FakeDuplexStream:
             raise RuntimeError("FakeDuplexStream is not running.")
         self.written_frames.append(frame)
 
-    def inject_frame(self, frame: bytes) -> None:
+    def inject_frame(
+        self,
+        frame: bytes,
+        *,
+        input_overflow: bool = False,
+        input_underflow: bool = False,
+    ) -> None:
         """Push an RX capture frame to the registered callback (test helper)."""
+        if input_overflow or input_underflow:
+            status = type("_Status", (), {})()
+            if input_overflow:
+                status.input_overflow = True
+            if input_underflow:
+                status.input_underflow = True
+            self._capture_health.record_status(status, input_only=True)
         if self._callback is not None:
             try:
                 self._callback(frame)

--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -50,6 +50,7 @@ from .backend import (
     DuplexStream,
     PortAudioBackend,
     RxStream,
+    RxStreamHealth,
     TxStream,
 )
 from .session import AudioSession, AudioSessionState, RxSubscription, TxLease
@@ -324,6 +325,12 @@ class AudioBridge:
         self._rx_drops = 0
         self._rx_underruns = 0
         self._tx_overruns = 0
+        self._tx_silence_suppressed = 0
+        self._capture_input_overflows = 0
+        self._capture_input_underflows = 0
+        self._capture_callback_status_flags: dict[str, int] = {}
+        self._capture_health_stream: RxStream | DuplexStream | None = None
+        self._capture_health_last = RxStreamHealth()
         self._rx_latency_samples: list[float] = []
         self._tx_latency_samples: list[float] = []
         self._last_rx_time: float = 0.0
@@ -356,6 +363,7 @@ class AudioBridge:
     @property
     def metrics(self) -> BridgeMetrics:
         """Structured bridge telemetry snapshot."""
+        self._sync_capture_health_metrics()
         uptime = time.monotonic() - self._start_time if self._running else 0.0
         rx_avg = (
             sum(self._rx_latency_samples) / len(self._rx_latency_samples)
@@ -385,8 +393,12 @@ class AudioBridge:
             rx_frames=self._rx_frames,
             tx_frames=self._tx_frames,
             rx_drops=self._rx_drops,
+            tx_silence_suppressed=self._tx_silence_suppressed,
             rx_underruns=self._rx_underruns,
             tx_overruns=self._tx_overruns,
+            capture_input_overflows=self._capture_input_overflows,
+            capture_input_underflows=self._capture_input_underflows,
+            capture_callback_status_flags=dict(self._capture_callback_status_flags),
             uptime_seconds=round(uptime, 1),
             rx_interval_ms=round(rx_avg * 1000, 1),
             tx_interval_ms=round(tx_avg * 1000, 1),
@@ -691,6 +703,7 @@ class AudioBridge:
             self._tx_lease = None
 
         if self._tx_stream is not None:
+            self._sync_capture_health_metrics()
             try:
                 await self._tx_stream.stop()
             except Exception:
@@ -706,6 +719,7 @@ class AudioBridge:
 
         # The single duplex stream serves both directions — stop it once.
         if self._duplex_stream is not None:
+            self._sync_capture_health_metrics()
             try:
                 await self._duplex_stream.stop()
             except Exception:
@@ -926,6 +940,48 @@ class AudioBridge:
             self._tx_queue.put_nowait(frame)
 
     @property
+    def _capture_stream(self) -> RxStream | DuplexStream | None:
+        """Active device→radio capture stream."""
+        if self._duplex_stream is not None:
+            return self._duplex_stream
+        return self._tx_stream
+
+    def _sync_capture_health_metrics(self) -> None:
+        """Accumulate capture callback health into bridge-level counters."""
+        stream = self._capture_stream
+        if stream is None:
+            self._capture_health_stream = None
+            self._capture_health_last = RxStreamHealth()
+            return
+
+        health = getattr(stream, "capture_health", None)
+        if not isinstance(health, RxStreamHealth):
+            return
+
+        if stream is not self._capture_health_stream:
+            self._capture_health_stream = stream
+            self._capture_health_last = RxStreamHealth()
+
+        last = self._capture_health_last
+        if health.input_overflow_events > last.input_overflow_events:
+            self._capture_input_overflows += (
+                health.input_overflow_events - last.input_overflow_events
+            )
+        if health.input_underflow_events > last.input_underflow_events:
+            self._capture_input_underflows += (
+                health.input_underflow_events - last.input_underflow_events
+            )
+        for flag, count in health.callback_status_flags.items():
+            previous = last.callback_status_flags.get(flag, 0)
+            if count > previous:
+                self._capture_callback_status_flags[flag] = (
+                    self._capture_callback_status_flags.get(flag, 0)
+                    + (count - previous)
+                )
+
+        self._capture_health_last = health
+
+    @property
     def _playback_stream(self) -> TxStream | DuplexStream | None:
         """Active radio→device playback stream.
 
@@ -1027,6 +1083,7 @@ class AudioBridge:
                 samples = _pcm16le_samples(pcm_bytes)
                 peak = max((abs(sample) for sample in samples), default=0)
                 if peak < silence_threshold:
+                    self._tx_silence_suppressed += 1
                     continue
 
                 now = time.monotonic()

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -17,6 +17,7 @@ from rigplane.audio.backend import (
     AudioDeviceInfo,
     FakeAudioBackend,
     FakeRxStream,
+    RxStreamHealth,
 )
 from rigplane.audio.lan_stream import AudioPacket
 from rigplane.audio_bridge import (
@@ -116,6 +117,12 @@ def _make_radio() -> types.SimpleNamespace:
 def _bare_radio(**kwargs: object) -> types.SimpleNamespace:
     """Minimal radio stub for tests that don't call bridge.start()."""
     return types.SimpleNamespace(**kwargs)
+
+
+async def _drain_bridge_callbacks() -> None:
+    """Let call_soon_threadsafe + tx loop callbacks run in tests."""
+    for _ in range(5):
+        await asyncio.sleep(0)
 
 
 # ---------------------------------------------------------------------------
@@ -619,6 +626,58 @@ async def test_bridge_tx_queue_overflow_drops_oldest_and_counts_overrun():
     assert bridge._tx_frames == 2
 
 
+def test_metrics_include_dedicated_capture_health_separately_from_queue_overruns():
+    radio = _bare_radio()
+    bridge = AudioBridge(radio)
+    bridge._tx_stream = types.SimpleNamespace(
+        running=True,
+        capture_health=RxStreamHealth(
+            input_overflow_events=2,
+            input_underflow_events=1,
+            callback_status_flags={
+                "input_overflow": 2,
+                "input_underflow": 1,
+            },
+        ),
+    )
+
+    m = bridge.metrics
+
+    assert m.capture_input_overflows == 2
+    assert m.capture_input_underflows == 1
+    assert m.capture_callback_status_flags == {
+        "input_overflow": 2,
+        "input_underflow": 1,
+    }
+    assert m.tx_overruns == 0
+
+
+async def test_bridge_tx_silence_gate_counts_suppressed_frames_separately():
+    radio = _bare_radio(push_audio_tx_pcm=AsyncMock())
+    bridge = AudioBridge(radio)
+    bridge._running = True
+    bridge._tx_stream = types.SimpleNamespace(
+        running=True,
+        capture_health=RxStreamHealth(),
+    )
+
+    silent = b"\x00\x00" * SAMPLES_PER_FRAME
+    bridge._enqueue_tx(silent)
+
+    task = asyncio.create_task(bridge._tx_loop())
+    await asyncio.sleep(0.05)
+    bridge._running = False
+    task.cancel()
+    await task
+
+    m = bridge.metrics
+
+    assert m.tx_silence_suppressed == 1
+    assert m.capture_input_overflows == 0
+    assert m.tx_overruns == 0
+    radio.push_audio_tx_pcm.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # State machine — BridgeState transitions
 # ---------------------------------------------------------------------------
@@ -969,6 +1028,10 @@ def test_metrics_to_dict_backward_compat():
     assert "rx_jitter_ms" in s
     assert "rx_level_dbfs" in s
     assert "tx_overruns" in s
+    assert "capture_input_overflows" in s
+    assert "capture_input_underflows" in s
+    assert "capture_callback_status_flags" in s
+    assert "tx_silence_suppressed" in s
     assert "bridge_state" in s
 
 
@@ -1008,6 +1071,48 @@ async def test_on_metrics_callback():
     assert len(metrics_list) >= 1
     assert isinstance(metrics_list[0], BridgeMetrics)
     assert metrics_list[0].rx_frames > 0
+
+
+async def test_bridge_metrics_surface_capture_overflow_separately_from_queue_drops():
+    radio = _make_radio()
+    backend = _bridge_backend()
+    bridge = AudioBridge(radio, device_name="BlackHole", backend=backend)
+    await bridge.start()
+    try:
+        capture = backend.rx_streams[0]
+        frame = (1000).to_bytes(2, "little", signed=True) * SAMPLES_PER_FRAME
+        capture.inject_frame(frame, input_overflow=True)
+
+        await _drain_bridge_callbacks()
+
+        assert bridge.metrics.capture_input_overflows == 1
+        assert bridge.metrics.capture_input_underflows == 0
+        assert bridge.metrics.capture_callback_status_flags == {"input_overflow": 1}
+        assert bridge.metrics.tx_overruns == 0
+        radio.push_audio_tx_pcm.assert_awaited_once_with(frame)
+    finally:
+        await bridge.stop()
+
+
+async def test_bridge_metrics_track_silence_suppression_separately_from_capture_health():
+    radio = _make_radio()
+    backend = _bridge_backend()
+    bridge = AudioBridge(radio, device_name="BlackHole", backend=backend)
+    await bridge.start()
+    try:
+        capture = backend.rx_streams[0]
+        silence = b"\x00\x00" * SAMPLES_PER_FRAME
+        capture.inject_frame(silence)
+
+        await _drain_bridge_callbacks()
+
+        assert bridge.metrics.tx_silence_suppressed == 1
+        assert bridge.metrics.capture_input_overflows == 0
+        assert bridge.metrics.capture_input_underflows == 0
+        assert bridge.metrics.tx_overruns == 0
+        radio.push_audio_tx_pcm.assert_not_awaited()
+    finally:
+        await bridge.stop()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_audio_duplex.py
+++ b/tests/test_audio_duplex.py
@@ -16,7 +16,9 @@ PortAudio-level callback semantics are exercised against a tiny in-test fake
 
 from __future__ import annotations
 
+import asyncio
 import struct
+import types
 
 import pytest
 
@@ -28,7 +30,9 @@ from rigplane.audio.backend import (
     FakeAudioBackend,
     FakeDuplexStream,
     PortAudioBackend,
+    RxStreamHealth,
 )
+from rigplane.audio_bridge import AudioBridge
 
 DUPLEX_DEVICE = AudioDeviceInfo(
     id=AudioDeviceId(0),
@@ -96,6 +100,34 @@ class TestFakeDuplexStream:
         assert stream.written_frames == [b"\x03\x04"]
         await stream.stop()
         assert not stream.running
+
+
+def test_bridge_metrics_prefer_active_duplex_capture_health() -> None:
+    bridge = AudioBridge(types.SimpleNamespace())
+    bridge._tx_stream = types.SimpleNamespace(
+        running=True,
+        capture_health=RxStreamHealth(input_overflow_events=9),
+    )
+    bridge._duplex_stream = types.SimpleNamespace(
+        running=True,
+        capture_health=RxStreamHealth(
+            input_overflow_events=3,
+            input_underflow_events=2,
+            callback_status_flags={
+                "input_overflow": 3,
+                "input_underflow": 2,
+            },
+        ),
+    )
+
+    m = bridge.metrics
+
+    assert m.capture_input_overflows == 3
+    assert m.capture_input_underflows == 2
+    assert m.capture_callback_status_flags == {
+        "input_overflow": 3,
+        "input_underflow": 2,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -431,5 +463,34 @@ class TestBridgeDuplexSelection:
             assert backend.duplex_streams == []
             assert len(backend.tx_streams) == 1  # radio→device playback only
             assert backend.rx_streams == []  # no capture leg
+        finally:
+            await bridge.stop()
+
+    @pytest.mark.asyncio()
+    async def test_bridge_duplex_metrics_surface_capture_overflow_separately(
+        self,
+    ) -> None:
+        from rigplane.audio.bridge import AudioBridge
+
+        backend = FakeAudioBackend(devices=[DUPLEX_DEVICE])
+        radio = _FakeRadio()
+        bridge = AudioBridge(
+            radio,  # type: ignore[arg-type]
+            device_name="USB Audio CODEC",
+            backend=backend,
+            tx_enabled=True,
+        )
+        await bridge.start()
+        try:
+            capture = backend.duplex_streams[0]
+            frame = b"\x10\x00" * 960
+            capture.inject_frame(frame, input_overflow=True)
+
+            for _ in range(5):
+                await asyncio.sleep(0)
+
+            assert bridge.metrics.capture_input_overflows == 1
+            assert bridge.metrics.capture_input_underflows == 0
+            assert bridge.metrics.tx_overruns == 0
         finally:
             await bridge.stop()


### PR DESCRIPTION
## Summary

- add additive bridge/runtime metrics for capture callback health: `capture_input_overflows`, `capture_input_underflows`, and `capture_callback_status_flags`
- add separate `tx_silence_suppressed` metric for silence/noise-gate suppression
- keep `tx_overruns` as queue/backpressure drops and cover dedicated capture plus duplex paths with fake-stream tests

Closes #1864

## Verification

- `uv run pytest tests/test_audio_bridge.py tests/test_audio_bridge_stereo.py tests/test_audio_duplex.py -q --tb=short` -> `86 passed, 2 skipped`
- `uv run pytest tests/test_audio_backend.py -q --tb=short` -> `46 passed`
- `uv run ruff check src/ tests/` -> passed
- `uv run ruff format --check src/ tests/` -> passed
- `uv run pytest tests/ -q --tb=short` -> `8189 passed, 129 skipped, 3 deselected, 11 xfailed, 1 xpassed`

## Review

Independent agent review: PASS by Mill (`gpt-5.5`, high). Blocking findings: none.
