### PR TITLE
docs(#1865): document audio capture health diagnostics

### DIFF
--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -55,6 +55,65 @@ print(stats["packet_loss_percent"], stats["reorder_depth_ema_ms"])
 | `stale_packets_dropped` | packets | `>= 0` | Stale/old RX packets dropped |
 | `out_of_order_packets` | packets | `>= 0` | RX packets observed out of sequence |
 
+## Capture Health And Bridge Metrics
+
+PortAudio-backed capture and the PCM TX bridge expose a second set of metrics
+that answer a different question from `get_audio_stats()`: whether the local
+OS audio callback and the bridge TX path are keeping up.
+
+### Capture callback health (`RxStreamHealth`)
+
+`RxStreamHealth` snapshots input-side callback delivery for RX-only and
+full-duplex capture streams.
+
+| Field | Unit | Meaning | Typical next step |
+|------|------|---------|-------------------|
+| `frames_delivered` | frames | PCM frames successfully handed to the bridge/callback | Confirms the callback is running at all |
+| `input_overflow_events` | events | PortAudio reported captured input was dropped because the process/backend could not keep up | Check host CPU pressure, device/driver stability, and callback cadence before blaming RigPlane TX |
+| `input_underflow_events` | events | PortAudio reported the input callback arrived without enough fresh captured samples | Check capture device/driver health and OS scheduling; this is still capture-side, not radio TX failure |
+| `callback_errors` | events | Callback-level errors while processing capture frames | Inspect logs for the paired exception or status context |
+| `callback_status_flags` | map | Per-flag totals such as `input_overflow` / `input_underflow` | Use the exact flag mix to separate capture starvation from other failures |
+
+### Bridge TX path health (`BridgeMetrics`)
+
+These counters are surfaced on `AudioBridge.metrics`, `AudioBridge.stats`, and
+runtime bridge-status consumers such as the Web server's `audio_bridge_stats`.
+
+| Field | Unit | Meaning | Not the same as |
+|------|------|---------|-----------------|
+| `capture_input_overflows` | events | Cumulative `RxStreamHealth.input_overflow_events` observed by the active bridge capture stream | `tx_overruns` queue drops |
+| `capture_input_underflows` | events | Cumulative `RxStreamHealth.input_underflow_events` observed by the active bridge capture stream | TX playback underruns or radio write failures |
+| `capture_callback_status_flags` | map | Bridge-side rollup of capture callback flags, for example `{"input_overflow": 3}` | Silence gating decisions |
+| `tx_silence_suppressed` | frames | Frames intentionally skipped because captured PCM stayed below the bridge silence/noise-gate threshold | Capture overrun or lost OS buffers |
+| `tx_overruns` | events | Bridge TX queue drops: RigPlane evicted stale queued frames to preserve bounded latency before `push_audio_tx_pcm()` | PortAudio callback overflow |
+
+### TX playback write health (`TxStreamHealth`)
+
+These counters live on the writable PortAudio TX stream itself and describe
+playback-side queue pressure after audio has already left the bridge queue.
+
+| Field | Unit | Meaning | Not the same as |
+|------|------|---------|-----------------|
+| `overrun_events` | events | TX playback queue overflow events on the writable stream | `BridgeMetrics.tx_overruns` bridge queue drops |
+| `overrun_audio_ms` | milliseconds | Total playback-queue audio duration dropped during TX stream overflow handling | Bridge capture callback overflow |
+| `frames_dropped` | frames | TX playback frames dropped by the writable stream while preserving bounded latency | Silence gating or radio write failure |
+
+### Interpretation Rules
+
+- `capture_input_overflows > 0` means the OS capture callback already lost input
+  before RigPlane could bridge it. Start with local capture/device pressure.
+- `tx_overruns > 0` with zero capture overflow means capture kept running, but
+  the bridge TX queue backed up and RigPlane dropped stale frames on purpose.
+- `TxStreamHealth.overrun_events > 0`, `overrun_audio_ms > 0`, or
+  `frames_dropped > 0` mean the writable TX playback queue overflowed later in
+  the path; that is distinct from bridge queue pressure and uses different
+  counters.
+- `tx_silence_suppressed > 0` means quiet frames were filtered by policy. This
+  is expected during RX silence and is not evidence of callback starvation.
+- Downstream TX push/write failures live elsewhere: `TxStreamHealth.write_failures`,
+  `last_error`, or radio/backend error logs indicate that RigPlane tried to
+  send audio onward and that stage failed after capture succeeded.
+
 ## AudioPacket
 
 ::: rigplane.audio.lan_stream.AudioPacket
@@ -141,11 +200,18 @@ subscriber.
 
 ## Queue And Frame Semantics
 
-Audio queues are bounded to preserve real-time behavior. When a TX playback or
-bridge capture queue overflows, RigPlane drops the oldest queued audio and
-keeps the newest live frame. This intentionally favors bounded latency over
-perfect delivery of stale audio. Diagnostics count the event as an overrun and
-record dropped/overrun audio duration when that metric is available.
+Audio queues are bounded to preserve real-time behavior. When the bridge TX
+queue overflows, RigPlane drops the oldest queued audio and keeps the newest
+live frame. Diagnostics count that bridge-side event as `tx_overruns`.
+
+When the writable TX playback queue overflows later in the path, `TxStreamHealth`
+tracks it separately via `overrun_events`, `overrun_audio_ms`, and
+`frames_dropped`. Those playback counters are not reported as `tx_overruns`.
+
+Do not confuse bridge queue drops with PortAudio capture callback overflow:
+`tx_overruns` means RigPlane chose to evict stale already-captured audio,
+whereas `capture_input_overflows` / `input_overflow_events` mean the OS/backend
+capture callback reported lost input before the bridge queue decision.
 
 PortAudio capture uses engine-native callback periods (`blocksize=0`) and then
 losslessly re-chunks the continuous callback stream into fixed `frame_ms`

--- a/docs/guide/audio-recipes.md
+++ b/docs/guide/audio-recipes.md
@@ -126,6 +126,63 @@ export RIGPLANE_HW_AUDIO_FRAMES=20
 
 ---
 
+## TX reverse-path health: what to check first
+
+When reverse-path audio fails, separate the symptom before changing devices or
+radio mode:
+
+1. `capture_input_overflows` / `capture_input_underflows`
+   PortAudio capture callback trouble. The OS audio input side is already
+   losing or starving samples.
+2. `tx_overruns`
+   Bridge queue pressure. RigPlane captured audio, but dropped stale queued
+   frames to keep latency bounded before TX push.
+3. `tx_silence_suppressed`
+   Intentional silence/noise-gate filtering. Quiet frames were skipped by
+   policy; this is not a capture failure.
+4. Downstream TX push/write failures
+   The capture side succeeded, but the radio/backend TX stage rejected or
+   failed to write audio.
+
+### Quick operator actions
+
+| Signal | What it usually means | Try next |
+| --- | --- | --- |
+| `capture_input_overflows` rising | Local capture callback is missing deadlines | Reduce host CPU pressure, confirm the selected input device is stable, and retry before changing radio settings |
+| `tx_overruns` rising with capture overflow at `0` | The bridge TX queue is backing up, not the input callback | Check the downstream TX path, queue pressure, and whether the consumer is slower than real time |
+| `tx_silence_suppressed` rising while capture overflow stays at `0` | RigPlane is suppressing near-silence on purpose | Confirm your source is actually above the gate threshold before treating this as a transport bug |
+| Capture counters stay at `0`, but TX still fails | The failure is after capture | Inspect radio/backend TX write errors and mode or route policy only after capture looks healthy |
+
+Maintainers and agents debugging saved metrics should follow the deterministic
+[internal capture-health checklist](../internals/audio-capture-health.md).
+
+### Example snapshot
+
+```json
+{
+  "bridge_state": "running",
+  "capture_input_overflows": 4,
+  "capture_input_underflows": 0,
+  "capture_callback_status_flags": {
+    "input_overflow": 4
+  },
+  "tx_overruns": 0,
+  "tx_silence_suppressed": 0
+}
+```
+
+Interpretation: this is a capture-side problem, not a bridge queue problem.
+PortAudio already reported dropped input before RigPlane had a chance to queue
+or suppress anything. Start with the local capture device, driver, and host
+scheduling pressure. Do not treat this as silence gating, and do not assume the
+radio TX path is the first failure point.
+
+If the same snapshot instead showed `tx_overruns: 4` and
+`capture_input_overflows: 0`, capture would be healthy and the bridge would be
+dropping stale queued frames later in the reverse path.
+
+---
+
 ## 1) RX → WAV file (10 seconds)
 
 Saves the incoming audio stream from the radio to `rx.wav`.

--- a/docs/guide/diagnostic-reports.md
+++ b/docs/guide/diagnostic-reports.md
@@ -121,6 +121,15 @@ IC-7610 can request radio-native `PCM_2CH_16BIT` at `48000` Hz from its profile
 while the Web UI emits Opus as a browser transport. That means only the browser
 leg is Opus; the direct radio LAN stream remains PCM.
 
+`audio/audio.json` is contract and device metadata, not a live bridge-health
+snapshot. It tells you which radio-native and browser-facing audio contracts
+were selected, plus whether the bridge was active when the bundle was created.
+Capture callback counters such as `capture_input_overflows`,
+`capture_input_underflows`, `capture_callback_status_flags`, bridge queue drops
+such as `tx_overruns`, and silence-gate counters such as
+`tx_silence_suppressed` come from runtime bridge metrics or logs, not from the
+static diagnostic contributor payload.
+
 ## Privacy
 
 The diagnostic report carve-out in

--- a/docs/internals/audio-capture-health.md
+++ b/docs/internals/audio-capture-health.md
@@ -1,0 +1,132 @@
+---
+robots: noindex, follow
+---
+
+# Audio capture health triage
+
+This note is for agents and maintainers diagnosing TX reverse-path failures
+from logs, runtime metrics, or diagnostic bundles.
+
+## Scope
+
+Use this checklist when RigPlane is capturing local PCM and forwarding it
+toward radio TX through `AudioBridge`. The goal is to separate:
+
+- PortAudio capture callback overflow or underflow;
+- bridge queue drops or backpressure;
+- silence or noise-gate suppression;
+- downstream TX push or write failures after capture succeeds.
+
+Do not use this doc to infer customer-specific support steps. Keep triage at
+the public open-core behavior boundary.
+
+## Deterministic triage order
+
+1. Confirm the bridge is actually running.
+   - Check `bridge_state == "running"` and that `rx_frames` or
+     `frames_delivered` are moving.
+   - If frames never advance, this is not yet a queue-pressure or radio-write
+     problem.
+2. Check capture callback health first.
+   - Read `capture_input_overflows`, `capture_input_underflows`, and
+     `capture_callback_status_flags`.
+   - If any capture counter is rising, stop here and treat the first fault as
+     local capture pressure or device instability.
+3. Check bridge queue drops next.
+   - Read `tx_overruns`.
+   - Non-zero `tx_overruns` with zero capture overflows means RigPlane is
+     dropping stale queued frames after capture, to preserve latency.
+4. Check silence suppression separately.
+   - Read `tx_silence_suppressed`.
+   - Rising silence suppression with zero capture overflows means the source is
+     below the bridge gate threshold, not that PortAudio lost buffers.
+5. Check downstream TX failures only after capture looks healthy.
+   - Inspect `write_failures`, `last_error`, raised exceptions, or backend/radio
+     TX logs.
+   - This is where push/write rejection belongs.
+6. Only then inspect mode, DATA policy, route policy, or codec negotiation.
+   - Those may block successful TX, but they are later than capture-health and
+     queue-pressure faults.
+
+## Field meanings
+
+| Field | Meaning | First interpretation |
+| --- | --- | --- |
+| `capture_input_overflows` | Active bridge saw input-side callback overflow events | OS/backend capture lost input before bridge queueing |
+| `capture_input_underflows` | Active bridge saw input-side callback underflow events | Capture callback ran without enough fresh source samples |
+| `capture_callback_status_flags` | Rollup of exact input callback flags | Confirms which callback condition occurred |
+| `tx_overruns` | Bridge TX queue evicted stale frames | Capture succeeded; latency protection dropped queued audio later |
+| `tx_silence_suppressed` | Frames skipped because peak stayed below gate threshold | Intentional policy, not callback starvation |
+| `write_failures` / `last_error` | TX write or push failed after capture | Downstream radio/backend failure |
+
+## Example snapshots
+
+### Healthy capture, silence-gated source
+
+```json
+{
+  "bridge_state": "running",
+  "capture_input_overflows": 0,
+  "capture_input_underflows": 0,
+  "capture_callback_status_flags": {},
+  "tx_overruns": 0,
+  "tx_silence_suppressed": 18
+}
+```
+
+Interpretation: reverse-path capture is healthy. RigPlane is intentionally
+dropping near-silent frames. Check source level and gate expectations before
+investigating transport.
+
+### Bad capture callback, not a queue drop
+
+```json
+{
+  "bridge_state": "running",
+  "capture_input_overflows": 6,
+  "capture_input_underflows": 1,
+  "capture_callback_status_flags": {
+    "input_overflow": 6,
+    "input_underflow": 1
+  },
+  "tx_overruns": 0,
+  "tx_silence_suppressed": 0
+}
+```
+
+Interpretation: the first failure is at the local capture callback. The bridge
+never needed to drop queued frames, and silence gating is irrelevant here. Look
+at host scheduling pressure, capture device stability, or callback cadence.
+
+### Queue pressure after healthy capture
+
+```json
+{
+  "bridge_state": "running",
+  "capture_input_overflows": 0,
+  "capture_input_underflows": 0,
+  "capture_callback_status_flags": {},
+  "tx_overruns": 9,
+  "tx_silence_suppressed": 0
+}
+```
+
+Interpretation: capture is healthy. RigPlane is evicting stale queued frames
+later in the TX bridge path. Investigate downstream consumption speed, not the
+capture device.
+
+## Diagnostic bundle notes
+
+- `audio/audio.json` records contract, device, and bridge-active metadata.
+- It does not carry live `capture_input_overflows`, `tx_overruns`, or
+  `tx_silence_suppressed` counters by itself.
+- When only a diagnostic bundle is available, use it to confirm the selected
+  contract and device first, then correlate with runtime logs or separately
+  captured bridge stats.
+
+## Test and CI notes
+
+CI coverage for these semantics uses fake audio backends and fake PortAudio
+status flags in unit tests such as `tests/test_audio_backend.py`,
+`tests/test_audio_bridge.py`, and `tests/test_audio_duplex.py`. No live radio
+or hardware validation is required to confirm the documented field meanings.

--- a/tests/test_docs_runtime_sync.py
+++ b/tests/test_docs_runtime_sync.py
@@ -109,3 +109,51 @@ def test_docs_sync_web_ui_invariants() -> None:
             r"scope.*(defer|deferred).*radio_ready",
         ],
     )
+
+
+def test_docs_sync_audio_capture_health_invariants() -> None:
+    _assert_doc_patterns(
+        "docs/api/audio.md",
+        [
+            r"RxStreamHealth",
+            r"capture_input_overflows",
+            r"capture_input_underflows",
+            r"capture_callback_status_flags",
+            r"tx_silence_suppressed",
+            r"tx_overruns",
+            r"Bridge TX queue drops",
+            r"TxStreamHealth",
+            r"overrun_events",
+            r"overrun_audio_ms",
+            r"frames_dropped",
+        ],
+    )
+    _assert_doc_patterns(
+        "docs/guide/audio-recipes.md",
+        [
+            r"TX reverse-path health",
+            r"capture_input_overflows",
+            r"tx_overruns",
+            r"tx_silence_suppressed",
+        ],
+    )
+    _assert_doc_patterns(
+        "docs/guide/diagnostic-reports.md",
+        [
+            r"audio/audio\.json",
+            r"contract and device metadata",
+            r"live bridge[- ]health",
+            r"capture_input_overflows",
+            r"tx_overruns",
+        ],
+    )
+    _assert_doc_patterns(
+        "docs/internals/audio-capture-health.md",
+        [
+            r"Deterministic triage order",
+            r"fake PortAudio",
+            r"status flags",
+            r"tx_silence_suppressed",
+            r"write_failures",
+        ],
+    )


### PR DESCRIPTION
## Summary

- document the audio capture-health model for operators and agents
- add a canonical API field table covering capture callback health, bridge queue drops, silence suppression, and TX playback health
- add docs-runtime sync checks for the new field names and `tx_overruns` scope

Refs #1865

## Verification

- `uv run pytest tests/test_docs_runtime_sync.py -q --tb=short` -> `6 passed`
- `uv run pytest tests/test_diagnostics_contributors_batch2.py -q --tb=short` -> `24 passed`
- `uv run ruff check src/ tests/` -> passed
- `uv run ruff format --check src/ tests/` -> passed
- `uv run pytest tests/ -q --tb=short` -> `8190 passed, 129 skipped, 3 deselected, 11 xfailed, 1 xpassed`

## Review

Independent agent review: PASS by Laplace (`gpt-5.5`, medium) after addressing the initial doc accuracy finding about `tx_overruns` scope.
