### PR TITLE
[codex] Split TX health producer and callback metrics

### DIFF
--- a/docs/api/audio.md
+++ b/docs/api/audio.md
@@ -94,9 +94,45 @@ playback-side queue pressure after audio has already left the bridge queue.
 
 | Field | Unit | Meaning | Not the same as |
 |------|------|---------|-----------------|
-| `overrun_events` | events | TX playback queue overflow events on the writable stream | `BridgeMetrics.tx_overruns` bridge queue drops |
-| `overrun_audio_ms` | milliseconds | Total playback-queue audio duration dropped during TX stream overflow handling | Bridge capture callback overflow |
+| `frames_queued` | frames | Total frames accepted from the producer/write side | Callback playback completions |
+| `enqueued_audio_ms` | milliseconds | Total audio duration accepted from producer writes | Current live queue depth |
+| `buffered_audio_ms` | milliseconds | Current queued playback audio still buffered in the writable stream | Cumulative accepted or consumed audio |
 | `frames_dropped` | frames | TX playback frames dropped by the writable stream while preserving bounded latency | Silence gating or radio write failure |
+| `dropped_audio_ms` | milliseconds | Total duration represented by dropped playback frames | Callback underruns |
+| `enqueue_overrun_events` | events | TX playback queue overflow events on the writable stream | `BridgeMetrics.tx_overruns` bridge queue drops |
+| `enqueue_overrun_audio_ms` | milliseconds | Total playback-queue audio duration dropped during TX stream overflow handling | Bridge capture callback overflow |
+| `write_attempts` | callbacks | Total playback callback attempts / output fill cycles | Producer `write()` calls |
+| `writes_completed` | callbacks | Playback callbacks that completed their output fill path | Producer enqueue success count |
+| `write_failures` | events | Playback callback failures or fake-stream write failures | Queue overflow or underrun counters |
+| `callback_consumed_audio_ms` | milliseconds | Audio duration actually consumed from the queued ring by the playback callback | Silence padded during underrun |
+| `callback_output_audio_ms` | milliseconds | Total output duration the callback filled, including silence on underrun | Audio duration consumed from the queue |
+| `callback_underrun_events` | events | Playback callbacks that had to pad with silence because queued audio ran short | Bridge queue overflow |
+| `callback_underrun_audio_ms` | milliseconds | Total silence-padded output duration caused by playback underruns | Queue drops on producer overflow |
+| `callback_calls_per_sec_ewma` | callbacks/sec | Smoothed callback cadence estimate for the active PortAudio stream | Producer write rate |
+| `callback_errors` | events | Callback-level errors while filling playback output | Bridge capture callback errors |
+| `callback_status_flags` | map | Per-flag totals such as `output_underflow` from PortAudio status callbacks | Bridge metrics or radio send errors |
+| `last_error` | string or `null` | Most recent callback/write failure summary | Callback status flag counts |
+
+Canonical producer/callback names above are the stable contract. Legacy aliases
+remain available on `TxStreamHealth` attributes and in `TxStreamHealth.to_dict()`
+for compatibility during the deprecation window:
+
+- `queued_audio_ms` -> `enqueued_audio_ms`
+- `consumed_audio_ms` -> `callback_consumed_audio_ms`
+- `written_audio_ms` -> `callback_output_audio_ms`
+- `overrun_audio_ms` -> `enqueue_overrun_audio_ms`
+- `overrun_events` -> `enqueue_overrun_events`
+- `underrun_audio_ms` -> `callback_underrun_audio_ms`
+- `underrun_events` -> `callback_underrun_events`
+- `write_calls_per_sec_ewma` -> `callback_calls_per_sec_ewma`
+
+PortAudio-backed TX streams populate `write_attempts`, `writes_completed`,
+callback cadence, and the callback-duration fields from actual playback-callback
+activity. Fake TX/test-double streams are compatibility helpers rather than
+PortAudio callback simulators: `FakeTxStream` keeps its historical producer-write
+accounting, while duplex test doubles may only report captured write frames and
+leave callback attempt, duration, or cadence fields at their defaults unless
+they explicitly simulate playback.
 
 ### Interpretation Rules
 
@@ -104,10 +140,11 @@ playback-side queue pressure after audio has already left the bridge queue.
   before RigPlane could bridge it. Start with local capture/device pressure.
 - `tx_overruns > 0` with zero capture overflow means capture kept running, but
   the bridge TX queue backed up and RigPlane dropped stale frames on purpose.
-- `TxStreamHealth.overrun_events > 0`, `overrun_audio_ms > 0`, or
-  `frames_dropped > 0` mean the writable TX playback queue overflowed later in
-  the path; that is distinct from bridge queue pressure and uses different
-  counters.
+- `TxStreamHealth.enqueue_overrun_events > 0`,
+  `enqueue_overrun_audio_ms > 0`, or `frames_dropped > 0` mean the writable TX
+  playback queue overflowed later in the path; that is distinct from bridge
+  queue pressure and uses different counters. Legacy alias names still report
+  the same values.
 - `tx_silence_suppressed > 0` means quiet frames were filtered by policy. This
   is expected during RX silence and is not evidence of callback starvation.
 - Downstream TX push/write failures live elsewhere: `TxStreamHealth.write_failures`,
@@ -205,8 +242,10 @@ queue overflows, RigPlane drops the oldest queued audio and keeps the newest
 live frame. Diagnostics count that bridge-side event as `tx_overruns`.
 
 When the writable TX playback queue overflows later in the path, `TxStreamHealth`
-tracks it separately via `overrun_events`, `overrun_audio_ms`, and
-`frames_dropped`. Those playback counters are not reported as `tx_overruns`.
+tracks it separately via `enqueue_overrun_events`,
+`enqueue_overrun_audio_ms`, and `frames_dropped`. Those playback counters are
+not reported as `tx_overruns`. Legacy aliases `overrun_events` and
+`overrun_audio_ms` still mirror the canonical values for compatibility.
 
 Do not confuse bridge queue drops with PortAudio capture callback overflow:
 `tx_overruns` means RigPlane chose to evict stale already-captured audio,

--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -118,6 +118,51 @@ class TxStreamHealth:
     callback_status_flags: dict[str, int] = field(default_factory=dict)
     write_calls_per_sec_ewma: float | None = None
     last_error: str | None = None
+    enqueued_audio_ms: float = 0.0
+    callback_consumed_audio_ms: float = 0.0
+    callback_output_audio_ms: float = 0.0
+    enqueue_overrun_audio_ms: float = 0.0
+    enqueue_overrun_events: int = 0
+    callback_underrun_audio_ms: float = 0.0
+    callback_underrun_events: int = 0
+    callback_calls_per_sec_ewma: float | None = None
+
+    def __post_init__(self) -> None:
+        self._sync_alias_pair("enqueued_audio_ms", "queued_audio_ms", 0.0)
+        self._sync_alias_pair("callback_consumed_audio_ms", "consumed_audio_ms", 0.0)
+        self._sync_alias_pair("callback_output_audio_ms", "written_audio_ms", 0.0)
+        self._sync_alias_pair("enqueue_overrun_audio_ms", "overrun_audio_ms", 0.0)
+        self._sync_alias_pair("enqueue_overrun_events", "overrun_events", 0)
+        self._sync_alias_pair("callback_underrun_audio_ms", "underrun_audio_ms", 0.0)
+        self._sync_alias_pair("callback_underrun_events", "underrun_events", 0)
+        self._sync_alias_pair(
+            "callback_calls_per_sec_ewma",
+            "write_calls_per_sec_ewma",
+            None,
+        )
+
+    def _sync_alias_pair(
+        self,
+        canonical_name: str,
+        legacy_name: str,
+        default: float | int | None,
+    ) -> None:
+        canonical_value = getattr(self, canonical_name)
+        legacy_value = getattr(self, legacy_name)
+        if (
+            canonical_value != default
+            and legacy_value != default
+            and canonical_value != legacy_value
+        ):
+            raise ValueError(
+                "Conflicting TxStreamHealth alias values for "
+                f"{canonical_name} and {legacy_name}: "
+                f"{canonical_value!r} != {legacy_value!r}"
+            )
+        if canonical_value == default and legacy_value != default:
+            object.__setattr__(self, canonical_name, legacy_value)
+        elif legacy_value == default and canonical_value != default:
+            object.__setattr__(self, legacy_name, canonical_value)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -127,17 +172,25 @@ class TxStreamHealth:
             "write_attempts": self.write_attempts,
             "writes_completed": self.writes_completed,
             "write_failures": self.write_failures,
+            "enqueued_audio_ms": self.enqueued_audio_ms,
             "queued_audio_ms": self.queued_audio_ms,
             "buffered_audio_ms": self.buffered_audio_ms,
+            "callback_consumed_audio_ms": self.callback_consumed_audio_ms,
             "consumed_audio_ms": self.consumed_audio_ms,
+            "callback_output_audio_ms": self.callback_output_audio_ms,
             "written_audio_ms": self.written_audio_ms,
             "dropped_audio_ms": self.dropped_audio_ms,
+            "enqueue_overrun_audio_ms": self.enqueue_overrun_audio_ms,
             "overrun_audio_ms": self.overrun_audio_ms,
+            "enqueue_overrun_events": self.enqueue_overrun_events,
             "overrun_events": self.overrun_events,
+            "callback_underrun_audio_ms": self.callback_underrun_audio_ms,
             "underrun_audio_ms": self.underrun_audio_ms,
+            "callback_underrun_events": self.callback_underrun_events,
             "underrun_events": self.underrun_events,
             "callback_errors": self.callback_errors,
             "callback_status_flags": dict(self.callback_status_flags),
+            "callback_calls_per_sec_ewma": self.callback_calls_per_sec_ewma,
             "write_calls_per_sec_ewma": self.write_calls_per_sec_ewma,
             "last_error": self.last_error,
         }
@@ -771,18 +824,18 @@ class _PortAudioTxStream:
                 write_attempts=self._write_attempts,
                 writes_completed=self._writes_completed,
                 write_failures=self._write_failures,
-                queued_audio_ms=round(self._queued_audio_ms, 3),
+                enqueued_audio_ms=round(self._queued_audio_ms, 3),
                 buffered_audio_ms=round(buffered_audio_ms, 3),
-                consumed_audio_ms=round(self._consumed_audio_ms, 3),
-                written_audio_ms=round(self._written_audio_ms, 3),
+                callback_consumed_audio_ms=round(self._consumed_audio_ms, 3),
+                callback_output_audio_ms=round(self._written_audio_ms, 3),
                 dropped_audio_ms=round(self._dropped_audio_ms, 3),
-                overrun_audio_ms=round(self._overrun_audio_ms, 3),
-                overrun_events=self._overrun_events,
-                underrun_audio_ms=round(self._underrun_audio_ms, 3),
-                underrun_events=self._underrun_events,
+                enqueue_overrun_audio_ms=round(self._overrun_audio_ms, 3),
+                enqueue_overrun_events=self._overrun_events,
+                callback_underrun_audio_ms=round(self._underrun_audio_ms, 3),
+                callback_underrun_events=self._underrun_events,
                 callback_errors=self._callback_errors,
                 callback_status_flags=dict(self._callback_status_flags),
-                write_calls_per_sec_ewma=(
+                callback_calls_per_sec_ewma=(
                     round(self._write_calls_per_sec_ewma, 3)
                     if self._write_calls_per_sec_ewma is not None
                     else None

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -108,6 +108,129 @@ class TestProtocolConformance:
         assert health["overrun_events"] == 0
         assert health["underrun_events"] == 0
 
+    def test_tx_stream_health_exports_canonical_and_legacy_metric_keys(self) -> None:
+        health = TxStreamHealth(
+            enqueued_audio_ms=1.5,
+            callback_consumed_audio_ms=2.5,
+            callback_output_audio_ms=3.5,
+            enqueue_overrun_audio_ms=4.5,
+            enqueue_overrun_events=6,
+            callback_underrun_audio_ms=7.5,
+            callback_underrun_events=8,
+            callback_calls_per_sec_ewma=9.5,
+        ).to_dict()
+
+        assert health["enqueued_audio_ms"] == 1.5
+        assert health["callback_consumed_audio_ms"] == 2.5
+        assert health["callback_output_audio_ms"] == 3.5
+        assert health["enqueue_overrun_audio_ms"] == 4.5
+        assert health["enqueue_overrun_events"] == 6
+        assert health["callback_underrun_audio_ms"] == 7.5
+        assert health["callback_underrun_events"] == 8
+        assert health["callback_calls_per_sec_ewma"] == 9.5
+        assert health["queued_audio_ms"] == 1.5
+        assert health["consumed_audio_ms"] == 2.5
+        assert health["written_audio_ms"] == 3.5
+        assert health["overrun_audio_ms"] == 4.5
+        assert health["overrun_events"] == 6
+        assert health["underrun_audio_ms"] == 7.5
+        assert health["underrun_events"] == 8
+        assert health["write_calls_per_sec_ewma"] == 9.5
+
+    def test_tx_stream_health_legacy_metric_constructor_mirrors_canonical_keys(
+        self,
+    ) -> None:
+        health = TxStreamHealth(
+            queued_audio_ms=1.5,
+            consumed_audio_ms=2.5,
+            written_audio_ms=3.5,
+            overrun_audio_ms=4.5,
+            overrun_events=6,
+            underrun_audio_ms=7.5,
+            underrun_events=8,
+            write_calls_per_sec_ewma=9.5,
+        )
+
+        assert health.enqueued_audio_ms == 1.5
+        assert health.callback_consumed_audio_ms == 2.5
+        assert health.callback_output_audio_ms == 3.5
+        assert health.enqueue_overrun_audio_ms == 4.5
+        assert health.enqueue_overrun_events == 6
+        assert health.callback_underrun_audio_ms == 7.5
+        assert health.callback_underrun_events == 8
+        assert health.callback_calls_per_sec_ewma == 9.5
+        assert health.to_dict()["enqueued_audio_ms"] == 1.5
+        assert health.to_dict()["callback_calls_per_sec_ewma"] == 9.5
+
+    def test_tx_stream_health_rejects_conflicting_alias_values(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="enqueued_audio_ms.*queued_audio_ms",
+        ):
+            TxStreamHealth(enqueued_audio_ms=1.0, queued_audio_ms=2.0)
+
+        with pytest.raises(
+            ValueError,
+            match="callback_calls_per_sec_ewma.*write_calls_per_sec_ewma",
+        ):
+            TxStreamHealth(
+                callback_calls_per_sec_ewma=1.0,
+                write_calls_per_sec_ewma=2.0,
+            )
+
+    def test_tx_stream_health_preserves_legacy_positional_constructor_order(
+        self,
+    ) -> None:
+        health = TxStreamHealth(
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7.5,
+            8.5,
+            9.5,
+            10.5,
+            11.5,
+            12.5,
+            13,
+            14.5,
+            15,
+            16,
+            {"output_underflow": 2},
+            17.5,
+            "backend write failed",
+        )
+
+        assert health.queued_frames == 1
+        assert health.frames_queued == 2
+        assert health.frames_dropped == 3
+        assert health.write_attempts == 4
+        assert health.writes_completed == 5
+        assert health.write_failures == 6
+        assert health.queued_audio_ms == 7.5
+        assert health.buffered_audio_ms == 8.5
+        assert health.consumed_audio_ms == 9.5
+        assert health.written_audio_ms == 10.5
+        assert health.dropped_audio_ms == 11.5
+        assert health.overrun_audio_ms == 12.5
+        assert health.overrun_events == 13
+        assert health.underrun_audio_ms == 14.5
+        assert health.underrun_events == 15
+        assert health.callback_errors == 16
+        assert health.callback_status_flags == {"output_underflow": 2}
+        assert health.write_calls_per_sec_ewma == 17.5
+        assert health.last_error == "backend write failed"
+        assert health.enqueued_audio_ms == 7.5
+        assert health.callback_consumed_audio_ms == 9.5
+        assert health.callback_output_audio_ms == 10.5
+        assert health.enqueue_overrun_audio_ms == 12.5
+        assert health.enqueue_overrun_events == 13
+        assert health.callback_underrun_audio_ms == 14.5
+        assert health.callback_underrun_events == 15
+        assert health.callback_calls_per_sec_ewma == 17.5
+
     def test_rx_stream_health_is_exported(self) -> None:
         health = RxStreamHealth().to_dict()
         assert health["frames_delivered"] == 0
@@ -235,6 +358,24 @@ class TestFakeDuplexStreamCaptureHealth:
         assert stream.capture_health.frames_delivered == 1
         assert stream.capture_health.input_overflow_events == 0
         assert stream.capture_health.input_underflow_events == 0
+
+        await stream.stop()
+
+    @pytest.mark.asyncio()
+    async def test_write_health_preserves_test_double_snapshot_shape(
+        self, fake_backend: FakeAudioBackend
+    ) -> None:
+        stream = fake_backend.open_duplex(DUPLEX_DEVICE.id)
+        await stream.start(lambda _: None)
+
+        await stream.write(b"\x00\x01")
+        health = stream.write_health
+
+        assert health.frames_queued == 1
+        assert health.writes_completed == 1
+        assert health.write_attempts == 0
+        assert health.enqueued_audio_ms == 0.0
+        assert health.callback_calls_per_sec_ewma is None
 
         await stream.stop()
 
@@ -886,12 +1027,17 @@ class TestPortAudioBackendDeps:
         assert health.frames_dropped == 0
         assert health.write_attempts == 50
         assert health.writes_completed == 50
+        assert health.enqueued_audio_ms == pytest.approx(1000.0)
         assert health.queued_audio_ms == pytest.approx(1000.0)
         assert health.buffered_audio_ms == 0.0
+        assert health.callback_consumed_audio_ms == pytest.approx(1000.0)
         assert health.consumed_audio_ms == pytest.approx(1000.0)
+        assert health.callback_output_audio_ms == pytest.approx(1000.0)
         assert health.written_audio_ms == pytest.approx(1000.0)
         assert health.dropped_audio_ms == 0.0
+        assert health.callback_underrun_audio_ms == 0.0
         assert health.underrun_audio_ms == 0.0
+        assert health.callback_calls_per_sec_ewma is not None
         assert health.write_calls_per_sec_ewma is not None
 
         await stream.stop()
@@ -910,9 +1056,13 @@ class TestPortAudioBackendDeps:
         health = stream.write_health
         assert health.write_attempts == 1
         assert health.writes_completed == 1
+        assert health.callback_consumed_audio_ms == 0.0
         assert health.consumed_audio_ms == 0.0
+        assert health.callback_output_audio_ms == pytest.approx(20.0)
         assert health.written_audio_ms == pytest.approx(20.0)
+        assert health.callback_underrun_events == 1
         assert health.underrun_events == 1
+        assert health.callback_underrun_audio_ms == pytest.approx(20.0)
         assert health.underrun_audio_ms == pytest.approx(20.0)
 
     @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary

Closes #1564.

This PR splits TX playback health into canonical producer/enqueue and PortAudio callback/consumer metric names while preserving the existing `TxStreamHealth` legacy fields as compatibility aliases.

## Changes

- Adds canonical TX health fields such as `enqueued_audio_ms`, `callback_consumed_audio_ms`, `callback_output_audio_ms`, `enqueue_overrun_*`, `callback_underrun_*`, and `callback_calls_per_sec_ewma`.
- Keeps legacy attributes and `to_dict()` keys (`queued_audio_ms`, `consumed_audio_ms`, `written_audio_ms`, `overrun_*`, `underrun_*`, `write_calls_per_sec_ewma`) as mirrored aliases.
- Preserves the old positional constructor order through `last_error`; new canonical fields are appended after the legacy surface.
- Rejects conflicting canonical + legacy constructor values with `ValueError` so diagnostics cannot report contradictory alias values.
- Documents the stable contract, alias deprecation mapping, and PortAudio-vs-fake-stream semantics.
- Adds compatibility and behavior tests for canonical export, legacy-only construction, conflict rejection, positional constructor stability, PortAudio callback metrics, and fake-duplex snapshot shape.

## Validation

- Independent agent review: PASS
- `uv run ruff check src/ tests/` -> `All checks passed!`
- `uv run pytest tests/test_audio_backend.py tests/test_docs_runtime_sync.py -q --tb=short` -> `57 passed`
- `uv run pytest tests/test_audio_duplex.py -q --tb=short` -> `14 passed`
- `uv run pytest tests/ -q --tb=short` -> `8256 passed, 68 skipped, 3 deselected, 11 xfailed, 1 xpassed`
