### PR TITLE
MOR-471: render calibrated S-meter values

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
@@ -58,56 +58,49 @@ describe('formatStep', () => {
 });
 
 describe('formatSValue', () => {
-  it('returns S0 for zero', () => {
-    expect(formatSValue(0)).toBe('S0');
+  it('returns S9 for a calibrated 0 dB-rel-S9 reading', () => {
+    expect(formatSValue(0)).toBe('S9');
   });
 
-  it('returns S0 for negative values', () => {
-    expect(formatSValue(-10)).toBe('S0');
+  it('returns S0 at the calibrated floor', () => {
+    expect(formatSValue(-54)).toBe('S0');
   });
 
-  it('returns S-unit for mid-range', () => {
-    // raw 60 → 60/120*9 = 4.5 → round = 5
-    expect(formatSValue(60)).toBe('S5');
+  it('returns S-unit for calibrated sub-S9 values', () => {
+    expect(formatSValue(-24)).toBe('S5');
   });
 
-  it('returns S9 at raw 120', () => {
-    expect(formatSValue(120)).toBe('S9');
+  it('returns S9+20 at +20 dB-rel-S9', () => {
+    expect(formatSValue(20)).toBe('S9+20');
   });
 
-  it('returns S9+60 at raw 241', () => {
-    expect(formatSValue(241)).toBe('S9+60');
+  it('clamps strong readings to the top of the mobile scale', () => {
+    expect(formatSValue(255)).toBe('S9+40');
   });
 
-  it('clamps values above 241 to S9+60', () => {
-    expect(formatSValue(255)).toBe('S9+60');
-  });
-
-  it('returns S9+ for values above 120', () => {
-    const result = formatSValue(200);
+  it('returns S9+ for values above S9', () => {
+    const result = formatSValue(33);
     expect(result).toMatch(/^S9\+/);
   });
 });
 
 describe('formatDbm', () => {
-  it('returns -73 dBm at S9 (raw=120)', () => {
-    expect(formatDbm(120)).toBe('-73 dBm');
+  it('returns -73 dBm at S9 (0 dB-rel-S9)', () => {
+    expect(formatDbm(0)).toBe('-73 dBm');
   });
 
   it('returns lower dBm for weaker signals', () => {
-    const result = formatDbm(0);
-    // raw=0 → calibration floor near -127 dBm in the mobile view.
+    const result = formatDbm(-54);
     expect(result).toBe('-127 dBm');
   });
 
   it('returns higher dBm for strong signals', () => {
-    const result = formatDbm(241);
-    // raw=241 → S9+60 / about -13 dBm.
-    expect(result).toBe('-13 dBm');
+    const result = formatDbm(20);
+    expect(result).toBe('-53 dBm');
   });
 
-  it('clamps values above 241 to the top of the mobile scale', () => {
-    expect(formatDbm(255)).toBe('-13 dBm');
+  it('clamps values above the top of the mobile scale', () => {
+    expect(formatDbm(255)).toBe('-33 dBm');
   });
 });
 

--- a/frontend/src/components-v2/layout/mobile-layout-logic.ts
+++ b/frontend/src/components-v2/layout/mobile-layout-logic.ts
@@ -24,25 +24,19 @@ export function formatStep(hz: number): string {
 
 // ── S-meter formatting ──
 
-export function formatSValue(raw: number): string {
-  const v = Math.max(0, Math.min(241, raw));
-  if (v <= 0) return 'S0';
-  if (v <= 120) {
-    const s = Math.round((v / 120) * 9);
-    return `S${Math.min(9, Math.max(0, s))}`;
+export function formatSValue(actual: number): string {
+  const v = Math.max(-54, Math.min(40, actual));
+  if (v >= 0) {
+    const over = Math.round(v);
+    return over > 0 ? `S9+${over}` : 'S9';
   }
-  const over = Math.round(((v - 120) / (241 - 120)) * 60);
-  return `S9+${over}`;
+  const s = Math.max(0, Math.min(9, Math.floor((v + 54) / 6)));
+  return `S${s}`;
 }
 
-export function formatDbm(raw: number): string {
-  const v = Math.max(0, Math.min(241, raw));
-  if (v <= 120) {
-    const dbm = -127 + (v / 120) * 54;
-    return `${Math.round(dbm)} dBm`;
-  }
-  const dbm = -73 + ((v - 120) / (241 - 120)) * 60;
-  return `${Math.round(dbm)} dBm`;
+export function formatDbm(actual: number): string {
+  const v = Math.max(-54, Math.min(40, actual));
+  return `${Math.round(-73 + v)} dBm`;
 }
 
 // ── RF Power display ──

--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { createSmoother } from '$lib/utils/smoothing.svelte';
-  import { rawToSegments, rawToSUnit, rawToDbm, formatDbm } from './smeter-scale';
+  import {
+    calibratedToSegments,
+    calibratedToSUnit,
+    calibratedToDbm,
+    formatDbm,
+    rawToSegments,
+  } from './smeter-scale';
 
   interface Props {
-    value: number;    // raw 0-255 from CI-V get_s_meter
+    value: number;    // calibrated dB relative to S9 from backend state
     compact?: boolean;
     label?: string;
     variant?: string;
@@ -138,7 +144,7 @@
   const smoother = createSmoother(0.06, 0.1);
 
   $effect(() => {
-    smoother.update(rawToSegments(value));
+    smoother.update(calibratedToSegments(value));
   });
 
   onMount(() => {
@@ -196,8 +202,8 @@
   let fullSegs = $derived(Math.floor(smoother.value));
   let fracSeg  = $derived(smoother.value - Math.floor(smoother.value));
 
-  let displaySUnit = $derived(rawToSUnit(value));
-  let displayDbm   = $derived(formatDbm(rawToDbm(value)));
+  let displaySUnit = $derived(calibratedToSUnit(value));
+  let displayDbm   = $derived(formatDbm(calibratedToDbm(value)));
 </script>
 
 <svg

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
@@ -1,12 +1,35 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { mount, unmount, flushSync } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import LinearSMeter from '../LinearSMeter.svelte';
 import {
   rawToSegments,
   rawToSUnit,
   rawToDbm,
   formatDbm,
 } from '../smeter-scale';
+
+let components: ReturnType<typeof mount>[] = [];
+let roots: HTMLElement[] = [];
+
+function mountMeter(props: ComponentProps<typeof LinearSMeter>) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  roots.push(target);
+  const component = mount(LinearSMeter, { target, props });
+  flushSync();
+  components.push(component);
+  return target;
+}
+
+afterEach(() => {
+  components.forEach((component) => unmount(component));
+  roots.forEach((root) => root.remove());
+  components = [];
+  roots = [];
+});
 
 // ── rawToSegments ──────────────────────────────────────────────────────────
 
@@ -185,5 +208,23 @@ describe('LinearSMeter smoother release τ', () => {
     // ~150 ms. Anything ≥ 0.25 reintroduces the visible lag (MOR-481).
     expect(release).toBeCloseTo(0.1, 5);
     expect(release).toBeLessThan(0.25);
+  });
+});
+
+describe('LinearSMeter calibrated S-meter domain', () => {
+  it('renders S9 and -73 dBm for a calibrated 0 dB-rel-S9 reading', () => {
+    const target = mountMeter({ value: 0 });
+    const text = target.textContent ?? '';
+
+    expect(text).toContain('S9');
+    expect(text).toContain('\u221273 dBm');
+  });
+
+  it('renders S9+20 and -53 dBm for a calibrated +20 dB reading', () => {
+    const target = mountMeter({ value: 20 });
+    const text = target.textContent ?? '';
+
+    expect(text).toContain('S9+20');
+    expect(text).toContain('\u221253 dBm');
   });
 });

--- a/frontend/src/components-v2/meters/smeter-scale.ts
+++ b/frontend/src/components-v2/meters/smeter-scale.ts
@@ -32,6 +32,7 @@ const DEFAULT_CAL: CalPoint[] = [
 ];
 
 const MAX_RAW = 255;
+const S9_DBM = -73;
 
 function getCal(): CalPoint[] {
   return getSmeterCalibration() ?? DEFAULT_CAL;
@@ -64,6 +65,25 @@ function interpolate(raw: number, table: CalPoint[], outKey: 'actual'): number {
     }
   }
   return table[table.length - 1][outKey];
+}
+
+/** Inverse interpolation from calibrated dB-rel-S9 back to the scale raw axis. */
+function interpolateActual(actual: number, table: CalPoint[]): number {
+  if (table.length === 0) return 0;
+  const minActual = table[0].actual;
+  const maxActual = table[table.length - 1].actual;
+  const v = Math.max(minActual, Math.min(maxActual, actual));
+  if (v <= minActual) return table[0].raw;
+  for (let i = 0; i < table.length - 1; i++) {
+    const p0 = table[i];
+    const p1 = table[i + 1];
+    if (v <= p1.actual) {
+      const span = p1.actual - p0.actual;
+      const t = span === 0 ? 0 : (v - p0.actual) / span;
+      return p0.raw + t * (p1.raw - p0.raw);
+    }
+  }
+  return table[table.length - 1].raw;
 }
 
 /** Map raw to fractional S-unit (0.0 - 9.0+ range). */
@@ -129,6 +149,30 @@ export function rawToSUnit(raw: number): string {
 /** Map raw 0-255 to dBm value (linear interpolation between calibration points). */
 export function rawToDbm(raw: number): number {
   return Math.round(interpolate(raw, getCal(), 'actual'));
+}
+
+/** Map calibrated dB-rel-S9 from backend state to the raw axis used by the UI scale. */
+export function calibratedToRaw(actual: number): number {
+  return interpolateActual(actual, getCal());
+}
+
+/** Map calibrated dB-rel-S9 to fractional segment count 0-20 for the top S-meter. */
+export function calibratedToSegments(actual: number): number {
+  return rawToSegments(calibratedToRaw(actual));
+}
+
+/** Map calibrated dB-rel-S9 to an S-unit label, e.g. "S7", "S9+20". */
+export function calibratedToSUnit(actual: number): string {
+  return rawToSUnit(calibratedToRaw(actual));
+}
+
+/** Map calibrated dB-rel-S9 to user-facing dBm referenced to S9=-73 dBm. */
+export function calibratedToDbm(actual: number): number {
+  const cal = getCal();
+  const minActual = cal[0]?.actual ?? -54;
+  const maxActual = cal[cal.length - 1]?.actual ?? 40;
+  const clamped = Math.max(minActual, Math.min(maxActual, actual));
+  return Math.round(S9_DBM + clamped);
 }
 
 /** Format dBm value as display string, e.g. "−67 dBm". Uses Unicode minus. */

--- a/frontend/src/components-v2/panels/MeterPanel.svelte
+++ b/frontend/src/components-v2/panels/MeterPanel.svelte
@@ -9,6 +9,7 @@
     formatAlc,
     formatSMeter,
     getNeedleMarks,
+    sLevel,
     type MeterSource,
   } from './meter-utils';
 
@@ -36,7 +37,7 @@
 
   let needleValue = $derived(
     meterSource === 'S'
-      ? normalize(sValue)
+      ? sLevel(sValue)
       : meterSource === 'SWR'
         ? normalize(swr)
         : normalize(rfPower),

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
@@ -176,7 +176,7 @@ afterEach(() => {
 });
 
 const fullProps: ComponentProps<typeof MetersDockPanel> = {
-  sValue: 120,
+  sValue: 0,
   powerMeter: 143,
   swrMeter: 48,
   alcMeter: 60,
@@ -415,8 +415,8 @@ describe('MetersDockPanel calibrated bar fill (MOR-482)', () => {
     expect(parseFloat(fill.style.width)).toBeGreaterThan(95);
   });
 
-  it('fills the S bar to ~100% at S9+60 (raw=241), not ~94.5%', () => {
-    const t = mountPanel({ ...fullProps, sValue: 241, txActive: false });
+  it('fills the S bar to ~100% at the strongest calibrated reading', () => {
+    const t = mountPanel({ ...fullProps, sValue: 40, txActive: false });
     const fill = t.querySelector('[data-meter="s"] .tile-bar-fill') as HTMLElement;
     expect(parseFloat(fill.style.width)).toBeGreaterThan(99);
   });

--- a/frontend/src/components-v2/panels/lcd/AmberSmeter.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberSmeter.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { createSmoother } from '$lib/utils/smoothing.svelte';
-  import { getCalibrationPoints, getS9Raw, rawToSUnit, rawToDbm } from '../../meters/smeter-scale';
+  import {
+    calibratedToDbm,
+    calibratedToRaw,
+    calibratedToSUnit,
+    formatDbm,
+    getCalibrationPoints,
+    getS9Raw,
+  } from '../../meters/smeter-scale';
   import { formatPowerWatts, formatSwr, formatAlc, formatCompDb } from '../meter-utils';
 
   type MeterSource = 'S' | 'PO' | 'SWR' | 'ALC' | 'COMP';
 
   interface Props {
-    value: number;      // Raw meter 0-255
+    value: number;      // calibrated dB relative to S9
     txActive?: boolean;
     source?: MeterSource;
   }
@@ -53,7 +60,8 @@
   // with the current computed segment count so the first synchronous render
   // matches the raw target (no flash to 0 on mount).
   function computeSegs(raw: number): number {
-    return Math.min(SEGMENTS, Math.max(0, (raw / MAX_RAW) * SEGMENTS));
+    const scaled = calibratedToRaw(raw);
+    return Math.min(SEGMENTS, Math.max(0, (scaled / MAX_RAW) * SEGMENTS));
   }
 
   // svelte-ignore state_referenced_locally — intentional one-shot seed read
@@ -72,12 +80,12 @@
   // (shared with the desktop meters) instead of crude raw/255 maps, so the
   // LCD agrees with the rest of the UI (MOR-483 part 2).
   let sReadout = $derived.by(() => {
-    if (source === 'S') return { label: rawToSUnit(value), sub: rawToDbm(value) + ' dBm' };
+    if (source === 'S') return { label: calibratedToSUnit(value), sub: formatDbm(calibratedToDbm(value)) };
     if (source === 'PO') return { label: 'PO', sub: formatPowerWatts(value) };
     if (source === 'SWR') return { label: 'SWR', sub: formatSwr(value) };
     if (source === 'ALC') return { label: 'ALC', sub: formatAlc(value) };
     if (source === 'COMP') return { label: 'COMP', sub: formatCompDb(value) };
-    return { label: rawToSUnit(value), sub: rawToDbm(value) + ' dBm' };
+    return { label: calibratedToSUnit(value), sub: formatDbm(calibratedToDbm(value)) };
   });
 </script>
 

--- a/frontend/src/components-v2/panels/lcd/__tests__/lcd-components.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/lcd-components.test.ts
@@ -166,8 +166,8 @@ describe('AmberSmeter', () => {
     unmount(component);
   });
 
-  it('handles zero signal — no filled segments', () => {
-    const component = mount(AmberSmeter, { target, props: { value: 0 } });
+  it('handles the calibrated floor — no filled segments', () => {
+    const component = mount(AmberSmeter, { target, props: { value: -54 } });
     const filled = target.querySelectorAll('.seg.filled');
     expect(filled.length).toBe(0);
     // S-unit readout should show S0
@@ -175,24 +175,23 @@ describe('AmberSmeter', () => {
     unmount(component);
   });
 
-  it('fills proportional segments for mid-range signal', () => {
-    const component = mount(AmberSmeter, { target, props: { value: 128 } });
+  it('fills proportional segments for a mid-range calibrated signal', () => {
+    const component = mount(AmberSmeter, { target, props: { value: -24 } });
     const filled = target.querySelectorAll('.seg.filled');
-    // 128/255 * 192 ≈ 97 segments
-    expect(filled.length).toBeGreaterThan(80);
-    expect(filled.length).toBeLessThan(120);
+    expect(filled.length).toBeGreaterThan(35);
+    expect(filled.length).toBeLessThan(75);
     unmount(component);
   });
 
-  it('fills all segments for max signal (255)', () => {
-    const component = mount(AmberSmeter, { target, props: { value: 255 } });
+  it('fills to the top calibrated anchor for the strongest signal', () => {
+    const component = mount(AmberSmeter, { target, props: { value: 40 } });
     const filled = target.querySelectorAll('.seg.filled');
-    expect(filled.length).toBe(192);
+    expect(filled.length).toBe(181);
     unmount(component);
   });
 
   it('marks over-S9 segments with over-s9 class', () => {
-    const component = mount(AmberSmeter, { target, props: { value: 200 } });
+    const component = mount(AmberSmeter, { target, props: { value: 20 } });
     const overS9 = target.querySelectorAll('.seg.filled.over-s9');
     expect(overS9.length).toBeGreaterThan(0);
     unmount(component);
@@ -217,10 +216,9 @@ describe('AmberSmeter', () => {
   });
 
   it('shows dBm in readout', () => {
-    const component = mount(AmberSmeter, { target, props: { value: 162 } });
+    const component = mount(AmberSmeter, { target, props: { value: 0 } });
     const dbm = target.querySelector('.readout-dbm')!;
-    // At S9 (raw=162), dBm should be 0
-    expect(dbm.textContent).toContain('0');
+    expect(dbm.textContent).toContain('\u221273');
     expect(dbm.textContent).toContain('dBm');
     unmount(component);
   });

--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -119,27 +119,30 @@ describe('formatAlc', () => {
 });
 
 describe('formatSMeter', () => {
-  it('returns S0 for raw=0', () => {
-    expect(formatSMeter(0)).toBe('S0');
+  it('returns S0 for the calibrated floor (-54 dB-rel-S9)', () => {
+    expect(formatSMeter(-54)).toBe('S0');
   });
-  it('returns S9 for raw=120', () => {
-    expect(formatSMeter(120)).toBe('S9');
+  it('returns S9 for a calibrated 0 dB-rel-S9 reading', () => {
+    expect(formatSMeter(0)).toBe('S9');
   });
-  it('returns S9+60 for raw=241', () => {
-    expect(formatSMeter(241)).toBe('S9+60');
+  it('returns S9+20 for a calibrated +20 dB reading', () => {
+    expect(formatSMeter(20)).toBe('S9+20');
   });
-  it('returns S9+dB for values above 120', () => {
-    const result = formatSMeter(180);
+  it('clamps weaker-than-floor readings to S0', () => {
+    expect(formatSMeter(-80)).toBe('S0');
+  });
+  it('returns S9+dB for calibrated values above S9', () => {
+    const result = formatSMeter(33);
     expect(result).toMatch(/^S9\+\d+$/);
     const db = parseInt(result.replace('S9+', ''));
     expect(db).toBeGreaterThan(0);
-    expect(db).toBeLessThan(60);
+    expect(db).toBeLessThanOrEqual(40);
   });
-  it('returns correct S-unit below S9', () => {
-    // raw=60 -> S-unit = round((60/120)*9) = round(4.5) = 5
-    expect(formatSMeter(60)).toBe('S5');
+  it('returns correct S-unit below S9 for calibrated values', () => {
+    // -24 dB-rel-S9 is the S5 anchor on the 6 dB/S-unit scale.
+    expect(formatSMeter(-24)).toBe('S5');
   });
-  it('handles raw=255 (above S9+60 range)', () => {
+  it('handles very strong readings by clamping to the top of the scale', () => {
     const result = formatSMeter(255);
     expect(result).toMatch(/^S9\+\d+$/);
   });
@@ -219,11 +222,11 @@ describe('compLevel (calibrated bar)', () => {
 });
 
 describe('sLevel (calibrated bar)', () => {
-  it('returns ~1.0 at S9+60 (raw=241), not 241/255=0.945', () => {
-    expect(sLevel(241)).toBeCloseTo(1.0);
+  it('returns ~1.0 at the strongest calibrated reading', () => {
+    expect(sLevel(40)).toBeCloseTo(1.0);
   });
-  it('returns ~0.498 at S9 (raw=120) — 120/241', () => {
-    expect(sLevel(120)).toBeCloseTo(120 / 241);
+  it('returns the S9 marker position for a calibrated 0 dB-rel-S9 reading', () => {
+    expect(sLevel(0)).toBeCloseTo(120 / 241);
   });
 });
 

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -84,6 +84,11 @@ const ALC_MAX_DEFAULT = 120;
 /** IC-7610 S-meter: S9 = raw 120, S9+60 = raw 241 */
 const S9_RAW_DEFAULT = 120;
 const S9_PLUS60_RAW_DEFAULT = 241;
+const S_METER_KNOTS_DEFAULT: [number, number][] = [
+  [0, -54],
+  [S9_RAW_DEFAULT, 0],
+  [S9_PLUS60_RAW_DEFAULT, 40],
+];
 
 // ---- Public formatters ----
 
@@ -132,26 +137,51 @@ function getSmeterBounds(): [number, number] {
     // Find S9 and S9+60 calibration points
     const s9 = cal.find((p) => p.label === 'S9');
     const s9p60 = cal.find((p) => p.label === 'S9+60dB' || p.label === 'S9+60');
-    if (s9 && s9p60) return [s9.raw, s9p60.raw];
-    // Fallback: last two points as S9 boundary and max
-    if (cal.length >= 2) return [cal[cal.length - 2].raw, cal[cal.length - 1].raw];
+    if (s9) return [s9.raw, s9p60?.raw ?? cal[cal.length - 1].raw];
+    // Fallback: first point is floor, last point is max.
+    if (cal.length >= 2) return [cal[0].raw, cal[cal.length - 1].raw];
   }
   return [S9_RAW_DEFAULT, S9_PLUS60_RAW_DEFAULT];
 }
 
-/**
- * Formats raw S-meter value (BCD 0-255) as an S-unit string.
- */
-export function formatSMeter(raw: number): string {
-  const [s9Raw, s9Plus60Raw] = getSmeterBounds();
-  if (raw >= s9Raw) {
-    // S9+ range
-    const span = s9Plus60Raw - s9Raw;
-    const db = span > 0 ? Math.round(((raw - s9Raw) / span) * 60) : 0;
-    return db > 0 ? `S9+${db}` : 'S9';
+function getSmeterKnots(): [number, number][] {
+  return calToKnots('s_meter') ?? S_METER_KNOTS_DEFAULT;
+}
+
+function calibratedSmeterToRaw(actual: number): number {
+  const knots = getSmeterKnots();
+  const minActual = knots[0][1];
+  const maxActual = knots[knots.length - 1][1];
+  const clamped = Math.max(minActual, Math.min(maxActual, actual));
+
+  for (let i = 0; i < knots.length - 1; i++) {
+    const [raw0, actual0] = knots[i];
+    const [raw1, actual1] = knots[i + 1];
+    if (clamped <= actual1) {
+      const span = actual1 - actual0;
+      const t = span === 0 ? 0 : (clamped - actual0) / span;
+      return raw0 + t * (raw1 - raw0);
+    }
   }
-  // S0-S9 range
-  const s = s9Raw > 0 ? Math.round((raw / s9Raw) * 9) : 0;
+
+  return knots[knots.length - 1][0];
+}
+
+/**
+ * Formats calibrated S-meter value (dB relative to S9) as an S-unit string.
+ */
+export function formatSMeter(actual: number): string {
+  const knots = getSmeterKnots();
+  const minActual = knots[0][1];
+  const maxActual = knots[knots.length - 1][1];
+  const clamped = Math.max(minActual, Math.min(maxActual, actual));
+
+  if (clamped >= 0) {
+    const over = Math.round(clamped);
+    return over > 0 ? `S9+${over}` : 'S9';
+  }
+
+  const s = Math.max(0, Math.min(9, Math.floor((clamped - minActual) / 6)));
   return `S${s}`;
 }
 
@@ -277,10 +307,11 @@ export function compLevel(raw: number): number {
   return maxDb > 0 ? Math.max(0, Math.min(1, piecewise(raw, knots) / maxDb)) : 0;
 }
 
-/** Bar level for S-meter: raw relative to the S9+60 full-scale calibration. */
-export function sLevel(raw: number): number {
+/** Bar level for calibrated S-meter values relative to the UI scale full-scale. */
+export function sLevel(actual: number): number {
   const [, s9Plus60Raw] = getSmeterBounds();
-  return s9Plus60Raw > 0 ? Math.max(0, Math.min(1, raw / s9Plus60Raw)) : 0;
+  const scaled = calibratedSmeterToRaw(actual);
+  return s9Plus60Raw > 0 ? Math.max(0, Math.min(1, scaled / s9Plus60Raw)) : 0;
 }
 
 /** True when SWR exceeds the 2.0 TX-safety threshold. */

--- a/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
@@ -165,16 +165,16 @@ describe('calibrated control defaults', () => {
   });
 });
 
-describe('toMeterProps raw contract', () => {
-  it('keeps sValue and signal on the public raw sMeter domain', () => {
+describe('toMeterProps S-meter contract', () => {
+  it('passes through calibrated sMeter values without re-normalizing them', () => {
     const props = toMeterProps({
       active: 'MAIN',
-      main: { sMeter: 120 },
+      main: { sMeter: -47 },
       sub: { sMeter: 0 },
     } as any);
 
-    expect(props.sValue).toBe(120);
-    expect(props.signal).toBe(120);
+    expect(props.sValue).toBe(-47);
+    expect(props.signal).toBe(-47);
   });
 });
 


### PR DESCRIPTION
## Summary

- render frontend S-meter inputs as calibrated dB-relative-to-S9 values instead of raw 0-255
- update top linear S-meter, LCD/Amber S-meter, lower/station meter formatting and fill level
- keep raw helpers for genuinely raw meter paths and preserve mobile RF power normalized percent

## Live Validation Context

During IC-7610 LAN validation, `/api/v1/state` returned calibrated values like `main.sMeter=-47` while UI consumers still treated `sMeter` as raw 0-255. Result: top meters displayed `S0 / -54 dBm` and lower station meter displayed nonsense regardless of signal.

Expected calibrated anchors now covered by tests:
- `-54 => S0 / -127 dBm`
- `0 => S9 / -73 dBm`
- `+20 => S9+20 / -53 dBm`

## Validation

- `npm test` -> 2173 passed
- `npm run check`
- `npm run lint`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/test_web_runtime_helpers.py tests/test_state_pipeline_contracts.py -q --tb=short` -> 212 passed

## Linear

MOR-471
