### PR TITLE
MOR-471: align S-meter bar fills with calibrated scale

### DIFF
--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -6,6 +6,7 @@
     calibratedToSUnit,
     calibratedToDbm,
     formatDbm,
+    getScaleMarks,
     rawToSegments,
   } from './smeter-scale';
 
@@ -53,16 +54,7 @@
   }
 
   // ── Label marks ─────────────────────────────────────────────────────────────
-  const LABEL_MARKS: ReadonlyArray<{ raw: number; text: string; color: string }> = [
-    { raw: 18,  text: 'S1',  color: 'var(--v2-text-bright)' },
-    { raw: 54,  text: 'S3',  color: 'var(--v2-text-bright)' },
-    { raw: 90,  text: 'S5',  color: 'var(--v2-text-bright)' },
-    { raw: 126, text: 'S7',  color: 'var(--v2-text-bright)' },
-    { raw: 162, text: 'S9',  color: 'var(--v2-text-bright)' },
-    { raw: 202, text: '+20', color: 'var(--v2-accent-yellow)' },
-    { raw: 241, text: '+40', color: 'var(--v2-accent-orange-alt)' },
-    { raw: 255, text: '+60', color: 'var(--v2-accent-red-alt)' },
-  ];
+  let labelMarks = $derived(getScaleMarks());
 
   // ── Tick marks ──────────────────────────────────────────────────────────────
   // Generate dense ticks: 9 subdivisions between each labeled S-unit position,
@@ -72,45 +64,49 @@
 
   function generateTicks(): Tick[] {
     const ticks: Tick[] = [];
-    // S-zone anchor points (raw values where labels sit)
-    const sAnchors = [0, 18, 36, 54, 72, 90, 108, 126, 144, 162];
-    // Over-S9 anchors
-    const overAnchors = [162, 182, 202, 222, 241, 255];
+    const anchors = getScaleMarks().map((m) => ({ raw: m.raw, actual: m.actual }));
+    const first = anchors[0];
 
-    function colorForRaw(raw: number): string {
-      if (raw <= 162) return 'var(--v2-text-bright)';
-      if (raw <= 210) return 'var(--v2-accent-yellow)';
-      if (raw <= 245) return 'var(--v2-accent-orange-alt)';
+    if (!first || first.raw > 0) {
+      anchors.unshift({ raw: 0, actual: -54 });
+    }
+
+    function colorForActual(actual: number): string {
+      if (actual <= 0) return 'var(--v2-text-bright)';
+      if (actual <= 20) return 'var(--v2-accent-yellow)';
+      if (actual <= 40) return 'var(--v2-accent-orange-alt)';
       return 'var(--v2-accent-red-alt)';
     }
 
-    function addSubdivisions(startRaw: number, endRaw: number) {
+    function addSubdivisions(startRaw: number, endRaw: number, startActual: number, endActual: number) {
       // Major tick at start
-      ticks.push({ raw: startRaw, kind: 'major', color: colorForRaw(startRaw) });
+      ticks.push({ raw: startRaw, kind: 'major', color: colorForActual(startActual) });
       // 9 subdivision ticks between start and end
       const step = (endRaw - startRaw) / 10;
+      const actualStep = (endActual - startActual) / 10;
       for (let j = 1; j <= 9; j++) {
         const raw = startRaw + step * j;
         const kind: TickKind = j === 5 ? 'mid' : 'minor';
-        ticks.push({ raw, kind, color: colorForRaw(raw) });
+        ticks.push({ raw, kind, color: colorForActual(startActual + actualStep * j) });
       }
     }
 
-    // S0-S9 subdivisions
-    for (let i = 0; i < sAnchors.length - 1; i++) {
-      addSubdivisions(sAnchors[i], sAnchors[i + 1]);
-    }
-    // Over-S9 subdivisions
-    for (let i = 0; i < overAnchors.length - 1; i++) {
-      addSubdivisions(overAnchors[i], overAnchors[i + 1]);
+    for (let i = 0; i < anchors.length - 1; i++) {
+      addSubdivisions(
+        anchors[i].raw,
+        anchors[i + 1].raw,
+        anchors[i].actual,
+        anchors[i + 1].actual,
+      );
     }
     // Final tick at max
-    ticks.push({ raw: 255, kind: 'major', color: 'var(--v2-accent-red-alt)' });
+    const last = anchors[anchors.length - 1];
+    ticks.push({ raw: last.raw, kind: 'major', color: colorForActual(last.actual) });
 
     return ticks;
   }
 
-  const TICK_MARKS = generateTicks();
+  let tickMarks = $derived(generateTicks());
 
   // ── Layout (switches between full / compact) ────────────────────────────────
   //   When label is present: label at top → meter shifted down
@@ -236,7 +232,7 @@
   {/if}
 
   <!-- Scale labels -->
-  {#each LABEL_MARKS as m}
+  {#each labelMarks as m}
     <text
       x={rawToX(m.raw)}
       y={SCALE_LABEL_Y}
@@ -250,7 +246,7 @@
   {/each}
 
   <!-- Tick marks -->
-  {#each TICK_MARKS as t}
+  {#each tickMarks as t}
     {@const tx = rawToX(t.raw)}
     {@const y1 = t.kind === 'major' ? TICK_MAJOR_Y1 : t.kind === 'mid' ? TICK_MID_Y1 : TICK_MINOR_Y1}
     {@const y2 = t.kind === 'major' ? TICK_MAJOR_Y2 : t.kind === 'mid' ? TICK_MID_Y2 : TICK_MINOR_Y2}

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
@@ -38,21 +38,21 @@ describe('rawToSegments', () => {
     expect(rawToSegments(0)).toBe(0);
   });
 
-  it('maps S1 (raw 18) to ~1.22 segments', () => {
-    expect(rawToSegments(18)).toBeCloseTo((18 / 162) * 11, 5);
+  it('maps S1 (raw 26 in the IC-7610 profile) to ~1.22 segments', () => {
+    expect(rawToSegments(26)).toBeCloseTo((1 / 9) * 11, 5);
   });
 
-  it('maps S9 (raw 162) to exactly 11 segments', () => {
-    expect(rawToSegments(162)).toBe(11);
+  it('maps S9 (raw 130 in the IC-7610 profile) to exactly 11 segments', () => {
+    expect(rawToSegments(130)).toBe(11);
   });
 
-  it('maps S9+20 (raw 202) to ~14.87 segments', () => {
-    const expected = 11 + ((202 - 162) / (255 - 162)) * 9;
-    expect(rawToSegments(202)).toBeCloseTo(expected, 5);
+  it('maps S9+20 (raw 200) to its calibrated tick position', () => {
+    const expected = 11 + ((200 - 130) / (240 - 130)) * 9;
+    expect(rawToSegments(200)).toBeCloseTo(expected, 5);
   });
 
-  it('maps max (raw 255) to exactly 20 segments', () => {
-    expect(rawToSegments(255)).toBe(20);
+  it('maps the top calibrated anchor (raw 240) to exactly 20 segments', () => {
+    expect(rawToSegments(240)).toBe(20);
   });
 
   it('clamps values below 0', () => {
@@ -77,28 +77,28 @@ describe('rawToSUnit', () => {
     expect(rawToSUnit(0)).toBe('S0');
   });
 
-  it('returns S1 for raw 18', () => {
-    expect(rawToSUnit(18)).toBe('S1');
+  it('returns S1 for raw 26', () => {
+    expect(rawToSUnit(26)).toBe('S1');
   });
 
-  it('returns S5 for raw 90', () => {
-    expect(rawToSUnit(90)).toBe('S5');
+  it('returns S5 for raw 78', () => {
+    expect(rawToSUnit(78)).toBe('S5');
   });
 
-  it('returns S9 for raw 162', () => {
-    expect(rawToSUnit(162)).toBe('S9');
+  it('returns S9 for raw 130', () => {
+    expect(rawToSUnit(130)).toBe('S9');
   });
 
   it('returns S9+ for raw just above S9 but below S9+10', () => {
-    expect(rawToSUnit(170)).toBe('S9+');
+    expect(rawToSUnit(140)).toBe('S9+');
   });
 
-  it('returns S9+20 for raw 202', () => {
-    expect(rawToSUnit(202)).toBe('S9+20');
+  it('returns S9+20 for raw 200', () => {
+    expect(rawToSUnit(200)).toBe('S9+20');
   });
 
-  it('returns S9+40 for raw 241', () => {
-    expect(rawToSUnit(241)).toBe('S9+40');
+  it('returns S9+40 for raw 240', () => {
+    expect(rawToSUnit(240)).toBe('S9+40');
   });
 
   it('returns S9+40 for raw 255 (max in default cal)', () => {
@@ -118,12 +118,12 @@ describe('rawToDbm', () => {
     expect(rawToDbm(0)).toBe(-54);
   });
 
-  it('returns 0 dBm at S9 (raw 162)', () => {
-    expect(rawToDbm(162)).toBe(0);
+  it('returns 0 dBm at S9 (raw 130)', () => {
+    expect(rawToDbm(130)).toBe(0);
   });
 
-  it('returns 20 dBm at S9+20 (raw 202)', () => {
-    expect(rawToDbm(202)).toBe(20);
+  it('returns 20 dBm at S9+20 (raw 200)', () => {
+    expect(rawToDbm(200)).toBe(20);
   });
 
   it('returns 40 dBm at max (raw 255)', () => {
@@ -131,10 +131,10 @@ describe('rawToDbm', () => {
   });
 
   it('interpolates between breakpoints', () => {
-    // raw 172 is halfway between 162 (0) and 182 (10) → t=0.5 → 5
+    // raw 172 is between 165 (+10) and 200 (+20) in the IC-7610 profile.
     const dbm = rawToDbm(172);
-    expect(dbm).toBeGreaterThanOrEqual(0);
-    expect(dbm).toBeLessThanOrEqual(10);
+    expect(dbm).toBeGreaterThanOrEqual(10);
+    expect(dbm).toBeLessThanOrEqual(20);
   });
 });
 
@@ -161,22 +161,22 @@ describe('segment rendering logic', () => {
     expect(Math.floor(rawToSegments(0))).toBe(0);
   });
 
-  it('~6 segments at S5 (raw 90)', () => {
-    const segs = rawToSegments(90);
+  it('~6 segments at S5 (raw 78)', () => {
+    const segs = rawToSegments(78);
     expect(segs).toBeGreaterThan(6);
     expect(segs).toBeLessThan(7);
   });
 
-  it('11 full segments at S9 (raw 162)', () => {
-    expect(Math.floor(rawToSegments(162))).toBe(11);
+  it('11 full segments at S9 (raw 130)', () => {
+    expect(Math.floor(rawToSegments(130))).toBe(11);
   });
 
-  it('14 full segments at S9+20 (raw 202)', () => {
-    expect(Math.floor(rawToSegments(202))).toBe(14);
+  it('16 full segments at S9+20 (raw 200)', () => {
+    expect(Math.floor(rawToSegments(200))).toBe(16);
   });
 
-  it('20 full segments at max (raw 255)', () => {
-    expect(Math.floor(rawToSegments(255))).toBe(20);
+  it('20 full segments at the top calibrated anchor (raw 240)', () => {
+    expect(Math.floor(rawToSegments(240))).toBe(20);
   });
 
   it('fractional segment for mid-S-unit value', () => {

--- a/frontend/src/components-v2/meters/smeter-scale.ts
+++ b/frontend/src/components-v2/meters/smeter-scale.ts
@@ -13,22 +13,24 @@ interface CalPoint {
   label: string;
 }
 
-// IC-7610 fallback (original hardcoded values)
+export interface SmeterMark {
+  raw: number;
+  actual: number;
+  text: string;
+  color: string;
+}
+
+// IC-7610 fallback mirrors rigs/ic7610.toml.
 const DEFAULT_CAL: CalPoint[] = [
   { raw: 0, actual: -54, label: 'S0' },
-  { raw: 18, actual: -48, label: 'S1' },
-  { raw: 36, actual: -42, label: 'S2' },
-  { raw: 54, actual: -36, label: 'S3' },
-  { raw: 72, actual: -30, label: 'S4' },
-  { raw: 90, actual: -24, label: 'S5' },
-  { raw: 108, actual: -18, label: 'S6' },
-  { raw: 126, actual: -12, label: 'S7' },
-  { raw: 144, actual: -6, label: 'S8' },
-  { raw: 162, actual: 0, label: 'S9' },
-  { raw: 182, actual: 10, label: 'S9+10' },
-  { raw: 202, actual: 20, label: 'S9+20' },
-  { raw: 222, actual: 30, label: 'S9+30' },
-  { raw: 241, actual: 40, label: 'S9+40' },
+  { raw: 26, actual: -48, label: 'S1' },
+  { raw: 52, actual: -36, label: 'S3' },
+  { raw: 78, actual: -24, label: 'S5' },
+  { raw: 103, actual: -12, label: 'S7' },
+  { raw: 130, actual: 0, label: 'S9' },
+  { raw: 165, actual: 10, label: 'S9+10' },
+  { raw: 200, actual: 20, label: 'S9+20' },
+  { raw: 240, actual: 40, label: 'S9+40' },
 ];
 
 const MAX_RAW = 255;
@@ -42,12 +44,18 @@ function getCal(): CalPoint[] {
 export function getS9Raw(): number {
   const cal = getCal();
   const s9 = cal.find(p => p.label === 'S9');
-  return s9?.raw ?? 162;
+  return s9?.raw ?? 130;
 }
 
 /** Get redline raw value. */
 export function getRedlineRaw(): number {
   return getSmeterRedline() ?? getS9Raw();
+}
+
+/** Last calibration raw knot, used as the right edge of visual S-meter scales. */
+export function getScaleMaxRaw(): number {
+  const cal = getCal();
+  return cal[cal.length - 1]?.raw ?? MAX_RAW;
 }
 
 /** Piecewise linear interpolation over calibration table. */
@@ -116,11 +124,12 @@ function rawToSFloat(raw: number): number {
 /** Map raw 0-255 to fractional segment count 0-20. */
 export function rawToSegments(raw: number): number {
   const s9Raw = getS9Raw();
-  const v = Math.max(0, Math.min(MAX_RAW, raw));
+  const maxRaw = Math.max(s9Raw + 1, getScaleMaxRaw());
+  const v = Math.max(0, Math.min(maxRaw, raw));
   if (v <= s9Raw) {
     return (rawToSFloat(v) / 9) * 11;
   }
-  return 11 + ((v - s9Raw) / (MAX_RAW - s9Raw)) * 9;
+  return 11 + ((v - s9Raw) / (maxRaw - s9Raw)) * 9;
 }
 
 /** Map raw 0-255 to S-unit string, e.g. "S7", "S9+20". */
@@ -173,6 +182,30 @@ export function calibratedToDbm(actual: number): number {
   const maxActual = cal[cal.length - 1]?.actual ?? 40;
   const clamped = Math.max(minActual, Math.min(maxActual, actual));
   return Math.round(S9_DBM + clamped);
+}
+
+function colorForActual(actual: number): string {
+  if (actual <= 0) return 'var(--v2-text-bright)';
+  if (actual <= 20) return 'var(--v2-accent-yellow)';
+  if (actual <= 40) return 'var(--v2-accent-orange-alt)';
+  return 'var(--v2-accent-red-alt)';
+}
+
+function markText(label: string): string {
+  if (label.startsWith('S9+')) return `+${label.slice(3)}`;
+  return label;
+}
+
+/** Major S-meter marks derived from the active calibration table. */
+export function getScaleMarks(): SmeterMark[] {
+  return getCal()
+    .filter((p) => /^S[13579]$/.test(p.label) || /^S9\+/.test(p.label))
+    .map((p) => ({
+      raw: p.raw,
+      actual: p.actual,
+      text: markText(p.label),
+      color: colorForActual(p.actual),
+    }));
 }
 
 /** Format dBm value as display string, e.g. "−67 dBm". Uses Unicode minus. */

--- a/frontend/src/components-v2/panels/__tests__/DockMeterPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DockMeterPanel.test.ts
@@ -81,8 +81,15 @@ describe('DockMeterPanel calibrated bar fill (MOR-482)', () => {
     expect(pct).toBeLessThan(70);
   });
 
-  it('fills the S bar to ~100% at S9+60 (raw=241), not ~94.5%', () => {
-    const t = mountPanel({ ...baseProps, sValue: 241 });
+  it('fills the S bar to the shared S9 position at calibrated 0 dB-rel-S9', () => {
+    const t = mountPanel({ ...baseProps, sValue: 0 });
+    const pct = fillPctForLabel(t, 'S');
+    expect(pct).toBeGreaterThan(53);
+    expect(pct).toBeLessThan(56);
+  });
+
+  it('fills the S bar to ~100% at the top calibrated S anchor (+40 dB)', () => {
+    const t = mountPanel({ ...baseProps, sValue: 40 });
     expect(fillPctForLabel(t, 'S')).toBeGreaterThan(99);
   });
 

--- a/frontend/src/components-v2/panels/__tests__/MeterPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MeterPanel.test.ts
@@ -106,16 +106,16 @@ describe('formatAlc (IC-7610 CI-V p.4: 0=Min, 120=Max)', () => {
 // getNeedleMarks
 // ---------------------------------------------------------------------------
 
-describe('getNeedleMarks S-meter (IC-7610: 120=S9, 241=S9+60)', () => {
+describe('getNeedleMarks S-meter (IC-7610 profile: 130=S9, 240=S9+40)', () => {
   it('returns 7 marks for S source', () => {
     expect(getNeedleMarks('S')).toHaveLength(7);
   });
 
-  it('S9 mark at 120/255', () => {
+  it('S9 mark at 130/240 on the shared calibrated scale', () => {
     const marks = getNeedleMarks('S');
     const s9 = marks.find((m) => m.label === 'S9');
     expect(s9).toBeDefined();
-    expect(s9!.pos).toBeCloseTo(120 / 255, 3);
+    expect(s9!.pos).toBeCloseTo(130 / 240, 3);
   });
 
   it('last mark is +40', () => {

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.test.ts
@@ -420,6 +420,14 @@ describe('MetersDockPanel calibrated bar fill (MOR-482)', () => {
     const fill = t.querySelector('[data-meter="s"] .tile-bar-fill') as HTMLElement;
     expect(parseFloat(fill.style.width)).toBeGreaterThan(99);
   });
+
+  it('places the S bar at the shared S9 position for a calibrated 0 dB reading', () => {
+    const t = mountPanel({ ...fullProps, sValue: 0, txActive: false });
+    const fill = t.querySelector('[data-meter="s"] .tile-bar-fill') as HTMLElement;
+    const pct = parseFloat(fill.style.width);
+    expect(pct).toBeGreaterThan(53);
+    expect(pct).toBeLessThan(56);
+  });
 });
 
 describe('MetersDockPanel fault highlighting', () => {

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -7,6 +7,7 @@
   import AmberAfScope from './AmberAfScope.svelte';
   import AmberFilterGhost from './AmberFilterGhost.svelte';
   import AmberIndStrip from './AmberIndStrip.svelte';
+  import AmberSmeter from './AmberSmeter.svelte';
   import type { IndToken } from './AmberIndStrip.svelte';
   import { runtime } from '$lib/runtime';
   import { isFieldAvailable } from '$lib/state/field-status';
@@ -239,6 +240,10 @@
       <AmberIndStrip zone="global" tokens={globalTokens} />
     </div>
 
+    <div class="lcd-meter-row" style:grid-area="meter">
+      <AmberSmeter value={rx?.sMeter ?? -54} source="S" />
+    </div>
+
     <!-- ═══ Scope: dominant AfScope ═══ -->
     <div class="lcd-scope" style:grid-area="scope">
       {#if showFft}
@@ -290,12 +295,13 @@
       0 0 8px rgba(0, 0, 0, 0.5);
     min-height: 0;
 
-    /* Grid: header / indicator-zones / scope (scope-dominant) */
+    /* Grid: header / indicator-zones / S-meter / scope (scope-dominant) */
     display: grid;
-    grid-template-rows: auto auto minmax(0, 1fr);
+    grid-template-rows: auto auto auto minmax(0, 1fr);
     grid-template-areas:
       "header"
       "ind-strips"
+      "meter"
       "scope";
     grid-template-columns: minmax(0, 1fr);
     gap: 4px;
@@ -430,6 +436,42 @@
     flex-shrink: 0;
     margin: 0 6px;
     align-self: center;
+  }
+
+  .lcd-meter-row {
+    position: relative;
+    z-index: 2;
+    min-height: 42px;
+    overflow: hidden;
+    border-top: 1px solid rgba(26, 16, 0, calc(var(--lcd-alpha-ghost) * 2));
+    padding-top: 2px;
+  }
+
+  .lcd-meter-row :global(.lcd-smeter) {
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .lcd-meter-row :global(.meter-bar) {
+    height: 11px;
+  }
+
+  .lcd-meter-row :global(.meter-scale) {
+    height: 24px;
+  }
+
+  .lcd-meter-row :global(.tick-label),
+  .lcd-meter-row :global(.scale-s-label),
+  .lcd-meter-row :global(.scale-db-zone) {
+    font-size: 9px;
+  }
+
+  .lcd-meter-row :global(.readout-s) {
+    font-size: 28px;
+  }
+
+  .lcd-meter-row :global(.readout-dbm) {
+    font-size: 10px;
   }
 
   /* ── Scope cell: fills remaining height ── */

--- a/frontend/src/components-v2/panels/lcd/AmberSmeter.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberSmeter.svelte
@@ -7,6 +7,7 @@
     calibratedToSUnit,
     formatDbm,
     getCalibrationPoints,
+    getScaleMaxRaw,
     getS9Raw,
   } from '../../meters/smeter-scale';
   import { formatPowerWatts, formatSwr, formatAlc, formatCompDb } from '../meter-utils';
@@ -21,11 +22,11 @@
 
   let { value, txActive = false, source = 'S' }: Props = $props();
 
-  const MAX_RAW = 255;
   const SEGMENTS = 192;
 
   let s9Raw = $derived(getS9Raw());
-  let s9Seg = $derived(Math.round((s9Raw / MAX_RAW) * SEGMENTS));
+  let scaleMaxRaw = $derived(getScaleMaxRaw());
+  let s9Seg = $derived(Math.round((s9Raw / scaleMaxRaw) * SEGMENTS));
 
   // Build ticks from calibration
   let calPoints = $derived(getCalibrationPoints());
@@ -45,7 +46,7 @@
   // Minor ticks: subdivisions between cal points
   let minorTicks = $derived((() => {
     const ticks: number[] = [];
-    for (let raw = 4; raw < MAX_RAW; raw += 4.5) {
+    for (let raw = 4; raw < scaleMaxRaw; raw += 4.5) {
       const r = Math.round(raw);
       const isMajor = majorTicks.some((t: any) => Math.abs(t.raw - r) < 3);
       const isMedium = mediumTicks.some((t: any) => Math.abs(t.raw - r) < 3);
@@ -61,7 +62,7 @@
   // matches the raw target (no flash to 0 on mount).
   function computeSegs(raw: number): number {
     const scaled = calibratedToRaw(raw);
-    return Math.min(SEGMENTS, Math.max(0, (scaled / MAX_RAW) * SEGMENTS));
+    return Math.min(SEGMENTS, Math.max(0, (scaled / scaleMaxRaw) * SEGMENTS));
   }
 
   // svelte-ignore state_referenced_locally — intentional one-shot seed read
@@ -106,22 +107,22 @@
     <!-- Scale below bar -->
     <div class="meter-scale">
       {#each minorTicks as raw}
-        <div class="tick tick-minor" style="left: {(raw / MAX_RAW) * 100}%"></div>
+        <div class="tick tick-minor" style="left: {(raw / scaleMaxRaw) * 100}%"></div>
       {/each}
       {#each mediumTicks as tick}
-        <div class="tick tick-medium" style="left: {(tick.raw / MAX_RAW) * 100}%"></div>
+        <div class="tick tick-medium" style="left: {(tick.raw / scaleMaxRaw) * 100}%"></div>
       {/each}
       {#each majorTicks as tick}
         <div
           class="tick tick-major"
           class:over-s9={tick.raw > s9Raw}
-          style="left: {(tick.raw / MAX_RAW) * 100}%"
+          style="left: {(tick.raw / scaleMaxRaw) * 100}%"
         >
           <span class="tick-label">{tick.label}</span>
         </div>
       {/each}
       <span class="scale-s-label">S</span>
-      <span class="scale-db-zone" style="left: {(s9Raw / MAX_RAW) * 100}%">dB</span>
+      <span class="scale-db-zone" style="left: {(s9Raw / scaleMaxRaw) * 100}%">dB</span>
     </div>
   </div>
 

--- a/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.test.ts
@@ -92,6 +92,25 @@ afterEach(() => {
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 describe('AmberScope availability gating (MOR-429)', () => {
+  it('renders an S-meter row for the active receiver when scope is shown', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+      fieldStatus: {
+        'main.agc': {
+          storePath: 'receiver.main.operator_controls.agc',
+          observed: true,
+          freshness: 'fresh',
+          availability: 'available',
+        },
+      },
+    } as unknown as ServerState;
+
+    const target = mountScope(state);
+    expect(target.querySelector('.lcd-smeter')).not.toBeNull();
+  });
+
   it('renders AGC as active when the field is observed/available', () => {
     const state = {
       active: 'MAIN',

--- a/frontend/src/components-v2/panels/lcd/__tests__/lcd-components.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/lcd-components.test.ts
@@ -186,7 +186,7 @@ describe('AmberSmeter', () => {
   it('fills to the top calibrated anchor for the strongest signal', () => {
     const component = mount(AmberSmeter, { target, props: { value: 40 } });
     const filled = target.querySelectorAll('.seg.filled');
-    expect(filled.length).toBe(181);
+    expect(filled.length).toBe(192);
     unmount(component);
   });
 

--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -226,7 +226,10 @@ describe('sLevel (calibrated bar)', () => {
     expect(sLevel(40)).toBeCloseTo(1.0);
   });
   it('returns the S9 marker position for a calibrated 0 dB-rel-S9 reading', () => {
-    expect(sLevel(0)).toBeCloseTo(120 / 241);
+    expect(sLevel(0)).toBeCloseTo(130 / 240);
+  });
+  it('returns the +20 marker position for a calibrated +20 dB reading', () => {
+    expect(sLevel(20)).toBeCloseTo(200 / 240);
   });
 });
 
@@ -294,8 +297,8 @@ describe('getNeedleMarks', () => {
     expect(marks[4].label).toBe('S9');
     expect(marks[5].label).toBe('+20');
     expect(marks[6].label).toBe('+40');
-    // S9 pos should be 120/255
-    expect(marks[4].pos).toBeCloseTo(120 / 255);
+    // S9 pos should follow the shared IC-7610 profile scale: 130/240
+    expect(marks[4].pos).toBeCloseTo(130 / 240);
   });
 
   it('returns SWR marks for source "SWR"', () => {

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -81,13 +81,19 @@ const SWR_KNOTS: [number, number][] = [
 /** IC-7610 ALC max raw value */
 const ALC_MAX_DEFAULT = 120;
 
-/** IC-7610 S-meter: S9 = raw 120, S9+60 = raw 241 */
-const S9_RAW_DEFAULT = 120;
-const S9_PLUS60_RAW_DEFAULT = 241;
+/** IC-7610 S-meter fallback mirrors rigs/ic7610.toml. */
+const S9_RAW_DEFAULT = 130;
+const S9_SCALE_MAX_RAW_DEFAULT = 240;
 const S_METER_KNOTS_DEFAULT: [number, number][] = [
   [0, -54],
+  [26, -48],
+  [52, -36],
+  [78, -24],
+  [103, -12],
   [S9_RAW_DEFAULT, 0],
-  [S9_PLUS60_RAW_DEFAULT, 40],
+  [165, 10],
+  [200, 20],
+  [S9_SCALE_MAX_RAW_DEFAULT, 40],
 ];
 
 // ---- Public formatters ----
@@ -129,23 +135,26 @@ export function formatAlc(raw: number): string {
 }
 
 /**
- * Returns S-meter calibration boundaries: [s9Raw, s9Plus60Raw].
+ * Returns S-meter calibration boundaries: [s9Raw, scaleMaxRaw].
  */
 function getSmeterBounds(): [number, number] {
   const cal = getMeterCalibration('s_meter');
   if (cal && cal.length >= 2) {
-    // Find S9 and S9+60 calibration points
     const s9 = cal.find((p) => p.label === 'S9');
-    const s9p60 = cal.find((p) => p.label === 'S9+60dB' || p.label === 'S9+60');
-    if (s9) return [s9.raw, s9p60?.raw ?? cal[cal.length - 1].raw];
+    if (s9) return [s9.raw, cal[cal.length - 1].raw];
     // Fallback: first point is floor, last point is max.
     if (cal.length >= 2) return [cal[0].raw, cal[cal.length - 1].raw];
   }
-  return [S9_RAW_DEFAULT, S9_PLUS60_RAW_DEFAULT];
+  return [S9_RAW_DEFAULT, S9_SCALE_MAX_RAW_DEFAULT];
 }
 
 function getSmeterKnots(): [number, number][] {
   return calToKnots('s_meter') ?? S_METER_KNOTS_DEFAULT;
+}
+
+function getSmeterMaxRaw(): number {
+  const knots = getSmeterKnots();
+  return knots[knots.length - 1][0];
 }
 
 function calibratedSmeterToRaw(actual: number): number {
@@ -309,9 +318,9 @@ export function compLevel(raw: number): number {
 
 /** Bar level for calibrated S-meter values relative to the UI scale full-scale. */
 export function sLevel(actual: number): number {
-  const [, s9Plus60Raw] = getSmeterBounds();
+  const scaleMaxRaw = getSmeterMaxRaw();
   const scaled = calibratedSmeterToRaw(actual);
-  return s9Plus60Raw > 0 ? Math.max(0, Math.min(1, scaled / s9Plus60Raw)) : 0;
+  return scaleMaxRaw > 0 ? Math.max(0, Math.min(1, scaled / scaleMaxRaw)) : 0;
 }
 
 /** True when SWR exceeds the 2.0 TX-safety threshold. */
@@ -381,16 +390,13 @@ export function peakHoldDisplay(
 export function getNeedleMarks(source: MeterSource): Mark[] {
   switch (source) {
     case 'S': {
-      const [s9Raw, s9Plus60Raw] = getSmeterBounds();
-      return [
-        { pos: (s9Raw * (1 / 9)) / 255, label: 'S1' },
-        { pos: (s9Raw * (3 / 9)) / 255, label: 'S3' },
-        { pos: (s9Raw * (5 / 9)) / 255, label: 'S5' },
-        { pos: (s9Raw * (7 / 9)) / 255, label: 'S7' },
-        { pos: s9Raw / 255, label: 'S9' },
-        { pos: (s9Raw + (s9Plus60Raw - s9Raw) * (20 / 60)) / 255, label: '+20' },
-        { pos: (s9Raw + (s9Plus60Raw - s9Raw) * (40 / 60)) / 255, label: '+40' },
-      ];
+      const maxRaw = getSmeterMaxRaw();
+      return getSmeterKnots()
+        .filter(([, actual]) => [-48, -36, -24, -12, 0, 20, 40].includes(Math.round(actual)))
+        .map(([raw, actual]) => ({
+          pos: maxRaw > 0 ? Math.max(0, Math.min(1, raw / maxRaw)) : 0,
+          label: actual > 0 ? `+${Math.round(actual)}` : `S${Math.round((actual + 54) / 6)}`,
+        }));
     }
     case 'SWR': {
       const knots = getKnots('swr', SWR_KNOTS);

--- a/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
+++ b/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
@@ -14,6 +14,7 @@
 <script lang="ts">
   import { formatFrequency } from '../../components-v2/display/frequency-format';
   import type { VfoStateProps } from '../../components-v2/layout/layout-utils';
+  import { calibratedToRaw, calibratedToSUnit, getScaleMaxRaw, getS9Raw } from '../../components-v2/meters/smeter-scale';
   import { HardwareButton } from '$lib/Button';
 
   /**
@@ -137,21 +138,20 @@
     return `${mhz.toFixed(1)}MHz`;
   }
 
-  // sMeter is RAW 0..255: S9 ≈ 120, S9+60dB ≈ 241 (IC-7610 calibration).
-  // Map to 0..80 sub-segments: S0..S9 → 0..42, S9..S9+60 → 42..80.
-  const S9_RAW = 120;
-  const S9P60_RAW = 241;
-  function sMeterFill(raw: number): number {
-    if (!raw || raw < 0) return 0;
-    if (raw <= S9_RAW) return Math.round((raw / S9_RAW) * 42);
-    const over = Math.min(raw - S9_RAW, S9P60_RAW - S9_RAW);
-    return Math.round(42 + (over / (S9P60_RAW - S9_RAW)) * 38);
+  // sMeter values are calibrated dB relative to S9 from backend state. Convert
+  // through the active calibration table so fill and text agree with the rig.
+  function sMeterFill(actual: number): number {
+    const s9Raw = getS9Raw();
+    const maxRaw = getScaleMaxRaw();
+    const raw = calibratedToRaw(actual);
+    if (raw <= 0 || maxRaw <= 0) return 0;
+    const s9Fill = Math.round((s9Raw / maxRaw) * SEGS * SUB_PER_SEG);
+    if (raw <= s9Raw) return Math.round((raw / s9Raw) * s9Fill);
+    const over = Math.min(raw - s9Raw, maxRaw - s9Raw);
+    return Math.round(s9Fill + (over / (maxRaw - s9Raw)) * (SEGS * SUB_PER_SEG - s9Fill));
   }
-  function sUnitLabel(raw: number): string {
-    if (!raw || raw < 0) return '0';
-    if (raw <= S9_RAW) return String(Math.round((raw / S9_RAW) * 9));
-    const db = Math.round(((raw - S9_RAW) / (S9P60_RAW - S9_RAW)) * 60);
-    return `9+${db}`;
+  function sUnitLabel(actual: number): string {
+    return calibratedToSUnit(actual).replace(/^S/, '');
   }
 
   const SEGS = 40;


### PR DESCRIPTION
## Summary
- derive S-meter ticks/labels/fill from the active calibration table instead of hardcoded raw anchors
- align desktop dock/needle meters, LCD cockpit S-meter, and SDR VFO screen with calibrated dB-rel-S9 values
- add an S-meter row to LCD Scope so signal strength is visible there too

## Validation
- npm test -- --run src/components-v2/meters/__tests__/LinearSMeter.test.ts src/components-v2/panels/meter-utils.test.ts src/components-v2/panels/lcd/__tests__/lcd-components.test.ts src/components-v2/panels/__tests__/DockMeterPanel.test.ts src/components-v2/panels/__tests__/MetersDockPanel.test.ts
- npm run check
- npm run lint
- npm test
- uv run ruff check src/ tests/
- uv run pytest tests/ -q --tb=short