### PR TITLE
Release 2.10.1: IC-7610 radio-state-pipeline regression fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.1] — 2026-06-17
+
+### Fixed
+
+- IC-7610 S-meter no longer stuck at S0: repaired the MOR-334 state-pipeline
+  reconciliation (1bd57e10), applied the first meter sample immediately
+  instead of holding it in the coalescer (53374bcc), and raised
+  streaming-meter freshness TTLs above the live poll cadence so the value
+  no longer decays to the calibrated floor between frames (8a64942f).
+- Mode, data-mode, RF gain, AF level and squelch no longer revert ~1 s after
+  being set: optimistic command-response overlay plus correct normalized
+  level scaling (53374bcc); digital modes D1/D2/D3 now reflect correctly
+  (1bd57e10).
+- IC-7610 MOD-input source (MIC/ACC/USB/LAN) no longer reverts to a blank
+  value after selection (ae0bd583, MOR-616).
+- Operating-UI control units: RF gain (5ef3d9ef) and the mobile TX-power
+  readout (4e62a5af) now consume the backend's normalized 0–1 scale instead
+  of a raw 0–255 range, so they show the real percentage / watts.
+- Waterfall tuning now holds the commanded frequency via the optimistic
+  overlay instead of snapping back after a click or drag (4e62a5af).
+- LAN radio discovery retransmits the UDP probe within the scan window with
+  dedup, so a network radio is found on the first scan instead of after
+  several attempts (2ea0bf2e).
+
 ## [2.10.0] — 2026-06-11
 
 ### Added
@@ -1794,7 +1818,9 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.9.0...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.10.1...HEAD
+[2.10.1]: https://github.com/rigplane/rigplane-core/compare/v2.10.0...v2.10.1
+[2.10.0]: https://github.com/rigplane/rigplane-core/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/rigplane/rigplane-core/compare/v2.8.0...v2.9.0
 [2.8.0]: https://github.com/rigplane/rigplane-core/compare/v2.7.3...v2.8.0
 [2.7.3]: https://github.com/rigplane/rigplane-core/compare/v2.7.2...v2.7.3

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -39,6 +39,11 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getRigConnected: vi.fn(() => false),
   getRadioReady: vi.fn(() => false),
   getRadioHealth: vi.fn(() => null),
+  // Under the fast pool's ``isolate: false`` this hoisted mock is shared
+  // module-wide; scope-controller.svelte (loaded by a sibling fast-pool
+  // test) imports the real ``markScopeFrame``, so it must be stubbed here
+  // or that sibling throws "No markScopeFrame export". See issue #771.
+  markScopeFrame: vi.fn(),
 }));
 
 vi.mock('$lib/stores/tuning.svelte', () => ({

--- a/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
@@ -105,16 +105,21 @@ describe('formatDbm', () => {
 });
 
 describe('formatPower', () => {
+  // power_level is served normalized 0.0-1.0 (MOR-334 contract), not raw 0-255.
   it('returns 0W for zero', () => {
     expect(formatPower(0)).toBe('0W');
   });
 
-  it('returns 100W for max (255)', () => {
-    expect(formatPower(255)).toBe('100W');
+  it('returns 100W for max (1.0)', () => {
+    expect(formatPower(1)).toBe('100W');
   });
 
   it('returns approximate wattage for mid-range', () => {
-    // 128/255*100 ≈ 50.2 → round = 50
-    expect(formatPower(128)).toBe('50W');
+    // 0.5 * 100 → 50
+    expect(formatPower(0.5)).toBe('50W');
+  });
+
+  it('clamps out-of-range normalized input', () => {
+    expect(formatPower(1.4)).toBe('100W');
   });
 });

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
@@ -34,6 +34,11 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getRigConnected: vi.fn(() => false),
   getRadioReady: vi.fn(() => false),
   getRadioHealth: vi.fn(() => null),
+  // Under the fast pool's ``isolate: false`` this hoisted mock is shared
+  // module-wide; scope-controller.svelte (loaded by a sibling fast-pool
+  // test) imports the real ``markScopeFrame``, so it must be stubbed here
+  // or that sibling throws "No markScopeFrame export". See issue #771.
+  markScopeFrame: vi.fn(),
 }));
 
 vi.mock('$lib/stores/tuning.svelte', () => ({

--- a/frontend/src/components-v2/layout/mobile-layout-logic.ts
+++ b/frontend/src/components-v2/layout/mobile-layout-logic.ts
@@ -41,8 +41,11 @@ export function formatDbm(actual: number): string {
 
 // ── RF Power display ──
 
-export function formatPower(raw: number): string {
-  // 0-255 → 0-100W (approx for IC-7610)
-  const watts = Math.round(raw / 255 * 100);
+export function formatPower(level: number): string {
+  // power_level arrives normalized 0.0-1.0 from the backend (CI-V raw 0-255 is
+  // divided by 255 at the source — see runtime/_civ_rx.py; matches rf_gain /
+  // af_level / squelch). 1.0 ≈ 100W (approx for IC-7610). Previously this
+  // divided a 0-1 value by 255 again, collapsing 50% to ~0W (MOR-334 class).
+  const watts = Math.round(Math.max(0, Math.min(1, level)) * 100);
   return `${watts}W`;
 }

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -15,7 +15,7 @@
   import { getChannel, onMessage, sendCommand } from '../../lib/transport/ws-client';
   import { setScopeConnected, markScopeFrame, isScopeConnected } from '../../lib/stores/connection.svelte';
   import { type DxSpot } from '../../lib/types/protocol';
-  import { patchActiveReceiver, radio } from '../../lib/stores/radio.svelte';
+  import { patchActiveReceiver, patchReceiver, radio } from '../../lib/stores/radio.svelte';
   import { getFilterWidthHz } from '../../lib/utils/filter-width';
   import { snapToStep, tuneBy } from '../../lib/stores/tuning.svelte';
   import SpectrumToolbar from './SpectrumToolbar.svelte';
@@ -206,6 +206,7 @@
     const freq = snapToStep(Math.round(hz));
     if (freq <= 0) return;
     const receiver = radio.current?.active === 'SUB' ? 1 : 0;
+    patchReceiver(receiver, { freqHz: freq }, true);
     sendCommand('set_freq', { freq, receiver });
   }
 
@@ -295,6 +296,7 @@
     lastDragSendTime = now;
     lastDragSendFreq = newFreq;
     const receiver = radio.current?.active === 'SUB' ? 1 : 0;
+    patchReceiver(receiver, { freqHz: newFreq }, true);
     sendCommand('set_freq', { freq: newFreq, receiver });
   }
 
@@ -305,6 +307,7 @@
       // Drag-to-pan: send final frequency on release
       if (dragFreq > 0 && dragFreq !== lastDragSendFreq) {
         const receiver = radio.current?.active === 'SUB' ? 1 : 0;
+        patchReceiver(receiver, { freqHz: dragFreq }, true);
         sendCommand('set_freq', { freq: dragFreq, receiver });
       }
     }

--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -20,6 +20,11 @@ vi.mock('../../stores/connection.svelte', () => ({
   setReconnecting: vi.fn(),
   setRadioStatus: vi.fn(),
   isLiveRadioAvailable: vi.fn(() => true),
+  // Under the fast pool's ``isolate: false`` this hoisted mock is shared
+  // module-wide; scope-controller.svelte (loaded by a sibling fast-pool
+  // test) imports the real ``markScopeFrame``, so it must be stubbed here
+  // or that sibling throws "No markScopeFrame export". See issue #771.
+  markScopeFrame: vi.fn(),
 }));
 
 vi.mock('../../stores/radio.svelte', () => ({

--- a/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
+++ b/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
@@ -111,14 +111,16 @@
     const m = num(rx, 'agc');
     return AGC_LABELS[m] ? `AGC ${AGC_LABELS[m]}` : 'AGC';
   }
-  // rfGain is raw 0..255 — convert to 0..100 for display
+  // rfGain is the backend-normalized 0.0..1.0 float (CI-V raw 0-255 is divided
+  // by 255 at the source — see runtime/_civ_rx.py). Convert to 0..100 for
+  // display; 1.0 = 100% = neutral/max. (MOR-334)
   function rfgPercent(rx: Record<string, unknown> | null | undefined): number {
-    const raw = num(rx, 'rfGain', 255);
-    return Math.round((raw / 255) * 100);
+    const level = num(rx, 'rfGain', 1);
+    return Math.round(level * 100);
   }
   function rfgActive(rx: Record<string, unknown> | null | undefined): boolean {
-    // Active = reduced from max (255 = 100% = off/neutral)
-    return num(rx, 'rfGain', 255) < 255;
+    // Active = reduced from max (1.0 = 100% = off/neutral)
+    return num(rx, 'rfGain', 1) < 1;
   }
 
   // Band label (e.g., "20M") derived from freq MHz — coarse, ham-band only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.10.0"
+version = "2.10.1"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -239,43 +239,43 @@ supported_controls = [
 
 [state_acquisition.field_policies."receiver.main.meters.s_meter"]
 cadence_seconds = 0.2
-freshness_ttl_seconds = 0.8
+freshness_ttl_seconds = 2.0
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 
 [state_acquisition.field_policies."global.meters.power"]
 cadence_seconds = 0.2
-freshness_ttl_seconds = 0.8
+freshness_ttl_seconds = 2.0
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 
 [state_acquisition.field_policies."global.meters.swr"]
 cadence_seconds = 0.2
-freshness_ttl_seconds = 0.8
+freshness_ttl_seconds = 2.0
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 
 [state_acquisition.field_policies."global.meters.alc"]
 cadence_seconds = 0.2
-freshness_ttl_seconds = 0.8
+freshness_ttl_seconds = 2.0
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 
 [state_acquisition.field_policies."global.meters.comp"]
 cadence_seconds = 0.2
-freshness_ttl_seconds = 0.8
+freshness_ttl_seconds = 2.0
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 
 [state_acquisition.field_policies."global.meters.vd"]
 cadence_seconds = 0.2
-freshness_ttl_seconds = 0.8
+freshness_ttl_seconds = 2.0
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 
 [state_acquisition.field_policies."global.meters.id"]
 cadence_seconds = 0.2
-freshness_ttl_seconds = 0.8
+freshness_ttl_seconds = 2.0
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 

--- a/src/rigplane/backends/discovery.py
+++ b/src/rigplane/backends/discovery.py
@@ -601,6 +601,12 @@ async def discover_lan_radios(timeout: float = 3.0) -> list[dict[str, object]]:
     import struct
     import time
 
+    # Re-send the "Are You There" probe periodically across the listen window
+    # so a single dropped UDP packet (or brief control-port contention) does
+    # not hide a radio for the entire scan. A radio that only answers a later
+    # probe is still discovered; responses are deduplicated by host.
+    RESEND_INTERVAL = 0.6
+
     def _scan() -> list[dict[str, object]]:
         import random
 
@@ -616,32 +622,52 @@ async def discover_lan_radios(timeout: float = 3.0) -> list[dict[str, object]]:
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        sock.settimeout(0.5)
+        sock.settimeout(0.3)
 
-        # Broadcast on common Icom ports
-        for port in [50001]:
-            try:
-                sock.sendto(bytes(pkt), ("255.255.255.255", port))
-            except OSError as exc:
-                logger.warning("discover: broadcast failed on port %d: %s", port, exc)
-                sock.close()
-                return []
+        # Broadcast on common Icom ports. Returns False only if the very first
+        # send fails on every port (no usable socket); a later transient send
+        # failure is logged and tolerated so listening continues.
+        def _broadcast(*, first: bool) -> bool:
+            sent_any = False
+            for port in [50001]:
+                try:
+                    sock.sendto(bytes(pkt), ("255.255.255.255", port))
+                    sent_any = True
+                except OSError as exc:
+                    logger.warning(
+                        "discover: broadcast failed on port %d: %s", port, exc
+                    )
+            return sent_any or not first
+
+        if not _broadcast(first=True):
+            sock.close()
+            return []
 
         found: dict[str, dict[str, object]] = {}
-        deadline = time.monotonic() + timeout
+        start = time.monotonic()
+        deadline = start + timeout
+        next_resend = start + RESEND_INTERVAL
         while time.monotonic() < deadline:
+            # Spread retransmits across the window; keep within `timeout`.
+            now = time.monotonic()
+            if now >= next_resend:
+                _broadcast(first=False)
+                next_resend = now + RESEND_INTERVAL
             try:
                 data, addr = sock.recvfrom(256)
                 if len(data) >= 0x10:
                     ptype = struct.unpack_from("<H", data, 4)[0]
                     if ptype == 0x04:  # I_AM_HERE
                         remote_id = struct.unpack_from("<I", data, 8)[0]
+                        if addr[0] not in found:
+                            logger.info(
+                                "discover_lan_radios: found %s id=0x%08X",
+                                addr[0],
+                                remote_id,
+                            )
+                        # Dedup by host: a radio answering multiple probes is
+                        # recorded once.
                         found[addr[0]] = {"host": addr[0], "remote_id": remote_id}
-                        logger.info(
-                            "discover_lan_radios: found %s id=0x%08X",
-                            addr[0],
-                            remote_id,
-                        )
             except socket.timeout:
                 continue
 

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -631,6 +631,26 @@ def _should_normalize_level_expectation(name: str, path: FieldPath) -> bool:
     return _NORMALIZED_LEVEL_EXPECTATION_COMMANDS.get(name) == path.name
 
 
+def _raw_level_from_param(value: Any) -> int:
+    """Coerce a level command param to the raw 0-255 scale.
+
+    MOR-334 regression fix: ``set_rf_gain``/``set_af_level``/``set_squelch``
+    accept a level either pre-scaled (raw 0-255) or normalized (0.0-1.0, as the
+    web sliders emit). The migration replaced the prior scale-aware coercion
+    with a bare ``int()``, so a normalized slider value (e.g. ``0.98``)
+    collapsed to ``int(0.98) == 0``. The expected/overlay value (used for
+    readback reconciliation) then sat at the opposite end of the scale from the
+    value the radio was actually set to, which surfaced as the control snapping
+    back to ``0`` (left edge) ~1s after a set. Mirror the web control-handler
+    coercion (``_normalized_or_raw_level``) so the StateStore expectation tracks
+    reality. Raw ints (and the boundary ``1.0``) round-trip unchanged.
+    """
+    numeric = float(value)
+    if 0.0 <= numeric <= 1.0:
+        return max(0, min(255, round(numeric * 255)))
+    return max(0, min(255, int(numeric)))
+
+
 def _normalize_raw_level_value(value: Any) -> Any:
     if isinstance(value, bool):
         return value
@@ -838,11 +858,11 @@ def command_intent_from_request(
     elif command_name == "ptt_off":
         normalized["ptt"] = False
     elif command_name == "set_rf_gain":
-        normalized["rf_gain"] = int(normalized["level"])
+        normalized["rf_gain"] = _raw_level_from_param(normalized["level"])
     elif command_name == "set_af_level":
-        normalized["af_level"] = int(normalized["level"])
+        normalized["af_level"] = _raw_level_from_param(normalized["level"])
     elif command_name in ("set_sql", "set_squelch"):
-        normalized["squelch"] = int(normalized["level"])
+        normalized["squelch"] = _raw_level_from_param(normalized["level"])
     elif command_name in ("set_att", "set_attenuator", "set_attenuator_level"):
         raw_value = (
             normalized["db"]

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -55,6 +55,7 @@ from rigplane.core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
+from rigplane.core.state_store import FreshnessState
 from rigplane.scope import ScopeFrame
 from rigplane.core.types import CivFrame, Mode
 from rigplane.runtime.meter_cal import interpolate_meter
@@ -1379,16 +1380,30 @@ class CivRuntime:
         coalescer = getattr(self._host, "_meter_observation_coalescer", None)
         if not isinstance(coalescer, MeterObservationCoalescer):
             return False
-        # MOR-334 regression fix (s_meter stuck at 0): seed-then-coalesce. The
-        # coalescer only flushes a sample once it has aged past its window, and
-        # the post-record flush below runs with ``now`` equal to this sample's
-        # own timestamp — so the very first sample for a path is never flushed
-        # until a *later* sample (or a poll-cycle flush) arrives. Until then the
-        # store has no entry for the meter and the public projection falls back
-        # to the RadioState default (sMeter=0). When the store has no confirmed
-        # value yet for this path, apply this first sample immediately so the
-        # meter is never stuck at its default; subsequent samples coalesce.
-        if not self._state_store_has_path(observation.path):
+        # MOR-334 regression fix (s_meter / rf-readback meters stuck at a stale
+        # low reading): apply-fresh-then-coalesce.
+        #
+        # ``flush_due`` only releases a path once its *latest* pending sample has
+        # aged past the coalescing window, and the post-record flush below runs
+        # with ``now`` equal to this sample's own timestamp — so the latest
+        # sample is never due on its own arrival. With live meters arriving ~1/s
+        # but a short window (0.2s) and a short freshness TTL (0.6-0.8s), the
+        # store value lagged ~1-2 samples *and* decayed to ``stale`` between
+        # arrivals. A stale store entry then drives the public S-meter to its
+        # floor even though the radio is reporting a real value on the wire —
+        # the reported "S0 / S-1 with signal present".
+        #
+        # The earlier seed-only fix (apply immediately *only when the store has
+        # no entry yet*) covered the very first sample but left every later
+        # sample held in the coalescer behind a stale reading. Extend it: when
+        # the store holds no confirmed FRESH value for this path (absent or
+        # already decayed to STALE/UNKNOWN as of this sample's timestamp), apply
+        # the sample immediately so a live meter tracks promptly. Only when the
+        # store value is still FRESH (rapid burst within the window) do we
+        # coalesce, preserving the burst-rate throttling the window is for.
+        if not self._state_store_value_is_fresh(
+            observation.path, now=observation.timestamp_monotonic
+        ):
             changeset = self._host._state_store.apply(observation)
             self._record_scheduler_result_for_observation(observation, changeset)
             self._notify_state_store_changed(changeset)
@@ -1402,13 +1417,21 @@ class CivRuntime:
         self.flush_due_meter_observations(now=observation.timestamp_monotonic)
         return True
 
-    def _state_store_has_path(self, path: FieldPath) -> bool:
-        """Return True if the StateStore already holds a confirmed value."""
+    def _state_store_value_is_fresh(self, path: FieldPath, *, now: float) -> bool:
+        """Return True only if the store holds a FRESH confirmed value for path.
+
+        Freshness in :class:`StateStore` decays solely via ``mark_stale_due``, so
+        evaluate expiry as of ``now`` (this sample's timestamp) before reading the
+        entry — otherwise a value that has aged out since its last apply would
+        still report ``FRESH`` and the meter would stay stuck behind the window.
+        """
+        store = self._host._state_store
+        store.mark_stale_due(now=now)
         try:
-            self._host._state_store.snapshot().field(path)
+            field = store.snapshot().field(path)
         except KeyError:
             return False
-        return True
+        return field.freshness is FreshnessState.FRESH
 
     def flush_due_meter_observations(
         self, *, now: float | None = None

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -55,7 +55,6 @@ from rigplane.core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
-from rigplane.core.state_store import FreshnessState
 from rigplane.scope import ScopeFrame
 from rigplane.core.types import CivFrame, Mode
 from rigplane.runtime.meter_cal import interpolate_meter
@@ -81,7 +80,14 @@ _OBSERVATION_MAX_AGE_SECONDS: dict[tuple[str, str, str], float] = {
     ("receiver", "freq_mode", "freq_hz"): 5.0,
     ("receiver", "freq_mode", "mode"): 5.0,
     ("receiver", "vfo", "active_slot"): 5.0,
-    ("receiver", "meters", "s_meter"): 0.6,
+    # MOR-334 (s_meter stuck-low, 3rd attempt): streaming meters arrive ~1/s on a
+    # live IC-7610 (with occasional multi-second gaps). A 0.6s TTL is SHORTER than
+    # the real inter-arrival interval, so the field decayed to ``stale`` between
+    # every arrival even when the radio was streaming healthily — and a stale/
+    # missing meter floors to S0 on the LCD layout. Use a TTL that exceeds the
+    # real cadence so a streaming meter stays FRESH between samples; it still
+    # expires promptly (2s) once the radio genuinely stops streaming.
+    ("receiver", "meters", "s_meter"): 2.0,
     ("receiver", "operator_toggles", "nb"): 10.0,
     ("receiver", "operator_toggles", "nr"): 10.0,
     ("receiver", "operator_controls", "af_level"): 10.0,
@@ -95,12 +101,14 @@ _OBSERVATION_MAX_AGE_SECONDS: dict[tuple[str, str, str], float] = {
     ("global", "tx_state", "power_on"): 30.0,
     ("global", "operator_controls", "rit_freq"): 10.0,
     ("global", "operator_controls", "power_level"): 30.0,
-    ("global", "meters", "alc"): 0.6,
-    ("global", "meters", "power"): 0.6,
-    ("global", "meters", "swr"): 0.6,
-    ("global", "meters", "comp"): 0.6,
-    ("global", "meters", "vd"): 0.6,
-    ("global", "meters", "id"): 0.6,
+    # See the s_meter note above: streaming TX/PA meters share the same ~1/s live
+    # cadence, so they get the same 2s freshness TTL to avoid chronic staleness.
+    ("global", "meters", "alc"): 2.0,
+    ("global", "meters", "power"): 2.0,
+    ("global", "meters", "swr"): 2.0,
+    ("global", "meters", "comp"): 2.0,
+    ("global", "meters", "vd"): 2.0,
+    ("global", "meters", "id"): 2.0,
 }
 
 _CIV_STATE_FIELD_FAMILIES = {
@@ -1380,29 +1388,30 @@ class CivRuntime:
         coalescer = getattr(self._host, "_meter_observation_coalescer", None)
         if not isinstance(coalescer, MeterObservationCoalescer):
             return False
-        # MOR-334 regression fix (s_meter / rf-readback meters stuck at a stale
-        # low reading): apply-fresh-then-coalesce.
+        # MOR-334 (s_meter stuck-low, 3rd attempt): apply-unless-rapid-burst.
         #
         # ``flush_due`` only releases a path once its *latest* pending sample has
         # aged past the coalescing window, and the post-record flush below runs
         # with ``now`` equal to this sample's own timestamp — so the latest
-        # sample is never due on its own arrival. With live meters arriving ~1/s
-        # but a short window (0.2s) and a short freshness TTL (0.6-0.8s), the
-        # store value lagged ~1-2 samples *and* decayed to ``stale`` between
-        # arrivals. A stale store entry then drives the public S-meter to its
-        # floor even though the radio is reporting a real value on the wire —
-        # the reported "S0 / S-1 with signal present".
+        # sample is never due on its own arrival and stays held in the coalescer
+        # until a *later* sample bypasses it. Coalescing must therefore apply
+        # ONLY to genuine sub-window bursts; a sample that arrives more than one
+        # coalescing window after the stored value must land immediately so the
+        # public S-meter tracks the live reading and never decays to ``stale``
+        # (which floors to S0 on the LCD layout via ``rx.sMeter ?? -54``).
         #
-        # The earlier seed-only fix (apply immediately *only when the store has
-        # no entry yet*) covered the very first sample but left every later
-        # sample held in the coalescer behind a stale reading. Extend it: when
-        # the store holds no confirmed FRESH value for this path (absent or
-        # already decayed to STALE/UNKNOWN as of this sample's timestamp), apply
-        # the sample immediately so a live meter tracks promptly. Only when the
-        # store value is still FRESH (rapid burst within the window) do we
-        # coalesce, preserving the burst-rate throttling the window is for.
-        if not self._state_store_value_is_fresh(
-            observation.path, now=observation.timestamp_monotonic
+        # The previous attempt gated this on the freshness *TTL*
+        # (``_state_store_value_is_fresh``). That conflated two unrelated
+        # timescales: with the meter TTL now raised above the ~1/s live
+        # inter-arrival interval (so the field stays FRESH between arrivals),
+        # a TTL-based gate treats every ~1s-apart sample as a "fresh burst" and
+        # coalesces it — re-introducing the stuck-low lag. Discriminate bursts
+        # by the coalescing *window* instead: only samples within one window of
+        # the stored value's own observation are throttled.
+        if not self._store_value_within_coalescing_window(
+            observation.path,
+            now=observation.timestamp_monotonic,
+            window=policy.meter_coalescing.window_seconds,
         ):
             changeset = self._host._state_store.apply(observation)
             self._record_scheduler_result_for_observation(observation, changeset)
@@ -1417,21 +1426,27 @@ class CivRuntime:
         self.flush_due_meter_observations(now=observation.timestamp_monotonic)
         return True
 
-    def _state_store_value_is_fresh(self, path: FieldPath, *, now: float) -> bool:
-        """Return True only if the store holds a FRESH confirmed value for path.
+    def _store_value_within_coalescing_window(
+        self, path: FieldPath, *, now: float, window: float
+    ) -> bool:
+        """Return True only if the stored value for ``path`` is a rapid burst.
 
-        Freshness in :class:`StateStore` decays solely via ``mark_stale_due``, so
-        evaluate expiry as of ``now`` (this sample's timestamp) before reading the
-        entry — otherwise a value that has aged out since its last apply would
-        still report ``FRESH`` and the meter would stay stuck behind the window.
+        "Rapid burst" means the store's current value for this path was observed
+        within one coalescing ``window`` of ``now`` (this sample's timestamp).
+        Such sub-window samples are throttled by the coalescer; anything older
+        (the common ~1/s live-meter case) must apply immediately so the value
+        tracks the radio and the field never decays to ``stale``.
+
+        Discriminating on the observation timestamp (not the freshness state)
+        decouples burst-throttling from the freshness TTL, so the TTL can exceed
+        the live inter-arrival interval without turning every arrival into a
+        coalesced "burst".
         """
-        store = self._host._state_store
-        store.mark_stale_due(now=now)
         try:
-            field = store.snapshot().field(path)
+            field = self._host._state_store.snapshot().field(path)
         except KeyError:
             return False
-        return field.freshness is FreshnessState.FRESH
+        return now - field.last_observed_monotonic < window
 
     def flush_due_meter_observations(
         self, *, now: float | None = None

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -1379,6 +1379,20 @@ class CivRuntime:
         coalescer = getattr(self._host, "_meter_observation_coalescer", None)
         if not isinstance(coalescer, MeterObservationCoalescer):
             return False
+        # MOR-334 regression fix (s_meter stuck at 0): seed-then-coalesce. The
+        # coalescer only flushes a sample once it has aged past its window, and
+        # the post-record flush below runs with ``now`` equal to this sample's
+        # own timestamp — so the very first sample for a path is never flushed
+        # until a *later* sample (or a poll-cycle flush) arrives. Until then the
+        # store has no entry for the meter and the public projection falls back
+        # to the RadioState default (sMeter=0). When the store has no confirmed
+        # value yet for this path, apply this first sample immediately so the
+        # meter is never stuck at its default; subsequent samples coalesce.
+        if not self._state_store_has_path(observation.path):
+            changeset = self._host._state_store.apply(observation)
+            self._record_scheduler_result_for_observation(observation, changeset)
+            self._notify_state_store_changed(changeset)
+            return True
         coalescer.record(observation, policy.meter_coalescing)
         self._record_state_diagnostic(
             "meter_coalescing",
@@ -1386,6 +1400,14 @@ class CivRuntime:
             **coalescer.diagnostics(),
         )
         self.flush_due_meter_observations(now=observation.timestamp_monotonic)
+        return True
+
+    def _state_store_has_path(self, path: FieldPath) -> bool:
+        """Return True if the StateStore already holds a confirmed value."""
+        try:
+            self._host._state_store.snapshot().field(path)
+        except KeyError:
+            return False
         return True
 
     def flush_due_meter_observations(
@@ -1539,6 +1561,18 @@ class CivRuntime:
                     frame=frame,
                 )
             )
+            if len(frame.data) >= 3:
+                # MOR-334 regression fix: the 0x26 answer carries the DATA-mode
+                # flag in data[2]. The legacy ``_handle_26`` mirror reads it, but
+                # the StateStore observation path dropped it, so D1/D2/D3 never
+                # reached the web UI. Project it as the active-slot data_mode.
+                observations.append(
+                    self._observation(
+                        FieldPath.active(target_receiver, "freq_mode", "data_mode"),
+                        int(frame.data[2]),
+                        frame=frame,
+                    )
+                )
             if len(frame.data) >= 4:
                 observations.append(
                     self._observation(

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -406,6 +406,18 @@ class _HttpCommandExecutor:
         raise ValueError(f"unsupported HTTP command intent: {intent.name!r}")
 
 
+# MOR-616: SET command name -> ``global.slow_state.<field>`` for the
+# per-DATA-group MOD-input selector. The optimistic overlay and the poller
+# readback (radio_poller._apply_global_control_observation) must agree on these
+# paths for last-writer-wins reconciliation to work.
+_MOD_INPUT_COMMAND_FIELDS: dict[str, str] = {
+    "set_data_off_mod_input": "data_off_mod_input",
+    "set_data1_mod_input": "data1_mod_input",
+    "set_data2_mod_input": "data2_mod_input",
+    "set_data3_mod_input": "data3_mod_input",
+}
+
+
 @dataclass(slots=True)
 class _SharedControlCommandExecutor:
     server: "WebServer"
@@ -450,9 +462,9 @@ class _SharedControlCommandExecutor:
             else None
         )
 
-        def _observation(name: str, value: Any) -> Observation:
+        def _observation(path: FieldPath, value: Any) -> Observation:
             return Observation(
-                path=FieldPath.active(receiver, "freq_mode", name),
+                path=path,
                 value=value,
                 source=SourceMetadata(
                     source="command_response",
@@ -464,12 +476,33 @@ class _SharedControlCommandExecutor:
                 correlation_id=intent.id,
             )
 
+        def _active(name: str, value: Any) -> Observation:
+            return _observation(FieldPath.active(receiver, "freq_mode", name), value)
+
         if intent.name == "set_freq":
-            return (_observation("freq_hz", int(intent.params["freq_hz"])),)
+            return (_active("freq_hz", int(intent.params["freq_hz"])),)
         if intent.name == "set_mode":
-            return (_observation("mode", str(intent.params["mode"])),)
+            return (_active("mode", str(intent.params["mode"])),)
         if intent.name == "set_data_mode":
-            return (_observation("data_mode", int(intent.params["mode"])),)
+            return (_active("data_mode", int(intent.params["mode"])),)
+        # MOR-616 regression fix: the per-DATA-group MOD-input selector
+        # (set_data_off/1/2/3_mod_input, payload ``{source: int}``) had the same
+        # snap-back defect — the executor returned an ack with no observation, so
+        # the published source reverted to the stale store value until the
+        # deferred readback (radio_poller._fetch_mod_inputs, gated behind
+        # external_cat_pause and a data_mode-change refetch) landed, longer than
+        # the frontend optimistic TTL. The readback writes the confirmed value to
+        # ``global.slow_state.<field>`` via _apply_global_control_observation, so
+        # the overlay must target the SAME path to keep last-writer-wins
+        # reconciliation (front-panel tracking preserved).
+        mod_input_field = _MOD_INPUT_COMMAND_FIELDS.get(intent.name)
+        if mod_input_field is not None:
+            return (
+                _observation(
+                    FieldPath.global_("slow_state", mod_input_field),
+                    int(intent.params["source"]),
+                ),
+            )
         return ()
 
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -423,32 +423,54 @@ class _SharedControlCommandExecutor:
             command_service=self.server.command_service,
         )
         # MOR-485: publish an optimistic command-response overlay for set_freq
-        # so the projected snapshot reflects the commanded freq immediately
+        # so the projected snapshot reflects the commanded value immediately
         # instead of snapping back until the deferred readback lands. Emitted
         # only on enqueue SUCCESS (a raised enqueue never reaches here, so the
         # optimistic value is never written for a failed set). The ACTIVE slot
         # matches the readback emitters in runtime/_civ_rx.py and the projection
         # in web/runtime_helpers.py.
-        observations: tuple[Observation, ...] = ()
-        if intent.name == "set_freq":
-            receiver = str(int(intent.params.get("receiver", 0)))
-            observations = (
-                Observation(
-                    path=FieldPath.active(receiver, "freq_mode", "freq_hz"),
-                    value=int(intent.params["freq_hz"]),
-                    source=SourceMetadata(
-                        source="command_response",
-                        provider="web_command",
-                        command_source=intent.source,
-                        session_id=str(intent.params["session_id"])
-                        if intent.params.get("session_id")
-                        else None,
-                    ),
-                    timestamp_monotonic=time.monotonic(),
-                    correlation_id=intent.id,
-                ),
-            )
+        #
+        # MOR-334 regression fix: ``set_mode`` and ``set_data_mode`` had the
+        # identical snap-back defect MOR-485 fixed for freq — the executor
+        # returned an ack with no observation, so the published mode reverted to
+        # the stale store value until the readback (deferred ~2-4.3s by
+        # external_cat_pause=pause_polling, longer than the frontend optimistic
+        # TTL) landed. The same active-slot path keeps later readbacks
+        # reconciling via last-writer-wins (front-panel tracking preserved).
+        observations = self._optimistic_observations(intent)
         return CommandExecutionResult(details=result, observations=observations)
+
+    def _optimistic_observations(
+        self, intent: CommandIntent
+    ) -> tuple[Observation, ...]:
+        receiver = str(int(intent.params.get("receiver", 0)))
+        session_id = (
+            str(intent.params["session_id"])
+            if intent.params.get("session_id")
+            else None
+        )
+
+        def _observation(name: str, value: Any) -> Observation:
+            return Observation(
+                path=FieldPath.active(receiver, "freq_mode", name),
+                value=value,
+                source=SourceMetadata(
+                    source="command_response",
+                    provider="web_command",
+                    command_source=intent.source,
+                    session_id=session_id,
+                ),
+                timestamp_monotonic=time.monotonic(),
+                correlation_id=intent.id,
+            )
+
+        if intent.name == "set_freq":
+            return (_observation("freq_hz", int(intent.params["freq_hz"])),)
+        if intent.name == "set_mode":
+            return (_observation("mode", str(intent.params["mode"])),)
+        if intent.name == "set_data_mode":
+            return (_observation("data_mode", int(intent.params["mode"])),)
+        return ()
 
 
 async def _read_capped_body(

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -1786,6 +1786,102 @@ def test_first_coalesced_meter_sample_seeds_store_immediately(
     assert radio._meter_observation_coalescer._pending == []  # noqa: SLF001
 
 
+def test_stale_meter_sample_applies_immediately_and_reaches_projection(
+    radio: IcomRadio,
+) -> None:
+    """MOR-334 regression (s_meter stuck low / "S0 with signal present").
+
+    A live meter arriving ~1/s with a short freshness TTL decays to ``stale``
+    between arrivals. The seed-only fix held every post-seed sample in the
+    coalescer behind that stale reading, so the public projection (the thing the
+    WS broadcasts) lagged 1-2 samples and sat at the floor. After the fix, a
+    sample whose stored value has already decayed past freshness is applied
+    immediately and the *projected* payload — not just the store — carries it.
+    """
+    from rigplane.web.runtime_helpers import build_public_state_payload_from_snapshot
+
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    # IC-7610 streaming-meter shape: fast cadence with a short freshness TTL
+    # (0.8s). Frames below arrive 1s apart, so the value decays to stale between
+    # them.
+    policy = AcquisitionPolicy(
+        cadence_seconds=0.2,
+        freshness_ttl_seconds=0.8,
+        meter_coalescing=MeterCoalescingPolicy(window_seconds=0.2),
+    )
+    radio._acquisition_scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path, policy=policy)
+    )
+    radio._meter_observation_coalescer = MeterObservationCoalescer()
+
+    stored_path = "receiver.0.meters.s_meter"
+
+    # First sample seeds (calibrated raw 0 -> -54 = S0 floor).
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=100.0):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(0))
+        )
+    assert radio._state_store.snapshot().field(stored_path).value == -54
+
+    # Second sample arrives ~1s later — the seeded value has decayed past the
+    # 0.8s TTL, so the live reading (calibrated raw 122 -> -4) must land in the
+    # store immediately rather than being held behind the stale floor.
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=101.0):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(122))
+        )
+    stored = radio._state_store.snapshot().field(stored_path).value
+    assert stored != -54, "live meter must not stay stuck at the S0 floor"
+    assert stored == -4
+    # The coalescer is not holding the live sample.
+    assert radio._meter_observation_coalescer._pending == []  # noqa: SLF001
+
+    # The value survives all the way to the projected WS payload.
+    payload = build_public_state_payload_from_snapshot(
+        radio._state_store.snapshot(),
+        radio=None,
+        receiver_count=2,
+    )
+    assert payload["main"]["sMeter"] == -4
+
+
+def test_fresh_burst_meter_samples_still_coalesce(radio: IcomRadio) -> None:
+    """The stale-apply fix must not defeat burst coalescing: when the stored
+    value is still FRESH, rapid samples within the window coalesce as before.
+    """
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    policy = AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=4.0,
+        meter_coalescing=MeterCoalescingPolicy(window_seconds=0.2),
+    )
+    radio._acquisition_scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path, policy=policy)
+    )
+    radio._meter_observation_coalescer = MeterObservationCoalescer()
+    stored_path = "receiver.0.meters.s_meter"
+
+    # Seed (raw 111 -> -8).
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=200.0):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(111))
+        )
+    assert radio._state_store.snapshot().field(stored_path).value == -8
+
+    # A second sample 0.05s later, still FRESH (TTL 4.0s) and within the 0.2s
+    # window — coalesced, so the store still holds the seeded value.
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=200.05):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(222))
+        )
+    assert radio._state_store.snapshot().field(stored_path).value == -8
+    assert radio._meter_observation_coalescer._pending != []  # noqa: SLF001
+
+    # After the window elapses the coalesced latest sample lands (raw 222 -> 31).
+    radio._civ_runtime.flush_due_meter_observations(now=200.3)
+    assert radio._state_store.snapshot().field(stored_path).value == 31
+
+
 def test_same_value_coalesced_meter_flush_completes_scheduler_request(
     radio: IcomRadio,
 ) -> None:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -1882,6 +1882,84 @@ def test_fresh_burst_meter_samples_still_coalesce(radio: IcomRadio) -> None:
     assert radio._state_store.snapshot().field(stored_path).value == 31
 
 
+def test_meter_value_survives_freshness_window_between_live_arrivals(
+    radio: IcomRadio,
+) -> None:
+    """MOR-334 (s_meter stuck-low, 3rd attempt): the stale *window*, not apply.
+
+    The prior regression tests projected the payload immediately after applying a
+    sample — while the field is still FRESH — which is exactly the window the live
+    failure hides in. On real hardware the meter arrives ~1/s; if the freshness
+    TTL is SHORTER than that interval the field decays to ``stale`` between every
+    arrival, and a stale/last-known meter floors to S0 on the LCD layout
+    (``rx.sMeter ?? -54``). This test advances the clock PAST the inter-arrival
+    interval, runs the freshness-decay tick (the production
+    ``StateFreshnessService`` path), and asserts the projected WS payload the
+    frontend consumes still carries the real last-known value — not the floor.
+
+    Fail-without: with the meter TTL at the old 0.6s the field is ``stale`` 0.9s
+    after the sample and the public S-meter sits behind a stale reading. Pass-
+    with: the TTL exceeds the live cadence, so a streaming meter stays FRESH and
+    the real value reaches the UI.
+    """
+    from rigplane.web.runtime_helpers import build_public_state_payload_from_snapshot
+
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    # Production cadence: fast nominal cadence, short coalescing window, and the
+    # freshness TTL the shipped IC-7610 CI-V path assigns to s_meter
+    # (``_OBSERVATION_MAX_AGE_SECONDS``). The observation carries that TTL into
+    # the store, so the test asserts against the real shipped value rather than a
+    # synthetic one.
+    from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
+
+    s_meter_ttl = _OBSERVATION_MAX_AGE_SECONDS[("receiver", "meters", "s_meter")]
+    policy = AcquisitionPolicy(
+        cadence_seconds=0.2,
+        freshness_ttl_seconds=4.0,
+        meter_coalescing=MeterCoalescingPolicy(window_seconds=0.2),
+    )
+    radio._acquisition_scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path, policy=policy)
+    )
+    radio._meter_observation_coalescer = MeterObservationCoalescer()
+    stored_path = "receiver.0.meters.s_meter"
+
+    # A real mid-scale sample (raw 122 -> calibrated -4 dB-rel-S9 ≈ S8) arrives.
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=300.0):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(122))
+        )
+    assert radio._state_store.snapshot().field(stored_path).value == -4
+
+    # The next live frame is ~1s away. Drive the freshness-decay tick (the
+    # production StateFreshnessService loop) to the moment just before that next
+    # arrival — i.e. one full inter-arrival interval after the sample. This is the
+    # exact window the old 0.6s TTL fell into (0.9s age > 0.6s TTL -> STALE); the
+    # prior sim never advanced the clock here, so it missed the failure.
+    inter_arrival = 1.0
+    decay_at = 300.0 + inter_arrival - 0.1  # 0.9s after the sample
+    radio._state_store.mark_stale_due(now=decay_at)
+
+    field = radio._state_store.snapshot().field(stored_path)
+    # The shipped TTL must exceed the ~1s live inter-arrival interval so the field
+    # stays FRESH between arrivals (the actual fix).
+    assert s_meter_ttl > 1.0, (
+        "s_meter freshness TTL must exceed the ~1/s live inter-arrival interval "
+        "or the field decays to stale (S0 floor) between every frame"
+    )
+    assert field.freshness is FreshnessState.FRESH
+
+    # The real last-known value reaches the projected WS payload — never the
+    # floor — across the inter-arrival window.
+    payload = build_public_state_payload_from_snapshot(
+        radio._state_store.snapshot(),
+        radio=None,
+        receiver_count=2,
+    )
+    assert payload["main"]["sMeter"] == -4
+    assert payload["main"]["sMeter"] != -54  # the calibrated S0 floor
+
+
 def test_same_value_coalesced_meter_flush_completes_scheduler_request(
     radio: IcomRadio,
 ) -> None:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -1030,6 +1030,36 @@ def test_update_state_cache_omits_filter_num_when_byte_absent(
         snapshot.field(f"receiver.{target_receiver}.active.freq_mode.filter_num")
 
 
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("frame", "target_receiver", "expected"),
+    [
+        # MAIN, USB, DATA1, filter 2
+        (_make_frame(cmd=0x26, data=bytes([0x00, Mode.USB.value, 0x01, 0x02])), "0", 1),
+        # SUB, CW, DATA3, filter 1
+        (_make_frame(cmd=0x26, data=bytes([0x01, Mode.CW.value, 0x03, 0x01])), "1", 3),
+        # MAIN, USB, DATA OFF (3-byte frame, no filter byte)
+        (_make_frame(cmd=0x26, data=bytes([0x00, Mode.USB.value, 0x00])), "0", 0),
+    ],
+)
+def test_update_state_cache_projects_data_mode_from_cmd26(
+    radio: IcomRadio,
+    frame: CivFrame,
+    target_receiver: str,
+    expected: int,
+) -> None:
+    """MOR-334 regression: the 0x26 answer carries the DATA-mode flag in data[2].
+
+    The StateStore observation path dropped data[2], so D1/D2/D3 never reached
+    the web UI even though the legacy ``_handle_26`` mirror read it.
+    """
+    radio._civ_runtime._update_state_cache_from_frame(frame)
+
+    field = radio._state_store.snapshot().field(
+        f"receiver.{target_receiver}.active.freq_mode.data_mode"
+    )
+    assert field.value == expected
+
+
 # ---------------------------------------------------------------------------
 # MOR-437: slow-state bool/status families observation-backed
 # ---------------------------------------------------------------------------
@@ -1668,28 +1698,45 @@ def test_meter_coalescing_applies_latest_due_sample_and_records_diagnostics(
     events: list[tuple[str, dict[str, object]]] = []
     radio._on_state_change = lambda name, data: events.append((name, data))
 
+    # MOR-334 regression (s_meter stuck at 0): seed-then-coalesce. The FIRST
+    # sample for a path is applied immediately (the store was empty, so holding
+    # it in the coalescer would leave the public projection at the sMeter=0
+    # default until a later sample/flush). Subsequent samples coalesce.
     with patch(
         "rigplane.runtime._civ_rx.time.monotonic",
-        side_effect=[100.0, 100.0, 100.1, 100.1],
+        return_value=100.0,
     ):
         radio._civ_runtime._apply_state_store_observations(
             _make_frame(cmd=0x15, sub=0x02, data=_bcd2(111))
         )
+
+    # First sample applied immediately (calibrated raw 111 -> -8).
+    assert radio._state_store.snapshot().field("receiver.0.meters.s_meter").value == -8
+
+    with patch(
+        "rigplane.runtime._civ_rx.time.monotonic",
+        return_value=100.1,
+    ):
         radio._civ_runtime._apply_state_store_observations(
             _make_frame(cmd=0x15, sub=0x02, data=_bcd2(222))
         )
 
-    with pytest.raises(KeyError):
-        radio._state_store.snapshot().field("receiver.0.meters.s_meter")
+    # Second sample coalesced (store still holds the seeded value until flush).
+    assert radio._state_store.snapshot().field("receiver.0.meters.s_meter").value == -8
 
     radio._civ_runtime.flush_due_meter_observations(now=100.3)
 
+    # After the window elapses the coalesced latest sample lands (raw 222 -> 31).
     assert radio._state_store.snapshot().field("receiver.0.meters.s_meter").value == 31
     assert events == [
         (
             "state_store_changed",
+            {"coalesced": False, "paths": ["receiver.0.meters.s_meter"]},
+        ),
+        (
+            "state_store_changed",
             {"coalesced": True, "paths": ["receiver.0.meters.s_meter"]},
-        )
+        ),
     ]
     meter_events = [
         event
@@ -1700,9 +1747,43 @@ def test_meter_coalescing_applies_latest_due_sample_and_records_diagnostics(
         "pendingSampleCount": 0,
         "pendingPaths": [],
         "droppedSampleCount": 0,
-        "coalescedSampleCount": 1,
+        "coalescedSampleCount": 0,
         "nextFlushMonotonic": None,
     }
+
+
+def test_first_coalesced_meter_sample_seeds_store_immediately(
+    radio: IcomRadio,
+) -> None:
+    """MOR-334 regression (s_meter stuck at 0): the first meter sample for an
+    unseen path is applied immediately rather than held in the coalescer.
+
+    The coalescer only flushes a sample once it has aged past its window, and
+    the post-record flush runs with ``now`` equal to the sample's own
+    timestamp, so the very first sample for a path would otherwise never reach
+    the store until a *later* sample arrived. Until then the public projection
+    falls back to the RadioState ``sMeter=0`` default — the reported stuck-at-0.
+    """
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    policy = AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=4.0,
+        meter_coalescing=MeterCoalescingPolicy(window_seconds=0.2),
+    )
+    radio._acquisition_scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path, policy=policy)
+    )
+    radio._meter_observation_coalescer = MeterObservationCoalescer()
+
+    # A single sample, no later sample and no explicit flush: the value must
+    # already be in the store (calibrated raw 150 -> 6).
+    radio._civ_runtime._apply_state_store_observations(
+        _make_frame(cmd=0x15, sub=0x02, data=_bcd2(150))
+    )
+
+    assert radio._state_store.snapshot().field("receiver.0.meters.s_meter").value == 6
+    # The seed went straight to the store, not the coalescer.
+    assert radio._meter_observation_coalescer._pending == []  # noqa: SLF001
 
 
 def test_same_value_coalesced_meter_flush_completes_scheduler_request(

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1331,6 +1331,57 @@ async def test_set_squelch_command_response_reconciles_normalized_overlay() -> N
     ]
 
 
+@pytest.mark.parametrize(
+    ("name", "path_name"),
+    [
+        ("set_rf_gain", "rf_gain"),
+        ("set_af_level", "af_level"),
+        ("set_squelch", "squelch"),
+    ],
+)
+def test_normalized_level_command_expectation_matches_radio_scale(
+    name: str,
+    path_name: str,
+) -> None:
+    """MOR-334 regression (rf-gain set reverts to 0 / left edge).
+
+    Web level sliders emit a normalized 0.0-1.0 ``level``. The migration
+    coerced the command param with a bare ``int()``, so a slider at 98%
+    (``0.98``) collapsed to ``int(0.98) == 0`` and the StateStore expectation /
+    overlay sat at the *opposite* end of the scale from the value the radio was
+    actually driven to (``round(0.98 * 255) == 250``). The deferred readback
+    (~0.98) then never matched the bogus ``0`` expectation, surfacing as the
+    control snapping back to 0. The expected/overlay value must track the same
+    raw scale the radio is set to via ``_normalized_or_raw_level``.
+    """
+    from rigplane.web.handlers.control import _normalized_or_raw_level
+
+    intent = command_intent_from_request(
+        name,
+        {"level": 0.98, "receiver": 0},
+        source="websocket",
+        command_id=f"ws-{name}",
+        session_id="client-a",
+    )
+    path = FieldPath.receiver("0", "operator_controls", path_name)
+
+    # Param is coerced to the raw scale the radio actually receives — not 0.
+    radio_raw = _normalized_or_raw_level(0.98)
+    assert radio_raw == 250
+    assert intent.params[path_name] == radio_raw
+
+    # The expectation/overlay value the readback reconciles against is the
+    # normalized form of that same raw value (~0.98), not 0.0.
+    observation = command_response_observation(
+        intent,
+        timestamp_monotonic=70.0,
+        provider="test",
+    )
+    assert str(intent.target) == str(path)
+    assert observation.value == pytest.approx(250 / 255)
+    assert observation.value > 0.9
+
+
 @pytest.mark.asyncio
 async def test_raw_external_rigctld_level_readback_normalizes_before_reconcile() -> (
     None

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -20,6 +20,7 @@ from rigplane.discovery import (
     build_setup_discovery_payload,
     _parse_yaesu_id_response,
     dedupe_radios,
+    discover_lan_radios,
     discover_serial_radios,
     enumerate_serial_ports,
     probe_serial_civ,
@@ -1305,3 +1306,153 @@ class TestDiscoverSerialRadios:
         assert len(results) == 2
         protocols = {r.protocol for r in results}
         assert protocols == {"civ", "yaesu_cat"}
+
+
+# ---------------------------------------------------------------------------
+# LAN UDP discovery (discover_lan_radios) — probe retransmit / dedup
+# ---------------------------------------------------------------------------
+
+
+def _i_am_here(remote_id: int) -> bytes:
+    """Build a minimal Icom I_AM_HERE (0x04) reply packet."""
+    import struct
+
+    pkt = bytearray(0x10)
+    struct.pack_into("<I", pkt, 0, 0x10)  # size
+    struct.pack_into("<H", pkt, 4, 0x04)  # I_AM_HERE
+    struct.pack_into("<H", pkt, 6, 0)  # seq
+    struct.pack_into("<I", pkt, 8, remote_id)  # remote_id
+    struct.pack_into("<I", pkt, 0x0C, 0)
+    return bytes(pkt)
+
+
+class _FakeClock:
+    """Monotonic clock that advances a fixed step on every read.
+
+    Lets the scan loop terminate deterministically without real waiting while
+    still crossing the resend thresholds so retransmits fire.
+    """
+
+    def __init__(self, step: float = 0.05) -> None:
+        self._t = 1000.0
+        self._step = step
+
+    def __call__(self) -> float:
+        now = self._t
+        self._t += self._step
+        return now
+
+
+class _FakeUdpSocket:
+    """Fake UDP socket for discover_lan_radios.
+
+    ``responses`` maps a probe index (1-based count of sendto calls so far) to
+    a list of (data, addr) tuples to hand back from the *next* recvfrom calls.
+    Each scripted response is delivered exactly once; otherwise recvfrom raises
+    socket.timeout so the scan keeps looping until the clock passes the
+    deadline.
+    """
+
+    def __init__(self, responses: dict[int, list[tuple[bytes, tuple]]]) -> None:
+        self._responses = {k: list(v) for k, v in responses.items()}
+        self.send_count = 0
+        self.closed = False
+        self._pending: list[tuple[bytes, tuple]] = []
+
+    def setsockopt(self, *_a: object, **_k: object) -> None:
+        pass
+
+    def settimeout(self, *_a: object, **_k: object) -> None:
+        pass
+
+    def sendto(self, _data: bytes, _addr: tuple) -> int:
+        self.send_count += 1
+        # Queue any responses unlocked by reaching this probe count.
+        self._pending.extend(self._responses.pop(self.send_count, []))
+        return len(_data)
+
+    def recvfrom(self, _bufsize: int) -> tuple[bytes, tuple]:
+        import socket as _socket
+
+        if self._pending:
+            return self._pending.pop(0)
+        raise _socket.timeout()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@contextmanager
+def _patched_lan_socket(fake: _FakeUdpSocket, *, step: float = 0.05):
+    import socket as _socket
+    import time as _time
+
+    with (
+        patch.object(_socket, "socket", return_value=fake),
+        patch.object(_time, "monotonic", _FakeClock(step=step)),
+    ):
+        yield
+
+
+class TestDiscoverLanRadios:
+    async def test_radio_answering_only_later_probe_is_found(self) -> None:
+        # Radio stays silent for probe #1, replies only after the 3rd probe.
+        addr = ("192.168.1.50", 50001)
+        fake = _FakeUdpSocket({3: [(_i_am_here(0xDEADBEEF), addr)]})
+        with _patched_lan_socket(fake):
+            result = await discover_lan_radios(timeout=3.0)
+
+        assert fake.send_count >= 3  # the probe was retransmitted
+        assert result == [{"host": "192.168.1.50", "remote_id": 0xDEADBEEF}]
+
+    async def test_single_probe_would_miss_late_responder(self) -> None:
+        # Sanity-anchor the regression: a radio that ignores the first probe is
+        # only recoverable because of retransmits. With responses gated behind
+        # probe #2+, a single-shot scan (send_count==1) would return nothing.
+        addr = ("192.168.1.51", 50001)
+        fake = _FakeUdpSocket({2: [(_i_am_here(0x11112222), addr)]})
+        with _patched_lan_socket(fake):
+            result = await discover_lan_radios(timeout=3.0)
+
+        assert fake.send_count >= 2
+        assert result == [{"host": "192.168.1.51", "remote_id": 0x11112222}]
+
+    async def test_radio_answering_multiple_probes_is_deduplicated(self) -> None:
+        # Same host replies to probe #1 and probe #2 -> returned exactly once.
+        addr = ("192.168.1.60", 50001)
+        fake = _FakeUdpSocket(
+            {
+                1: [(_i_am_here(0xAABBCCDD), addr)],
+                2: [(_i_am_here(0xAABBCCDD), addr)],
+            }
+        )
+        with _patched_lan_socket(fake):
+            result = await discover_lan_radios(timeout=3.0)
+
+        assert result == [{"host": "192.168.1.60", "remote_id": 0xAABBCCDD}]
+        assert len(result) == 1
+
+    async def test_multiple_distinct_radios_collected(self) -> None:
+        a = ("192.168.1.70", 50001)
+        b = ("192.168.1.71", 50001)
+        fake = _FakeUdpSocket(
+            {
+                1: [(_i_am_here(0x1), a)],
+                2: [(_i_am_here(0x2), b)],
+            }
+        )
+        with _patched_lan_socket(fake):
+            result = await discover_lan_radios(timeout=3.0)
+
+        hosts = {r["host"] for r in result}
+        assert hosts == {"192.168.1.70", "192.168.1.71"}
+        assert len(result) == 2
+
+    async def test_no_responder_returns_empty(self) -> None:
+        fake = _FakeUdpSocket({})
+        with _patched_lan_socket(fake):
+            result = await discover_lan_radios(timeout=3.0)
+
+        assert result == []
+        assert fake.send_count >= 2  # still retransmitted across the window
+        assert fake.closed

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -433,7 +433,15 @@ def test_known_profiles_stream_like_meters_use_fast_non_decaying_policies() -> N
             assert policy.cadence_seconds is not None
             assert policy.cadence_seconds <= 0.25
             assert policy.freshness_ttl_seconds is not None
-            assert policy.freshness_ttl_seconds <= 1.0
+            # MOR-334 (s_meter stuck-low): a streaming meter's freshness TTL must
+            # EXCEED its own cadence so the field stays FRESH between live
+            # arrivals (otherwise it decays to stale between every sample and
+            # floors to S0 on the LCD layout). It must also stay fast-expiring
+            # relative to slow controls so a genuinely stopped stream is detected
+            # promptly. Bound it well below the slow-control TTLs (>= 8.0s) while
+            # comfortably above the streaming cadence.
+            assert policy.cadence_seconds < policy.freshness_ttl_seconds
+            assert policy.freshness_ttl_seconds <= 2.0
             assert policy.adaptive_decay.enabled is False
             assert policy.meter_coalescing is not None
             assert (

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1064,6 +1064,110 @@ async def test_set_freq_failure_does_not_publish_command_overlay() -> None:
 
 
 @pytest.mark.asyncio
+async def test_set_mode_publishes_command_overlay_before_readback() -> None:
+    # MOR-334 regression (mode reverts ~1s after the user sets it): a set_mode
+    # through the shared (WS) command executor must write the commanded mode
+    # into the command_state_store and projected public state immediately,
+    # mirroring the MOR-485 set_freq fix. Without the optimistic observation the
+    # published mode snapped back to the stale store value until the deferred
+    # readback (delayed by external_cat_pause=pause_polling) landed.
+    radio = SimpleNamespace(connected=True, capabilities=set())
+    srv = WebServer(radio, WebConfig())
+    srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
+
+    intent = command_intent_from_request(
+        "set_mode",
+        {"mode": "CW", "receiver": 0},
+        source="websocket",
+        command_id="ws-mode-main",
+    )
+    await srv.command_service.execute(intent)
+
+    mode_path = FieldPath.active("0", "freq_mode", "mode")
+    assert srv.command_state_store.snapshot().field(mode_path).value == "CW"
+    assert srv.build_public_state()["main"]["mode"] == "CW"
+
+
+@pytest.mark.asyncio
+async def test_set_mode_overlay_yields_to_newer_external_readback() -> None:
+    # MOR-334 regression: front-panel tracking preserved. A later readback with
+    # a DIFFERENT mode must win (last-writer-wins); the optimistic value must
+    # not pin the mode.
+    radio = SimpleNamespace(connected=True, capabilities=set())
+    srv = WebServer(radio, WebConfig())
+    srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
+
+    intent = command_intent_from_request(
+        "set_mode",
+        {"mode": "CW", "receiver": 0},
+        source="websocket",
+        command_id="ws-mode-external",
+    )
+    await srv.command_service.execute(intent)
+
+    mode_path = FieldPath.active("0", "freq_mode", "mode")
+    srv.command_service.apply_observation(
+        Observation(
+            path=mode_path,
+            value="USB",
+            source=SourceMetadata(source="poll_response", provider="icom_civ"),
+            timestamp_monotonic=time.monotonic(),
+            correlation_id=None,
+        )
+    )
+
+    assert srv.command_state_store.snapshot().field(mode_path).value == "USB"
+
+
+@pytest.mark.asyncio
+async def test_set_mode_failure_does_not_publish_command_overlay() -> None:
+    # MOR-334 regression: the optimistic overlay is emitted ONLY on enqueue
+    # success — a raised enqueue must leave the command_state_store untouched.
+    radio = SimpleNamespace(connected=True, capabilities=set())
+    srv = WebServer(radio, WebConfig())
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise RuntimeError("radio rejected command")
+
+    srv.command_queue.put = _boom  # type: ignore[method-assign]
+
+    intent = command_intent_from_request(
+        "set_mode",
+        {"mode": "CW", "receiver": 0},
+        source="websocket",
+        command_id="ws-mode-fail",
+    )
+    with pytest.raises(RuntimeError, match="radio rejected command"):
+        await srv.command_service.execute(intent)
+
+    snapshot = srv.command_state_store.snapshot()
+    with pytest.raises(KeyError):
+        snapshot.field(FieldPath.active("0", "freq_mode", "mode"))
+
+
+@pytest.mark.asyncio
+async def test_set_data_mode_publishes_command_overlay_before_readback() -> None:
+    # MOR-334 regression: data_mode (D1/D2/D3) must be published optimistically
+    # just like mode, so the DATA indicator reflects the user's set immediately
+    # instead of reverting until the deferred readback lands.
+    radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
+    srv = WebServer(radio, WebConfig())
+    srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
+
+    intent = command_intent_from_request(
+        "set_data_mode",
+        {"mode": 1, "receiver": 0},
+        source="websocket",
+        command_id="ws-data-mode-main",
+    )
+    await srv.command_service.execute(intent)
+
+    data_mode_path = FieldPath.active("0", "freq_mode", "data_mode")
+    assert srv.command_state_store.snapshot().field(data_mode_path).value == 1
+    assert srv.build_public_state()["main"]["dataMode"] == 1
+
+
+@pytest.mark.asyncio
 async def test_websocket_reused_command_ids_are_scoped_per_connection() -> None:
     radio = SimpleNamespace(connected=True, capabilities=set())
     srv = WebServer(radio, WebConfig())

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1168,6 +1168,88 @@ async def test_set_data_mode_publishes_command_overlay_before_readback() -> None
 
 
 @pytest.mark.asyncio
+async def test_set_mod_input_publishes_command_overlay_before_readback() -> None:
+    # MOR-616 regression: the MOD-input source selector (set_data*_mod_input)
+    # had the same snap-back defect as freq/mode — the executor returned an ack
+    # with no observation, so the published source reverted to "—"/stale until
+    # the deferred readback landed. The overlay must write the commanded source
+    # to the SAME ``global.slow_state.<field>`` path the poller readback uses.
+    radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
+    srv = WebServer(radio, WebConfig())
+    srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
+
+    intent = command_intent_from_request(
+        "set_data2_mod_input",
+        {"source": 5},
+        source="websocket",
+        command_id="ws-mod-input-data2",
+    )
+    await srv.command_service.execute(intent)
+
+    mod_path = FieldPath.global_("slow_state", "data2_mod_input")
+    assert srv.command_state_store.snapshot().field(mod_path).value == 5
+    assert srv.build_public_state()["data2ModInput"] == 5
+
+
+@pytest.mark.asyncio
+async def test_set_mod_input_overlay_yields_to_newer_external_readback() -> None:
+    # MOR-616 regression: front-panel tracking preserved. A later poll readback
+    # with a DIFFERENT source must win (last-writer-wins); the optimistic value
+    # must not pin the source.
+    radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
+    srv = WebServer(radio, WebConfig())
+    srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
+
+    intent = command_intent_from_request(
+        "set_data_off_mod_input",
+        {"source": 0},
+        source="websocket",
+        command_id="ws-mod-input-external",
+    )
+    await srv.command_service.execute(intent)
+
+    mod_path = FieldPath.global_("slow_state", "data_off_mod_input")
+    srv.command_service.apply_observation(
+        Observation(
+            path=mod_path,
+            value=3,
+            source=SourceMetadata(source="poll_response", provider="web_poller"),
+            timestamp_monotonic=time.monotonic(),
+            correlation_id=None,
+        )
+    )
+
+    assert srv.command_state_store.snapshot().field(mod_path).value == 3
+    assert srv.build_public_state()["dataOffModInput"] == 3
+
+
+@pytest.mark.asyncio
+async def test_set_mod_input_failure_does_not_publish_command_overlay() -> None:
+    # MOR-616 regression: the optimistic overlay is emitted ONLY on enqueue
+    # success — a raised enqueue must leave the command_state_store untouched.
+    radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
+    srv = WebServer(radio, WebConfig())
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise RuntimeError("radio rejected command")
+
+    srv.command_queue.put = _boom  # type: ignore[method-assign]
+
+    intent = command_intent_from_request(
+        "set_data1_mod_input",
+        {"source": 2},
+        source="websocket",
+        command_id="ws-mod-input-fail",
+    )
+    with pytest.raises(RuntimeError, match="radio rejected command"):
+        await srv.command_service.execute(intent)
+
+    snapshot = srv.command_state_store.snapshot()
+    with pytest.raises(KeyError):
+        snapshot.field(FieldPath.global_("slow_state", "data1_mod_input"))
+
+
+@pytest.mark.asyncio
 async def test_websocket_reused_command_ids_are_scoped_per_connection() -> None:
     radio = SimpleNamespace(connected=True, capabilities=set())
     srv = WebServer(radio, WebConfig())


### PR DESCRIPTION
Lands the 2.10.1 fixes on main (tag v2.10.1 + PyPI release already cut from this head). IC-7610: s-meter stuck-at-S0, control reverts (mode/data-mode/RF gain/AF/squelch/MOD-input), D1/D2/D3, normalized RF gain + TX power units, waterfall freq optimistic hold, LAN discovery retransmit. Each fix independently verified during development. Boundary: open-core.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>