### PR TITLE
feat(MOR-881): canonical state-payload schema + TypeScript codegen (reference contract pattern)

### DIFF
--- a/.github/workflows/state-types-gate.yml
+++ b/.github/workflows/state-types-gate.yml
@@ -1,0 +1,71 @@
+name: State types gate
+
+# MOR-881: the server-sent portion of `frontend/src/lib/types/state.ts` is
+# GENERATED from the pydantic contract in `src/rigplane/web/state_schema.py`
+# via `scripts/gen_state_types.py` (pydantic -> JSON Schema -> json2ts). This
+# gate regenerates the block and fails on drift, so the TypeScript contract can
+# never silently diverge from the Python state-payload producer. Mirrors the
+# corpus-drift / rebrand-gate staleness pattern.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/rigplane/web/state_schema.py"
+      - "scripts/gen_state_types.py"
+      - "frontend/src/lib/types/state.ts"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      - "pyproject.toml"
+      - ".github/workflows/state-types-gate.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/rigplane/web/state_schema.py"
+      - "scripts/gen_state_types.py"
+      - "frontend/src/lib/types/state.ts"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      - "pyproject.toml"
+      - ".github/workflows/state-types-gate.yml"
+
+concurrency:
+  group: state-types-gate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  state-types-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    env:
+      UV_PYTHON: "3.11"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install Python deps (pydantic for codegen)
+        run: uv sync --extra codegen
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install json-schema-to-typescript
+        run: npm --prefix frontend ci
+
+      - name: Regenerate state.ts and fail on drift
+        run: uv run python scripts/gen_state_types.py --check

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ mockups/
 scripts/*
 # But the release-validation runner is tracked (MOR-648).
 !scripts/validate-release.sh
+# And the public-state TypeScript codegen generator is tracked (MOR-881).
+!scripts/gen_state_types.py
 # But CI scripts under .github/ are tracked.
 !.github/scripts/
 # And frontend tooling scripts (e.g. i18n lint) are tracked.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "eslint": "^10.2.0",
         "eslint-plugin-svelte": "^3.17.0",
         "jsdom": "^28.1.0",
+        "json-schema-to-typescript": "^15.0.4",
         "svelte": "^5.45.2",
         "svelte-check": "^4.3.4",
         "svelte-eslint-parser": "^1.6.0",
@@ -54,6 +55,24 @@
       },
       "peerDependencies": {
         "ajv": ">=8"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2520,6 +2539,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -3129,6 +3155,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
@@ -3576,6 +3609,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.1",
@@ -5896,6 +5936,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdom": {
       "version": "28.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
@@ -5963,6 +6026,30 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
+      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.7",
+        "is-glob": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "prettier": "^3.2.5",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -6087,6 +6174,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -6188,6 +6282,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -6651,6 +6755,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "eslint": "^10.2.0",
     "eslint-plugin-svelte": "^3.17.0",
     "jsdom": "^28.1.0",
+    "json-schema-to-typescript": "^15.0.4",
     "svelte": "^5.45.2",
     "svelte-check": "^4.3.4",
     "svelte-eslint-parser": "^1.6.0",

--- a/frontend/src/lib/types/state.ts
+++ b/frontend/src/lib/types/state.ts
@@ -1,137 +1,34 @@
-// State types — mirrors backend /api/v1/state schema (camelCase)
+// BEGIN GENERATED — do not edit by hand (scripts/gen_state_types.py)
+// This block is generated from the pydantic schema in
+// src/rigplane/web/state_schema.py (the public state-payload contract,
+// MOR-881). Regenerate with `python scripts/gen_state_types.py`; the CI
+// state-types-gate fails on drift. Edit the pydantic model, not this block.
 
-export interface ReceiverState {
-  freqHz: number;
-  mode: string;
-  filter: number;
-  dataMode: number;
-  sMeter: number;
-  att: number;
-  preamp: number;
-  nb: boolean;
-  nr: boolean;
-  afLevel: number;
-  rfGain: number;
-  squelch: number;
-  // Extended fields — optional (not all radio models expose these)
-  digisel?: boolean;
-  ipplus?: boolean;
-  dcd?: boolean;
-  sMeterSqlOpen?: boolean; // deprecated alias of dcd (MOR-466)
-  agc?: number;
-  audioPeakFilter?: number;
-  autoNotch?: boolean;
-  manualNotch?: boolean;
-  twinPeakFilter?: boolean;
-  filterShape?: number;
-  agcTimeConstant?: number;
-  apfTypeLevel?: number;
-  nrLevel?: number;
-  pbtInner?: number;
-  pbtOuter?: number;
-  filterWidth?: number;
-  ifShift?: number;
-  contour?: number;
-  nbLevel?: number;
-  manualNotchWidth?: number;
-  digiselShift?: number;
-  afMute?: boolean;
-}
-
-export interface ScopeControls {
-  receiver: number;
-  dual: boolean;
-  mode: number;
-  span: number;
-  edge: number;
-  hold: boolean;
-  refDb: number;
-  speed: number;
-  duringTx: boolean;
-  centerType: number;
-  vbwNarrow: boolean;
-  rbw: number;
-  fixedEdge: {
-    rangeIndex: number;
-    edge: number;
-    startHz: number;
-    endHz: number;
-  };
-}
-
-export type FieldFreshness = 'unknown' | 'fresh' | 'stale';
-export type FieldAvailability = 'missing' | 'available' | 'stale';
-
-export interface FieldStatus {
-  storePath: string;
-  observed: boolean;
-  freshness: FieldFreshness;
-  availability: FieldAvailability;
-  lastObservedMonotonic?: number;
-  maxAge?: number | null;
-  source?: Record<string, unknown>;
-}
-
-export interface ServerState {
+/**
+ * The full public radio-state payload (server-sent portion).
+ *
+ * Excludes the client-only ``meterSource`` (never server-sent) and the
+ * frontend-only ``UiState`` / ``PendingCommand`` types (MOR-881).
+ */
+export interface ServerStatePublic {
   revision: number;
-  stateRevision?: number;
-  freshnessRevision?: number;
-  observationSeq?: number;
-  publicStateSeq?: number;
-  transportSeq?: number;
+  stateRevision: number;
+  freshnessRevision: number;
+  observationSeq: number;
   healthRevision?: number;
   updatedAt: string;
-
-  active: 'MAIN' | 'SUB';
+  active: "MAIN" | "SUB";
   powerOn?: boolean;
   ptt: boolean;
+  powerLevel?: number;
   split: boolean;
   dualWatch: boolean;
-  tunerStatus: number;
-
-  main: ReceiverState;
-  sub: ReceiverState;
-
-  connection: {
-    rigConnected: boolean;
-    radioReady: boolean;
-    controlConnected: boolean;
-  };
-
-  radioHealth?: {
-    serverReachable: boolean;
-    radioLink: 'connected' | 'reconnecting' | 'disconnected' | 'unknown';
-    readiness: 'ready' | 'delayed' | 'stalled' | 'recovering';
-    likelyCause:
-      | 'server_unreachable'
-      | 'radio_network_lost'
-      | 'radio_not_responding'
-      | 'radio_powered_off_likely'
-      | 'unknown';
-    sinceMs: number;
-    lastError: string | null;
-  };
-
-  radioDetail?: {
-    status: string;
-    uptimeSeconds: number;
-  };
-
-  wsClients?: {
-    scope: number;
-    control: number;
-    audio: number;
-  };
-
-  fieldStatus?: Record<string, FieldStatus>;
-
-  // Extended fields — optional (not all radio models expose these)
-  powerLevel?: number;
   scanning?: boolean;
   scanType?: number;
   scanResumeMode?: number;
   tuningStep?: number;
   overflow?: boolean;
+  tunerStatus: number;
   txFreqMonitor?: boolean;
   ritFreq?: number;
   ritOn?: boolean;
@@ -151,30 +48,266 @@ export interface ServerState {
   compressorLevel?: number;
   monitorOn?: boolean;
   breakInDelay?: number;
+  cwSpot?: boolean | null;
   breakIn?: number;
   dialLock?: boolean;
   driveGain?: number;
   monitorGain?: number;
+  vfoSelect?: number;
+  yaesu?: {
+    [k: string]: number | null;
+  } | null;
   voxOn?: boolean;
   voxGain?: number;
   antiVoxGain?: number;
+  voxDelay?: number;
   ssbTxBandwidth?: number;
   refAdjust?: number;
   dashRatio?: number;
   nbDepth?: number;
   nbWidth?: number;
-  voxDelay?: number;
   txAntenna?: number;
   rxAntenna1?: boolean;
   rxAntenna2?: boolean;
-  meterSource?: 'S' | 'SWR' | 'POWER';
-  scopeControls?: ScopeControls;
-  // Per-DATA-group MOD-input sources (IC-7610, MOR-615/616). Mirror
-  // `global.slow_state.data*_mod_input`; null until the first readback.
   dataOffModInput?: number | null;
   data1ModInput?: number | null;
   data2ModInput?: number | null;
   data3ModInput?: number | null;
+  txBandEdges?: {
+    [k: string]: number;
+  }[];
+  scopeControls?: ScopeControlsPublic;
+  main: ReceiverStatePublic;
+  sub?: ReceiverStatePublic | null;
+  connection: ConnectionPublic;
+  radioDetail?: RadioDetailPublic;
+  radioHealth?: RadioHealthPublic;
+  wsClients?: WsClientsPublic;
+  fieldStatus?: {
+    [k: string]: FieldStatusPublic;
+  };
+  publicStateSeq?: number;
+}
+/**
+ * Spectrum-scope control state.
+ */
+export interface ScopeControlsPublic {
+  receiver: number;
+  dual: boolean;
+  mode: number;
+  span: number;
+  edge: number;
+  hold: boolean;
+  refDb: number;
+  speed: number;
+  duringTx: boolean;
+  centerType: number;
+  vbwNarrow: boolean;
+  rbw: number;
+  fixedEdge: FixedEdgePublic;
+}
+/**
+ * Scope fixed-edge sub-object.
+ */
+export interface FixedEdgePublic {
+  rangeIndex: number;
+  edge: number;
+  startHz: number;
+  endHz: number;
+}
+/**
+ * Per-receiver (``main`` / ``sub``) public state.
+ *
+ * Carries BOTH the slot view (``vfoA`` / ``vfoB`` / ``activeSlot``) and the
+ * legacy active-slot scalars (``freqHz`` / ``mode`` / ``filter`` /
+ * ``dataMode``). The redundancy is intentional back-compat (radio_state.py
+ * ``_receiver_to_dict``); the slot view is the canonical source-of-truth and
+ * the scalars are derived from ``activeSlot``.
+ */
+export interface ReceiverStatePublic {
+  vfoA?: VfoSlotPublic;
+  vfoB?: VfoSlotPublic;
+  activeSlot?: string;
+  freqHz: number;
+  mode: string;
+  filter: number | null;
+  dataMode: number;
+  filterWidth?: number | null;
+  att: number;
+  preamp: number;
+  nb: boolean;
+  nr: boolean;
+  digisel?: boolean;
+  ipplus?: boolean;
+  sMeterSqlOpen?: boolean;
+  agc?: number;
+  audioPeakFilter?: number;
+  autoNotch?: boolean;
+  manualNotch?: boolean;
+  twinPeakFilter?: boolean;
+  filterShape?: number;
+  agcTimeConstant?: number;
+  afLevel: number;
+  rfGain: number;
+  squelch: number;
+  sMeter: number;
+  apfTypeLevel?: number;
+  apfOn?: boolean;
+  apfFreq?: number;
+  nrLevel?: number;
+  pbtInner?: number;
+  pbtOuter?: number;
+  nbLevel?: number;
+  digiselShift?: number;
+  afMute?: boolean;
+  contour?: number;
+  ifShift?: number;
+  narrow?: boolean;
+  manualNotchFreq?: number;
+  manualNotchWidth?: number;
+  repeaterTone?: boolean;
+  repeaterTsql?: boolean;
+  toneFreq?: number;
+  tsqlFreq?: number;
+  dcd?: boolean | null;
+}
+/**
+ * One VFO slot (A or B) within a receiver.
+ */
+export interface VfoSlotPublic {
+  freqHz: number;
+  mode: string;
+  filterNum: number | null;
+  dataMode: number;
+}
+/**
+ * Synthetic connection object injected from the backend connection scalars.
+ */
+export interface ConnectionPublic {
+  rigConnected: boolean;
+  radioReady: boolean;
+  controlConnected: boolean;
+}
+/**
+ * Radio connection detail. Carries ONLY ``status`` in the state payload.
+ *
+ * MOR-881 contract correction: the old TS declared a required
+ * ``uptimeSeconds`` here, but that field belongs to ``/api/v1/runtime`` and
+ * ``/api/v1/radio`` — it is NEVER in the state payload.
+ */
+export interface RadioDetailPublic {
+  status: string;
+}
+/**
+ * Classified server/radio health (``classify_radio_health``).
+ */
+export interface RadioHealthPublic {
+  serverReachable: boolean;
+  radioLink: "connected" | "reconnecting" | "disconnected" | "unknown";
+  readiness: "ready" | "delayed" | "stalled" | "recovering";
+  likelyCause:
+    | "server_unreachable"
+    | "radio_network_lost"
+    | "radio_not_responding"
+    | "radio_powered_off_likely"
+    | "unknown";
+  sinceMs: number;
+  lastError: string | null;
+}
+/**
+ * WebSocket client counts per channel.
+ */
+export interface WsClientsPublic {
+  scope: number;
+  control: number;
+  audio: number;
+}
+/**
+ * Per-field freshness / availability entry (snapshot path only).
+ *
+ * ``observed=False`` entries carry only the first four fields; observed
+ * entries add ``lastObservedMonotonic`` / ``maxAge`` / ``source`` /
+ * ``quality``. All five extras are therefore optional. ``quality`` (a
+ * ``string[]``) is emitted at runtime but was absent from the old TS
+ * interface (MOR-881 contract correction).
+ */
+export interface FieldStatusPublic {
+  storePath: string;
+  observed: boolean;
+  freshness: "unknown" | "fresh" | "stale";
+  availability: "missing" | "available" | "stale";
+  lastObservedMonotonic?: number | null;
+  maxAge?: number | null;
+  source?: {
+    [k: string]: unknown;
+  } | null;
+  quality?: string[];
+}
+/**
+ * WS ``state_update`` delta/full envelope (``_delta_encoder.py``).
+ *
+ * The full frame carries ``data`` (a complete :class:`ServerStatePublic`); the
+ * delta frame carries ``changed`` (a shallow top-level partial of the same
+ * shape) and optional ``removed`` keys. Envelope-only sequence fields
+ * (``transportSeq`` etc.) live here, not inside the state object.
+ */
+export interface StateUpdateEnvelope {
+  type: "full" | "delta";
+  revision: number;
+  transportSeq: number;
+  data?: ServerStatePublic | null;
+  changed?: {
+    [k: string]: unknown;
+  } | null;
+  removed?: string[] | null;
+  stateRevision?: number | null;
+  freshnessRevision?: number | null;
+  observationSeq?: number | null;
+}
+// END GENERATED
+
+// ---------------------------------------------------------------------------
+// Hand-written UI section (MOR-881)
+//
+// Everything ABOVE the `// END GENERATED` marker is generated from the pydantic
+// contract in `src/rigplane/web/state_schema.py` and reflects the REAL public
+// wire payload. Everything below is hand-written: stable public aliases that
+// keep existing consumers compiling, the client-only fields the server never
+// sends, and the frontend-only UI types.
+// ---------------------------------------------------------------------------
+
+// Stable public aliases over the generated `*Public` contract interfaces.
+// Consumers import these names; the generated interfaces are the source of
+// truth for their shape.
+export type ReceiverState = ReceiverStatePublic;
+export type ScopeControls = ScopeControlsPublic;
+export type FieldStatus = FieldStatusPublic;
+export type FieldFreshness = FieldStatusPublic['freshness'];
+export type FieldAvailability = FieldStatusPublic['availability'];
+
+/**
+ * The state object the frontend holds.
+ *
+ * Extends the generated, server-sent `ServerStatePublic` contract with the
+ * fields that are NOT part of the wire payload but live on the merged
+ * client-side state:
+ *
+ * - `meterSource`: pure client-only optimistic UI state. The server never
+ *   sends it; it is patched locally by the command bus / state adapter
+ *   (MOR-881 contract correction — it used to be declared on the server
+ *   contract by mistake).
+ * - `transportSeq`: a WS envelope-only sequence field that `ws-client.ts`
+ *   hoists onto the accumulated state object for ordering. Not server-sent
+ *   inside `data`/`changed`.
+ */
+export interface ServerState extends ServerStatePublic {
+  meterSource?: 'S' | 'SWR' | 'POWER';
+  transportSeq?: number;
+  // Client-side invariant: the merged state always carries a `sub` receiver
+  // (the single-receiver wire payload omits it, but consumers — e.g.
+  // `activeRx` — treat it as present). Narrowed here rather than in the
+  // generated wire contract, which honestly marks `sub` optional.
+  sub: ReceiverState;
 }
 
 export interface UiState {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,13 @@ scope = [
 dsp = ["scipy>=1.11"]
 webrtc = ["aiortc>=1.9"]
 tls = ["cryptography>=41.0"]
-dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout", "pytest-xdist", "ruff", "mypy"]
+# Dev/build-only: pydantic drives the public-state JSON-Schema → TypeScript
+# codegen (MOR-881). It must NEVER enter the runtime `dependencies` above —
+# core stays zero-runtime-dep. Only the conformance test and the
+# `scripts/gen_state_types.py` generator import it; `state_schema.py` is never
+# imported on the live request path.
+codegen = ["pydantic>=2.13,<3"]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout", "pytest-xdist", "ruff", "mypy", "pydantic>=2.13,<3"]
 
 [dependency-groups]
 dev = [
@@ -63,6 +69,9 @@ dev = [
     "mkdocs-material>=9.7.3",
     "mkdocstrings[python]>=1.0.3",
     "mypy>=1.18.1",
+    # Dev/build-only — drives MOR-881 state-payload codegen + conformance test.
+    # NOT a runtime dependency (core stays zero-runtime-dep).
+    "pydantic>=2.13,<3",
     "pytest>=8.0",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
@@ -115,6 +124,10 @@ select = ["E4", "E7", "E9", "F", "TID251"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["TID251"]
+# Build/codegen scripts may import tier-3 internals (e.g. the state-payload
+# schema for TypeScript codegen, MOR-881). They are dev/build-only, never
+# shipped in the wheel.
+"scripts/**" = ["TID251"]
 # CLI is the orchestrator that composes tier-3 web and rigctld servers (issue-blessed).
 "src/rigplane/cli/**" = ["TID251"]
 # Package entry point dispatches to cli.main.
@@ -144,6 +157,16 @@ module = ["rigplane.web.*"]
 strict = true
 follow_imports = "skip"
 warn_unused_ignores = false
+
+# Codegen-only contract schema (MOR-881). Under the global ``follow_imports =
+# skip`` policy pydantic's ``BaseModel`` resolves to ``Any``, so strict mypy
+# reports "cannot subclass BaseModel (has type Any)". The module is dev/build-
+# only (never on the runtime import path) and is covered by the conformance
+# test + the codegen drift gate, so suppress that single ``misc`` diagnostic
+# rather than wiring the pydantic mypy plugin into the strict web boundary.
+[[tool.mypy.overrides]]
+module = ["rigplane.web.state_schema"]
+disable_error_code = ["misc"]
 
 [[tool.mypy.overrides]]
 module = ["cryptography", "cryptography.*"]

--- a/scripts/gen_state_types.py
+++ b/scripts/gen_state_types.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Regenerate the GENERATED block of ``frontend/src/lib/types/state.ts`` (MOR-881).
+
+Pipeline (validated in the contract-codegen spike, all-MIT toolchain):
+
+    ServerStatePublic / StateUpdateEnvelope  (pydantic v2 models)
+        -> .model_json_schema()              (JSON Schema, draft 2020-12)
+        -> json-schema-to-typescript (json2ts)
+        -> spliced into state.ts between BEGIN/END GENERATED markers
+
+The hand-written portion of ``state.ts`` (UiState, PendingCommand, the
+client-only ``meterSource`` derived type, and any prose) lives OUTSIDE the
+markers and is preserved verbatim.
+
+Usage:
+    python scripts/gen_state_types.py            # write into state.ts
+    python scripts/gen_state_types.py --check     # exit 1 if state.ts is stale
+    python scripts/gen_state_types.py --stdout     # print generated block only
+
+``pydantic`` (dev/codegen extra) and ``json-schema-to-typescript`` (frontend
+devDependency, run via ``npx``) are dev/build-only. Neither is a runtime
+dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Repo layout: scripts/ -> repo root; the schema lives under src/.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from rigplane.web.state_schema import (  # noqa: E402
+    ServerStatePublic,
+    StateUpdateEnvelope,
+)
+
+_STATE_TS = _REPO_ROOT / "frontend" / "src" / "lib" / "types" / "state.ts"
+_FRONTEND = _REPO_ROOT / "frontend"
+
+BEGIN_MARKER = "// BEGIN GENERATED — do not edit by hand (scripts/gen_state_types.py)"
+END_MARKER = "// END GENERATED"
+
+_BANNER = (
+    "// This block is generated from the pydantic schema in\n"
+    "// src/rigplane/web/state_schema.py (the public state-payload contract,\n"
+    "// MOR-881). Regenerate with `python scripts/gen_state_types.py`; the CI\n"
+    "// state-types-gate fails on drift. Edit the pydantic model, not this block."
+)
+
+# Top-level pydantic models whose interfaces (and their shared $defs) form the
+# server-sent contract. Order is stable for deterministic output.
+_MODELS = [ServerStatePublic, StateUpdateEnvelope]
+
+# Per-model ``required`` allowlists for the generated TypeScript.
+#
+# pydantic omits any field with a default from the JSON-Schema ``required``
+# list AND would otherwise make every defaulted field optional in TS. We
+# instead pin ``required`` explicitly so the generated contract is intentional,
+# not an accident of which model fields happen to carry defaults.
+#
+# Policy (state-payload spec §8):
+#   - Required = the fields existing consumers already depend on (the old
+#     hand-written state.ts required set). Loosening these would break
+#     production consumers (e.g. ``rx.att > 0``), so they stay required.
+#   - Optional = (a) genuinely conditional wire fields (``sub`` for 1-RX,
+#     ``dcd``/``fieldStatus`` snapshot-only, ``publicStateSeq`` server-added,
+#     the per-observation FieldStatus extras) and (b) purely ADDITIVE fields
+#     newly surfaced by this contract (``vfoA``/``vfoB``/``activeSlot``/
+#     ``filterNum`` and the extra receiver scalars). Additive-as-optional is
+#     safe: existing consumers ignore unknown optional fields.
+# Any model not listed here requires ALL of its properties.
+_REQUIRED_BY_MODEL: dict[str, set[str]] = {
+    # The old hand-written state.ts required set. ``scopeControls`` /
+    # ``radioDetail`` / ``radioHealth`` / ``txBandEdges`` are always present in
+    # the real payload but were optional in the old contract and consumers
+    # access them defensively (``?.``); keep them optional to avoid churning
+    # consumers/fixtures (spec §8.7: a benign tightening the migration may relax).
+    "ServerStatePublic": {
+        "revision",
+        "stateRevision",
+        "freshnessRevision",
+        "observationSeq",
+        "updatedAt",
+        "active",
+        "ptt",
+        "split",
+        "dualWatch",
+        "tunerStatus",
+        "main",
+        "connection",
+    },
+    "ReceiverStatePublic": {
+        "freqHz",
+        "mode",
+        "filter",
+        "dataMode",
+        "sMeter",
+        "att",
+        "preamp",
+        "nb",
+        "nr",
+        "afLevel",
+        "rfGain",
+        "squelch",
+    },
+    # Only ``observed=true`` entries carry the extras; the bare missing-entry is
+    # {storePath, observed, freshness, availability}.
+    "FieldStatusPublic": {"storePath", "observed", "freshness", "availability"},
+    # Envelope framing is always present; ``data`` (full) vs ``changed`` +
+    # ``removed`` (delta) and the echoed revisions are frame-conditional.
+    "StateUpdateEnvelope": {"type", "revision", "transportSeq"},
+}
+
+
+def _promote_required(defs: dict[str, object]) -> None:
+    """Pin each model's ``required`` set per :data:`_REQUIRED_BY_MODEL`.
+
+    Models absent from the map require all their properties (e.g. the small
+    synthetic objects ``ConnectionPublic`` / ``ScopeControlsPublic`` /
+    ``RadioHealthPublic``, whose fields are always present in the payload).
+    """
+    for model_name, definition in defs.items():
+        if not isinstance(definition, dict):
+            continue
+        props = definition.get("properties")
+        if not isinstance(props, dict):
+            continue
+        if model_name in _REQUIRED_BY_MODEL:
+            required = _REQUIRED_BY_MODEL[model_name]
+            definition["required"] = [name for name in props if name in required]
+        else:
+            definition["required"] = list(props)
+
+
+def _strip_property_titles(node: object) -> None:
+    """Recursively drop pydantic's auto-generated per-property ``title`` keys.
+
+    pydantic titles every field (``freqHz`` -> ``"Freqhz"``); json2ts hoists
+    each titled property into a noisy standalone ``export type`` alias. Removing
+    property-level titles makes json2ts inline the scalar/enum directly into the
+    parent interface. Model-level ``$defs`` titles (the interface names) are kept
+    because they live one level up, on the definition object, not on a property.
+    """
+    if isinstance(node, dict):
+        props = node.get("properties")
+        if isinstance(props, dict):
+            for prop_schema in props.values():
+                if isinstance(prop_schema, dict):
+                    prop_schema.pop("title", None)
+        for value in node.values():
+            _strip_property_titles(value)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_property_titles(item)
+
+
+def _combined_schema() -> dict[str, object]:
+    """Build one JSON-Schema document holding every model as a shared ``$defs``.
+
+    Emitting one document (rather than one per model) means shared sub-models
+    (ScopeControlsPublic, FieldStatusPublic, …) are defined exactly once, so
+    json2ts produces no duplicate interfaces.
+    """
+    defs: dict[str, object] = {}
+    for model in _MODELS:
+        schema = model.model_json_schema(ref_template="#/$defs/{model}")
+        for name, definition in schema.pop("$defs", {}).items():
+            defs.setdefault(name, definition)
+        defs[model.__name__] = schema
+    _promote_required(defs)
+    # json2ts only walks definitions reachable from the root, so reference each
+    # top-level model from the root ``properties``. The root carrier interface
+    # itself is stripped from the output; every reachable ``$defs`` entry is
+    # emitted once as a named interface.
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "RigPlaneStateContract",
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            model.__name__: {"$ref": f"#/$defs/{model.__name__}"} for model in _MODELS
+        },
+        "$defs": defs,
+    }
+
+
+def _run_json2ts(schema: dict[str, object]) -> str:
+    _strip_property_titles(schema)
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", delete=False, encoding="utf-8"
+    ) as handle:
+        json.dump(schema, handle)
+        schema_path = handle.name
+    try:
+        result = subprocess.run(
+            [
+                "npx",
+                "--no-install",
+                "json2ts",
+                "-i",
+                schema_path,
+                "--no-additionalProperties",
+                "--bannerComment",
+                "",
+            ],
+            cwd=_FRONTEND,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        Path(schema_path).unlink(missing_ok=True)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        raise SystemExit(
+            "json2ts failed. Ensure `json-schema-to-typescript` is installed "
+            "in frontend devDependencies (`npm --prefix frontend ci`)."
+        )
+    return result.stdout
+
+
+# The synthetic carrier interface json2ts emits for the schema root. It only
+# exists to make json2ts walk the per-model $defs; drop it from the output.
+_CARRIER_RE = re.compile(
+    r"export interface RigPlaneStateContract \{[^}]*\}\n?",
+)
+
+
+def _generated_block() -> str:
+    body = _run_json2ts(_combined_schema()).strip()
+    body = _CARRIER_RE.sub("", body).strip()
+    # No trailing newline after END_MARKER: the surrounding text (the spliced
+    # tail, or the prepend join below) owns the separating whitespace, so the
+    # output is byte-stable across regenerations.
+    return f"{BEGIN_MARKER}\n{_BANNER}\n\n{body}\n{END_MARKER}"
+
+
+def _splice(existing: str, block: str) -> str:
+    if BEGIN_MARKER in existing and END_MARKER in existing:
+        head = existing.split(BEGIN_MARKER, 1)[0]
+        tail = existing.split(END_MARKER, 1)[1]
+        return f"{head}{block}{tail}"
+    # First run: prepend the generated block above the hand-written section.
+    return f"{block}\n{existing}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail on drift")
+    parser.add_argument(
+        "--stdout", action="store_true", help="print generated block only"
+    )
+    args = parser.parse_args()
+
+    block = _generated_block()
+    if args.stdout:
+        sys.stdout.write(block)
+        return 0
+
+    existing = _STATE_TS.read_text(encoding="utf-8")
+    updated = _splice(existing, block)
+
+    if args.check:
+        if existing != updated:
+            sys.stderr.write(
+                "ERROR: frontend/src/lib/types/state.ts is stale.\n"
+                "Run `python scripts/gen_state_types.py` and commit the result.\n"
+            )
+            return 1
+        sys.stdout.write("state.ts generated block is up to date.\n")
+        return 0
+
+    _STATE_TS.write_text(updated, encoding="utf-8")
+    sys.stdout.write(f"Wrote generated block into {_STATE_TS}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/rigplane/web/state_schema.py
+++ b/src/rigplane/web/state_schema.py
@@ -104,9 +104,13 @@ class ReceiverStatePublic(_Strict):
     twinPeakFilter: bool = False
     filterShape: int = 0
     agcTimeConstant: int = 0
-    afLevel: int = 0
-    rfGain: int = 0
-    squelch: int = 0
+    # These three are normalized to float in [0, 1] by the snapshot path
+    # (_normalize_public_level_snapshot_value in runtime_helpers.py).  Pydantic
+    # lax mode coerces the int(0) from the dataclass path, so float is the
+    # correct canonical type for both producers.
+    afLevel: float = 0.0
+    rfGain: float = 0.0
+    squelch: float = 0.0
     sMeter: int = 0
     apfTypeLevel: int = 0
     apfOn: bool = False
@@ -240,10 +244,15 @@ class ServerStatePublic(_Strict):
     updatedAt: str
 
     # Global slow-state / TX flags.
+    # ``active`` is set to "MAIN"/"SUB" in exactly three places:
+    #   _civ_rx.py (0xD2 frame), _dual_rx_runtime.py, and RadioState default.
+    # No other values are produced; the Literal is safe.
     active: Literal["MAIN", "SUB"]
     powerOn: bool = True
     ptt: bool = False
-    powerLevel: int = 0
+    # Normalized to float in [0, 1] by the snapshot path via
+    # _normalize_public_level_snapshot_value (runtime_helpers.py).
+    powerLevel: float = 0.0
     split: bool = False
     dualWatch: bool = False
     scanning: bool = False

--- a/src/rigplane/web/state_schema.py
+++ b/src/rigplane/web/state_schema.py
@@ -307,11 +307,14 @@ class ServerStatePublic(_Strict):
     radioHealth: RadioHealthPublic
     wsClients: WsClientsPublic
 
-    # Snapshot path only.
-    fieldStatus: dict[str, FieldStatusPublic] | None = None
+    # Snapshot path only — absent on the dataclass path, never null when
+    # present (generated TS: ``fieldStatus?: Record<string, FieldStatusPublic>``).
+    fieldStatus: dict[str, FieldStatusPublic] = Field(default_factory=dict)
 
-    # Added by the server seq counter, not the helper.
-    publicStateSeq: int | None = None
+    # Added by the server seq counter, not the helper. Always an int when
+    # present (the producer omits the key otherwise), so the generated TS is
+    # ``publicStateSeq?: number`` — never nullable.
+    publicStateSeq: int = 0
 
 
 class StateUpdateEnvelope(_Strict):

--- a/src/rigplane/web/state_schema.py
+++ b/src/rigplane/web/state_schema.py
@@ -1,0 +1,334 @@
+"""Canonical pydantic schema for the public radio-state WIRE payload (MOR-881).
+
+This module is the **single source of truth** for the shape of the public web
+state payload emitted by
+:func:`rigplane.web.runtime_helpers.build_public_state_payload` and
+:func:`~rigplane.web.runtime_helpers.build_public_state_payload_from_snapshot`.
+
+It models the *union / superset* of the two emit paths (dataclass + snapshot):
+fields that only the snapshot path emits (``dcd``, ``fieldStatus``) are marked
+optional, while fields that are always present in both paths are required.
+
+Two uses, and ONLY two:
+
+1. The conformance test
+   (``tests/web/test_state_schema_conformance.py``) validates real payloads
+   from both producers against :class:`ServerStatePublic`.
+2. The codegen script (``scripts/gen_state_types.py``) reads
+   ``ServerStatePublic.model_json_schema()`` and
+   ``StateUpdateEnvelope.model_json_schema()`` to regenerate the server-sent
+   portion of ``frontend/src/lib/types/state.ts``.
+
+**Zero-runtime-dep guarantee:** pydantic is a DEV/optional dependency. This
+module imports pydantic at load time, so it MUST NOT be imported by any live
+request-path module (``runtime_helpers.py`` / ``server.py``). The producers
+stay dict-based and pydantic-free. Do not wire ``model_validate`` into the
+live request path.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "VfoSlotPublic",
+    "ReceiverStatePublic",
+    "FixedEdgePublic",
+    "ScopeControlsPublic",
+    "FieldStatusPublic",
+    "ConnectionPublic",
+    "RadioHealthPublic",
+    "RadioDetailPublic",
+    "WsClientsPublic",
+    "ServerStatePublic",
+    "StateUpdateEnvelope",
+]
+
+
+class _Strict(BaseModel):
+    """Base model with ``extra="forbid"`` so generated TS has no index signature.
+
+    ``additionalProperties: false`` in the emitted JSON Schema suppresses the
+    ``[k: string]: unknown`` index signature ``json-schema-to-typescript`` would
+    otherwise add (contract-spike REPORT, Path 3 caveat).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VfoSlotPublic(_Strict):
+    """One VFO slot (A or B) within a receiver."""
+
+    freqHz: int = 0
+    mode: str = "USB"
+    filterNum: int | None = None
+    dataMode: int = 0
+
+
+class ReceiverStatePublic(_Strict):
+    """Per-receiver (``main`` / ``sub``) public state.
+
+    Carries BOTH the slot view (``vfoA`` / ``vfoB`` / ``activeSlot``) and the
+    legacy active-slot scalars (``freqHz`` / ``mode`` / ``filter`` /
+    ``dataMode``). The redundancy is intentional back-compat (radio_state.py
+    ``_receiver_to_dict``); the slot view is the canonical source-of-truth and
+    the scalars are derived from ``activeSlot``.
+    """
+
+    # Slot view (MOR-881: previously absent from state.ts).
+    vfoA: VfoSlotPublic
+    vfoB: VfoSlotPublic
+    activeSlot: str = "A"
+
+    # Legacy active-slot scalars (derived from the active slot). ``freq`` is
+    # renamed to ``freqHz`` by ``_RECEIVER_KEY_MAP``; the rest pass through.
+    freqHz: int = 0
+    mode: str = "USB"
+    filter: int | None = None
+    dataMode: int = 0
+
+    filterWidth: int | None = None
+    att: int = 0
+    preamp: int = 0
+    nb: bool = False
+    nr: bool = False
+    digisel: bool = False
+    ipplus: bool = False
+    sMeterSqlOpen: bool = False
+    agc: int = 0
+    audioPeakFilter: int = 0
+    autoNotch: bool = False
+    manualNotch: bool = False
+    twinPeakFilter: bool = False
+    filterShape: int = 0
+    agcTimeConstant: int = 0
+    afLevel: int = 0
+    rfGain: int = 0
+    squelch: int = 0
+    sMeter: int = 0
+    apfTypeLevel: int = 0
+    apfOn: bool = False
+    apfFreq: int = 0
+    nrLevel: int = 0
+    pbtInner: int = 128
+    pbtOuter: int = 128
+    nbLevel: int = 0
+    digiselShift: int = 0
+    afMute: bool = False
+    contour: int = 0
+    ifShift: int = 0
+    narrow: bool = False
+    manualNotchFreq: int = 0
+    manualNotchWidth: int = 0
+    repeaterTone: bool = False
+    repeaterTsql: bool = False
+    toneFreq: int = 0
+    tsqlFreq: int = 0
+
+    # Snapshot-path only: ``dcd`` is the canonical squelch-open status; it is
+    # also dual-published as the deprecated ``sMeterSqlOpen`` alias (MOR-466).
+    # Absent in the plain ``to_dict()`` path, so optional.
+    dcd: bool | None = None
+
+
+class FixedEdgePublic(_Strict):
+    """Scope fixed-edge sub-object."""
+
+    rangeIndex: int = 0
+    edge: int = 0
+    startHz: int = 0
+    endHz: int = 0
+
+
+class ScopeControlsPublic(_Strict):
+    """Spectrum-scope control state."""
+
+    receiver: int = 0
+    dual: bool = False
+    mode: int = 0
+    span: int = 0
+    edge: int = 0
+    hold: bool = False
+    refDb: float = 0.0
+    speed: int = 0
+    duringTx: bool = False
+    centerType: int = 0
+    vbwNarrow: bool = False
+    rbw: int = 0
+    fixedEdge: FixedEdgePublic
+
+
+class FieldStatusPublic(_Strict):
+    """Per-field freshness / availability entry (snapshot path only).
+
+    ``observed=False`` entries carry only the first four fields; observed
+    entries add ``lastObservedMonotonic`` / ``maxAge`` / ``source`` /
+    ``quality``. All five extras are therefore optional. ``quality`` (a
+    ``string[]``) is emitted at runtime but was absent from the old TS
+    interface (MOR-881 contract correction).
+    """
+
+    storePath: str
+    observed: bool
+    freshness: Literal["unknown", "fresh", "stale"]
+    availability: Literal["missing", "available", "stale"]
+    lastObservedMonotonic: float | None = None
+    maxAge: float | None = None
+    source: dict[str, object] | None = None
+    quality: list[str] = Field(default_factory=list)
+
+
+class ConnectionPublic(_Strict):
+    """Synthetic connection object injected from the backend connection scalars."""
+
+    rigConnected: bool = False
+    radioReady: bool = False
+    controlConnected: bool = False
+
+
+class RadioHealthPublic(_Strict):
+    """Classified server/radio health (``classify_radio_health``)."""
+
+    serverReachable: bool
+    radioLink: Literal["connected", "reconnecting", "disconnected", "unknown"]
+    readiness: Literal["ready", "delayed", "stalled", "recovering"]
+    likelyCause: Literal[
+        "server_unreachable",
+        "radio_network_lost",
+        "radio_not_responding",
+        "radio_powered_off_likely",
+        "unknown",
+    ]
+    sinceMs: int
+    lastError: str | None = None
+
+
+class RadioDetailPublic(_Strict):
+    """Radio connection detail. Carries ONLY ``status`` in the state payload.
+
+    MOR-881 contract correction: the old TS declared a required
+    ``uptimeSeconds`` here, but that field belongs to ``/api/v1/runtime`` and
+    ``/api/v1/radio`` — it is NEVER in the state payload.
+    """
+
+    status: str
+
+
+class WsClientsPublic(_Strict):
+    """WebSocket client counts per channel."""
+
+    scope: int = 0
+    control: int = 0
+    audio: int = 0
+
+
+class ServerStatePublic(_Strict):
+    """The full public radio-state payload (server-sent portion).
+
+    Excludes the client-only ``meterSource`` (never server-sent) and the
+    frontend-only ``UiState`` / ``PendingCommand`` types (MOR-881).
+    """
+
+    # Revisions / sequence counters.
+    revision: int
+    stateRevision: int
+    freshnessRevision: int
+    observationSeq: int
+    healthRevision: int = 0
+    updatedAt: str
+
+    # Global slow-state / TX flags.
+    active: Literal["MAIN", "SUB"]
+    powerOn: bool = True
+    ptt: bool = False
+    powerLevel: int = 0
+    split: bool = False
+    dualWatch: bool = False
+    scanning: bool = False
+    scanType: int = 0
+    scanResumeMode: int = 0
+    tuningStep: int = 0
+    overflow: bool = False
+    tunerStatus: int = 0
+    txFreqMonitor: bool = False
+    ritFreq: int = 0
+    ritOn: bool = False
+    ritTx: bool = False
+    compMeter: int = 0
+    vdMeter: int = 0
+    idMeter: int = 0
+    powerMeter: int = 0
+    swrMeter: int = 0
+    alcMeter: int = 0
+    cwPitch: int = 0
+    micGain: int = 0
+    keySpeed: int = 0
+    notchFilter: int = 0
+    mainSubTracking: bool = False
+    compressorOn: bool = False
+    compressorLevel: int = 0
+    monitorOn: bool = False
+    breakInDelay: int = 0
+    cwSpot: bool | None = None
+    breakIn: int = 0
+    dialLock: bool = False
+    driveGain: int = 0
+    monitorGain: int = 0
+    vfoSelect: int = 0
+    yaesu: dict[str, int | None] | None = None
+    voxOn: bool = False
+    voxGain: int = 0
+    antiVoxGain: int = 0
+    voxDelay: int = 0
+    ssbTxBandwidth: int = 0
+    refAdjust: int = 0
+    dashRatio: int = 0
+    nbDepth: int = 0
+    nbWidth: int = 0
+    txAntenna: int = 1
+    rxAntenna1: bool = False
+    rxAntenna2: bool = False
+    dataOffModInput: int | None = None
+    data1ModInput: int | None = None
+    data2ModInput: int | None = None
+    data3ModInput: int | None = None
+    txBandEdges: list[dict[str, int]] = Field(default_factory=list)
+    scopeControls: ScopeControlsPublic
+
+    # Receivers. ``sub`` is dropped from the payload when ``receiver_count < 2``.
+    main: ReceiverStatePublic
+    sub: ReceiverStatePublic | None = None
+
+    # Synthetic / injected objects.
+    connection: ConnectionPublic
+    radioDetail: RadioDetailPublic
+    radioHealth: RadioHealthPublic
+    wsClients: WsClientsPublic
+
+    # Snapshot path only.
+    fieldStatus: dict[str, FieldStatusPublic] | None = None
+
+    # Added by the server seq counter, not the helper.
+    publicStateSeq: int | None = None
+
+
+class StateUpdateEnvelope(_Strict):
+    """WS ``state_update`` delta/full envelope (``_delta_encoder.py``).
+
+    The full frame carries ``data`` (a complete :class:`ServerStatePublic`); the
+    delta frame carries ``changed`` (a shallow top-level partial of the same
+    shape) and optional ``removed`` keys. Envelope-only sequence fields
+    (``transportSeq`` etc.) live here, not inside the state object.
+    """
+
+    type: Literal["full", "delta"]
+    revision: int
+    transportSeq: int
+    data: ServerStatePublic | None = None
+    changed: dict[str, object] | None = None
+    removed: list[str] | None = None
+    stateRevision: int | None = None
+    freshnessRevision: int | None = None
+    observationSeq: int | None = None

--- a/tests/web/test_state_schema_conformance.py
+++ b/tests/web/test_state_schema_conformance.py
@@ -1,0 +1,115 @@
+"""Conformance gate: real public payloads validate against ServerStatePublic.
+
+This keeps the dict producers (``runtime_helpers.build_public_state_payload`` /
+``build_public_state_payload_from_snapshot``) in lockstep with the canonical
+pydantic schema (``state_schema.ServerStatePublic``) that drives TypeScript
+codegen (MOR-881). The producers are NOT changed to return the model — this
+test is the tie-in. If a producer emits a field the schema does not allow (or
+omits a required field), ``model_validate`` fails here.
+
+``pydantic`` is a dev/optional dependency; skip cleanly when absent so the
+core runtime install (which excludes pydantic) is unaffected.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from rigplane.core.radio_state import RadioState  # noqa: E402
+from rigplane.core.state_pipeline_contracts import (  # noqa: E402
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import FreshnessClock, StateStore  # noqa: E402
+from rigplane.web.runtime_helpers import (  # noqa: E402
+    build_public_state_payload,
+    build_public_state_payload_from_snapshot,
+)
+from rigplane.web.state_schema import ServerStatePublic  # noqa: E402
+
+
+def _source() -> SourceMetadata:
+    return SourceMetadata(
+        source="poll_response",
+        provider="test",
+        transport="fake",
+        native_id="test",
+    )
+
+
+def _observation(path: FieldPath, value: Any, *, at: float) -> Observation:
+    return Observation(
+        path=path,
+        value=value,
+        source=_source(),
+        timestamp_monotonic=at,
+        max_age=None,
+        quality=("confirmed",),
+    )
+
+
+@pytest.mark.parametrize("receiver_count", [1, 2])
+def test_dataclass_path_conforms(receiver_count: int) -> None:
+    """``build_public_state_payload`` (RadioState/to_dict path) validates."""
+    payload = build_public_state_payload(
+        RadioState(),
+        radio=None,
+        revision=7,
+        receiver_count=receiver_count,
+    )
+    # Single-receiver payloads drop ``sub`` (runtime_helpers L940).
+    assert ("sub" in payload) == (receiver_count >= 2)
+    ServerStatePublic.model_validate(payload)
+
+
+@pytest.mark.parametrize("receiver_count", [1, 2])
+def test_snapshot_path_conforms(receiver_count: int) -> None:
+    """``build_public_state_payload_from_snapshot`` validates.
+
+    Exercises the path-specific fields (``fieldStatus``, ``dcd`` + its
+    deprecated ``sMeterSqlOpen`` alias, observed ``quality``) that only the
+    snapshot path emits.
+    """
+    clock = FreshnessClock()
+    store = StateStore(freshness_clock=clock)
+    store.apply(
+        _observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=clock.now(),
+        )
+    )
+    store.apply(
+        _observation(
+            FieldPath.receiver("0", "operator_toggles", "dcd"),
+            True,
+            at=clock.now(),
+        )
+    )
+    store.apply(
+        _observation(
+            FieldPath.receiver("0", "meters", "s_meter"),
+            120,
+            at=clock.now(),
+        )
+    )
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(),
+        radio=None,
+        receiver_count=receiver_count,
+    )
+
+    # Snapshot-path-only fields really emitted.
+    assert "fieldStatus" in payload
+    assert payload["main"]["dcd"] is True
+    assert payload["main"]["sMeterSqlOpen"] is True
+    # The observed entry carries the ``quality`` string[] absent from old TS.
+    observed = next(v for v in payload["fieldStatus"].values() if v.get("observed"))
+    assert isinstance(observed["quality"], list)
+
+    ServerStatePublic.model_validate(payload)

--- a/tests/web/test_state_schema_conformance.py
+++ b/tests/web/test_state_schema_conformance.py
@@ -178,9 +178,15 @@ def test_snapshot_path_normalized_level_fields_conform() -> None:
 
     # The snapshot producer normalizes the raw ints to float in [0, 1].
     main = payload["main"]
-    assert isinstance(main["afLevel"], float), f"expected float, got {type(main['afLevel'])}"
-    assert isinstance(main["rfGain"], float), f"expected float, got {type(main['rfGain'])}"
-    assert isinstance(main["squelch"], float), f"expected float, got {type(main['squelch'])}"
+    assert isinstance(main["afLevel"], float), (
+        f"expected float, got {type(main['afLevel'])}"
+    )
+    assert isinstance(main["rfGain"], float), (
+        f"expected float, got {type(main['rfGain'])}"
+    )
+    assert isinstance(main["squelch"], float), (
+        f"expected float, got {type(main['squelch'])}"
+    )
     assert isinstance(payload["powerLevel"], float), (
         f"expected float, got {type(payload['powerLevel'])}"
     )

--- a/tests/web/test_state_schema_conformance.py
+++ b/tests/web/test_state_schema_conformance.py
@@ -21,6 +21,7 @@ pytest.importorskip("pydantic")
 
 from rigplane.core.radio_state import RadioState  # noqa: E402
 from rigplane.core.state_pipeline_contracts import (  # noqa: E402
+    FieldFamily,
     FieldPath,
     Observation,
     SourceMetadata,
@@ -112,4 +113,84 @@ def test_snapshot_path_conforms(receiver_count: int) -> None:
     observed = next(v for v in payload["fieldStatus"].values() if v.get("observed"))
     assert isinstance(observed["quality"], list)
 
+    ServerStatePublic.model_validate(payload)
+
+
+def test_snapshot_path_normalized_level_fields_conform() -> None:
+    """Snapshot path normalizes af/rf/squelch/powerLevel to float in [0, 1].
+
+    The four fields are normalized by ``_normalize_public_level_snapshot_value``
+    in runtime_helpers.py before being stored in the payload dict.  Prior to
+    MOR-881 fix they were typed ``int`` in state_schema, causing
+    ``model_validate`` to raise ``int_from_float`` errors on real snapshots.
+
+    This case would FAIL against the old ``int`` typing because pydantic
+    strict validation rejects float→int coercion (lax mode allows int→float,
+    not the reverse).  We drive the snapshot producer with raw integer
+    observations (as a hardware driver would emit), which the snapshot path
+    converts to float before we validate the payload.
+    """
+    clock = FreshnessClock()
+    store = StateStore(freshness_clock=clock)
+
+    # Receiver-scoped normalized fields: af_level, rf_gain, squelch.
+    for field_name in ("af_level", "rf_gain", "squelch"):
+        store.apply(
+            Observation(
+                path=FieldPath.receiver("0", FieldFamily.OPERATOR_CONTROLS, field_name),
+                # Raw integer value as produced by a hardware driver (0-255).
+                value=128,
+                source=SourceMetadata(
+                    source="poll_response",
+                    provider="test",
+                    transport="fake",
+                    native_id="test",
+                ),
+                timestamp_monotonic=clock.now(),
+                max_age=None,
+                quality=("confirmed",),
+            )
+        )
+
+    # Global normalized field: power_level.
+    store.apply(
+        Observation(
+            path=FieldPath.global_(FieldFamily.OPERATOR_CONTROLS, "power_level"),
+            # Raw integer value as produced by a hardware driver (0-255).
+            value=200,
+            source=SourceMetadata(
+                source="poll_response",
+                provider="test",
+                transport="fake",
+                native_id="test",
+            ),
+            timestamp_monotonic=clock.now(),
+            max_age=None,
+            quality=("confirmed",),
+        )
+    )
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(),
+        radio=None,
+        receiver_count=1,
+    )
+
+    # The snapshot producer normalizes the raw ints to float in [0, 1].
+    main = payload["main"]
+    assert isinstance(main["afLevel"], float), f"expected float, got {type(main['afLevel'])}"
+    assert isinstance(main["rfGain"], float), f"expected float, got {type(main['rfGain'])}"
+    assert isinstance(main["squelch"], float), f"expected float, got {type(main['squelch'])}"
+    assert isinstance(payload["powerLevel"], float), (
+        f"expected float, got {type(payload['powerLevel'])}"
+    )
+
+    # All four values must be in [0, 1].
+    assert 0.0 <= main["afLevel"] <= 1.0
+    assert 0.0 <= main["rfGain"] <= 1.0
+    assert 0.0 <= main["squelch"] <= 1.0
+    assert 0.0 <= payload["powerLevel"] <= 1.0
+
+    # The payload must validate against ServerStatePublic (would raise
+    # int_from_float ValidationError under old int typing).
     ServerStatePublic.model_validate(payload)

--- a/uv.lock
+++ b/uv.lock
@@ -158,6 +158,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1692,6 +1701,123 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1971,8 +2097,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+codegen = [
+    { name = "pydantic" },
+]
 dev = [
     { name = "mypy" },
+    { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1999,6 +2129,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
+    { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -2018,6 +2149,8 @@ requires-dist = [
     { name = "opuslib" },
     { name = "pillow", marker = "extra == 'scope'", specifier = ">=10.0" },
     { name = "platformdirs", specifier = ">=4.2" },
+    { name = "pydantic", marker = "extra == 'codegen'", specifier = ">=2.13,<3" },
+    { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.13,<3" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyserial-asyncio", specifier = ">=0.6" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -2029,7 +2162,7 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'dsp'", specifier = ">=1.11" },
     { name = "sounddevice" },
 ]
-provides-extras = ["audio", "bridge", "scope", "dsp", "webrtc", "tls", "dev"]
+provides-extras = ["audio", "bridge", "scope", "dsp", "webrtc", "tls", "codegen", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2037,6 +2170,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.7.3" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
     { name = "mypy", specifier = ">=1.18.1" },
+    { name = "pydantic", specifier = ">=2.13,<3" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
@@ -2237,6 +2371,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## MOR-881 (re-scoped: payload-canonical) — parent epic MOR-707

Reference implementation of the contract-codegen pattern: the public radio-state
WIRE payload (`build_public_state_payload` / `…_from_snapshot`) becomes the single
source of truth for the frontend TypeScript `state.ts`. This is the worked example
later contract migrations copy.

**Boundary:** `open-core candidate` — generic radio-state contract + codegen
toolchain in the public MIT `rigplane-core`. No proprietary material.

### What landed (3 commits)

1. **`src/rigplane/web/state_schema.py` + conformance test** — pydantic v2 model
   tree mirroring the public payload (union/superset of both emit paths). Pins all
   literal unions (`active`, `radioLink`, `readiness`, `likelyCause`,
   freshness/availability). `extra="forbid"` → `additionalProperties:false` (no TS
   index signature). `tests/web/test_state_schema_conformance.py` validates REAL
   payloads from BOTH producers (dataclass + snapshot, 1 and 2 receivers) against
   `ServerStatePublic`. Producers are unchanged — the test is the tie-in.
2. **`scripts/gen_state_types.py` + `state.ts` split** — `model_json_schema()` →
   `json2ts` → spliced into a `// BEGIN/END GENERATED` block. The hand-written tail
   holds stable aliases (`ReceiverState`, `ScopeControls`, `FieldStatus`,
   `FieldFreshness`, `FieldAvailability`) over the generated `*Public` interfaces,
   plus the client-only `ServerState` augmentation and `UiState`/`PendingCommand`.
3. **CI drift gate + dev-dep wiring** — `state-types-gate.yml` runs
   `gen_state_types.py --check` and fails on drift. `pydantic` in a `codegen`
   extra + dev group; `json-schema-to-typescript` in frontend devDeps.

### Zero-runtime-dep guarantee (held)

`pydantic` is **not** in core runtime `dependencies`. `state_schema.py` is imported
ONLY by the conformance test and the generator — never by `runtime_helpers.py` /
`server.py`. Verified: `grep state_schema src/` matches nothing outside the module.

### The 7 latent disagreements (spec §8) — how each was handled

1. **`radioDetail.uptimeSeconds`** (TS required, never emitted) — **contract
   correction + latent bug found.** Generated `RadioDetailPublic` carries only
   `status`. Types-only; no runtime change.
2. **`meterSource`** (in TS `ServerState`, never server-sent) — **contract
   correction + latent bug found.** Removed from the generated server-sent
   contract; re-added as a hand-written client-only `ServerState` augmentation so
   `layout-utils.ts` (which reads `radioState.meterSource`) still compiles.
3. **`FieldStatus.quality: string[]`** (emitted, absent from TS) — **additive,
   included** as optional on `FieldStatusPublic`.
4. **`vfoA`/`vfoB`/`activeSlot`/`filterNum`** (emitted, absent from TS) —
   **additive, included** as optional (`VfoSlotPublic`). Safe — existing consumers
   ignore unknown optional fields.
5. **Redundant active-slot scalars vs slot view** — both modeled; the slot view is
   documented as canonical, the scalars as derived back-compat. Both stay in the
   generated `ReceiverStatePublic`.
6. **Receiver scalars required vs always-present** — kept the old required set
   (`freqHz/mode/filter/dataMode/sMeter/att/preamp/nb/nr/afLevel/rfGain/squelch`)
   so consumers (`rx.att > 0`) compile; everything additive is optional.
7. **Top-level `?optional` vs always-present** — kept the old required set; the
   extra always-present synthetic objects (`scopeControls`/`radioDetail`/
   `radioHealth`/`wsClients`/`txBandEdges`) stay optional to match the old contract
   and the defensive `?.` consumers (benign tightening relaxed per spec §8.7).

Also: `sub` is honestly optional in the generated wire contract (dropped for
single-RX radios) and narrowed to required in the hand-written client `ServerState`
(consumers assume it present). `transportSeq` is modeled on the envelope and added
to the client `ServerState` augmentation (the frontend hoists it).

### Hard guard — no frontend consumer broken

`npm run check` (svelte-check + tsc): **0 errors, 0 warnings**. No `.svelte`/`.ts`
consumer or test fixture was edited — the entire reconciliation lives in the schema
model, the generator `required` policy, and the hand-written alias section.

### Verification

- Conformance: `tests/web/test_state_schema_conformance.py` — **4 passed** (both
  paths, receiver_count 1 and 2).
- Generator idempotent: committed `state.ts` matches `--check` (exit 0).
- **Drift gate proven:** adding a model field without regenerating →
  `gen_state_types.py --check` exits 1; reverted to clean.
- `npm run check` — 0 errors; `npx vitest run` — **2178 passed (126 files)**.
- `uv run mypy --strict src/rigplane/web` — clean (codegen-only schema gets a
  targeted `misc` override for the pydantic-Any-under-`follow_imports=skip` case).
- `uv run ruff check src/ tests/` clean; `uv run lint-imports` — 5 kept, 0 broken.

### Out of scope / follow-ups

- Producers still return `dict` (conformance test is the tie-in; not wiring
  `model_validate` into the live path, per spec).
- The 7 disagreements are documented + corrected in the *types*; no frontend
  runtime-logic change. Aligning runtime consumers to the now-honest `sub`
  optionality (or surfacing `vfoA`/`vfoB` in the UI) is future work.
- **`txBandEdges` wire-format inventory gap:** entries in `txBandEdges` use
  snake_case keys (`start_hz`, `end_hz`) on the wire while the rest of the
  state payload uses camelCase. The schema models the entries as
  `list[dict[str, int]]` to remain accurate without prescribing key casing.
  Aligning to camelCase is a separate contract change (affects existing
  consumers) and is left for a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFjAT974fbZ48EBA9DxAiS