### PR TITLE
feat(MOR-887): dispatch-downstream — cross-repo auto-bump PRs on core release

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -1,0 +1,220 @@
+name: Dispatch downstream version-bump PRs
+
+# Triggered when a core GitHub Release is published (not a pre-release).
+# Opens bump PRs in rigplane-pro and rigplane-station via a GitHub App token
+# so the workflow operates across repository boundaries without using a PAT.
+#
+# INERT UNTIL CONFIGURED: if DOWNSTREAM_APP_ID or DOWNSTREAM_APP_PRIVATE_KEY
+# are absent the job logs a clear message and exits 0 — the core release is
+# not blocked. See the "Maintainer setup" section below for required steps.
+#
+# Maintainer setup (do this once):
+# ─────────────────────────────────
+# 1. Create a GitHub App in the rigplane org (Settings → Developer settings →
+#    GitHub Apps → New GitHub App):
+#      Name:        rigplane-downstream-bump (or similar)
+#      Homepage:    https://github.com/rigplane
+#      Webhook:     disable (uncheck "Active")
+#      Permissions (repository, Contents):  Read & write
+#      Permissions (repository, Pull requests): Read & write
+#      Where can it be installed? → Only on this account
+#
+# 2. After creation, note the numeric App ID shown on the App's settings page.
+#
+# 3. Generate a private key (App settings → "Private keys" → Generate a private
+#    key). Download the .pem file.
+#
+# 4. Install the App on the downstream repos:
+#      App settings → Install App → rigplane org →
+#      select repositories: rigplane-pro, rigplane-station
+#
+# 5. Add secrets to rigplane-core (Settings → Secrets and variables → Actions):
+#      DOWNSTREAM_APP_ID          — the numeric App ID (e.g. 123456)
+#      DOWNSTREAM_APP_PRIVATE_KEY — the full PEM content of the private key
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  bump-downstream:
+    name: Open downstream bump PRs
+    runs-on: ubuntu-latest
+    # Skip pre-releases (alpha, beta, rc). Only stable releases trigger bumps.
+    if: ${{ github.event.release.prerelease == false }}
+
+    steps:
+      - name: Check that App secrets are configured
+        id: secrets-check
+        env:
+          APP_ID: ${{ secrets.DOWNSTREAM_APP_ID }}
+          APP_KEY: ${{ secrets.DOWNSTREAM_APP_PRIVATE_KEY }}
+        run: |
+          if [ -z "$APP_ID" ] || [ -z "$APP_KEY" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::DOWNSTREAM_APP_ID or DOWNSTREAM_APP_PRIVATE_KEY secret is not set."
+            echo "Downstream bump PRs are SKIPPED. See workflow comments for setup instructions."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint GitHub App token
+        id: app-token
+        if: steps.secrets-check.outputs.configured == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DOWNSTREAM_APP_ID }}
+          private-key: ${{ secrets.DOWNSTREAM_APP_PRIVATE_KEY }}
+          # Grant the token access to both downstream repos.
+          repositories: rigplane-pro,rigplane-station
+          owner: rigplane
+
+      - name: Checkout rigplane-core (for bump script)
+        if: steps.secrets-check.outputs.configured == 'true'
+        uses: actions/checkout@v6
+        with:
+          path: rigplane-core
+
+      - name: Extract version from release tag
+        if: steps.secrets-check.outputs.configured == 'true'
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Core version: $VERSION (tag $TAG)"
+
+      # ── rigplane-pro ──────────────────────────────────────────────────────
+
+      - name: Checkout rigplane-pro
+        if: steps.secrets-check.outputs.configured == 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: rigplane/rigplane-pro
+          token: ${{ steps.app-token.outputs.token }}
+          path: rigplane-pro
+
+      - name: Bump rigplane-pro pins
+        if: steps.secrets-check.outputs.configured == 'true'
+        run: |
+          python rigplane-core/scripts/bump_downstream_pin.py \
+            --repo pro \
+            --version "${{ steps.version.outputs.version }}" \
+            --root rigplane-pro
+
+      - name: Open PR in rigplane-pro
+        if: steps.secrets-check.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          cd rigplane-pro
+          BRANCH="codex/auto-bump-core-${VERSION}"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "$BRANCH"
+          git add CORE_VERSION pyproject.toml
+          git diff --cached --stat
+          git commit -m "chore: bump core pin to v${VERSION} (auto)"
+          git push origin "$BRANCH"
+
+          PR_BODY="$(cat <<EOF
+          ## Auto-bump: core pin → \`v${VERSION}\`
+
+          This PR was opened automatically by the \`dispatch-downstream\` workflow
+          in [rigplane-core](https://github.com/rigplane/rigplane-core) when
+          release \`${TAG}\` was published.
+
+          ### Changes
+          | File | Edit |
+          |---|---|
+          | \`CORE_VERSION\` | \`v${VERSION}\` |
+          | \`pyproject.toml\` | \`rigplane[bridge]==${VERSION}\` |
+
+          Both edits are coupled and satisfy \`tests/test_core_version_contract.py\`.
+
+          ### Release notes
+          ${RELEASE_URL}
+
+          ### Checklist
+          - [ ] CI green
+          - [ ] Spot-check that \`CORE_VERSION\` and \`rigplane[bridge]==\` match
+          EOF
+          )"
+
+          gh pr create \
+            --repo rigplane/rigplane-pro \
+            --title "chore: bump core pin to v${VERSION} (auto)" \
+            --body "$PR_BODY" \
+            --head "$BRANCH" \
+            --base main
+
+      # ── rigplane-station ──────────────────────────────────────────────────
+
+      - name: Checkout rigplane-station
+        if: steps.secrets-check.outputs.configured == 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: rigplane/rigplane-station
+          token: ${{ steps.app-token.outputs.token }}
+          path: rigplane-station
+
+      - name: Bump rigplane-station pin
+        if: steps.secrets-check.outputs.configured == 'true'
+        run: |
+          python rigplane-core/scripts/bump_downstream_pin.py \
+            --repo station \
+            --version "${{ steps.version.outputs.version }}" \
+            --root rigplane-station
+
+      - name: Open PR in rigplane-station
+        if: steps.secrets-check.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          cd rigplane-station
+          BRANCH="codex/auto-bump-core-${VERSION}"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "$BRANCH"
+          git add pyproject.toml
+          git diff --cached --stat
+          git commit -m "chore: bump core pin to v${VERSION} (auto)"
+          git push origin "$BRANCH"
+
+          PR_BODY="$(cat <<EOF
+          ## Auto-bump: core pin → \`v${VERSION}\`
+
+          This PR was opened automatically by the \`dispatch-downstream\` workflow
+          in [rigplane-core](https://github.com/rigplane/rigplane-core) when
+          release \`${TAG}\` was published.
+
+          ### Changes
+          | File | Edit |
+          |---|---|
+          | \`pyproject.toml\` | \`rigplane==${VERSION}\` |
+
+          ### Release notes
+          ${RELEASE_URL}
+
+          ### Checklist
+          - [ ] CI green
+          - [ ] Confirm station image build picks up the new wheel
+          EOF
+          )"
+
+          gh pr create \
+            --repo rigplane/rigplane-station \
+            --title "chore: bump core pin to v${VERSION} (auto)" \
+            --body "$PR_BODY" \
+            --head "$BRANCH" \
+            --base main

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -44,7 +44,10 @@ jobs:
     name: Open downstream bump PRs
     runs-on: ubuntu-latest
     # Skip pre-releases (alpha, beta, rc). Only stable releases trigger bumps.
-    if: ${{ github.event.release.prerelease == false }}
+    # Also skip if the release body contains the opt-out marker [no-downstream-bump].
+    if: |
+      github.event.release.prerelease == false &&
+      !contains(github.event.release.body, '[no-downstream-bump]')
 
     steps:
       - name: Check that App secrets are configured

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ scripts/*
 !scripts/gen_state_types.py
 # And the consumer-driven contract (CDC) runner is tracked (MOR-883).
 !scripts/run_consumer_contracts.py
+# And the downstream-bump script is tracked (MOR-887).
+!scripts/bump_downstream_pin.py
 # But CI scripts under .github/ are tracked.
 !.github/scripts/
 # And frontend tooling scripts (e.g. i18n lint) are tracked.

--- a/scripts/bump_downstream_pin.py
+++ b/scripts/bump_downstream_pin.py
@@ -1,0 +1,127 @@
+"""
+bump_downstream_pin.py — edit downstream pin files for a new core version.
+
+Usage (from the root of the target downstream repo):
+    python bump_downstream_pin.py --repo pro   --version 2.11.0
+    python bump_downstream_pin.py --repo station --version 2.11.0
+
+For "pro":
+  - Writes `v<version>` to CORE_VERSION
+  - Replaces `rigplane[bridge]==<old>` with `rigplane[bridge]==<version>` in pyproject.toml
+
+For "station":
+  - Replaces `rigplane==<old>` with `rigplane==<version>` in pyproject.toml
+
+The script exits with code 0 and a summary on success, non-zero on error.
+It is intentionally free of third-party deps (stdlib only) so it can run
+in a bare `actions/checkout` step with no dependency install.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def _replace_once(text: str, pattern: str, replacement: str, label: str) -> str:
+    """Replace exactly one occurrence; raise if zero or >1 matches."""
+    matches = list(re.finditer(pattern, text))
+    if len(matches) == 0:
+        raise ValueError(f"Pattern not found in {label}: {pattern!r}")
+    if len(matches) > 1:
+        raise ValueError(
+            f"Ambiguous: {len(matches)} matches for {pattern!r} in {label}; "
+            "expected exactly one."
+        )
+    return text[: matches[0].start()] + replacement + text[matches[0].end() :]
+
+
+def bump_pro(repo_root: Path, version: str) -> None:
+    """Bump CORE_VERSION and rigplane[bridge]== in pyproject.toml for rigplane-pro."""
+    core_version_file = repo_root / "CORE_VERSION"
+    pyproject_file = repo_root / "pyproject.toml"
+
+    if not core_version_file.exists():
+        raise FileNotFoundError(f"CORE_VERSION not found at {core_version_file}")
+    if not pyproject_file.exists():
+        raise FileNotFoundError(f"pyproject.toml not found at {pyproject_file}")
+
+    old_tag = core_version_file.read_text(encoding="utf-8").strip()
+    old_version = old_tag.removeprefix("v")
+
+    new_tag = f"v{version}"
+    core_version_file.write_text(new_tag + "\n", encoding="utf-8")
+    print(f"  CORE_VERSION: {old_tag!r} -> {new_tag!r}")
+
+    pyproject_text = pyproject_file.read_text(encoding="utf-8")
+    old_pin = f"rigplane[bridge]=={old_version}"
+    new_pin = f"rigplane[bridge]=={version}"
+    # Match the pin as it appears inside the TOML deps array (possibly quoted)
+    pattern = re.escape(old_pin)
+    updated = _replace_once(pyproject_text, pattern, new_pin, "pyproject.toml")
+    pyproject_file.write_text(updated, encoding="utf-8")
+    print(f"  pyproject.toml: {old_pin!r} -> {new_pin!r}")
+
+
+def bump_station(repo_root: Path, version: str) -> None:
+    """Bump rigplane== in pyproject.toml for rigplane-station."""
+    pyproject_file = repo_root / "pyproject.toml"
+
+    if not pyproject_file.exists():
+        raise FileNotFoundError(f"pyproject.toml not found at {pyproject_file}")
+
+    pyproject_text = pyproject_file.read_text(encoding="utf-8")
+
+    # Find current pinned version to report it
+    m = re.search(r"rigplane==(\d+\.\d+\.\d+)", pyproject_text)
+    old_pin = m.group(0) if m else "rigplane==<unknown>"
+    new_pin = f"rigplane=={version}"
+
+    if old_pin == new_pin:
+        print(f"  pyproject.toml already at {new_pin!r} — no-op")
+        return
+
+    updated = _replace_once(
+        pyproject_text, re.escape(old_pin), new_pin, "pyproject.toml"
+    )
+    pyproject_file.write_text(updated, encoding="utf-8")
+    print(f"  pyproject.toml: {old_pin!r} -> {new_pin!r}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Bump downstream core pin files.")
+    parser.add_argument(
+        "--repo",
+        required=True,
+        choices=["pro", "station"],
+        help="Which downstream repo layout to bump.",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="New core version WITHOUT leading 'v' (e.g. 2.11.0).",
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Root directory of the downstream repo (default: cwd).",
+    )
+    args = parser.parse_args(argv)
+
+    version = args.version.lstrip("v")  # tolerate accidental 'v' prefix
+    repo_root = Path(args.root).resolve()
+
+    print(f"Bumping {args.repo} pin to {version} in {repo_root}")
+    if args.repo == "pro":
+        bump_pro(repo_root, version)
+    else:
+        bump_station(repo_root, version)
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bump_downstream_pin.py
+++ b/tests/test_bump_downstream_pin.py
@@ -1,0 +1,152 @@
+"""Unit tests for scripts/bump_downstream_pin.py.
+
+Tests verify the precise file-edit logic against sample content
+that mirrors the real rigplane-pro and rigplane-station pin files.
+They also confirm the resulting pro state satisfies the same assertion
+as rigplane-pro/tests/test_core_version_contract.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the scripts/ directory importable.
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from bump_downstream_pin import bump_pro, bump_station  # noqa: E402
+
+
+# ── sample file content ───────────────────────────────────────────────────────
+
+PRO_PYPROJECT_TEMPLATE = """\
+[project]
+name = "rigplane-pro"
+version = "0.9.0-beta.8"
+dependencies = [
+    "aiohttp>=3.9",
+    "rigplane[bridge]=={old}",
+    "keyring>=25.0",
+]
+"""
+
+STATION_PYPROJECT_TEMPLATE = """\
+[project]
+name = "rigplane-station"
+dependencies = [
+    "rigplane=={old}",
+    "aiohttp>=3.13",
+]
+"""
+
+
+# ── pro tests ─────────────────────────────────────────────────────────────────
+
+
+def test_bump_pro_core_version(tmp_path: Path) -> None:
+    (tmp_path / "CORE_VERSION").write_text("v2.10.1\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        PRO_PYPROJECT_TEMPLATE.format(old="2.10.1"), encoding="utf-8"
+    )
+
+    bump_pro(tmp_path, "2.11.0")
+
+    assert (tmp_path / "CORE_VERSION").read_text(encoding="utf-8").strip() == "v2.11.0"
+
+
+def test_bump_pro_pyproject_pin(tmp_path: Path) -> None:
+    (tmp_path / "CORE_VERSION").write_text("v2.10.1\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        PRO_PYPROJECT_TEMPLATE.format(old="2.10.1"), encoding="utf-8"
+    )
+
+    bump_pro(tmp_path, "2.11.0")
+
+    pyproject = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"rigplane[bridge]==2.11.0"' in pyproject
+    assert '"rigplane[bridge]==2.10.1"' not in pyproject
+
+
+def test_bump_pro_satisfies_version_contract(tmp_path: Path) -> None:
+    """Verify the edited state satisfies test_core_version_contract.py logic."""
+    import tomllib
+
+    (tmp_path / "CORE_VERSION").write_text("v2.10.1\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        PRO_PYPROJECT_TEMPLATE.format(old="2.10.1"), encoding="utf-8"
+    )
+
+    bump_pro(tmp_path, "2.11.0")
+
+    # Replicate the contract test assertion exactly.
+    core_tag = (tmp_path / "CORE_VERSION").read_text(encoding="utf-8").strip()
+    assert core_tag.startswith("v"), (
+        f"CORE_VERSION must start with 'v', got {core_tag!r}"
+    )
+    core_version = core_tag.removeprefix("v")
+
+    pyproject = tomllib.loads((tmp_path / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = pyproject["project"]["dependencies"]
+    assert f"rigplane[bridge]=={core_version}" in dependencies, (
+        f"rigplane[bridge]=={core_version} not found in dependencies: {dependencies}"
+    )
+
+
+def test_bump_pro_missing_core_version_file_raises(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        PRO_PYPROJECT_TEMPLATE.format(old="2.10.1"), encoding="utf-8"
+    )
+    with pytest.raises(FileNotFoundError, match="CORE_VERSION"):
+        bump_pro(tmp_path, "2.11.0")
+
+
+def test_bump_pro_missing_pin_line_raises(tmp_path: Path) -> None:
+    (tmp_path / "CORE_VERSION").write_text("v2.10.1\n", encoding="utf-8")
+    # pyproject.toml with a different pin version (simulates desync)
+    (tmp_path / "pyproject.toml").write_text(
+        PRO_PYPROJECT_TEMPLATE.format(old="2.9.0"), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="not found"):
+        bump_pro(tmp_path, "2.11.0")
+
+
+# ── station tests ─────────────────────────────────────────────────────────────
+
+
+def test_bump_station_pyproject_pin(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        STATION_PYPROJECT_TEMPLATE.format(old="2.10.0"), encoding="utf-8"
+    )
+
+    bump_station(tmp_path, "2.11.0")
+
+    pyproject = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"rigplane==2.11.0"' in pyproject
+    assert '"rigplane==2.10.0"' not in pyproject
+
+
+def test_bump_station_noop_if_already_current(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        STATION_PYPROJECT_TEMPLATE.format(old="2.11.0"), encoding="utf-8"
+    )
+    original = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+
+    bump_station(tmp_path, "2.11.0")
+
+    assert (tmp_path / "pyproject.toml").read_text(encoding="utf-8") == original
+    captured = capsys.readouterr()
+    assert "no-op" in captured.out
+
+
+def test_bump_station_missing_pin_raises(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'rigplane-station'\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="not found"):
+        bump_station(tmp_path, "2.11.0")


### PR DESCRIPTION
## Summary

Implements MOR-887 (epic MOR-707): when a stable rigplane-core GitHub Release is
published, a new workflow automatically opens version-bump PRs in rigplane-pro and
rigplane-station via a GitHub App token.

**This workflow is inert until the maintainer completes the one-time App setup
(documented below and in the workflow file header).**

## What ships

| File | Purpose |
|---|---|
| `.github/workflows/dispatch-downstream.yml` | Triggered on `release: published`; skips prereleases; no-ops with a warning when App secrets absent |
| `scripts/bump_downstream_pin.py` | Stdlib-only script that makes the precise in-file edits (testable, importable) |
| `tests/test_bump_downstream_pin.py` | 8 unit tests; includes contract test mirroring `test_core_version_contract.py` |
| `.gitignore` | Un-ignore `scripts/bump_downstream_pin.py` |

## Workflow behaviour

1. **Prerelease check** — `if: github.event.release.prerelease == false`. Alpha/beta/rc releases are skipped.
2. **Opt-out marker** — add `[no-downstream-bump]` to the release body to skip a specific release.
3. **Secrets check** — if `DOWNSTREAM_APP_ID` or `DOWNSTREAM_APP_PRIVATE_KEY` are absent, the job emits a `::warning::` and exits 0. The core release publish step is not blocked.
4. **Token mint** — `actions/create-github-app-token@v1` grants the minted token access to `rigplane-pro` and `rigplane-station`.
5. **rigplane-pro** — bumps `CORE_VERSION` to `vX.Y.Z` and `pyproject.toml` `rigplane[bridge]==X.Y.Z` (coupled, satisfies `test_core_version_contract.py`). Opens PR with title `chore: bump core pin to vX.Y.Z (auto)`.
6. **rigplane-station** — bumps `pyproject.toml` `rigplane==X.Y.Z`. Opens PR with same title pattern.

## Maintainer setup checklist (one-time, required to activate)

- [ ] **Create a GitHub App** in the `rigplane` org (Settings → Developer settings → GitHub Apps → New GitHub App):
  - Name: `rigplane-downstream-bump` (or similar)
  - Webhook: disabled (uncheck "Active")
  - Repository permissions: **Contents** = Read & write, **Pull requests** = Read & write
  - "Where can it be installed?" → Only on this account
- [ ] Note the numeric **App ID** on the App's settings page
- [ ] Generate a **private key** (App settings → "Private keys" → Generate a private key) — download the `.pem`
- [ ] **Install the App** on downstream repos: App settings → Install App → rigplane org → select `rigplane-pro`, `rigplane-station`
- [ ] Add **secrets** to `rigplane/rigplane-core` (Settings → Secrets and variables → Actions):
  - `DOWNSTREAM_APP_ID` — the numeric App ID (e.g. `123456`)
  - `DOWNSTREAM_APP_PRIVATE_KEY` — the full PEM content of the private key

## Bump script test output

```
tests/test_bump_downstream_pin.py::test_bump_pro_core_version PASSED
tests/test_bump_downstream_pin.py::test_bump_pro_pyproject_pin PASSED
tests/test_bump_downstream_pin.py::test_bump_pro_satisfies_version_contract PASSED
tests/test_bump_downstream_pin.py::test_bump_pro_missing_core_version_file_raises PASSED
tests/test_bump_downstream_pin.py::test_bump_pro_missing_pin_line_raises PASSED
tests/test_bump_downstream_pin.py::test_bump_station_pyproject_pin PASSED
tests/test_bump_downstream_pin.py::test_bump_station_noop_if_already_current PASSED
tests/test_bump_downstream_pin.py::test_bump_station_missing_pin_raises PASSED
8 passed in 0.03s
```

`test_bump_pro_satisfies_version_contract` replicates the exact assertion from
`rigplane-pro/tests/test_core_version_contract.py` and passes post-bump.

## Out of scope

- Does not modify core publish/release workflow (`publish.yml`).
- Does not auto-merge downstream PRs — maintainer reviews and merges.
- rigplane-tower and rigplane-strategy have no core pin; not bumped.

Closes MOR-887 · Epic MOR-707

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01MFjAT974fbZ48EBA9DxAiS