### PR TITLE
style: fix ruff format in _discover_hamlib.py

### DIFF
--- a/src/rigplane/cli/_discover_hamlib.py
+++ b/src/rigplane/cli/_discover_hamlib.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 # Re-export from the canonical public location.  All helpers that were private
 # to this module have been moved to rigplane.backends.discovery; they are not
 # part of the public API and are not re-exported here.
-from rigplane.backends.discovery import build_hamlib_discovery_payload as build_hamlib_discovery_payload  # noqa: PLC0414
+from rigplane.backends.discovery import (
+    build_hamlib_discovery_payload as build_hamlib_discovery_payload,
+)  # noqa: PLC0414
 
 
 def print_hamlib_human(payload: dict[str, object]) -> None:


### PR DESCRIPTION
## Summary
Fixes ruff format drift in `src/rigplane/cli/_discover_hamlib.py` introduced in MOR-911 (#1888). This was causing the `Tests (quick)` gate to fail on main.

## Changes
- Applied `ruff format` to `src/rigplane/cli/_discover_hamlib.py`
- Verified: `ruff format --check src/ tests/` now passes
- Verified: `ruff check src/rigplane/cli/_discover_hamlib.py` clean

## Related
- Closes formatting regression from #1888
- Fixes main quick gate failure

🤖 Generated with Claude Code
https://claude.ai/code/session_01MFjAT974fbZ48EBA9DxAiS