### PR TITLE
Core: implement backend TX safety supervisor model

### DIFF
--- a/src/rigplane/core/tx_safety.py
+++ b/src/rigplane/core/tx_safety.py
@@ -1,0 +1,536 @@
+"""Pure, single-target policy for managed radio PTT.
+
+The supervisor emits bounded provider operations but performs no I/O. Runtime
+integration enforces each operation's timeout and reports its settlement plus
+field-specific PTT observations back to this model.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from typing import TypeAlias
+
+Clock = Callable[[], float]
+IdFactory = Callable[[], str]
+
+
+class TxSource(StrEnum):
+    WEBSOCKET = "websocket"
+    RIGCTLD = "rigctld"
+    SDK = "sdk"
+    HAMLIB_BRIDGE = "hamlib_bridge"
+    INTERNAL = "internal"
+
+
+class RadioTx(StrEnum):
+    OFF = "off"
+    ON = "on"
+    UNKNOWN = "unknown"
+
+
+class TxPhase(StrEnum):
+    IDLE = "idle"
+    KEY_PENDING = "key_pending"
+    KEYED = "keyed"
+    RELEASE_REQUIRED = "release_required"
+    RELEASE_CONFIRMING = "release_confirming"
+    FAULTED = "faulted"
+    EXTERNAL_UNOWNED = "external_unowned"
+
+
+class TxOutcome(StrEnum):
+    ACCEPTED = "accepted"
+    IDEMPOTENT = "idempotent"
+    BUSY = "tx_busy"
+    NOT_READY = "provider_not_ready"
+    RADIO_NOT_OFF = "radio_not_off"
+    RELEASE_PENDING = "release_pending"
+    STALE = "stale"
+    APPLIED = "applied"
+    NOOP = "noop"
+
+
+class TxReleaseReason(StrEnum):
+    OPERATOR_RELEASE = "operator_release"
+    SOURCE_DETACHED = "source_detached"
+    PRESENTATION_REPLACED = "presentation_replaced"
+    CLIENT_DISCONNECTED = "client_disconnected"
+    AUDIO_FAILED = "audio_failed"
+    CONTROL_TRANSPORT_LOST = "control_transport_lost"
+    RADIO_TRANSPORT_LOST = "radio_transport_lost"
+    CAPABILITY_LOST = "capability_lost"
+    PERMIT_LOST = "permit_lost"
+    FRONTEND_SAFETY_TIMEOUT = "frontend_safety_timeout"
+    BACKEND_MAX_KEY_DOWN = "backend_max_key_down"
+    EXTERNAL_CAT_PREEMPTED = "external_cat_preempted"
+    APP_SHUTDOWN = "app_shutdown"
+    SERVER_SHUTDOWN = "server_shutdown"
+    RECOVERY_EXHAUSTED = "recovery_exhausted"
+    ADMIN_EMERGENCY_STOP = "admin_emergency_stop"
+
+
+class ProviderAttemptKind(StrEnum):
+    WRITE_ON = "write_on"
+    WRITE_OFF = "write_off"
+    READ_PTT = "read_ptt"
+
+
+@dataclass(frozen=True, slots=True)
+class TxOwner:
+    source: TxSource
+    session_id: str
+
+    def __post_init__(self) -> None:
+        if not self.session_id:
+            raise ValueError("session_id must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderPttObservation:
+    value: RadioTx
+    provider_generation: int
+    ptt_observation_seq: int
+    observed_at_monotonic: float
+
+    def __post_init__(self) -> None:
+        if self.value is RadioTx.UNKNOWN:
+            raise ValueError("PTT observations must decode to ON or OFF")
+        if self.provider_generation < 0:
+            raise ValueError("provider_generation must be non-negative")
+        if self.ptt_observation_seq <= 0:
+            raise ValueError("ptt_observation_seq must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAttempt:
+    id: str
+    kind: ProviderAttemptKind
+    provider_generation: int
+    lease_id: str
+    started_at_monotonic: float
+    timeout_seconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class CancelProviderAttempt:
+    attempt_id: str
+    provider_generation: int
+
+
+TxEffect: TypeAlias = ProviderAttempt | CancelProviderAttempt
+
+
+@dataclass(frozen=True, slots=True)
+class TxSafetySnapshot:
+    phase: TxPhase
+    radio_tx: RadioTx
+    provider_generation: int | None
+    provider_ready: bool
+    lease_id: str | None
+    owner: TxOwner | None
+    release_reason: TxReleaseReason | None
+    terminal_release_reason: TxReleaseReason | None
+    release_attempt_count: int
+    release_last_error: str | None
+    active_attempt: ProviderAttempt | None
+    watchdog_deadline_monotonic: float | None
+    watchdog_enabled: bool
+    external_conflict: bool
+
+
+@dataclass(frozen=True, slots=True)
+class TxTransition:
+    outcome: TxOutcome
+    snapshot: TxSafetySnapshot
+    effects: tuple[TxEffect, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class _Lease:
+    id: str
+    owner: TxOwner
+
+
+@dataclass(frozen=True, slots=True)
+class _Boundary:
+    generation: int
+    sequence: int
+    not_before: float
+
+    def accepts(self, observation: ProviderPttObservation | None) -> bool:
+        return observation is not None and (
+            observation.provider_generation == self.generation
+            and observation.ptt_observation_seq > self.sequence
+            and observation.observed_at_monotonic >= self.not_before
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _Release:
+    requested_reason: TxReleaseReason
+    terminal_reason: TxReleaseReason
+    boundary: _Boundary
+    attempts: int = 0
+    retry_due: float | None = None
+    error: str | None = None
+
+
+class TxSafetySupervisor:
+    """Owner, watchdog, causal confirmation, and durable OFF reducer."""
+
+    def __init__(
+        self,
+        *,
+        clock: Clock | None = None,
+        id_factory: IdFactory | None = None,
+        watchdog_seconds: float | None = 180.0,
+        write_timeout_seconds: float = 2.0,
+        read_timeout_seconds: float = 2.0,
+        retry_schedule_seconds: Sequence[float] = (0.25, 1.0, 2.0, 5.0),
+    ) -> None:
+        if watchdog_seconds is not None and watchdog_seconds <= 0:
+            raise ValueError("watchdog_seconds must be positive or None")
+        if write_timeout_seconds <= 0 or read_timeout_seconds <= 0:
+            raise ValueError("provider timeouts must be positive")
+        retries = tuple(float(delay) for delay in retry_schedule_seconds)
+        if (
+            not retries
+            or any(delay < 0 for delay in retries)
+            or any(b < a for a, b in zip(retries, retries[1:]))
+        ):
+            raise ValueError("retry schedule must be non-empty and non-decreasing")
+
+        self._clock = clock or time.monotonic
+        self._id_factory = id_factory or (lambda: uuid.uuid4().hex)
+        self._watchdog_seconds = watchdog_seconds
+        self._write_timeout = float(write_timeout_seconds)
+        self._read_timeout = float(read_timeout_seconds)
+        self._retries = retries
+        self._generation: int | None = None
+        self._ready = False
+        self._observation: ProviderPttObservation | None = None
+        self._lease: _Lease | None = None
+        self._acquisition: _Boundary | None = None
+        self._release: _Release | None = None
+        self._active: ProviderAttempt | None = None
+        self._watchdog_deadline: float | None = None
+
+    @property
+    def snapshot(self) -> TxSafetySnapshot:
+        radio = self._observation.value if self._observation else RadioTx.UNKNOWN
+        managed_on = bool(
+            self._lease
+            and not self._release
+            and radio is RadioTx.ON
+            and self._acquisition
+        )
+        confirmed = bool(
+            managed_on
+            and self._acquisition
+            and self._acquisition.accepts(self._observation)
+        )
+        if self._release:
+            if self._release.error:
+                phase = TxPhase.FAULTED
+            elif self._active and self._active.kind is ProviderAttemptKind.READ_PTT:
+                phase = TxPhase.RELEASE_CONFIRMING
+            else:
+                phase = TxPhase.RELEASE_REQUIRED
+        elif not self._lease:
+            phase = TxPhase.EXTERNAL_UNOWNED if radio is RadioTx.ON else TxPhase.IDLE
+        else:
+            phase = TxPhase.KEYED if confirmed else TxPhase.KEY_PENDING
+        return TxSafetySnapshot(
+            phase=phase,
+            radio_tx=radio,
+            provider_generation=self._generation,
+            provider_ready=self._ready,
+            lease_id=self._lease.id if self._lease else None,
+            owner=self._lease.owner if self._lease else None,
+            release_reason=self._release.requested_reason if self._release else None,
+            terminal_release_reason=(
+                self._release.terminal_reason if self._release else None
+            ),
+            release_attempt_count=self._release.attempts if self._release else 0,
+            release_last_error=self._release.error if self._release else None,
+            active_attempt=self._active,
+            watchdog_deadline_monotonic=self._watchdog_deadline,
+            watchdog_enabled=self._watchdog_seconds is not None,
+            external_conflict=managed_on and not confirmed,
+        )
+
+    def replace_provider(self, generation: int, *, ready: bool) -> TxTransition:
+        if generation < 0:
+            raise ValueError("provider_generation must be non-negative")
+        if self._generation is not None and generation <= self._generation:
+            return self._result(TxOutcome.STALE)
+        now = self._clock()
+        had_lease = self._lease is not None
+        self._generation, self._ready = generation, ready
+        self._observation = None
+        self._active = None
+        self._acquisition = None
+        if had_lease:
+            if not self._release:
+                self._begin_release(TxReleaseReason.CONTROL_TRANSPORT_LOST, now)
+            assert self._release is not None
+            self._release = replace(
+                self._release, boundary=self._boundary(now), retry_due=now
+            )
+        return self._result(TxOutcome.APPLIED, self._service_release(force=ready))
+
+    def set_provider_ready(self, generation: int, *, ready: bool) -> TxTransition:
+        if generation != self._generation:
+            return self._result(TxOutcome.STALE)
+        if ready == self._ready:
+            return self._result(
+                TxOutcome.IDEMPOTENT, self._service_release(force=ready)
+            )
+        self._ready = ready
+        if not ready:
+            self._observation = None
+            self._active = None
+            if self._lease and not self._release:
+                self._begin_release(
+                    TxReleaseReason.CONTROL_TRANSPORT_LOST, self._clock()
+                )
+            return self._result(TxOutcome.APPLIED)
+        return self._result(TxOutcome.APPLIED, self._service_release(force=True))
+
+    def observe_ptt(self, observation: ProviderPttObservation) -> TxTransition:
+        """Record globally newer truth, then apply acquisition/release causality."""
+        previous = self._observation
+        if observation.provider_generation != self._generation or (
+            previous is not None
+            and (
+                observation.ptt_observation_seq <= previous.ptt_observation_seq
+                or observation.observed_at_monotonic < previous.observed_at_monotonic
+            )
+        ):
+            return self._result(TxOutcome.STALE)
+        self._observation = observation
+        if (
+            self._release
+            and observation.value is RadioTx.OFF
+            and self._release.boundary.accepts(observation)
+        ):
+            self._clear_managed()
+        return self._result(TxOutcome.APPLIED)
+
+    def request_on(self, owner: TxOwner) -> TxTransition:
+        """Acquire once and emit the only WRITE_ON this lease can produce."""
+        if self._release:
+            return self._result(TxOutcome.RELEASE_PENDING)
+        if self._lease:
+            return self._result(
+                TxOutcome.IDEMPOTENT if self._lease.owner == owner else TxOutcome.BUSY
+            )
+        if not self._ready or self._generation is None:
+            return self._result(TxOutcome.NOT_READY)
+        if not self._observation or self._observation.value is not RadioTx.OFF:
+            return self._result(TxOutcome.RADIO_NOT_OFF)
+        now = self._clock()
+        self._lease = _Lease(self._id_factory(), owner)
+        self._acquisition = self._boundary(now)
+        self._watchdog_deadline = (
+            now + self._watchdog_seconds if self._watchdog_seconds else None
+        )
+        return self._result(
+            TxOutcome.ACCEPTED,
+            (self._start(ProviderAttemptKind.WRITE_ON, self._write_timeout),),
+        )
+
+    def request_off(
+        self,
+        owner: TxOwner,
+        lease_id: str,
+        *,
+        reason: TxReleaseReason = TxReleaseReason.OPERATOR_RELEASE,
+    ) -> TxTransition:
+        if not self._lease or (self._lease.owner, self._lease.id) != (owner, lease_id):
+            return self._result(TxOutcome.STALE)
+        return self._release_current(reason)
+
+    def release_owner(self, owner: TxOwner, *, reason: TxReleaseReason) -> TxTransition:
+        if not self._lease or self._lease.owner != owner:
+            return self._result(TxOutcome.STALE)
+        return self._release_current(reason)
+
+    def emergency_release(self, *, reason: TxReleaseReason) -> TxTransition:
+        return (
+            self._release_current(reason)
+            if self._lease
+            else self._result(TxOutcome.NOOP)
+        )
+
+    def settle_attempt(
+        self,
+        attempt_id: str,
+        provider_generation: int,
+        *,
+        succeeded: bool,
+        error: str | None = None,
+    ) -> TxTransition:
+        attempt = self._active
+        if (
+            not attempt
+            or (attempt.id, attempt.provider_generation)
+            != (attempt_id, provider_generation)
+            or provider_generation != self._generation
+        ):
+            return self._result(TxOutcome.STALE)
+        self._active = None
+
+        if attempt.kind is ProviderAttemptKind.WRITE_ON:
+            if not self._release and not succeeded:
+                self._begin_release(
+                    TxReleaseReason.CONTROL_TRANSPORT_LOST,
+                    self._clock(),
+                    error or "write_on_failed",
+                )
+            if self._release:
+                return self._result(
+                    TxOutcome.APPLIED, self._service_release(force=True)
+                )
+            return self._result(
+                TxOutcome.APPLIED,
+                (self._start(ProviderAttemptKind.READ_PTT, self._read_timeout),),
+            )
+
+        if not self._release:
+            if attempt.kind is ProviderAttemptKind.READ_PTT and not succeeded:
+                self._begin_release(
+                    TxReleaseReason.CONTROL_TRANSPORT_LOST,
+                    self._clock(),
+                    error or "read_ptt_failed",
+                )
+                return self._result(
+                    TxOutcome.APPLIED, self._service_release(force=True)
+                )
+            return self._result(TxOutcome.APPLIED)
+
+        if self._release.attempts == 0:
+            return self._result(TxOutcome.APPLIED, self._service_release(force=True))
+        if attempt.kind is ProviderAttemptKind.WRITE_OFF:
+            if not succeeded:
+                self._schedule_retry(error or "write_off_failed")
+                return self._result(TxOutcome.APPLIED)
+            return self._result(
+                TxOutcome.APPLIED,
+                (self._start(ProviderAttemptKind.READ_PTT, self._read_timeout),),
+            )
+        self._schedule_retry(
+            error or ("read_ptt_unconfirmed" if succeeded else "read_ptt_failed")
+        )
+        return self._result(TxOutcome.APPLIED)
+
+    def tick(self) -> TxTransition:
+        now = self._clock()
+        effects: tuple[TxEffect, ...] = ()
+        if (
+            self._lease
+            and not self._release
+            and self._watchdog_deadline is not None
+            and now >= self._watchdog_deadline
+        ):
+            active = self._active
+            self._begin_release(TxReleaseReason.BACKEND_MAX_KEY_DOWN, now)
+            if active:
+                effects = (
+                    CancelProviderAttempt(active.id, active.provider_generation),
+                )
+        if not effects:
+            effects = self._service_release(force=False)
+        outcome = TxOutcome.APPLIED if effects or self._release else TxOutcome.NOOP
+        return self._result(outcome, effects)
+
+    def _release_current(self, reason: TxReleaseReason) -> TxTransition:
+        if self._release:
+            self._release = replace(self._release, terminal_reason=reason)
+            return self._result(TxOutcome.IDEMPOTENT)
+        self._begin_release(reason, self._clock())
+        if self._active:
+            return self._result(
+                TxOutcome.ACCEPTED,
+                (
+                    CancelProviderAttempt(
+                        self._active.id, self._active.provider_generation
+                    ),
+                ),
+            )
+        return self._result(TxOutcome.ACCEPTED, self._service_release(force=True))
+
+    def _begin_release(
+        self, reason: TxReleaseReason, now: float, error: str | None = None
+    ) -> None:
+        if not self._lease:
+            return
+        self._release = _Release(
+            requested_reason=reason,
+            terminal_reason=reason,
+            boundary=self._boundary(now),
+            retry_due=now,
+            error=error,
+        )
+        self._watchdog_deadline = None
+
+    def _service_release(self, *, force: bool) -> tuple[TxEffect, ...]:
+        release = self._release
+        if (
+            not release
+            or not self._ready
+            or self._generation is None
+            or self._active
+            or (
+                not force
+                and (release.retry_due is None or self._clock() < release.retry_due)
+            )
+        ):
+            return ()
+        attempt = self._start(ProviderAttemptKind.WRITE_OFF, self._write_timeout)
+        self._release = replace(
+            release, attempts=release.attempts + 1, retry_due=None, error=None
+        )
+        return (attempt,)
+
+    def _schedule_retry(self, error: str) -> None:
+        if not self._release:
+            return
+        index = max(self._release.attempts - 1, 0)
+        delay = self._retries[min(index, len(self._retries) - 1)]
+        self._release = replace(
+            self._release, retry_due=self._clock() + delay, error=error
+        )
+
+    def _start(self, kind: ProviderAttemptKind, timeout: float) -> ProviderAttempt:
+        if self._active or self._generation is None or not self._lease:
+            raise RuntimeError("provider attempt requires one generation and lease")
+        attempt = ProviderAttempt(
+            self._id_factory(),
+            kind,
+            self._generation,
+            self._lease.id,
+            self._clock(),
+            timeout,
+        )
+        self._active = attempt
+        return attempt
+
+    def _boundary(self, now: float) -> _Boundary:
+        if self._generation is None:
+            raise RuntimeError("causal boundary requires provider generation")
+        sequence = self._observation.ptt_observation_seq if self._observation else 0
+        return _Boundary(self._generation, sequence, now)
+
+    def _clear_managed(self) -> None:
+        self._lease = self._acquisition = self._release = self._active = None
+        self._watchdog_deadline = None
+
+    def _result(
+        self, outcome: TxOutcome, effects: Sequence[TxEffect] = ()
+    ) -> TxTransition:
+        return TxTransition(outcome, self.snapshot, tuple(effects))

--- a/src/rigplane/core/tx_safety.py
+++ b/src/rigplane/core/tx_safety.py
@@ -104,6 +104,8 @@ class ProviderPttObservation:
             raise ValueError("provider_generation must be non-negative")
         if self.ptt_observation_seq <= 0:
             raise ValueError("ptt_observation_seq must be positive")
+        if not isfinite(self.observed_at_monotonic):
+            raise ValueError("observed_at_monotonic must be finite")
 
 
 @dataclass(frozen=True, slots=True)
@@ -213,7 +215,7 @@ class TxSafetySupervisor:
         watchdog_seconds: float | None = 180.0,
         write_timeout_seconds: float = 2.0,
         read_timeout_seconds: float = 2.0,
-        cancel_timeout_seconds: float = 2.0,
+        cancel_timeout_seconds: float = 0.5,
         retry_schedule_seconds: Sequence[float] = (0.25, 1.0, 2.0, 5.0),
     ) -> None:
         if watchdog_seconds is not None and (
@@ -245,6 +247,7 @@ class TxSafetySupervisor:
         self._acquisition: _Boundary | None = None
         self._release: _Release | None = None
         self._active: ProviderAttempt | None = None
+        self._cancel_pending: CancelProviderAttempt | None = None
         self._watchdog_deadline: float | None = None
 
     @property
@@ -301,6 +304,7 @@ class TxSafetySupervisor:
         self._generation, self._ready = generation, ready
         self._observation = None
         self._active = None
+        self._cancel_pending = None
         self._acquisition = None
         if had_lease:
             if not self._release:
@@ -322,7 +326,7 @@ class TxSafetySupervisor:
             self._observation = None
             if self._lease and not self._release:
                 self._begin_release(TxReleaseReason.CONTROL_TRANSPORT_LOST, now)
-            effects = (self._cancel(self._active, now),) if self._active else ()
+            effects = self._cancel(self._active, now) if self._active else ()
             return self._result(TxOutcome.APPLIED, effects)
         return self._result(
             TxOutcome.APPLIED, self._service_release(force=True, now=now)
@@ -415,6 +419,7 @@ class TxSafetySupervisor:
         ):
             return self._result(TxOutcome.STALE)
         self._active = None
+        self._cancel_pending = None
         now = self._clock()
         if not self._lease:
             return self._result(TxOutcome.APPLIED)
@@ -476,7 +481,7 @@ class TxSafetySupervisor:
             active = self._active
             self._begin_release(TxReleaseReason.BACKEND_MAX_KEY_DOWN, now)
             if active:
-                effects = (self._cancel(active, now),)
+                effects = self._cancel(active, now)
         if not effects:
             effects = self._service_release(force=False, now=now)
         outcome = TxOutcome.APPLIED if effects or self._release else TxOutcome.NOOP
@@ -491,7 +496,7 @@ class TxSafetySupervisor:
         if self._active:
             return self._result(
                 TxOutcome.ACCEPTED,
-                (self._cancel(self._active, now),),
+                self._cancel(self._active, now),
             )
         return self._result(TxOutcome.ACCEPTED, self._service_release(force=True))
 
@@ -555,16 +560,27 @@ class TxSafetySupervisor:
             timeout,
         )
         self._active = attempt
+        self._cancel_pending = None
         return attempt
 
-    def _cancel(self, attempt: ProviderAttempt, now: float) -> CancelProviderAttempt:
-        return CancelProviderAttempt(
+    def _cancel(
+        self, attempt: ProviderAttempt, now: float
+    ) -> tuple[CancelProviderAttempt, ...]:
+        pending = self._cancel_pending
+        if pending and (
+            pending.attempt_id,
+            pending.provider_generation,
+        ) == (attempt.id, attempt.provider_generation):
+            return ()
+        pending = CancelProviderAttempt(
             attempt.id,
             attempt.provider_generation,
             now,
             self._cancel_timeout,
             now + self._cancel_timeout,
         )
+        self._cancel_pending = pending
+        return (pending,)
 
     def _boundary(self, now: float) -> _Boundary:
         if self._generation is None:

--- a/src/rigplane/core/tx_safety.py
+++ b/src/rigplane/core/tx_safety.py
@@ -1,14 +1,15 @@
 """Pure, single-target policy for managed radio PTT.
 
 The supervisor emits bounded provider operations but performs no I/O. Runtime
-integration enforces each operation's timeout and reports its settlement plus
-field-specific PTT observations back to this model.
+integration enforces operation and cancellation-settlement deadlines, then
+reports settlement plus field-specific PTT observations back to this model.
 """
 
 from __future__ import annotations
 
 import time
 import uuid
+from math import isfinite
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
@@ -117,8 +118,13 @@ class ProviderAttempt:
 
 @dataclass(frozen=True, slots=True)
 class CancelProviderAttempt:
+    """Cancel an active lane; runtime must settle it by the deadline."""
+
     attempt_id: str
     provider_generation: int
+    requested_at_monotonic: float
+    settlement_timeout_seconds: float
+    settlement_deadline_monotonic: float
 
 
 TxEffect: TypeAlias = ProviderAttempt | CancelProviderAttempt
@@ -179,6 +185,23 @@ class _Release:
     error: str | None = None
 
 
+_SYSTEM_RELEASE_REASONS = frozenset(
+    {
+        TxReleaseReason.AUDIO_FAILED,
+        TxReleaseReason.CONTROL_TRANSPORT_LOST,
+        TxReleaseReason.RADIO_TRANSPORT_LOST,
+        TxReleaseReason.CAPABILITY_LOST,
+        TxReleaseReason.PERMIT_LOST,
+        TxReleaseReason.BACKEND_MAX_KEY_DOWN,
+        TxReleaseReason.EXTERNAL_CAT_PREEMPTED,
+        TxReleaseReason.APP_SHUTDOWN,
+        TxReleaseReason.SERVER_SHUTDOWN,
+        TxReleaseReason.RECOVERY_EXHAUSTED,
+        TxReleaseReason.ADMIN_EMERGENCY_STOP,
+    }
+)
+
+
 class TxSafetySupervisor:
     """Owner, watchdog, causal confirmation, and durable OFF reducer."""
 
@@ -190,16 +213,20 @@ class TxSafetySupervisor:
         watchdog_seconds: float | None = 180.0,
         write_timeout_seconds: float = 2.0,
         read_timeout_seconds: float = 2.0,
+        cancel_timeout_seconds: float = 2.0,
         retry_schedule_seconds: Sequence[float] = (0.25, 1.0, 2.0, 5.0),
     ) -> None:
-        if watchdog_seconds is not None and watchdog_seconds <= 0:
-            raise ValueError("watchdog_seconds must be positive or None")
-        if write_timeout_seconds <= 0 or read_timeout_seconds <= 0:
+        if watchdog_seconds is not None and (
+            not isfinite(watchdog_seconds) or watchdog_seconds <= 0
+        ):
+            raise ValueError("watchdog_seconds must be finite-positive or None")
+        timeouts = (write_timeout_seconds, read_timeout_seconds, cancel_timeout_seconds)
+        if any(not isfinite(value) or value <= 0 for value in timeouts):
             raise ValueError("provider timeouts must be positive")
         retries = tuple(float(delay) for delay in retry_schedule_seconds)
         if (
             not retries
-            or any(delay < 0 for delay in retries)
+            or any(not isfinite(delay) or delay < 0 for delay in retries)
             or any(b < a for a, b in zip(retries, retries[1:]))
         ):
             raise ValueError("retry schedule must be non-empty and non-decreasing")
@@ -209,6 +236,7 @@ class TxSafetySupervisor:
         self._watchdog_seconds = watchdog_seconds
         self._write_timeout = float(write_timeout_seconds)
         self._read_timeout = float(read_timeout_seconds)
+        self._cancel_timeout = float(cancel_timeout_seconds)
         self._retries = retries
         self._generation: int | None = None
         self._ready = False
@@ -287,19 +315,18 @@ class TxSafetySupervisor:
         if generation != self._generation:
             return self._result(TxOutcome.STALE)
         if ready == self._ready:
-            return self._result(
-                TxOutcome.IDEMPOTENT, self._service_release(force=ready)
-            )
+            return self._result(TxOutcome.IDEMPOTENT)
+        now = self._clock()
         self._ready = ready
         if not ready:
             self._observation = None
-            self._active = None
             if self._lease and not self._release:
-                self._begin_release(
-                    TxReleaseReason.CONTROL_TRANSPORT_LOST, self._clock()
-                )
-            return self._result(TxOutcome.APPLIED)
-        return self._result(TxOutcome.APPLIED, self._service_release(force=True))
+                self._begin_release(TxReleaseReason.CONTROL_TRANSPORT_LOST, now)
+            effects = (self._cancel(self._active, now),) if self._active else ()
+            return self._result(TxOutcome.APPLIED, effects)
+        return self._result(
+            TxOutcome.APPLIED, self._service_release(force=True, now=now)
+        )
 
     def observe_ptt(self, observation: ProviderPttObservation) -> TxTransition:
         """Record globally newer truth, then apply acquisition/release causality."""
@@ -329,6 +356,8 @@ class TxSafetySupervisor:
             return self._result(
                 TxOutcome.IDEMPOTENT if self._lease.owner == owner else TxOutcome.BUSY
             )
+        if self._active:
+            return self._result(TxOutcome.BUSY)
         if not self._ready or self._generation is None:
             return self._result(TxOutcome.NOT_READY)
         if not self._observation or self._observation.value is not RadioTx.OFF:
@@ -341,7 +370,7 @@ class TxSafetySupervisor:
         )
         return self._result(
             TxOutcome.ACCEPTED,
-            (self._start(ProviderAttemptKind.WRITE_ON, self._write_timeout),),
+            (self._start(ProviderAttemptKind.WRITE_ON, self._write_timeout, now),),
         )
 
     def request_off(
@@ -361,6 +390,8 @@ class TxSafetySupervisor:
         return self._release_current(reason)
 
     def emergency_release(self, *, reason: TxReleaseReason) -> TxTransition:
+        if reason not in _SYSTEM_RELEASE_REASONS:
+            raise ValueError("unqualified release requires a trusted system reason")
         return (
             self._release_current(reason)
             if self._lease
@@ -384,44 +415,49 @@ class TxSafetySupervisor:
         ):
             return self._result(TxOutcome.STALE)
         self._active = None
+        now = self._clock()
+        if not self._lease:
+            return self._result(TxOutcome.APPLIED)
 
         if attempt.kind is ProviderAttemptKind.WRITE_ON:
             if not self._release and not succeeded:
                 self._begin_release(
                     TxReleaseReason.CONTROL_TRANSPORT_LOST,
-                    self._clock(),
+                    now,
                     error or "write_on_failed",
                 )
             if self._release:
                 return self._result(
-                    TxOutcome.APPLIED, self._service_release(force=True)
+                    TxOutcome.APPLIED, self._service_release(force=True, now=now)
                 )
             return self._result(
                 TxOutcome.APPLIED,
-                (self._start(ProviderAttemptKind.READ_PTT, self._read_timeout),),
+                (self._start(ProviderAttemptKind.READ_PTT, self._read_timeout, now),),
             )
 
         if not self._release:
             if attempt.kind is ProviderAttemptKind.READ_PTT and not succeeded:
                 self._begin_release(
                     TxReleaseReason.CONTROL_TRANSPORT_LOST,
-                    self._clock(),
+                    now,
                     error or "read_ptt_failed",
                 )
                 return self._result(
-                    TxOutcome.APPLIED, self._service_release(force=True)
+                    TxOutcome.APPLIED, self._service_release(force=True, now=now)
                 )
             return self._result(TxOutcome.APPLIED)
 
         if self._release.attempts == 0:
-            return self._result(TxOutcome.APPLIED, self._service_release(force=True))
+            return self._result(
+                TxOutcome.APPLIED, self._service_release(force=True, now=now)
+            )
         if attempt.kind is ProviderAttemptKind.WRITE_OFF:
             if not succeeded:
                 self._schedule_retry(error or "write_off_failed")
                 return self._result(TxOutcome.APPLIED)
             return self._result(
                 TxOutcome.APPLIED,
-                (self._start(ProviderAttemptKind.READ_PTT, self._read_timeout),),
+                (self._start(ProviderAttemptKind.READ_PTT, self._read_timeout, now),),
             )
         self._schedule_retry(
             error or ("read_ptt_unconfirmed" if succeeded else "read_ptt_failed")
@@ -440,11 +476,9 @@ class TxSafetySupervisor:
             active = self._active
             self._begin_release(TxReleaseReason.BACKEND_MAX_KEY_DOWN, now)
             if active:
-                effects = (
-                    CancelProviderAttempt(active.id, active.provider_generation),
-                )
+                effects = (self._cancel(active, now),)
         if not effects:
-            effects = self._service_release(force=False)
+            effects = self._service_release(force=False, now=now)
         outcome = TxOutcome.APPLIED if effects or self._release else TxOutcome.NOOP
         return self._result(outcome, effects)
 
@@ -452,15 +486,12 @@ class TxSafetySupervisor:
         if self._release:
             self._release = replace(self._release, terminal_reason=reason)
             return self._result(TxOutcome.IDEMPOTENT)
-        self._begin_release(reason, self._clock())
+        now = self._clock()
+        self._begin_release(reason, now)
         if self._active:
             return self._result(
                 TxOutcome.ACCEPTED,
-                (
-                    CancelProviderAttempt(
-                        self._active.id, self._active.provider_generation
-                    ),
-                ),
+                (self._cancel(self._active, now),),
             )
         return self._result(TxOutcome.ACCEPTED, self._service_release(force=True))
 
@@ -478,20 +509,24 @@ class TxSafetySupervisor:
         )
         self._watchdog_deadline = None
 
-    def _service_release(self, *, force: bool) -> tuple[TxEffect, ...]:
+    def _service_release(
+        self, *, force: bool, now: float | None = None
+    ) -> tuple[TxEffect, ...]:
         release = self._release
+        instant = self._clock() if now is None else now
         if (
             not release
             or not self._ready
             or self._generation is None
             or self._active
             or (
-                not force
-                and (release.retry_due is None or self._clock() < release.retry_due)
+                not force and (release.retry_due is None or instant < release.retry_due)
             )
         ):
             return ()
-        attempt = self._start(ProviderAttemptKind.WRITE_OFF, self._write_timeout)
+        attempt = self._start(
+            ProviderAttemptKind.WRITE_OFF, self._write_timeout, instant
+        )
         self._release = replace(
             release, attempts=release.attempts + 1, retry_due=None, error=None
         )
@@ -506,7 +541,9 @@ class TxSafetySupervisor:
             self._release, retry_due=self._clock() + delay, error=error
         )
 
-    def _start(self, kind: ProviderAttemptKind, timeout: float) -> ProviderAttempt:
+    def _start(
+        self, kind: ProviderAttemptKind, timeout: float, now: float
+    ) -> ProviderAttempt:
         if self._active or self._generation is None or not self._lease:
             raise RuntimeError("provider attempt requires one generation and lease")
         attempt = ProviderAttempt(
@@ -514,11 +551,20 @@ class TxSafetySupervisor:
             kind,
             self._generation,
             self._lease.id,
-            self._clock(),
+            now,
             timeout,
         )
         self._active = attempt
         return attempt
+
+    def _cancel(self, attempt: ProviderAttempt, now: float) -> CancelProviderAttempt:
+        return CancelProviderAttempt(
+            attempt.id,
+            attempt.provider_generation,
+            now,
+            self._cancel_timeout,
+            now + self._cancel_timeout,
+        )
 
     def _boundary(self, now: float) -> _Boundary:
         if self._generation is None:
@@ -527,7 +573,7 @@ class TxSafetySupervisor:
         return _Boundary(self._generation, sequence, now)
 
     def _clear_managed(self) -> None:
-        self._lease = self._acquisition = self._release = self._active = None
+        self._lease = self._acquisition = self._release = None
         self._watchdog_deadline = None
 
     def _result(

--- a/tests/test_tx_safety.py
+++ b/tests/test_tx_safety.py
@@ -30,6 +30,18 @@ class Clock:
         self.now += seconds
 
 
+class AdvancingClock(Clock):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    def __call__(self) -> float:
+        value = self.now
+        self.now += 1
+        self.calls += 1
+        return value
+
+
 def ids() -> Iterator[str]:
     index = 0
     while True:
@@ -216,6 +228,9 @@ def test_release_cancels_inflight_then_services_off(
     cancel = released.effects[0]
     assert isinstance(cancel, CancelProviderAttempt)
     assert cancel.attempt_id == on.id
+    assert cancel.requested_at_monotonic == on.started_at_monotonic
+    assert cancel.settlement_timeout_seconds == 2.0
+    assert cancel.settlement_deadline_monotonic == 12.0
     settled = supervisor.settle_attempt(on.id, 1, succeeded=False)
     assert isinstance(settled.effects[0], ProviderAttempt)
     assert settled.effects[0].kind is ProviderAttemptKind.WRITE_OFF
@@ -367,11 +382,61 @@ def test_new_generation_services_off_first(
 def test_not_ready_pauses_off_and_ready_resumes(
     supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
 ) -> None:
-    acquire(supervisor, clock, owner)
+    _, active = acquire(supervisor, clock, owner)
     paused = supervisor.set_provider_ready(1, ready=False)
-    assert paused.effects == ()
+    assert isinstance(paused.effects[0], CancelProviderAttempt)
+    assert paused.snapshot.active_attempt == active
+    assert supervisor.set_provider_ready(1, ready=False).effects == ()
+    settled = supervisor.settle_attempt(active.id, 1, succeeded=False)
+    assert settled.effects == ()
     resumed = supervisor.set_provider_ready(1, ready=True)
     assert resumed.effects[0].kind is ProviderAttemptKind.WRITE_OFF
+
+
+def test_ready_recovery_cannot_overlap_unsettled_lane(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    _, active = acquire(supervisor, clock, owner)
+    supervisor.set_provider_ready(1, ready=False)
+    recovered = supervisor.set_provider_ready(1, ready=True)
+    assert recovered.effects == ()
+    assert recovered.snapshot.active_attempt == active
+    settled = supervisor.settle_attempt(active.id, 1, succeeded=False)
+    assert settled.effects[0].kind is ProviderAttemptKind.WRITE_OFF
+
+
+def test_authoritative_off_clears_managed_state_but_not_attempt_lane(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, active = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    clock.advance(0.01)
+    cleared = observe(supervisor, clock, RadioTx.OFF, sequence=2)
+    assert cleared.snapshot.lease_id is None
+    assert cleared.snapshot.active_attempt == active
+    assert supervisor.request_on(owner).outcome is TxOutcome.BUSY
+    assert (
+        supervisor.settle_attempt(active.id, 1, succeeded=False).outcome
+        is TxOutcome.APPLIED
+    )
+    assert (
+        supervisor.settle_attempt(active.id, 1, succeeded=False).outcome
+        is TxOutcome.STALE
+    )
+    assert supervisor.request_on(owner).outcome is TxOutcome.ACCEPTED
+
+
+def test_unchanged_ready_does_not_bypass_retry_due(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, on = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    off = supervisor.settle_attempt(on.id, 1, succeeded=False).effects[0]
+    supervisor.settle_attempt(off.id, 1, succeeded=False)
+    unchanged = supervisor.set_provider_ready(1, ready=True)
+    assert unchanged.outcome is TxOutcome.IDEMPOTENT
+    assert unchanged.effects == ()
+    assert supervisor.tick().effects == ()
 
 
 def test_release_read_failure_schedules_retry(
@@ -458,6 +523,47 @@ def test_emergency_release(
 
 
 @pytest.mark.parametrize(
+    "reason",
+    [
+        TxReleaseReason.OPERATOR_RELEASE,
+        TxReleaseReason.SOURCE_DETACHED,
+        TxReleaseReason.PRESENTATION_REPLACED,
+        TxReleaseReason.CLIENT_DISCONNECTED,
+        TxReleaseReason.FRONTEND_SAFETY_TIMEOUT,
+    ],
+)
+def test_unqualified_release_rejects_untrusted_reason(
+    supervisor: TxSafetySupervisor,
+    clock: Clock,
+    owner: TxOwner,
+    reason: TxReleaseReason,
+) -> None:
+    acquire(supervisor, clock, owner)
+    with pytest.raises(ValueError):
+        supervisor.emergency_release(reason=reason)
+
+
+def test_acquisition_uses_one_clock_instant(owner: TxOwner) -> None:
+    clock = AdvancingClock()
+    generated = ids()
+    supervisor = TxSafetySupervisor(clock=clock, id_factory=lambda: next(generated))
+    supervisor.replace_provider(1, ready=True)
+    supervisor.observe_ptt(ProviderPttObservation(RadioTx.OFF, 1, 1, 10.5))
+    before = clock.calls
+    result = supervisor.request_on(owner)
+    attempt = result.effects[0]
+    assert clock.calls == before + 1
+    assert (
+        result.snapshot.watchdog_deadline_monotonic
+        == attempt.started_at_monotonic + 180
+    )
+    supervisor.observe_ptt(
+        ProviderPttObservation(RadioTx.ON, 1, 2, attempt.started_at_monotonic)
+    )
+    assert supervisor.snapshot.phase is TxPhase.KEYED
+
+
+@pytest.mark.parametrize(
     "factory",
     [
         lambda: TxOwner(TxSource.WEBSOCKET, ""),
@@ -465,9 +571,16 @@ def test_emergency_release(
         lambda: ProviderPttObservation(RadioTx.OFF, -1, 1, 0),
         lambda: ProviderPttObservation(RadioTx.OFF, 1, 0, 0),
         lambda: TxSafetySupervisor(watchdog_seconds=0),
+        lambda: TxSafetySupervisor(watchdog_seconds=float("inf")),
+        lambda: TxSafetySupervisor(watchdog_seconds=float("nan")),
         lambda: TxSafetySupervisor(write_timeout_seconds=0),
+        lambda: TxSafetySupervisor(write_timeout_seconds=float("inf")),
+        lambda: TxSafetySupervisor(read_timeout_seconds=float("nan")),
+        lambda: TxSafetySupervisor(cancel_timeout_seconds=float("inf")),
         lambda: TxSafetySupervisor(retry_schedule_seconds=()),
         lambda: TxSafetySupervisor(retry_schedule_seconds=(1, 0)),
+        lambda: TxSafetySupervisor(retry_schedule_seconds=(float("nan"),)),
+        lambda: TxSafetySupervisor(retry_schedule_seconds=(float("inf"),)),
     ],
 )
 def test_invalid_inputs_are_rejected(factory) -> None:

--- a/tests/test_tx_safety.py
+++ b/tests/test_tx_safety.py
@@ -229,11 +229,31 @@ def test_release_cancels_inflight_then_services_off(
     assert isinstance(cancel, CancelProviderAttempt)
     assert cancel.attempt_id == on.id
     assert cancel.requested_at_monotonic == on.started_at_monotonic
-    assert cancel.settlement_timeout_seconds == 2.0
-    assert cancel.settlement_deadline_monotonic == 12.0
+    assert cancel.settlement_timeout_seconds == 0.5
+    assert cancel.settlement_deadline_monotonic == 10.5
     settled = supervisor.settle_attempt(on.id, 1, succeeded=False)
     assert isinstance(settled.effects[0], ProviderAttempt)
     assert settled.effects[0].kind is ProviderAttemptKind.WRITE_OFF
+
+
+def test_cancel_coalesces_across_release_and_readiness_loss(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, _ = acquire(supervisor, clock, owner)
+    cancel = supervisor.request_off(owner, lease).effects[0]
+    assert isinstance(cancel, CancelProviderAttempt)
+    original_deadline = cancel.settlement_deadline_monotonic
+    clock.advance(0.25)
+
+    assert supervisor.set_provider_ready(1, ready=False).effects == ()
+    assert (
+        supervisor.emergency_release(
+            reason=TxReleaseReason.ADMIN_EMERGENCY_STOP
+        ).effects
+        == ()
+    )
+    assert supervisor._cancel_pending is cancel
+    assert cancel.settlement_deadline_monotonic == original_deadline
 
 
 def test_release_of_inflight_read_services_off_without_backoff(
@@ -570,6 +590,9 @@ def test_acquisition_uses_one_clock_instant(owner: TxOwner) -> None:
         lambda: ProviderPttObservation(RadioTx.UNKNOWN, 1, 1, 0),
         lambda: ProviderPttObservation(RadioTx.OFF, -1, 1, 0),
         lambda: ProviderPttObservation(RadioTx.OFF, 1, 0, 0),
+        lambda: ProviderPttObservation(RadioTx.OFF, 1, 1, float("nan")),
+        lambda: ProviderPttObservation(RadioTx.OFF, 1, 1, float("inf")),
+        lambda: ProviderPttObservation(RadioTx.OFF, 1, 1, float("-inf")),
         lambda: TxSafetySupervisor(watchdog_seconds=0),
         lambda: TxSafetySupervisor(watchdog_seconds=float("inf")),
         lambda: TxSafetySupervisor(watchdog_seconds=float("nan")),
@@ -586,3 +609,8 @@ def test_acquisition_uses_one_clock_instant(owner: TxOwner) -> None:
 def test_invalid_inputs_are_rejected(factory) -> None:
     with pytest.raises(ValueError):
         factory()
+
+
+def test_observation_accepts_finite_negative_monotonic_time() -> None:
+    observation = ProviderPttObservation(RadioTx.OFF, 1, 1, -1.5)
+    assert observation.observed_at_monotonic == -1.5

--- a/tests/test_tx_safety.py
+++ b/tests/test_tx_safety.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from rigplane.core.tx_safety import (
+    CancelProviderAttempt,
+    ProviderAttempt,
+    ProviderAttemptKind,
+    ProviderPttObservation,
+    RadioTx,
+    TxOutcome,
+    TxOwner,
+    TxPhase,
+    TxReleaseReason,
+    TxSafetySupervisor,
+    TxSource,
+)
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.now = 10.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def ids() -> Iterator[str]:
+    index = 0
+    while True:
+        index += 1
+        yield f"id-{index}"
+
+
+@pytest.fixture
+def clock() -> Clock:
+    return Clock()
+
+
+@pytest.fixture
+def owner() -> TxOwner:
+    return TxOwner(TxSource.WEBSOCKET, "web-1")
+
+
+@pytest.fixture
+def other() -> TxOwner:
+    return TxOwner(TxSource.RIGCTLD, "cat-1")
+
+
+@pytest.fixture
+def supervisor(clock: Clock) -> TxSafetySupervisor:
+    generated = ids()
+    return TxSafetySupervisor(clock=clock, id_factory=lambda: next(generated))
+
+
+def observe(
+    supervisor: TxSafetySupervisor,
+    clock: Clock,
+    value: RadioTx,
+    *,
+    generation: int = 1,
+    sequence: int = 1,
+    at: float | None = None,
+):
+    return supervisor.observe_ptt(
+        ProviderPttObservation(
+            value,
+            generation,
+            sequence,
+            clock.now if at is None else at,
+        )
+    )
+
+
+def ready_off(supervisor: TxSafetySupervisor, clock: Clock) -> None:
+    supervisor.replace_provider(1, ready=True)
+    observe(supervisor, clock, RadioTx.OFF)
+
+
+def acquire(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> tuple[str, ProviderAttempt]:
+    ready_off(supervisor, clock)
+    result = supervisor.request_on(owner)
+    assert result.snapshot.lease_id
+    effect = result.effects[0]
+    assert isinstance(effect, ProviderAttempt)
+    return result.snapshot.lease_id, effect
+
+
+def settle_on(
+    supervisor: TxSafetySupervisor, attempt: ProviderAttempt
+) -> ProviderAttempt:
+    effect = supervisor.settle_attempt(
+        attempt.id, attempt.provider_generation, succeeded=True
+    ).effects[0]
+    assert isinstance(effect, ProviderAttempt)
+    return effect
+
+
+def test_on_requires_ready_authoritative_off(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    assert supervisor.request_on(owner).outcome is TxOutcome.NOT_READY
+    supervisor.replace_provider(1, ready=True)
+    assert supervisor.request_on(owner).outcome is TxOutcome.RADIO_NOT_OFF
+    observe(supervisor, clock, RadioTx.ON)
+    assert supervisor.request_on(owner).outcome is TxOutcome.RADIO_NOT_OFF
+
+
+def test_acquire_emits_one_bounded_on_and_fixed_watchdog(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    ready_off(supervisor, clock)
+    first = supervisor.request_on(owner)
+    attempt = first.effects[0]
+    assert isinstance(attempt, ProviderAttempt)
+    assert attempt.kind is ProviderAttemptKind.WRITE_ON
+    assert attempt.timeout_seconds == 2.0
+    assert first.snapshot.watchdog_deadline_monotonic == 190.0
+    clock.advance(50)
+    repeated = supervisor.request_on(owner)
+    assert repeated.outcome is TxOutcome.IDEMPOTENT
+    assert repeated.effects == ()
+    assert repeated.snapshot.watchdog_deadline_monotonic == 190.0
+
+
+def test_other_owner_is_busy(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner, other: TxOwner
+) -> None:
+    acquire(supervisor, clock, owner)
+    assert supervisor.request_on(other).outcome is TxOutcome.BUSY
+
+
+def test_on_is_never_replayed_after_generation_change(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    acquire(supervisor, clock, owner)
+    changed = supervisor.replace_provider(2, ready=True)
+    assert [x.kind for x in changed.effects if isinstance(x, ProviderAttempt)] == [
+        ProviderAttemptKind.WRITE_OFF
+    ]
+
+
+def test_failed_on_creates_durable_off(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    _, attempt = acquire(supervisor, clock, owner)
+    result = supervisor.settle_attempt(attempt.id, 1, succeeded=False, error="lost")
+    off = result.effects[0]
+    assert isinstance(off, ProviderAttempt)
+    assert off.kind is ProviderAttemptKind.WRITE_OFF
+    assert result.snapshot.release_reason is TxReleaseReason.CONTROL_TRANSPORT_LOST
+
+
+def test_write_success_needs_causal_observation(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    _, attempt = acquire(supervisor, clock, owner)
+    read = settle_on(supervisor, attempt)
+    assert read.kind is ProviderAttemptKind.READ_PTT
+    assert supervisor.snapshot.phase is TxPhase.KEY_PENDING
+    clock.advance(0.01)
+    observe(supervisor, clock, RadioTx.ON, sequence=2)
+    assert supervisor.snapshot.phase is TxPhase.KEYED
+
+
+def test_newer_but_pre_boundary_on_is_external_conflict(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    ready_off(supervisor, clock)
+    clock.advance(1)
+    supervisor.request_on(owner)
+    result = observe(supervisor, clock, RadioTx.ON, sequence=2, at=10.5)
+    assert result.outcome is TxOutcome.APPLIED
+    assert result.snapshot.external_conflict
+    assert result.snapshot.phase is TxPhase.KEY_PENDING
+
+
+def test_globally_older_observation_is_stale(
+    supervisor: TxSafetySupervisor, clock: Clock
+) -> None:
+    ready_off(supervisor, clock)
+    observe(supervisor, clock, RadioTx.ON, sequence=2, at=11)
+    stale = observe(supervisor, clock, RadioTx.OFF, sequence=3, at=10.5)
+    assert stale.outcome is TxOutcome.STALE
+    assert stale.snapshot.radio_tx is RadioTx.ON
+
+
+@pytest.mark.parametrize("wrong", ["owner", "lease"])
+def test_wrong_owner_or_lease_cannot_release(
+    supervisor: TxSafetySupervisor,
+    clock: Clock,
+    owner: TxOwner,
+    other: TxOwner,
+    wrong: str,
+) -> None:
+    lease, _ = acquire(supervisor, clock, owner)
+    result = supervisor.request_off(
+        other if wrong == "owner" else owner,
+        "stale" if wrong == "lease" else lease,
+    )
+    assert result.outcome is TxOutcome.STALE
+
+
+def test_release_cancels_inflight_then_services_off(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, on = acquire(supervisor, clock, owner)
+    released = supervisor.request_off(owner, lease)
+    cancel = released.effects[0]
+    assert isinstance(cancel, CancelProviderAttempt)
+    assert cancel.attempt_id == on.id
+    settled = supervisor.settle_attempt(on.id, 1, succeeded=False)
+    assert isinstance(settled.effects[0], ProviderAttempt)
+    assert settled.effects[0].kind is ProviderAttemptKind.WRITE_OFF
+
+
+def test_release_of_inflight_read_services_off_without_backoff(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, on = acquire(supervisor, clock, owner)
+    read = settle_on(supervisor, on)
+    supervisor.request_off(owner, lease)
+    settled = supervisor.settle_attempt(read.id, 1, succeeded=False)
+    assert settled.effects[0].kind is ProviderAttemptKind.WRITE_OFF
+    assert settled.snapshot.release_last_error is None
+
+
+def test_repeated_release_coalesces_and_updates_terminal_reason(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, _ = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease, reason=TxReleaseReason.CLIENT_DISCONNECTED)
+    repeated = supervisor.request_off(
+        owner, lease, reason=TxReleaseReason.ADMIN_EMERGENCY_STOP
+    )
+    assert repeated.outcome is TxOutcome.IDEMPOTENT
+    assert repeated.snapshot.release_reason is TxReleaseReason.CLIENT_DISCONNECTED
+    assert (
+        repeated.snapshot.terminal_release_reason
+        is TxReleaseReason.ADMIN_EMERGENCY_STOP
+    )
+
+
+def test_failed_off_persists_and_retries_when_due(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, on = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    off = supervisor.settle_attempt(on.id, 1, succeeded=False).effects[0]
+    failed = supervisor.settle_attempt(off.id, 1, succeeded=False, error="timeout")
+    assert failed.snapshot.phase is TxPhase.FAULTED
+    assert failed.snapshot.release_last_error == "timeout"
+    assert supervisor.tick().effects == ()
+    clock.advance(0.25)
+    retry = supervisor.tick().effects[0]
+    assert retry.kind is ProviderAttemptKind.WRITE_OFF
+    assert supervisor.snapshot.release_attempt_count == 2
+
+
+def test_retry_backoff_caps_but_never_drops_obligation(
+    clock: Clock, owner: TxOwner
+) -> None:
+    generated = ids()
+    supervisor = TxSafetySupervisor(
+        clock=clock,
+        id_factory=lambda: next(generated),
+        retry_schedule_seconds=(0.1, 0.2),
+    )
+    lease, on = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    attempt = supervisor.settle_attempt(on.id, 1, succeeded=False).effects[0]
+    for delay in (0.1, 0.2, 0.2):
+        supervisor.settle_attempt(attempt.id, 1, succeeded=False)
+        clock.advance(delay)
+        attempt = supervisor.tick().effects[0]
+    assert supervisor.snapshot.release_attempt_count == 4
+    assert supervisor.snapshot.lease_id == lease
+
+
+def test_off_write_success_reads_but_does_not_clear(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, on = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    off = supervisor.settle_attempt(on.id, 1, succeeded=False).effects[0]
+    result = supervisor.settle_attempt(off.id, 1, succeeded=True)
+    assert result.effects[0].kind is ProviderAttemptKind.READ_PTT
+    assert result.snapshot.phase is TxPhase.RELEASE_CONFIRMING
+    assert result.snapshot.lease_id == lease
+
+
+@pytest.mark.parametrize(
+    ("generation", "sequence", "at"),
+    [(2, 2, 11.0), (1, 1, 11.0), (1, 2, 9.0)],
+    ids=["old-generation", "same-sequence", "old-time"],
+)
+def test_off_must_cross_every_release_boundary(
+    supervisor: TxSafetySupervisor,
+    clock: Clock,
+    owner: TxOwner,
+    generation: int,
+    sequence: int,
+    at: float,
+) -> None:
+    lease, _ = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    if generation == 2:
+        supervisor.replace_provider(2, ready=False)
+        generation = 1
+    result = observe(
+        supervisor, clock, RadioTx.OFF, generation=generation, sequence=sequence, at=at
+    )
+    assert result.outcome is TxOutcome.STALE
+    assert result.snapshot.lease_id == lease
+
+
+def test_fresh_authoritative_off_is_only_release_clear(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, _ = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    clock.advance(0.01)
+    result = observe(supervisor, clock, RadioTx.OFF, sequence=2)
+    assert result.snapshot.lease_id is None
+    assert result.snapshot.phase is TxPhase.IDLE
+
+
+def test_stale_attempt_callback_is_noop(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    _, attempt = acquire(supervisor, clock, owner)
+    result = supervisor.settle_attempt("stale", 1, succeeded=True)
+    assert result.outcome is TxOutcome.STALE
+    assert result.snapshot.active_attempt == attempt
+
+
+def test_old_generation_callbacks_and_observations_are_noops(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    _, old = acquire(supervisor, clock, owner)
+    supervisor.replace_provider(2, ready=False)
+    assert (
+        supervisor.settle_attempt(old.id, 1, succeeded=True).outcome is TxOutcome.STALE
+    )
+    assert (
+        observe(supervisor, clock, RadioTx.OFF, generation=1, sequence=9).outcome
+        is TxOutcome.STALE
+    )
+
+
+def test_new_generation_services_off_first(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    acquire(supervisor, clock, owner)
+    changed = supervisor.replace_provider(2, ready=True)
+    assert changed.snapshot.radio_tx is RadioTx.UNKNOWN
+    assert changed.effects[0].kind is ProviderAttemptKind.WRITE_OFF
+
+
+def test_not_ready_pauses_off_and_ready_resumes(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    acquire(supervisor, clock, owner)
+    paused = supervisor.set_provider_ready(1, ready=False)
+    assert paused.effects == ()
+    resumed = supervisor.set_provider_ready(1, ready=True)
+    assert resumed.effects[0].kind is ProviderAttemptKind.WRITE_OFF
+
+
+def test_release_read_failure_schedules_retry(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, on = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    off = supervisor.settle_attempt(on.id, 1, succeeded=False).effects[0]
+    read = supervisor.settle_attempt(off.id, 1, succeeded=True).effects[0]
+    failed = supervisor.settle_attempt(read.id, 1, succeeded=False)
+    assert failed.snapshot.release_last_error == "read_ptt_failed"
+    clock.advance(0.25)
+    assert supervisor.tick().effects[0].kind is ProviderAttemptKind.WRITE_OFF
+
+
+def test_acquisition_read_failure_fails_closed(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    _, on = acquire(supervisor, clock, owner)
+    read = settle_on(supervisor, on)
+    result = supervisor.settle_attempt(read.id, 1, succeeded=False)
+    assert result.effects[0].kind is ProviderAttemptKind.WRITE_OFF
+    assert result.snapshot.release_reason is TxReleaseReason.CONTROL_TRANSPORT_LOST
+
+
+@pytest.mark.parametrize("settle_on_first", [False, True])
+def test_watchdog_expires_at_dispatch_deadline(
+    supervisor: TxSafetySupervisor,
+    clock: Clock,
+    owner: TxOwner,
+    settle_on_first: bool,
+) -> None:
+    _, on = acquire(supervisor, clock, owner)
+    active = settle_on(supervisor, on) if settle_on_first else on
+    clock.advance(180)
+    result = supervisor.tick()
+    assert result.snapshot.release_reason is TxReleaseReason.BACKEND_MAX_KEY_DOWN
+    assert result.snapshot.watchdog_deadline_monotonic is None
+    assert result.effects[0].attempt_id == active.id
+
+
+def test_watchdog_can_be_disabled(clock: Clock, owner: TxOwner) -> None:
+    generated = ids()
+    supervisor = TxSafetySupervisor(
+        clock=clock, id_factory=lambda: next(generated), watchdog_seconds=None
+    )
+    acquire(supervisor, clock, owner)
+    clock.advance(1000)
+    assert supervisor.tick().outcome is TxOutcome.NOOP
+    assert not supervisor.snapshot.watchdog_enabled
+
+
+def test_unowned_on_is_honest_and_not_auto_dekeyed(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    supervisor.replace_provider(1, ready=True)
+    result = observe(supervisor, clock, RadioTx.ON)
+    assert result.snapshot.phase is TxPhase.EXTERNAL_UNOWNED
+    assert result.effects == ()
+    assert supervisor.request_on(owner).outcome is TxOutcome.RADIO_NOT_OFF
+    observe(supervisor, clock, RadioTx.OFF, sequence=2)
+    assert supervisor.request_on(owner).outcome is TxOutcome.ACCEPTED
+
+
+def test_on_after_release_clear_is_new_external_activity(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, _ = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    clock.advance(0.01)
+    observe(supervisor, clock, RadioTx.OFF, sequence=2)
+    clock.advance(0.01)
+    result = observe(supervisor, clock, RadioTx.ON, sequence=3)
+    assert result.snapshot.phase is TxPhase.EXTERNAL_UNOWNED
+
+
+def test_emergency_release(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    acquire(supervisor, clock, owner)
+    result = supervisor.emergency_release(reason=TxReleaseReason.ADMIN_EMERGENCY_STOP)
+    assert result.outcome is TxOutcome.ACCEPTED
+    assert isinstance(result.effects[0], CancelProviderAttempt)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: TxOwner(TxSource.WEBSOCKET, ""),
+        lambda: ProviderPttObservation(RadioTx.UNKNOWN, 1, 1, 0),
+        lambda: ProviderPttObservation(RadioTx.OFF, -1, 1, 0),
+        lambda: ProviderPttObservation(RadioTx.OFF, 1, 0, 0),
+        lambda: TxSafetySupervisor(watchdog_seconds=0),
+        lambda: TxSafetySupervisor(write_timeout_seconds=0),
+        lambda: TxSafetySupervisor(retry_schedule_seconds=()),
+        lambda: TxSafetySupervisor(retry_schedule_seconds=(1, 0)),
+    ],
+)
+def test_invalid_inputs_are_rejected(factory) -> None:
+    with pytest.raises(ValueError):
+        factory()


### PR DESCRIPTION
## Summary

- add a pure, dependency-injected single-target TX ownership and safety reducer
- keep managed ON one-shot and non-replayable while making OFF a durable, causally confirmed obligation
- model provider generations, bounded attempts, retries, watchdog expiry, stale callbacks, and honest external/unowned TX
- derive presentation phase/conflict from authoritative state instead of storing duplicated projections

## Scope

Exactly two new files: the core model and its exhaustive acceptance matrix. No runtime, web, provider, or multi-target wiring is included.

## Verification

- focused: 40 passed
- full non-integration suite: 8,241 passed, 73 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff check and format: passed
- mypy (new core module): passed
- import-lint: 5 contracts kept
- git diff check: passed

## Planning

- Linear: [MOR-1005](https://linear.app/morozsm/issue/MOR-1005/core-implement-the-backend-tx-safety-supervisor-model)
- accepted contract: MOR-986

Closes #1929