### PR TITLE
Core: own managed TX runtime lifetime

### DIFF
--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+from rigplane.core.tx_safety import (
+    Clock,
+    IdFactory,
+    TxOutcome,
+    TxReleaseReason,
+    TxSafetySupervisor,
+    TxTransition,
+)
+
+TxService = Callable[[TxSafetySupervisor, TxTransition], Awaitable[None]]
+ProviderRelease = Callable[[], Awaitable[None]]
+
+
+class ManagedRadioRuntime:
+    def __init__(
+        self,
+        target_id: str,
+        *,
+        clock: Clock | None = None,
+        id_factory: IdFactory | None = None,
+        shutdown_timeout_seconds: float = 3.0,
+    ) -> None:
+        if not 0 < shutdown_timeout_seconds < float("inf"):
+            raise ValueError("shutdown_timeout_seconds must be finite-positive")
+        self.target_id = target_id
+        self._tx_safety = TxSafetySupervisor(clock=clock, id_factory=id_factory)
+        self._provider_generation = 0
+        self._shutdown_timeout = shutdown_timeout_seconds
+
+    @property
+    def tx_safety(self) -> TxSafetySupervisor:
+        return self._tx_safety
+
+    async def replace_provider(
+        self, *, ready: bool, service: TxService
+    ) -> TxTransition:
+        self._provider_generation += 1
+        transition = self.tx_safety.replace_provider(
+            self._provider_generation, ready=ready
+        )
+        if transition.effects:
+            await service(self.tx_safety, transition)
+        return transition
+
+    async def set_provider_ready(
+        self, *, ready: bool, service: TxService
+    ) -> TxTransition:
+        transition = self.tx_safety.set_provider_ready(
+            self._provider_generation, ready=ready
+        )
+        if transition.effects:
+            await service(self.tx_safety, transition)
+        return transition
+
+    async def shutdown(
+        self, *, dekey: TxService, release_provider: ProviderRelease
+    ) -> TxTransition:
+        transition = self.tx_safety.emergency_release(
+            reason=TxReleaseReason.SERVER_SHUTDOWN
+        )
+        try:
+            if transition.outcome is not TxOutcome.NOOP:
+                await asyncio.wait_for(
+                    dekey(self.tx_safety, transition),
+                    timeout=self._shutdown_timeout,
+                )
+        except TimeoutError:
+            pass
+        finally:
+            await release_provider()
+        return transition

--- a/tests/test_managed_radio_runtime.py
+++ b/tests/test_managed_radio_runtime.py
@@ -1,0 +1,124 @@
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+
+from rigplane.core.tx_safety import (
+    ProviderAttempt,
+    ProviderAttemptKind,
+    ProviderPttObservation,
+    RadioTx,
+    TxOwner,
+    TxPhase,
+    TxSafetySupervisor,
+    TxSource,
+)
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+
+
+def ids() -> Iterator[str]:
+    index = 0
+    while True:
+        index += 1
+        yield f"id-{index}"
+
+
+def runtime(target: str = "radio-a", *, timeout: float = 0.01) -> ManagedRadioRuntime:
+    generated = ids()
+    return ManagedRadioRuntime(
+        target,
+        clock=lambda: 10.0,
+        id_factory=lambda: next(generated),
+        shutdown_timeout_seconds=timeout,
+    )
+
+
+async def no_effects(_supervisor: TxSafetySupervisor, transition: object) -> None:
+    assert not getattr(transition, "effects")
+
+
+async def acquire(rt: ManagedRadioRuntime) -> tuple[TxOwner, ProviderAttempt]:
+    await rt.replace_provider(ready=True, service=no_effects)
+    rt.tx_safety.observe_ptt(ProviderPttObservation(RadioTx.OFF, 1, 1, 10.0))
+    owner = TxOwner(TxSource.WEBSOCKET, "web-1")
+    attempt = rt.tx_safety.request_on(owner).effects[0]
+    assert isinstance(attempt, ProviderAttempt)
+    return owner, attempt
+
+
+@pytest.mark.parametrize("timeout", [0, float("nan"), float("inf")])
+def test_shutdown_timeout_must_be_bounded(timeout: float) -> None:
+    with pytest.raises(ValueError):
+        runtime(timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_target_owns_one_supervisor_across_consumers_and_generations() -> None:
+    first, second = runtime("a"), runtime("b")
+    supervisor = first.tx_safety
+    await acquire(first)
+    lease = first.tx_safety.snapshot.lease_id
+
+    changed = await first.replace_provider(ready=False, service=no_effects)
+
+    assert first.tx_safety is supervisor is not second.tx_safety
+    assert changed.snapshot.lease_id == lease
+    assert changed.snapshot.phase is TxPhase.RELEASE_REQUIRED
+
+
+@pytest.mark.asyncio
+async def test_ready_provider_services_pending_off_before_return() -> None:
+    rt = runtime()
+    owner, attempt = await acquire(rt)
+    lease = rt.tx_safety.snapshot.lease_id or ""
+    rt.tx_safety.request_off(owner, lease)
+    order: list[str] = []
+
+    async def service(_supervisor: TxSafetySupervisor, transition: object) -> None:
+        effect = getattr(transition, "effects")[0]
+        assert effect.kind is ProviderAttemptKind.WRITE_OFF
+        order.append("off")
+
+    await rt.replace_provider(ready=False, service=no_effects)
+    await rt.set_provider_ready(ready=True, service=service)
+    order.append("ordinary")
+
+    assert order == ["off", "ordinary"]
+    assert rt.tx_safety.snapshot.active_attempt != attempt
+
+
+@pytest.mark.asyncio
+async def test_shutdown_bounds_dekey_before_provider_release() -> None:
+    rt = runtime()
+    await acquire(rt)
+    order: list[str] = []
+
+    async def dekey(_supervisor: TxSafetySupervisor, _transition: object) -> None:
+        order.append("dekey")
+        await asyncio.Event().wait()
+
+    async def release() -> None:
+        order.append("release")
+
+    result = await rt.shutdown(dekey=dekey, release_provider=release)
+
+    assert order == ["dekey", "release"]
+    assert result.snapshot.phase is TxPhase.RELEASE_REQUIRED
+
+
+@pytest.mark.asyncio
+async def test_shutdown_error_still_releases_provider() -> None:
+    rt = runtime()
+    await acquire(rt)
+    released = False
+
+    async def fail(_supervisor: TxSafetySupervisor, _transition: object) -> None:
+        raise RuntimeError("dekey failed")
+
+    async def release() -> None:
+        nonlocal released
+        released = True
+
+    with pytest.raises(RuntimeError, match="dekey failed"):
+        await rt.shutdown(dekey=fail, release_provider=release)
+    assert released


### PR DESCRIPTION
## Summary

- add one backend-neutral `ManagedRadioRuntime` that privately owns a single `TxSafetySupervisor` and provider-generation counter per target runtime
- order provider-ready TX-effect servicing before the lifecycle seam returns
- bound shutdown de-key work and always release the provider without clearing unresolved TX state

Linear: [MOR-1007](https://linear.app/morozsm/issue/MOR-1007/core-own-one-tx-supervisor-per-managed-radio-runtime)
Accepted decision: [MOR-986](https://linear.app/morozsm/issue/MOR-986/decision-define-backend-tx-ownership-stale-queue-and-session-loss)
Closes #1935

## Scope

Exactly two new files and 200 net lines. This is lifetime ownership only. Production factory/CLI assembly, Web/rigctld ingress, managed SDK facade, provider PTT execution/readback, and IC-7610 authority remain later slices. No public API, CLI, config, rigctld wire, server, or frontend behavior changes.

## Verification

- `uv run pytest -q --tb=short tests/test_managed_radio_runtime.py` — 7 passed
- full non-integration pytest — 8273 passed, 73 skipped, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — passed
- targeted runtime mypy + strict Web mypy — passed
- import-linter — 5/5 contracts kept
- full repository mypy baseline still has 13 pre-existing errors in three untouched runtime files
- diff check — exactly two files, 200 insertions

## Review notes

This PR is intentionally draft and must receive independent safety review before merge.