### PR TITLE
feat: bind managed TX provider lifecycle

### DIFF
--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
 from rigplane.core.tx_safety import (
     Clock,
     IdFactory,
+    ProviderPttObservation,
     TxOutcome,
     TxOwner,
     TxReleaseReason,
@@ -16,6 +18,14 @@ from rigplane.core.tx_safety import (
 
 TxService = Callable[[TxSafetySupervisor, TxTransition], Awaitable[None]]
 ProviderRelease = Callable[[], Awaitable[None]]
+PttObserver = Callable[[ProviderPttObservation], None]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderTxLifecycle:
+    bind: Callable[[int, PttObserver], None]
+    unbind: Callable[[], None]
+    read_ptt: Callable[[], Awaitable[None]]
 
 
 class ManagedRadioRuntime:
@@ -24,6 +34,7 @@ class ManagedRadioRuntime:
         target_id: str,
         *,
         service: TxService,
+        provider_lifecycle: ProviderTxLifecycle | None = None,
         clock: Clock | None = None,
         id_factory: IdFactory | None = None,
         shutdown_timeout_seconds: float = 3.0,
@@ -33,6 +44,7 @@ class ManagedRadioRuntime:
         self.target_id = target_id
         self._tx_safety = TxSafetySupervisor(clock=clock, id_factory=id_factory)
         self._service = service
+        self._provider_lifecycle = provider_lifecycle
         self._provider_generation = 0
         self._shutdown_timeout = shutdown_timeout_seconds
 
@@ -45,9 +57,39 @@ class ManagedRadioRuntime:
             await self._service(self._tx_safety, transition)
 
     async def replace_provider(self, *, ready: bool) -> TxTransition:
-        self._provider_generation += 1
+        generation = self._provider_generation + 1
+        if self._provider_lifecycle:
+            self._provider_lifecycle.bind(generation, self._observe_ptt)
+        self._provider_generation = generation
         transition = self._tx_safety.replace_provider(
             self._provider_generation, ready=ready
+        )
+        await self._service_effects(transition)
+        return transition
+
+    def _observe_ptt(self, observation: ProviderPttObservation) -> None:
+        self._tx_safety.observe_ptt(observation)
+
+    async def request_fresh_ptt(self, provider_generation: int) -> TxTransition:
+        lifecycle = self._provider_lifecycle
+        if lifecycle is None or provider_generation != self._provider_generation:
+            return TxTransition(TxOutcome.STALE, self.tx_snapshot)
+        await lifecycle.read_ptt()
+        outcome = (
+            TxOutcome.APPLIED
+            if provider_generation == self._provider_generation
+            else TxOutcome.STALE
+        )
+        return TxTransition(outcome, self.tx_snapshot)
+
+    async def invalidate_provider(self, provider_generation: int) -> TxTransition:
+        if provider_generation != self._provider_generation:
+            return TxTransition(TxOutcome.STALE, self.tx_snapshot)
+        if self._provider_lifecycle:
+            self._provider_lifecycle.unbind()
+        self._provider_generation += 1
+        transition = self._tx_safety.replace_provider(
+            self._provider_generation, ready=False
         )
         await self._service_effects(transition)
         return transition
@@ -95,5 +137,9 @@ class ManagedRadioRuntime:
         except TimeoutError:
             pass
         finally:
-            await release_provider()
+            try:
+                if self._provider_lifecycle:
+                    self._provider_lifecycle.unbind()
+            finally:
+                await release_provider()
         return transition

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -2963,6 +2963,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """Detach the managed-provider PTT readback observer."""
         self._civ_runtime.unbind_ptt_observer()
 
+    async def _request_authoritative_ptt_read(self) -> None:
+        """Request fresh PTT truth through the decoded observer path."""
+        self._check_connected()
+        civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1C, sub=0x00)
+        await self._send_civ_expect(civ, label="get_ptt")
+
     # ------------------------------------------------------------------
     # Transceiver status family (#136)
     # ------------------------------------------------------------------

--- a/tests/test_managed_provider_tx_binding.py
+++ b/tests/test_managed_provider_tx_binding.py
@@ -1,0 +1,134 @@
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
+from rigplane.core.tx_safety import ProviderPttObservation, RadioTx, TxOutcome
+from rigplane.runtime.managed_radio_runtime import (
+    ManagedRadioRuntime,
+    ProviderTxLifecycle,
+)
+from rigplane.runtime.radio import CoreRadio
+
+
+class ProviderLifecycle:
+    def __init__(self) -> None:
+        self.bindings: list[tuple[int, Callable[[ProviderPttObservation], None]]] = []
+        self.unbinds = 0
+        self.read_started = asyncio.Event()
+        self.read_release = asyncio.Event()
+        self.block_read = False
+
+    def bind(
+        self,
+        generation: int,
+        observer: Callable[[ProviderPttObservation], None],
+    ) -> None:
+        self.bindings.append((generation, observer))
+
+    def unbind(self) -> None:
+        self.unbinds += 1
+
+    async def read_ptt(self) -> None:
+        generation, observer = self.bindings[-1]
+        self.read_started.set()
+        if self.block_read:
+            await self.read_release.wait()
+        observer(ProviderPttObservation(RadioTx.OFF, generation, 1, 10.0))
+
+    def contract(self) -> ProviderTxLifecycle:
+        return ProviderTxLifecycle(self.bind, self.unbind, self.read_ptt)
+
+
+def runtime(provider: ProviderLifecycle) -> ManagedRadioRuntime:
+    async def no_effects(*_args: object) -> None:
+        pass
+
+    return ManagedRadioRuntime(
+        "radio-a",
+        service=no_effects,
+        provider_lifecycle=provider.contract(),
+        clock=lambda: 10.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_effectless_replacement_binds_host_generation_before_ready() -> None:
+    provider = ProviderLifecycle()
+    managed = runtime(provider)
+
+    changed = await managed.replace_provider(ready=True)
+
+    assert changed.snapshot.provider_generation == 1
+    assert changed.snapshot.provider_ready is True
+    assert [generation for generation, _ in provider.bindings] == [1]
+
+
+@pytest.mark.asyncio
+async def test_fresh_read_uses_bound_observer_and_rejects_stale_callback() -> None:
+    provider = ProviderLifecycle()
+    managed = runtime(provider)
+    await managed.replace_provider(ready=True)
+    old_generation, old_observer = provider.bindings[-1]
+
+    read = await managed.request_fresh_ptt(old_generation)
+    assert read.outcome is TxOutcome.APPLIED
+    assert read.snapshot.radio_tx is RadioTx.OFF
+
+    await managed.replace_provider(ready=False)
+    old_observer(ProviderPttObservation(RadioTx.ON, old_generation, 2, 11.0))
+    assert managed.tx_snapshot.radio_tx is RadioTx.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_read_completion_is_stale_after_provider_replacement() -> None:
+    provider = ProviderLifecycle()
+    provider.block_read = True
+    managed = runtime(provider)
+    await managed.replace_provider(ready=True)
+
+    pending = asyncio.create_task(managed.request_fresh_ptt(1))
+    await provider.read_started.wait()
+    await managed.replace_provider(ready=False)
+    provider.read_release.set()
+
+    assert (await pending).outcome is TxOutcome.STALE
+    assert managed.tx_snapshot.provider_generation == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidation_advances_host_and_supervisor_together() -> None:
+    provider = ProviderLifecycle()
+    managed = runtime(provider)
+    await managed.replace_provider(ready=True)
+
+    assert (await managed.invalidate_provider(0)).outcome is TxOutcome.STALE
+    invalidated = await managed.invalidate_provider(1)
+
+    assert invalidated.snapshot.provider_generation == 2
+    assert invalidated.snapshot.provider_ready is False
+    assert provider.unbinds == 1
+    assert [generation for generation, _ in provider.bindings] == [1]
+    replaced = await managed.replace_provider(ready=True)
+    assert replaced.snapshot.provider_generation == 3
+    assert [generation for generation, _ in provider.bindings] == [1, 3]
+
+
+@pytest.mark.asyncio
+async def test_icom_fresh_read_sends_real_ptt_query() -> None:
+    radio = SimpleNamespace(
+        _radio_addr=0x98,
+        _check_connected=Mock(),
+        _send_civ_expect=AsyncMock(),
+    )
+
+    await CoreRadio._request_authoritative_ptt_read(radio)  # type: ignore[arg-type]
+
+    radio._check_connected.assert_called_once()
+    radio._send_civ_expect.assert_awaited_once_with(
+        build_civ_frame(0x98, CONTROLLER_ADDR, 0x1C, sub=0x00),
+        label="get_ptt",
+    )


### PR DESCRIPTION
Closes #1953

Linear: https://linear.app/rigplane/issue/MOR-1044

## Scope
- make ManagedRadioRuntime own monotonic provider generations and bind the authoritative PTT observer before provider readiness is published
- add explicit fresh PTT reads and generation-checked invalidation/unbind without exposing the raw provider
- add the IC-7610 CI-V PTT read request through the existing decoded observer path
- reject stale observer callbacks and read completions after provider replacement

## Lifecycle contract
Before: provider replacement only advanced TxSafetySupervisor; observer binding and fresh reads were outside the managed host boundary.

After: host generation -> bind(observer, generation) -> supervisor replace/ready; fresh read -> decoded observer -> TxSafetySupervisor. Invalidation checks the expected generation, unbinds, advances host and supervisor together, and leaves the invalidated generation not-ready.

## Validation
- red-before: focused test collection failed because ProviderTxLifecycle was absent
- focused: 248 passed
- non-integration: 8503 passed, 73 skipped, 112 deselected, 11 xfailed, 1 xpassed
- ruff check src/ tests/
- ruff format --check src/ tests/
- mypy --strict on both changed source files
- lint-imports: 5 contracts kept
- git diff --check

## Bounds
Exactly 3 files; 188 insertions / 2 deletions. No executor, SDK routing, Web, or poller changes.