### PR TITLE
feat: token-bind authoritative IC-7610 PTT reads

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -537,6 +537,7 @@ class CivRuntime:
         self._ptt_observer_provider_generation: int | None = None
         self._ptt_observer_civ_generation: int | None = None
         self._ptt_observation_seq = 0
+        self._ptt_read_lock = asyncio.Lock()
         self._active_rx_source_generation: int | None = None
 
     # ------------------------------------------------------------------
@@ -568,6 +569,34 @@ class CivRuntime:
     def unbind_ptt_observer(self) -> None:
         """Detach the callback while preserving this provider's sequence."""
         self._ptt_observer = None
+
+    async def request_authoritative_ptt_read(
+        self,
+        civ_frame: bytes,
+        *,
+        provider_generation: int,
+        observer: Callable[[ProviderPttObservation], None],
+    ) -> bool:
+        async with self._ptt_read_lock:
+            source_generation = self._host._civ_epoch
+            if (
+                provider_generation != self._ptt_observer_provider_generation
+                or observer != self._ptt_observer
+                or source_generation != self._ptt_observer_civ_generation
+            ):
+                return False
+            frame = await self.send_civ_raw(civ_frame)
+            if (
+                frame is None
+                or frame.to_addr != CONTROLLER_ADDR
+                or source_generation != self._active_rx_source_generation
+                or provider_generation != self._ptt_observer_provider_generation
+                or observer != self._ptt_observer
+            ):
+                return False
+            return self._emit_authoritative_ptt(
+                frame, source_generation=source_generation
+            )
 
     async def stop_pump(self) -> None:
         """Stop CI-V receive pump and fail pending request futures."""
@@ -629,6 +658,7 @@ class CivRuntime:
 
     def advance_generation(self, reason: str) -> None:
         """Advance CI-V request generation and fail stale waiters."""
+        self.unbind_ptt_observer()
         self._host._civ_epoch = self._host._civ_request_tracker.advance_generation(
             ConnectionError(f"CI-V generation advanced: {reason}")
         )
@@ -1154,27 +1184,31 @@ class CivRuntime:
                 self._publish_scope_frame(scope_frame)
             return
 
+        bound_ptt_read = (
+            self._ptt_read_lock.locked() and frame.command == 0x1C and frame.sub == 0x00
+        )
         if frame.command == 0xFB:
             event = CivEvent(type=CivEventType.ACK, frame=frame)
         elif frame.command == 0xFA:
             event = CivEvent(type=CivEventType.NAK, frame=frame)
         else:
             event = CivEvent(type=CivEventType.RESPONSE, frame=frame)
-            self._emit_authoritative_ptt(
-                frame,
-                source_generation=(
-                    generation
-                    if self._active_rx_source_generation is None
-                    else self._active_rx_source_generation
-                ),
+            resolved_ptt = bound_ptt_read and self._host._civ_request_tracker.resolve(
+                event, generation=generation
             )
+            if not resolved_ptt:
+                source_generation = self._active_rx_source_generation
+                if source_generation is None:
+                    source_generation = generation
+                self._emit_authoritative_ptt(frame, source_generation=source_generation)
             self._update_state_cache_from_frame(frame)
         self._publish_civ_event(event)
-        self._host._civ_request_tracker.resolve(event, generation=generation)
+        if event.type is not CivEventType.RESPONSE or not bound_ptt_read:
+            self._host._civ_request_tracker.resolve(event, generation=generation)
 
     def _emit_authoritative_ptt(
         self, frame: CivFrame, *, source_generation: int
-    ) -> None:
+    ) -> bool:
         """Publish only exact, generation-bound CI-V PTT state responses."""
         observer = self._ptt_observer
         provider_generation = self._ptt_observer_provider_generation
@@ -1187,7 +1221,7 @@ class CivRuntime:
             or len(frame.data) != 1
             or frame.data[0] not in (0x00, 0x01)
         ):
-            return
+            return False
         self._ptt_observation_seq += 1
         observation = ProviderPttObservation(
             value=RadioTx.ON if frame.data[0] else RadioTx.OFF,
@@ -1199,6 +1233,8 @@ class CivRuntime:
             observer(observation)
         except Exception:  # noqa: BLE001 - observer failure must not break CI-V RX
             logger.exception("Authoritative PTT observer raised")
+            return False
+        return True
 
     def deliver_raw_civ(self, frame_bytes: bytes) -> None:
         """Forward a raw inbound CI-V frame to registered raw-pipe listeners.

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -2963,6 +2963,22 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """Detach the managed-provider PTT readback observer."""
         self._civ_runtime.unbind_ptt_observer()
 
+    async def _request_authoritative_ptt_read(
+        self,
+        *,
+        provider_generation: int,
+        observer: "Callable[[ProviderPttObservation], None]",
+    ) -> None:
+        self._check_connected()
+        civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1C, sub=0x00)
+        published = await self._civ_runtime.request_authoritative_ptt_read(
+            civ,
+            provider_generation=provider_generation,
+            observer=observer,
+        )
+        if not published:
+            raise CommandError("PTT response was not authoritative for this request")
+
     # ------------------------------------------------------------------
     # Transceiver status family (#136)
     # ------------------------------------------------------------------

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -23,7 +23,7 @@ from rigplane.commands import (
     build_cmd29_frame,
 )
 from rigplane.commander import Priority
-from rigplane.exceptions import ConnectionError, TimeoutError
+from rigplane.exceptions import CommandError, ConnectionError, TimeoutError
 from rigplane.core import tx_safety as tx
 from rigplane.radio import IcomRadio
 from rigplane.types import (
@@ -81,14 +81,14 @@ def _power_response(level: int) -> bytes:
     return _wrap_civ_in_udp(civ)
 
 
-def _ptt_response(on: bool) -> bytes:
+def _ptt_response(on: bool | int) -> bytes:
     """Build a CI-V PTT status response wrapped in UDP."""
     civ = build_civ_frame(
         CONTROLLER_ADDR,
         IC_7610_ADDR,
         _CMD_PTT,
         sub=_SUB_PTT,
-        data=bytes([0x01 if on else 0x00]),
+        data=bytes([on]),
     )
     return _wrap_civ_in_udp(civ)
 
@@ -867,6 +867,104 @@ class TestPtt:
             assert observations[0].provider_generation == 8
         finally:
             await radio._civ_runtime.stop_pump()
+
+    @pytest.mark.asyncio
+    async def test_fresh_ptt_read_rejects_response_after_observer_rebind(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        old: list[tx.ProviderPttObservation] = []
+        current: list[tx.ProviderPttObservation] = []
+        bind = radio._bind_authoritative_ptt_observer
+        bind(provider_generation=1, observer=old.append)
+        pending = asyncio.create_task(
+            radio._request_authoritative_ptt_read(
+                provider_generation=1, observer=old.append
+            )
+        )
+        while not mock_transport.sent_packets:
+            await asyncio.sleep(0)
+        bind(provider_generation=2, observer=current.append)
+        mock_transport.queue_response(_ptt_response(False))
+
+        with pytest.raises(CommandError, match="authoritative"):
+            await pending
+        assert old == current == []
+
+    @pytest.mark.asyncio
+    async def test_concurrent_fresh_ptt_reads_are_correlated_in_send_order(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        observations: list[tx.ProviderPttObservation] = []
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=3, observer=observations.append
+        )
+        reads = [
+            asyncio.create_task(
+                radio._request_authoritative_ptt_read(
+                    provider_generation=3, observer=observations.append
+                )
+            )
+            for _ in range(2)
+        ]
+        while len(mock_transport.sent_packets) < 1:
+            await asyncio.sleep(0)
+        mock_transport.queue_response(_ptt_response(True))
+        await reads[0]
+        while len(mock_transport.sent_packets) < 2:
+            await asyncio.sleep(0)
+        mock_transport.queue_response(_ptt_response(False))
+        await reads[1]
+
+        assert [item.value for item in observations] == [tx.RadioTx.ON, tx.RadioTx.OFF]
+        assert [item.ptt_observation_seq for item in observations] == [1, 2]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("response", [_nak_response(), _ptt_response(2)])
+    async def test_fresh_ptt_read_rejects_non_response(
+        self, radio: IcomRadio, mock_transport: MockTransport, response: bytes
+    ) -> None:
+        observations: list[tx.ProviderPttObservation] = []
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=4, observer=observations.append
+        )
+        mock_transport.queue_response(response)
+        with pytest.raises((asyncio.TimeoutError, CommandError, TimeoutError)):
+            await radio._request_authoritative_ptt_read(
+                provider_generation=4, observer=observations.append
+            )
+        assert observations == []
+
+    @pytest.mark.asyncio
+    async def test_fresh_ptt_read_fails_closed_on_callback_and_reconnect(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        def broken(_observation: tx.ProviderPttObservation) -> None:
+            raise RuntimeError("observer")
+
+        radio._bind_authoritative_ptt_observer(provider_generation=5, observer=broken)
+        mock_transport.queue_response(_ptt_response(True))
+        with pytest.raises(CommandError, match="authoritative"):
+            await radio._request_authoritative_ptt_read(
+                provider_generation=5, observer=broken
+            )
+
+        observations: list[tx.ProviderPttObservation] = []
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=6, observer=observations.append
+        )
+        pending = asyncio.create_task(
+            radio._request_authoritative_ptt_read(
+                provider_generation=6, observer=observations.append
+            )
+        )
+        while len(mock_transport.sent_packets) < 2:
+            await asyncio.sleep(0)
+        radio._civ_runtime.advance_generation("test-reconnect")
+        mock_transport.queue_response(_ptt_response(False))
+        with pytest.raises(ConnectionError):
+            await pending
+        await asyncio.sleep(0)
+        assert observations == []
 
 
 class TestTimeout:


### PR DESCRIPTION
Closes #1957

Linear: https://linear.app/morozsm/issue/MOR-1103

## Contract
- serialize authoritative PTT queries and correlate each through the request tracker future created for its actual CI-V command
- capture the provider observer binding and CI-V source generation before dispatch; publish only if both remain exact when the response completes
- suppress the ordinary current-observer emission only for the token-bound read while its request owns the matching response
- invalidate the observer binding whenever the CI-V request generation advances
- preserve unsolicited MOR-1010 observations and generic/raw request tracker behavior outside the dedicated read

## Fail-closed cases
Observer/provider rebind, reconnect, NAK, timeout, malformed PTT payload, non-controller response, callback exception, and stale source generation publish no fresh-read authority. Concurrent reads serialize in send order.

## Scope
Exactly 3 files; 163 insertions / 13 deletions = net +150. No ManagedRadioRuntime lifecycle, executor, SDK, Web/poller, or frontend changes.

## Validation
- red-before: 4 focused tests failed because the production read API was absent
- focused CI-V/radio: 608 passed
- full non-integration: 8291 passed, 73 skipped, 5 deselected, 11 xfailed, 1 xpassed
- full Ruff check and format check: pass
- import-linter: 5/5 contracts kept
- diff check: pass
- changed-source mypy: no new errors; `_civ_rx.py` has the same 6 pre-existing diagnostics on exact origin/main and this head