### PR TITLE
feat: expose and enforce browser TX-audio facts

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -127,8 +127,6 @@ class RxPcmTapSource:
 
 @dataclass(frozen=True, slots=True)
 class BrowserTxAudioFacts:
-    """Backend-authoritative browser TX-audio capability tuple (MOR-1050)."""
-
     available: bool
     route: str | None
     required_mod_input_source: int | None
@@ -152,40 +150,51 @@ def _tx_codec_for_radio(radio: object) -> AudioCodec | None:
         )
     if tx_codec is None:
         tx_codec = getattr(radio, "audio_codec", None)
-    if not isinstance(tx_codec, AudioCodec) or tx_codec not in (
-        AudioCodec.PCM_1CH_16BIT,
-        AudioCodec.OPUS_1CH,
-    ):
-        return None
-    return tx_codec
-
-
-def _browser_tx_path(
-    radio: object, codec: AudioCodec
-) -> tuple[str, tuple[Any, ...]] | None:
-    neutral = tuple(
-        getattr(radio, name, None) for name in ("start_tx", "push_tx", "stop_tx")
+    supported = (AudioCodec.PCM_1CH_16BIT, AudioCodec.OPUS_1CH)
+    return (
+        tx_codec if isinstance(tx_codec, AudioCodec) and tx_codec in supported else None
     )
+
+
+def _concrete_lifecycle_method(owner: object, name: str) -> Any | None:
+    method = getattr(owner, name, None)
+    if not callable(method) or not asyncio.iscoroutinefunction(method):
+        return None
+    if name in getattr(owner, "__dict__", {}):
+        return method
+    base = next((item for item in type(owner).__mro__ if name in item.__dict__), None)
+    if base is None or getattr(base, "_is_protocol", False):
+        return None
+    definition = base.__dict__[name]
+    if getattr(definition, "__isabstractmethod__", False):
+        return None
+    if getattr(method, "__self__", None) is owner or method is definition:
+        return method
+    return None
+
+
+def _lifecycle(owner: object, names: tuple[str, ...]) -> tuple[Any, ...] | None:
+    methods = tuple(_concrete_lifecycle_method(owner, name) for name in names)
+    return methods if all(method is not None for method in methods) else None
+
+
+def _tx_path(radio: object, codec: AudioCodec) -> tuple[str, tuple[Any, ...]] | None:
+    neutral_names = ("start_tx", "push_tx", "stop_tx")
+    neutral = _lifecycle(radio, neutral_names)
     session = getattr(radio, "audio_session", None)
     if session is not None:
-        acquire = getattr(session, "acquire_tx", None)
-        if callable(acquire) and all(callable(method) for method in neutral):
+        acquire = _concrete_lifecycle_method(session, "acquire_tx")
+        if acquire is not None and neutral is not None:
             return "session", (acquire, neutral[1], neutral[2])
         return None
-    if any(method is not None for method in neutral):
-        return (
-            ("neutral", neutral)
-            if all(callable(method) for method in neutral)
-            else None
-        )
+    if any(getattr(radio, name, None) is not None for name in neutral_names):
+        return ("neutral", neutral) if neutral is not None else None
     suffix = "pcm" if codec == AudioCodec.PCM_1CH_16BIT else "opus"
-    lifecycle = tuple(
-        getattr(radio, f"{operation}_audio_tx_{suffix}", None)
-        for operation in ("start", "push", "stop")
+    names = tuple(
+        f"{operation}_audio_tx_{suffix}" for operation in ("start", "push", "stop")
     )
-    return (
-        (suffix, lifecycle) if all(callable(method) for method in lifecycle) else None
-    )
+    lifecycle = _lifecycle(radio, names)
+    return (suffix, lifecycle) if lifecycle is not None else None
 
 
 def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
@@ -199,7 +208,7 @@ def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
         codec = _tx_codec_for_radio(radio)
         if codec is None:
             return unavailable
-        path = _browser_tx_path(radio, codec)
+        path = _tx_path(radio, codec)
         route = resolve_audio_route(radio)
         source, policy = route.tx_audio_source, route.data_mode_policy
         valid_route = (

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -49,7 +49,6 @@ from ...capabilities import (
 __all__ = [
     "AudioBroadcaster",
     "AudioHandler",
-    "BrowserTxAudioFacts",
     "RxPcmTapSource",
     "browser_tx_audio_facts",
 ]

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -190,9 +190,7 @@ def _tx_path(radio: object, codec: AudioCodec) -> tuple[str, tuple[Any, ...]] | 
     if any(getattr(radio, name, None) is not None for name in neutral_names):
         return ("neutral", neutral) if neutral is not None else None
     suffix = "pcm" if codec == AudioCodec.PCM_1CH_16BIT else "opus"
-    names = tuple(
-        f"{operation}_audio_tx_{suffix}" for operation in ("start", "push", "stop")
-    )
+    names = tuple(f"{op}_audio_tx_{suffix}" for op in ("start", "push", "stop"))
     lifecycle = _lifecycle(radio, names)
     return (suffix, lifecycle) if lifecycle is not None else None
 
@@ -1401,40 +1399,44 @@ class AudioHandler:
                     identity=_parse_client_identity(msg),
                 )
             elif direction == "tx":
+                was_active = self._tx_active or self._tx_lease is not None
+                previous_facts = self._tx_facts
                 facts = browser_tx_audio_facts(self._radio)
                 if not facts.available:
-                    self._tx_active = False
-                    self._tx_facts = None
+                    await self._abort_tx_start(previous_facts, was_active)
                     await self._send_error("audio_start: TX audio unavailable")
                     return
                 self._tx_facts = facts
-                was_active = self._tx_active or self._tx_lease is not None
                 self._tx_active = False
                 try:
                     if facts.codec == AudioCodec.PCM_1CH_16BIT:
                         self._ensure_tx_transcoder()
                 except Exception:
-                    if was_active:
-                        await self._stop_tx(
-                            reason="failed TX audio restart", force=True
-                        )
-                    raise
+                    await self._abort_tx_start(previous_facts, was_active)
+                    await self._send_error("audio_start: TX transcoder unavailable")
+                    return
                 assert facts.lifecycle is not None
                 start = facts.lifecycle[0]
-                if facts.path == "session":
-                    if self._tx_lease is None or self._tx_lease.released:
-                        self._tx_lease = await start("web")
-                else:
-                    try:
+                try:
+                    if facts.path == "session":
+                        if self._tx_lease is None or self._tx_lease.released:
+                            self._tx_lease = await start("web")
+                    else:
                         if facts.path == "pcm":
                             await start(sample_rate=self._tx_sample_rate())
                         else:
                             await start()
-                    except RuntimeError as exc:
-                        if _is_benign_tx_restart(exc):
-                            logger.info("audio: TX already started by poller, reusing")
-                        else:
-                            raise
+                except RuntimeError as exc:
+                    if _is_benign_tx_restart(exc):
+                        logger.info("audio: TX already started by poller, reusing")
+                    else:
+                        await self._abort_tx_start(previous_facts, was_active)
+                        raise
+                except (asyncio.CancelledError, Exception):
+                    await asyncio.shield(
+                        self._abort_tx_start(previous_facts, was_active)
+                    )
+                    raise
                 self._tx_active = True
                 logger.info("audio: TX active")
         elif msg_type == "audio_stop":
@@ -1458,6 +1460,13 @@ class AudioHandler:
         self._link_quality = stats
         if self._rx_active and self._broadcaster is not None:
             self._broadcaster.record_client_stats(self._frame_queue, stats)
+
+    async def _abort_tx_start(
+        self, previous_facts: BrowserTxAudioFacts | None, was_active: bool
+    ) -> None:
+        self._tx_facts = previous_facts if was_active else None
+        if was_active:
+            await self._stop_tx(reason="failed TX audio restart", force=True)
 
     async def _stop_tx(
         self,

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -143,7 +143,7 @@ def _tx_codec_for_radio(radio: object) -> AudioCodec | None:
         tx_codec = getattr(contract, "tx_codec", None)
     if tx_codec is None:
         tx_codec = getattr(radio, "audio_codec", None)
-    return cast(AudioCodec | None, tx_codec)
+    return tx_codec
 
 
 def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
@@ -1398,6 +1398,7 @@ class AudioHandler:
                     self._tx_active = False
                     await self._send_error("audio_start: TX audio unavailable")
                     return
+                self._tx_active = False
                 self._ensure_tx_transcoder()
                 session = getattr(self._radio, "audio_session", None)
                 if session is not None:

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -132,6 +132,9 @@ class BrowserTxAudioFacts:
     available: bool
     route: str | None
     required_mod_input_source: int | None
+    codec: AudioCodec | None = None
+    path: str | None = None
+    lifecycle: tuple[Any, ...] | None = None
 
     def as_payload(self) -> dict[str, bool | int | str | None]:
         return {
@@ -157,21 +160,31 @@ def _tx_codec_for_radio(radio: object) -> AudioCodec | None:
     return tx_codec
 
 
-def _has_browser_tx_path(radio: object, codec: AudioCodec) -> bool:
+def _browser_tx_path(
+    radio: object, codec: AudioCodec
+) -> tuple[str, tuple[Any, ...]] | None:
     neutral = tuple(
         getattr(radio, name, None) for name in ("start_tx", "push_tx", "stop_tx")
     )
     session = getattr(radio, "audio_session", None)
     if session is not None:
-        return callable(getattr(session, "acquire_tx", None)) and all(
-            callable(method) for method in neutral
-        )
+        acquire = getattr(session, "acquire_tx", None)
+        if callable(acquire) and all(callable(method) for method in neutral):
+            return "session", (acquire, neutral[1], neutral[2])
+        return None
     if any(method is not None for method in neutral):
-        return all(callable(method) for method in neutral)
+        return (
+            ("neutral", neutral)
+            if all(callable(method) for method in neutral)
+            else None
+        )
     suffix = "pcm" if codec == AudioCodec.PCM_1CH_16BIT else "opus"
-    return all(
-        callable(getattr(radio, f"{operation}_audio_tx_{suffix}", None))
+    lifecycle = tuple(
+        getattr(radio, f"{operation}_audio_tx_{suffix}", None)
         for operation in ("start", "push", "stop")
+    )
+    return (
+        (suffix, lifecycle) if all(callable(method) for method in lifecycle) else None
     )
 
 
@@ -186,6 +199,7 @@ def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
         codec = _tx_codec_for_radio(radio)
         if codec is None:
             return unavailable
+        path = _browser_tx_path(radio, codec)
         route = resolve_audio_route(radio)
         source, policy = route.tx_audio_source, route.data_mode_policy
         valid_route = (
@@ -199,7 +213,7 @@ def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
                 (TxAudioSource.ACC, DataModePolicy.LEGACY),
             }
         )
-        if not _has_browser_tx_path(radio, codec) or not valid_route:
+        if path is None or not valid_route:
             return unavailable
         candidate = (
             rigctld_wsjtx_policy(route)[1] if CAP_MOD_INPUT_ROUTING in caps else None
@@ -211,7 +225,9 @@ def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
             or not 0 <= candidate <= 9_007_199_254_740_991
         ):
             return unavailable
-        return BrowserTxAudioFacts(True, source.value, candidate)
+        return BrowserTxAudioFacts(
+            True, source.value, candidate, codec, path[0], path[1]
+        )
     except Exception:
         return unavailable
 
@@ -1268,20 +1284,7 @@ class AudioBroadcaster:
 
 
 class AudioHandler:
-    """Handler for the /api/v1/audio WebSocket channel.
-
-    Streams RX audio from the radio to the browser as binary audio frames,
-    and accepts TX audio frames from the browser to push to the radio.
-
-    Control flow:
-        Client sends JSON text: ``audio_start`` / ``audio_stop``
-        Server sends binary audio frames continuously while RX is active.
-        Client sends binary Opus frames while TX is active (after PTT on).
-
-    Args:
-        ws: Established WebSocket connection.
-        radio: Radio protocol instance (may be None).
-    """
+    """Bidirectional audio WebSocket handler."""
 
     def __init__(
         self,
@@ -1294,39 +1297,24 @@ class AudioHandler:
         self._broadcaster = broadcaster
         self._rx_active = False
         self._tx_active = False
-        # TX lease on the radio-owned AudioSession singleton (MOR-580,
-        # ADR §3.3). None when the radio lacks a session (legacy direct
-        # path) or when TX is not active.
         self._tx_lease: TxLease | None = None
+        self._tx_facts: BrowserTxAudioFacts | None = None
         self._tx_stop_lock = asyncio.Lock()
         self._seq: int = 0
-        # Latest client-reported link-quality snapshot from the periodic
-        # ``audio_stats`` uplink (MOR-585) — mirrored per client on the
-        # broadcaster while RX is subscribed.
         self._link_quality: dict[str, int | float] = {}
         self._frame_queue: asyncio.Queue[bytes] = asyncio.Queue()
         self._done = asyncio.Event()
-        # Opus decoder for TX when radio uses PCM codec.
-        # Created lazily on TX start so we pass the radio's negotiated sample rate
-        # (otherwise a 24 kHz radio silently drops TX audio decoded at 48 kHz — #691).
         self._transcoder: PcmOpusTranscoder | None = None
         self._transcoder_rate: int = 0
 
     async def run(self) -> None:
-        """Run the audio channel lifecycle.
-
-        Reader and sender run as concurrent tasks. When EITHER exits
-        (WS close, send timeout, error), the other is cancelled and
-        cleanup (unsubscribe from broadcaster) runs unconditionally.
-        """
+        """Run reader and sender until either exits, then clean up."""
         reader = asyncio.create_task(self._reader_loop(), name="audio-reader")
         sender = asyncio.create_task(self._sender_loop(), name="audio-sender")
         try:
-            # Wait for the first task to finish — then cancel the other
             done, pending = await asyncio.wait(
                 {reader, sender}, return_when=asyncio.FIRST_COMPLETED
             )
-            # Log which task exited first
             for task in done:
                 exc = task.exception() if not task.cancelled() else None
                 if exc:
@@ -1335,10 +1323,8 @@ class AudioHandler:
                     )
                 else:
                     logger.debug("audio: %s exited normally", task.get_name())
-            # Cancel the remaining task and close WS to unblock any stuck recv()
             for task in pending:
                 task.cancel()
-            # Close WS to ensure recv() in reader raises EOF
             try:
                 await self._ws.close(1001, "peer task exited")
             except Exception:
@@ -1383,7 +1369,6 @@ class AudioHandler:
                         continue
                     await self._handle_control(msg)
                 elif opcode == WS_OP_BINARY:
-                    # TX audio frame from browser
                     await self._handle_tx_audio(payload)
         except EOFError as exc:
             logger.info("audio: reader EOF: %s", exc)
@@ -1393,8 +1378,6 @@ class AudioHandler:
     async def _handle_control(self, msg: dict[str, Any]) -> None:
         """Handle audio_start / audio_stop messages."""
         msg_type = msg.get("type", "")
-        # Periodic audio_stats (~1.5 s per client, MOR-585) stays at DEBUG;
-        # everything else keeps the established INFO trace.
         logger.log(
             logging.DEBUG if msg_type == "audio_stats" else logging.INFO,
             "audio: control msg: %s",
@@ -1412,12 +1395,14 @@ class AudioHandler:
                 facts = browser_tx_audio_facts(self._radio)
                 if not facts.available:
                     self._tx_active = False
+                    self._tx_facts = None
                     await self._send_error("audio_start: TX audio unavailable")
                     return
+                self._tx_facts = facts
                 was_active = self._tx_active or self._tx_lease is not None
                 self._tx_active = False
                 try:
-                    if self._tx_codec() == AudioCodec.PCM_1CH_16BIT:
+                    if facts.codec == AudioCodec.PCM_1CH_16BIT:
                         self._ensure_tx_transcoder()
                 except Exception:
                     if was_active:
@@ -1425,18 +1410,17 @@ class AudioHandler:
                             reason="failed TX audio restart", force=True
                         )
                     raise
-                session = getattr(self._radio, "audio_session", None)
-                if session is not None:
-                    # Shared session serializes arming with other lease holders.
+                assert facts.lifecycle is not None
+                start = facts.lifecycle[0]
+                if facts.path == "session":
                     if self._tx_lease is None or self._tx_lease.released:
-                        self._tx_lease = await session.acquire_tx("web")
+                        self._tx_lease = await start("web")
                 else:
                     try:
-                        start_tx = getattr(self._radio, "start_tx", None)
-                        if start_tx is not None:
-                            await start_tx()
+                        if facts.path == "pcm":
+                            await start(sample_rate=self._tx_sample_rate())
                         else:
-                            await self._legacy_tx_lifecycle("start")
+                            await start()
                     except RuntimeError as exc:
                         if _is_benign_tx_restart(exc):
                             logger.info("audio: TX already started by poller, reusing")
@@ -1479,6 +1463,7 @@ class AudioHandler:
             if not self._tx_active and not force and self._tx_lease is None:
                 return
             self._tx_active = False
+            facts, self._tx_facts = self._tx_facts, None
 
             if not self._radio or CAP_AUDIO not in getattr(
                 self._radio, "capabilities", ()
@@ -1489,23 +1474,21 @@ class AudioHandler:
             try:
                 lease = self._tx_lease
                 if lease is not None:
-                    # Session path (MOR-580): drop this handler's TX demand;
-                    # the session disarms radio TX only when the lease
-                    # refcount reaches zero (release is idempotent).
                     self._tx_lease = None
                     stop_tx: Awaitable[None] = lease.release()
-                elif getattr(self._radio, "audio_session", None) is not None:
-                    # Session radio with no held lease: this handler owns no
-                    # TX demand — never direct-stop the radio out from under
-                    # other lease holders (bridge, poller PTT). MOR-580.
+                elif (facts is not None and facts.path == "session") or (
+                    facts is None
+                    and getattr(self._radio, "audio_session", None) is not None
+                ):
                     logger.info(
                         "audio: TX stop skipped (%s, no session lease held)", reason
                     )
                     return
                 else:
-                    stop_tx_method = getattr(self._radio, "stop_tx", None)
+                    stop_tx_method = (
+                        facts.lifecycle[2] if facts and facts.lifecycle else None
+                    )
                     if stop_tx_method is not None:
-                        # Neutral AudioTransport surface (MOR-544).
                         stop_tx = stop_tx_method()
                     else:
                         stop_tx = self._legacy_tx_lifecycle("stop")
@@ -1556,17 +1539,12 @@ class AudioHandler:
         except Exception:
             logger.debug("audio: late TX stop failed after timeout", exc_info=True)
 
-    # --------------------------------------------------------------
     # audio_config — MAIN/SUB focus + stereo split (issue #752, revised in #788)
-    # --------------------------------------------------------------
-    #
     # IC-7610 CI-V ``0x1A 05 00 72`` "Connectors > Phones > L/R Mix" —
     # per official CI-V reference p. 5: **data is 00 or 01 only**.
-    #
     #   0x00 = Mix OFF → L=MAIN, R=SUB separated in the LAN stream.
     #   0x01 = Mix ON  → radio pre-sums MAIN + SUB to both channels
     #                    before transmission (LAN output becomes mono).
-    #
     # Contract for dual-RX routing (epic #787, #792): the backend must
     # **always** keep Mix OFF while a 2-channel codec is active.  The
     # frontend recovers ``focus`` × ``split_stereo`` purely via WebAudio
@@ -1574,7 +1552,6 @@ class AudioHandler:
     # ON the radio has already mixed the receivers, so ``focus=main`` /
     # ``focus=sub`` can no longer isolate a single receiver — the
     # frontend would play the summed signal instead.
-    #
     # Both ``focus`` and ``split_stereo`` stay on the wire so the client
     # can persist + echo them, but neither round-trips to CI-V anymore.
     # Broadcaster start-up also forces Mix OFF once per session via
@@ -1584,16 +1561,7 @@ class AudioHandler:
     _VALID_AUDIO_FOCUS: frozenset[str] = frozenset({"main", "sub", "both"})
 
     async def _handle_audio_config(self, msg: dict[str, Any]) -> None:
-        """Apply MAIN/SUB audio focus + stereo split via CI-V Phones L/R Mix.
-
-        Fire-and-forget on radios declaring the
-        ``lan_dual_rx_audio_routing`` capability (IC-7610 only today —
-        see ``capabilities.CAP_LAN_DUAL_RX_AUDIO_ROUTING``).  Echoes the
-        applied config back on the WS so the client can confirm
-        persistence.  Silent no-op on radios that don't declare the
-        capability — e.g. IC-9700 (dual-RX but different menu layout)
-        and FTX-1 (Yaesu CAT, no ``send_civ`` at all).  Issue #799.
-        """
+        """Apply MAIN/SUB audio focus on supported dual-RX radios."""
         focus = msg.get("focus", "")
         split_stereo = bool(msg.get("split_stereo", False))
 
@@ -1697,11 +1665,15 @@ class AudioHandler:
         if lease is not None and not lease.released:
             await lease.push(data)
             return
-        push_tx = getattr(self._radio, "push_tx", None)
-        if push_tx is not None:
-            await push_tx(data)
+        facts = self._tx_facts
+        if facts is not None and facts.lifecycle is not None:
+            await facts.lifecycle[1](data)
         else:
-            await getattr(self._radio, legacy_method)(data)
+            push_tx = getattr(self._radio, "push_tx", None)
+            if push_tx is not None:
+                await push_tx(data)
+            else:
+                await getattr(self._radio, legacy_method)(data)
 
     async def _start_rx(
         self,
@@ -1765,7 +1737,7 @@ class AudioHandler:
         audio_data = payload[AUDIO_HEADER_SIZE:]
         if audio_data:
             try:
-                tx_codec = self._tx_codec()
+                tx_codec = self._tx_facts.codec if self._tx_facts else self._tx_codec()
                 if browser_codec == AUDIO_CODEC_PCM16:
                     await self._push_tx(audio_data, legacy_method="push_audio_tx_pcm")
                     tx_data_desc = f"{len(audio_data)} bytes pcm"

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 from rigplane.audio._codecs import decode_ulaw_to_pcm16
 from rigplane.audio._transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
 from ...audio.bus import STAGE_RX_POST_DSP
+from ...audio.route import TxAudioSource, resolve_audio_route, rigctld_wsjtx_policy
 from ...audio.session import RxSubscription
 from ...audio.usb_driver import AudioAlreadyStartedError
 from ...dsp.tap_registry import TapHandle, TapRegistry
@@ -38,9 +39,20 @@ if TYPE_CHECKING:
     from ...dsp.pipeline import DSPPipeline
     from ...radio_protocol import Radio
 
-from ...capabilities import CAP_AUDIO, CAP_LAN_DUAL_RX_AUDIO_ROUTING
+from ...capabilities import (
+    CAP_AUDIO,
+    CAP_LAN_DUAL_RX_AUDIO_ROUTING,
+    CAP_MOD_INPUT_ROUTING,
+    CAP_TX,
+)
 
-__all__ = ["AudioBroadcaster", "AudioHandler", "RxPcmTapSource"]
+__all__ = [
+    "AudioBroadcaster",
+    "AudioHandler",
+    "BrowserTxAudioFacts",
+    "RxPcmTapSource",
+    "browser_tx_audio_facts",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +119,77 @@ class RxPcmTapSource:
 
     codec: AudioCodec
     sample_rate: int
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserTxAudioFacts:
+    """Backend-authoritative browser TX-audio capability tuple (MOR-1050)."""
+
+    available: bool
+    route: str | None
+    required_mod_input_source: int | None
+
+    def as_payload(self) -> dict[str, bool | int | str | None]:
+        return {
+            "audioTx": self.available,
+            "audioTxRoute": self.route,
+            "audioTxRequiredModInputSource": self.required_mod_input_source,
+        }
+
+
+def _tx_codec_for_radio(radio: object) -> AudioCodec | None:
+    tx_codec = getattr(radio, "audio_tx_codec", None)
+    if tx_codec is None:
+        contract = getattr(radio, "audio_stream_contract", None)
+        tx_codec = getattr(contract, "tx_codec", None)
+    if tx_codec is None:
+        tx_codec = getattr(radio, "audio_codec", None)
+    return cast(AudioCodec | None, tx_codec)
+
+
+def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
+    """Resolve the exact structural predicate used by HTTP and audio WS."""
+    unavailable = BrowserTxAudioFacts(False, None, None)
+    caps = runtime_capabilities(radio)
+    if radio is None or not {CAP_AUDIO, CAP_TX}.issubset(caps):
+        return unavailable
+
+    neutral_names = ("start_tx", "push_tx", "stop_tx")
+    try:
+        neutral = tuple(getattr(radio, name, None) for name in neutral_names)
+        session = getattr(radio, "audio_session", None)
+        if session is not None:
+            usable = callable(getattr(session, "acquire_tx", None)) and all(
+                callable(method) for method in neutral
+            )
+        elif any(method is not None for method in neutral):
+            usable = all(callable(method) for method in neutral)
+        else:
+            suffix = (
+                "pcm"
+                if _tx_codec_for_radio(radio) == AudioCodec.PCM_1CH_16BIT
+                else "opus"
+            )
+            usable = all(
+                callable(getattr(radio, f"{operation}_audio_tx_{suffix}", None))
+                for operation in ("start", "push", "stop")
+            )
+        route = resolve_audio_route(radio)
+    except Exception:
+        return unavailable
+    if not usable or route.tx_audio_source is TxAudioSource.UNAVAILABLE:
+        return unavailable
+
+    required_source = None
+    if CAP_MOD_INPUT_ROUTING in caps:
+        candidate = rigctld_wsjtx_policy(route)[1]
+        if (
+            isinstance(candidate, int)
+            and not isinstance(candidate, bool)
+            and 0 <= candidate <= 9_007_199_254_740_991
+        ):
+            required_source = candidate
+    return BrowserTxAudioFacts(True, route.tx_audio_source.value, required_source)
 
 
 def _is_benign_tx_restart(exc: RuntimeError) -> bool:
@@ -1311,37 +1394,39 @@ class AudioHandler:
                     identity=_parse_client_identity(msg),
                 )
             elif direction == "tx":
-                if self._radio and CAP_AUDIO in self._radio.capabilities:
-                    self._ensure_tx_transcoder()
-                    session = getattr(self._radio, "audio_session", None)
-                    if session is not None:
-                        # Shared AudioSession lease (MOR-580, ADR §3.3): the
-                        # session's single-lock refcount serializes arming
-                        # with other lease holders (bridge, poller PTT), so
-                        # the double-start benign-tolerance below is
-                        # unnecessary on this path.
-                        if self._tx_lease is None or self._tx_lease.released:
-                            self._tx_lease = await session.acquire_tx("web")
-                    else:
-                        # Legacy direct-arm fallback for radios without a
-                        # session (bare test doubles, not-yet-migrated
-                        # backends).
-                        try:
-                            start_tx = getattr(self._radio, "start_tx", None)
-                            if start_tx is not None:
-                                # Neutral AudioTransport surface (MOR-544):
-                                # the backend resolves the TX format from
-                                # its negotiated contract.
-                                await start_tx()
-                            else:
-                                await self._legacy_tx_lifecycle("start")
-                        except RuntimeError as exc:
-                            if _is_benign_tx_restart(exc):
-                                logger.info(
-                                    "audio: TX already started by poller, reusing"
-                                )
-                            else:
-                                raise
+                facts = browser_tx_audio_facts(self._radio)
+                if not facts.available:
+                    self._tx_active = False
+                    await self._send_error("audio_start: TX audio unavailable")
+                    return
+                self._ensure_tx_transcoder()
+                session = getattr(self._radio, "audio_session", None)
+                if session is not None:
+                    # Shared AudioSession lease (MOR-580, ADR §3.3): the
+                    # session's single-lock refcount serializes arming
+                    # with other lease holders (bridge, poller PTT), so
+                    # the double-start benign-tolerance below is
+                    # unnecessary on this path.
+                    if self._tx_lease is None or self._tx_lease.released:
+                        self._tx_lease = await session.acquire_tx("web")
+                else:
+                    # Legacy direct-arm fallback for radios without a
+                    # session (bare test doubles, not-yet-migrated
+                    # backends).
+                    try:
+                        start_tx = getattr(self._radio, "start_tx", None)
+                        if start_tx is not None:
+                            # Neutral AudioTransport surface (MOR-544):
+                            # backend resolves the TX format from its
+                            # negotiated contract.
+                            await start_tx()
+                        else:
+                            await self._legacy_tx_lifecycle("start")
+                    except RuntimeError as exc:
+                        if _is_benign_tx_restart(exc):
+                            logger.info("audio: TX already started by poller, reusing")
+                        else:
+                            raise
                 self._tx_active = True
                 logger.info("audio: TX active")
         elif msg_type == "audio_stop":
@@ -1600,14 +1685,7 @@ class AudioHandler:
         #
         # Preference order (MOR-544): first-class ``audio_tx_codec``
         # (AudioTransport) → contract ``tx_codec`` → RX ``audio_codec``.
-        tx_codec = getattr(self._radio, "audio_tx_codec", None)
-        if tx_codec is not None:
-            return tx_codec  # type: ignore[no-any-return]
-        contract = getattr(self._radio, "audio_stream_contract", None)
-        tx_codec = getattr(contract, "tx_codec", None)
-        if tx_codec is not None:
-            return tx_codec  # type: ignore[no-any-return]
-        return getattr(self._radio, "audio_codec", None)  # type: ignore[no-any-return]
+        return _tx_codec_for_radio(self._radio)  # type: ignore[no-any-return]
 
     def _tx_sample_rate(self) -> int:
         """Resolve the TX sample rate: contract → radio property → 48000.

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -12,7 +12,12 @@ from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 from rigplane.audio._codecs import decode_ulaw_to_pcm16
 from rigplane.audio._transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
 from ...audio.bus import STAGE_RX_POST_DSP
-from ...audio.route import TxAudioSource, resolve_audio_route, rigctld_wsjtx_policy
+from ...audio.route import (
+    DataModePolicy,
+    TxAudioSource,
+    resolve_audio_route,
+    rigctld_wsjtx_policy,
+)
 from ...audio.session import RxSubscription
 from ...audio.usb_driver import AudioAlreadyStartedError
 from ...dsp.tap_registry import TapHandle, TapRegistry
@@ -139,11 +144,35 @@ class BrowserTxAudioFacts:
 def _tx_codec_for_radio(radio: object) -> AudioCodec | None:
     tx_codec = getattr(radio, "audio_tx_codec", None)
     if tx_codec is None:
-        contract = getattr(radio, "audio_stream_contract", None)
-        tx_codec = getattr(contract, "tx_codec", None)
+        tx_codec = getattr(
+            getattr(radio, "audio_stream_contract", None), "tx_codec", None
+        )
     if tx_codec is None:
         tx_codec = getattr(radio, "audio_codec", None)
+    if not isinstance(tx_codec, AudioCodec) or tx_codec not in (
+        AudioCodec.PCM_1CH_16BIT,
+        AudioCodec.OPUS_1CH,
+    ):
+        return None
     return tx_codec
+
+
+def _has_browser_tx_path(radio: object, codec: AudioCodec) -> bool:
+    neutral = tuple(
+        getattr(radio, name, None) for name in ("start_tx", "push_tx", "stop_tx")
+    )
+    session = getattr(radio, "audio_session", None)
+    if session is not None:
+        return callable(getattr(session, "acquire_tx", None)) and all(
+            callable(method) for method in neutral
+        )
+    if any(method is not None for method in neutral):
+        return all(callable(method) for method in neutral)
+    suffix = "pcm" if codec == AudioCodec.PCM_1CH_16BIT else "opus"
+    return all(
+        callable(getattr(radio, f"{operation}_audio_tx_{suffix}", None))
+        for operation in ("start", "push", "stop")
+    )
 
 
 def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
@@ -153,55 +182,42 @@ def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
     if radio is None or not {CAP_AUDIO, CAP_TX}.issubset(caps):
         return unavailable
 
-    neutral_names = ("start_tx", "push_tx", "stop_tx")
     try:
-        neutral = tuple(getattr(radio, name, None) for name in neutral_names)
-        session = getattr(radio, "audio_session", None)
-        if session is not None:
-            usable = callable(getattr(session, "acquire_tx", None)) and all(
-                callable(method) for method in neutral
-            )
-        elif any(method is not None for method in neutral):
-            usable = all(callable(method) for method in neutral)
-        else:
-            suffix = (
-                "pcm"
-                if _tx_codec_for_radio(radio) == AudioCodec.PCM_1CH_16BIT
-                else "opus"
-            )
-            usable = all(
-                callable(getattr(radio, f"{operation}_audio_tx_{suffix}", None))
-                for operation in ("start", "push", "stop")
-            )
+        codec = _tx_codec_for_radio(radio)
+        if codec is None:
+            return unavailable
         route = resolve_audio_route(radio)
+        source, policy = route.tx_audio_source, route.data_mode_policy
+        valid_route = (
+            isinstance(source, TxAudioSource)
+            and isinstance(policy, DataModePolicy)
+            and (source, policy)
+            in {
+                (TxAudioSource.LAN, DataModePolicy.DATA2_LAN),
+                (TxAudioSource.LAN, DataModePolicy.LEGACY),
+                (TxAudioSource.USB, DataModePolicy.DATA1_USB),
+                (TxAudioSource.ACC, DataModePolicy.LEGACY),
+            }
+        )
+        if not _has_browser_tx_path(radio, codec) or not valid_route:
+            return unavailable
+        candidate = (
+            rigctld_wsjtx_policy(route)[1] if CAP_MOD_INPUT_ROUTING in caps else None
+        )
+        if candidate is not None and (
+            source is not TxAudioSource.LAN
+            or not isinstance(candidate, int)
+            or isinstance(candidate, bool)
+            or not 0 <= candidate <= 9_007_199_254_740_991
+        ):
+            return unavailable
+        return BrowserTxAudioFacts(True, source.value, candidate)
     except Exception:
         return unavailable
-    if not usable or route.tx_audio_source is TxAudioSource.UNAVAILABLE:
-        return unavailable
-
-    required_source = None
-    if CAP_MOD_INPUT_ROUTING in caps:
-        candidate = rigctld_wsjtx_policy(route)[1]
-        if (
-            isinstance(candidate, int)
-            and not isinstance(candidate, bool)
-            and 0 <= candidate <= 9_007_199_254_740_991
-        ):
-            required_source = candidate
-    return BrowserTxAudioFacts(True, route.tx_audio_source.value, required_source)
 
 
 def _is_benign_tx_restart(exc: RuntimeError) -> bool:
-    """True when TX start failed only because the stream is already open.
-
-    The Icom LAN stream and the USB driver raise
-    :class:`~rigplane.audio.usb_driver.AudioAlreadyStartedError` (a
-    ``RuntimeError`` subclass, MOR-563), meaning the poller (or a prior
-    client) already opened TX and the handler can simply reuse it —
-    re-raising would close the audio WebSocket (MOR-541 review note,
-    MOR-544). The substring fallback covers not-yet-migrated raisers that
-    still signal the same condition with a bare ``RuntimeError``.
-    """
+    """Return whether TX is already open and safe to reuse."""
     if isinstance(exc, AudioAlreadyStartedError):
         return True
     text = str(exc).lower()
@@ -1398,27 +1414,26 @@ class AudioHandler:
                     self._tx_active = False
                     await self._send_error("audio_start: TX audio unavailable")
                     return
+                was_active = self._tx_active or self._tx_lease is not None
                 self._tx_active = False
-                self._ensure_tx_transcoder()
+                try:
+                    if self._tx_codec() == AudioCodec.PCM_1CH_16BIT:
+                        self._ensure_tx_transcoder()
+                except Exception:
+                    if was_active:
+                        await self._stop_tx(
+                            reason="failed TX audio restart", force=True
+                        )
+                    raise
                 session = getattr(self._radio, "audio_session", None)
                 if session is not None:
-                    # Shared AudioSession lease (MOR-580, ADR §3.3): the
-                    # session's single-lock refcount serializes arming
-                    # with other lease holders (bridge, poller PTT), so
-                    # the double-start benign-tolerance below is
-                    # unnecessary on this path.
+                    # Shared session serializes arming with other lease holders.
                     if self._tx_lease is None or self._tx_lease.released:
                         self._tx_lease = await session.acquire_tx("web")
                 else:
-                    # Legacy direct-arm fallback for radios without a
-                    # session (bare test doubles, not-yet-migrated
-                    # backends).
                     try:
                         start_tx = getattr(self._radio, "start_tx", None)
                         if start_tx is not None:
-                            # Neutral AudioTransport surface (MOR-544):
-                            # backend resolves the TX format from its
-                            # negotiated contract.
                             await start_tx()
                         else:
                             await self._legacy_tx_lifecycle("start")
@@ -1440,15 +1455,7 @@ class AudioHandler:
             self._handle_audio_stats(msg)
 
     def _handle_audio_stats(self, msg: dict[str, Any]) -> None:
-        """Record the client's periodic link-quality report (MOR-585).
-
-        Stats collection only (ADR §3.6 step 18): the browser player
-        reports playback ``underruns``, ``buffer_depth_ms`` and
-        ``dropped_frames`` every ~1.5 s; only numeric fields are kept
-        (latest-wins), and unknown numeric fields pass through so future
-        carriers (WebRTC RTCP, step 19) can reuse the envelope.  Clients
-        that never send ``audio_stats`` are entirely unaffected.
-        """
+        """Record the client's latest numeric link-quality report."""
         stats: dict[str, int | float] = {}
         for key, value in msg.items():
             if key == "type" or isinstance(value, bool):
@@ -1653,46 +1660,19 @@ class AudioHandler:
         await self._send_json({"type": "error", "message": message})
 
     def _ensure_tx_transcoder(self) -> None:
-        """Create (or recreate) the TX Opus→PCM transcoder at the radio's rate.
-
-        TX-side fix for issue #691: previously the transcoder was constructed
-        in ``__init__`` before the radio's negotiated ``audio_sample_rate`` was
-        known, so the browser's 24 kHz Opus stream was decoded to 48 kHz PCM
-        and the radio silently dropped TX audio. Called on ``audio_start
-        direction=tx``, when the rate is guaranteed available.
-        """
+        """Prepare the required Opus→PCM transcoder before TX starts."""
         rate = self._tx_sample_rate()
         if self._transcoder is not None and self._transcoder_rate == rate:
             return
-        try:
-            self._transcoder = create_pcm_opus_transcoder(sample_rate=rate)
-            self._transcoder_rate = rate
-            logger.info("audio: TX transcoder ready at %d Hz", rate)
-        except Exception:
-            logger.debug("audio: TX transcoder unavailable (opus codec missing?)")
-            self._transcoder = None
-            self._transcoder_rate = 0
+        self._transcoder, self._transcoder_rate = None, 0
+        self._transcoder = create_pcm_opus_transcoder(sample_rate=rate)
+        self._transcoder_rate = rate
+        logger.info("audio: TX transcoder ready at %d Hz", rate)
 
     def _tx_codec(self) -> AudioCodec | None:
-        # Under the ``rigplane.web.*`` strict override with
-        # ``follow_imports = "skip"``, ``AudioCodec`` resolves to ``Any`` in
-        # this module's view, so the function effectively returns
-        # ``Any | None`` and the ``getattr`` results below are also ``Any``.
-        # That triggers ``no-any-return``; suppress it locally rather than
-        # carrying a runtime-redundant ``cast``.  ``warn_unused_ignores`` is
-        # off for ``rigplane.web.*``, so the ignore stays safe in any future
-        # non-strict context.
-        #
-        # Preference order (MOR-544): first-class ``audio_tx_codec``
-        # (AudioTransport) → contract ``tx_codec`` → RX ``audio_codec``.
         return _tx_codec_for_radio(self._radio)  # type: ignore[no-any-return]
 
     def _tx_sample_rate(self) -> int:
-        """Resolve the TX sample rate: contract → radio property → 48000.
-
-        Single source for both the legacy ``start_audio_tx_pcm`` call and
-        the TX transcoder (the two used to carry half-duplicated fallback
-        chains; unified in MOR-544)."""
         contract = getattr(self._radio, "audio_stream_contract", None)
         sr = getattr(contract, "tx_sample_rate_hz", None)
         if not isinstance(sr, int) or isinstance(sr, bool) or sr <= 0:
@@ -1702,24 +1682,17 @@ class AudioHandler:
         return 48000
 
     async def _legacy_tx_lifecycle(self, op: str) -> None:
-        """Per-codec TX ``"start"``/``"stop"`` fallback for radios without
-        the neutral ``AudioTransport`` surface (MOR-544)."""
-        if self._tx_codec() == AudioCodec.PCM_1CH_16BIT:
-            if op == "start":
-                await self._radio.start_audio_tx_pcm(  # type: ignore[union-attr]
-                    sample_rate=self._tx_sample_rate()
-                )
-            else:
-                await self._radio.stop_audio_tx_pcm()  # type: ignore[union-attr]
-        elif op == "start":
-            await self._radio.start_audio_tx_opus()  # type: ignore[union-attr]
+        codec = self._tx_codec()
+        if codec not in (AudioCodec.PCM_1CH_16BIT, AudioCodec.OPUS_1CH):
+            raise RuntimeError("browser TX audio codec is unresolved")
+        suffix = "pcm" if codec == AudioCodec.PCM_1CH_16BIT else "opus"
+        method = getattr(self._radio, f"{op}_audio_tx_{suffix}")
+        if op == "start" and suffix == "pcm":
+            await method(sample_rate=self._tx_sample_rate())
         else:
-            await self._radio.stop_audio_tx_opus()  # type: ignore[union-attr]
+            await method()
 
     async def _push_tx(self, data: bytes, *, legacy_method: str) -> None:
-        """Push TX bytes via the held session lease (MOR-580); without one,
-        via neutral ``push_tx``, falling back to the named legacy per-codec
-        push method (MOR-544)."""
         lease = self._tx_lease
         if lease is not None and not lease.released:
             await lease.push(data)
@@ -1745,10 +1718,7 @@ class AudioHandler:
             preferred_rx_codec=preferred_rx_codec,
             identity=identity,
         )
-        # Per-connection negotiation ack (MOR-584): tell the client which
-        # wire codec/format it will receive.  Advisory and fire-and-forget
-        # — legacy clients ignore text frames on the audio WS and keep
-        # decoding from the per-frame binary header.
+        # Advisory per-connection format ack; legacy clients ignore it.
         await self._send_json(
             {
                 "type": "audio_format",
@@ -1813,7 +1783,6 @@ class AudioHandler:
                         )
                         return
                     try:
-                        # Decode Opus → PCM16
                         pcm_data = self._transcoder.opus_to_pcm(audio_data)
                         await self._push_tx(pcm_data, legacy_method="push_audio_tx_pcm")
                         tx_data_desc = f"{len(pcm_data)} bytes pcm"
@@ -1838,7 +1807,6 @@ class AudioHandler:
                     )
                     return
 
-                # Log every 50th frame to avoid spam
                 if not hasattr(self, "_tx_frame_count"):
                     self._tx_frame_count = 0
                 self._tx_frame_count += 1

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -82,6 +82,7 @@ from .handlers import (  # noqa: TID251
     DiagnosticsHandler,
     ScopeHandler,
 )
+from .handlers.audio import browser_tx_audio_facts  # noqa: TID251
 from .transport.webrtc import webrtc_available  # noqa: TID251
 from .radio_poller import (  # noqa: TID251
     CommandQueue,
@@ -2724,6 +2725,7 @@ class WebServer:
         self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
     ) -> None:
         caps = _runtime_capabilities(self._radio)
+        audio_tx_facts = browser_tx_audio_facts(self._radio)
         _raw_model = (
             getattr(self._radio, "model", None) if self._radio is not None else None
         )
@@ -2757,6 +2759,7 @@ class WebServer:
                 "scope": "scope" in caps,
                 "audio": "audio" in caps,
                 "tx": "tx" in caps,
+                **audio_tx_facts.as_payload(),
                 "capabilities": sorted(caps),
                 "receivers": profile.receiver_count,
                 "vfoScheme": profile.vfo_scheme,

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -282,22 +282,24 @@ class TestCapabilitiesEndpoint:
         assert data["antennas"] == 1
 
     @pytest.mark.asyncio
-    async def test_capabilities_browser_tx_audio_facts(self):
-        cases = (("IC-7610", (True, "lan", 5)), ("FTX-1", (True, "usb", None)))
-        for model, expected in cases:
-            radio, writer = _make_radio(model), _FakeWriter()
-            radio.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
-            suffix = "_audio_tx_pcm" if model == "IC-7610" else "_tx"
-            for operation in ("start", "push", "stop"):
-                setattr(radio, f"{operation}{suffix}", AsyncMock())
-            await WebServer(radio)._serve_capabilities(writer)  # noqa: SLF001
-            data, facts = _parse_json_body(writer), browser_tx_audio_facts(radio)
-            keys = ("audioTx", "audioTxRoute", "audioTxRequiredModInputSource")
-            assert (
-                tuple(data[key] for key in keys)
-                == (facts.available, facts.route, facts.required_mod_input_source)
-                == expected
-            )
+    @pytest.mark.parametrize(
+        ("model", "suffix", "expected"),
+        [
+            ("IC-7610", "_audio_tx_pcm", (True, "lan", 5)),
+            ("FTX-1", "_tx", (True, "usb", None)),
+        ],
+    )
+    async def test_capabilities_browser_tx_audio_facts(
+        self, model: str, suffix: str, expected: tuple[bool, str, int | None]
+    ):
+        radio, writer = _make_radio(model), _FakeWriter()
+        radio.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+        for operation in ("start", "push", "stop"):
+            setattr(radio, f"{operation}{suffix}", AsyncMock())
+        await WebServer(radio)._serve_capabilities(writer)  # noqa: SLF001
+        data = _parse_json_body(writer)
+        keys = ("audioTx", "audioTxRoute", "audioTxRequiredModInputSource")
+        assert tuple(data[key] for key in keys) == expected
 
 
 def _neutral_tx_radio(**changes: object) -> SimpleNamespace:
@@ -325,8 +327,8 @@ def test_browser_tx_audio_requires_caps_and_complete_neutral_transport():
         ({}, True),
         ({"start_tx": None}, False),
         ({"push_tx": None}, False),
+        ({"push_tx": lambda _data: None}, False),
         ({"stop_tx": None}, False),
-        ({"start_tx": None, "push_tx": None, "stop_tx": None}, False),
         ({"capabilities": {"audio"}}, False),
         ({"capabilities": {"tx"}}, False),
         ({"audio_tx_codec": None}, False),
@@ -334,24 +336,13 @@ def test_browser_tx_audio_requires_caps_and_complete_neutral_transport():
         ({"audio_tx_codec": AudioCodec.PCM_1CH_8BIT}, False),
         ({"audio_tx_codec": AudioCodec.OPUS_2CH}, False),
         ({"audio_session": SimpleNamespace(acquire_tx=None)}, False),
+        ({"audio_session": SimpleNamespace(acquire_tx=AsyncMock())}, True),
     )
     for changes, expected in cases:
         facts = browser_tx_audio_facts(_neutral_tx_radio(**changes))
-        assert (facts.available, facts.route) == (
-            (True, "usb") if expected else (False, None)
-        )
+        assert (facts.available, facts.route) == (expected, "usb" if expected else None)
         assert facts.required_mod_input_source is None
     assert browser_tx_audio_facts(None).available is False
-    session_radio = _neutral_tx_radio(
-        capabilities={"audio", "tx", "mod_input_routing"},
-        audio_session=SimpleNamespace(acquire_tx=AsyncMock()),
-    )
-    facts = browser_tx_audio_facts(session_radio)
-    assert (facts.available, facts.route, facts.required_mod_input_source) == (
-        True,
-        "usb",
-        None,
-    )
 
 
 def test_browser_tx_audio_accepts_only_complete_selected_legacy():
@@ -390,28 +381,31 @@ def test_browser_tx_audio_validates_route_source_policy(monkeypatch):
 
 def test_browser_tx_audio_route_and_policy_exceptions_fail_closed(monkeypatch):
     radio = _neutral_tx_radio(capabilities={"audio", "tx", "mod_input_routing"})
-    monkeypatch.setattr(
-        audio_module, "resolve_audio_route", Mock(side_effect=RuntimeError("route"))
-    )
+    resolve = Mock(side_effect=RuntimeError("route"))
+    monkeypatch.setattr(audio_module, "resolve_audio_route", resolve)
     assert browser_tx_audio_facts(radio).available is False
     route = SimpleNamespace(
-        tx_audio_source=TxAudioSource.LAN,
-        data_mode_policy=DataModePolicy.DATA2_LAN,
+        tx_audio_source=TxAudioSource.LAN, data_mode_policy=DataModePolicy.DATA2_LAN
     )
     monkeypatch.setattr(audio_module, "resolve_audio_route", lambda _: route)
-    monkeypatch.setattr(
-        audio_module, "rigctld_wsjtx_policy", Mock(side_effect=RuntimeError("policy"))
-    )
+    policy = Mock(side_effect=RuntimeError("policy"))
+    monkeypatch.setattr(audio_module, "rigctld_wsjtx_policy", policy)
     assert browser_tx_audio_facts(radio).available is False
 
 
 @pytest.mark.asyncio
-async def test_browser_tx_audio_denial_has_no_lifecycle_side_effects():
-    radio = _neutral_tx_radio(push_tx=None, stop_tx=None)
+async def test_browser_tx_audio_rejects_inherited_protocol_lifecycle_stubs():
+    radio, writer = _make_radio("FTX-1"), _FakeWriter()
+    radio.audio_tx_codec = AudioCodec.OPUS_1CH
+    await WebServer(radio)._serve_capabilities(writer)  # noqa: SLF001
+    assert _parse_json_body(writer)["audioTx"] is False
+
     handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
     await handler._handle_control({"type": "audio_start", "direction": "tx"})
-    assert (handler._tx_active, handler._tx_lease) == (False, None)
-    radio.start_tx.assert_not_awaited()
+    await handler._handle_tx_audio(b"\x02\x01\x00\x00payload")
+    await handler._stop_tx(reason="denied stub lifecycle")
+    assert not handler._tx_active
+    assert handler._tx_lease is handler._tx_facts is None
 
 
 @pytest.mark.asyncio
@@ -422,13 +416,11 @@ async def test_browser_tx_audio_denial_has_no_lifecycle_side_effects():
 async def test_browser_tx_audio_failed_start_or_transcoder_is_inactive(
     monkeypatch, failure: str, prior_active: bool
 ):
+    error = RuntimeError("start failed") if failure == "start" else None
+    codec = AudioCodec.OPUS_1CH if failure == "start" else AudioCodec.PCM_1CH_16BIT
     radio = _neutral_tx_radio(
-        start_tx=AsyncMock(
-            side_effect=RuntimeError("start failed") if failure == "start" else None
-        ),
-        audio_tx_codec=(
-            AudioCodec.OPUS_1CH if failure == "start" else AudioCodec.PCM_1CH_16BIT
-        ),
+        start_tx=AsyncMock(side_effect=error),
+        audio_tx_codec=codec,
     )
     handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
     handler._tx_active = prior_active
@@ -454,23 +446,20 @@ async def test_browser_tx_audio_uses_one_validated_codec_snapshot(monkeypatch):
     radio = _FlippingCodecRadio(**values, codec_reads=0)
     radio.capabilities.add("mod_input_routing")
     handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
-    transcoder = Mock()
     route = SimpleNamespace(
-        tx_audio_source=TxAudioSource.LAN,
-        data_mode_policy=DataModePolicy.DATA2_LAN,
+        tx_audio_source=TxAudioSource.LAN, data_mode_policy=DataModePolicy.DATA2_LAN
     )
     resolve, policy = Mock(return_value=route), Mock(return_value=(2, 5))
-    monkeypatch.setattr(audio_module, "resolve_audio_route", resolve)
-    monkeypatch.setattr(audio_module, "rigctld_wsjtx_policy", policy)
-    monkeypatch.setattr(
-        audio_module, "create_pcm_opus_transcoder", Mock(return_value=transcoder)
-    )
+    transcoder = Mock()
+    for name, value in (
+        ("resolve_audio_route", resolve),
+        ("rigctld_wsjtx_policy", policy),
+        ("create_pcm_opus_transcoder", Mock(return_value=transcoder)),
+    ):
+        monkeypatch.setattr(audio_module, name, value)
     await handler._handle_control({"type": "audio_start", "direction": "tx"})
-    assert (radio.codec_reads, handler._tx_active, handler._transcoder) == (
-        1,
-        True,
-        transcoder,
-    )
+    assert (radio.codec_reads, handler._tx_active) == (1, True)
+    assert handler._transcoder is transcoder
     radio.start_tx.assert_awaited_once_with()
     resolve.assert_called_once_with(radio)
     policy.assert_called_once_with(route)

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -12,6 +12,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from rigplane.audio.route import TxAudioSource
+from rigplane.types import AudioCodec
 from rigplane.web.handlers.audio import AudioHandler, browser_tx_audio_facts
 from rigplane.web.server import WebServer
 
@@ -309,19 +311,22 @@ class TestCapabilitiesEndpoint:
         ],
     )
     async def test_capabilities_browser_tx_audio_facts(self, model, expected):
+        radio = _make_radio(model)
         writer = _FakeWriter()
-        await WebServer(_make_radio(model))._serve_capabilities(writer)  # noqa: SLF001
+        await WebServer(radio)._serve_capabilities(writer)  # noqa: SLF001
         data = _parse_json_body(writer)
-        assert (
+        facts = browser_tx_audio_facts(radio)
+        actual = (
             data["audioTx"],
             data["audioTxRoute"],
             data["audioTxRequiredModInputSource"],
-        ) == expected
+        )
+        assert actual == (facts.available, facts.route, facts.required_mod_input_source)
+        assert actual == expected
 
 
-@pytest.mark.parametrize("missing", [None, "start_tx", "push_tx", "stop_tx"])
-def test_browser_tx_audio_requires_complete_neutral_transport(missing):
-    radio = SimpleNamespace(
+def _neutral_tx_radio(**changes: object) -> SimpleNamespace:
+    values: dict[str, object] = dict(
         capabilities={"audio", "tx"},
         backend_id="yaesu_cat",
         has_usb_audio=True,
@@ -329,6 +334,13 @@ def test_browser_tx_audio_requires_complete_neutral_transport(missing):
         push_tx=AsyncMock(),
         stop_tx=AsyncMock(),
     )
+    values.update(changes)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.parametrize("missing", [None, "start_tx", "push_tx", "stop_tx"])
+def test_browser_tx_audio_requires_complete_neutral_transport(missing):
+    radio = _neutral_tx_radio()
     if missing:
         setattr(radio, missing, None)
     facts = browser_tx_audio_facts(radio)
@@ -337,19 +349,67 @@ def test_browser_tx_audio_requires_complete_neutral_transport(missing):
     )
 
 
-@pytest.mark.asyncio
-async def test_browser_tx_audio_denial_has_no_lifecycle_side_effects():
+@pytest.mark.parametrize(
+    ("codec", "suffix"),
+    [(AudioCodec.PCM_1CH_16BIT, "pcm"), (AudioCodec.OPUS_1CH, "opus")],
+)
+def test_browser_tx_audio_accepts_complete_selected_legacy(codec, suffix):
     radio = SimpleNamespace(
         capabilities={"audio", "tx"},
         backend_id="yaesu_cat",
         has_usb_audio=True,
-        start_tx=AsyncMock(),
+        audio_codec=codec,
     )
+    for operation in ("start", "push", "stop"):
+        setattr(radio, f"{operation}_audio_tx_{suffix}", AsyncMock())
+    assert browser_tx_audio_facts(radio).available is True
+
+
+def test_browser_tx_audio_session_and_unknown_mod_source():
+    radio = _neutral_tx_radio(
+        capabilities={"audio", "tx", "mod_input_routing"},
+        audio_session=SimpleNamespace(acquire_tx=AsyncMock()),
+    )
+    facts = browser_tx_audio_facts(radio)
+    assert (facts.available, facts.required_mod_input_source) == (True, None)
+    radio.capabilities.remove("mod_input_routing")
+    assert browser_tx_audio_facts(radio).available is True
+    radio.audio_session.acquire_tx = None
+    assert browser_tx_audio_facts(radio).available is False
+
+
+def test_browser_tx_audio_route_exception_and_acc(monkeypatch):
+    radio = _neutral_tx_radio()
+    monkeypatch.setattr(
+        "rigplane.web.handlers.audio.resolve_audio_route",
+        lambda _radio: SimpleNamespace(tx_audio_source=TxAudioSource.ACC),
+    )
+    assert browser_tx_audio_facts(radio).route == "acc"
+    monkeypatch.setattr(
+        "rigplane.web.handlers.audio.resolve_audio_route",
+        lambda _radio: (_ for _ in ()).throw(RuntimeError("route failed")),
+    )
+    assert browser_tx_audio_facts(radio).available is False
+
+
+@pytest.mark.asyncio
+async def test_browser_tx_audio_denial_has_no_lifecycle_side_effects():
+    radio = _neutral_tx_radio(push_tx=None, stop_tx=None)
     handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
     await handler._handle_control({"type": "audio_start", "direction": "tx"})
-    assert handler._tx_active is False
-    assert handler._tx_lease is None
+    assert (handler._tx_active, handler._tx_lease) == (False, None)
     radio.start_tx.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_browser_tx_audio_failed_start_keeps_handler_inactive():
+    radio = _neutral_tx_radio(
+        start_tx=AsyncMock(side_effect=RuntimeError("start failed")),
+    )
+    handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
+    with pytest.raises(RuntimeError, match="start failed"):
+        await handler._handle_control({"type": "audio_start", "direction": "tx"})
+    assert handler._tx_active is False
 
 
 # ── /api/v1/state tests ───────────────────────────────────────

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import replace
 from types import SimpleNamespace
@@ -281,54 +282,25 @@ class TestCapabilitiesEndpoint:
         data = _parse_json_body(writer)
         assert data["antennas"] == 1
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("model", "suffix", "expected"),
-        [
-            ("IC-7610", "_audio_tx_pcm", (True, "lan", 5)),
-            ("FTX-1", "_tx", (True, "usb", None)),
-        ],
-    )
-    async def test_capabilities_browser_tx_audio_facts(
-        self, model: str, suffix: str, expected: tuple[bool, str, int | None]
-    ):
-        radio, writer = _make_radio(model), _FakeWriter()
-        radio.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
-        for operation in ("start", "push", "stop"):
-            setattr(radio, f"{operation}{suffix}", AsyncMock())
-        await WebServer(radio)._serve_capabilities(writer)  # noqa: SLF001
-        data = _parse_json_body(writer)
-        keys = ("audioTx", "audioTxRoute", "audioTxRequiredModInputSource")
-        assert tuple(data[key] for key in keys) == expected
-
 
 def _neutral_tx_radio(**changes: object) -> SimpleNamespace:
-    values: dict[str, object] = {
-        "capabilities": {"audio", "tx"},
-        "backend_id": "yaesu_cat",
-        "has_usb_audio": True,
-        "start_tx": AsyncMock(),
-        "push_tx": AsyncMock(),
-        "stop_tx": AsyncMock(),
-        "audio_tx_codec": AudioCodec.PCM_1CH_16BIT,
-    }
+    values = dict(
+        capabilities={"audio", "tx"},
+        backend_id="yaesu_cat",
+        has_usb_audio=True,
+        start_tx=AsyncMock(),
+        push_tx=AsyncMock(),
+        stop_tx=AsyncMock(),
+        audio_tx_codec=AudioCodec.PCM_1CH_16BIT,
+    )
     return SimpleNamespace(**(values | changes))
 
 
-class _FlippingCodecRadio(SimpleNamespace):
-    @property
-    def audio_tx_codec(self):
-        self.codec_reads += 1
-        return AudioCodec.PCM_1CH_16BIT if self.codec_reads == 1 else None
-
-
-def test_browser_tx_audio_requires_caps_and_complete_neutral_transport():
-    cases = (
+def test_browser_tx_audio_fact_validation(monkeypatch):
+    for changes, expected in (
         ({}, True),
         ({"start_tx": None}, False),
-        ({"push_tx": None}, False),
         ({"push_tx": lambda _data: None}, False),
-        ({"stop_tx": None}, False),
         ({"capabilities": {"audio"}}, False),
         ({"capabilities": {"tx"}}, False),
         ({"audio_tx_codec": None}, False),
@@ -337,15 +309,11 @@ def test_browser_tx_audio_requires_caps_and_complete_neutral_transport():
         ({"audio_tx_codec": AudioCodec.OPUS_2CH}, False),
         ({"audio_session": SimpleNamespace(acquire_tx=None)}, False),
         ({"audio_session": SimpleNamespace(acquire_tx=AsyncMock())}, True),
-    )
-    for changes, expected in cases:
+    ):
         facts = browser_tx_audio_facts(_neutral_tx_radio(**changes))
         assert (facts.available, facts.route) == (expected, "usb" if expected else None)
-        assert facts.required_mod_input_source is None
     assert browser_tx_audio_facts(None).available is False
 
-
-def test_browser_tx_audio_accepts_only_complete_selected_legacy():
     for codec, suffix in (
         (AudioCodec.PCM_1CH_16BIT, "pcm"),
         (AudioCodec.OPUS_1CH, "opus"),
@@ -360,8 +328,6 @@ def test_browser_tx_audio_accepts_only_complete_selected_legacy():
                 setattr(radio, f"{missing}_audio_tx_{suffix}", None)
             assert browser_tx_audio_facts(radio).available is (missing is None)
 
-
-def test_browser_tx_audio_validates_route_source_policy(monkeypatch):
     radio = _neutral_tx_radio()
     for source, policy, expected in (
         (TxAudioSource.ACC, DataModePolicy.LEGACY, "acc"),
@@ -378,22 +344,21 @@ def test_browser_tx_audio_validates_route_source_policy(monkeypatch):
         facts = browser_tx_audio_facts(radio)
         assert (facts.route if facts.available else None) == expected
 
-
-def test_browser_tx_audio_route_and_policy_exceptions_fail_closed(monkeypatch):
     radio = _neutral_tx_radio(capabilities={"audio", "tx", "mod_input_routing"})
-    resolve = Mock(side_effect=RuntimeError("route"))
-    monkeypatch.setattr(audio_module, "resolve_audio_route", resolve)
+    monkeypatch.setattr(
+        audio_module, "resolve_audio_route", Mock(side_effect=RuntimeError("route"))
+    )
     assert browser_tx_audio_facts(radio).available is False
     route = SimpleNamespace(
         tx_audio_source=TxAudioSource.LAN, data_mode_policy=DataModePolicy.DATA2_LAN
     )
     monkeypatch.setattr(audio_module, "resolve_audio_route", lambda _: route)
-    policy = Mock(side_effect=RuntimeError("policy"))
-    monkeypatch.setattr(audio_module, "rigctld_wsjtx_policy", policy)
+    monkeypatch.setattr(
+        audio_module, "rigctld_wsjtx_policy", Mock(side_effect=RuntimeError("policy"))
+    )
     assert browser_tx_audio_facts(radio).available is False
 
 
-@pytest.mark.asyncio
 async def test_browser_tx_audio_rejects_inherited_protocol_lifecycle_stubs():
     radio, writer = _make_radio("FTX-1"), _FakeWriter()
     radio.audio_tx_codec = AudioCodec.OPUS_1CH
@@ -404,51 +369,81 @@ async def test_browser_tx_audio_rejects_inherited_protocol_lifecycle_stubs():
     await handler._handle_control({"type": "audio_start", "direction": "tx"})
     await handler._handle_tx_audio(b"\x02\x01\x00\x00payload")
     await handler._stop_tx(reason="denied stub lifecycle")
-    assert not handler._tx_active
-    assert handler._tx_lease is handler._tx_facts is None
+    assert not handler._tx_active and handler._tx_lease is handler._tx_facts is None
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("failure", "prior_active"),
-    [("start", True), ("factory", False), ("factory", True)],
-)
-async def test_browser_tx_audio_failed_start_or_transcoder_is_inactive(
-    monkeypatch, failure: str, prior_active: bool
-):
-    error = RuntimeError("start failed") if failure == "start" else None
-    codec = AudioCodec.OPUS_1CH if failure == "start" else AudioCodec.PCM_1CH_16BIT
-    radio = _neutral_tx_radio(
-        start_tx=AsyncMock(side_effect=error),
-        audio_tx_codec=codec,
-    )
+@pytest.mark.parametrize("failure", ["facts", "start", "cancel"])
+async def test_browser_tx_audio_failed_rearm_dekeys_once(failure: str):
+    radio = _neutral_tx_radio(audio_tx_codec=AudioCodec.OPUS_1CH)
     handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
-    handler._tx_active = prior_active
-    if failure == "factory":
-        monkeypatch.setattr(
-            audio_module,
-            "create_pcm_opus_transcoder",
-            Mock(side_effect=RuntimeError("factory failed")),
-        )
-    with pytest.raises(RuntimeError, match=f"{failure} failed"):
-        await handler._handle_control({"type": "audio_start", "direction": "tx"})
-    assert (handler._tx_active, handler._tx_lease) == (False, None)
-    if failure == "factory":
-        assert handler._transcoder is None
-        assert radio.start_tx.await_count == 0
-        assert radio.stop_tx.await_count == int(prior_active)
+    start = {"type": "audio_start", "direction": "tx"}
+    await handler._handle_control(start)
+    assert handler._tx_active
+
+    if failure == "facts":
+        radio.capabilities = {"audio"}
+        await handler._handle_control(start)
+    elif failure == "start":
+        radio.start_tx = AsyncMock(side_effect=RuntimeError("start failed"))
+        with pytest.raises(RuntimeError, match="start failed"):
+            await handler._handle_control(start)
+    else:
+        entered = asyncio.Event()
+
+        async def _cancelled_start() -> None:
+            entered.set()
+            await asyncio.Event().wait()
+
+        radio.start_tx = AsyncMock(side_effect=_cancelled_start)
+        task = asyncio.create_task(handler._handle_control(start))
+        await entered.wait()
+        task.cancel()
+        result = await asyncio.gather(task, return_exceptions=True)
+        assert isinstance(result[0], asyncio.CancelledError)
+    assert not handler._tx_active and handler._tx_lease is handler._tx_facts is None
+    radio.stop_tx.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+async def test_browser_tx_audio_transcoder_error_keeps_reader_alive(
+    monkeypatch,
+):
+    radio = _neutral_tx_radio(audio_tx_codec=AudioCodec.OPUS_1CH)
+    ws = SimpleNamespace(send_text=AsyncMock())
+    handler = AudioHandler(ws, radio)
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+    radio.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+    monkeypatch.setattr(
+        audio_module,
+        "create_pcm_opus_transcoder",
+        Mock(side_effect=RuntimeError("factory failed")),
+    )
+    text = audio_module.WS_OP_TEXT
+    start = (text, b'{"type":"audio_start","direction":"tx"}')
+    stats = (text, b'{"type":"audio_stats","rtt":1}')
+    ws.recv = AsyncMock(side_effect=[start, stats, EOFError()])
+    await handler._reader_loop()
+    assert ws.recv.await_count == 3
+    assert not handler._tx_active and handler._tx_lease is handler._tx_facts is None
+    assert (radio.start_tx.await_count, radio.stop_tx.await_count) == (1, 1)
+    error = json.loads(ws.send_text.await_args.args[0])
+    assert error["type"] == "error" and "transcoder unavailable" in error["message"]
+
+
+class _FlippingCodecRadio(SimpleNamespace):
+    @property
+    def audio_tx_codec(self):
+        self.codec_reads += 1
+        return AudioCodec.PCM_1CH_16BIT if self.codec_reads == 1 else None
+
+
 async def test_browser_tx_audio_uses_one_validated_codec_snapshot(monkeypatch):
     values = _neutral_tx_radio().__dict__.copy()
     values.pop("audio_tx_codec")
     radio = _FlippingCodecRadio(**values, codec_reads=0)
     radio.capabilities.add("mod_input_routing")
     handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
-    route = SimpleNamespace(
-        tx_audio_source=TxAudioSource.LAN, data_mode_policy=DataModePolicy.DATA2_LAN
-    )
+    route = SimpleNamespace(tx_audio_source=TxAudioSource.LAN)
+    route.data_mode_policy = DataModePolicy.DATA2_LAN
     resolve, policy = Mock(return_value=route), Mock(return_value=(2, 5))
     transcoder = Mock()
     for name, value in (
@@ -460,9 +455,7 @@ async def test_browser_tx_audio_uses_one_validated_codec_snapshot(monkeypatch):
     await handler._handle_control({"type": "audio_start", "direction": "tx"})
     assert (radio.codec_reads, handler._tx_active) == (1, True)
     assert handler._transcoder is transcoder
-    radio.start_tx.assert_awaited_once_with()
-    resolve.assert_called_once_with(radio)
-    policy.assert_called_once_with(route)
+    assert {radio.start_tx.await_count, resolve.call_count, policy.call_count} == {1}
 
 
 class TestStateEndpoint:

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -177,9 +177,6 @@ class TestCapabilitiesEndpoint:
         assert isinstance(data["tx"], bool)
         assert isinstance(data["audioTx"], bool)
         assert data["audioTxRoute"] in {"lan", "usb", "acc", None}
-        assert data["audioTxRequiredModInputSource"] is None or isinstance(
-            data["audioTxRequiredModInputSource"], int
-        )
         assert isinstance(data["freqRanges"], list)
         assert isinstance(data["modes"], list)
         assert isinstance(data["filters"], list)
@@ -303,66 +300,64 @@ class TestCapabilitiesEndpoint:
         assert data["antennas"] == 1
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("model", "expected"),
-        [
-            ("IC-7610", (True, "lan", 5)),
-            ("FTX-1", (True, "usb", None)),
-        ],
-    )
-    async def test_capabilities_browser_tx_audio_facts(self, model, expected):
-        radio = _make_radio(model)
-        writer = _FakeWriter()
-        await WebServer(radio)._serve_capabilities(writer)  # noqa: SLF001
-        data = _parse_json_body(writer)
-        facts = browser_tx_audio_facts(radio)
-        actual = (
-            data["audioTx"],
-            data["audioTxRoute"],
-            data["audioTxRequiredModInputSource"],
-        )
-        assert actual == (facts.available, facts.route, facts.required_mod_input_source)
-        assert actual == expected
+    async def test_capabilities_browser_tx_audio_facts(self):
+        cases = (("IC-7610", (True, "lan", 5)), ("FTX-1", (True, "usb", None)))
+        for model, expected in cases:
+            radio, writer = _make_radio(model), _FakeWriter()
+            await WebServer(radio)._serve_capabilities(writer)  # noqa: SLF001
+            data, facts = _parse_json_body(writer), browser_tx_audio_facts(radio)
+            keys = ("audioTx", "audioTxRoute", "audioTxRequiredModInputSource")
+            assert (
+                tuple(data[key] for key in keys)
+                == (facts.available, facts.route, facts.required_mod_input_source)
+                == expected
+            )
 
 
 def _neutral_tx_radio(**changes: object) -> SimpleNamespace:
-    values: dict[str, object] = dict(
-        capabilities={"audio", "tx"},
-        backend_id="yaesu_cat",
-        has_usb_audio=True,
-        start_tx=AsyncMock(),
-        push_tx=AsyncMock(),
-        stop_tx=AsyncMock(),
+    values: dict[str, object] = {
+        "capabilities": {"audio", "tx"},
+        "backend_id": "yaesu_cat",
+        "has_usb_audio": True,
+        "start_tx": AsyncMock(),
+        "push_tx": AsyncMock(),
+        "stop_tx": AsyncMock(),
+    }
+    return SimpleNamespace(**(values | changes))
+
+
+def test_browser_tx_audio_requires_caps_and_complete_neutral_transport():
+    cases = (
+        ({}, True),
+        ({"start_tx": None}, False),
+        ({"push_tx": None}, False),
+        ({"stop_tx": None}, False),
+        ({"start_tx": None, "push_tx": None, "stop_tx": None}, False),
+        ({"capabilities": {"audio"}}, False),
+        ({"capabilities": {"tx"}}, False),
     )
-    values.update(changes)
-    return SimpleNamespace(**values)
+    for changes, expected in cases:
+        facts = browser_tx_audio_facts(_neutral_tx_radio(**changes))
+        assert (facts.available, facts.route) == (
+            (True, "usb") if expected else (False, None)
+        )
+    assert browser_tx_audio_facts(None).available is False
 
 
-@pytest.mark.parametrize("missing", [None, "start_tx", "push_tx", "stop_tx"])
-def test_browser_tx_audio_requires_complete_neutral_transport(missing):
-    radio = _neutral_tx_radio()
-    if missing:
-        setattr(radio, missing, None)
-    facts = browser_tx_audio_facts(radio)
-    assert (facts.available, facts.route) == (
-        (True, "usb") if missing is None else (False, None)
-    )
-
-
-@pytest.mark.parametrize(
-    ("codec", "suffix"),
-    [(AudioCodec.PCM_1CH_16BIT, "pcm"), (AudioCodec.OPUS_1CH, "opus")],
-)
-def test_browser_tx_audio_accepts_complete_selected_legacy(codec, suffix):
-    radio = SimpleNamespace(
-        capabilities={"audio", "tx"},
-        backend_id="yaesu_cat",
-        has_usb_audio=True,
-        audio_codec=codec,
-    )
-    for operation in ("start", "push", "stop"):
-        setattr(radio, f"{operation}_audio_tx_{suffix}", AsyncMock())
-    assert browser_tx_audio_facts(radio).available is True
+def test_browser_tx_audio_accepts_only_complete_selected_legacy():
+    for codec, suffix in (
+        (AudioCodec.PCM_1CH_16BIT, "pcm"),
+        (AudioCodec.OPUS_1CH, "opus"),
+    ):
+        for missing in (None, "start", "push", "stop"):
+            radio = _neutral_tx_radio(
+                start_tx=None, push_tx=None, stop_tx=None, audio_codec=codec
+            )
+            for operation in ("start", "push", "stop"):
+                setattr(radio, f"{operation}_audio_tx_{suffix}", AsyncMock())
+            if missing:
+                setattr(radio, f"{missing}_audio_tx_{suffix}", None)
+            assert browser_tx_audio_facts(radio).available is (missing is None)
 
 
 def test_browser_tx_audio_session_and_unknown_mod_source():
@@ -372,19 +367,22 @@ def test_browser_tx_audio_session_and_unknown_mod_source():
     )
     facts = browser_tx_audio_facts(radio)
     assert (facts.available, facts.required_mod_input_source) == (True, None)
-    radio.capabilities.remove("mod_input_routing")
-    assert browser_tx_audio_facts(radio).available is True
     radio.audio_session.acquire_tx = None
     assert browser_tx_audio_facts(radio).available is False
 
 
 def test_browser_tx_audio_route_exception_and_acc(monkeypatch):
     radio = _neutral_tx_radio()
-    monkeypatch.setattr(
-        "rigplane.web.handlers.audio.resolve_audio_route",
-        lambda _radio: SimpleNamespace(tx_audio_source=TxAudioSource.ACC),
-    )
-    assert browser_tx_audio_facts(radio).route == "acc"
+    for source, expected in (
+        (TxAudioSource.ACC, "acc"),
+        (TxAudioSource.UNAVAILABLE, None),
+    ):
+        monkeypatch.setattr(
+            "rigplane.web.handlers.audio.resolve_audio_route",
+            lambda _radio, source=source: SimpleNamespace(tx_audio_source=source),
+        )
+        facts = browser_tx_audio_facts(radio)
+        assert (facts.route if facts.available else None) == expected
     monkeypatch.setattr(
         "rigplane.web.handlers.audio.resolve_audio_route",
         lambda _radio: (_ for _ in ()).throw(RuntimeError("route failed")),
@@ -407,6 +405,7 @@ async def test_browser_tx_audio_failed_start_keeps_handler_inactive():
         start_tx=AsyncMock(side_effect=RuntimeError("start failed")),
     )
     handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
+    handler._tx_active = True
     with pytest.raises(RuntimeError, match="start failed"):
         await handler._handle_control({"type": "audio_start", "direction": "tx"})
     assert handler._tx_active is False

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -313,6 +313,13 @@ def _neutral_tx_radio(**changes: object) -> SimpleNamespace:
     return SimpleNamespace(**(values | changes))
 
 
+class _FlippingCodecRadio(SimpleNamespace):
+    @property
+    def audio_tx_codec(self):
+        self.codec_reads += 1
+        return AudioCodec.PCM_1CH_16BIT if self.codec_reads == 1 else None
+
+
 def test_browser_tx_audio_requires_caps_and_complete_neutral_transport():
     cases = (
         ({}, True),
@@ -438,6 +445,35 @@ async def test_browser_tx_audio_failed_start_or_transcoder_is_inactive(
         assert handler._transcoder is None
         assert radio.start_tx.await_count == 0
         assert radio.stop_tx.await_count == int(prior_active)
+
+
+@pytest.mark.asyncio
+async def test_browser_tx_audio_uses_one_validated_codec_snapshot(monkeypatch):
+    values = _neutral_tx_radio().__dict__.copy()
+    values.pop("audio_tx_codec")
+    radio = _FlippingCodecRadio(**values, codec_reads=0)
+    radio.capabilities.add("mod_input_routing")
+    handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
+    transcoder = Mock()
+    route = SimpleNamespace(
+        tx_audio_source=TxAudioSource.LAN,
+        data_mode_policy=DataModePolicy.DATA2_LAN,
+    )
+    resolve, policy = Mock(return_value=route), Mock(return_value=(2, 5))
+    monkeypatch.setattr(audio_module, "resolve_audio_route", resolve)
+    monkeypatch.setattr(audio_module, "rigctld_wsjtx_policy", policy)
+    monkeypatch.setattr(
+        audio_module, "create_pcm_opus_transcoder", Mock(return_value=transcoder)
+    )
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+    assert (radio.codec_reads, handler._tx_active, handler._transcoder) == (
+        1,
+        True,
+        transcoder,
+    )
+    radio.start_tx.assert_awaited_once_with()
+    resolve.assert_called_once_with(radio)
+    policy.assert_called_once_with(route)
 
 
 class TestStateEndpoint:

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -7,9 +7,12 @@ from __future__ import annotations
 
 import json
 from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
+from rigplane.web.handlers.audio import AudioHandler, browser_tx_audio_facts
 from rigplane.web.server import WebServer
 
 
@@ -53,6 +56,7 @@ def _make_radio(model: str = "IC-7610", caps: set[str] | None = None):
 
     radio = _FakeRadio()
     radio.model = model
+    radio.backend_id = "rigplane" if model == "IC-7610" else "yaesu_cat"
     radio.connected = True
     radio.control_connected = False
     radio.radio_ready = True
@@ -169,6 +173,11 @@ class TestCapabilitiesEndpoint:
         assert isinstance(data["scope"], bool)
         assert isinstance(data["audio"], bool)
         assert isinstance(data["tx"], bool)
+        assert isinstance(data["audioTx"], bool)
+        assert data["audioTxRoute"] in {"lan", "usb", "acc", None}
+        assert data["audioTxRequiredModInputSource"] is None or isinstance(
+            data["audioTxRequiredModInputSource"], int
+        )
         assert isinstance(data["freqRanges"], list)
         assert isinstance(data["modes"], list)
         assert isinstance(data["filters"], list)
@@ -290,6 +299,57 @@ class TestCapabilitiesEndpoint:
         await srv._serve_capabilities(writer)  # noqa: SLF001
         data = _parse_json_body(writer)
         assert data["antennas"] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("IC-7610", (True, "lan", 5)),
+            ("FTX-1", (True, "usb", None)),
+        ],
+    )
+    async def test_capabilities_browser_tx_audio_facts(self, model, expected):
+        writer = _FakeWriter()
+        await WebServer(_make_radio(model))._serve_capabilities(writer)  # noqa: SLF001
+        data = _parse_json_body(writer)
+        assert (
+            data["audioTx"],
+            data["audioTxRoute"],
+            data["audioTxRequiredModInputSource"],
+        ) == expected
+
+
+@pytest.mark.parametrize("missing", [None, "start_tx", "push_tx", "stop_tx"])
+def test_browser_tx_audio_requires_complete_neutral_transport(missing):
+    radio = SimpleNamespace(
+        capabilities={"audio", "tx"},
+        backend_id="yaesu_cat",
+        has_usb_audio=True,
+        start_tx=AsyncMock(),
+        push_tx=AsyncMock(),
+        stop_tx=AsyncMock(),
+    )
+    if missing:
+        setattr(radio, missing, None)
+    facts = browser_tx_audio_facts(radio)
+    assert (facts.available, facts.route) == (
+        (True, "usb") if missing is None else (False, None)
+    )
+
+
+@pytest.mark.asyncio
+async def test_browser_tx_audio_denial_has_no_lifecycle_side_effects():
+    radio = SimpleNamespace(
+        capabilities={"audio", "tx"},
+        backend_id="yaesu_cat",
+        has_usb_audio=True,
+        start_tx=AsyncMock(),
+    )
+    handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+    assert handler._tx_active is False
+    assert handler._tx_lease is None
+    radio.start_tx.assert_not_awaited()
 
 
 # ── /api/v1/state tests ───────────────────────────────────────

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -1,26 +1,22 @@
-"""Web UI capability guards — verify API responses adapt to rig profile.
-
-TDD: these tests were written FIRST, then the backend was modified to pass them.
-"""
+"""Web UI capability guards for rig-profile-adaptive API responses."""
 
 from __future__ import annotations
 
 import json
 from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from rigplane.audio.route import TxAudioSource
+from rigplane.audio.route import DataModePolicy, TxAudioSource
 from rigplane.types import AudioCodec
+from rigplane.web.handlers import audio as audio_module
 from rigplane.web.handlers.audio import AudioHandler, browser_tx_audio_facts
 from rigplane.web.server import WebServer
 
 
 class _FakeWriter:
-    """Minimal asyncio.StreamWriter stand-in that captures bytes."""
-
     def __init__(self) -> None:
         self.buffer = bytearray()
 
@@ -43,11 +39,7 @@ def _parse_json_body(writer: _FakeWriter) -> dict:
     return json.loads(text[body_start:])
 
 
-# ── Helpers: fake radios with profiles ──────────────────────────
-
-
 def _make_radio(model: str = "IC-7610", caps: set[str] | None = None):
-    """Build a fake radio with a real RadioProfile resolved by model name."""
     from rigplane.profiles import resolve_radio_profile
     from rigplane.radio_protocol import AudioCapable, DualReceiverCapable, ScopeCapable
 
@@ -67,12 +59,7 @@ def _make_radio(model: str = "IC-7610", caps: set[str] | None = None):
     return radio
 
 
-# ── /api/v1/info tests ─────────────────────────────────────────
-
-
 class TestInfoEndpoint:
-    """Verify /api/v1/info includes rig-specific metadata."""
-
     @pytest.mark.asyncio
     async def test_info_includes_receivers_for_dual(self):
         radio = _make_radio("IC-7610")
@@ -137,12 +124,7 @@ class TestInfoEndpoint:
         assert "dual_rx" not in data["capabilities"]["tags"]
 
 
-# ── /api/v1/capabilities tests ─────────────────────────────────
-
-
 class TestCapabilitiesEndpoint:
-    """Verify /api/v1/capabilities includes rig-specific metadata."""
-
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("model", "receivers", "vfo_scheme"),
@@ -304,6 +286,10 @@ class TestCapabilitiesEndpoint:
         cases = (("IC-7610", (True, "lan", 5)), ("FTX-1", (True, "usb", None)))
         for model, expected in cases:
             radio, writer = _make_radio(model), _FakeWriter()
+            radio.audio_tx_codec = AudioCodec.PCM_1CH_16BIT
+            suffix = "_audio_tx_pcm" if model == "IC-7610" else "_tx"
+            for operation in ("start", "push", "stop"):
+                setattr(radio, f"{operation}{suffix}", AsyncMock())
             await WebServer(radio)._serve_capabilities(writer)  # noqa: SLF001
             data, facts = _parse_json_body(writer), browser_tx_audio_facts(radio)
             keys = ("audioTx", "audioTxRoute", "audioTxRequiredModInputSource")
@@ -322,6 +308,7 @@ def _neutral_tx_radio(**changes: object) -> SimpleNamespace:
         "start_tx": AsyncMock(),
         "push_tx": AsyncMock(),
         "stop_tx": AsyncMock(),
+        "audio_tx_codec": AudioCodec.PCM_1CH_16BIT,
     }
     return SimpleNamespace(**(values | changes))
 
@@ -335,13 +322,29 @@ def test_browser_tx_audio_requires_caps_and_complete_neutral_transport():
         ({"start_tx": None, "push_tx": None, "stop_tx": None}, False),
         ({"capabilities": {"audio"}}, False),
         ({"capabilities": {"tx"}}, False),
+        ({"audio_tx_codec": None}, False),
+        ({"audio_tx_codec": "invalid"}, False),
+        ({"audio_tx_codec": AudioCodec.PCM_1CH_8BIT}, False),
+        ({"audio_tx_codec": AudioCodec.OPUS_2CH}, False),
+        ({"audio_session": SimpleNamespace(acquire_tx=None)}, False),
     )
     for changes, expected in cases:
         facts = browser_tx_audio_facts(_neutral_tx_radio(**changes))
         assert (facts.available, facts.route) == (
             (True, "usb") if expected else (False, None)
         )
+        assert facts.required_mod_input_source is None
     assert browser_tx_audio_facts(None).available is False
+    session_radio = _neutral_tx_radio(
+        capabilities={"audio", "tx", "mod_input_routing"},
+        audio_session=SimpleNamespace(acquire_tx=AsyncMock()),
+    )
+    facts = browser_tx_audio_facts(session_radio)
+    assert (facts.available, facts.route, facts.required_mod_input_source) == (
+        True,
+        "usb",
+        None,
+    )
 
 
 def test_browser_tx_audio_accepts_only_complete_selected_legacy():
@@ -351,7 +354,7 @@ def test_browser_tx_audio_accepts_only_complete_selected_legacy():
     ):
         for missing in (None, "start", "push", "stop"):
             radio = _neutral_tx_radio(
-                start_tx=None, push_tx=None, stop_tx=None, audio_codec=codec
+                start_tx=None, push_tx=None, stop_tx=None, audio_tx_codec=codec
             )
             for operation in ("start", "push", "stop"):
                 setattr(radio, f"{operation}_audio_tx_{suffix}", AsyncMock())
@@ -360,32 +363,37 @@ def test_browser_tx_audio_accepts_only_complete_selected_legacy():
             assert browser_tx_audio_facts(radio).available is (missing is None)
 
 
-def test_browser_tx_audio_session_and_unknown_mod_source():
-    radio = _neutral_tx_radio(
-        capabilities={"audio", "tx", "mod_input_routing"},
-        audio_session=SimpleNamespace(acquire_tx=AsyncMock()),
-    )
-    facts = browser_tx_audio_facts(radio)
-    assert (facts.available, facts.required_mod_input_source) == (True, None)
-    radio.audio_session.acquire_tx = None
-    assert browser_tx_audio_facts(radio).available is False
-
-
-def test_browser_tx_audio_route_exception_and_acc(monkeypatch):
+def test_browser_tx_audio_validates_route_source_policy(monkeypatch):
     radio = _neutral_tx_radio()
-    for source, expected in (
-        (TxAudioSource.ACC, "acc"),
-        (TxAudioSource.UNAVAILABLE, None),
+    for source, policy, expected in (
+        (TxAudioSource.ACC, DataModePolicy.LEGACY, "acc"),
+        (TxAudioSource.UNAVAILABLE, DataModePolicy.LEGACY, None),
+        (TxAudioSource.USB, DataModePolicy.DATA2_LAN, None),
+        (TxAudioSource.LAN, DataModePolicy.DATA1_USB, None),
+        ("usb", DataModePolicy.DATA1_USB, None),
+        (TxAudioSource.USB, "data1_usb", None),
     ):
+        route = SimpleNamespace(tx_audio_source=source, data_mode_policy=policy)
         monkeypatch.setattr(
-            "rigplane.web.handlers.audio.resolve_audio_route",
-            lambda _radio, source=source: SimpleNamespace(tx_audio_source=source),
+            audio_module, "resolve_audio_route", lambda _radio, route=route: route
         )
         facts = browser_tx_audio_facts(radio)
         assert (facts.route if facts.available else None) == expected
+
+
+def test_browser_tx_audio_route_and_policy_exceptions_fail_closed(monkeypatch):
+    radio = _neutral_tx_radio(capabilities={"audio", "tx", "mod_input_routing"})
     monkeypatch.setattr(
-        "rigplane.web.handlers.audio.resolve_audio_route",
-        lambda _radio: (_ for _ in ()).throw(RuntimeError("route failed")),
+        audio_module, "resolve_audio_route", Mock(side_effect=RuntimeError("route"))
+    )
+    assert browser_tx_audio_facts(radio).available is False
+    route = SimpleNamespace(
+        tx_audio_source=TxAudioSource.LAN,
+        data_mode_policy=DataModePolicy.DATA2_LAN,
+    )
+    monkeypatch.setattr(audio_module, "resolve_audio_route", lambda _: route)
+    monkeypatch.setattr(
+        audio_module, "rigctld_wsjtx_policy", Mock(side_effect=RuntimeError("policy"))
     )
     assert browser_tx_audio_facts(radio).available is False
 
@@ -400,23 +408,39 @@ async def test_browser_tx_audio_denial_has_no_lifecycle_side_effects():
 
 
 @pytest.mark.asyncio
-async def test_browser_tx_audio_failed_start_keeps_handler_inactive():
+@pytest.mark.parametrize(
+    ("failure", "prior_active"),
+    [("start", True), ("factory", False), ("factory", True)],
+)
+async def test_browser_tx_audio_failed_start_or_transcoder_is_inactive(
+    monkeypatch, failure: str, prior_active: bool
+):
     radio = _neutral_tx_radio(
-        start_tx=AsyncMock(side_effect=RuntimeError("start failed")),
+        start_tx=AsyncMock(
+            side_effect=RuntimeError("start failed") if failure == "start" else None
+        ),
+        audio_tx_codec=(
+            AudioCodec.OPUS_1CH if failure == "start" else AudioCodec.PCM_1CH_16BIT
+        ),
     )
     handler = AudioHandler(SimpleNamespace(send_text=AsyncMock()), radio)
-    handler._tx_active = True
-    with pytest.raises(RuntimeError, match="start failed"):
+    handler._tx_active = prior_active
+    if failure == "factory":
+        monkeypatch.setattr(
+            audio_module,
+            "create_pcm_opus_transcoder",
+            Mock(side_effect=RuntimeError("factory failed")),
+        )
+    with pytest.raises(RuntimeError, match=f"{failure} failed"):
         await handler._handle_control({"type": "audio_start", "direction": "tx"})
-    assert handler._tx_active is False
-
-
-# ── /api/v1/state tests ───────────────────────────────────────
+    assert (handler._tx_active, handler._tx_lease) == (False, None)
+    if failure == "factory":
+        assert handler._transcoder is None
+        assert radio.start_tx.await_count == 0
+        assert radio.stop_tx.await_count == int(prior_active)
 
 
 class TestStateEndpoint:
-    """Verify /api/v1/state adapts to receiver count."""
-
     @pytest.mark.asyncio
     async def test_state_dual_receiver_includes_sub(self):
         radio = _make_radio("IC-7610")


### PR DESCRIPTION
Closes #1958
Linear: MOR-1050

## Summary

- compute one frozen `BrowserTxAudioFacts` admission snapshot containing the public capability tuple plus the validated codec, selected path, and concrete lifecycle callables
- serialize only its public fields as `audioTx`, `audioTxRoute`, and `audioTxRequiredModInputSource`
- use that exact snapshot for transcoder preparation, session/direct start, frame push, stop, and active codec routing without re-reading mutable codec/route/path authority
- keep `_tx_active` false across denial and failed/retried starts; set it true only after successful transcoder preparation and lease/start

## Helper contract

`audioTx=true` requires canonical runtime `audio` + `tx`, exactly `PCM_1CH_16BIT` or `OPUS_1CH`, one complete callable shared-session/neutral/codec-selected legacy path, and a coherent resolved `lan|usb|acc` ingress route. Missing, partial, contradictory, marker-only, unavailable, unsupported, changing, or throwing evidence returns `false/null/null` or is handled using the single validated snapshot. Unknown required MOD source remains null without weakening downstream controller fail-closed policy.

Current provider facts:

- IC-7610: `true / lan / 5`
- FTX-1: `true / usb / null`

## Scope

- exactly 3 approved files
- +402 / -202, net +200 LOC against the PR base
- no frontend, profile/model guessing, TxTarget, or fixture-workaround changes

## Verification

- corrected focused capability/handler/route/session/server matrix: 383 passed, 2 skipped
- stateful codec/route/policy snapshot regression and prior adversarial cases: 8 passed
- full non-integration: 8,407 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed, plus one local libopus-availability smoke failure; exact-head CI is authoritative
- Ruff check + format: passed
- strict web mypy: passed
- import-linter: 5 contracts kept
- `git diff --check`: passed
