### PR TITLE
MOR-1112: invalidate Yaesu TX target across CAT generations

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -105,7 +105,7 @@ class YaesuCatPoller:
         self._last_ptt = bool(getattr(radio.radio_state, "ptt", False))
         self._tx_target_generation = self._current_tx_target_generation()
         self._tx_target_invalidated_generation: tuple[str | None, int] | None = None
-        self._tx_target_ever_known = False
+        self._tx_target_known_generation: tuple[str | None, int] | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -189,6 +189,9 @@ class YaesuCatPoller:
         callback = self._observation_callback
         profile = self._tx_target_profile()
         generation = self._current_tx_target_generation()
+        known = self._tx_target_known_generation == self._tx_target_generation
+        if generation != self._tx_target_generation:
+            self._tx_target_known_generation = None
         self._tx_target_generation = generation
         if (
             callback is None
@@ -201,18 +204,18 @@ class YaesuCatPoller:
             source="yaesu_poll_response",
             transport="serial",
         )
-        callback(
-            (
-                adapter.observation(
-                    _TX_TARGET_PATH,
-                    UnknownTxTarget(
-                        reason="stale" if self._tx_target_ever_known else "not-observed"
-                    ),
-                    native_id="connection_generation",
-                ),
-            )
+        observations = (
+            adapter.observation(
+                _TX_TARGET_PATH,
+                UnknownTxTarget(reason="stale" if known else "not-observed"),
+                native_id="connection_generation",
+            ),
         )
         self._tx_target_invalidated_generation = generation
+        try:
+            callback(observations)
+        except (Exception, asyncio.CancelledError):
+            logger.warning("YaesuCatPoller: TX target callback failed", exc_info=True)
 
     def _sync_tx_target_generation(self) -> tuple[str | None, int]:
         generation = self._current_tx_target_generation()
@@ -244,7 +247,7 @@ class YaesuCatPoller:
             elif observation.path == _TX_TARGET_PATH:
                 self._tx_target_invalidated_generation = None
                 if isinstance(observation.value, KnownTxTarget):
-                    self._tx_target_ever_known = True
+                    self._tx_target_known_generation = generation
         self._observation_callback(observations)
         return True
 
@@ -302,9 +305,11 @@ class YaesuCatPoller:
         except Exception:
             logger.error("YaesuCatPoller: reconnect failed", exc_info=True)
         finally:
-            self._tx_target_generation = self._current_tx_target_generation()
-            if self._tx_target_profile() is not None:
-                self._tx_target_invalidated_generation = self._tx_target_generation
+            generation = self._current_tx_target_generation()
+            if generation != self._tx_target_generation:
+                self._tx_target_known_generation = None
+                self._tx_target_invalidated_generation = None
+            self._tx_target_generation = generation
             self._reconnecting = False
 
     async def _run_poll_cycle(

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -26,8 +26,14 @@ import logging
 from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
+from rigplane.core.observation_adapter import ProviderObservationAdapter
+from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
+from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
+
 from ...exceptions import ConnectionError as RadioConnectionError
 from ...radio_state import YaesuStateExtension
+from .transport import CatTransportError
 
 if TYPE_CHECKING:
     from ..._poller_types import CommandQueue
@@ -43,6 +49,7 @@ _FAST_INTERVAL: float = 0.075  # 13.3 Hz
 _MEDIUM_INTERVAL: float = 0.200  # 5 Hz
 _SLOW_INTERVAL: float = 1.000  # 1 Hz
 _EMA_ALPHA: float = 0.3
+_TX_TARGET_PATH = FieldPath.global_("tx_state", "tx_target")
 
 
 class YaesuCatPoller:
@@ -96,6 +103,9 @@ class YaesuCatPoller:
         self._ema_s_main: float | None = None
         self._ema_s_sub: float | None = None
         self._last_ptt = bool(getattr(radio.radio_state, "ptt", False))
+        self._tx_target_generation = self._current_tx_target_generation()
+        self._tx_target_invalidated_generation: tuple[str | None, int] | None = None
+        self._tx_target_ever_known = False
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -159,17 +169,84 @@ class YaesuCatPoller:
         if self._callback is not None and self._observation_callback is None:
             self._callback(self._radio.radio_state)
 
+    def _tx_target_profile(self) -> RadioAcquisitionProfile | None:
+        profile = getattr(
+            getattr(self._radio, "profile", None), "state_acquisition", None
+        )
+        if not isinstance(profile, RadioAcquisitionProfile):
+            return None
+        return profile if profile.capability_for(_TX_TARGET_PATH).can_poll else None
+
+    def _current_tx_target_generation(self) -> tuple[str | None, int]:
+        profile = self._tx_target_profile()
+        stats = getattr(getattr(self._radio, "_transport", None), "stats", None)
+        reconnects = getattr(stats, "reconnects", 0)
+        if not isinstance(reconnects, int) or isinstance(reconnects, bool):
+            reconnects = 0
+        return (None if profile is None else profile.provider, reconnects)
+
+    def _invalidate_tx_target(self) -> None:
+        callback = self._observation_callback
+        profile = self._tx_target_profile()
+        generation = self._current_tx_target_generation()
+        self._tx_target_generation = generation
+        if (
+            callback is None
+            or profile is None
+            or self._tx_target_invalidated_generation == generation
+        ):
+            return
+        adapter = ProviderObservationAdapter(
+            profile=profile,
+            source="yaesu_poll_response",
+            transport="serial",
+        )
+        callback(
+            (
+                adapter.observation(
+                    _TX_TARGET_PATH,
+                    UnknownTxTarget(
+                        reason="stale"
+                        if self._tx_target_ever_known
+                        else "not-observed"
+                    ),
+                    native_id="connection_generation",
+                ),
+            )
+        )
+        self._tx_target_invalidated_generation = generation
+
+    def _sync_tx_target_generation(self) -> tuple[str | None, int]:
+        generation = self._current_tx_target_generation()
+        if generation != self._tx_target_generation:
+            self._invalidate_tx_target()
+        return generation
+
     async def _emit_medium_observations(self) -> bool:
         if self._observation_callback is None:
             return False
         from .observations import YAESU_PTT_PATH, YaesuObservationAdapter
 
-        observations = await YaesuObservationAdapter.from_radio(
-            self._radio
-        ).poll_medium()
+        generation = self._sync_tx_target_generation()
+        try:
+            observations = await YaesuObservationAdapter.from_radio(
+                self._radio
+            ).poll_medium()
+        except (RadioConnectionError, ConnectionError, OSError, CatTransportError):
+            self._invalidate_tx_target()
+            raise
+        if self._current_tx_target_generation() != generation:
+            observations = tuple(
+                item for item in observations if item.path != _TX_TARGET_PATH
+            )
+            self._invalidate_tx_target()
         for observation in observations:
             if observation.path == YAESU_PTT_PATH:
                 self._last_ptt = bool(observation.value)
+            elif observation.path == _TX_TARGET_PATH:
+                self._tx_target_invalidated_generation = None
+                if isinstance(observation.value, KnownTxTarget):
+                    self._tx_target_ever_known = True
         self._observation_callback(observations)
         return True
 
@@ -221,11 +298,15 @@ class YaesuCatPoller:
         self._reconnecting = True
         try:
             logger.warning("YaesuCatPoller: triggering auto-reconnect")
+            self._invalidate_tx_target()
             await transport.reconnect()
             logger.info("YaesuCatPoller: reconnected successfully")
         except Exception:
             logger.error("YaesuCatPoller: reconnect failed", exc_info=True)
         finally:
+            self._tx_target_generation = self._current_tx_target_generation()
+            if self._tx_target_profile() is not None:
+                self._tx_target_invalidated_generation = self._tx_target_generation
             self._reconnecting = False
 
     async def _run_poll_cycle(
@@ -244,6 +325,7 @@ class YaesuCatPoller:
                 continue
             try:
                 async with self._lock:
+                    self._sync_tx_target_generation()
                     await coro_fn()
                 _conn_backoff = 0.0  # reset on success
             except asyncio.CancelledError:

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -206,9 +206,7 @@ class YaesuCatPoller:
                 adapter.observation(
                     _TX_TARGET_PATH,
                     UnknownTxTarget(
-                        reason="stale"
-                        if self._tx_target_ever_known
-                        else "not-observed"
+                        reason="stale" if self._tx_target_ever_known else "not-observed"
                     ),
                     native_id="connection_generation",
                 ),

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -4,15 +4,23 @@ from __future__ import annotations
 
 import ast
 import asyncio
+from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
+from rigplane.core.observation_adapter import ProviderObservationAdapter
+from rigplane.core.state_acquisition_policy import (
+    FieldCapability,
+    RadioAcquisitionProfile,
+)
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation
-from rigplane.core.tx_target import KnownTxTarget
+from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
 from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
+from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
+from rigplane.backends.yaesu_cat.transport import CatTimeoutError
 from rigplane.profiles import get_radio_profile
 from rigplane.radio_state import RadioState
 from rigplane.web.radio_poller import CommandQueue, SetFreq
@@ -387,6 +395,36 @@ def _profile_state_acquisition() -> RadioAcquisitionProfile:
     return profile.state_acquisition
 
 
+def _tx_target_radio() -> MagicMock:
+    radio = make_radio()
+    profile = _profile_state_acquisition()
+    target_path = FieldPath.global_("tx_state", "tx_target")
+    radio.profile.state_acquisition = replace(
+        profile,
+        capabilities=profile.capabilities
+        + (FieldCapability(path=target_path, polling=True),),
+    )
+    radio._transport = SimpleNamespace(
+        stats=SimpleNamespace(reconnects=0),
+        reconnect=AsyncMock(),
+        _maybe_reconnect_needed=lambda: False,
+    )
+    return radio
+
+
+def _target_observation(
+    radio: MagicMock, value: KnownTxTarget | UnknownTxTarget
+) -> Observation:
+    profile = radio.profile.state_acquisition
+    return ProviderObservationAdapter(
+        profile, source="yaesu_poll_response", transport="serial"
+    ).observation(
+        FieldPath.global_("tx_state", "tx_target"),
+        value,
+        native_id="read_tx_target",
+    )
+
+
 def _state_write_target(node: ast.AST) -> str | None:
     parts: list[str] = []
     current = node
@@ -622,6 +660,79 @@ async def test_medium_poll_emits_observations_without_legacy_state_callback() ->
         ("receiver.main.active.freq_mode.filter_width", 2400),
     ]
     assert {item.source.source for item in observations} == {"yaesu_poll_response"}
+
+
+@pytest.mark.asyncio
+async def test_medium_transport_error_invalidates_tx_target_before_reraise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = _tx_target_radio()
+    emitted: list[Observation] = []
+
+    async def fail_poll(_adapter: YaesuObservationAdapter) -> tuple[Observation, ...]:
+        raise CatTimeoutError("link reset")
+
+    monkeypatch.setattr(YaesuObservationAdapter, "poll_medium", fail_poll)
+    poller = YaesuCatPoller(radio, observation_callback=emitted.extend)
+
+    with pytest.raises(CatTimeoutError, match="link reset"):
+        await poller._poll_medium()  # noqa: SLF001
+
+    assert [item.value for item in emitted] == [
+        UnknownTxTarget(reason="not-observed")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_late_tx_target_from_old_connection_generation_is_discarded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = _tx_target_radio()
+    emitted: list[Observation] = []
+    known = KnownTxTarget(receiver="MAIN", slot=None, frequency_hz=14_074_000)
+    calls = 0
+
+    async def poll_target(
+        _adapter: YaesuObservationAdapter,
+    ) -> tuple[Observation, ...]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            radio._transport.stats.reconnects += 1
+        return (_target_observation(radio, known),)
+
+    monkeypatch.setattr(YaesuObservationAdapter, "poll_medium", poll_target)
+    poller = YaesuCatPoller(radio, observation_callback=emitted.extend)
+
+    await poller._poll_medium()  # noqa: SLF001
+    assert [item.value for item in emitted] == [
+        UnknownTxTarget(reason="not-observed")
+    ]
+
+    await poller._poll_medium()  # noqa: SLF001
+    assert emitted[-1].value == known
+
+
+@pytest.mark.asyncio
+async def test_unsupported_tx_target_does_not_trigger_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = _tx_target_radio()
+    unsupported = UnknownTxTarget(reason="unsupported")
+    emitted: list[Observation] = []
+
+    async def poll_target(
+        _adapter: YaesuObservationAdapter,
+    ) -> tuple[Observation, ...]:
+        return (_target_observation(radio, unsupported),)
+
+    monkeypatch.setattr(YaesuObservationAdapter, "poll_medium", poll_target)
+    poller = YaesuCatPoller(radio, observation_callback=emitted.extend)
+
+    await poller._poll_medium()  # noqa: SLF001
+
+    assert emitted[-1].value == unsupported
+    radio._transport.reconnect.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -662,73 +662,79 @@ async def test_medium_poll_emits_observations_without_legacy_state_callback() ->
     assert {item.source.source for item in observations} == {"yaesu_poll_response"}
 
 
-@pytest.mark.asyncio
-async def test_medium_transport_error_invalidates_tx_target_before_reraise(
+@pytest.mark.parametrize("operation", ["poll", "reconnect"])
+@pytest.mark.parametrize("callback_error", [RuntimeError, asyncio.CancelledError])
+async def test_invalidation_callback_failure_preserves_transport_flow(
     monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    callback_error: type[BaseException],
 ) -> None:
     radio = _tx_target_radio()
+    callback = MagicMock(side_effect=callback_error("consumer failed"))
+    poller = YaesuCatPoller(radio, observation_callback=callback)
+    if operation == "poll":
+        monkeypatch.setattr(
+            YaesuObservationAdapter,
+            "poll_medium",
+            AsyncMock(side_effect=[CatTimeoutError("cat reset")] * 2),
+        )
+        for _ in range(2):
+            with pytest.raises(CatTimeoutError, match="cat reset"):
+                await poller._poll_medium()  # noqa: SLF001
+        assert callback.call_count == 1
+    else:
+        radio._transport._maybe_reconnect_needed = lambda: True
+        await poller._try_reconnect()  # noqa: SLF001
+        radio._transport.reconnect.assert_awaited_once()
+    callback.assert_called_once()
+
+
+@pytest.mark.parametrize("boundary", ["reconnect", "provider"])
+async def test_tx_target_known_state_is_generation_scoped(
+    monkeypatch: pytest.MonkeyPatch, boundary: str
+) -> None:
+    radio = _tx_target_radio()
+    known = KnownTxTarget(receiver="MAIN", slot=None, frequency_hz=14_074_000)
     emitted: list[Observation] = []
-
-    async def fail_poll(_adapter: YaesuObservationAdapter) -> tuple[Observation, ...]:
-        raise CatTimeoutError("link reset")
-
-    monkeypatch.setattr(YaesuObservationAdapter, "poll_medium", fail_poll)
+    monkeypatch.setattr(
+        YaesuObservationAdapter,
+        "poll_medium",
+        AsyncMock(side_effect=[(_target_observation(radio, known),), (), ()]),
+    )
     poller = YaesuCatPoller(radio, observation_callback=emitted.extend)
 
-    with pytest.raises(CatTimeoutError, match="link reset"):
+    await poller._poll_medium()  # noqa: SLF001
+    for generation in (1, 2):
+        if boundary == "reconnect":
+            radio._transport.stats.reconnects = generation
+        else:
+            radio.profile.state_acquisition = replace(
+                radio.profile.state_acquisition, provider=f"yaesu_cat_{generation}"
+            )
         await poller._poll_medium()  # noqa: SLF001
 
-    assert [item.value for item in emitted] == [UnknownTxTarget(reason="not-observed")]
-
-
-@pytest.mark.asyncio
-async def test_late_tx_target_from_old_connection_generation_is_discarded(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    radio = _tx_target_radio()
-    emitted: list[Observation] = []
-    known = KnownTxTarget(receiver="MAIN", slot=None, frequency_hz=14_074_000)
-    calls = 0
-
-    async def poll_target(
-        _adapter: YaesuObservationAdapter,
-    ) -> tuple[Observation, ...]:
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            radio._transport.stats.reconnects += 1
-        return (_target_observation(radio, known),)
-
-    monkeypatch.setattr(YaesuObservationAdapter, "poll_medium", poll_target)
-    poller = YaesuCatPoller(radio, observation_callback=emitted.extend)
-
-    await poller._poll_medium()  # noqa: SLF001
-    assert [item.value for item in emitted] == [UnknownTxTarget(reason="not-observed")]
-
-    await poller._poll_medium()  # noqa: SLF001
-    assert emitted[-1].value == known
-
-
-@pytest.mark.asyncio
-async def test_unsupported_tx_target_does_not_trigger_reconnect(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    radio = _tx_target_radio()
+    assert [item.value for item in emitted] == [
+        known,
+        UnknownTxTarget(reason="stale"),
+        UnknownTxTarget(reason="not-observed"),
+    ]
     unsupported = UnknownTxTarget(reason="unsupported")
-    emitted: list[Observation] = []
-
-    async def poll_target(
-        _adapter: YaesuObservationAdapter,
-    ) -> tuple[Observation, ...]:
-        return (_target_observation(radio, unsupported),)
-
-    monkeypatch.setattr(YaesuObservationAdapter, "poll_medium", poll_target)
-    poller = YaesuCatPoller(radio, observation_callback=emitted.extend)
-
+    monkeypatch.setattr(
+        YaesuObservationAdapter,
+        "poll_medium",
+        AsyncMock(return_value=(_target_observation(radio, unsupported),)),
+    )
     await poller._poll_medium()  # noqa: SLF001
-
     assert emitted[-1].value == unsupported
     radio._transport.reconnect.assert_not_awaited()
+
+    async def late(_adapter: YaesuObservationAdapter) -> tuple[Observation, ...]:
+        radio._transport.stats.reconnects += 1
+        return (_target_observation(radio, known),)
+
+    monkeypatch.setattr(YaesuObservationAdapter, "poll_medium", late)
+    await poller._poll_medium()  # noqa: SLF001
+    assert emitted[-1].value == UnknownTxTarget(reason="not-observed")
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -678,9 +678,7 @@ async def test_medium_transport_error_invalidates_tx_target_before_reraise(
     with pytest.raises(CatTimeoutError, match="link reset"):
         await poller._poll_medium()  # noqa: SLF001
 
-    assert [item.value for item in emitted] == [
-        UnknownTxTarget(reason="not-observed")
-    ]
+    assert [item.value for item in emitted] == [UnknownTxTarget(reason="not-observed")]
 
 
 @pytest.mark.asyncio
@@ -705,9 +703,7 @@ async def test_late_tx_target_from_old_connection_generation_is_discarded(
     poller = YaesuCatPoller(radio, observation_callback=emitted.extend)
 
     await poller._poll_medium()  # noqa: SLF001
-    assert [item.value for item in emitted] == [
-        UnknownTxTarget(reason="not-observed")
-    ]
+    assert [item.value for item in emitted] == [UnknownTxTarget(reason="not-observed")]
 
     await poller._poll_medium()  # noqa: SLF001
     assert emitted[-1].value == known


### PR DESCRIPTION
## Summary

- gate TX-target generation tracking on the profile capability
- isolate invalidation callback failures so the original CAT transport exception remains observable and reconnect is always attempted
- scope known-target evidence to the current provider/reconnect generation
- discard late target observations from an old generation
- preserve `unsupported` as a normal non-transport observation without reconnecting

Fixes #1975
Linear: MOR-1112

## Verification

- focused poller/adapter/profile/loader matrix: `229 passed`
- full non-integration suite: `8337 passed, 73 skipped, 5 deselected, 11 xfailed, 1 xpassed`
- `uv run pytest -q tests/test_yaesu_cat_poller.py`: `45 passed`
- Ruff lint and format check: pass
- strict changed-source mypy: pass
- import-linter: 5 contracts kept
- `git diff --check`: pass

## Scope

- exact 2 files
- 203 additions / 5 deletions = 198 net LOC
- no producer, web, frontend, schema, or audio changes

This PR remains Draft pending independent re-review of head `c5dc156dd348c54035448227b7296f13fa04e507`.
