### PR TITLE
MOR-1114: require TxTarget in generated frontend contract

### DIFF
--- a/frontend/src/lib/types/state.ts
+++ b/frontend/src/lib/types/state.ts
@@ -77,7 +77,7 @@ export interface ServerStatePublic {
     [k: string]: number;
   }[];
   scopeControls?: ScopeControlsPublic;
-  txTarget?: KnownTxTargetPublic | UnknownTxTargetPublic;
+  txTarget: KnownTxTargetPublic | UnknownTxTargetPublic;
   main: ReceiverStatePublic;
   sub?: ReceiverStatePublic | null;
   connection: ConnectionPublic;

--- a/scripts/gen_state_types.py
+++ b/scripts/gen_state_types.py
@@ -93,6 +93,7 @@ _REQUIRED_BY_MODEL: dict[str, set[str]] = {
         "split",
         "dualWatch",
         "tunerStatus",
+        "txTarget",
         "main",
         "connection",
     },

--- a/tests/test_state_type_codegen.py
+++ b/tests/test_state_type_codegen.py
@@ -1,0 +1,103 @@
+"""Focused contract tests for generated public-state TypeScript."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_FRONTEND = _ROOT / "frontend"
+_STATE_TYPES = _FRONTEND / "src/lib/types/state.ts"
+_TSC = _FRONTEND / "node_modules/.bin/tsc"
+_JSON2TS = _FRONTEND / "node_modules/.bin/json2ts"
+
+
+def test_generated_server_state_requires_tx_target() -> None:
+    generated = _STATE_TYPES.read_text()
+
+    assert "txTarget: KnownTxTargetPublic | UnknownTxTargetPublic;" in generated
+    assert "txTarget?: KnownTxTargetPublic | UnknownTxTargetPublic;" not in generated
+
+
+@pytest.mark.skipif(not _TSC.exists(), reason="frontend dev dependencies not installed")
+def test_required_tx_target_union_narrows_without_undefined_guard() -> None:
+    source = """
+import type { ServerStatePublic } from "./src/lib/types/state";
+
+type MissingTxTarget = Omit<ServerStatePublic, "txTarget">;
+declare const missing: MissingTxTarget;
+// @ts-expect-error txTarget is required by the generated server contract.
+const rejected: ServerStatePublic = missing;
+void rejected;
+
+declare const state: ServerStatePublic;
+if (state.txTarget.status === "known") {
+  const receiver: "MAIN" | "SUB" = state.txTarget.receiver;
+  void receiver;
+} else {
+  const reason: "not-observed" | "stale" | "unsupported" | "contradiction" =
+    state.txTarget.reason;
+  void reason;
+}
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".ts",
+        prefix=".mor1114-",
+        dir=_FRONTEND,
+        delete=False,
+    ) as handle:
+        handle.write(source)
+        fixture = Path(handle.name)
+    try:
+        result = subprocess.run(
+            [
+                str(_TSC),
+                "--strict",
+                "--noEmit",
+                "--skipLibCheck",
+                "--moduleResolution",
+                "bundler",
+                "--module",
+                "esnext",
+                "--target",
+                "es2022",
+                str(fixture),
+            ],
+            cwd=_FRONTEND,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        fixture.unlink(missing_ok=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(
+    not _JSON2TS.exists(), reason="frontend dev dependencies not installed"
+)
+def test_state_type_generation_is_deterministic_and_current() -> None:
+    command = [sys.executable, "scripts/gen_state_types.py"]
+    first = subprocess.run(
+        [*command, "--stdout"],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    second = subprocess.run(
+        [*command, "--stdout"],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    assert first == second
+    subprocess.run([*command, "--check"], cwd=_ROOT, check=True)


### PR DESCRIPTION
## Summary

- add `txTarget` to the explicit `ServerStatePublic` requiredness policy
- regenerate the TypeScript contract so `txTarget` is required without changing the known/unknown union
- add durable generated-text, strict-TypeScript narrowing, missing-field, and deterministic-codegen proofs
- rebase onto current `main` after prerequisite fixture PRs #1988 and #1989 merged

Closes #1982
Linear: MOR-1114

## Scope

- exactly 3 owned files
- +105/-1, net +104 LOC
- no backend schema, runtime, provider, selector, fixture, component, capability, split, or selected-RX changes

## Verification

- generator `--check` twice — pass
- `npm run check` — 0 errors, 0 warnings
- `npm run lint` and `npm run build` — pass
- affected frontend tests — 144 passed
- full frontend tests — 2,286 passed (local Node 25 run with `NODE_OPTIONS=--no-experimental-webstorage`; CI uses Node 20)
- relevant backend/codegen tests — 68 passed
- full non-integration backend suite — 8,637 selected, 112 deselected, exit 0
- Ruff check/format, strict web mypy, import-linter, and `git diff --check` — pass

## State

Prerequisite fixture work is merged and this branch is rebased and fully reverified at exact head `972357da0454c6c2dc4f737cb2eb37ade0369ea3`.

This PR intentionally remains Draft pending independent review.