### PR TITLE
MOR-1116: declare TxTarget in store and HTTP fixtures

### DIFF
--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -10,6 +10,10 @@ type ServerStateWithObservation = ServerState & {
 function makeState(overrides: Partial<ServerStateWithObservation> = {}): ServerStateWithObservation {
   const revision = overrides.stateRevision ?? overrides.revision ?? 1;
   const freshnessRevision = overrides.freshnessRevision ?? 1;
+  const {
+    txTarget = { status: 'unknown', reason: 'not-observed' },
+    ...stateOverrides
+  } = overrides;
   return {
     revision,
     stateRevision: revision,
@@ -132,7 +136,8 @@ function makeState(overrides: Partial<ServerStateWithObservation> = {}): ServerS
       rbw: 0,
       fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
     },
-    ...overrides,
+    txTarget,
+    ...stateOverrides,
   };
 }
 

--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -21,6 +21,7 @@ function makeState(revision: number): ServerStateWithObservation {
     split: false,
     dualWatch: false,
     tunerStatus: 0,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
     main: {
       freqHz: 14074000,
       mode: 'USB',


### PR DESCRIPTION
## Summary

- make the radio-store fixture normalize an omitted or `undefined` override to canonical `unknown/not-observed`
- make the HTTP state fixture declare the same explicit fail-closed target
- preserve existing fixture overrides and all original assertions

Closes #1983
Linear: MOR-1116
Blocks: #1982 / #1985

## Scope

- exactly 2 approved test files
- +7/-1, net +6 LOC
- no production, generated, generator, runtime, provider, selector, or component changes

## Verification

- focused store + HTTP Vitest: 103 passed
- current-main `npm run check`: 0 errors / 0 warnings
- focused ESLint: pass
- frontend production build: pass
- overlay proof against #1985 required generated contract: the original 4 fixture errors reduce to only the 2 MOR-1117 WebSocket fixtures; neither owned file errors
- diff/scope check: pass

A full local Vitest run under the host Node version reports 37 unrelated pre-existing `localStorage` environment failures in i18n/Toast/mod-input tests; the two owned suites pass and CI is authoritative for the Node 20 full run.