### PR TITLE
MOR-1117: declare TxTarget in WebSocket fixtures

### DIFF
--- a/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
@@ -100,7 +100,7 @@ function makeState(
     connection?: Partial<ServerState['connection']>;
   } = {},
 ): ServerStateWithObservation {
-  const { main, sub, connection, ...topLevel } = overrides;
+  const { main, sub, connection, txTarget, ...topLevel } = overrides;
   const revision = topLevel.stateRevision ?? topLevel.revision ?? 1;
   return {
     revision,
@@ -124,6 +124,7 @@ function makeState(
       ...connection,
     },
     ...topLevel,
+    txTarget: txTarget ?? { status: 'unknown', reason: 'not-observed' },
   };
 }
 

--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -172,7 +172,7 @@ function makeState(
     connection?: Partial<ServerState['connection']>;
   } = {},
 ): ServerStateWithObservation {
-  const { main, sub, connection, ...topLevel } = overrides;
+  const { main, sub, connection, txTarget, ...topLevel } = overrides;
   const revision = topLevel.stateRevision ?? topLevel.revision ?? 1;
   return {
     revision,
@@ -196,6 +196,7 @@ function makeState(
       ...connection,
     },
     ...topLevel,
+    txTarget: txTarget ?? { status: 'unknown', reason: 'not-observed' },
   };
 }
 


### PR DESCRIPTION
## Summary

- make both WebSocket `ServerStateWithObservation` builders destructure `txTarget` explicitly
- default missing or undefined overrides to canonical fail-closed `{ status: 'unknown', reason: 'not-observed' }`
- preserve canonical test-specific target overrides after the remaining top-level spread

Closes #1984
Linear: MOR-1117

## Why

MOR-1114 / #1985 makes generated `ServerStatePublic.txTarget` required. These two builders previously left it inside a `Partial` spread, so strict type-checking correctly inferred `txTarget | undefined`.

## Verification

Current `main`:

- frontend check: 0 errors, 0 warnings
- full frontend lint: pass
- focused WebSocket tests: 2 files, 41 tests passed
- `git diff --check`: pass

Stacked validation:

- exact #1985 generated-requiredness head `cb0fa018`
- sibling #1988 fixture prerequisite head `c54c3d55`
- this branch
- frontend check: 0 errors, 0 warnings
- four affected fixture suites: 4 files, 144 tests passed

## Scope

- exact 2 approved test files
- 4 additions / 2 deletions = 2 net LOC
- no production, generated, generator, provider, selector, or component changes

This PR remains Draft pending independent review.
