### PR TITLE
Model App-owned resource demand and lease identity

### DIFF
--- a/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
+++ b/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { ResourceDemand } from '../resource-demand';
-type Resource = 'hardware-scope' | 'audio-fft' | 'rx-audio'; const ready = (m: ResourceDemand<string>, r: Resource) => m.configure(r, { selected: true, available: true });
+
+type Resource = 'hardware-scope' | 'audio-fft' | 'rx-audio';
+
+const ready = (m: ResourceDemand<string>, r: Resource) => {
+  m.configure(r, { selected: true, available: true });
+};
+
 const one = (m: ResourceDemand<string>) => {
-  const ops = m.takeOperations(); expect(ops).toHaveLength(1);
+  const ops = m.takeOperations();
+  expect(ops).toHaveLength(1);
   return ops[0];
 };
+
 describe('ResourceDemand', () => {
   it('uses exact unique leases and emits only first start and last stop', () => {
     const m = new ResourceDemand<string>('s1');
@@ -20,7 +28,41 @@ describe('ResourceDemand', () => {
     expect(m.release({ ...b } as typeof b)).toBe(false);
     expect(m.release(b)).toBe(true);
     expect(one(m)).toMatchObject({ kind: 'stop', handle: 'scope' });
-    expect(m.release(b)).toBe(false); expect(new ResourceDemand<string>('s2').release(b)).toBe(false);
+    expect(m.release(b)).toBe(false);
+    expect(new ResourceDemand<string>('s2').release(b)).toBe(false);
+  });
+  it('treats a replayed successful start completion as inert', () => {
+    const m = new ResourceDemand<string>('s1');
+    ready(m, 'hardware-scope');
+    m.acquire('hardware-scope', 'scope');
+    const start = one(m);
+
+    expect(m.completeStart(start, { handle: 'LIVE' })).toBe(true);
+    expect(m.completeStart(start, { handle: 'LIVE' })).toBe(false);
+    expect(m.takeOperations()).toEqual([]);
+    expect(m.snapshot('hardware-scope')).toMatchObject({
+      activeHandle: 'LIVE',
+      health: 'streaming',
+    });
+  });
+  it('does not dispose a stable handle returned by stale and current A→B→A starts', () => {
+    const m = new ResourceDemand<string>('s1');
+    ready(m, 'hardware-scope');
+    const a = m.acquire('hardware-scope', 'A');
+    const startA = one(m);
+    m.release(a);
+    expect(m.takeOperations()).toEqual([]);
+
+    const b = m.acquire('hardware-scope', 'B');
+    const startB = one(m);
+    expect(m.completeStart(startA, { handle: 'STABLE' })).toBe(false);
+    expect(m.takeOperations()).toEqual([]);
+    expect(m.completeStart(startB, { handle: 'STABLE' })).toBe(true);
+    expect(m.takeOperations()).toEqual([]);
+    expect(m.snapshot('hardware-scope').activeHandle).toBe('STABLE');
+
+    expect(m.release(b)).toBe(true);
+    expect(one(m)).toMatchObject({ kind: 'stop', handle: 'STABLE' });
   });
   it('keeps unavailable and failed selection honest until explicit retry', () => {
     const m = new ResourceDemand<string>('s1');
@@ -36,6 +78,32 @@ describe('ResourceDemand', () => {
     ready(m, 'hardware-scope');
     expect(m.takeOperations()).toEqual([]);
     m.retry('hardware-scope');
+    expect(one(m).kind).toBe('start');
+  });
+  it('copies only public configuration fields from wider caller objects', () => {
+    const m = new ResourceDemand<string>('s1');
+    const widerConfig = {
+      selected: true,
+      available: true,
+      demand: 99,
+      health: 'streaming',
+      activeHandle: 'ghost',
+      generation: 99,
+      pending: { kind: 'start' },
+    };
+
+    m.configure('audio-fft', widerConfig);
+    const snapshot = m.snapshot('audio-fft');
+    expect(snapshot).toMatchObject({
+      selected: true,
+      available: true,
+      demand: 0,
+      health: 'inactive',
+      generation: 0,
+    });
+    expect(snapshot.activeHandle).toBeUndefined();
+    expect(snapshot.pending).toBeUndefined();
+    m.acquire('audio-fft', 'real consumer');
     expect(one(m).kind).toBe('start');
   });
   it('disposes a pending start whose demand vanished', () => {
@@ -63,7 +131,9 @@ describe('ResourceDemand', () => {
   it('tears down each active handle once and invalidates all old work', () => {
     const m = new ResourceDemand<string>('s1');
     for (const r of ['hardware-scope', 'rx-audio'] as const) {
-      ready(m, r); m.acquire(r, r); m.completeStart(one(m), { handle: r });
+      ready(m, r);
+      m.acquire(r, r);
+      m.completeStart(one(m), { handle: r });
     }
     ready(m, 'audio-fft');
     const pendingLease = m.acquire('audio-fft', 'pending');

--- a/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
+++ b/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { ResourceDemand } from '../resource-demand';
+type Resource = 'hardware-scope' | 'audio-fft' | 'rx-audio'; const ready = (m: ResourceDemand<string>, r: Resource) => m.configure(r, { selected: true, available: true });
+const one = (m: ResourceDemand<string>) => {
+  const ops = m.takeOperations(); expect(ops).toHaveLength(1);
+  return ops[0];
+};
+describe('ResourceDemand', () => {
+  it('uses exact unique leases and emits only first start and last stop', () => {
+    const m = new ResourceDemand<string>('s1');
+    ready(m, 'hardware-scope');
+    const a = m.acquire('hardware-scope', 'old');
+    const start = one(m);
+    const b = m.acquire('hardware-scope', 'new');
+    expect(b.leaseId).not.toBe(a.leaseId);
+    expect(m.takeOperations()).toEqual([]);
+    expect(m.completeStart(start, { handle: 'scope' })).toBe(true);
+    expect(m.release(a)).toBe(true);
+    expect(m.takeOperations()).toEqual([]);
+    expect(m.release({ ...b } as typeof b)).toBe(false);
+    expect(m.release(b)).toBe(true);
+    expect(one(m)).toMatchObject({ kind: 'stop', handle: 'scope' });
+    expect(m.release(b)).toBe(false); expect(new ResourceDemand<string>('s2').release(b)).toBe(false);
+  });
+  it('keeps unavailable and failed selection honest until explicit retry', () => {
+    const m = new ResourceDemand<string>('s1');
+    m.configure('hardware-scope', { selected: true, available: false });
+    m.acquire('hardware-scope', 'scope');
+    expect(m.takeOperations()).toEqual([]);
+    ready(m, 'hardware-scope');
+    m.completeStart(one(m), { error: 'offline' });
+    expect(m.snapshot('hardware-scope')).toMatchObject(
+      { selected: true, available: true, health: 'failed' },
+    );
+    expect(m.snapshot('audio-fft').demand).toBe(0);
+    ready(m, 'hardware-scope');
+    expect(m.takeOperations()).toEqual([]);
+    m.retry('hardware-scope');
+    expect(one(m).kind).toBe('start');
+  });
+  it('disposes a pending start whose demand vanished', () => {
+    const m = new ResourceDemand<string>('s1');
+    ready(m, 'audio-fft');
+    const lease = m.acquire('audio-fft', 'panel');
+    const start = one(m);
+    m.release(lease);
+    expect(m.completeStart(start, { handle: 'late' })).toBe(false);
+    expect(one(m)).toMatchObject({ kind: 'dispose', handle: 'late' });
+    expect(m.snapshot('audio-fft').activeHandle).toBeUndefined();
+  });
+  it('rejects stale stop completion across A→B→A', () => {
+    const m = new ResourceDemand<string>('s1');
+    ready(m, 'rx-audio');
+    const a = m.acquire('rx-audio', 'A');
+    m.completeStart(one(m), { handle: 'A' });
+    m.release(a);
+    const oldStop = one(m);
+    m.acquire('rx-audio', 'B');
+    m.completeStart(one(m), { handle: 'B' });
+    expect(m.completeStop(oldStop)).toBe(false);
+    expect(m.snapshot('rx-audio')).toMatchObject({ activeHandle: 'B', health: 'streaming' });
+  });
+  it('tears down each active handle once and invalidates all old work', () => {
+    const m = new ResourceDemand<string>('s1');
+    for (const r of ['hardware-scope', 'rx-audio'] as const) {
+      ready(m, r); m.acquire(r, r); m.completeStart(one(m), { handle: r });
+    }
+    ready(m, 'audio-fft');
+    const pendingLease = m.acquire('audio-fft', 'pending');
+    const pendingStart = one(m);
+    expect(m.teardown()).toMatchObject([{ handle: 'hardware-scope' }, { handle: 'rx-audio' }]);
+    expect(m.teardown()).toEqual([]);
+    expect(m.release(pendingLease)).toBe(false);
+    expect(() => m.acquire('rx-audio', 'late')).toThrow('torn down');
+    expect(m.completeStart(pendingStart, { handle: 'late' })).toBe(false);
+    expect(one(m)).toMatchObject({ kind: 'dispose', handle: 'late' });
+  });
+});

--- a/frontend/src/lib/runtime/resource-demand.ts
+++ b/frontend/src/lib/runtime/resource-demand.ts
@@ -1,0 +1,122 @@
+export type AppResource = 'hardware-scope' | 'audio-fft' | 'rx-audio';
+export type ResourceHealth = 'inactive' | 'starting' | 'streaming' | 'failed';
+declare const leaseBrand: unique symbol;
+export interface ResourceLease {
+  readonly resource: AppResource; readonly sessionEpoch: string; readonly leaseId: number; readonly [leaseBrand]: never;
+}
+export type ResourceOperation<H> =
+  | { kind: 'start'; resource: AppResource; sessionEpoch: string; generation: number }
+  | { kind: 'stop' | 'dispose'; resource: AppResource; sessionEpoch: string; generation: number; handle: H };
+interface State<H> {
+  available: boolean; selected: boolean; demand: number; generation: number;
+  health: ResourceHealth; activeHandle?: H; pending?: ResourceOperation<H>;
+}
+/** Pure App-session demand model; callers execute the returned operations. */
+export class ResourceDemand<H> {
+  private readonly states = new Map<AppResource, State<H>>();
+  private readonly leases = new Set<ResourceLease>();
+  private operations: ResourceOperation<H>[] = []; private nextLeaseId = 0; private ended = false;
+  constructor(readonly sessionEpoch: string) {}
+  configure(resource: AppResource, config: { available: boolean; selected: boolean }): void {
+    const state = this.state(resource), newlySelected = !state.selected && config.selected;
+    Object.assign(state, config);
+    if (newlySelected && state.health === 'failed') state.health = 'inactive';
+    this.reconcile(resource, state);
+  }
+  acquire(resource: AppResource, consumer: string): ResourceLease {
+    if (this.ended) throw new Error('resource demand session is torn down');
+    void consumer; // Diagnostic only; never lease identity.
+    const lease = Object.freeze({
+      resource, sessionEpoch: this.sessionEpoch, leaseId: ++this.nextLeaseId,
+    }) as ResourceLease;
+    this.leases.add(lease); const state = this.state(resource);
+    state.demand++;
+    this.reconcile(resource, state);
+    return lease;
+  }
+  release(lease: ResourceLease): boolean {
+    if (this.ended || !this.leases.delete(lease)) return false;
+    const state = this.state(lease.resource); state.demand--;
+    this.reconcile(lease.resource, state);
+    return true;
+  }
+  retry(resource: AppResource): void {
+    const state = this.state(resource);
+    if (state.health === 'failed') {
+      state.health = 'inactive';
+      this.reconcile(resource, state);
+    }
+  }
+  takeOperations(): ResourceOperation<H>[] {
+    const result = this.operations; this.operations = [];
+    return result;
+  }
+  completeStart(op: ResourceOperation<H>, result: { handle: H } | { error: string }): boolean {
+    const state = this.state(op.resource);
+    if (op.kind !== 'start' || state.pending !== op || this.ended) {
+      if (op.kind === 'start' && 'handle' in result)
+        this.operations.push({ ...op, kind: 'dispose', handle: result.handle });
+      return false;
+    }
+    state.pending = undefined;
+    if ('error' in result) state.health = 'failed';
+    else {
+      state.activeHandle = result.handle;
+      state.health = 'streaming';
+    }
+    return true;
+  }
+  completeStop(op: ResourceOperation<H>): boolean {
+    const state = this.state(op.resource);
+    if (op.kind !== 'stop' || state.pending !== op || this.ended) return false;
+    state.pending = undefined; state.health = 'inactive';
+    return true;
+  }
+  snapshot(resource: AppResource): Readonly<State<H>> { return { ...this.state(resource) }; }
+  teardown(): ResourceOperation<H>[] {
+    if (this.ended) return [];
+    this.ended = true; this.leases.clear(); this.operations = [];
+    const stops: ResourceOperation<H>[] = [];
+    for (const [resource, state] of this.states) {
+      state.demand = 0; state.pending = undefined; state.generation++;
+      if (state.activeHandle !== undefined) {
+        stops.push(this.op('stop', resource, state, state.activeHandle));
+        state.activeHandle = undefined;
+      }
+      state.health = 'inactive';
+    }
+    return stops;
+  }
+  private state(resource: AppResource): State<H> {
+    let state = this.states.get(resource);
+    if (!state) {
+      state = { available: false, selected: false, demand: 0, generation: 0, health: 'inactive' };
+      this.states.set(resource, state);
+    }
+    return state;
+  }
+  private reconcile(resource: AppResource, state: State<H>): void {
+    const wanted = !this.ended && state.demand > 0 && state.selected && state.available;
+    if (!wanted) {
+      if (state.pending?.kind === 'start') { state.generation++; state.pending = undefined; }
+      if (state.activeHandle !== undefined) {
+        const handle = state.activeHandle;
+        state.activeHandle = undefined;
+        const stop = this.op('stop', resource, state, handle);
+        state.pending = stop;
+        this.operations.push(stop);
+      } else if (state.health !== 'failed') state.health = 'inactive';
+      return;
+    }
+    if (state.health === 'failed' || state.activeHandle !== undefined || state.pending?.kind === 'start') return;
+    const start = this.op('start', resource, state);
+    state.pending = start; state.health = 'starting';
+    this.operations.push(start);
+  }
+  private op(kind: 'start', resource: AppResource, state: State<H>): ResourceOperation<H>;
+  private op(kind: 'stop', resource: AppResource, state: State<H>, handle: H): ResourceOperation<H>;
+  private op(kind: 'start' | 'stop', resource: AppResource, state: State<H>, handle?: H): ResourceOperation<H> {
+    const base = { kind, resource, sessionEpoch: this.sessionEpoch, generation: ++state.generation };
+    return (kind === 'start' ? base : { ...base, handle: handle as H }) as ResourceOperation<H>;
+  }
+}

--- a/frontend/src/lib/runtime/resource-demand.ts
+++ b/frontend/src/lib/runtime/resource-demand.ts
@@ -2,24 +2,44 @@ export type AppResource = 'hardware-scope' | 'audio-fft' | 'rx-audio';
 export type ResourceHealth = 'inactive' | 'starting' | 'streaming' | 'failed';
 declare const leaseBrand: unique symbol;
 export interface ResourceLease {
-  readonly resource: AppResource; readonly sessionEpoch: string; readonly leaseId: number; readonly [leaseBrand]: never;
+  readonly resource: AppResource;
+  readonly sessionEpoch: string;
+  readonly leaseId: number;
+  readonly [leaseBrand]: never;
 }
 export type ResourceOperation<H> =
   | { kind: 'start'; resource: AppResource; sessionEpoch: string; generation: number }
-  | { kind: 'stop' | 'dispose'; resource: AppResource; sessionEpoch: string; generation: number; handle: H };
+  | { kind: 'stop'; resource: AppResource; sessionEpoch: string; generation: number; handle: H }
+  | { kind: 'dispose'; resource: AppResource; sessionEpoch: string; generation: number; handle: H };
 interface State<H> {
-  available: boolean; selected: boolean; demand: number; generation: number;
-  health: ResourceHealth; activeHandle?: H; pending?: ResourceOperation<H>;
+  available: boolean;
+  selected: boolean;
+  demand: number;
+  generation: number;
+  health: ResourceHealth;
+  activeHandle?: H;
+  pending?: ResourceOperation<H>;
 }
-/** Pure App-session demand model; callers execute the returned operations. */
+/**
+ * Pure App-session demand model; callers execute the returned operations.
+ * Exact operation identity, session epoch, and generation jointly qualify completions.
+ */
 export class ResourceDemand<H> {
   private readonly states = new Map<AppResource, State<H>>();
   private readonly leases = new Set<ResourceLease>();
-  private operations: ResourceOperation<H>[] = []; private nextLeaseId = 0; private ended = false;
+  private readonly issuedStarts = new WeakSet<object>();
+  private readonly completedStarts = new WeakSet<object>();
+  private operations: ResourceOperation<H>[] = [];
+  private nextLeaseId = 0;
+  private ended = false;
+
   constructor(readonly sessionEpoch: string) {}
+
   configure(resource: AppResource, config: { available: boolean; selected: boolean }): void {
-    const state = this.state(resource), newlySelected = !state.selected && config.selected;
-    Object.assign(state, config);
+    const state = this.state(resource);
+    const newlySelected = !state.selected && config.selected;
+    state.available = config.available;
+    state.selected = config.selected;
     if (newlySelected && state.health === 'failed') state.health = 'inactive';
     this.reconcile(resource, state);
   }
@@ -29,14 +49,16 @@ export class ResourceDemand<H> {
     const lease = Object.freeze({
       resource, sessionEpoch: this.sessionEpoch, leaseId: ++this.nextLeaseId,
     }) as ResourceLease;
-    this.leases.add(lease); const state = this.state(resource);
+    this.leases.add(lease);
+    const state = this.state(resource);
     state.demand++;
     this.reconcile(resource, state);
     return lease;
   }
   release(lease: ResourceLease): boolean {
-    if (this.ended || !this.leases.delete(lease)) return false;
-    const state = this.state(lease.resource); state.demand--;
+    if (this.ended || lease.sessionEpoch !== this.sessionEpoch || !this.leases.delete(lease)) return false;
+    const state = this.state(lease.resource);
+    state.demand--;
     this.reconcile(lease.resource, state);
     return true;
   }
@@ -48,13 +70,34 @@ export class ResourceDemand<H> {
     }
   }
   takeOperations(): ResourceOperation<H>[] {
-    const result = this.operations; this.operations = [];
-    return result;
+    const ready: ResourceOperation<H>[] = [];
+    const deferred: ResourceOperation<H>[] = [];
+    for (const operation of this.operations) {
+      if (operation.kind !== 'dispose') {
+        ready.push(operation);
+        continue;
+      }
+      const state = this.state(operation.resource);
+      if (state.pending?.kind === 'start') {
+        deferred.push(operation);
+      } else if (!Object.is(state.activeHandle, operation.handle)) {
+        ready.push(operation);
+      }
+    }
+    this.operations = deferred;
+    return ready;
   }
   completeStart(op: ResourceOperation<H>, result: { handle: H } | { error: string }): boolean {
+    if (
+      op.kind !== 'start'
+      || op.sessionEpoch !== this.sessionEpoch
+      || !this.issuedStarts.has(op)
+      || this.completedStarts.has(op)
+    ) return false;
+    this.completedStarts.add(op);
     const state = this.state(op.resource);
-    if (op.kind !== 'start' || state.pending !== op || this.ended) {
-      if (op.kind === 'start' && 'handle' in result)
+    if (state.pending !== op || op.generation !== state.generation || this.ended) {
+      if ('handle' in result && !Object.is(state.activeHandle, result.handle))
         this.operations.push({ ...op, kind: 'dispose', handle: result.handle });
       return false;
     }
@@ -68,17 +111,40 @@ export class ResourceDemand<H> {
   }
   completeStop(op: ResourceOperation<H>): boolean {
     const state = this.state(op.resource);
-    if (op.kind !== 'stop' || state.pending !== op || this.ended) return false;
-    state.pending = undefined; state.health = 'inactive';
+    if (
+      op.kind !== 'stop'
+      || op.sessionEpoch !== this.sessionEpoch
+      || op.generation !== state.generation
+      || state.pending !== op
+      || this.ended
+    ) return false;
+    state.pending = undefined;
+    state.health = 'inactive';
     return true;
   }
-  snapshot(resource: AppResource): Readonly<State<H>> { return { ...this.state(resource) }; }
+
+  snapshot(resource: AppResource): Readonly<State<H>> {
+    return { ...this.state(resource) };
+  }
+
   teardown(): ResourceOperation<H>[] {
     if (this.ended) return [];
-    this.ended = true; this.leases.clear(); this.operations = [];
+    this.ended = true;
+    this.leases.clear();
+    const deferredDisposals = this.operations.filter(
+      (operation): operation is Extract<ResourceOperation<H>, { kind: 'dispose' }> =>
+        operation.kind === 'dispose',
+    );
+    this.operations = [];
     const stops: ResourceOperation<H>[] = [];
+    for (const disposal of deferredDisposals) {
+      const state = this.state(disposal.resource);
+      if (!Object.is(state.activeHandle, disposal.handle)) stops.push(disposal);
+    }
     for (const [resource, state] of this.states) {
-      state.demand = 0; state.pending = undefined; state.generation++;
+      state.demand = 0;
+      state.pending = undefined;
+      state.generation++;
       if (state.activeHandle !== undefined) {
         stops.push(this.op('stop', resource, state, state.activeHandle));
         state.activeHandle = undefined;
@@ -98,7 +164,10 @@ export class ResourceDemand<H> {
   private reconcile(resource: AppResource, state: State<H>): void {
     const wanted = !this.ended && state.demand > 0 && state.selected && state.available;
     if (!wanted) {
-      if (state.pending?.kind === 'start') { state.generation++; state.pending = undefined; }
+      if (state.pending?.kind === 'start') {
+        state.generation++;
+        state.pending = undefined;
+      }
       if (state.activeHandle !== undefined) {
         const handle = state.activeHandle;
         state.activeHandle = undefined;
@@ -110,13 +179,16 @@ export class ResourceDemand<H> {
     }
     if (state.health === 'failed' || state.activeHandle !== undefined || state.pending?.kind === 'start') return;
     const start = this.op('start', resource, state);
-    state.pending = start; state.health = 'starting';
+    state.pending = start;
+    state.health = 'starting';
     this.operations.push(start);
   }
   private op(kind: 'start', resource: AppResource, state: State<H>): ResourceOperation<H>;
   private op(kind: 'stop', resource: AppResource, state: State<H>, handle: H): ResourceOperation<H>;
   private op(kind: 'start' | 'stop', resource: AppResource, state: State<H>, handle?: H): ResourceOperation<H> {
     const base = { kind, resource, sessionEpoch: this.sessionEpoch, generation: ++state.generation };
-    return (kind === 'start' ? base : { ...base, handle: handle as H }) as ResourceOperation<H>;
+    const operation = (kind === 'start' ? base : { ...base, handle: handle as H }) as ResourceOperation<H>;
+    if (kind === 'start') this.issuedStarts.add(operation);
+    return operation;
   }
 }


### PR DESCRIPTION
## What changed

- add a pure App-session resource-demand model for hardware scope, audio FFT, and RX audio
- represent first/shared/last demand as qualified start/stop operations
- use exact opaque lease identity plus session epochs and per-resource operation generations
- reject stale tokens and A→B→A completions, and represent late-start disposal explicitly
- prevent duplicate or stable-handle start completions from disposing the active live handle
- whitelist public configuration fields so caller objects cannot overwrite private demand state
- keep unavailable/failed selection honest and make retries explicit
- add deterministic teardown with exactly-once active-handle release
- add focused adversarial unit coverage

## Why

Linear MOR-1056 is the first implementation slice of the accepted MOR-983 presentation-lifetime contract. This model establishes the pure ownership and reconciliation semantics before any App, Svelte component, transport, scope, audio, or TX wiring changes.

Linear: https://linear.app/morozsm/issue/MOR-1056/model-app-owned-presentation-resource-demand-independently-of-mounted

Closes #1994

## Scope

Exactly two new files: 194 production lines and 148 focused test lines. The original 200-line estimate was exceeded by the review remediation and readable regressions; no additional ownership scope, runtime authority, component, channel, provider, registry, overlay, or public API was added.

## Validation

- `npm test -- --run src/lib/runtime/__tests__/resource-demand.test.ts` — 8 passed
- `npm run check` — 0 errors / 0 warnings
- `npm run lint` — passed
- `npm run build` — passed (existing chunk warnings only)
- `NODE_OPTIONS=--localstorage-file=/tmp/rigplane-core-mor1056-fix-localstorage npm test` — 2,293 passed / 1 existing order-dependent failure in `mod-input-tx-guard.test.ts`
- isolated `mod-input-tx-guard.test.ts` — 13 passed
- `git diff --check` — passed
- exact-head GitHub `quick` — passed for `9f3ff12d62ed96404c4640068c8bc0785def9507`
- exact-head GitHub `grep-gate` — passed
- Agent Review Gate — expected fail until a fresh independent PASS is posted for this head

The Node 26 full frontend run requires `--localstorage-file`. The unrelated full-suite failure is reproducible in repeated full runs and passes in isolation; this PR does not change that test or its runtime path.
