### PR TITLE
fix(#2042): use runtime hardware-scope health in StatusBar

### DIFF
--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -7,7 +7,6 @@
   import {
     getRadioStatus,
     getConnectionStatus,
-    isScopeConnected,
     isAudioConnected,
     getHttpConnected,
     getRadioPowerOn,
@@ -62,7 +61,9 @@
   // When radio is powered off, override statuses that depend on the radio
   let radioState = $derived(isPoweredOff ? 'disconnected' : getRadioStatus());
   let controlState = $derived(getConnectionStatus()); // server link — always real
-  let scopeState = $derived(isPoweredOff ? 'disconnected' : (isScopeConnected() ? 'connected' : 'disconnected'));
+  let scopeState = $derived(
+    isPoweredOff || !runtime.scope.hardwareScopeConnected ? 'disconnected' : 'connected'
+  );
   let audioState = $derived(isPoweredOff ? 'disconnected' : (isAudioConnected() ? 'connected' : 'disconnected'));
   let httpState = $derived(getHttpConnected() ? 'connected' : 'disconnected'); // server link — always real
   let rigConnected = $derived(getRigConnected());

--- a/frontend/src/components-v2/layout/__tests__/StatusBar.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/StatusBar.component.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+
+const {
+  runtimeScope,
+  acquireHardwareScopeSpy,
+  releaseHardwareScopeSpy,
+  subscribeHardwareSpy,
+  sendSpy,
+  connectSpy,
+  disconnectSpy,
+  powerOnSpy,
+  powerOffSpy,
+  identifyFrequencySpy,
+  legacyScopeConnectedSpy,
+  radioPowerOnSpy,
+  hasAnyScopeSpy,
+} = vi.hoisted(() => ({
+  runtimeScope: { hardwareScopeConnected: false },
+  acquireHardwareScopeSpy: vi.fn(),
+  releaseHardwareScopeSpy: vi.fn(),
+  subscribeHardwareSpy: vi.fn(),
+  sendSpy: vi.fn(),
+  connectSpy: vi.fn(),
+  disconnectSpy: vi.fn(),
+  powerOnSpy: vi.fn(),
+  powerOffSpy: vi.fn(),
+  identifyFrequencySpy: vi.fn(),
+  legacyScopeConnectedSpy: vi.fn(),
+  radioPowerOnSpy: vi.fn(),
+  hasAnyScopeSpy: vi.fn(),
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    scope: {
+      get hardwareScopeConnected() {
+        return runtimeScope.hardwareScopeConnected;
+      },
+      subscribeHardware: subscribeHardwareSpy,
+    },
+    acquireHardwareScope: acquireHardwareScopeSpy,
+    releaseHardwareScope: releaseHardwareScopeSpy,
+    send: sendSpy,
+    system: {
+      connect: connectSpy,
+      disconnect: disconnectSpy,
+      powerOn: powerOnSpy,
+      powerOff: powerOffSpy,
+      identifyFrequency: identifyFrequencySpy,
+    },
+  },
+}));
+
+vi.mock('$lib/stores/connection.svelte', () => ({
+  getRadioStatus: vi.fn(() => 'connected'),
+  getConnectionStatus: vi.fn(() => 'connected'),
+  isScopeConnected: legacyScopeConnectedSpy,
+  isAudioConnected: vi.fn(() => false),
+  getHttpConnected: vi.fn(() => true),
+  getRadioPowerOn: radioPowerOnSpy,
+  getRigConnected: vi.fn(() => true),
+  getRadioReady: vi.fn(() => true),
+  getRadioHealth: vi.fn(() => null),
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasAnyScope: hasAnyScopeSpy,
+  hasAudio: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => false),
+}));
+
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getFrequency: vi.fn(() => 0),
+}));
+
+vi.mock('$lib/stores/layout.svelte', () => ({
+  getLayoutMode: vi.fn(() => 'standard'),
+  setLayoutMode: vi.fn(),
+}));
+
+vi.mock('$lib/i18n', () => ({
+  t: (key: string, params?: Record<string, unknown>) =>
+    params?.state ? `${key}:${params.state}` : key,
+}));
+
+vi.mock('../../controls/ThemePicker.svelte', () => ({
+  default: function ThemePickerStub() { return {}; },
+}));
+vi.mock('../../dialogs/SendReportDialog.svelte', () => ({
+  default: function SendReportDialogStub() { return {}; },
+}));
+vi.mock('lucide-svelte', () => {
+  const IconStub = function () { return {}; };
+  return {
+    Radio: IconStub,
+    Cable: IconStub,
+    Activity: IconStub,
+    Volume2: IconStub,
+    ArrowDownUp: IconStub,
+    Power: IconStub,
+    Unplug: IconStub,
+    Monitor: IconStub,
+    Tv: IconStub,
+    Settings: IconStub,
+    Bug: IconStub,
+  };
+});
+
+import StatusBar from '../StatusBar.svelte';
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountStatusBar(): HTMLElement {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  components.push(mount(StatusBar, { target }));
+  flushSync();
+  return target;
+}
+
+function scopeIndicator(target: HTMLElement): HTMLElement | null {
+  return target.querySelector(
+    '[role="status"][title^="core.statusbar.indicator.scope:"]',
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  components = [];
+  runtimeScope.hardwareScopeConnected = false;
+  legacyScopeConnectedSpy.mockReturnValue(false);
+  radioPowerOnSpy.mockReturnValue(true);
+  hasAnyScopeSpy.mockReturnValue(true);
+});
+
+afterEach(() => {
+  components.forEach((component) => unmount(component));
+  document.body.innerHTML = '';
+});
+
+describe('StatusBar scope health', () => {
+  it('renders runtime-connected scope health when the legacy store is disconnected', () => {
+    runtimeScope.hardwareScopeConnected = true;
+    legacyScopeConnectedSpy.mockReturnValue(false);
+
+    expect(scopeIndicator(mountStatusBar())?.title)
+      .toBe('core.statusbar.indicator.scope:connected');
+  });
+
+  it('renders runtime-disconnected scope health when the legacy store is connected', () => {
+    runtimeScope.hardwareScopeConnected = false;
+    legacyScopeConnectedSpy.mockReturnValue(true);
+
+    expect(scopeIndicator(mountStatusBar())?.title)
+      .toBe('core.statusbar.indicator.scope:disconnected');
+  });
+
+  it('forces the scope indicator disconnected while radio power is off', () => {
+    runtimeScope.hardwareScopeConnected = true;
+    radioPowerOnSpy.mockReturnValue(false);
+
+    expect(scopeIndicator(mountStatusBar())?.title)
+      .toBe('core.statusbar.indicator.scope:disconnected');
+  });
+
+  it('hides the scope indicator when no scope capability is available', () => {
+    runtimeScope.hardwareScopeConnected = true;
+    hasAnyScopeSpy.mockReturnValue(false);
+
+    expect(scopeIndicator(mountStatusBar())).toBeNull();
+  });
+
+  it('observes scope health without demand or transport work', () => {
+    runtimeScope.hardwareScopeConnected = true;
+    mountStatusBar();
+
+    expect(acquireHardwareScopeSpy).not.toHaveBeenCalled();
+    expect(releaseHardwareScopeSpy).not.toHaveBeenCalled();
+    expect(subscribeHardwareSpy).not.toHaveBeenCalled();
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(connectSpy).not.toHaveBeenCalled();
+    expect(disconnectSpy).not.toHaveBeenCalled();
+    expect(powerOnSpy).not.toHaveBeenCalled();
+    expect(powerOffSpy).not.toHaveBeenCalled();
+    expect(identifyFrequencySpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- make `StatusBar` render scope transport health from the canonical `runtime.scope.hardwareScopeConnected` state
- preserve the existing radio-power-off override and `hasAnyScope()` visibility gate
- add focused component coverage for connected/disconnected rendering, power-off override, capability-hidden behavior, and observational-only mount behavior

## Root cause

`StatusBar` still read the legacy `isScopeConnected` store flag. PR #2041 removes that flag's last writer, which would otherwise leave the global SCOPE indicator disconnected even while the runtime-owned hardware-scope channel is connected.

## Impact

This is an observational presentation change only. It does not acquire or release scope demand, subscribe to hardware scope, open or reconnect a channel, send commands, change the resource host, or manufacture physical-active truth. Labels, `role="status"`, tooltip semantics, layout, and unrelated indicators remain unchanged.

## Validation

Focused RED before implementation:

- runtime connected / legacy disconnected rendered `disconnected`
- runtime disconnected / legacy connected rendered `connected`

Passing after implementation:

- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/components-v2/layout/__tests__/StatusBar.component.test.ts` — 5/5
- `NODE_OPTIONS=--no-experimental-webstorage npm test` — 135 files, 2388 tests
- `NODE_OPTIONS=--no-experimental-webstorage npm run check`
- `NODE_OPTIONS=--no-experimental-webstorage npm run lint`
- `NODE_OPTIONS=--no-experimental-webstorage npm run lint:boundaries`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build`
- `NODE_OPTIONS=--no-experimental-webstorage npm run i18n:check`
- `uv run lint-imports` — 5 contracts kept, 0 broken
- `git diff --check`
- static scan: no `isScopeConnected` or scope demand/subscription/transport/command calls in `StatusBar.svelte`

## Ordering

This foundation PR must merge before #2041.

No real-hardware validation was performed and this PR makes no hardware-acceptance claim.

Linear: [MOR-1140](https://linear.app/morozsm/issue/MOR-1140)

Closes #2042
